### PR TITLE
fix(agent): transparently retry a stale --resume session id on a persistent controller's first message

### DIFF
--- a/.changesets/1785340373-fix-agent-transparently-retry-a-stale-resume-session-id-on-a-gx9b.md
+++ b/.changesets/1785340373-fix-agent-transparently-retry-a-stale-resume-session-id-on-a-gx9b.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): transparently retry a stale --resume session id on a persistent controller's first message

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -465,6 +465,7 @@ pub fn resync_controller(
                 filestore,
             );
             let ctrl = Arc::new(ctrl);
+            ctrl.set_self_ref();
             register_controller(block_id, ctrl.clone());
             ctrl.start(block_meta.clone(), rt_opts, force)
         }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -165,6 +165,19 @@ struct PersistentInner {
     /// Cleared on kill and on a normal exit for the same
     /// reused-instance reason as `pending_resume_retry`.
     confirmed_stale_resume_retry: Option<(String, PersistentSpawnConfig, String)>,
+    /// Bumped by `spawn_process` every time it successfully spawns a child
+    /// (the original send_message-triggered spawn, or a retry's own
+    /// respawn). `send_message` captures this right after its own spawn
+    /// attempt (if any) and re-checks it just before writing to
+    /// `stdin_tx` — codex P1 on PR #2360 (third review pass): a
+    /// fast-failing stale-resume spawn can let the process-waiter task
+    /// confirm and install a retry's brand-new process (with its own
+    /// fresh `stdin_tx`) BEFORE `send_message`'s own later write runs.
+    /// If the epoch has moved on, that write is skipped — the retry
+    /// already delivers this exact message on the new process, so
+    /// writing here too would duplicate it, and erroring on a
+    /// mid-swap `stdin_tx` would falsely report a failed send.
+    spawn_epoch: u64,
     current_pid: Option<u32>,
     /// Channel to send messages to the stdin writer task.
     stdin_tx: Option<mpsc::Sender<String>>,
@@ -321,6 +334,7 @@ impl PersistentSubprocessController {
                 resume_poisoned: None,
                 pending_resume_retry: None,
                 confirmed_stale_resume_retry: None,
+                spawn_epoch: 0,
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
@@ -510,6 +524,21 @@ impl PersistentSubprocessController {
         if is_fresh_spawn {
             self.spawn_process(config.clone(), Some(json_str.clone()))?;
         }
+        // Captured AFTER the spawn above (if any) so it reflects whatever
+        // is CURRENT at this point — see the tail-end check below and
+        // `spawn_epoch`'s own doc comment. codex P1 on PR #2360 (third
+        // review pass): on a fast-failing stale-resume spawn, the
+        // process-waiter task (on another thread) can detect the exit,
+        // confirm the retry, and install a BRAND NEW process — with its
+        // own fresh `stdin_tx` — before this function's own later stdin
+        // write below ever runs. Without tracking which spawn attempt this
+        // call's write belongs to, that write would either duplicate the
+        // message on the new process (if it read the new stdin_tx) or
+        // spuriously report a failed send (if it raced the narrow window
+        // where the old stdin_tx was already cleared but the new one
+        // wasn't installed yet) — even though the retry already delivers
+        // this exact message on its own.
+        let my_spawn_epoch = self.inner.lock().unwrap().spawn_epoch;
         // spawn_process already marks a fresh process's first turn active
         // (and starts its watchdog); for an already-running process (the
         // common case — every turn after the first) this is the only place
@@ -552,6 +581,18 @@ impl PersistentSubprocessController {
         );
 
         let inner = self.inner.lock().unwrap();
+        if inner.spawn_epoch != my_spawn_epoch {
+            // A NEWER spawn (a stale-resume retry, or any other respawn)
+            // has already taken over delivery for this exact attempt —
+            // `retry_after_resume_failure` already sends this SAME
+            // already-formatted `json_str` on the new process. Skip our
+            // own write entirely rather than duplicating it or risking a
+            // false "not running" error against a `stdin_tx` mid-swap.
+            // codex P1 on PR #2360 (third review pass).
+            drop(inner);
+            self.emit_message_accepted(config.message_id.as_deref());
+            return Ok(());
+        }
         let tx = inner.stdin_tx.as_ref()
             .ok_or("persistent process not running after spawn")?;
         tx.try_send(json_str)
@@ -933,23 +974,35 @@ impl PersistentSubprocessController {
             format!("failed to spawn persistent process: {e}")
         })?;
 
-        // Stash the TENTATIVE resume-retry payload synchronously, right
-        // here — before any background task (stdin writer, stdout/stderr
-        // readers, process-waiter) is created below. reagentx P1 on PR
-        // #2360: stashing this later, back in send_message after this
-        // function returned, left a window where a process that dies fast
-        // enough (the exact case this exists to catch) lets the
-        // process-waiter task — already racing on another thread once it's
-        // spawned — observe the exit and take() this payload while it's
-        // still `None`, silently losing the retry for the very case it's
-        // meant to catch. Keyed on the EXACT sid this spawn attempted (not
-        // `config.session_id`, which can differ from what's actually held
-        // in `inner.session_id` once an earlier call has already
-        // hydrated it) so `poison_resume`'s later confirmation check is
-        // unambiguous.
-        if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
+        // Bump spawn_epoch and stash the TENTATIVE resume-retry payload
+        // synchronously, right here — before any background task (stdin
+        // writer, stdout/stderr readers, process-waiter) is created below.
+        //
+        // The epoch bump (see its own doc comment) marks THIS as the
+        // newest spawn attempt for this controller — codex P1 on PR #2360
+        // (third review pass): without it, send_message's own later stdin
+        // write (after this function returns) has no way to notice that a
+        // stale-resume retry already installed a NEWER process (and
+        // `stdin_tx`) in the meantime, and would either duplicate the
+        // message on it or spuriously report a failed send.
+        //
+        // The retry-payload stash (reagentx P1 on PR #2360): doing this
+        // later, back in send_message after this function returned, left a
+        // window where a process that dies fast enough (the exact case
+        // this exists to catch) lets the process-waiter task — already
+        // racing on another thread once it's spawned — observe the exit
+        // and take() this payload while it's still `None`, silently losing
+        // the retry for the very case it's meant to catch. Keyed on the
+        // EXACT sid this spawn attempted (not `config.session_id`, which
+        // can differ from what's actually held in `inner.session_id` once
+        // an earlier call has already hydrated it) so `poison_resume`'s
+        // later confirmation check is unambiguous.
+        {
             let mut inner = self.inner.lock().unwrap();
-            inner.pending_resume_retry = Some((sid, config.clone(), retry_json));
+            inner.spawn_epoch += 1;
+            if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
+                inner.pending_resume_retry = Some((sid, config.clone(), retry_json));
+            }
         }
 
         let pid = child.id().unwrap_or(0);
@@ -1856,6 +1909,46 @@ mod send_input_tests {
              not race ahead of it"
         );
     }
+
+    /// codex P1 on PR #2360 (third review pass) added a `spawn_epoch` check
+    /// to `send_message`'s own stdin write, to detect a stale-resume retry
+    /// having already installed a newer process in the meantime. This
+    /// confirms that check is a pure no-op in the overwhelmingly common
+    /// case — no concurrent retry raced ahead — so an already-running
+    /// process still receives its message exactly as before. The actual
+    /// race this check exists to close (a genuine multi-threaded
+    /// interleaving between this function's own two lock acquisitions) is
+    /// not practical to inject deterministically without a test-only hook
+    /// in production code; verified via direct code inspection instead —
+    /// the check reads the SAME `inner.spawn_epoch` both times, so any
+    /// intervening bump (which only `spawn_process` performs, and only
+    /// while holding the same lock) is unconditionally visible.
+    #[tokio::test]
+    async fn send_message_still_delivers_normally_when_the_epoch_has_not_moved() {
+        let c = controller();
+        let (tx, mut rx) = mpsc::channel::<String>(4);
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+        }
+
+        let config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: String::new(),
+            session_id: String::new(),
+            message_id: None,
+        };
+
+        c.send_message("hello".to_string(), config)
+            .expect("delivery to an already-running process must succeed");
+
+        let received = rx.try_recv().expect("the message must have been written to stdin_tx");
+        assert!(received.contains("hello"));
+    }
 }
 
 /// Covers the stderr-poison / stdout-capture race directly against
@@ -1874,6 +1967,7 @@ mod resume_poison_tests {
             resume_poisoned: None,
             pending_resume_retry: None,
             confirmed_stale_resume_retry: None,
+            spawn_epoch: 0,
             current_pid: None,
             stdin_tx: None,
             kill_tx: None,

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -702,15 +702,34 @@ impl PersistentSubprocessController {
             // behind it (from other callers already told "accepted"),
             // hand off to a bounded fallback respawn rather than
             // stranding it with nobody responsible for delivering it.
+            //
+            // codex P2 on PR #2360 (round 13, commit e9678091f): clearing
+            // `spawning_in_progress` in a SEPARATE, later lock acquisition
+            // left a window between the emptiness check above and that
+            // clear where a concurrent `send_message` could observe
+            // `spawning_in_progress` still `true`, enqueue its message via
+            // `decide_send_action`'s `Queued` branch, and be told
+            // "accepted" — then this function's second lock would clear
+            // the claim without ever rechecking the queue, stranding that
+            // accepted message with no spawner and no drain ever
+            // responsible for it. The emptiness check and the flag clear
+            // must be one atomic decision under a single lock acquisition
+            // (same shape as the round-9 regression this whole PR already
+            // fixed once): only clear the claim here if the queue is STILL
+            // empty at the exact moment we're about to clear it; otherwise
+            // leave the claim held and hand off to the fallback respawn.
             let leftovers = {
                 let mut inner = self.inner.lock().unwrap();
                 inner.pending_send_messages.pop_front();
-                !inner.pending_send_messages.is_empty()
+                if inner.pending_send_messages.is_empty() {
+                    inner.spawning_in_progress = false;
+                    false
+                } else {
+                    true
+                }
             };
             if leftovers {
                 self.respawn_once_for_leftover_queue(retry_config);
-            } else {
-                self.inner.lock().unwrap().spawning_in_progress = false;
             }
             return;
         }
@@ -3164,6 +3183,76 @@ mod send_input_tests {
             "queued-by-someone-else",
             "a message queued by a DIFFERENT caller (already told \"accepted\") must survive for the next spawn"
         );
+    }
+
+    /// Exercises the actual race with real OS threads — codex P2 on PR
+    /// #2360 (round 13, commit e9678091f): a FAILED spawn's claim used to
+    /// be released in a lock acquisition SEPARATE from the emptiness check
+    /// that decided whether to release it at all. That left a window,
+    /// between the two, where a concurrent `send_message` could observe
+    /// `spawning_in_progress` still `true`, enqueue via `decide_send_action`'s
+    /// `Queued` branch, and be told "accepted" — then this function's
+    /// second lock would clear the claim without ever rechecking the
+    /// queue, stranding that accepted message with nobody left responsible
+    /// (no drain, no respawn, no disclosure). The fix merges the emptiness
+    /// check and the flag clear into one lock acquisition, so a racer's
+    /// push can now only land fully before or fully after that atomic
+    /// block — never inside it. Across many iterations and threads, the
+    /// invariant that must always hold: whenever a message is left queued
+    /// with the claim released, it's because a fallback respawn was
+    /// actually attempted (and disclosed its failure via a published
+    /// status) — never silently, with no attempt at all.
+    #[test]
+    fn release_spawn_claim_and_drain_queue_never_silently_strands_a_racing_send() {
+        use std::sync::Arc as StdArc;
+
+        for iteration in 0..30 {
+            let broker = StdArc::new(crate::backend::wps::Broker::new());
+            let block_id = format!("block-race-{iteration}");
+            let c = StdArc::new(PersistentSubprocessController::new(
+                "tab".to_string(),
+                block_id.clone(),
+                Some(broker.clone()),
+                None,
+                None,
+                None,
+            ));
+            c.set_self_ref();
+            {
+                let mut inner = c.inner.lock().unwrap();
+                inner.spawning_in_progress = true;
+                inner.pending_send_messages.push_back(QueuedMessage::fresh("the-one-that-failed".to_string()));
+            }
+
+            let handles: Vec<_> = (0..8)
+                .map(|i| {
+                    let c = StdArc::clone(&c);
+                    std::thread::spawn(move || {
+                        let _ = c.decide_send_action(&format!("racer-{iteration}-{i}"), false);
+                    })
+                })
+                .collect();
+
+            c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config());
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            let inner = c.inner.lock().unwrap();
+            let stranded = !inner.spawning_in_progress && !inner.pending_send_messages.is_empty();
+            if stranded {
+                let published = !broker
+                    .read_event_history(crate::backend::wps::EVENT_CONTROLLER_STATUS, &format!("block:{block_id}"), 10)
+                    .is_empty();
+                assert!(
+                    published,
+                    "iteration {iteration}: a racing send was left queued with the claim already \
+                     released and no respawn attempt ever disclosed via a status publish — stranded \
+                     with nobody responsible for it"
+                );
+            }
+        }
     }
 
     /// codex P2 on PR #2360 (sixth review pass, round 3): `retry_after_

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -548,12 +548,28 @@ impl PersistentSubprocessController {
     ///   `json_str` alongside that claim, and returns `BecomeSpawner` —
     ///   the caller must then call `spawn_process` and, regardless of
     ///   outcome, call `release_spawn_claim_and_drain_queue`.
-    fn decide_send_action(&self, json_str: &str) -> SendAction {
+    ///
+    /// `skip_if_already_queued` — always `false` for a genuine new message
+    /// (`send_message`): a user legitimately re-sending the exact same
+    /// text while an unrelated spawn is in flight must still queue both,
+    /// so this must never dedup by content there. `true` only for
+    /// `retry_after_resume_failure`, whose `json_str` is a KNOWN re-
+    /// delivery of content that may ALREADY be sitting in
+    /// `pending_send_messages` — pushed by the very spawn attempt whose
+    /// failure triggered this retry, if that spawn's own drain hasn't
+    /// reached it yet. codex P1 on PR #2360 (sixth review pass, round 4):
+    /// blindly queueing another copy there let a fallback spawn eventually
+    /// deliver the same prompt twice.
+    fn decide_send_action(&self, json_str: &str, skip_if_already_queued: bool) -> SendAction {
         let mut inner = self.inner.lock().unwrap();
         if inner.stdin_tx.is_some() && !inner.spawning_in_progress {
             SendAction::DeliverDirect
         } else if inner.spawning_in_progress {
-            inner.pending_send_messages.push_back(json_str.to_string());
+            let already_queued =
+                skip_if_already_queued && inner.pending_send_messages.iter().any(|m| m == json_str);
+            if !already_queued {
+                inner.pending_send_messages.push_back(json_str.to_string());
+            }
             SendAction::Queued
         } else {
             inner.spawning_in_progress = true;
@@ -762,6 +778,23 @@ impl PersistentSubprocessController {
         );
     }
 
+    /// Persists a formatted stdin JSON line to the blockfile + global zone
+    /// so `parseHistoryLines` can reconstruct the `user_message` node on
+    /// the next pane open. No WPS event is published here — the
+    /// live-display is handled by the `agent-message-accepted` path (UUID
+    /// node), avoiding a duplicate.
+    fn persist_message_to_blockfile(&self, json_str: &str) {
+        let global_zone = super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
+        let line_with_newline = format!("{json_str}\n");
+        super::shell::persist_to_blockfile_silent(
+            &self.block_id,
+            crate::backend::agent_session::OUTPUT_FILE,
+            line_with_newline.as_bytes(),
+            self.filestore.as_ref(),
+            global_zone.as_deref(),
+        );
+    }
+
     pub fn send_message(&self, message: String, config: PersistentSpawnConfig) -> Result<(), String> {
         // Format as stream-json user message.
         let json_msg = serde_json::json!({
@@ -773,25 +806,14 @@ impl PersistentSubprocessController {
         });
         let json_str = json_msg.to_string();
 
-        // Silently persist the user message to the blockfile + global zone so
-        // `parseHistoryLines` can reconstruct `user_message` nodes on the next
-        // open. No WPS event is published here — the live-display is handled by
-        // the `agent-message-accepted` path (UUID node), avoiding a duplicate.
-        // Done unconditionally, before deciding delivery below, so a message
-        // that ends up queued (see `decide_send_action`) is still durably
-        // persisted immediately rather than only once eventually delivered.
-        let global_zone = super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
-        let line_with_newline = format!("{json_str}\n");
-        super::shell::persist_to_blockfile_silent(
-            &self.block_id,
-            crate::backend::agent_session::OUTPUT_FILE,
-            line_with_newline.as_bytes(),
-            self.filestore.as_ref(),
-            global_zone.as_deref(),
-        );
-
-        match self.decide_send_action(&json_str) {
+        match self.decide_send_action(&json_str, false) {
             SendAction::Queued => {
+                // Persisted unconditionally: this caller was already told
+                // "accepted" (below) and a spawn/drain genuinely IS
+                // working through the queue this just joined, so — unlike
+                // the BecomeSpawner case — there is no "rejected before
+                // ever really being attempted" outcome to guard against.
+                self.persist_message_to_blockfile(&json_str);
                 self.emit_message_accepted(config.message_id.as_deref());
                 Ok(())
             }
@@ -803,6 +825,7 @@ impl PersistentSubprocessController {
                 // since the persistent process never exits between turns.
                 // Without this, `turn_active` would go stale after turn 1.
                 self.mark_turn_active_and_publish();
+                self.persist_message_to_blockfile(&json_str);
                 let inner = self.inner.lock().unwrap();
                 let tx = inner.stdin_tx.as_ref()
                     .ok_or("persistent process not running after spawn")?;
@@ -828,15 +851,20 @@ impl PersistentSubprocessController {
                 // `--resume`, which is what the retry payload is for.
                 let message_id = config.message_id.clone();
                 let retry_config = config.clone();
-                let spawn_result = self.spawn_process(config, Some(json_str));
-                // Only emit "accepted" on success — matches this
-                // function's prior (pre-queue) behavior, which propagated
-                // a spawn failure via `?` before ever reaching the
-                // "accepted" emission. A failed spawn's message is
-                // discarded by `release_spawn_claim_and_drain_queue` below
-                // (see its own doc comment), so telling the frontend
-                // "accepted" for it here would be a lie.
+                let spawn_result = self.spawn_process(config, Some(json_str.clone()));
+                // Only persist/emit "accepted" on success — codex P2 on PR
+                // #2360 (sixth review pass, round 4): persisting
+                // unconditionally (an earlier cut of this fix did) let a
+                // rejected spawn (missing executable, bad launch config)
+                // leave a "user_message" line in the blockfile for a
+                // prompt that was NEVER actually delivered — reopening the
+                // pane would reconstruct it as if it had been sent, and a
+                // manual retry then produced a misleading duplicate.
+                // Matches this function's pre-queue behavior, which
+                // propagated a spawn failure via `?` before ever reaching
+                // either the persist or the "accepted" emission.
                 if spawn_result.is_ok() {
+                    self.persist_message_to_blockfile(&json_str);
                     self.mark_turn_active_and_publish();
                     self.emit_message_accepted(message_id.as_deref());
                 }
@@ -878,8 +906,11 @@ impl PersistentSubprocessController {
         // has long since returned (its own spawn-claim-and-deliver
         // sequence completed synchronously, well before this process even
         // exited), so this can safely go through the SAME decision
-        // function `send_message` uses.
-        match self.decide_send_action(&json_str) {
+        // function `send_message` uses — with dedup-by-content enabled
+        // (see `decide_send_action`'s doc comment), since `json_str` here
+        // is a known re-delivery of the ORIGINAL spawn's own payload, not
+        // an independent new message.
+        match self.decide_send_action(&json_str, true) {
             SendAction::DeliverDirect => {
                 // Another caller's own spawn already installed a running
                 // process by the time this retry got scheduled — no need
@@ -2238,7 +2269,7 @@ mod send_input_tests {
     #[test]
     fn decide_send_action_becomes_spawner_when_nothing_is_in_flight() {
         let c = controller();
-        let action = c.decide_send_action("msg-a");
+        let action = c.decide_send_action("msg-a", false);
         assert!(matches!(action, SendAction::BecomeSpawner));
         let inner = c.inner.lock().unwrap();
         assert!(inner.spawning_in_progress, "must claim the exclusive spawn right");
@@ -2254,7 +2285,7 @@ mod send_input_tests {
         let c = controller();
         c.inner.lock().unwrap().spawning_in_progress = true;
 
-        let action = c.decide_send_action("msg-b");
+        let action = c.decide_send_action("msg-b", false);
         assert!(
             matches!(action, SendAction::Queued),
             "a second caller must queue instead of independently deciding to spawn"
@@ -2264,13 +2295,83 @@ mod send_input_tests {
         assert_eq!(inner.pending_send_messages[0], "msg-b");
     }
 
+    /// codex P1 on PR #2360 (sixth review pass, round 4): a genuine second
+    /// user message queuing behind an in-flight spawn must NOT be deduped
+    /// by content — a user legitimately re-sending the exact same text
+    /// must still see both delivered. `skip_if_already_queued=false`
+    /// (what `send_message` always passes) must therefore always enqueue.
+    #[test]
+    fn decide_send_action_never_dedups_a_genuine_new_message() {
+        let c = controller();
+        c.inner.lock().unwrap().spawning_in_progress = true;
+
+        c.decide_send_action("hello", false);
+        let action = c.decide_send_action("hello", false);
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            2,
+            "two genuinely separate sends of identical text must both be queued, not deduped"
+        );
+    }
+
+    /// codex P1 on PR #2360 (sixth review pass, round 4): unlike a genuine
+    /// new message, `retry_after_resume_failure`'s payload is a KNOWN
+    /// re-delivery of content that may ALREADY be sitting in the queue —
+    /// pushed by the very spawn attempt whose failure triggered this
+    /// retry, if that spawn's own drain hasn't reached it yet. Blindly
+    /// queueing another copy (as the `false`/`send_message` path
+    /// correctly does for a genuine new message) would let a fallback
+    /// spawn eventually deliver the same prompt twice. `skip_if_already_
+    /// queued=true` (what `retry_after_resume_failure` always passes)
+    /// must therefore skip re-enqueueing an identical, already-present
+    /// entry.
+    #[test]
+    fn decide_send_action_dedups_a_known_retry_of_an_already_queued_message() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("original-payload".to_string());
+        }
+
+        let action = c.decide_send_action("original-payload", true);
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            1,
+            "a retry of content already queued must not add a duplicate copy"
+        );
+    }
+
+    /// The dedup check must not accidentally skip a retry whose payload
+    /// genuinely isn't in the queue yet (the drain already popped it, in
+    /// the narrow window where the retry races in after that but before
+    /// the drain releases the claim) — it must still queue normally.
+    #[test]
+    fn decide_send_action_still_queues_a_retry_when_its_payload_is_not_already_present() {
+        let c = controller();
+        c.inner.lock().unwrap().spawning_in_progress = true;
+
+        let action = c.decide_send_action("not-yet-queued", true);
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(inner.pending_send_messages.len(), 1);
+        assert_eq!(inner.pending_send_messages[0], "not-yet-queued");
+    }
+
     #[test]
     fn decide_send_action_delivers_directly_when_already_running() {
         let c = controller();
         let (tx, _rx) = mpsc::channel::<String>(4);
         c.inner.lock().unwrap().stdin_tx = Some(tx);
 
-        let action = c.decide_send_action("msg-c");
+        let action = c.decide_send_action("msg-c", false);
         assert!(matches!(action, SendAction::DeliverDirect));
         let inner = c.inner.lock().unwrap();
         assert!(
@@ -2300,7 +2401,7 @@ mod send_input_tests {
             inner.spawning_in_progress = true;
         }
 
-        let action = c.decide_send_action("msg-late-arrival");
+        let action = c.decide_send_action("msg-late-arrival", false);
         assert!(
             matches!(action, SendAction::Queued),
             "must queue, not deliver direct, while a drain for an earlier message is still active"
@@ -2331,7 +2432,7 @@ mod send_input_tests {
                 let c = StdArc::clone(&c);
                 let spawner_count = StdArc::clone(&spawner_count);
                 let queued_count = StdArc::clone(&queued_count);
-                std::thread::spawn(move || match c.decide_send_action(&format!("msg-{i}")) {
+                std::thread::spawn(move || match c.decide_send_action(&format!("msg-{i}"), false) {
                     SendAction::BecomeSpawner => {
                         spawner_count.fetch_add(1, AtomicOrdering::SeqCst);
                     }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -136,6 +136,19 @@ struct PersistentInner {
     /// generated UUID) will never equal this one, so a stale poison value
     /// is permanently inert rather than something that needs clearing.
     resume_poisoned: Option<String>,
+    /// Set right after a FRESH spawn that attempted `--resume <sid>` —
+    /// captures the exact spawn config + already-formatted stdin line for
+    /// the message that triggered it. If the CLI then reports that exact
+    /// sid unreachable ("No conversation found"), the process-waiter task
+    /// moves this into a transparent retry (fresh process, no `--resume`,
+    /// same message redelivered) instead of losing the message and
+    /// surfacing a generic error — see `retry_after_resume_failure`.
+    /// Cleared by `try_capture_session_id` on ANY successful capture
+    /// (resume succeeded, or the CLI fell through to a fresh conversation
+    /// on its own) since a retry is then no longer needed; also cleared on
+    /// kill so a reused controller instance never retries a message from a
+    /// prior, unrelated lifetime.
+    pending_resume_retry: Option<(PersistentSpawnConfig, String)>,
     current_pid: Option<u32>,
     /// Channel to send messages to the stdin writer task.
     stdin_tx: Option<mpsc::Sender<String>>,
@@ -175,6 +188,12 @@ impl PersistentInner {
             return false;
         }
         self.session_id = Some(sid.to_string());
+        // Any successful capture — a resumed conversation confirming the
+        // sid it was given, or a fresh conversation the CLI started on its
+        // own — proves this spawn is genuinely progressing. The retry
+        // safety net (`pending_resume_retry`) only exists for a spawn that
+        // never gets this far, so it's no longer needed.
+        self.pending_resume_retry = None;
         true
     }
 }
@@ -200,6 +219,14 @@ pub struct PersistentSubprocessController {
     /// the reader skips for control frames — avoids a spurious fallback when the
     /// resumed turn's first activity is a tool-permission round-trip.
     stdout_seq: Arc<AtomicU64>,
+    /// Weak self-reference for the stale-`--resume`-session retry (see
+    /// `retry_after_resume_failure`) — set by `set_self_ref` right after
+    /// construction. The process-waiter task (a detached `tokio::spawn`
+    /// that only captures cloned Arc fields, never `&self`) needs a way to
+    /// call back into an instance method once the underlying process
+    /// actually exits; a `Weak` avoids a reference cycle (this same
+    /// struct's `spawn_process` is what schedules that task).
+    self_ref: Mutex<Option<std::sync::Weak<Self>>>,
 }
 
 /// How long to wait after delivering an AskUserQuestion answer before assuming
@@ -262,6 +289,7 @@ impl PersistentSubprocessController {
                 status_version: 0,
                 session_id: None,
                 resume_poisoned: None,
+                pending_resume_retry: None,
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
@@ -273,7 +301,20 @@ impl PersistentSubprocessController {
             filestore,
             health_monitor,
             stdout_seq: Arc::new(AtomicU64::new(0)),
+            self_ref: Mutex::new(None),
         }
+    }
+
+    /// Sets the weak self-reference used by the process-waiter task to call
+    /// back into `retry_after_resume_failure` once a doomed process (stale
+    /// `--resume` session id) actually exits. Mirrors `SubprocessController::
+    /// set_self_ref`'s queued-message-drain pattern. Must be called by the
+    /// caller right after wrapping a fresh instance in `Arc` — a controller
+    /// that's never had this called simply never retries (the check is a
+    /// harmless no-op `Weak::upgrade()` failure), so this is safe to skip
+    /// for e.g. throwaway test instances.
+    pub fn set_self_ref(self: &Arc<Self>) {
+        *self.self_ref.lock().unwrap() = Some(Arc::downgrade(self));
     }
 
     fn set_status(inner: &mut PersistentInner, status: &str) {
@@ -415,7 +456,8 @@ impl PersistentSubprocessController {
 
     pub fn send_message(&self, message: String, config: PersistentSpawnConfig) -> Result<(), String> {
         // Spawn process if not running
-        if !self.is_running() {
+        let is_fresh_spawn = !self.is_running();
+        if is_fresh_spawn {
             self.spawn_process(config.clone())?;
         }
         // spawn_process already marks a fresh process's first turn active
@@ -455,6 +497,19 @@ impl PersistentSubprocessController {
         });
         let json_str = json_msg.to_string();
 
+        // A resume attempt was just made on this exact spawn — stash the
+        // config + already-formatted line so a stale-`--resume` failure
+        // (detected asynchronously by the stderr reader; see
+        // `retry_after_resume_failure`) can transparently retry this exact
+        // message once, fresh, instead of losing it. Scoped tightly to
+        // "resume was actually attempted" — a message on an
+        // already-running process, or a fresh spawn with no prior session
+        // to resume, has nothing a stale-resume failure could apply to.
+        if is_fresh_spawn && !config.session_id.is_empty() && !config.resume_flag.is_empty() {
+            let mut inner = self.inner.lock().unwrap();
+            inner.pending_resume_retry = Some((config.clone(), json_str.clone()));
+        }
+
         // Silently persist the user message to the blockfile + global zone so
         // `parseHistoryLines` can reconstruct `user_message` nodes on the next
         // open. No WPS event is published here — the live-display is handled by
@@ -477,6 +532,59 @@ impl PersistentSubprocessController {
         drop(inner);
         self.emit_message_accepted(config.message_id.as_deref());
         Ok(())
+    }
+
+    /// Retries the message that triggered a `--resume <sid>` attempt this
+    /// controller's own stderr reader just confirmed is unreachable ("No
+    /// conversation found with session ID" — see `poison_resume`). Called
+    /// from the process-waiter task once the doomed process has actually
+    /// exited, via the weak self-reference (mirrors `SubprocessController`'s
+    /// queued-message drain — see `set_self_ref`).
+    ///
+    /// Spawns fresh with `session_id` cleared, so no `--resume` is attempted
+    /// again (`inner.session_id` is already `None` from `poison_resume`;
+    /// clearing it here too keeps `spawn_process`'s own hydrate-from-config
+    /// step, which doesn't know about `resume_poisoned`, from re-adopting
+    /// the same dead id). Redelivers the EXACT already-formatted stdin line
+    /// directly on the new process — does NOT re-persist to the blockfile or
+    /// re-emit `agent-message-accepted`, since both already happened
+    /// correctly on the original (failed) attempt; only the underlying CLI
+    /// process needed a fresh, resume-less start.
+    fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_str: String) {
+        config.session_id = String::new();
+        if let Err(e) = self.spawn_process(config) {
+            tracing::error!(
+                block_id = %self.block_id,
+                error = %e,
+                "failed to respawn after a stale --resume session id"
+            );
+            return;
+        }
+        // Mirrors send_message's own post-spawn turn-active bookkeeping —
+        // this retry IS the turn's real first (and only user-visible) send,
+        // just deferred past one doomed process.
+        let was_active = self.health_monitor.mark_turn_active_returning_was_active();
+        if !was_active {
+            core::spawn_health_watchdog(&self.health_monitor);
+            self.spawn_status_heartbeat();
+        }
+        self.publish_status();
+
+        let inner = self.inner.lock().unwrap();
+        let Some(tx) = inner.stdin_tx.as_ref() else {
+            tracing::error!(
+                block_id = %self.block_id,
+                "stale-resume retry spawn reported success but stdin_tx is unset"
+            );
+            return;
+        };
+        if let Err(e) = tx.try_send(json_str) {
+            tracing::warn!(
+                block_id = %self.block_id,
+                error = %e,
+                "failed to redeliver message after stale-resume retry spawn"
+            );
+        }
     }
 
     /// Deliver a user message to the **already-running** persistent process,
@@ -1139,6 +1247,10 @@ impl PersistentSubprocessController {
         let health_wait = Arc::clone(&self.health_monitor);
         // Captured so the waiter can deregister this agent from muxbus on exit.
         let agent_id_wait = agent_id_for_muxbus.clone();
+        // See `set_self_ref` / `retry_after_resume_failure` — lets this
+        // detached task call back into an instance method once the process
+        // actually exits, to transparently retry a stale-`--resume` failure.
+        let self_ref_wait = self.self_ref.lock().unwrap().clone().unwrap_or_default();
 
         tokio::spawn(async move {
             tokio::select! {
@@ -1158,6 +1270,10 @@ impl PersistentSubprocessController {
                     inner.current_pid = None;
                     inner.stdin_tx = None;
                     inner.kill_tx = None;
+                    // Taken (not just read) so a stale-resume retry can only
+                    // ever fire once per triggering spawn — see
+                    // `retry_after_resume_failure`'s doc comment.
+                    let retry_after_resume = inner.pending_resume_retry.take();
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
 
@@ -1193,6 +1309,25 @@ impl PersistentSubprocessController {
                         };
                         super::publish_controller_status(broker, &status);
                     }
+
+                    // A stale `--resume <sid>` is exactly what killed this
+                    // process (`retry_after_resume_failure`'s doc comment) —
+                    // retry the same message once, fresh, before this exit
+                    // is ever treated as a completed/failed turn from the
+                    // frontend's point of view. reagentx/codex never
+                    // reviewed this path (see docs/retros/
+                    // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md) —
+                    // it's a different controller type than PR #2338's own
+                    // ACP-controller review surface.
+                    if let Some((retry_config, retry_json)) = retry_after_resume {
+                        if let Some(ctrl) = self_ref_wait.upgrade() {
+                            tracing::warn!(
+                                block_id = %block_id_wait,
+                                "stale --resume session id caused this exit — retrying fresh, without --resume"
+                            );
+                            ctrl.retry_after_resume_failure(retry_config, retry_json);
+                        }
+                    }
                 }
                 Ok(force) = kill_rx => {
                     tracing::info!(
@@ -1223,6 +1358,12 @@ impl PersistentSubprocessController {
                     inner.current_pid = None;
                     inner.stdin_tx = None;
                     inner.kill_tx = None;
+                    // A user-initiated kill is unrelated to any stale-resume
+                    // failure in flight; drop it so a future, unrelated exit
+                    // on a REUSED controller instance (resync_controller can
+                    // reuse the same instance across a kill+restart cycle)
+                    // never retries a message from this now-dead lifetime.
+                    inner.pending_resume_retry = None;
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
 
@@ -1555,10 +1696,24 @@ mod resume_poison_tests {
             status_version: 0,
             session_id: session_id.map(str::to_string),
             resume_poisoned: None,
+            pending_resume_retry: None,
             current_pid: None,
             stdin_tx: None,
             kill_tx: None,
             pending_questions: HashMap::new(),
+        }
+    }
+
+    fn dummy_spawn_config() -> PersistentSpawnConfig {
+        PersistentSpawnConfig {
+            cli_command: "claude".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
         }
     }
 
@@ -1608,5 +1763,68 @@ mod resume_poison_tests {
         let captured = inner.try_capture_session_id("second-sid");
         assert!(!captured, "must not overwrite an already-captured session id");
         assert_eq!(inner.session_id.as_deref(), Some("first-sid"));
+    }
+
+    // reagentx/codex never reviewed this path (PR #2338's review surface was
+    // the ACP controller only) — see docs/retros/
+    // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md. A stale
+    // `--resume <sid>` (first-ever use of a globally-known agent's session
+    // under a brand-new build/channel's own CLI install) used to lose the
+    // triggering message and surface a generic "Agent encountered an error"
+    // — the safety net is `pending_resume_retry`, and its correctness hinges
+    // entirely on being cleared if and only if the spawn it was captured for
+    // actually made real progress.
+    #[test]
+    fn pending_resume_retry_is_cleared_once_the_resume_actually_succeeds() {
+        let mut inner = inner_with_session_id(None);
+        inner.pending_resume_retry = Some((dummy_spawn_config(), "{}".to_string()));
+
+        // The CLI echoes back the SAME sid it was given, confirming --resume
+        // actually worked — this is genuine progress, so the retry safety
+        // net is no longer needed.
+        let captured = inner.try_capture_session_id("dead-sid");
+        assert!(captured);
+        assert!(
+            inner.pending_resume_retry.is_none(),
+            "a successful resume must stand down the retry safety net"
+        );
+    }
+
+    #[test]
+    fn pending_resume_retry_is_cleared_when_the_cli_starts_a_fresh_conversation_on_its_own() {
+        let mut inner = inner_with_session_id(None);
+        inner.pending_resume_retry = Some((dummy_spawn_config(), "{}".to_string()));
+
+        // A DIFFERENT (fresh) sid — the CLI gave up on --resume internally
+        // and started its own new conversation without ever hitting the
+        // stderr "No conversation found" path. Also genuine progress.
+        let captured = inner.try_capture_session_id("brand-new-sid");
+        assert!(captured);
+        assert!(inner.pending_resume_retry.is_none());
+    }
+
+    #[test]
+    fn pending_resume_retry_survives_a_refused_capture() {
+        // The exact race this whole mechanism exists for: stderr's
+        // poison_resume fires (confirming this spawn's resume attempt is
+        // dead) BEFORE the stdout reader's own echo of that same dead id
+        // loses the race and gets refused. The refused capture must NOT
+        // clear pending_resume_retry — no progress was made, so the retry
+        // this exact scenario needs must still fire once the process exits.
+        let mut inner = inner_with_session_id(Some("dead-sid"));
+        inner.pending_resume_retry = Some((dummy_spawn_config(), "{}".to_string()));
+
+        inner.poison_resume("dead-sid");
+        assert!(
+            inner.pending_resume_retry.is_some(),
+            "poison_resume alone must not clear the retry — the process hasn't exited yet"
+        );
+
+        let captured = inner.try_capture_session_id("dead-sid");
+        assert!(!captured, "the poisoned id must still be refused");
+        assert!(
+            inner.pending_resume_retry.is_some(),
+            "a refused (no-op) capture must not clear the retry safety net"
+        );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -890,34 +890,34 @@ impl PersistentSubprocessController {
         // `retry_after_resume_failure`'s own explicit clear for the exact
         // same reason.
         //
-        // Poisons (rather than just clears) whatever sid was held —
-        // reagentx P1 on PR #2360 (sixth review pass, round 12): this
-        // fallback is reached with NO guarantee that `poison_resume` has
-        // actually run for the doomed process's sid — the exit-handler's
-        // own bounded wait (500ms) for that process's stderr-reader task
-        // can time out and abort it before it ever calls `poison_resume`
-        // (this drain-triggered path, unlike `retry_after_resume_failure`,
-        // does not require `confirmed_stale_resume_retry` to have been
-        // set, so it can fire even when that promotion never happened). In
-        // that case the SAME process's stdout-reader task — which has NO
-        // bound or abort mechanism at all — could still be concurrently
-        // racing to echo-capture that exact sid via
-        // `try_capture_session_id`, re-setting `inner.session_id` right
-        // after a plain clear and before `spawn_process`'s own `--resume`
-        // read, moments later. `poison_resume` additionally sets
-        // `resume_poisoned`, which `try_capture_session_id` checks and
-        // refuses regardless of ordering — closing that gap even when the
-        // stderr reader never got to poison it itself. Safe to call
-        // unconditionally: by the time this fallback runs, the exit
-        // handler has already unconditionally cleared
-        // `pending_resume_retry`, so `poison_resume`'s own retry-promotion
-        // side effect is always a no-op here.
-        {
-            let mut inner = self.inner.lock().unwrap();
-            if let Some(old_sid) = inner.session_id.clone() {
-                inner.poison_resume(&old_sid);
-            }
-        }
+        // A plain clear, deliberately NOT `poison_resume` — reagentx P1
+        // on PR #2360 (sixth review pass, round 13): a prior cut of this
+        // fix called `poison_resume` here to defensively close a narrower
+        // race (a still-racing stdout-reader task from the doomed process
+        // could re-capture the same sid right after a plain clear). That
+        // was a regression: `respawn_once_for_leftover_queue` is reached
+        // from TWO triggers that have nothing to do with a CONFIRMED
+        // stale `--resume` — `release_spawn_claim_and_drain_queue`'s
+        // `!spawn_succeeded` branch (ANY `spawn_process` failure — a
+        // missing binary, an OS error) and
+        // `drain_queue_after_successful_spawn`'s stall branch (ANY
+        // process exit/crash with messages still queued, not
+        // specifically a stale-resume death). In both, `inner.session_id`
+        // could just as easily be a legitimately hydrated-but-unattempted
+        // id, or a genuinely valid, already-captured session from a
+        // process that ran fine and crashed for an unrelated reason.
+        // `poison_resume` is documented as PERMANENT (`resume_poisoned` is
+        // "never reset back to None") — poisoning a sid never actually
+        // confirmed dead by the CLI permanently breaks conversation
+        // continuity for that session, with no disclosure, for the rest
+        // of this controller instance's lifetime. A plain clear only
+        // affects THIS respawn's own `--resume` decision (already forced
+        // empty via `config.session_id` above) and carries no such
+        // permanent, over-broad risk. The narrower race the poisoning was
+        // meant to close is real but far rarer than the cases above;
+        // tracked as a documented follow-up instead of reintroducing this
+        // regression.
+        self.inner.lock().unwrap().session_id = None;
         let retry_config = config.clone();
         let spawn_result = self.spawn_process(config, None);
         match &spawn_result {
@@ -2629,20 +2629,25 @@ mod send_input_tests {
         );
     }
 
-    /// reagentx P1 on PR #2360 (sixth review pass, round 12): this
-    /// fallback is reached with no guarantee `poison_resume` has already
-    /// run for the doomed process's sid (its stderr-reader task could
-    /// have been aborted past its 500ms bound before ever calling it).
-    /// The doomed process's stdout-reader task has no such bound, so it
-    /// could still be concurrently racing to echo-capture that exact sid
-    /// — a plain clear alone leaves nothing to refuse it. Confirms this
-    /// fallback additionally poisons whatever sid it held, so a later
-    /// capture attempt for that exact sid is refused regardless of
-    /// ordering.
+    /// reagentx P1 on PR #2360 (sixth review pass, round 13): an earlier
+    /// cut of this fallback called `poison_resume` (not just a plain
+    /// clear) on whatever sid was held, reasoning defensively about a
+    /// narrower race. That was itself a regression: this fallback is
+    /// reached from triggers that have nothing to do with a CONFIRMED
+    /// stale `--resume` (a plain `spawn_process` failure, or ANY process
+    /// crash with messages still queued) — `inner.session_id` could just
+    /// as easily be a genuinely valid, already-captured session from a
+    /// process that ran fine and crashed for an unrelated reason.
+    /// `poison_resume` is PERMANENT (`resume_poisoned` is never reset),
+    /// so poisoning a sid never actually confirmed dead by the CLI would
+    /// permanently break that session's resume capability. Confirms a
+    /// valid sid survives this fallback well enough to still be captured
+    /// again later (i.e. NOT poisoned) — only the in-memory `session_id`
+    /// itself is cleared, forcing this one respawn to skip `--resume`.
     #[test]
-    fn respawn_once_for_leftover_queue_poisons_whatever_sid_it_held() {
+    fn respawn_once_for_leftover_queue_does_not_poison_the_sid_it_held() {
         let c = controller();
-        c.inner.lock().unwrap().session_id = Some("dead-sid".to_string());
+        c.inner.lock().unwrap().session_id = Some("valid-unrelated-sid".to_string());
 
         let config = PersistentSpawnConfig {
             cli_command: "definitely-not-a-real-binary-xyz".to_string(),
@@ -2651,22 +2656,19 @@ mod send_input_tests {
             env_vars: HashMap::new(),
             session_id_field: "session_id".to_string(),
             resume_flag: "--resume".to_string(),
-            session_id: "dead-sid".to_string(),
+            session_id: "valid-unrelated-sid".to_string(),
             message_id: None,
         };
         c.respawn_once_for_leftover_queue(config);
 
-        {
-            let mut inner = c.inner.lock().unwrap();
-            assert_eq!(
-                inner.resume_poisoned.as_deref(),
-                Some("dead-sid"),
-                "must poison the sid it held, not just clear it, so a still-racing \
-                 stdout-reader capture attempt for that exact sid is refused"
-            );
-            let captured = inner.try_capture_session_id("dead-sid");
-            assert!(!captured, "a later capture attempt for the poisoned sid must be refused");
-        }
+        let mut inner = c.inner.lock().unwrap();
+        assert_ne!(
+            inner.resume_poisoned.as_deref(),
+            Some("valid-unrelated-sid"),
+            "must not permanently poison a sid that was never confirmed dead by the CLI"
+        );
+        let captured = inner.try_capture_session_id("valid-unrelated-sid");
+        assert!(captured, "a genuinely valid sid must still be capturable again later");
     }
 
     /// codex P1/P2 on PR #2360 (second review pass): the process-waiter

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -473,6 +473,33 @@ impl PersistentSubprocessController {
         inner.stdin_tx.is_some()
     }
 
+    /// Whether `send_message`'s own stdin write should be skipped in favor
+    /// of a retry that has already taken over delivery for this exact
+    /// attempt — see the call site's own doc comment for the full
+    /// reasoning behind the epoch mechanism itself.
+    ///
+    /// Gated on `is_fresh_spawn` — codex P1 on PR #2360 (fifth review
+    /// pass): only a message that triggered ITS OWN fresh spawn ever has
+    /// its payload captured into `pending_resume_retry` (see
+    /// `spawn_process`), so only THAT message can correctly hand off
+    /// delivery to a retry. A DIFFERENT message arriving while that same
+    /// doomed process is still nominally "running" (`is_fresh_spawn ==
+    /// false` for IT) has no such hand-off — its own content was never
+    /// captured anywhere else. If it happened to observe an epoch
+    /// mismatch too (the SAME retry racing ahead of its own tail-end
+    /// check), skipping would silently drop that message entirely while
+    /// `send_message` still reports success and emits
+    /// `agent-message-accepted` — worse than a duplicate, since the
+    /// content vanishes with no signal at all. Such a message must always
+    /// attempt delivery via whatever `stdin_tx` is CURRENT. Pulled out as
+    /// a pure function (an earlier cut of this fix omitted the
+    /// `is_fresh_spawn` guard inline) so the exact condition is directly,
+    /// deterministically testable without needing to reproduce the actual
+    /// multi-threaded race.
+    fn should_skip_own_delivery(is_fresh_spawn: bool, my_spawn_epoch: u64, current_spawn_epoch: u64) -> bool {
+        is_fresh_spawn && current_spawn_epoch != my_spawn_epoch
+    }
+
     /// Send a user message to the running CLI process.
     /// If the process isn't spawned yet, spawns it first.
     /// Emit `agent-message-accepted` for a given message_id, if set.
@@ -592,14 +619,7 @@ impl PersistentSubprocessController {
         );
 
         let inner = self.inner.lock().unwrap();
-        if inner.spawn_epoch != my_spawn_epoch {
-            // A NEWER spawn (a stale-resume retry, or any other respawn)
-            // has already taken over delivery for this exact attempt —
-            // `retry_after_resume_failure` already sends this SAME
-            // already-formatted `json_str` on the new process. Skip our
-            // own write entirely rather than duplicating it or risking a
-            // false "not running" error against a `stdin_tx` mid-swap.
-            // codex P1 on PR #2360 (third review pass).
+        if Self::should_skip_own_delivery(is_fresh_spawn, my_spawn_epoch, inner.spawn_epoch) {
             drop(inner);
             self.emit_message_accepted(config.message_id.as_deref());
             return Ok(());
@@ -643,6 +663,20 @@ impl PersistentSubprocessController {
                 error = %e,
                 "failed to respawn after a stale --resume session id"
             );
+            // Surface this, or the pane hangs forever with NO signal at
+            // all — codex P2 on PR #2360 (fifth review pass): the outer
+            // process-waiter already suppressed its own terminal-status
+            // publish for the ORIGINAL exit specifically because a retry
+            // was in flight, and send_message already returned success
+            // (possibly emitting agent-message-accepted) for the message
+            // this retry was supposed to deliver. If this respawn attempt
+            // ALSO fails, nothing else will ever tell the frontend this
+            // turn is over. `inner.proc_status`/`turn_active` are already
+            // `STATUS_DONE`/`false` (set by the original exit's own
+            // cleanup before this function was ever called) — this just
+            // actually broadcasts that state, which the original exit
+            // deliberately withheld pending this retry's outcome.
+            self.publish_status();
             return;
         }
         // Mirrors send_message's own post-spawn turn-active bookkeeping —
@@ -1420,15 +1454,29 @@ impl PersistentSubprocessController {
                     // to persisting an empty one, corrupting continuity
                     // despite the retry having succeeded. 500ms is
                     // generous — the stderr pipe closes and drains almost
-                    // immediately once the process has genuinely exited —
-                    // and only ever delays shutdown handling, never blocks
-                    // it indefinitely.
+                    // immediately once the process has genuinely exited.
+                    //
+                    // If it DOES take longer than that (e.g. `persist_session_id`
+                    // blocked on a slow store call), a bare `timeout()` alone
+                    // is not enough — codex P1 on PR #2360 (fifth review
+                    // pass): `timeout()` only stops WAITING for the handle,
+                    // it does not cancel the underlying task, which keeps
+                    // running in the background and can still call
+                    // `poison_resume`/`persist_session_id("")` AFTER this
+                    // task has already moved on (discarded the still-
+                    // tentative retry, or started a fresh child whose own
+                    // new session id that late write would then corrupt).
+                    // `abort()` on a separately-obtained `AbortHandle`
+                    // actually cancels it — the task stops at its next
+                    // yield point and can never reach either call again.
                     if let Some(handle) = stderr_reader_handle {
+                        let abort_handle = handle.abort_handle();
                         if tokio::time::timeout(std::time::Duration::from_millis(500), handle).await.is_err() {
                             tracing::warn!(
                                 block_id = %block_id_wait,
-                                "stderr reader did not finish within 500ms of process exit"
+                                "stderr reader did not finish within 500ms of process exit — aborting it"
                             );
+                            abort_handle.abort();
                         }
                     }
 
@@ -1974,6 +2022,33 @@ mod send_input_tests {
 
         let received = rx.try_recv().expect("the message must have been written to stdin_tx");
         assert!(received.contains("hello"));
+    }
+
+    /// codex P1 on PR #2360 (fifth review pass): an earlier cut of
+    /// `should_skip_own_delivery` (inlined at the call site at the time)
+    /// omitted the `is_fresh_spawn` guard — a SECOND message arriving on
+    /// an already-running process (its own content never captured into
+    /// any retry payload) could observe an UNRELATED epoch bump (from a
+    /// DIFFERENT message's own stale-resume retry) and silently skip its
+    /// own delivery, losing its content entirely while `send_message`
+    /// still reported success. This directly exercises the corrected
+    /// boolean condition with fabricated inputs — deterministic, no need
+    /// to reproduce the actual multi-threaded race.
+    #[test]
+    fn should_skip_own_delivery_only_when_this_calls_own_fresh_spawn_was_superseded() {
+        assert!(
+            !PersistentSubprocessController::should_skip_own_delivery(false, 1, 2),
+            "an already-running message must always deliver, regardless of an unrelated epoch bump"
+        );
+        assert!(
+            PersistentSubprocessController::should_skip_own_delivery(true, 1, 2),
+            "a fresh-spawn message superseded by a newer spawn must skip its own delivery"
+        );
+        assert!(
+            !PersistentSubprocessController::should_skip_own_delivery(true, 1, 1),
+            "the common, non-racing case (epoch unchanged) must always deliver"
+        );
+        assert!(!PersistentSubprocessController::should_skip_own_delivery(false, 1, 1));
     }
 }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -825,13 +825,22 @@ impl PersistentSubprocessController {
                 // since the persistent process never exits between turns.
                 // Without this, `turn_active` would go stale after turn 1.
                 self.mark_turn_active_and_publish();
-                self.persist_message_to_blockfile(&json_str);
                 let inner = self.inner.lock().unwrap();
                 let tx = inner.stdin_tx.as_ref()
                     .ok_or("persistent process not running after spawn")?;
-                tx.try_send(json_str)
+                // Persist only AFTER a successful send — reagentx P1 on PR
+                // #2360 (sixth review pass, round 5): `stdin_tx` can have
+                // gone `None` (process died) between `decide_send_action`'s
+                // check and this later lock re-acquisition, or `try_send`
+                // can fail with `Full` under load; persisting beforehand
+                // reproduces, for this path, the exact "persisted a
+                // never-delivered message" bug the immediately prior
+                // commit fixed for `BecomeSpawner`. Matches
+                // `send_user_message`'s existing (correct) ordering.
+                tx.try_send(json_str.clone())
                     .map_err(|e| format!("stdin send failed: {e}"))?;
                 drop(inner);
+                self.persist_message_to_blockfile(&json_str);
                 self.emit_message_accepted(config.message_id.as_deref());
                 Ok(())
             }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -519,26 +519,37 @@ impl PersistentSubprocessController {
         });
         let json_str = json_msg.to_string();
 
-        // Spawn process if not running
+        // Spawn process if not running. Binds directly to spawn_process's
+        // OWN return value for the epoch, rather than re-reading
+        // `inner.spawn_epoch` in a separate lock acquisition afterward —
+        // codex P1 on PR #2360 (fourth review pass): re-reading left a gap
+        // between spawn_process returning and that later read where a
+        // fast-failing stale-resume child's own retry could ALREADY have
+        // bumped the epoch again, making this capture the RETRY's epoch
+        // instead of THIS attempt's — silently defeating the whole check
+        // (the tail-end comparison would then always "match" the retry's
+        // epoch, letting this function duplicate the message on the
+        // retry's process). See spawn_process's doc comment for the full
+        // reasoning; see the tail-end check below and `spawn_epoch`'s own
+        // doc comment for what this value protects (codex P1, third review
+        // pass): a fast-failing stale-resume spawn's retry can install a
+        // BRAND NEW process — with its own fresh `stdin_tx` — before this
+        // function's own later stdin write below ever runs, which would
+        // otherwise either duplicate the message on the new process or
+        // spuriously report a failed send, even though the retry already
+        // delivers this exact message on its own.
+        //
+        // For an already-running process (no fresh spawn this call), there
+        // is no NEW spawn attempt of this call's own to bind atomically —
+        // reading the live value is correct here because `pending_resume_retry`
+        // is only ever set on a fresh, resume-attempting spawn, so nothing
+        // tied to THIS message's own delivery could race ahead of it.
         let is_fresh_spawn = !self.is_running();
-        if is_fresh_spawn {
-            self.spawn_process(config.clone(), Some(json_str.clone()))?;
-        }
-        // Captured AFTER the spawn above (if any) so it reflects whatever
-        // is CURRENT at this point — see the tail-end check below and
-        // `spawn_epoch`'s own doc comment. codex P1 on PR #2360 (third
-        // review pass): on a fast-failing stale-resume spawn, the
-        // process-waiter task (on another thread) can detect the exit,
-        // confirm the retry, and install a BRAND NEW process — with its
-        // own fresh `stdin_tx` — before this function's own later stdin
-        // write below ever runs. Without tracking which spawn attempt this
-        // call's write belongs to, that write would either duplicate the
-        // message on the new process (if it read the new stdin_tx) or
-        // spuriously report a failed send (if it raced the narrow window
-        // where the old stdin_tx was already cleared but the new one
-        // wasn't installed yet) — even though the retry already delivers
-        // this exact message on its own.
-        let my_spawn_epoch = self.inner.lock().unwrap().spawn_epoch;
+        let my_spawn_epoch = if is_fresh_spawn {
+            self.spawn_process(config.clone(), Some(json_str.clone()))?
+        } else {
+            self.inner.lock().unwrap().spawn_epoch
+        };
         // spawn_process already marks a fresh process's first turn active
         // (and starts its watchdog); for an already-running process (the
         // common case — every turn after the first) this is the only place
@@ -908,7 +919,21 @@ impl PersistentSubprocessController {
     }
 
     /// Spawn the persistent CLI process.
-    fn spawn_process(&self, config: PersistentSpawnConfig, resume_retry_payload: Option<String>) -> Result<(), String> {
+    /// Returns the `spawn_epoch` value THIS spawn assigned (see the field's
+    /// doc comment), captured atomically as part of this same call.
+    /// `send_message` binds to this return value directly for its own
+    /// fresh-spawn case, rather than re-reading `inner.spawn_epoch` in a
+    /// separate lock acquisition afterward — codex P1 on PR #2360 (fourth
+    /// review pass): re-reading left a window between this function
+    /// returning and that later read where a fast-failing stale-resume
+    /// child's own retry could ALREADY have bumped the epoch again,
+    /// making `send_message` capture the RETRY's epoch instead of this
+    /// original attempt's — silently defeating the epoch check entirely
+    /// (the later comparison would then always "match" the retry's own
+    /// epoch, letting `send_message` duplicate the message on the
+    /// retry's process). Returning it directly here closes that gap by
+    /// construction: there is no intervening read to race.
+    fn spawn_process(&self, config: PersistentSpawnConfig, resume_retry_payload: Option<String>) -> Result<u64, String> {
         // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows
         let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
 
@@ -997,13 +1022,14 @@ impl PersistentSubprocessController {
         // can differ from what's actually held in `inner.session_id` once
         // an earlier call has already hydrated it) so `poison_resume`'s
         // later confirmation check is unambiguous.
-        {
+        let my_epoch = {
             let mut inner = self.inner.lock().unwrap();
             inner.spawn_epoch += 1;
             if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
                 inner.pending_resume_retry = Some((sid, config.clone(), retry_json));
             }
-        }
+            inner.spawn_epoch
+        };
 
         let pid = child.id().unwrap_or(0);
 
@@ -1548,7 +1574,7 @@ impl PersistentSubprocessController {
             }
         });
 
-        Ok(())
+        Ok(my_epoch)
     }
 
     pub fn stop_process(&self, force: bool) -> Result<(), String> {

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -889,7 +889,35 @@ impl PersistentSubprocessController {
         // silently drops the message for good. Mirrors
         // `retry_after_resume_failure`'s own explicit clear for the exact
         // same reason.
-        self.inner.lock().unwrap().session_id = None;
+        //
+        // Poisons (rather than just clears) whatever sid was held —
+        // reagentx P1 on PR #2360 (sixth review pass, round 12): this
+        // fallback is reached with NO guarantee that `poison_resume` has
+        // actually run for the doomed process's sid — the exit-handler's
+        // own bounded wait (500ms) for that process's stderr-reader task
+        // can time out and abort it before it ever calls `poison_resume`
+        // (this drain-triggered path, unlike `retry_after_resume_failure`,
+        // does not require `confirmed_stale_resume_retry` to have been
+        // set, so it can fire even when that promotion never happened). In
+        // that case the SAME process's stdout-reader task — which has NO
+        // bound or abort mechanism at all — could still be concurrently
+        // racing to echo-capture that exact sid via
+        // `try_capture_session_id`, re-setting `inner.session_id` right
+        // after a plain clear and before `spawn_process`'s own `--resume`
+        // read, moments later. `poison_resume` additionally sets
+        // `resume_poisoned`, which `try_capture_session_id` checks and
+        // refuses regardless of ordering — closing that gap even when the
+        // stderr reader never got to poison it itself. Safe to call
+        // unconditionally: by the time this fallback runs, the exit
+        // handler has already unconditionally cleared
+        // `pending_resume_retry`, so `poison_resume`'s own retry-promotion
+        // side effect is always a no-op here.
+        {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(old_sid) = inner.session_id.clone() {
+                inner.poison_resume(&old_sid);
+            }
+        }
         let retry_config = config.clone();
         let spawn_result = self.spawn_process(config, None);
         match &spawn_result {
@@ -2599,6 +2627,46 @@ mod send_input_tests {
             None,
             "must clear inner.session_id directly, not rely on config.session_id alone"
         );
+    }
+
+    /// reagentx P1 on PR #2360 (sixth review pass, round 12): this
+    /// fallback is reached with no guarantee `poison_resume` has already
+    /// run for the doomed process's sid (its stderr-reader task could
+    /// have been aborted past its 500ms bound before ever calling it).
+    /// The doomed process's stdout-reader task has no such bound, so it
+    /// could still be concurrently racing to echo-capture that exact sid
+    /// — a plain clear alone leaves nothing to refuse it. Confirms this
+    /// fallback additionally poisons whatever sid it held, so a later
+    /// capture attempt for that exact sid is refused regardless of
+    /// ordering.
+    #[test]
+    fn respawn_once_for_leftover_queue_poisons_whatever_sid_it_held() {
+        let c = controller();
+        c.inner.lock().unwrap().session_id = Some("dead-sid".to_string());
+
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        c.respawn_once_for_leftover_queue(config);
+
+        {
+            let mut inner = c.inner.lock().unwrap();
+            assert_eq!(
+                inner.resume_poisoned.as_deref(),
+                Some("dead-sid"),
+                "must poison the sid it held, not just clear it, so a still-racing \
+                 stdout-reader capture attempt for that exact sid is refused"
+            );
+            let captured = inner.try_capture_session_id("dead-sid");
+            assert!(!captured, "a later capture attempt for the poisoned sid must be refused");
+        }
     }
 
     /// codex P1/P2 on PR #2360 (second review pass): the process-waiter

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -136,19 +136,35 @@ struct PersistentInner {
     /// generated UUID) will never equal this one, so a stale poison value
     /// is permanently inert rather than something that needs clearing.
     resume_poisoned: Option<String>,
-    /// Set right after a FRESH spawn that attempted `--resume <sid>` —
-    /// captures the exact spawn config + already-formatted stdin line for
-    /// the message that triggered it. If the CLI then reports that exact
-    /// sid unreachable ("No conversation found"), the process-waiter task
-    /// moves this into a transparent retry (fresh process, no `--resume`,
-    /// same message redelivered) instead of losing the message and
-    /// surfacing a generic error — see `retry_after_resume_failure`.
-    /// Cleared by `try_capture_session_id` on ANY successful capture
-    /// (resume succeeded, or the CLI fell through to a fresh conversation
-    /// on its own) since a retry is then no longer needed; also cleared on
-    /// kill so a reused controller instance never retries a message from a
-    /// prior, unrelated lifetime.
-    pending_resume_retry: Option<(PersistentSpawnConfig, String)>,
+    /// TENTATIVE: set synchronously inside `spawn_process`, before any
+    /// background task exists, right after a FRESH spawn attaches
+    /// `--resume <sid>` — captures the exact spawn config + already-
+    /// formatted stdin line for the message that triggered it. This alone
+    /// does NOT mean a retry will happen: it only means "IF the CLI goes on
+    /// to confirm this exact sid unreachable, here is what to retry."
+    /// `poison_resume` is what promotes this to `confirmed_stale_resume_retry`
+    /// (the only thing the process-waiter task actually acts on) — see its
+    /// doc comment for why the two are kept separate. Cleared by
+    /// `try_capture_session_id` on ANY successful capture (resume
+    /// succeeded, or the CLI fell through to a fresh conversation on its
+    /// own) since neither a retry nor a later confirmation is possible
+    /// anymore; also cleared on kill and on a normal exit so a reused
+    /// controller instance never carries a tentative retry into an
+    /// unrelated later lifetime.
+    pending_resume_retry: Option<(String, PersistentSpawnConfig, String)>,
+    /// CONFIRMED: only `poison_resume` ever sets this, and only when the
+    /// sid it just confirmed unreachable is the exact one
+    /// `pending_resume_retry` was captured for. This is the ONLY field the
+    /// process-waiter task checks before retrying — reagentx P1 on PR
+    /// #2360: checking `pending_resume_retry` directly (as an earlier cut
+    /// of this fix did) would retry on ANY exit before the first session id
+    /// is captured, including an auth failure, network blip, or rate limit
+    /// that has nothing to do with a stale `--resume` — silently discarding
+    /// the user's existing conversation and the specific error they should
+    /// have seen instead of the confirmed case this mechanism exists for.
+    /// Cleared on kill and on a normal exit for the same
+    /// reused-instance reason as `pending_resume_retry`.
+    confirmed_stale_resume_retry: Option<(String, PersistentSpawnConfig, String)>,
     current_pid: Option<u32>,
     /// Channel to send messages to the stdin writer task.
     stdin_tx: Option<mpsc::Sender<String>>,
@@ -173,6 +189,19 @@ impl PersistentInner {
         if self.session_id.as_deref() == Some(bad_sid) {
             self.session_id = None;
         }
+        // Promote the tentative retry to CONFIRMED only if it was captured
+        // for this EXACT sid — see `confirmed_stale_resume_retry`'s doc
+        // comment. Compared against the ACTUAL sid the spawn attempted
+        // (stored alongside the payload in `spawn_process`), not
+        // `config.session_id` — those can differ once hydration has
+        // already happened on an earlier call. A tentative retry captured
+        // for a DIFFERENT (later, still in-flight) spawn attempt is left
+        // untouched.
+        if let Some((ref attempted_sid, _, _)) = self.pending_resume_retry {
+            if attempted_sid == bad_sid {
+                self.confirmed_stale_resume_retry = self.pending_resume_retry.take();
+            }
+        }
     }
 
     /// Attempts to adopt `sid` as the live session id. Returns `false`
@@ -190,10 +219,11 @@ impl PersistentInner {
         self.session_id = Some(sid.to_string());
         // Any successful capture — a resumed conversation confirming the
         // sid it was given, or a fresh conversation the CLI started on its
-        // own — proves this spawn is genuinely progressing. The retry
-        // safety net (`pending_resume_retry`) only exists for a spawn that
-        // never gets this far, so it's no longer needed.
+        // own — proves this spawn is genuinely progressing. Neither the
+        // tentative nor the (mutually-exclusive-in-practice, but cleared
+        // defensively) confirmed retry is needed anymore.
         self.pending_resume_retry = None;
+        self.confirmed_stale_resume_retry = None;
         true
     }
 }
@@ -290,6 +320,7 @@ impl PersistentSubprocessController {
                 session_id: None,
                 resume_poisoned: None,
                 pending_resume_retry: None,
+                confirmed_stale_resume_retry: None,
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
@@ -455,10 +486,29 @@ impl PersistentSubprocessController {
     }
 
     pub fn send_message(&self, message: String, config: PersistentSpawnConfig) -> Result<(), String> {
+        // Format as stream-json user message. Computed BEFORE spawning so a
+        // fresh spawn can hand it straight to spawn_process, which stashes
+        // it as the resume-retry payload SYNCHRONOUSLY — before any
+        // background task (including the process-waiter that later reads
+        // it back) even exists. reagentx P1 on PR #2360: stashing it here
+        // instead, after spawn_process returned, left a window where a
+        // process that dies fast enough (the exact case this exists to
+        // catch) lets the already-scheduled, concurrently-running waiter
+        // task observe the exit and take() this payload as still `None`,
+        // silently losing the retry for the very case it's meant to catch.
+        let json_msg = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": message
+            }
+        });
+        let json_str = json_msg.to_string();
+
         // Spawn process if not running
         let is_fresh_spawn = !self.is_running();
         if is_fresh_spawn {
-            self.spawn_process(config.clone())?;
+            self.spawn_process(config.clone(), Some(json_str.clone()))?;
         }
         // spawn_process already marks a fresh process's first turn active
         // (and starts its watchdog); for an already-running process (the
@@ -486,29 +536,6 @@ impl PersistentSubprocessController {
         // ControllerStatus subscription picks it up immediately instead of
         // waiting for the next unrelated status change (or process exit).
         self.publish_status();
-
-        // Format as stream-json user message
-        let json_msg = serde_json::json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": message
-            }
-        });
-        let json_str = json_msg.to_string();
-
-        // A resume attempt was just made on this exact spawn — stash the
-        // config + already-formatted line so a stale-`--resume` failure
-        // (detected asynchronously by the stderr reader; see
-        // `retry_after_resume_failure`) can transparently retry this exact
-        // message once, fresh, instead of losing it. Scoped tightly to
-        // "resume was actually attempted" — a message on an
-        // already-running process, or a fresh spawn with no prior session
-        // to resume, has nothing a stale-resume failure could apply to.
-        if is_fresh_spawn && !config.session_id.is_empty() && !config.resume_flag.is_empty() {
-            let mut inner = self.inner.lock().unwrap();
-            inner.pending_resume_retry = Some((config.clone(), json_str.clone()));
-        }
 
         // Silently persist the user message to the blockfile + global zone so
         // `parseHistoryLines` can reconstruct `user_message` nodes on the next
@@ -539,20 +566,26 @@ impl PersistentSubprocessController {
     /// conversation found with session ID" — see `poison_resume`). Called
     /// from the process-waiter task once the doomed process has actually
     /// exited, via the weak self-reference (mirrors `SubprocessController`'s
-    /// queued-message drain — see `set_self_ref`).
+    /// queued-message drain — see `set_self_ref`), and ONLY when
+    /// `confirmed_stale_resume_retry` was actually set — never for an
+    /// unrelated exit.
     ///
     /// Spawns fresh with `session_id` cleared, so no `--resume` is attempted
-    /// again (`inner.session_id` is already `None` from `poison_resume`;
-    /// clearing it here too keeps `spawn_process`'s own hydrate-from-config
-    /// step, which doesn't know about `resume_poisoned`, from re-adopting
-    /// the same dead id). Redelivers the EXACT already-formatted stdin line
-    /// directly on the new process — does NOT re-persist to the blockfile or
-    /// re-emit `agent-message-accepted`, since both already happened
-    /// correctly on the original (failed) attempt; only the underlying CLI
-    /// process needed a fresh, resume-less start.
+    /// again. Explicitly clears `inner.session_id` itself rather than
+    /// relying on `poison_resume` having already done so — reagentx P0 on PR
+    /// #2360: `poison_resume` runs on the stderr-reader task, this runs on
+    /// the process-waiter task; the two are independently scheduled with no
+    /// ordering guarantee, so this function cannot assume the former has
+    /// already completed by the time it runs. Redelivers the EXACT
+    /// already-formatted stdin line directly on the new process — does NOT
+    /// re-persist to the blockfile or re-emit `agent-message-accepted`,
+    /// since both already happened correctly on the original (failed)
+    /// attempt; only the underlying CLI process needed a fresh, resume-less
+    /// start.
     fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_str: String) {
         config.session_id = String::new();
-        if let Err(e) = self.spawn_process(config) {
+        self.inner.lock().unwrap().session_id = None;
+        if let Err(e) = self.spawn_process(config, None) {
             tracing::error!(
                 block_id = %self.block_id,
                 error = %e,
@@ -834,7 +867,7 @@ impl PersistentSubprocessController {
     }
 
     /// Spawn the persistent CLI process.
-    fn spawn_process(&self, config: PersistentSpawnConfig) -> Result<(), String> {
+    fn spawn_process(&self, config: PersistentSpawnConfig, resume_retry_payload: Option<String>) -> Result<(), String> {
         // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows
         let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
 
@@ -899,6 +932,25 @@ impl PersistentSubprocessController {
             tracing::error!(block_id = %self.block_id, error = %e, "persistent process spawn failed");
             format!("failed to spawn persistent process: {e}")
         })?;
+
+        // Stash the TENTATIVE resume-retry payload synchronously, right
+        // here — before any background task (stdin writer, stdout/stderr
+        // readers, process-waiter) is created below. reagentx P1 on PR
+        // #2360: stashing this later, back in send_message after this
+        // function returned, left a window where a process that dies fast
+        // enough (the exact case this exists to catch) lets the
+        // process-waiter task — already racing on another thread once it's
+        // spawned — observe the exit and take() this payload while it's
+        // still `None`, silently losing the retry for the very case it's
+        // meant to catch. Keyed on the EXACT sid this spawn attempted (not
+        // `config.session_id`, which can differ from what's actually held
+        // in `inner.session_id` once an earlier call has already
+        // hydrated it) so `poison_resume`'s later confirmation check is
+        // unambiguous.
+        if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.pending_resume_retry = Some((sid, config.clone(), retry_json));
+        }
 
         let pid = child.id().unwrap_or(0);
 
@@ -1270,10 +1322,18 @@ impl PersistentSubprocessController {
                     inner.current_pid = None;
                     inner.stdin_tx = None;
                     inner.kill_tx = None;
-                    // Taken (not just read) so a stale-resume retry can only
-                    // ever fire once per triggering spawn — see
-                    // `retry_after_resume_failure`'s doc comment.
-                    let retry_after_resume = inner.pending_resume_retry.take();
+                    // Only `confirmed_stale_resume_retry` (never
+                    // `pending_resume_retry`, which is merely "a resume was
+                    // attempted, not-yet-known outcome") triggers a retry —
+                    // see its doc comment and reagentx P1 on PR #2360. Taken
+                    // (not just read) so it can only ever fire once. Any
+                    // still-tentative `pending_resume_retry` is also
+                    // dropped here — this process (successful or not) is
+                    // done, so it can never be confirmed either way, and a
+                    // reused controller instance must not carry it into an
+                    // unrelated later lifetime.
+                    let retry_after_resume = inner.confirmed_stale_resume_retry.take();
+                    inner.pending_resume_retry = None;
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
 
@@ -1319,7 +1379,7 @@ impl PersistentSubprocessController {
                     // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md) —
                     // it's a different controller type than PR #2338's own
                     // ACP-controller review surface.
-                    if let Some((retry_config, retry_json)) = retry_after_resume {
+                    if let Some((_attempted_sid, retry_config, retry_json)) = retry_after_resume {
                         if let Some(ctrl) = self_ref_wait.upgrade() {
                             tracing::warn!(
                                 block_id = %block_id_wait,
@@ -1359,11 +1419,13 @@ impl PersistentSubprocessController {
                     inner.stdin_tx = None;
                     inner.kill_tx = None;
                     // A user-initiated kill is unrelated to any stale-resume
-                    // failure in flight; drop it so a future, unrelated exit
-                    // on a REUSED controller instance (resync_controller can
-                    // reuse the same instance across a kill+restart cycle)
-                    // never retries a message from this now-dead lifetime.
+                    // failure in flight; drop both so a future, unrelated
+                    // exit on a REUSED controller instance (resync_controller
+                    // can reuse the same instance across a kill+restart
+                    // cycle) never retries a message from this now-dead
+                    // lifetime.
                     inner.pending_resume_retry = None;
+                    inner.confirmed_stale_resume_retry = None;
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
 
@@ -1680,6 +1742,40 @@ mod send_input_tests {
              not silently disappear leaving the client on a stale turn_active: true"
         );
     }
+
+    /// reagentx P0 on PR #2360: `poison_resume` (the stderr-reader task) and
+    /// `retry_after_resume_failure` (called from the process-waiter task)
+    /// are two independently-scheduled tasks with no ordering guarantee —
+    /// this must clear `inner.session_id` itself rather than assuming
+    /// `poison_resume` already ran first. Uses a nonexistent binary so the
+    /// respawn attempt inside this function fails fast (no real process
+    /// needed) — the assertion only cares that `inner.session_id` was
+    /// cleared BEFORE that attempt, which is what stops a later, genuinely
+    /// successful respawn from ever re-attaching `--resume` to the same
+    /// dead id.
+    #[test]
+    fn retry_after_resume_failure_clears_inner_session_id_even_when_poison_resume_has_not_run_yet() {
+        let c = controller();
+        c.inner.lock().unwrap().session_id = Some("dead-sid".to_string());
+
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(config, "{}".to_string());
+
+        assert_eq!(
+            c.inner.lock().unwrap().session_id,
+            None,
+            "must clear inner.session_id directly, not rely on poison_resume having already done so"
+        );
+    }
 }
 
 /// Covers the stderr-poison / stdout-capture race directly against
@@ -1697,6 +1793,7 @@ mod resume_poison_tests {
             session_id: session_id.map(str::to_string),
             resume_poisoned: None,
             pending_resume_retry: None,
+            confirmed_stale_resume_retry: None,
             current_pid: None,
             stdin_tx: None,
             kill_tx: None,
@@ -1771,13 +1868,15 @@ mod resume_poison_tests {
     // `--resume <sid>` (first-ever use of a globally-known agent's session
     // under a brand-new build/channel's own CLI install) used to lose the
     // triggering message and surface a generic "Agent encountered an error"
-    // — the safety net is `pending_resume_retry`, and its correctness hinges
-    // entirely on being cleared if and only if the spawn it was captured for
-    // actually made real progress.
+    // — the safety net is `pending_resume_retry`/`confirmed_stale_resume_retry`,
+    // and its correctness hinges entirely on promoting/clearing them if and
+    // only if the spawn they were captured for actually confirmed dead or
+    // made real progress.
     #[test]
     fn pending_resume_retry_is_cleared_once_the_resume_actually_succeeds() {
         let mut inner = inner_with_session_id(None);
-        inner.pending_resume_retry = Some((dummy_spawn_config(), "{}".to_string()));
+        inner.pending_resume_retry =
+            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
 
         // The CLI echoes back the SAME sid it was given, confirming --resume
         // actually worked — this is genuine progress, so the retry safety
@@ -1788,12 +1887,14 @@ mod resume_poison_tests {
             inner.pending_resume_retry.is_none(),
             "a successful resume must stand down the retry safety net"
         );
+        assert!(inner.confirmed_stale_resume_retry.is_none());
     }
 
     #[test]
     fn pending_resume_retry_is_cleared_when_the_cli_starts_a_fresh_conversation_on_its_own() {
         let mut inner = inner_with_session_id(None);
-        inner.pending_resume_retry = Some((dummy_spawn_config(), "{}".to_string()));
+        inner.pending_resume_retry =
+            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
 
         // A DIFFERENT (fresh) sid — the CLI gave up on --resume internally
         // and started its own new conversation without ever hitting the
@@ -1801,30 +1902,72 @@ mod resume_poison_tests {
         let captured = inner.try_capture_session_id("brand-new-sid");
         assert!(captured);
         assert!(inner.pending_resume_retry.is_none());
+        assert!(inner.confirmed_stale_resume_retry.is_none());
     }
 
+    // reagentx P1 on PR #2360: poison_resume must promote a MATCHING
+    // tentative retry to confirmed — this is the ONLY path the
+    // process-waiter task ever acts on. An earlier cut of this fix checked
+    // `pending_resume_retry` directly, which retried on ANY exit before the
+    // first session id capture — including an unrelated auth failure,
+    // network blip, or rate limit — silently discarding the user's existing
+    // conversation with no disclosure.
     #[test]
-    fn pending_resume_retry_survives_a_refused_capture() {
-        // The exact race this whole mechanism exists for: stderr's
-        // poison_resume fires (confirming this spawn's resume attempt is
-        // dead) BEFORE the stdout reader's own echo of that same dead id
-        // loses the race and gets refused. The refused capture must NOT
-        // clear pending_resume_retry — no progress was made, so the retry
-        // this exact scenario needs must still fire once the process exits.
+    fn poison_resume_promotes_a_matching_pending_retry_to_confirmed() {
         let mut inner = inner_with_session_id(Some("dead-sid"));
-        inner.pending_resume_retry = Some((dummy_spawn_config(), "{}".to_string()));
+        inner.pending_resume_retry =
+            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
 
         inner.poison_resume("dead-sid");
+
         assert!(
-            inner.pending_resume_retry.is_some(),
-            "poison_resume alone must not clear the retry — the process hasn't exited yet"
+            inner.pending_resume_retry.is_none(),
+            "a promoted retry is taken out of the tentative slot"
         );
+        assert!(
+            inner.confirmed_stale_resume_retry.is_some(),
+            "poisoning the EXACT sid this retry was captured for must confirm it"
+        );
+    }
+
+    // The stdout reader's later echo of the same dead id (losing the race)
+    // must still be refused, and must NOT clear the now-confirmed retry —
+    // a refused (no-op) capture represents no progress at all.
+    #[test]
+    fn confirmed_retry_survives_a_subsequent_refused_capture() {
+        let mut inner = inner_with_session_id(Some("dead-sid"));
+        inner.pending_resume_retry =
+            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+        inner.poison_resume("dead-sid");
+        assert!(inner.confirmed_stale_resume_retry.is_some());
 
         let captured = inner.try_capture_session_id("dead-sid");
         assert!(!captured, "the poisoned id must still be refused");
         assert!(
+            inner.confirmed_stale_resume_retry.is_some(),
+            "a refused (no-op) capture must not clear the confirmed retry"
+        );
+    }
+
+    // A tentative retry captured for a DIFFERENT (still in-flight, unrelated)
+    // spawn attempt must NOT be promoted by a poison for some OTHER sid —
+    // the matching is keyed on the exact attempted sid, not "any pending
+    // retry, whatever it's for."
+    #[test]
+    fn poison_resume_does_not_promote_a_retry_captured_for_a_different_sid() {
+        let mut inner = inner_with_session_id(None);
+        inner.pending_resume_retry =
+            Some(("other-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+
+        inner.poison_resume("dead-sid");
+
+        assert!(
             inner.pending_resume_retry.is_some(),
-            "a refused (no-op) capture must not clear the retry safety net"
+            "an unrelated tentative retry must survive a poison for a different sid"
+        );
+        assert!(
+            inner.confirmed_stale_resume_retry.is_none(),
+            "must not confirm a retry that wasn't captured for the poisoned sid"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -773,15 +773,33 @@ impl PersistentSubprocessController {
         let block_id = self.block_id.clone();
         let self_ref = self.self_ref.lock().unwrap().clone().unwrap_or_default();
         tokio::spawn(async move {
-            // The very FIRST message this drain delivers is always the
-            // one that triggered the spawn — `spawn_process` already
-            // stashed it into `pending_resume_retry` synchronously,
-            // before this task even existed (necessary so a process that
-            // dies before this task's first poll can't lose it — see
-            // `pending_resume_retry`'s own doc comment). Appending it
-            // again below would duplicate that exact entry; only messages
-            // delivered AFTER it are genuinely new to the retry list.
-            let mut is_first_delivery = true;
+            // The message `spawn_process` already stashed synchronously
+            // into `pending_resume_retry` (before this task even existed —
+            // necessary so a process that dies before this task's first
+            // poll can't lose it, see that field's own doc comment) must
+            // be identified by CONTENT, not by "whatever this drain pops
+            // first" — codex P2 on PR #2360 (round 15, commit fdb8db6fd):
+            // a purely positional flag breaks exactly the way
+            // `release_spawn_claim_and_drain_queue`'s front-popping
+            // assumption did (see that function's own fix history): a
+            // prior "second stall" can leave older leftover messages
+            // queued ahead of a later spawner's own triggering message
+            // (`push_back` appends behind them), so the FIRST thing this
+            // drain pops isn't necessarily the seeded one. Treating it as
+            // if it were: (a) skips recording the OLDER leftover into the
+            // retry-batch tracking at all — silently dropping it forever
+            // if this process ALSO later dies from a stale resume, and
+            // (b) records the ACTUAL seeded/triggering message a SECOND
+            // time (once via `spawn_process`'s synchronous seed, once via
+            // this drain's own append) — a confirmed stale-resume retry
+            // would then redeliver that one message TWICE. Matching by
+            // content instead correctly identifies the seeded entry
+            // regardless of where it sits, exactly once (via
+            // `seed_already_matched`, so a later, genuinely-different
+            // delivery that happens to share identical content isn't ALSO
+            // wrongly skipped — same known, accepted content-identity
+            // limits as #2365).
+            let mut seed_already_matched = false;
             let stalled_with_leftovers = loop {
                 let next = {
                     let mut inner = inner_arc.lock().unwrap();
@@ -814,8 +832,18 @@ impl PersistentSubprocessController {
                 };
                 let QueuedMessage { json_str, already_persisted } = queued;
                 let delivered_copy = json_str.clone();
-                let was_first_delivery = is_first_delivery;
-                is_first_delivery = false;
+                let is_the_seed = !seed_already_matched && {
+                    let inner = inner_arc.lock().unwrap();
+                    inner
+                        .pending_resume_retry
+                        .as_ref()
+                        .or(inner.confirmed_stale_resume_retry.as_ref())
+                        .and_then(|(_, _, seeded)| seeded.first())
+                        == Some(&delivered_copy)
+                };
+                if is_the_seed {
+                    seed_already_matched = true;
+                }
                 // reagentx P1 on PR #2360 (sixth review pass, round 9):
                 // mark "in flight" for the ENTIRE send-then-append
                 // sequence below, not just the send — see
@@ -859,7 +887,7 @@ impl PersistentSubprocessController {
                 // and was persisted/removed from the queue without ever
                 // being added to the batch the replacement actually
                 // replays.
-                if !was_first_delivery {
+                if !is_the_seed {
                     let mut inner = inner_arc.lock().unwrap();
                     if let Some((_, _, ref mut delivered)) = inner.pending_resume_retry {
                         delivered.push(delivered_copy.clone());
@@ -1164,7 +1192,21 @@ impl PersistentSubprocessController {
                     let mut inner = self.inner.lock().unwrap();
                     let tx = inner.stdin_tx.clone();
                     for msg in std::iter::once(first).chain(rest) {
-                        let delivered = tx.as_ref().is_some_and(|tx| tx.try_send(msg.clone()).is_ok());
+                        // codex P2 on PR #2360 (round 15, commit
+                        // fdb8db6fd): once ANY earlier message in this
+                        // batch has failed direct delivery, stop
+                        // attempting `try_send` for the rest — the
+                        // bounded stdin channel's receiver runs
+                        // concurrently and can free capacity between
+                        // iterations, letting a LATER message in this same
+                        // batch succeed via `try_send` while an EARLIER
+                        // one sits queued (from the `Full` failure below),
+                        // reordering this batch relative to itself once
+                        // the drain eventually delivers the queued one.
+                        // `!any_failed` short-circuits every remaining
+                        // message straight to the queued branch, in
+                        // order, once the first failure is hit.
+                        let delivered = !any_failed && tx.as_ref().is_some_and(|tx| tx.try_send(msg.clone()).is_ok());
                         if !delivered {
                             any_failed = true;
                             // codex P2 on PR #2360 (sixth review pass,
@@ -3430,6 +3472,49 @@ mod send_input_tests {
         assert_eq!(inner.pending_send_messages[0], "stuck");
     }
 
+    /// codex P2 on PR #2360 (round 15, commit fdb8db6fd): once ANY message
+    /// in a multi-message retry batch fails direct delivery, every
+    /// remaining message must be queued too — not attempted via `try_send`
+    /// — so their relative order can never be disturbed by the bounded
+    /// stdin channel's receiver concurrently freeing capacity between
+    /// iterations (which could otherwise let a later message succeed
+    /// while an earlier, failed one sits queued behind it). Uses a
+    /// permanently-closed receiver so every message in the batch fails
+    /// deterministically; confirms all three end up queued in their
+    /// original order, none skipped, none lost.
+    #[tokio::test]
+    async fn retry_after_resume_failure_queues_the_rest_of_the_batch_in_order_once_one_fails() {
+        let c = controller();
+        let (tx, rx) = mpsc::channel::<String>(1);
+        drop(rx);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+
+        let config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(
+            config,
+            vec!["msg-1".to_string(), "msg-2".to_string(), "msg-3".to_string()],
+        );
+
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            3,
+            "every message in the batch must be queued, none skipped or lost"
+        );
+        assert_eq!(inner.pending_send_messages[0], "msg-1");
+        assert_eq!(inner.pending_send_messages[1], "msg-2");
+        assert_eq!(inner.pending_send_messages[2], "msg-3");
+    }
+
     /// codex P2 on PR #2360 (sixth review pass, round 7): pushing a failed
     /// direct-retry delivery onto the queue alone is not enough —
     /// `DeliverDirect` only fires when `spawning_in_progress` is `false`,
@@ -3524,6 +3609,74 @@ mod send_input_tests {
             delivered,
             &vec!["first".to_string(), "second".to_string()],
             "must contain the ORIGINAL message exactly once plus every later delivery, in order"
+        );
+    }
+
+    /// codex P2 on PR #2360 (round 15, commit fdb8db6fd): the message
+    /// `spawn_process` already stashed into `pending_resume_retry` is not
+    /// always the FIRST thing this drain pops — a prior "second stall" can
+    /// leave an older leftover queued ahead of a later spawner's own
+    /// triggering message (`push_back` appends behind it). A purely
+    /// positional "is this the first delivery" check would treat the
+    /// OLDER LEFTOVER as if it were the seed (dropping it from tracking
+    /// entirely) while recording the ACTUAL trigger message a second time
+    /// (once via the synchronous seed, once via this drain's own append).
+    /// Confirms content-based matching identifies the true seed regardless
+    /// of position: the older leftover is recorded, and the actual trigger
+    /// is not duplicated.
+    #[tokio::test]
+    async fn drain_identifies_the_seed_by_content_even_when_a_leftover_is_delivered_first() {
+        let c = controller();
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let retry_config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.spawning_in_progress = true;
+            // Simulates a "second stall" leaving an older leftover queued
+            // ahead of this spawn's own triggering message.
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("older-leftover".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("new-trigger".to_string()));
+            // spawn_process's own synchronous stash — seeded with the
+            // ACTUAL trigger message, not whatever happens to sit at the
+            // front of the queue.
+            inner.pending_resume_retry =
+                Some(("sid".to_string(), retry_config.clone(), vec!["new-trigger".to_string()]));
+        }
+
+        c.drain_queue_after_successful_spawn(retry_config, true);
+
+        assert_eq!(rx.recv().await.unwrap(), "older-leftover");
+        assert_eq!(rx.recv().await.unwrap(), "new-trigger");
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+
+        let inner = c.inner.lock().unwrap();
+        let (_, _, delivered) = inner
+            .pending_resume_retry
+            .as_ref()
+            .expect("must still be tracking this spawn's delivered messages");
+        assert_eq!(
+            delivered.len(),
+            2,
+            "must contain exactly the older leftover plus the trigger, no omission, no duplication: {delivered:?}"
+        );
+        assert!(
+            delivered.contains(&"older-leftover".to_string()),
+            "the older leftover must not be silently dropped from the retry batch"
+        );
+        assert_eq!(
+            delivered.iter().filter(|m| *m == "new-trigger").count(),
+            1,
+            "the actual trigger message must not be recorded twice"
         );
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -1059,26 +1059,45 @@ impl PersistentSubprocessController {
                             inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg));
                         }
                     }
+                    if any_failed {
+                        // codex P2 on PR #2360 (sixth review pass, round
+                        // 7): pushing onto the queue alone is not enough —
+                        // `DeliverDirect` only fires when
+                        // `spawning_in_progress` is `false`, so nothing
+                        // would EVER drain this entry: future callers ALSO
+                        // take `DeliverDirect` (bypassing the queue
+                        // entirely) for as long as this same process stays
+                        // alive, which could be indefinite, silently
+                        // reordering it behind much later input.
+                        //
+                        // Claimed in this SAME lock acquisition as the
+                        // push above — reagentx P1 on PR #2360 (sixth
+                        // review pass, round 8): an earlier cut of this
+                        // fix claimed it in a SEPARATE, later lock
+                        // acquisition, leaving a window where a
+                        // concurrent `send_message` could observe
+                        // `stdin_tx.is_some() && !spawning_in_progress`
+                        // and take `DeliverDirect` itself — jumping ahead
+                        // of the just-queued retry messages — or, if the
+                        // process also died in that same window, take
+                        // `BecomeSpawner` and spawn a second, independent
+                        // child process for the same block, reintroducing
+                        // the exact concurrent-spawn TOCTOU
+                        // `spawning_in_progress` exists to prevent.
+                        inner.spawning_in_progress = true;
+                    }
                 }
                 if any_failed {
                     tracing::warn!(
                         block_id = %self.block_id,
                         "failed to redeliver one or more messages after stale-resume retry (already-running path) — draining via the queue instead"
                     );
-                    // codex P2 on PR #2360 (sixth review pass, round 7):
-                    // pushing onto the queue alone is not enough —
-                    // `DeliverDirect` only fires when `spawning_in_progress`
-                    // is `false`, so nothing would EVER drain this entry:
-                    // future callers ALSO take `DeliverDirect` (bypassing
-                    // the queue entirely) for as long as this same process
-                    // stays alive, which could be indefinite, silently
-                    // reordering it behind much later input. Claim the
-                    // spawn flag and hand off to the SAME drain used after
-                    // a fresh spawn (with backpressure via `Sender::send`,
-                    // not `try_send`) instead of leaving it orphaned.
+                    // Claim the spawn flag (above) and hand off to the
+                    // SAME drain used after a fresh spawn (with
+                    // backpressure via `Sender::send`, not `try_send`)
+                    // instead of leaving it orphaned.
                     // `allow_fallback_respawn: false` — the process is
                     // still alive, there's nothing to fall back to spawn.
-                    self.inner.lock().unwrap().spawning_in_progress = true;
                     self.drain_queue_after_successful_spawn(config.clone(), false);
                 }
             }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -2114,6 +2114,28 @@ impl PersistentSubprocessController {
                         {
                             let mut inner = inner_wait.lock().unwrap();
                             inner.stdin_tx = None; // drops the sender → stdin writer exits → stdin closes
+                            // reagentx P0 on PR #2360 (sixth review pass,
+                            // round 10): must clear pending_send_messages/
+                            // spawning_in_progress in this SAME lock
+                            // acquisition as stdin_tx, not only later
+                            // (after child.wait()/the 5s timeout below).
+                            // During that window,
+                            // drain_queue_after_successful_spawn's
+                            // independently-scheduled background task
+                            // could observe stdin_tx.is_none() with
+                            // messages still queued, classify it as a
+                            // stall, and call
+                            // respawn_once_for_leftover_queue — spawning a
+                            // brand-new CLI process while the user's
+                            // graceful stop is still in progress. The
+                            // force-kill path doesn't have this gap (it
+                            // never clears stdin_tx early — all three
+                            // clear together below, after child.kill()
+                            // resolves), only this graceful one, since it
+                            // specifically needs stdin_tx gone early to
+                            // trigger EOF.
+                            inner.pending_send_messages.clear();
+                            inner.spawning_in_progress = false;
                         }
                         tokio::select! {
                             _ = child.wait() => {}

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -20,7 +20,7 @@
 //! 2. stdout_reader: process stdout → .jsonl persistence + WPS blockfile events
 //! 3. process_waiter: wait for exit, update status
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -165,19 +165,37 @@ struct PersistentInner {
     /// Cleared on kill and on a normal exit for the same
     /// reused-instance reason as `pending_resume_retry`.
     confirmed_stale_resume_retry: Option<(String, PersistentSpawnConfig, String)>,
-    /// Bumped by `spawn_process` every time it successfully spawns a child
-    /// (the original send_message-triggered spawn, or a retry's own
-    /// respawn). `send_message` captures this right after its own spawn
-    /// attempt (if any) and re-checks it just before writing to
-    /// `stdin_tx` — codex P1 on PR #2360 (third review pass): a
-    /// fast-failing stale-resume spawn can let the process-waiter task
-    /// confirm and install a retry's brand-new process (with its own
-    /// fresh `stdin_tx`) BEFORE `send_message`'s own later write runs.
-    /// If the epoch has moved on, that write is skipped — the retry
-    /// already delivers this exact message on the new process, so
-    /// writing here too would duplicate it, and erroring on a
-    /// mid-swap `stdin_tx` would falsely report a failed send.
-    spawn_epoch: u64,
+    /// True from the moment a caller commits to calling `spawn_process`
+    /// (in `send_message` or `retry_after_resume_failure`) until it has
+    /// delivered every message enqueued for that spawn — see
+    /// `pending_send_messages`. Checked and set together with
+    /// `stdin_tx.is_some()` under this same lock, in one acquisition —
+    /// reagentx P1 on PR #2360 (sixth review pass): `send_message`'s
+    /// `is_running()` check and its `spawn_process()` call used to be two
+    /// separate operations; a second concurrent `send_message` call (a
+    /// genuine second RPC, or a muxbus delivery) landing in the gap
+    /// between them could ALSO observe "not running" and independently
+    /// spawn a second child process, orphaning one (leaked, unkillable via
+    /// `stop_process`, unregistered from muxbus). Whichever caller sees
+    /// `stdin_tx.is_none() && !spawning_in_progress` first becomes the
+    /// sole spawner for this round; every other caller queues instead of
+    /// racing its own spawn.
+    ///
+    /// This also fully subsumes the earlier `spawn_epoch`/
+    /// `should_skip_own_delivery` mechanism (rounds 3-5 of this same PR):
+    /// that check existed only to catch a delivery landing in the window
+    /// between a caller's own `spawn_process` returning and its own
+    /// tail-end stdin write — a window that no longer exists, since
+    /// delivery now happens as part of the same atomic spawn-claim, before
+    /// the lock is released (see `release_spawn_claim_and_drain_queue`).
+    spawning_in_progress: bool,
+    /// Messages queued while `spawning_in_progress` was `true` — includes
+    /// the enqueuing caller's own message when it became the spawner (see
+    /// `SendAction::BecomeSpawner`), so the post-spawn drain uses one
+    /// uniform delivery path regardless of whether a message triggered the
+    /// spawn or arrived while someone else's spawn was already in flight.
+    /// Drained by `release_spawn_claim_and_drain_queue`.
+    pending_send_messages: VecDeque<String>,
     current_pid: Option<u32>,
     /// Channel to send messages to the stdin writer task.
     stdin_tx: Option<mpsc::Sender<String>>,
@@ -239,6 +257,21 @@ impl PersistentInner {
         self.confirmed_stale_resume_retry = None;
         true
     }
+}
+
+/// What `decide_send_action` determined a message's fate should be —
+/// see its own doc comment and `PersistentInner::spawning_in_progress`.
+enum SendAction {
+    /// The process is already running — deliver directly, no spawn
+    /// decision involved at all.
+    DeliverDirect,
+    /// Nobody else is currently spawning — this caller claimed the
+    /// exclusive right to do so and its message has already been enqueued
+    /// for the post-spawn drain.
+    BecomeSpawner,
+    /// Another caller is already spawning — this message has been
+    /// enqueued for that caller's own post-spawn drain to deliver.
+    Queued,
 }
 
 /// PersistentSubprocessController keeps a long-running CLI process alive,
@@ -334,7 +367,8 @@ impl PersistentSubprocessController {
                 resume_poisoned: None,
                 pending_resume_retry: None,
                 confirmed_stale_resume_retry: None,
-                spawn_epoch: 0,
+                spawning_in_progress: false,
+                pending_send_messages: VecDeque::new(),
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
@@ -468,36 +502,94 @@ impl PersistentSubprocessController {
         });
     }
 
-    fn is_running(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.stdin_tx.is_some()
+    /// Marks a turn active (re-arming the health watchdog and heartbeat
+    /// only if it was previously idle) and publishes the resulting status
+    /// flip. Shared by `send_message` and `retry_after_resume_failure` —
+    /// both represent "a user message is about to be delivered," just via
+    /// different spawn paths. See `send_message`'s original inline
+    /// comment (now here) for why the watchdog is re-armed conditionally:
+    /// a mid-turn steering send already has one running, so re-spawning on
+    /// every call would leak duplicate watchdog tasks.
+    fn mark_turn_active_and_publish(&self) {
+        let was_active = self.health_monitor.mark_turn_active_returning_was_active();
+        if !was_active {
+            core::spawn_health_watchdog(&self.health_monitor);
+            self.spawn_status_heartbeat();
+        }
+        self.publish_status();
     }
 
-    /// Whether `send_message`'s own stdin write should be skipped in favor
-    /// of a retry that has already taken over delivery for this exact
-    /// attempt — see the call site's own doc comment for the full
-    /// reasoning behind the epoch mechanism itself.
+    /// Atomically decides what to do with `json_str`, given the caller
+    /// wants it delivered to the persistent process — see
+    /// `PersistentInner::spawning_in_progress`'s doc comment for the race
+    /// this closes. All three outcomes are decided under ONE lock
+    /// acquisition so nothing can slip through the gaps between them:
+    /// - the process is already running → `DeliverDirect`, no spawn
+    ///   decision at all.
+    /// - nobody is currently spawning → this caller claims the exclusive
+    ///   right to (`spawning_in_progress = true`), enqueues `json_str`
+    ///   alongside that claim, and returns `BecomeSpawner` — the caller
+    ///   must then call `spawn_process` and, regardless of outcome, call
+    ///   `release_spawn_claim_and_drain_queue`.
+    /// - someone else is already spawning → `json_str` is enqueued for
+    ///   THAT caller's own drain to deliver, and this call returns
+    ///   `Queued` with nothing further to do.
+    fn decide_send_action(&self, json_str: &str) -> SendAction {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.stdin_tx.is_some() {
+            SendAction::DeliverDirect
+        } else if inner.spawning_in_progress {
+            inner.pending_send_messages.push_back(json_str.to_string());
+            SendAction::Queued
+        } else {
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back(json_str.to_string());
+            SendAction::BecomeSpawner
+        }
+    }
+
+    /// Releases the exclusive spawn claim taken by `decide_send_action`
+    /// returning `BecomeSpawner`, delivering everything enqueued while
+    /// this caller was busy spawning (including its own message — see
+    /// `SendAction::BecomeSpawner`'s doc comment). Draining happens under
+    /// the SAME lock used to decide "queue vs. spawn," one message at a
+    /// time, so a message pushed onto the queue by a losing caller can
+    /// never be missed by a drain that already believed the queue was
+    /// empty.
     ///
-    /// Gated on `is_fresh_spawn` — codex P1 on PR #2360 (fifth review
-    /// pass): only a message that triggered ITS OWN fresh spawn ever has
-    /// its payload captured into `pending_resume_retry` (see
-    /// `spawn_process`), so only THAT message can correctly hand off
-    /// delivery to a retry. A DIFFERENT message arriving while that same
-    /// doomed process is still nominally "running" (`is_fresh_spawn ==
-    /// false` for IT) has no such hand-off — its own content was never
-    /// captured anywhere else. If it happened to observe an epoch
-    /// mismatch too (the SAME retry racing ahead of its own tail-end
-    /// check), skipping would silently drop that message entirely while
-    /// `send_message` still reports success and emits
-    /// `agent-message-accepted` — worse than a duplicate, since the
-    /// content vanishes with no signal at all. Such a message must always
-    /// attempt delivery via whatever `stdin_tx` is CURRENT. Pulled out as
-    /// a pure function (an earlier cut of this fix omitted the
-    /// `is_fresh_spawn` guard inline) so the exact condition is directly,
-    /// deterministically testable without needing to reproduce the actual
-    /// multi-threaded race.
-    fn should_skip_own_delivery(is_fresh_spawn: bool, my_spawn_epoch: u64, current_spawn_epoch: u64) -> bool {
-        is_fresh_spawn && current_spawn_epoch != my_spawn_epoch
+    /// Safe to call even when the just-attempted spawn failed:
+    /// `inner.stdin_tx` will be `None` in that case, so this leaves
+    /// whatever is still queued in place (for the next successful spawn to
+    /// pick up) rather than silently discarding it, while still releasing
+    /// `spawning_in_progress` so a future caller isn't blocked forever.
+    fn release_spawn_claim_and_drain_queue(&self) {
+        loop {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.stdin_tx.is_none() {
+                // Nothing to deliver to right now (the spawn attempt
+                // failed, or the process has already exited again) —
+                // release the claim but leave whatever's still queued for
+                // the next successful spawn to pick up, rather than
+                // silently discarding it.
+                inner.spawning_in_progress = false;
+                break;
+            }
+            let Some(json_str) = inner.pending_send_messages.pop_front() else {
+                inner.spawning_in_progress = false;
+                break;
+            };
+            let tx = inner.stdin_tx.clone();
+            drop(inner);
+            if let Some(tx) = tx {
+                if let Err(e) = tx.try_send(json_str) {
+                    tracing::warn!(
+                        block_id = %self.block_id,
+                        error = %e,
+                        "failed to deliver a queued message after a spawn"
+                    );
+                }
+            }
+        }
     }
 
     /// Send a user message to the running CLI process.
@@ -527,16 +619,7 @@ impl PersistentSubprocessController {
     }
 
     pub fn send_message(&self, message: String, config: PersistentSpawnConfig) -> Result<(), String> {
-        // Format as stream-json user message. Computed BEFORE spawning so a
-        // fresh spawn can hand it straight to spawn_process, which stashes
-        // it as the resume-retry payload SYNCHRONOUSLY — before any
-        // background task (including the process-waiter that later reads
-        // it back) even exists. reagentx P1 on PR #2360: stashing it here
-        // instead, after spawn_process returned, left a window where a
-        // process that dies fast enough (the exact case this exists to
-        // catch) lets the already-scheduled, concurrently-running waiter
-        // task observe the exit and take() this payload as still `None`,
-        // silently losing the retry for the very case it's meant to catch.
+        // Format as stream-json user message.
         let json_msg = serde_json::json!({
             "type": "user",
             "message": {
@@ -546,68 +629,13 @@ impl PersistentSubprocessController {
         });
         let json_str = json_msg.to_string();
 
-        // Spawn process if not running. Binds directly to spawn_process's
-        // OWN return value for the epoch, rather than re-reading
-        // `inner.spawn_epoch` in a separate lock acquisition afterward —
-        // codex P1 on PR #2360 (fourth review pass): re-reading left a gap
-        // between spawn_process returning and that later read where a
-        // fast-failing stale-resume child's own retry could ALREADY have
-        // bumped the epoch again, making this capture the RETRY's epoch
-        // instead of THIS attempt's — silently defeating the whole check
-        // (the tail-end comparison would then always "match" the retry's
-        // epoch, letting this function duplicate the message on the
-        // retry's process). See spawn_process's doc comment for the full
-        // reasoning; see the tail-end check below and `spawn_epoch`'s own
-        // doc comment for what this value protects (codex P1, third review
-        // pass): a fast-failing stale-resume spawn's retry can install a
-        // BRAND NEW process — with its own fresh `stdin_tx` — before this
-        // function's own later stdin write below ever runs, which would
-        // otherwise either duplicate the message on the new process or
-        // spuriously report a failed send, even though the retry already
-        // delivers this exact message on its own.
-        //
-        // For an already-running process (no fresh spawn this call), there
-        // is no NEW spawn attempt of this call's own to bind atomically —
-        // reading the live value is correct here because `pending_resume_retry`
-        // is only ever set on a fresh, resume-attempting spawn, so nothing
-        // tied to THIS message's own delivery could race ahead of it.
-        let is_fresh_spawn = !self.is_running();
-        let my_spawn_epoch = if is_fresh_spawn {
-            self.spawn_process(config.clone(), Some(json_str.clone()))?
-        } else {
-            self.inner.lock().unwrap().spawn_epoch
-        };
-        // spawn_process already marks a fresh process's first turn active
-        // (and starts its watchdog); for an already-running process (the
-        // common case — every turn after the first) this is the only place
-        // that re-marks the turn active, since the persistent process never
-        // exits between turns. Without this, `turn_active` would go stale
-        // after turn 1 and never distinguish "generating" from "idle between
-        // turns" again. The watchdog spawned per-turn (`spawn_health_watchdog`
-        // exits as soon as `is_active_turn()` goes false — see
-        // `core::spawn_health_watchdog`'s doc comment) also needs
-        // re-arming here, but only when actually resuming from idle: a
-        // mid-turn steering send (`send_user_message`) already has one
-        // running, so re-spawning on every call would leak duplicate
-        // watchdog tasks. `mark_turn_active_returning_was_active` reads and
-        // flips the flag under one lock — a separate is_active_turn() +
-        // set_active_turn(true) would race a concurrent send_user_message
-        // (muxbus delivery) on the same block, letting both observe `false`
-        // and both spawn a watchdog.
-        let was_active = self.health_monitor.mark_turn_active_returning_was_active();
-        if !was_active {
-            core::spawn_health_watchdog(&self.health_monitor);
-            self.spawn_status_heartbeat();
-        }
-        // Publish the turn_active flip so the Swarm view's live
-        // ControllerStatus subscription picks it up immediately instead of
-        // waiting for the next unrelated status change (or process exit).
-        self.publish_status();
-
         // Silently persist the user message to the blockfile + global zone so
         // `parseHistoryLines` can reconstruct `user_message` nodes on the next
         // open. No WPS event is published here — the live-display is handled by
         // the `agent-message-accepted` path (UUID node), avoiding a duplicate.
+        // Done unconditionally, before deciding delivery below, so a message
+        // that ends up queued (see `decide_send_action`) is still durably
+        // persisted immediately rather than only once eventually delivered.
         let global_zone = super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
         let line_with_newline = format!("{json_str}\n");
         super::shell::persist_to_blockfile_silent(
@@ -618,19 +646,58 @@ impl PersistentSubprocessController {
             global_zone.as_deref(),
         );
 
-        let inner = self.inner.lock().unwrap();
-        if Self::should_skip_own_delivery(is_fresh_spawn, my_spawn_epoch, inner.spawn_epoch) {
-            drop(inner);
-            self.emit_message_accepted(config.message_id.as_deref());
-            return Ok(());
+        match self.decide_send_action(&json_str) {
+            SendAction::Queued => {
+                self.emit_message_accepted(config.message_id.as_deref());
+                Ok(())
+            }
+            SendAction::DeliverDirect => {
+                // spawn_process already marks a fresh process's first turn
+                // active (and starts its watchdog); for an already-running
+                // process (the common case — every turn after the first)
+                // this is the only place that re-marks the turn active,
+                // since the persistent process never exits between turns.
+                // Without this, `turn_active` would go stale after turn 1.
+                self.mark_turn_active_and_publish();
+                let inner = self.inner.lock().unwrap();
+                let tx = inner.stdin_tx.as_ref()
+                    .ok_or("persistent process not running after spawn")?;
+                tx.try_send(json_str)
+                    .map_err(|e| format!("stdin send failed: {e}"))?;
+                drop(inner);
+                self.emit_message_accepted(config.message_id.as_deref());
+                Ok(())
+            }
+            SendAction::BecomeSpawner => {
+                // `resume_retry_payload` is stashed SYNCHRONOUSLY inside
+                // spawn_process, before any background task exists —
+                // reagentx P1 on PR #2360: stashing it after spawn_process
+                // returned left a window where a process that dies fast
+                // enough lets the already-scheduled process-waiter task
+                // observe the exit and take() this payload as still
+                // `None`, silently losing the retry for the exact case it
+                // exists to catch. This is independent of, and still
+                // needed alongside, the spawn-claim/queue mechanism below:
+                // that mechanism only prevents a SECOND process from being
+                // spawned concurrently — it does nothing once THIS
+                // process is running and later dies from a stale
+                // `--resume`, which is what the retry payload is for.
+                let message_id = config.message_id.clone();
+                let spawn_result = self.spawn_process(config, Some(json_str));
+                if spawn_result.is_ok() {
+                    self.mark_turn_active_and_publish();
+                }
+                // Emit "accepted" for this caller's own message regardless
+                // of the spawn outcome — matches this function's prior
+                // behavior of always emitting it once the message was
+                // durably persisted above. `release_spawn_claim_and_drain_queue`
+                // (below) is what actually delivers it (or leaves it
+                // queued for a future spawn, on failure).
+                self.emit_message_accepted(message_id.as_deref());
+                self.release_spawn_claim_and_drain_queue();
+                spawn_result.map(|_| ())
+            }
         }
-        let tx = inner.stdin_tx.as_ref()
-            .ok_or("persistent process not running after spawn")?;
-        tx.try_send(json_str)
-            .map_err(|e| format!("stdin send failed: {e}"))?;
-        drop(inner);
-        self.emit_message_accepted(config.message_id.as_deref());
-        Ok(())
     }
 
     /// Retries the message that triggered a `--resume <sid>` attempt this
@@ -657,52 +724,67 @@ impl PersistentSubprocessController {
     fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_str: String) {
         config.session_id = String::new();
         self.inner.lock().unwrap().session_id = None;
-        if let Err(e) = self.spawn_process(config, None) {
-            tracing::error!(
-                block_id = %self.block_id,
-                error = %e,
-                "failed to respawn after a stale --resume session id"
-            );
-            // Surface this, or the pane hangs forever with NO signal at
-            // all — codex P2 on PR #2360 (fifth review pass): the outer
-            // process-waiter already suppressed its own terminal-status
-            // publish for the ORIGINAL exit specifically because a retry
-            // was in flight, and send_message already returned success
-            // (possibly emitting agent-message-accepted) for the message
-            // this retry was supposed to deliver. If this respawn attempt
-            // ALSO fails, nothing else will ever tell the frontend this
-            // turn is over. `inner.proc_status`/`turn_active` are already
-            // `STATUS_DONE`/`false` (set by the original exit's own
-            // cleanup before this function was ever called) — this just
-            // actually broadcasts that state, which the original exit
-            // deliberately withheld pending this retry's outcome.
-            self.publish_status();
-            return;
-        }
-        // Mirrors send_message's own post-spawn turn-active bookkeeping —
-        // this retry IS the turn's real first (and only user-visible) send,
-        // just deferred past one doomed process.
-        let was_active = self.health_monitor.mark_turn_active_returning_was_active();
-        if !was_active {
-            core::spawn_health_watchdog(&self.health_monitor);
-            self.spawn_status_heartbeat();
-        }
-        self.publish_status();
 
-        let inner = self.inner.lock().unwrap();
-        let Some(tx) = inner.stdin_tx.as_ref() else {
-            tracing::error!(
-                block_id = %self.block_id,
-                "stale-resume retry spawn reported success but stdin_tx is unset"
-            );
-            return;
-        };
-        if let Err(e) = tx.try_send(json_str) {
-            tracing::warn!(
-                block_id = %self.block_id,
-                error = %e,
-                "failed to redeliver message after stale-resume retry spawn"
-            );
+        // This retry is itself a spawn attempt, and must not race a
+        // genuinely concurrent `send_message` call the same way the
+        // ORIGINAL doomed spawn could — see `PersistentInner::
+        // spawning_in_progress`'s doc comment. By the time this runs, the
+        // original `send_message` call that triggered the doomed process
+        // has long since returned (its own spawn-claim-and-deliver
+        // sequence completed synchronously, well before this process even
+        // exited), so this can safely go through the SAME decision
+        // function `send_message` uses.
+        match self.decide_send_action(&json_str) {
+            SendAction::DeliverDirect => {
+                // Another caller's own spawn already installed a running
+                // process by the time this retry got scheduled — no need
+                // for a dedicated respawn; deliver straight to it.
+                self.mark_turn_active_and_publish();
+                let inner = self.inner.lock().unwrap();
+                if let Some(tx) = inner.stdin_tx.as_ref() {
+                    if let Err(e) = tx.try_send(json_str) {
+                        tracing::warn!(
+                            block_id = %self.block_id,
+                            error = %e,
+                            "failed to redeliver message after stale-resume retry (already-running path)"
+                        );
+                    }
+                }
+            }
+            SendAction::Queued => {
+                // Someone else is already spawning — their own
+                // `release_spawn_claim_and_drain_queue` will deliver this.
+            }
+            SendAction::BecomeSpawner => {
+                let spawn_result = self.spawn_process(config, None);
+                match &spawn_result {
+                    Ok(_) => self.mark_turn_active_and_publish(),
+                    Err(e) => tracing::error!(
+                        block_id = %self.block_id,
+                        error = %e,
+                        "failed to respawn after a stale --resume session id"
+                    ),
+                }
+                self.release_spawn_claim_and_drain_queue();
+                if spawn_result.is_err() {
+                    // Surface this, or the pane hangs forever with NO
+                    // signal at all — codex P2 on PR #2360 (fifth review
+                    // pass): the outer process-waiter already suppressed
+                    // its own terminal-status publish for the ORIGINAL
+                    // exit specifically because a retry was in flight, and
+                    // send_message already returned success (possibly
+                    // emitting agent-message-accepted) for the message
+                    // this retry was supposed to deliver. If this respawn
+                    // attempt ALSO fails, nothing else will ever tell the
+                    // frontend this turn is over. `inner.proc_status`/
+                    // `turn_active` are already `STATUS_DONE`/`false` (set
+                    // by the original exit's own cleanup before this
+                    // function was ever called) — this just actually
+                    // broadcasts that state, which the original exit
+                    // deliberately withheld pending this retry's outcome.
+                    self.publish_status();
+                }
+            }
         }
     }
 
@@ -952,22 +1034,10 @@ impl PersistentSubprocessController {
         }
     }
 
-    /// Spawn the persistent CLI process.
-    /// Returns the `spawn_epoch` value THIS spawn assigned (see the field's
-    /// doc comment), captured atomically as part of this same call.
-    /// `send_message` binds to this return value directly for its own
-    /// fresh-spawn case, rather than re-reading `inner.spawn_epoch` in a
-    /// separate lock acquisition afterward — codex P1 on PR #2360 (fourth
-    /// review pass): re-reading left a window between this function
-    /// returning and that later read where a fast-failing stale-resume
-    /// child's own retry could ALREADY have bumped the epoch again,
-    /// making `send_message` capture the RETRY's epoch instead of this
-    /// original attempt's — silently defeating the epoch check entirely
-    /// (the later comparison would then always "match" the retry's own
-    /// epoch, letting `send_message` duplicate the message on the
-    /// retry's process). Returning it directly here closes that gap by
-    /// construction: there is no intervening read to race.
-    fn spawn_process(&self, config: PersistentSpawnConfig, resume_retry_payload: Option<String>) -> Result<u64, String> {
+    /// Spawn the persistent CLI process. Called only while the caller
+    /// holds the exclusive spawn claim (`spawning_in_progress`, see
+    /// `decide_send_action`) — never directly.
+    fn spawn_process(&self, config: PersistentSpawnConfig, resume_retry_payload: Option<String>) -> Result<(), String> {
         // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows
         let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
 
@@ -1033,37 +1103,26 @@ impl PersistentSubprocessController {
             format!("failed to spawn persistent process: {e}")
         })?;
 
-        // Bump spawn_epoch and stash the TENTATIVE resume-retry payload
-        // synchronously, right here — before any background task (stdin
-        // writer, stdout/stderr readers, process-waiter) is created below.
-        //
-        // The epoch bump (see its own doc comment) marks THIS as the
-        // newest spawn attempt for this controller — codex P1 on PR #2360
-        // (third review pass): without it, send_message's own later stdin
-        // write (after this function returns) has no way to notice that a
-        // stale-resume retry already installed a NEWER process (and
-        // `stdin_tx`) in the meantime, and would either duplicate the
-        // message on it or spuriously report a failed send.
-        //
-        // The retry-payload stash (reagentx P1 on PR #2360): doing this
-        // later, back in send_message after this function returned, left a
-        // window where a process that dies fast enough (the exact case
-        // this exists to catch) lets the process-waiter task — already
-        // racing on another thread once it's spawned — observe the exit
-        // and take() this payload while it's still `None`, silently losing
-        // the retry for the very case it's meant to catch. Keyed on the
-        // EXACT sid this spawn attempted (not `config.session_id`, which
-        // can differ from what's actually held in `inner.session_id` once
-        // an earlier call has already hydrated it) so `poison_resume`'s
-        // later confirmation check is unambiguous.
-        let my_epoch = {
+        // Stash the TENTATIVE resume-retry payload synchronously, right
+        // here — before any background task (stdin writer, stdout/stderr
+        // readers, process-waiter) is created below — reagentx P1 on PR
+        // #2360: doing this later, back in send_message after this
+        // function returned, left a window where a process that dies fast
+        // enough (the exact case this exists to catch) lets the
+        // process-waiter task — already racing on another thread once
+        // it's spawned — observe the exit and take() this payload while
+        // it's still `None`, silently losing the retry for the very case
+        // it's meant to catch. Keyed on the EXACT sid this spawn attempted
+        // (not `config.session_id`, which can differ from what's actually
+        // held in `inner.session_id` once an earlier call has already
+        // hydrated it) so `poison_resume`'s later confirmation check is
+        // unambiguous.
+        {
             let mut inner = self.inner.lock().unwrap();
-            inner.spawn_epoch += 1;
             if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
                 inner.pending_resume_retry = Some((sid, config.clone(), retry_json));
             }
-            inner.spawn_epoch
-        };
+        }
 
         let pid = child.id().unwrap_or(0);
 
@@ -1622,7 +1681,7 @@ impl PersistentSubprocessController {
             }
         });
 
-        Ok(my_epoch)
+        Ok(())
     }
 
     pub fn stop_process(&self, force: bool) -> Result<(), String> {
@@ -1984,21 +2043,10 @@ mod send_input_tests {
         );
     }
 
-    /// codex P1 on PR #2360 (third review pass) added a `spawn_epoch` check
-    /// to `send_message`'s own stdin write, to detect a stale-resume retry
-    /// having already installed a newer process in the meantime. This
-    /// confirms that check is a pure no-op in the overwhelmingly common
-    /// case — no concurrent retry raced ahead — so an already-running
-    /// process still receives its message exactly as before. The actual
-    /// race this check exists to close (a genuine multi-threaded
-    /// interleaving between this function's own two lock acquisitions) is
-    /// not practical to inject deterministically without a test-only hook
-    /// in production code; verified via direct code inspection instead —
-    /// the check reads the SAME `inner.spawn_epoch` both times, so any
-    /// intervening bump (which only `spawn_process` performs, and only
-    /// while holding the same lock) is unconditionally visible.
+    /// Baseline: a message sent while the process is already running is
+    /// delivered directly, with no spawn decision involved at all.
     #[tokio::test]
-    async fn send_message_still_delivers_normally_when_the_epoch_has_not_moved() {
+    async fn send_message_delivers_directly_to_an_already_running_process() {
         let c = controller();
         let (tx, mut rx) = mpsc::channel::<String>(4);
         {
@@ -2024,31 +2072,154 @@ mod send_input_tests {
         assert!(received.contains("hello"));
     }
 
-    /// codex P1 on PR #2360 (fifth review pass): an earlier cut of
-    /// `should_skip_own_delivery` (inlined at the call site at the time)
-    /// omitted the `is_fresh_spawn` guard — a SECOND message arriving on
-    /// an already-running process (its own content never captured into
-    /// any retry payload) could observe an UNRELATED epoch bump (from a
-    /// DIFFERENT message's own stale-resume retry) and silently skip its
-    /// own delivery, losing its content entirely while `send_message`
-    /// still reported success. This directly exercises the corrected
-    /// boolean condition with fabricated inputs — deterministic, no need
-    /// to reproduce the actual multi-threaded race.
+    /// reagentx P1 on PR #2360 (sixth review pass): `decide_send_action` is
+    /// the primitive that closes the concurrent-spawn TOCTOU race — these
+    /// three cases cover its full decision space deterministically,
+    /// without needing to reproduce an actual multi-threaded race.
     #[test]
-    fn should_skip_own_delivery_only_when_this_calls_own_fresh_spawn_was_superseded() {
-        assert!(
-            !PersistentSubprocessController::should_skip_own_delivery(false, 1, 2),
-            "an already-running message must always deliver, regardless of an unrelated epoch bump"
+    fn decide_send_action_becomes_spawner_when_nothing_is_in_flight() {
+        let c = controller();
+        let action = c.decide_send_action("msg-a");
+        assert!(matches!(action, SendAction::BecomeSpawner));
+        let inner = c.inner.lock().unwrap();
+        assert!(inner.spawning_in_progress, "must claim the exclusive spawn right");
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            1,
+            "the caller's own message must be enqueued too, for the uniform post-spawn drain"
         );
+    }
+
+    #[test]
+    fn decide_send_action_queues_when_a_spawn_is_already_in_flight() {
+        let c = controller();
+        c.inner.lock().unwrap().spawning_in_progress = true;
+
+        let action = c.decide_send_action("msg-b");
         assert!(
-            PersistentSubprocessController::should_skip_own_delivery(true, 1, 2),
-            "a fresh-spawn message superseded by a newer spawn must skip its own delivery"
+            matches!(action, SendAction::Queued),
+            "a second caller must queue instead of independently deciding to spawn"
         );
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(inner.pending_send_messages.len(), 1);
+        assert_eq!(inner.pending_send_messages[0], "msg-b");
+    }
+
+    #[test]
+    fn decide_send_action_delivers_directly_when_already_running() {
+        let c = controller();
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+
+        let action = c.decide_send_action("msg-c");
+        assert!(matches!(action, SendAction::DeliverDirect));
+        let inner = c.inner.lock().unwrap();
         assert!(
-            !PersistentSubprocessController::should_skip_own_delivery(true, 1, 1),
-            "the common, non-racing case (epoch unchanged) must always deliver"
+            inner.pending_send_messages.is_empty(),
+            "must not queue when delivering directly to an already-running process"
         );
-        assert!(!PersistentSubprocessController::should_skip_own_delivery(false, 1, 1));
+    }
+
+    /// Exercises the actual race with real OS threads, not just sequential
+    /// state assertions — reagentx P1 on PR #2360 (sixth review pass): many
+    /// concurrent callers landing on a controller with no process running
+    /// (the exact shape of a genuine second `send_message` RPC, or a
+    /// muxbus delivery, racing this controller's own stale-resume retry)
+    /// must produce EXACTLY one spawner; everyone else must queue instead
+    /// of each independently deciding to spawn their own child process.
+    #[test]
+    fn decide_send_action_produces_exactly_one_spawner_under_real_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        use std::sync::Arc as StdArc;
+
+        let c = StdArc::new(controller());
+        let spawner_count = StdArc::new(AtomicUsize::new(0));
+        let queued_count = StdArc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..16)
+            .map(|i| {
+                let c = StdArc::clone(&c);
+                let spawner_count = StdArc::clone(&spawner_count);
+                let queued_count = StdArc::clone(&queued_count);
+                std::thread::spawn(move || match c.decide_send_action(&format!("msg-{i}")) {
+                    SendAction::BecomeSpawner => {
+                        spawner_count.fetch_add(1, AtomicOrdering::SeqCst);
+                    }
+                    SendAction::Queued => {
+                        queued_count.fetch_add(1, AtomicOrdering::SeqCst);
+                    }
+                    SendAction::DeliverDirect => panic!("process was never running in this test"),
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            spawner_count.load(AtomicOrdering::SeqCst),
+            1,
+            "exactly one caller must claim the exclusive right to spawn"
+        );
+        assert_eq!(queued_count.load(AtomicOrdering::SeqCst), 15, "everyone else must queue");
+        assert_eq!(
+            c.inner.lock().unwrap().pending_send_messages.len(),
+            16,
+            "every message — the spawner's own plus all queued — must be present, none dropped"
+        );
+    }
+
+    /// The drain must deliver everything queued (including a caller's own
+    /// message, enqueued alongside the claim by `decide_send_action`) in
+    /// order, then release the claim so a future caller can spawn again.
+    #[test]
+    fn release_spawn_claim_and_drain_queue_delivers_everything_and_releases_claim() {
+        let c = controller();
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("first".to_string());
+            inner.pending_send_messages.push_back("second".to_string());
+        }
+
+        c.release_spawn_claim_and_drain_queue();
+
+        assert_eq!(rx.try_recv().unwrap(), "first");
+        assert_eq!(rx.try_recv().unwrap(), "second");
+        assert!(rx.try_recv().is_err(), "no extra deliveries");
+        let inner = c.inner.lock().unwrap();
+        assert!(!inner.spawning_in_progress, "claim must be released once fully drained");
+        assert!(inner.pending_send_messages.is_empty());
+    }
+
+    /// Edge case: if the spawn this drain follows actually failed,
+    /// `stdin_tx` stays `None` — the drain must still release the claim
+    /// (or no future caller could ever spawn again) WITHOUT discarding
+    /// whatever is still queued, so a future successful spawn can deliver
+    /// it instead of the message being silently lost.
+    #[test]
+    fn release_spawn_claim_and_drain_queue_preserves_queue_when_spawn_failed() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("stuck".to_string());
+        }
+
+        c.release_spawn_claim_and_drain_queue();
+
+        let inner = c.inner.lock().unwrap();
+        assert!(
+            !inner.spawning_in_progress,
+            "claim must still be released even when there was nothing to deliver to"
+        );
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            1,
+            "message must be left queued, not silently discarded, when there was no process to deliver to"
+        );
     }
 }
 
@@ -2068,7 +2239,8 @@ mod resume_poison_tests {
             resume_poisoned: None,
             pending_resume_retry: None,
             confirmed_stale_resume_retry: None,
-            spawn_epoch: 0,
+            spawning_in_progress: false,
+            pending_send_messages: VecDeque::new(),
             current_pid: None,
             stdin_tx: None,
             kill_tx: None,

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -573,17 +573,58 @@ impl PersistentSubprocessController {
     ///   the bounded stdin channel was momentarily full — losing input
     ///   despite already having told that caller "accepted". Deferring to
     ///   a task lets delivery simply wait for capacity instead.
-    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool) {
+    ///
+    /// If the background task discovers the process it was meant to drain
+    /// into has ALREADY died (`stdin_tx` gone) with messages still left
+    /// queued, it hands off to `respawn_once_for_leftover_queue` using
+    /// `retry_config` — reagentx/codex P1 on PR #2360 (sixth review pass,
+    /// rounds 3-4): a fast-dying child can let the process-waiter run this
+    /// SAME controller's own `retry_after_resume_failure` (via
+    /// `decide_send_action` returning `Queued`, since this spawn's claim
+    /// hasn't been released yet) BEFORE this caller's own thread even
+    /// reaches this function; that retry's `Queued` branch then does
+    /// nothing further, assuming (wrongly, in this exact race) that this
+    /// drain will deliver it. Without a fallback respawn, NOTHING is ever
+    /// left responsible for the leftover messages or for telling the
+    /// frontend the turn ended — the ORIGINAL exit deliberately suppressed
+    /// its own terminal-status publish expecting the retry to eventually
+    /// publish one.
+    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool, retry_config: PersistentSpawnConfig) {
         if !spawn_succeeded {
-            let mut inner = self.inner.lock().unwrap();
-            inner.pending_send_messages.pop_front();
-            inner.spawning_in_progress = false;
+            // Discard only the front item — the caller's OWN message (see
+            // this function's own doc comment above for why it's
+            // guaranteed to be at the front). If anything else is queued
+            // behind it (from other callers already told "accepted"),
+            // hand off to a bounded fallback respawn rather than
+            // stranding it with nobody responsible for delivering it.
+            let leftovers = {
+                let mut inner = self.inner.lock().unwrap();
+                inner.pending_send_messages.pop_front();
+                !inner.pending_send_messages.is_empty()
+            };
+            if leftovers {
+                self.respawn_once_for_leftover_queue(retry_config);
+            } else {
+                self.inner.lock().unwrap().spawning_in_progress = false;
+            }
             return;
         }
+        self.drain_queue_after_successful_spawn(retry_config, true);
+    }
+
+    /// Drains the queue via a background task after a successful spawn —
+    /// see `release_spawn_claim_and_drain_queue`'s doc comment for the
+    /// `try_send` → `Sender::send` rationale. `allow_fallback_respawn`
+    /// bounds retry depth to exactly one extra hop: `true` from the public
+    /// entry point, `false` when called from `respawn_once_for_leftover_queue`
+    /// itself, so a SECOND stall just publishes a status update instead of
+    /// cascading indefinitely.
+    fn drain_queue_after_successful_spawn(&self, retry_config: PersistentSpawnConfig, allow_fallback_respawn: bool) {
         let inner_arc = Arc::clone(&self.inner);
         let block_id = self.block_id.clone();
+        let self_ref = self.self_ref.lock().unwrap().clone().unwrap_or_default();
         tokio::spawn(async move {
-            loop {
+            let stalled_with_leftovers = loop {
                 let next = {
                     let mut inner = inner_arc.lock().unwrap();
                     match inner.stdin_tx.clone() {
@@ -595,8 +636,10 @@ impl PersistentSubprocessController {
                     // Either the queue is empty, or the process has
                     // already exited again before we got to it — either
                     // way, release the claim so a future caller can spawn.
-                    inner_arc.lock().unwrap().spawning_in_progress = false;
-                    break;
+                    let mut inner = inner_arc.lock().unwrap();
+                    let stalled = inner.stdin_tx.is_none() && !inner.pending_send_messages.is_empty();
+                    inner.spawning_in_progress = false;
+                    break stalled;
                 };
                 if let Err(e) = tx.send(json_str).await {
                     tracing::warn!(
@@ -610,11 +653,54 @@ impl PersistentSubprocessController {
                     // on the same dead sender.
                     let mut inner = inner_arc.lock().unwrap();
                     inner.pending_send_messages.push_front(e.0);
+                    let stalled = !inner.pending_send_messages.is_empty();
                     inner.spawning_in_progress = false;
-                    break;
+                    break stalled;
+                }
+            };
+            if stalled_with_leftovers {
+                if let Some(ctrl) = self_ref.upgrade() {
+                    if allow_fallback_respawn {
+                        ctrl.respawn_once_for_leftover_queue(retry_config);
+                    } else {
+                        ctrl.publish_status();
+                    }
                 }
             }
         });
+    }
+
+    /// Attempts exactly one fallback respawn when either call site above is
+    /// about to release its claim with messages still queued and nobody
+    /// left responsible for delivering them. Forces `session_id` empty so
+    /// this fallback spawn never attempts `--resume` — reusing a
+    /// possibly-still-stale session id here would risk repeating the exact
+    /// failure this whole retry mechanism exists to recover from. If THIS
+    /// spawn also fails, or its own process also dies before its own drain
+    /// completes, gives up and publishes a status update rather than
+    /// cascading indefinitely — the queue itself is never discarded (this
+    /// function never pops anything itself — it isn't tied to a specific
+    /// message the way the original spawn attempt was), so a genuinely
+    /// later, unrelated send will still eventually pick it up.
+    fn respawn_once_for_leftover_queue(&self, mut config: PersistentSpawnConfig) {
+        config.session_id = String::new();
+        let retry_config = config.clone();
+        let spawn_result = self.spawn_process(config, None);
+        match &spawn_result {
+            Ok(_) => {
+                self.mark_turn_active_and_publish();
+                self.drain_queue_after_successful_spawn(retry_config, false);
+            }
+            Err(e) => {
+                tracing::error!(
+                    block_id = %self.block_id,
+                    error = %e,
+                    "fallback respawn for a leftover queue failed"
+                );
+                self.inner.lock().unwrap().spawning_in_progress = false;
+                self.publish_status();
+            }
+        }
     }
 
     /// Send a user message to the running CLI process.
@@ -708,6 +794,7 @@ impl PersistentSubprocessController {
                 // process is running and later dies from a stale
                 // `--resume`, which is what the retry payload is for.
                 let message_id = config.message_id.clone();
+                let retry_config = config.clone();
                 let spawn_result = self.spawn_process(config, Some(json_str));
                 // Only emit "accepted" on success — matches this
                 // function's prior (pre-queue) behavior, which propagated
@@ -720,7 +807,7 @@ impl PersistentSubprocessController {
                     self.mark_turn_active_and_publish();
                     self.emit_message_accepted(message_id.as_deref());
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok());
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
                 spawn_result
             }
         }
@@ -749,7 +836,6 @@ impl PersistentSubprocessController {
     /// start.
     fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_str: String) {
         config.session_id = String::new();
-        self.inner.lock().unwrap().session_id = None;
 
         // This retry is itself a spawn attempt, and must not race a
         // genuinely concurrent `send_message` call the same way the
@@ -779,9 +865,23 @@ impl PersistentSubprocessController {
             }
             SendAction::Queued => {
                 // Someone else is already spawning — their own
-                // `release_spawn_claim_and_drain_queue` will deliver this.
+                // `release_spawn_claim_and_drain_queue` will deliver this
+                // (or, if their process turns out to already be dead, its
+                // own bounded fallback respawn will).
             }
             SendAction::BecomeSpawner => {
+                // Only clear inner.session_id now that THIS retry is
+                // actually about to spawn — codex P2 on PR #2360 (sixth
+                // review pass, round 3): clearing it unconditionally at
+                // the top of this function (the previous cut) could erase
+                // a session id a DIFFERENT, concurrently-installed process
+                // had already legitimately captured, if this retry
+                // instead resolved via `DeliverDirect` or `Queued` above —
+                // breaking in-memory session tracking and turn-end
+                // subagent reconciliation for that process's remaining
+                // lifetime.
+                self.inner.lock().unwrap().session_id = None;
+                let retry_config = config.clone();
                 let spawn_result = self.spawn_process(config, None);
                 match &spawn_result {
                     Ok(_) => self.mark_turn_active_and_publish(),
@@ -791,7 +891,7 @@ impl PersistentSubprocessController {
                         "failed to respawn after a stale --resume session id"
                     ),
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok());
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
                 if spawn_result.is_err() {
                     // Surface this, or the pane hangs forever with NO
                     // signal at all — codex P2 on PR #2360 (fifth review
@@ -2213,7 +2313,9 @@ mod send_input_tests {
             inner.pending_send_messages.push_back("second".to_string());
         }
 
-        c.release_spawn_claim_and_drain_queue(true);
+        // Never used for a fallback spawn in this test — the drain fully
+        // succeeds without ever stalling.
+        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config());
 
         assert_eq!(rx.recv().await.unwrap(), "first");
         assert_eq!(rx.recv().await.unwrap(), "second");
@@ -2226,13 +2328,93 @@ mod send_input_tests {
         assert!(inner.pending_send_messages.is_empty());
     }
 
+    /// A `PersistentSpawnConfig` whose `cli_command` doesn't exist, so any
+    /// `spawn_process` attempt made with it fails fast and deterministically
+    /// (no real process, no hang) — used by tests that need to exercise
+    /// `respawn_once_for_leftover_queue`'s fallback path without spawning a
+    /// real CLI, matching this module's own established precedent (see
+    /// `retry_after_resume_failure_clears_inner_session_id_even_when_poison_resume_has_not_run_yet`).
+    fn unreachable_fallback_config() -> PersistentSpawnConfig {
+        PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: String::new(),
+            session_id: String::new(),
+            message_id: None,
+        }
+    }
+
+    /// reagentx/codex P1 on PR #2360 (sixth review pass, rounds 3-4): if
+    /// the process a successful spawn just established dies before the
+    /// drain even gets to run (found via `stdin_tx` already `None`) with
+    /// messages still queued, nothing else will ever tell the frontend
+    /// the turn ended — the ORIGINAL exit deliberately suppressed its own
+    /// publish expecting a retry to publish one instead, and
+    /// `retry_after_resume_failure`'s own `Queued` branch does nothing
+    /// further (see its own doc comment). Confirms the drain hands off to
+    /// `respawn_once_for_leftover_queue`, which — using a config that
+    /// itself fails fast (no real process needed) — logs the failure and
+    /// publishes a status update instead of leaving the pane hanging with
+    /// no signal at all, while leaving the leftover messages queued
+    /// (this fallback path never pops anything itself — it isn't tied to
+    /// a specific message).
+    #[tokio::test]
+    async fn release_spawn_claim_and_drain_queue_falls_back_and_publishes_status_when_stalled() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let c = Arc::new(PersistentSubprocessController::new(
+            "tab".to_string(),
+            "block-stalled".to_string(),
+            Some(broker.clone()),
+            None,
+            None,
+            None,
+        ));
+        c.set_self_ref();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("stuck-one".to_string());
+            inner.pending_send_messages.push_back("stuck-two".to_string());
+            // stdin_tx stays None — simulates the process this claim was
+            // spawning for having already died before the drain ran.
+        }
+
+        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config());
+        // Let the spawned background task, and the fallback respawn
+        // attempt it triggers, run to completion.
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_CONTROLLER_STATUS,
+            "block:block-stalled",
+            1,
+        );
+        assert_eq!(history.len(), 1, "must publish a status update instead of silently hanging");
+
+        let inner = c.inner.lock().unwrap();
+        assert!(!inner.spawning_in_progress, "claim must still be released");
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            2,
+            "leftover messages must stay queued for whatever spawn comes next \
+             (the fallback attempt itself failed, matching the config used)"
+        );
+    }
+
     /// codex P1 on PR #2360 (sixth review pass): a FAILED spawn must
     /// discard only the front item — the caller's own message, which
     /// `send_message`/`retry_after_resume_failure` already reported as a
     /// failure to their own caller — not leave it queued for an unrelated
     /// later spawn to silently execute. Anything ELSE queued behind it
     /// (from other callers who got `SendAction::Queued` and were already
-    /// told "accepted") must survive, for that next spawn to deliver.
+    /// told "accepted") must survive — handed off to a bounded fallback
+    /// respawn (codex P2, round 4) rather than stranded with nobody
+    /// responsible for it; using a config that itself fails fast here, so
+    /// the leftover message ends up back in the queue rather than
+    /// delivered, but never discarded.
     #[test]
     fn release_spawn_claim_and_drain_queue_discards_only_the_failed_spawners_own_message() {
         let c = controller();
@@ -2243,12 +2425,12 @@ mod send_input_tests {
             inner.pending_send_messages.push_back("queued-by-someone-else".to_string());
         }
 
-        c.release_spawn_claim_and_drain_queue(false);
+        c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config());
 
         let inner = c.inner.lock().unwrap();
         assert!(
             !inner.spawning_in_progress,
-            "claim must still be released even though the spawn failed"
+            "claim must still be released even though the spawn and its fallback both failed"
         );
         assert_eq!(
             inner.pending_send_messages.len(),
@@ -2259,6 +2441,42 @@ mod send_input_tests {
             inner.pending_send_messages[0],
             "queued-by-someone-else",
             "a message queued by a DIFFERENT caller (already told \"accepted\") must survive for the next spawn"
+        );
+    }
+
+    /// codex P2 on PR #2360 (sixth review pass, round 3): `retry_after_
+    /// resume_failure` used to clear `inner.session_id` unconditionally at
+    /// the top of the function, before even deciding whether this call is
+    /// the one that's actually going to spawn. Confirms it's now scoped to
+    /// only the `BecomeSpawner` path — a concurrently-installed session id
+    /// (simulating a DIFFERENT spawn that's already running, so this call
+    /// resolves via `DeliverDirect`) must survive.
+    #[tokio::test]
+    async fn retry_after_resume_failure_preserves_a_concurrently_installed_session_id_when_not_the_spawner() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            let (tx, _rx) = mpsc::channel::<String>(4);
+            inner.stdin_tx = Some(tx);
+            inner.session_id = Some("fresh-concurrently-installed-sid".to_string());
+        }
+
+        let config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(config, "{}".to_string());
+
+        assert_eq!(
+            c.inner.lock().unwrap().session_id.as_deref(),
+            Some("fresh-concurrently-installed-sid"),
+            "must not erase a session id a concurrent spawn already legitimately captured"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -733,10 +733,21 @@ impl PersistentSubprocessController {
                 // triggered the spawn — so a confirmed stale-resume retry
                 // redelivers all of them (see `pending_resume_retry`'s own
                 // doc comment), since channel acceptance is not proof the
-                // CLI ever read it.
+                // CLI ever read it. Checks `confirmed_stale_resume_retry`
+                // too — codex P1 on PR #2360 (sixth review pass, round 6):
+                // `poison_resume` (the stderr-reader task, running
+                // concurrently) can promote `pending_resume_retry` into
+                // `confirmed_stale_resume_retry` at any point; checking
+                // only the tentative field left a window where a message
+                // delivered right after that promotion found `None` there
+                // and was persisted/removed from the queue without ever
+                // being added to the batch the replacement actually
+                // replays.
                 if !was_first_delivery {
                     let mut inner = inner_arc.lock().unwrap();
                     if let Some((_, _, ref mut delivered)) = inner.pending_resume_retry {
+                        delivered.push(delivered_copy.clone());
+                    } else if let Some((_, _, ref mut delivered)) = inner.confirmed_stale_resume_retry {
                         delivered.push(delivered_copy.clone());
                     }
                 }
@@ -960,92 +971,131 @@ impl PersistentSubprocessController {
     /// comment. By the time this runs, the original `send_message` call
     /// that triggered the doomed process has long since returned (its own
     /// spawn-claim-and-deliver sequence completed synchronously, well
-    /// before this process even exited), so each message here can safely
-    /// go through the SAME decision function `send_message` uses — with
-    /// dedup-by-content enabled (see `decide_send_action`'s doc comment),
-    /// since every entry in `json_strs` is a known re-delivery of content
-    /// already accepted for the ORIGINAL spawn, not an independent new
-    /// message. Only the FIRST message in the batch can ever resolve to
-    /// `BecomeSpawner` (it's the only one that can see
-    /// `spawning_in_progress == false`); everything after it necessarily
-    /// resolves to `Queued` (behind that same claim) or `DeliverDirect`
-    /// (if some OTHER caller's process happened to come up in the
-    /// meantime) — looping the exact same per-message decision naturally
-    /// preserves delivery order without needing special-case handling for
-    /// "the rest of the batch."
-    fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_strs: Vec<String>) {
+    /// before this process even exited), so the WHOLE batch can safely go
+    /// through `decide_retry_batch_action` — the SAME decision
+    /// `send_message` uses, but enqueueing everything atomically in one
+    /// lock acquisition (see its own doc comment for why per-message
+    /// decisions aren't safe for a batch).
+    fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, mut json_strs: Vec<String>) {
         config.session_id = String::new();
+        let Some(first) = (!json_strs.is_empty()).then(|| json_strs.remove(0)) else {
+            return;
+        };
+        let rest = json_strs;
 
-        for json_str in json_strs {
-            match self.decide_send_action(&json_str, true) {
-                SendAction::DeliverDirect => {
-                    // Another caller's own spawn already installed a
-                    // running process by the time this retry got
-                    // scheduled — no need for a dedicated respawn; deliver
-                    // straight to it.
-                    self.mark_turn_active_and_publish();
-                    let inner = self.inner.lock().unwrap();
-                    if let Some(tx) = inner.stdin_tx.as_ref() {
-                        if let Err(e) = tx.try_send(json_str) {
-                            tracing::warn!(
-                                block_id = %self.block_id,
-                                error = %e,
-                                "failed to redeliver message after stale-resume retry (already-running path)"
-                            );
-                        }
-                    }
-                }
-                SendAction::Queued => {
-                    // Someone else is already spawning — their own
-                    // `release_spawn_claim_and_drain_queue` will deliver
-                    // this (or, if their process turns out to already be
-                    // dead, its own bounded fallback respawn will).
-                }
-                SendAction::BecomeSpawner => {
-                    // Only clear inner.session_id now that THIS retry is
-                    // actually about to spawn — codex P2 on PR #2360
-                    // (sixth review pass, round 3): clearing it
-                    // unconditionally up front could erase a session id a
-                    // DIFFERENT, concurrently-installed process had
-                    // already legitimately captured, if this retry
-                    // instead resolved via `DeliverDirect` or `Queued`
-                    // above — breaking in-memory session tracking and
-                    // turn-end subagent reconciliation for that process's
-                    // remaining lifetime.
-                    self.inner.lock().unwrap().session_id = None;
-                    let retry_config = config.clone();
-                    let spawn_result = self.spawn_process(config.clone(), None);
-                    match &spawn_result {
-                        Ok(_) => self.mark_turn_active_and_publish(),
-                        Err(e) => tracing::error!(
+        match self.decide_retry_batch_action(&first, &rest) {
+            SendAction::DeliverDirect => {
+                // Another caller's own spawn already installed a running
+                // process by the time this retry got scheduled — no need
+                // for a dedicated respawn; deliver straight to it.
+                self.mark_turn_active_and_publish();
+                let mut inner = self.inner.lock().unwrap();
+                let tx = inner.stdin_tx.clone();
+                for msg in std::iter::once(first).chain(rest) {
+                    let delivered = tx.as_ref().is_some_and(|tx| tx.try_send(msg.clone()).is_ok());
+                    if !delivered {
+                        tracing::warn!(
                             block_id = %self.block_id,
-                            error = %e,
-                            "failed to respawn after a stale --resume session id"
-                        ),
-                    }
-                    self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
-                    if spawn_result.is_err() {
-                        // Surface this, or the pane hangs forever with NO
-                        // signal at all — codex P2 on PR #2360 (fifth
-                        // review pass): the outer process-waiter already
-                        // suppressed its own terminal-status publish for
-                        // the ORIGINAL exit specifically because a retry
-                        // was in flight, and send_message already
-                        // returned success (possibly emitting
-                        // agent-message-accepted) for the message this
-                        // retry was supposed to deliver. If this respawn
-                        // attempt ALSO fails, nothing else will ever tell
-                        // the frontend this turn is over.
-                        // `inner.proc_status`/`turn_active` are already
-                        // `STATUS_DONE`/`false` (set by the original
-                        // exit's own cleanup before this function was
-                        // ever called) — this just actually broadcasts
-                        // that state, which the original exit deliberately
-                        // withheld pending this retry's outcome.
-                        self.publish_status();
+                            "failed to redeliver message after stale-resume retry (already-running path) — requeueing for a future spawn"
+                        );
+                        // codex P2 on PR #2360 (sixth review pass, round
+                        // 6): this is the retry's own LAST-CHANCE delivery
+                        // attempt for this message — nothing else will
+                        // ever resend it, so discarding it here (an
+                        // earlier cut of this fix did, on both a `Full`
+                        // channel and a process that died again in this
+                        // exact gap) would lose it permanently despite
+                        // already having been reported as accepted.
+                        inner.pending_send_messages.push_back(msg);
                     }
                 }
             }
+            SendAction::Queued => {
+                // Someone else is already spawning — their own
+                // `release_spawn_claim_and_drain_queue` will deliver this
+                // (or, if their process turns out to already be dead, its
+                // own bounded fallback respawn will).
+            }
+            SendAction::BecomeSpawner => {
+                // Only clear inner.session_id now that THIS retry is
+                // actually about to spawn — codex P2 on PR #2360 (sixth
+                // review pass, round 3): clearing it unconditionally up
+                // front could erase a session id a DIFFERENT,
+                // concurrently-installed process had already legitimately
+                // captured, if this retry instead resolved via
+                // `DeliverDirect` or `Queued` above — breaking in-memory
+                // session tracking and turn-end subagent reconciliation
+                // for that process's remaining lifetime.
+                self.inner.lock().unwrap().session_id = None;
+                let retry_config = config.clone();
+                let spawn_result = self.spawn_process(config, None);
+                match &spawn_result {
+                    Ok(_) => self.mark_turn_active_and_publish(),
+                    Err(e) => tracing::error!(
+                        block_id = %self.block_id,
+                        error = %e,
+                        "failed to respawn after a stale --resume session id"
+                    ),
+                }
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
+                if spawn_result.is_err() {
+                    // Surface this, or the pane hangs forever with NO
+                    // signal at all — codex P2 on PR #2360 (fifth review
+                    // pass): the outer process-waiter already suppressed
+                    // its own terminal-status publish for the ORIGINAL
+                    // exit specifically because a retry was in flight, and
+                    // send_message already returned success (possibly
+                    // emitting agent-message-accepted) for the message
+                    // this retry was supposed to deliver. If this respawn
+                    // attempt ALSO fails, nothing else will ever tell the
+                    // frontend this turn is over. `inner.proc_status`/
+                    // `turn_active` are already `STATUS_DONE`/`false` (set
+                    // by the original exit's own cleanup before this
+                    // function was ever called) — this just actually
+                    // broadcasts that state, which the original exit
+                    // deliberately withheld pending this retry's outcome.
+                    self.publish_status();
+                }
+            }
+        }
+    }
+
+    /// Same three-way decision as `decide_send_action`, but atomically
+    /// enqueues an ENTIRE batch of messages (not just one) when the
+    /// outcome is `Queued` or `BecomeSpawner` — used only by
+    /// `retry_after_resume_failure`. codex P2 on PR #2360 (sixth review
+    /// pass, round 6): deciding and enqueueing a multi-message retry batch
+    /// one call at a time (each through its own `decide_send_action` call)
+    /// left a window between them where a genuinely new, unrelated message
+    /// could interleave into the MIDDLE of the same original batch,
+    /// reordering it relative to how the doomed process actually received
+    /// it. `first` is checked for an already-queued duplicate the same way
+    /// `decide_send_action` does (see its own doc comment on
+    /// `skip_if_already_queued`) — it may still be sitting in
+    /// `pending_send_messages` if the drain hasn't reached it yet. `rest`
+    /// is always pushed as-is: content-based dedup must never apply WITHIN
+    /// the same batch, since two entries can legitimately be identical
+    /// (the user genuinely sent the same text twice) and both need
+    /// redelivering (codex P2 on PR #2360, sixth review pass, round 6).
+    fn decide_retry_batch_action(&self, first: &str, rest: &[String]) -> SendAction {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.stdin_tx.is_some() && !inner.spawning_in_progress {
+            SendAction::DeliverDirect
+        } else if inner.spawning_in_progress {
+            if !inner.pending_send_messages.iter().any(|m| m == first) {
+                inner.pending_send_messages.push_back(first.to_string());
+            }
+            for msg in rest {
+                inner.pending_send_messages.push_back(msg.clone());
+            }
+            SendAction::Queued
+        } else {
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back(first.to_string());
+            for msg in rest {
+                inner.pending_send_messages.push_back(msg.clone());
+            }
+            SendAction::BecomeSpawner
         }
     }
 
@@ -2764,6 +2814,40 @@ mod send_input_tests {
         assert_eq!(rx.recv().await.unwrap(), "msg-3");
     }
 
+    /// codex P2 on PR #2360 (sixth review pass, round 6): the `DeliverDirect`
+    /// path is the retry's own LAST-CHANCE delivery attempt — nothing else
+    /// will ever resend a message that fails here (e.g. the process died
+    /// again in the gap between `decide_retry_batch_action`'s check and
+    /// this lock re-acquisition, simulated here via a dropped receiver).
+    /// It must be requeued, not silently discarded.
+    #[tokio::test]
+    async fn retry_after_resume_failure_requeues_a_message_that_fails_direct_delivery() {
+        let c = controller();
+        let (tx, rx) = mpsc::channel::<String>(1);
+        drop(rx);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+
+        let config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(config, vec!["stuck".to_string()]);
+
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            1,
+            "a message that fails its last-chance delivery must be requeued, not discarded"
+        );
+        assert_eq!(inner.pending_send_messages[0], "stuck");
+    }
+
     /// codex P1 on PR #2360 (sixth review pass, round 5): the drain must
     /// track every message it successfully delivers beyond the first
     /// (which `spawn_process` already stashed synchronously — see
@@ -2812,6 +2896,115 @@ mod send_input_tests {
             delivered,
             &vec!["first".to_string(), "second".to_string()],
             "must contain the ORIGINAL message exactly once plus every later delivery, in order"
+        );
+    }
+
+    /// codex P1 on PR #2360 (sixth review pass, round 6): `poison_resume`
+    /// (the stderr-reader task, running concurrently with this drain) can
+    /// promote `pending_resume_retry` into `confirmed_stale_resume_retry`
+    /// at any point. A message delivered right after that promotion must
+    /// still be tracked — appending only to `pending_resume_retry` would
+    /// silently drop it from the batch the replacement actually replays.
+    #[tokio::test]
+    async fn drain_appends_to_confirmed_retry_once_already_promoted_from_pending() {
+        let c = controller();
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let retry_config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("first".to_string());
+            inner.pending_send_messages.push_back("second".to_string());
+            // Simulates poison_resume having ALREADY promoted
+            // pending_resume_retry to confirmed before the drain got to
+            // "second".
+            inner.confirmed_stale_resume_retry =
+                Some(("sid".to_string(), retry_config.clone(), vec!["first".to_string()]));
+        }
+
+        c.drain_queue_after_successful_spawn(retry_config, true);
+
+        assert_eq!(rx.recv().await.unwrap(), "first");
+        assert_eq!(rx.recv().await.unwrap(), "second");
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+
+        let inner = c.inner.lock().unwrap();
+        let (_, _, delivered) = inner
+            .confirmed_stale_resume_retry
+            .as_ref()
+            .expect("must still be tracking this spawn's delivered messages, even though it was already confirmed");
+        assert_eq!(delivered, &vec!["first".to_string(), "second".to_string()]);
+    }
+
+    /// codex P2 on PR #2360 (sixth review pass, round 6): deciding and
+    /// enqueueing a multi-message retry batch one call at a time left a
+    /// window where a genuinely new, unrelated message could interleave
+    /// into the MIDDLE of the batch. `decide_retry_batch_action` must
+    /// enqueue the whole batch atomically instead.
+    #[test]
+    fn decide_retry_batch_action_enqueues_the_whole_batch_atomically() {
+        let c = controller();
+        let action = c.decide_retry_batch_action("first", &["second".to_string(), "third".to_string()]);
+        assert!(matches!(action, SendAction::BecomeSpawner));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.iter().cloned().collect::<Vec<_>>(),
+            vec!["first".to_string(), "second".to_string(), "third".to_string()],
+        );
+    }
+
+    /// codex P2 on PR #2360 (sixth review pass, round 6): content-based
+    /// dedup must never apply WITHIN a retry batch — two entries can
+    /// legitimately be identical (the user genuinely sent the same text
+    /// twice, both accepted by the doomed process) and both need
+    /// redelivering.
+    #[test]
+    fn decide_retry_batch_action_preserves_duplicate_content_within_the_batch() {
+        let c = controller();
+        c.inner.lock().unwrap().spawning_in_progress = true;
+
+        let action =
+            c.decide_retry_batch_action("hello", &["hello".to_string(), "hello".to_string()]);
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            3,
+            "all three identical entries must be preserved, not deduped"
+        );
+    }
+
+    /// The dedup check still applies to `first` alone, against whatever
+    /// might ALREADY be queued from before this batch decision — e.g. the
+    /// drain hasn't reached the original triggering message yet.
+    #[test]
+    fn decide_retry_batch_action_dedups_only_the_first_against_pre_existing_queue() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("first".to_string());
+        }
+
+        let action = c.decide_retry_batch_action("first", &["second".to_string()]);
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.iter().cloned().collect::<Vec<_>>(),
+            vec!["first".to_string(), "second".to_string()],
+            "the already-queued first entry must not be duplicated, but the rest of the batch must still be appended"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -524,19 +524,33 @@ impl PersistentSubprocessController {
     /// `PersistentInner::spawning_in_progress`'s doc comment for the race
     /// this closes. All three outcomes are decided under ONE lock
     /// acquisition so nothing can slip through the gaps between them:
-    /// - the process is already running → `DeliverDirect`, no spawn
-    ///   decision at all.
-    /// - nobody is currently spawning → this caller claims the exclusive
-    ///   right to (`spawning_in_progress = true`), enqueues `json_str`
-    ///   alongside that claim, and returns `BecomeSpawner` — the caller
-    ///   must then call `spawn_process` and, regardless of outcome, call
-    ///   `release_spawn_claim_and_drain_queue`.
-    /// - someone else is already spawning → `json_str` is enqueued for
-    ///   THAT caller's own drain to deliver, and this call returns
-    ///   `Queued` with nothing further to do.
+    /// - the process is already running AND nobody is still draining a
+    ///   backlog into it → `DeliverDirect`, no spawn decision at all.
+    /// - someone is currently spawning OR still draining a backlog
+    ///   (`spawning_in_progress`) → `json_str` is enqueued for THAT
+    ///   caller's own drain to deliver, and this call returns `Queued`
+    ///   with nothing further to do. reagentx P1 on PR #2360 (sixth
+    ///   review pass, round 4): `spawn_process` sets `stdin_tx` well
+    ///   before the queued message that triggered the spawn is actually
+    ///   delivered (that happens later, on a background drain task —
+    ///   see `drain_queue_after_successful_spawn`). Gating `DeliverDirect`
+    ///   on `stdin_tx.is_some()` alone let a second, genuinely concurrent
+    ///   `send_message` call land in that exact window and write straight
+    ///   to stdin via `try_send`, racing ahead of the drain's own
+    ///   `Sender::send().await` for the message that actually triggered
+    ///   the spawn — silently reordering user input. Checking
+    ///   `!spawning_in_progress` too routes it into the queue instead,
+    ///   where the SAME already-running drain loop (it stays `true` for
+    ///   its entire lifetime — see the field's own doc comment) picks it
+    ///   up next, in order.
+    /// - nobody is running AND nobody is spawning → this caller claims the
+    ///   exclusive right to (`spawning_in_progress = true`), enqueues
+    ///   `json_str` alongside that claim, and returns `BecomeSpawner` —
+    ///   the caller must then call `spawn_process` and, regardless of
+    ///   outcome, call `release_spawn_claim_and_drain_queue`.
     fn decide_send_action(&self, json_str: &str) -> SendAction {
         let mut inner = self.inner.lock().unwrap();
-        if inner.stdin_tx.is_some() {
+        if inner.stdin_tx.is_some() && !inner.spawning_in_progress {
             SendAction::DeliverDirect
         } else if inner.spawning_in_progress {
             inner.pending_send_messages.push_back(json_str.to_string());
@@ -634,11 +648,24 @@ impl PersistentSubprocessController {
                 };
                 let Some((json_str, tx)) = next else {
                     // Either the queue is empty, or the process has
-                    // already exited again before we got to it — either
-                    // way, release the claim so a future caller can spawn.
+                    // already exited again before we got to it. Release
+                    // the claim ONLY if we're not about to hand off to a
+                    // fallback respawn — reagentx P1 on PR #2360 (sixth
+                    // review pass, round 4): releasing it unconditionally
+                    // here left a window, between this release and
+                    // `respawn_once_for_leftover_queue`'s own
+                    // `spawn_process` call re-establishing state, where a
+                    // concurrent `send_message`/`retry_after_resume_failure`
+                    // could see "not running, not spawning" and
+                    // independently spawn its own child process for the
+                    // same block — reintroducing the exact orphaned/
+                    // duplicate-process race `spawning_in_progress` was
+                    // added in this same PR to close.
                     let mut inner = inner_arc.lock().unwrap();
                     let stalled = inner.stdin_tx.is_none() && !inner.pending_send_messages.is_empty();
-                    inner.spawning_in_progress = false;
+                    if !(stalled && allow_fallback_respawn) {
+                        inner.spawning_in_progress = false;
+                    }
                     break stalled;
                 };
                 if let Err(e) = tx.send(json_str).await {
@@ -649,21 +676,27 @@ impl PersistentSubprocessController {
                     // The channel's gone, so no send from here will ever
                     // succeed again — put the message back (rather than
                     // silently discarding it) for a future spawn to pick
-                    // up, and release the claim now instead of busy-looping
-                    // on the same dead sender.
+                    // up. Same claim-retention rule as above.
                     let mut inner = inner_arc.lock().unwrap();
                     inner.pending_send_messages.push_front(e.0);
                     let stalled = !inner.pending_send_messages.is_empty();
-                    inner.spawning_in_progress = false;
+                    if !(stalled && allow_fallback_respawn) {
+                        inner.spawning_in_progress = false;
+                    }
                     break stalled;
                 }
             };
             if stalled_with_leftovers {
-                if let Some(ctrl) = self_ref.upgrade() {
-                    if allow_fallback_respawn {
-                        ctrl.respawn_once_for_leftover_queue(retry_config);
-                    } else {
-                        ctrl.publish_status();
+                match self_ref.upgrade() {
+                    Some(ctrl) if allow_fallback_respawn => ctrl.respawn_once_for_leftover_queue(retry_config),
+                    Some(ctrl) => ctrl.publish_status(),
+                    None => {
+                        // Nobody left to call back (e.g. a throwaway
+                        // instance that never called `set_self_ref`) — the
+                        // claim was deliberately kept held above pending
+                        // this hand-off, so it must still be released here
+                        // or no future caller could ever spawn again.
+                        inner_arc.lock().unwrap().spawning_in_progress = false;
                     }
                 }
             }
@@ -2244,6 +2277,37 @@ mod send_input_tests {
             inner.pending_send_messages.is_empty(),
             "must not queue when delivering directly to an already-running process"
         );
+    }
+
+    /// reagentx P1 on PR #2360 (sixth review pass, round 4): `spawn_process`
+    /// sets `stdin_tx` synchronously, well before the queued message that
+    /// triggered the spawn is actually delivered by the background drain
+    /// task (`drain_queue_after_successful_spawn`). A second caller
+    /// landing in that exact window — `stdin_tx` already live, but
+    /// `spawning_in_progress` still `true` because the drain hasn't
+    /// finished — must NOT take the `DeliverDirect` path: writing straight
+    /// to stdin via `try_send` there would race ahead of the drain's own
+    /// `Sender::send().await` for the message that actually triggered the
+    /// spawn, silently reordering user input. It must queue behind
+    /// whatever the still-active drain is working through instead.
+    #[test]
+    fn decide_send_action_queues_instead_of_delivering_direct_while_a_drain_is_still_active() {
+        let c = controller();
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.spawning_in_progress = true;
+        }
+
+        let action = c.decide_send_action("msg-late-arrival");
+        assert!(
+            matches!(action, SendAction::Queued),
+            "must queue, not deliver direct, while a drain for an earlier message is still active"
+        );
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(inner.pending_send_messages.len(), 1);
+        assert_eq!(inner.pending_send_messages[0], "msg-late-arrival");
     }
 
     /// Exercises the actual race with real OS threads, not just sequential

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -209,7 +209,7 @@ struct PersistentInner {
     /// uniform delivery path regardless of whether a message triggered the
     /// spawn or arrived while someone else's spawn was already in flight.
     /// Drained by `release_spawn_claim_and_drain_queue`.
-    pending_send_messages: VecDeque<String>,
+    pending_send_messages: VecDeque<QueuedMessage>,
     current_pid: Option<u32>,
     /// Channel to send messages to the stdin writer task.
     stdin_tx: Option<mpsc::Sender<String>>,
@@ -286,6 +286,48 @@ enum SendAction {
     /// Another caller is already spawning — this message has been
     /// enqueued for that caller's own post-spawn drain to deliver.
     Queued,
+}
+
+/// A single entry in `pending_send_messages`: the formatted stdin JSON
+/// payload plus whether it's already been persisted to the blockfile.
+/// codex P2 on PR #2360 (sixth review pass, round 7): a stale-resume
+/// retry's redelivery has already been correctly persisted on its
+/// original (failed) attempt — see `retry_after_resume_failure`'s own doc
+/// comment — but the drain used to persist EVERY message it delivers
+/// unconditionally, double-persisting a replayed retry batch into the
+/// blockfile transcript.
+#[derive(Clone, Debug)]
+struct QueuedMessage {
+    json_str: String,
+    already_persisted: bool,
+}
+
+impl QueuedMessage {
+    fn fresh(json_str: String) -> Self {
+        Self { json_str, already_persisted: false }
+    }
+
+    fn already_persisted(json_str: String) -> Self {
+        Self { json_str, already_persisted: true }
+    }
+}
+
+impl PartialEq<str> for QueuedMessage {
+    fn eq(&self, other: &str) -> bool {
+        self.json_str == other
+    }
+}
+
+impl PartialEq<&str> for QueuedMessage {
+    fn eq(&self, other: &&str) -> bool {
+        self.json_str == *other
+    }
+}
+
+impl PartialEq<String> for QueuedMessage {
+    fn eq(&self, other: &String) -> bool {
+        self.json_str == *other
+    }
 }
 
 /// PersistentSubprocessController keeps a long-running CLI process alive,
@@ -582,12 +624,12 @@ impl PersistentSubprocessController {
             let already_queued =
                 skip_if_already_queued && inner.pending_send_messages.iter().any(|m| m == json_str);
             if !already_queued {
-                inner.pending_send_messages.push_back(json_str.to_string());
+                inner.pending_send_messages.push_back(QueuedMessage::fresh(json_str.to_string()));
             }
             SendAction::Queued
         } else {
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(json_str.to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(json_str.to_string()));
             SendAction::BecomeSpawner
         }
     }
@@ -685,7 +727,7 @@ impl PersistentSubprocessController {
                         None => None,
                     }
                 };
-                let Some((json_str, tx)) = next else {
+                let Some((queued, tx)) = next else {
                     // Either the queue is empty, or the process has
                     // already exited again before we got to it. Release
                     // the claim ONLY if we're not about to hand off to a
@@ -707,6 +749,7 @@ impl PersistentSubprocessController {
                     }
                     break stalled;
                 };
+                let QueuedMessage { json_str, already_persisted } = queued;
                 let delivered_copy = json_str.clone();
                 let was_first_delivery = is_first_delivery;
                 is_first_delivery = false;
@@ -720,7 +763,7 @@ impl PersistentSubprocessController {
                     // silently discarding it) for a future spawn to pick
                     // up. Same claim-retention rule as above.
                     let mut inner = inner_arc.lock().unwrap();
-                    inner.pending_send_messages.push_front(e.0);
+                    inner.pending_send_messages.push_front(QueuedMessage { json_str: e.0, already_persisted });
                     let stalled = !inner.pending_send_messages.is_empty();
                     if !(stalled && allow_fallback_respawn) {
                         inner.spawning_in_progress = false;
@@ -757,9 +800,16 @@ impl PersistentSubprocessController {
                 // own synchronous code run (and thus persist) in a
                 // different order than their messages are actually
                 // delivered, producing a blockfile transcript that
-                // doesn't match what the agent received.
-                if let Some(ctrl) = self_ref.upgrade() {
-                    ctrl.persist_message_to_blockfile(&delivered_copy);
+                // doesn't match what the agent received. Skipped for a
+                // stale-resume retry's redelivery — codex P2 on PR #2360
+                // (sixth review pass, round 7): that content was already
+                // correctly persisted on its ORIGINAL (failed) attempt;
+                // persisting it again here duplicated every replayed
+                // prompt in the blockfile transcript.
+                if !already_persisted {
+                    if let Some(ctrl) = self_ref.upgrade() {
+                        ctrl.persist_message_to_blockfile(&delivered_copy);
+                    }
                 }
             };
             if stalled_with_leftovers {
@@ -989,25 +1039,47 @@ impl PersistentSubprocessController {
                 // process by the time this retry got scheduled — no need
                 // for a dedicated respawn; deliver straight to it.
                 self.mark_turn_active_and_publish();
-                let mut inner = self.inner.lock().unwrap();
-                let tx = inner.stdin_tx.clone();
-                for msg in std::iter::once(first).chain(rest) {
-                    let delivered = tx.as_ref().is_some_and(|tx| tx.try_send(msg.clone()).is_ok());
-                    if !delivered {
-                        tracing::warn!(
-                            block_id = %self.block_id,
-                            "failed to redeliver message after stale-resume retry (already-running path) — requeueing for a future spawn"
-                        );
-                        // codex P2 on PR #2360 (sixth review pass, round
-                        // 6): this is the retry's own LAST-CHANCE delivery
-                        // attempt for this message — nothing else will
-                        // ever resend it, so discarding it here (an
-                        // earlier cut of this fix did, on both a `Full`
-                        // channel and a process that died again in this
-                        // exact gap) would lose it permanently despite
-                        // already having been reported as accepted.
-                        inner.pending_send_messages.push_back(msg);
+                let mut any_failed = false;
+                {
+                    let mut inner = self.inner.lock().unwrap();
+                    let tx = inner.stdin_tx.clone();
+                    for msg in std::iter::once(first).chain(rest) {
+                        let delivered = tx.as_ref().is_some_and(|tx| tx.try_send(msg.clone()).is_ok());
+                        if !delivered {
+                            any_failed = true;
+                            // codex P2 on PR #2360 (sixth review pass,
+                            // round 6): this is the retry's own
+                            // LAST-CHANCE delivery attempt for this
+                            // message — nothing else will ever resend it,
+                            // so discarding it here (an earlier cut of
+                            // this fix did, on both a `Full` channel and a
+                            // process that died again in this exact gap)
+                            // would lose it permanently despite already
+                            // having been reported as accepted.
+                            inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg));
+                        }
                     }
+                }
+                if any_failed {
+                    tracing::warn!(
+                        block_id = %self.block_id,
+                        "failed to redeliver one or more messages after stale-resume retry (already-running path) — draining via the queue instead"
+                    );
+                    // codex P2 on PR #2360 (sixth review pass, round 7):
+                    // pushing onto the queue alone is not enough —
+                    // `DeliverDirect` only fires when `spawning_in_progress`
+                    // is `false`, so nothing would EVER drain this entry:
+                    // future callers ALSO take `DeliverDirect` (bypassing
+                    // the queue entirely) for as long as this same process
+                    // stays alive, which could be indefinite, silently
+                    // reordering it behind much later input. Claim the
+                    // spawn flag and hand off to the SAME drain used after
+                    // a fresh spawn (with backpressure via `Sender::send`,
+                    // not `try_send`) instead of leaving it orphaned.
+                    // `allow_fallback_respawn: false` — the process is
+                    // still alive, there's nothing to fall back to spawn.
+                    self.inner.lock().unwrap().spawning_in_progress = true;
+                    self.drain_queue_after_successful_spawn(config.clone(), false);
                 }
             }
             SendAction::Queued => {
@@ -1083,17 +1155,17 @@ impl PersistentSubprocessController {
             SendAction::DeliverDirect
         } else if inner.spawning_in_progress {
             if !inner.pending_send_messages.iter().any(|m| m == first) {
-                inner.pending_send_messages.push_back(first.to_string());
+                inner.pending_send_messages.push_back(QueuedMessage::already_persisted(first.to_string()));
             }
             for msg in rest {
-                inner.pending_send_messages.push_back(msg.clone());
+                inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg.clone()));
             }
             SendAction::Queued
         } else {
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(first.to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::already_persisted(first.to_string()));
             for msg in rest {
-                inner.pending_send_messages.push_back(msg.clone());
+                inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg.clone()));
             }
             SendAction::BecomeSpawner
         }
@@ -1130,6 +1202,30 @@ impl PersistentSubprocessController {
 
         {
             let inner = self.inner.lock().unwrap();
+            // reagentx P1 on PR #2360 (sixth review pass, round 7):
+            // `spawn_process` sets `stdin_tx` synchronously, well before
+            // the queued message that triggered the spawn is actually
+            // delivered by the background drain task
+            // (`drain_queue_after_successful_spawn`). Gating purely on
+            // `stdin_tx.is_some()` (as `decide_send_action` used to,
+            // before round 4) let a message land in that exact window and
+            // `try_send` straight to the live channel, jumping ahead of
+            // whatever's still queued — the same reordering bug fixed for
+            // `send_message`'s own delivery path. Unlike `send_message`,
+            // this function has no spawn config and its persistence is a
+            // LIVE, visible append (see below), not the silent persist
+            // the generic queue drain performs — there's no safe way to
+            // queue behind that drain without either bypassing its
+            // ordering guarantee or losing the visibility requirement, so
+            // this errors instead of reordering; the caller (muxbus/jekt
+            // delivery) can retry shortly. Checked in the SAME lock
+            // acquisition as `stdin_tx` below, not a separate one, so
+            // nothing can slip through the gap between two checks.
+            if inner.spawning_in_progress {
+                return Err(
+                    "persistent process is still starting up — try again shortly".to_string(),
+                );
+            }
             let tx = inner
                 .stdin_tx
                 .as_ref()
@@ -2470,7 +2566,7 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("original-payload".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("original-payload".to_string()));
         }
 
         let action = c.decide_send_action("original-payload", true);
@@ -2547,6 +2643,59 @@ mod send_input_tests {
         assert_eq!(inner.pending_send_messages[0], "msg-late-arrival");
     }
 
+    /// codex P2 on PR #2360 (sixth review pass, round 7): a fresh message
+    /// (from `decide_send_action`) must be marked NOT already persisted —
+    /// the drain is responsible for persisting it, in delivery order.
+    #[test]
+    fn decide_send_action_marks_a_fresh_message_as_not_yet_persisted() {
+        let c = controller();
+        c.decide_send_action("hello", false);
+        let inner = c.inner.lock().unwrap();
+        assert!(
+            !inner.pending_send_messages[0].already_persisted,
+            "a genuinely new message must not be marked already-persisted"
+        );
+    }
+
+    /// codex P2 on PR #2360 (sixth review pass, round 7): a stale-resume
+    /// retry's batch (from `decide_retry_batch_action`) must be marked
+    /// already persisted — it was correctly persisted on its ORIGINAL
+    /// attempt, and the shared drain must not persist it a second time.
+    #[test]
+    fn decide_retry_batch_action_marks_every_entry_as_already_persisted() {
+        let c = controller();
+        c.decide_retry_batch_action("hello", &["world".to_string()]);
+        let inner = c.inner.lock().unwrap();
+        assert!(inner.pending_send_messages[0].already_persisted);
+        assert!(inner.pending_send_messages[1].already_persisted);
+    }
+
+    /// reagentx P1 on PR #2360 (sixth review pass, round 7): `spawn_process`
+    /// sets `stdin_tx` synchronously, well before the queued message that
+    /// triggered the spawn is actually delivered by the background drain.
+    /// A muxbus/jekt steering message (`send_user_message`) landing in
+    /// that window must not `try_send` straight to the live channel — it
+    /// has no way to safely queue behind the drain (its persistence is a
+    /// live, visible append, not the drain's silent persist), so it must
+    /// error instead of reordering ahead of whatever the drain is still
+    /// working through.
+    #[tokio::test]
+    async fn send_user_message_errors_instead_of_reordering_while_a_drain_is_still_active() {
+        let c = controller();
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.spawning_in_progress = true;
+        }
+
+        let err = c.send_user_message("steer".to_string()).unwrap_err();
+        assert!(
+            err.contains("starting up"),
+            "should surface a clear, retryable error instead of reordering, got {err:?}"
+        );
+    }
+
     /// Exercises the actual race with real OS threads, not just sequential
     /// state assertions — reagentx P1 on PR #2360 (sixth review pass): many
     /// concurrent callers landing on a controller with no process running
@@ -2610,8 +2759,8 @@ mod send_input_tests {
             let mut inner = c.inner.lock().unwrap();
             inner.stdin_tx = Some(tx);
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("first".to_string());
-            inner.pending_send_messages.push_back("second".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("second".to_string()));
         }
 
         // Never used for a fallback spawn in this test — the drain fully
@@ -2677,8 +2826,8 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("stuck-one".to_string());
-            inner.pending_send_messages.push_back("stuck-two".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("stuck-one".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("stuck-two".to_string()));
             // stdin_tx stays None — simulates the process this claim was
             // spawning for having already died before the drain ran.
         }
@@ -2722,8 +2871,8 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("the-one-that-failed".to_string());
-            inner.pending_send_messages.push_back("queued-by-someone-else".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("the-one-that-failed".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("queued-by-someone-else".to_string()));
         }
 
         c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config());
@@ -2848,6 +2997,48 @@ mod send_input_tests {
         assert_eq!(inner.pending_send_messages[0], "stuck");
     }
 
+    /// codex P2 on PR #2360 (sixth review pass, round 7): pushing a failed
+    /// direct-retry delivery onto the queue alone is not enough —
+    /// `DeliverDirect` only fires when `spawning_in_progress` is `false`,
+    /// so nothing would EVER drain this entry for as long as the same
+    /// process stays alive (every future caller would ALSO take
+    /// `DeliverDirect`, bypassing the queue entirely). The claim must be
+    /// taken and a drain triggered instead — which, even against the same
+    /// dead sender used here, must still correctly release the claim
+    /// afterward (not leave it stuck forever) while preserving the
+    /// message for a future spawn.
+    #[tokio::test]
+    async fn retry_after_resume_failure_claims_the_spawn_flag_when_direct_delivery_fails() {
+        let c = controller();
+        let (tx, rx) = mpsc::channel::<String>(1);
+        drop(rx);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+
+        let config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(config, vec!["stuck".to_string()]);
+
+        assert!(
+            c.inner.lock().unwrap().spawning_in_progress,
+            "must claim the spawn flag immediately so no concurrent caller bypasses the queue via DeliverDirect"
+        );
+
+        // Let the background drain (which will also fail against this
+        // same dead sender) run to completion.
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+        let inner = c.inner.lock().unwrap();
+        assert!(!inner.spawning_in_progress, "claim must eventually be released, not stuck forever");
+        assert_eq!(inner.pending_send_messages.len(), 1, "message must remain queued, not lost");
+    }
+
     /// codex P1 on PR #2360 (sixth review pass, round 5): the drain must
     /// track every message it successfully delivers beyond the first
     /// (which `spawn_process` already stashed synchronously — see
@@ -2873,8 +3064,8 @@ mod send_input_tests {
             let mut inner = c.inner.lock().unwrap();
             inner.stdin_tx = Some(tx);
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("first".to_string());
-            inner.pending_send_messages.push_back("second".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("second".to_string()));
             // Simulates spawn_process's own synchronous stash for "first"
             // — the message that triggered this spawn.
             inner.pending_resume_retry =
@@ -2923,8 +3114,8 @@ mod send_input_tests {
             let mut inner = c.inner.lock().unwrap();
             inner.stdin_tx = Some(tx);
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("first".to_string());
-            inner.pending_send_messages.push_back("second".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("second".to_string()));
             // Simulates poison_resume having ALREADY promoted
             // pending_resume_retry to confirmed before the drain got to
             // "second".
@@ -2994,7 +3185,7 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("first".to_string());
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
         }
 
         let action = c.decide_retry_batch_action("first", &["second".to_string()]);

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -549,47 +549,72 @@ impl PersistentSubprocessController {
     }
 
     /// Releases the exclusive spawn claim taken by `decide_send_action`
-    /// returning `BecomeSpawner`, delivering everything enqueued while
-    /// this caller was busy spawning (including its own message — see
-    /// `SendAction::BecomeSpawner`'s doc comment). Draining happens under
-    /// the SAME lock used to decide "queue vs. spawn," one message at a
-    /// time, so a message pushed onto the queue by a losing caller can
-    /// never be missed by a drain that already believed the queue was
-    /// empty.
+    /// returning `BecomeSpawner`. `spawn_succeeded` distinguishes two very
+    /// different situations:
     ///
-    /// Safe to call even when the just-attempted spawn failed:
-    /// `inner.stdin_tx` will be `None` in that case, so this leaves
-    /// whatever is still queued in place (for the next successful spawn to
-    /// pick up) rather than silently discarding it, while still releasing
-    /// `spawning_in_progress` so a future caller isn't blocked forever.
-    fn release_spawn_claim_and_drain_queue(&self) {
-        loop {
+    /// - **Failed spawn**: discards only the front item of the queue —
+    ///   the caller's OWN message. This is guaranteed to be at the front:
+    ///   nothing else could have been queued before `spawning_in_progress`
+    ///   was set (see `decide_send_action`), and the queue is always empty
+    ///   at the moment a new spawner claims it (the previous claim only
+    ///   ever releases once fully drained). codex P1 on PR #2360 (sixth
+    ///   review pass): leaving this message queued let an unrelated LATER
+    ///   successful spawn silently execute a prompt the caller was already
+    ///   told had failed (`send_message`/`retry_after_resume_failure`
+    ///   already report the failure), sometimes duplicating a message the
+    ///   user had re-sent by hand. Anything queued AFTER it (from other
+    ///   callers who got `SendAction::Queued` and were already told
+    ///   "accepted") is left in place for the next successful spawn.
+    /// - **Successful spawn**: hands the drain off to a background task
+    ///   that delivers everything queued, in order, via `Sender::send`
+    ///   (which awaits free capacity) rather than `try_send`. codex P2 on
+    ///   PR #2360 (sixth review pass): a synchronous `try_send` loop
+    ///   popped a message off the queue and then discarded it outright if
+    ///   the bounded stdin channel was momentarily full — losing input
+    ///   despite already having told that caller "accepted". Deferring to
+    ///   a task lets delivery simply wait for capacity instead.
+    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool) {
+        if !spawn_succeeded {
             let mut inner = self.inner.lock().unwrap();
-            if inner.stdin_tx.is_none() {
-                // Nothing to deliver to right now (the spawn attempt
-                // failed, or the process has already exited again) —
-                // release the claim but leave whatever's still queued for
-                // the next successful spawn to pick up, rather than
-                // silently discarding it.
-                inner.spawning_in_progress = false;
-                break;
-            }
-            let Some(json_str) = inner.pending_send_messages.pop_front() else {
-                inner.spawning_in_progress = false;
-                break;
-            };
-            let tx = inner.stdin_tx.clone();
-            drop(inner);
-            if let Some(tx) = tx {
-                if let Err(e) = tx.try_send(json_str) {
+            inner.pending_send_messages.pop_front();
+            inner.spawning_in_progress = false;
+            return;
+        }
+        let inner_arc = Arc::clone(&self.inner);
+        let block_id = self.block_id.clone();
+        tokio::spawn(async move {
+            loop {
+                let next = {
+                    let mut inner = inner_arc.lock().unwrap();
+                    match inner.stdin_tx.clone() {
+                        Some(tx) => inner.pending_send_messages.pop_front().map(|m| (m, tx)),
+                        None => None,
+                    }
+                };
+                let Some((json_str, tx)) = next else {
+                    // Either the queue is empty, or the process has
+                    // already exited again before we got to it — either
+                    // way, release the claim so a future caller can spawn.
+                    inner_arc.lock().unwrap().spawning_in_progress = false;
+                    break;
+                };
+                if let Err(e) = tx.send(json_str).await {
                     tracing::warn!(
-                        block_id = %self.block_id,
-                        error = %e,
-                        "failed to deliver a queued message after a spawn"
+                        block_id = %block_id,
+                        "failed to deliver a queued message — receiver dropped, process likely exited"
                     );
+                    // The channel's gone, so no send from here will ever
+                    // succeed again — put the message back (rather than
+                    // silently discarding it) for a future spawn to pick
+                    // up, and release the claim now instead of busy-looping
+                    // on the same dead sender.
+                    let mut inner = inner_arc.lock().unwrap();
+                    inner.pending_send_messages.push_front(e.0);
+                    inner.spawning_in_progress = false;
+                    break;
                 }
             }
-        }
+        });
     }
 
     /// Send a user message to the running CLI process.
@@ -684,18 +709,19 @@ impl PersistentSubprocessController {
                 // `--resume`, which is what the retry payload is for.
                 let message_id = config.message_id.clone();
                 let spawn_result = self.spawn_process(config, Some(json_str));
+                // Only emit "accepted" on success — matches this
+                // function's prior (pre-queue) behavior, which propagated
+                // a spawn failure via `?` before ever reaching the
+                // "accepted" emission. A failed spawn's message is
+                // discarded by `release_spawn_claim_and_drain_queue` below
+                // (see its own doc comment), so telling the frontend
+                // "accepted" for it here would be a lie.
                 if spawn_result.is_ok() {
                     self.mark_turn_active_and_publish();
+                    self.emit_message_accepted(message_id.as_deref());
                 }
-                // Emit "accepted" for this caller's own message regardless
-                // of the spawn outcome — matches this function's prior
-                // behavior of always emitting it once the message was
-                // durably persisted above. `release_spawn_claim_and_drain_queue`
-                // (below) is what actually delivers it (or leaves it
-                // queued for a future spawn, on failure).
-                self.emit_message_accepted(message_id.as_deref());
-                self.release_spawn_claim_and_drain_queue();
-                spawn_result.map(|_| ())
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok());
+                spawn_result
             }
         }
     }
@@ -765,7 +791,7 @@ impl PersistentSubprocessController {
                         "failed to respawn after a stale --resume session id"
                     ),
                 }
-                self.release_spawn_claim_and_drain_queue();
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok());
                 if spawn_result.is_err() {
                     // Surface this, or the pane hangs forever with NO
                     // signal at all — codex P2 on PR #2360 (fifth review
@@ -2169,11 +2195,14 @@ mod send_input_tests {
         );
     }
 
-    /// The drain must deliver everything queued (including a caller's own
-    /// message, enqueued alongside the claim by `decide_send_action`) in
-    /// order, then release the claim so a future caller can spawn again.
-    #[test]
-    fn release_spawn_claim_and_drain_queue_delivers_everything_and_releases_claim() {
+    /// On a successful spawn, the drain must deliver everything queued
+    /// (including a caller's own message, enqueued alongside the claim by
+    /// `decide_send_action`) in order, then release the claim so a future
+    /// caller can spawn again. Delivery happens on a spawned background
+    /// task (see the function's own doc comment), so this must actually
+    /// wait for it rather than asserting immediately.
+    #[tokio::test]
+    async fn release_spawn_claim_and_drain_queue_delivers_everything_on_success() {
         let c = controller();
         let (tx, mut rx) = mpsc::channel::<String>(8);
         {
@@ -2184,41 +2213,52 @@ mod send_input_tests {
             inner.pending_send_messages.push_back("second".to_string());
         }
 
-        c.release_spawn_claim_and_drain_queue();
+        c.release_spawn_claim_and_drain_queue(true);
 
-        assert_eq!(rx.try_recv().unwrap(), "first");
-        assert_eq!(rx.try_recv().unwrap(), "second");
-        assert!(rx.try_recv().is_err(), "no extra deliveries");
+        assert_eq!(rx.recv().await.unwrap(), "first");
+        assert_eq!(rx.recv().await.unwrap(), "second");
+
+        // Give the background drain task its final iteration (observing
+        // the now-empty queue and releasing the claim) a chance to run.
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
         let inner = c.inner.lock().unwrap();
         assert!(!inner.spawning_in_progress, "claim must be released once fully drained");
         assert!(inner.pending_send_messages.is_empty());
     }
 
-    /// Edge case: if the spawn this drain follows actually failed,
-    /// `stdin_tx` stays `None` — the drain must still release the claim
-    /// (or no future caller could ever spawn again) WITHOUT discarding
-    /// whatever is still queued, so a future successful spawn can deliver
-    /// it instead of the message being silently lost.
+    /// codex P1 on PR #2360 (sixth review pass): a FAILED spawn must
+    /// discard only the front item — the caller's own message, which
+    /// `send_message`/`retry_after_resume_failure` already reported as a
+    /// failure to their own caller — not leave it queued for an unrelated
+    /// later spawn to silently execute. Anything ELSE queued behind it
+    /// (from other callers who got `SendAction::Queued` and were already
+    /// told "accepted") must survive, for that next spawn to deliver.
     #[test]
-    fn release_spawn_claim_and_drain_queue_preserves_queue_when_spawn_failed() {
+    fn release_spawn_claim_and_drain_queue_discards_only_the_failed_spawners_own_message() {
         let c = controller();
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back("stuck".to_string());
+            inner.pending_send_messages.push_back("the-one-that-failed".to_string());
+            inner.pending_send_messages.push_back("queued-by-someone-else".to_string());
         }
 
-        c.release_spawn_claim_and_drain_queue();
+        c.release_spawn_claim_and_drain_queue(false);
 
         let inner = c.inner.lock().unwrap();
         assert!(
             !inner.spawning_in_progress,
-            "claim must still be released even when there was nothing to deliver to"
+            "claim must still be released even though the spawn failed"
         );
         assert_eq!(
             inner.pending_send_messages.len(),
             1,
-            "message must be left queued, not silently discarded, when there was no process to deliver to"
+            "only the failed spawner's own (front) message must be discarded"
+        );
+        assert_eq!(
+            inner.pending_send_messages[0],
+            "queued-by-someone-else",
+            "a message queued by a DIFFERENT caller (already told \"accepted\") must survive for the next spawn"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -1203,11 +1203,37 @@ impl PersistentSubprocessController {
         if inner.stdin_tx.is_some() && !inner.spawning_in_progress {
             SendAction::DeliverDirect
         } else if inner.spawning_in_progress {
-            if !inner.pending_send_messages.iter().any(|m| m == first) {
-                inner.pending_send_messages.push_back(QueuedMessage::already_persisted(first.to_string()));
-            }
-            for msg in rest {
-                inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg.clone()));
+            // codex P2 on PR #2360 (sixth review pass, round 11): prepend
+            // rather than append. This retry batch represents messages
+            // that were accepted by the doomed process BEFORE whatever's
+            // currently sitting in the queue — anything already queued
+            // here arrived AFTER the original spawn had already claimed
+            // `spawning_in_progress`, so it's chronologically LATER than
+            // this batch. Appending would let the fresh process receive
+            // later-arriving input before this earlier-accepted batch.
+            //
+            // `first` may itself STILL be sitting in the queue (see
+            // `decide_send_action`'s doc comment on `skip_if_already_
+            // queued`) — always at index 0 if so, since it's the ONLY
+            // thing ever present when a claim starts and nothing but
+            // `push_back` ever touches this queue elsewhere. In that
+            // case `rest` belongs immediately after it (same batch,
+            // preserving order), not ahead of it.
+            let first_already_queued = inner.pending_send_messages.iter().any(|m| m == first);
+            if first_already_queued {
+                for (i, msg) in rest.iter().enumerate() {
+                    inner
+                        .pending_send_messages
+                        .insert(i + 1, QueuedMessage::already_persisted(msg.clone()));
+                }
+            } else {
+                let mut front: VecDeque<QueuedMessage> = VecDeque::new();
+                front.push_back(QueuedMessage::already_persisted(first.to_string()));
+                for msg in rest {
+                    front.push_back(QueuedMessage::already_persisted(msg.clone()));
+                }
+                front.append(&mut inner.pending_send_messages);
+                inner.pending_send_messages = front;
             }
             SendAction::Queued
         } else {
@@ -3327,6 +3353,36 @@ mod send_input_tests {
             inner.pending_send_messages.iter().cloned().collect::<Vec<_>>(),
             vec!["first".to_string(), "second".to_string()],
             "the already-queued first entry must not be duplicated, but the rest of the batch must still be appended"
+        );
+    }
+
+    /// codex P2 on PR #2360 (sixth review pass, round 11): the retry
+    /// batch represents content the doomed process accepted BEFORE
+    /// whatever's already sitting in the queue (which arrived AFTER the
+    /// original spawn claimed `spawning_in_progress`) — it must be
+    /// delivered first on the fresh process, not appended behind
+    /// later-arriving input.
+    #[test]
+    fn decide_retry_batch_action_prepends_ahead_of_an_unrelated_later_message() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            // "later-message" arrived after the original spawn's claim
+            // started, while the retry's own trigger ("A") had already
+            // been popped and delivered (and is no longer in the queue —
+            // it's now tracked only in the confirmed retry batch).
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("later-message".to_string()));
+        }
+
+        let action = c.decide_retry_batch_action("A", &[]);
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.iter().cloned().collect::<Vec<_>>(),
+            vec!["A".to_string(), "later-message".to_string()],
+            "the retry's own (chronologically earlier) message must precede the later, unrelated one"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -670,17 +670,25 @@ impl PersistentSubprocessController {
     ///   the caller must then call `spawn_process` and, regardless of
     ///   outcome, call `release_spawn_claim_and_drain_queue`.
     ///
-    /// `skip_if_already_queued` — always `false` for a genuine new message
-    /// (`send_message`): a user legitimately re-sending the exact same
-    /// text while an unrelated spawn is in flight must still queue both,
-    /// so this must never dedup by content there. `true` only for
-    /// `retry_after_resume_failure`, whose `json_str` is a KNOWN re-
-    /// delivery of content that may ALREADY be sitting in
-    /// `pending_send_messages` — pushed by the very spawn attempt whose
-    /// failure triggered this retry, if that spawn's own drain hasn't
-    /// reached it yet. codex P1 on PR #2360 (sixth review pass, round 4):
-    /// blindly queueing another copy there let a fallback spawn eventually
-    /// deliver the same prompt twice.
+    /// `skip_if_already_queued` — always `false` for the sole production
+    /// call site (`send_message`): a user legitimately re-sending the
+    /// exact same text while an unrelated spawn is in flight must still
+    /// queue both, so this must never dedup by content there.
+    ///
+    /// reagentx P2 on PR #2360 (round 16, commit ce1642d90): `true` is NOT
+    /// exercised by any production call site — `retry_after_resume_
+    /// failure` was refactored (round 6) to use `decide_retry_batch_
+    /// action` instead, a separate function with its own atomic,
+    /// batch-aware dedup/prepend logic (see that function's own doc
+    /// comment). The `true` path here now only exists for this file's own
+    /// unit tests, which document the exact scenario `decide_retry_batch_
+    /// action`'s own dedup check handles for a batch instead: codex P1 on
+    /// PR #2360 (sixth review pass, round 4) — a KNOWN re-delivery of
+    /// content that may ALREADY be sitting in `pending_send_messages`,
+    /// pushed by the very spawn attempt whose failure triggered a retry,
+    /// if that spawn's own drain hasn't reached it yet; blindly queueing
+    /// another copy there let a fallback spawn eventually deliver the
+    /// same prompt twice.
     fn decide_send_action(&self, json_str: &str, skip_if_already_queued: bool) -> SendAction {
         let mut inner = self.inner.lock().unwrap();
         if inner.stdin_tx.is_some() && !inner.spawning_in_progress {

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -233,6 +233,35 @@ struct PersistentInner {
     stdin_tx: Option<mpsc::Sender<String>>,
     /// Handle to kill the process.
     kill_tx: Option<tokio::sync::oneshot::Sender<bool>>,
+    /// Monotonic counter bumped once per `spawn_process` call (in the same
+    /// lock acquisition as stashing `pending_resume_retry`), uniquely
+    /// identifying that one spawn attempt for the rest of this controller
+    /// instance's lifetime. Note this is NOT the `spawn_epoch`/
+    /// `should_skip_own_delivery` mechanism removed earlier in this same
+    /// PR (see `spawning_in_progress`'s own doc comment) — that existed to
+    /// dedup a spawn-claim race, a job `spawning_in_progress` now fully
+    /// owns. This counter exists for a different, narrower purpose: giving
+    /// `stop_requested_generation` something stable to compare against.
+    spawn_generation: u64,
+    /// codex P1 on PR #2360 (round 16, commit ce1642d90): `stop_process`
+    /// can race a process that already exited (a confirmed stale-`--resume`
+    /// death) and is about to be silently retried — sending through
+    /// `kill_tx` is futile in that window regardless of whether it's
+    /// already `None` (the exit-handler cleared it) or still `Some`
+    /// (`tokio::select!` already committed to the `child.wait()` exit arm
+    /// before this call reached the lock, so the `kill_rx` arm will never
+    /// be polled again even if the send succeeds). Without an independent
+    /// signal, the exit-handler's retry decision has no way to know the
+    /// user explicitly asked to stop, and respawns a fresh CLI process
+    /// with the same prompt anyway — an explicit Stop that doesn't
+    /// actually stop anything. Set to the CURRENT `spawn_generation`
+    /// whenever `stop_process` runs (see its own doc comment); the
+    /// exit-handler compares this against the generation IT was spawned
+    /// with before deciding whether to retry, consuming (clearing) it
+    /// either way so it can never spuriously affect a later, different
+    /// generation — monotonic generation numbers are never reused, so an
+    /// unconsumed stale value here is inert, not a leak.
+    stop_requested_generation: Option<u64>,
     /// AskUserQuestion `can_use_tool` control_requests awaiting a user answer:
     /// `tool_use_id -> (request_id, questions JSON)`. Filled by the stdout
     /// reader when the CLI sends a `can_use_tool` control_request for
@@ -288,6 +317,21 @@ impl PersistentInner {
         self.pending_resume_retry = None;
         self.confirmed_stale_resume_retry = None;
         true
+    }
+
+    /// Returns `true` (and clears `stop_requested_generation`) if a stop
+    /// was requested for THIS exact spawn generation — see that field's
+    /// own doc comment for why `kill_tx` alone can't be trusted to signal
+    /// this. Extracted as its own method (mirroring `poison_resume`/
+    /// `try_capture_session_id` above) so this decision is directly unit
+    /// testable without needing a real child process exit.
+    fn consume_stop_requested_for_generation(&mut self, generation: u64) -> bool {
+        if self.stop_requested_generation == Some(generation) {
+            self.stop_requested_generation = None;
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -447,6 +491,8 @@ impl PersistentSubprocessController {
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
+                spawn_generation: 0,
+                stop_requested_generation: None,
                 pending_questions: HashMap::new(),
             })),
             broker,
@@ -1731,12 +1777,16 @@ impl PersistentSubprocessController {
         // held in `inner.session_id` once an earlier call has already
         // hydrated it) so `poison_resume`'s later confirmation check is
         // unambiguous.
-        {
+        // Bumped in this SAME lock acquisition — see `spawn_generation`'s
+        // own doc comment for what this identifies and why.
+        let my_generation = {
             let mut inner = self.inner.lock().unwrap();
             if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
                 inner.pending_resume_retry = Some((sid, config.clone(), vec![retry_json]));
             }
-        }
+            inner.spawn_generation += 1;
+            inner.spawn_generation
+        };
 
         let pid = child.id().unwrap_or(0);
 
@@ -2097,6 +2147,9 @@ impl PersistentSubprocessController {
         // detached task call back into an instance method once the process
         // actually exits, to transparently retry a stale-`--resume` failure.
         let self_ref_wait = self.self_ref.lock().unwrap().clone().unwrap_or_default();
+        // This exact spawn's identity — see `stop_requested_generation`'s
+        // doc comment for why the retry decision below needs it.
+        let my_generation_wait = my_generation;
 
         tokio::spawn(async move {
             tokio::select! {
@@ -2198,6 +2251,12 @@ impl PersistentSubprocessController {
                     // unrelated later lifetime.
                     let retry_after_resume = inner.confirmed_stale_resume_retry.take();
                     inner.pending_resume_retry = None;
+                    // codex P1 on PR #2360 (round 16, commit ce1642d90): a
+                    // stop meant for THIS exact spawn generation must
+                    // override a pending retry — see `stop_requested_
+                    // generation`'s own doc comment for why `kill_tx` alone
+                    // can't be trusted to signal this.
+                    let stop_was_requested = inner.consume_stop_requested_for_generation(my_generation_wait);
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
 
@@ -2235,6 +2294,20 @@ impl PersistentSubprocessController {
                     // status ever lands. reagentx/codex never reviewed this
                     // controller type in PR #2338 (see docs/retros/
                     // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md).
+                    // codex P1 on PR #2360 (round 16): an explicit stop
+                    // must win over a pending retry — treat it exactly
+                    // like "genuinely done, not retrying" below instead of
+                    // silently reviving the agent with the same prompt
+                    // right after the user asked it to stop.
+                    let retry_after_resume = if stop_was_requested {
+                        tracing::info!(
+                            block_id = %block_id_wait,
+                            "stop was requested while a stale-resume retry was pending — honoring the stop instead"
+                        );
+                        None
+                    } else {
+                        retry_after_resume
+                    };
                     if let Some((_attempted_sid, retry_config, retry_json)) = retry_after_resume {
                         if let Some(ctrl) = self_ref_wait.upgrade() {
                             tracing::warn!(
@@ -2361,15 +2434,17 @@ impl PersistentSubprocessController {
     pub fn stop_process(&self, force: bool) -> Result<(), String> {
         let kill_tx = {
             let mut inner = self.inner.lock().unwrap();
+            // Recorded unconditionally, not only when `kill_tx` is already
+            // `None` — see `stop_requested_generation`'s own doc comment
+            // for why a `Some(kill_tx)` here doesn't guarantee the send
+            // below actually reaches anything.
+            inner.stop_requested_generation = Some(inner.spawn_generation);
             inner.kill_tx.take()
         };
-        match kill_tx {
-            Some(tx) => {
-                let _ = tx.send(force);
-                Ok(())
-            }
-            None => Ok(()),
+        if let Some(tx) = kill_tx {
+            let _ = tx.send(force);
         }
+        Ok(())
     }
 
     pub fn session_id(&self) -> Option<String> {
@@ -2471,6 +2546,30 @@ mod send_input_tests {
             None,
             None,
         )
+    }
+
+    // codex P1 on PR #2360 (round 16, commit ce1642d90): `stop_process`
+    // must record which generation a stop was requested for even when
+    // there's no live `kill_tx` to send through — see
+    // `stop_requested_generation`'s own doc comment for why a `kill_tx`
+    // send alone can't be trusted (the process-waiter's `tokio::select!`
+    // can have already committed to its exit branch before this call
+    // reaches the lock, making the send futile even when `kill_tx` was
+    // still `Some`). Simulates the exact race here via no `kill_tx` at all
+    // (the narrower, always-reachable sub-case).
+    #[test]
+    fn stop_process_records_the_current_generation_even_with_no_live_kill_tx() {
+        let c = controller();
+        c.inner.lock().unwrap().spawn_generation = 3;
+        // kill_tx stays None — the process already exited (or never
+        // started); stop_process must still succeed and record intent.
+        let result = c.stop_process(false);
+        assert!(result.is_ok(), "must still return Ok when there's nothing live to signal");
+        assert_eq!(
+            c.inner.lock().unwrap().stop_requested_generation,
+            Some(3),
+            "must record a signal the exit-handler can check even with no live kill_tx to send through"
+        );
     }
 
     // A persistent controller has no PTY, but the agent pane's usePtyWidth hook
@@ -3842,6 +3941,8 @@ mod resume_poison_tests {
             current_pid: None,
             stdin_tx: None,
             kill_tx: None,
+            spawn_generation: 0,
+            stop_requested_generation: None,
             pending_questions: HashMap::new(),
         }
     }
@@ -3905,6 +4006,35 @@ mod resume_poison_tests {
         let captured = inner.try_capture_session_id("second-sid");
         assert!(!captured, "must not overwrite an already-captured session id");
         assert_eq!(inner.session_id.as_deref(), Some("first-sid"));
+    }
+
+    // codex P1 on PR #2360 (round 16, commit ce1642d90): the exit-handler's
+    // retry decision needs to recognize a stop requested for its EXACT
+    // generation and consume it exactly once.
+    #[test]
+    fn consume_stop_requested_for_generation_matches_and_clears() {
+        let mut inner = inner_with_session_id(None);
+        inner.stop_requested_generation = Some(5);
+        assert!(inner.consume_stop_requested_for_generation(5));
+        assert_eq!(
+            inner.stop_requested_generation, None,
+            "must clear once consumed so it can never spuriously affect a later generation"
+        );
+    }
+
+    // A stop recorded for a DIFFERENT generation (e.g. an older process
+    // that already finished handling it, or a not-yet-reached later one)
+    // must not be consumed or affect this one.
+    #[test]
+    fn consume_stop_requested_for_generation_ignores_a_mismatched_generation() {
+        let mut inner = inner_with_session_id(None);
+        inner.stop_requested_generation = Some(5);
+        assert!(!inner.consume_stop_requested_for_generation(7));
+        assert_eq!(
+            inner.stop_requested_generation,
+            Some(5),
+            "an unmatched generation must be left untouched, not discarded"
+        );
     }
 
     // reagentx/codex never reviewed this path (PR #2338's review surface was

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -210,6 +210,24 @@ struct PersistentInner {
     /// spawn or arrived while someone else's spawn was already in flight.
     /// Drained by `release_spawn_claim_and_drain_queue`.
     pending_send_messages: VecDeque<QueuedMessage>,
+    /// True while the drain (`drain_queue_after_successful_spawn`) is
+    /// between successfully sending a message on the live stdin channel
+    /// and finishing its OWN follow-up append of that message into
+    /// `pending_resume_retry`/`confirmed_stale_resume_retry` — see
+    /// `pending_resume_retry`'s own doc comment for why that append
+    /// exists. reagentx P1 on PR #2360 (sixth review pass, round 9): the
+    /// `Sender::send().await` and that follow-up append are two separate
+    /// lock acquisitions with an unavoidable gap between them (a mutex
+    /// can't be held across an `.await`). Without this flag, the
+    /// process-waiter's own exit-handling — running concurrently on a
+    /// DIFFERENT task — could `.take()` the confirmed retry batch in that
+    /// exact gap, dispatching a retry that's missing a message the doomed
+    /// process's channel had ALREADY accepted: the message stays marked
+    /// "accepted" and gets persisted, but is never actually delivered to
+    /// any process again. The exit-handling waits (briefly, bounded) for
+    /// this to go false before deciding the retry batch is final — see
+    /// its own comment at the `.take()` call site.
+    drain_send_in_flight: bool,
     current_pid: Option<u32>,
     /// Channel to send messages to the stdin writer task.
     stdin_tx: Option<mpsc::Sender<String>>,
@@ -425,6 +443,7 @@ impl PersistentSubprocessController {
                 confirmed_stale_resume_retry: None,
                 spawning_in_progress: false,
                 pending_send_messages: VecDeque::new(),
+                drain_send_in_flight: false,
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
@@ -753,6 +772,15 @@ impl PersistentSubprocessController {
                 let delivered_copy = json_str.clone();
                 let was_first_delivery = is_first_delivery;
                 is_first_delivery = false;
+                // reagentx P1 on PR #2360 (sixth review pass, round 9):
+                // mark "in flight" for the ENTIRE send-then-append
+                // sequence below, not just the send — see
+                // `PersistentInner::drain_send_in_flight`'s own doc
+                // comment for the race this closes (the process-waiter's
+                // exit-handling can `.take()` the confirmed retry batch
+                // in the gap between a successful send and this task
+                // getting back around to recording it there).
+                inner_arc.lock().unwrap().drain_send_in_flight = true;
                 if let Err(e) = tx.send(json_str).await {
                     tracing::warn!(
                         block_id = %block_id,
@@ -763,6 +791,7 @@ impl PersistentSubprocessController {
                     // silently discarding it) for a future spawn to pick
                     // up. Same claim-retention rule as above.
                     let mut inner = inner_arc.lock().unwrap();
+                    inner.drain_send_in_flight = false;
                     inner.pending_send_messages.push_front(QueuedMessage { json_str: e.0, already_persisted });
                     let stalled = !inner.pending_send_messages.is_empty();
                     if !(stalled && allow_fallback_respawn) {
@@ -794,6 +823,7 @@ impl PersistentSubprocessController {
                         delivered.push(delivered_copy.clone());
                     }
                 }
+                inner_arc.lock().unwrap().drain_send_in_flight = false;
                 // Persist in actual delivery order — codex P2 on PR #2360
                 // (sixth review pass, round 5): persisting at the
                 // `decide_send_action` call site instead let two callers'
@@ -1965,6 +1995,29 @@ impl PersistentSubprocessController {
                         }
                     }
 
+                    // Wait (briefly, bounded) for the drain to finish
+                    // appending whatever message it's currently
+                    // mid-delivery on before deciding the retry batch
+                    // below is final — reagentx P1 on PR #2360 (sixth
+                    // review pass, round 9): `drain_queue_after_
+                    // successful_spawn`'s own "send, then append to the
+                    // retry batch" sequence has an unavoidable gap at the
+                    // `.await` (a mutex can't be held across it). Without
+                    // this wait, the `.take()` below could run in that
+                    // exact gap and dispatch a retry missing a message
+                    // the doomed process's channel had ALREADY accepted —
+                    // it stays marked "accepted" and gets persisted, but
+                    // is never actually delivered to any process again.
+                    // Same 500ms bound as the stderr-reader wait above,
+                    // for the same "best effort, don't hang forever"
+                    // reason.
+                    for _ in 0..50 {
+                        if !inner_wait.lock().unwrap().drain_send_in_flight {
+                            break;
+                        }
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+
                     // Notify health monitor so Stalled/Dead watchdog stops.
                     health_wait.set_exited(exit_code);
 
@@ -2482,6 +2535,39 @@ mod send_input_tests {
             "awaiting the handle must observe the task's side effect having already happened, \
              not race ahead of it"
         );
+    }
+
+    /// Confirms the bounded-wait PRIMITIVE the process-waiter's
+    /// exit-handling relies on before deciding a confirmed stale-resume
+    /// retry batch is final — reagentx P1 on PR #2360 (sixth review pass,
+    /// round 9): it polls `drain_send_in_flight` every 10ms, bounded to
+    /// 500ms, so a flag that clears shortly after being observed `true`
+    /// must still be correctly picked up within the window (not missed by
+    /// a single stale read). The full cross-task race this guards against
+    /// isn't practical to reproduce deterministically (same reasoning as
+    /// this file's other cross-task timing fixes — see e.g. the
+    /// stderr-reader bound above), so this exercises the underlying
+    /// polling primitive directly.
+    #[tokio::test]
+    async fn a_flag_clearing_shortly_after_is_observed_by_a_bounded_polling_wait() {
+        let c = Arc::new(controller());
+        c.inner.lock().unwrap().drain_send_in_flight = true;
+
+        let c2 = Arc::clone(&c);
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            c2.inner.lock().unwrap().drain_send_in_flight = false;
+        });
+
+        let mut cleared = false;
+        for _ in 0..50 {
+            if !c.inner.lock().unwrap().drain_send_in_flight {
+                cleared = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(cleared, "the bounded wait must observe the flag clearing within its window");
     }
 
     /// Baseline: a message sent while the process is already running is
@@ -3102,6 +3188,10 @@ mod send_input_tests {
             .pending_resume_retry
             .as_ref()
             .expect("must still be tracking this spawn's delivered messages");
+        assert!(
+            !inner.drain_send_in_flight,
+            "must be cleared once the send-then-append sequence for the last message has fully completed"
+        );
         assert_eq!(
             delivered,
             &vec!["first".to_string(), "second".to_string()],
@@ -3237,6 +3327,7 @@ mod resume_poison_tests {
             confirmed_stale_resume_retry: None,
             spawning_in_progress: false,
             pending_send_messages: VecDeque::new(),
+            drain_send_in_flight: false,
             current_pid: None,
             stdin_tx: None,
             kill_tx: None,

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -657,19 +657,35 @@ impl PersistentSubprocessController {
     /// returning `BecomeSpawner`. `spawn_succeeded` distinguishes two very
     /// different situations:
     ///
-    /// - **Failed spawn**: discards only the front item of the queue —
-    ///   the caller's OWN message. This is guaranteed to be at the front:
-    ///   nothing else could have been queued before `spawning_in_progress`
-    ///   was set (see `decide_send_action`), and the queue is always empty
-    ///   at the moment a new spawner claims it (the previous claim only
-    ///   ever releases once fully drained). codex P1 on PR #2360 (sixth
-    ///   review pass): leaving this message queued let an unrelated LATER
-    ///   successful spawn silently execute a prompt the caller was already
-    ///   told had failed (`send_message`/`retry_after_resume_failure`
-    ///   already report the failure), sometimes duplicating a message the
-    ///   user had re-sent by hand. Anything queued AFTER it (from other
-    ///   callers who got `SendAction::Queued` and were already told
-    ///   "accepted") is left in place for the next successful spawn.
+    /// - **Failed spawn**: discards only `own_message` — the specific
+    ///   message THIS spawner pushed when it claimed `BecomeSpawner`, found
+    ///   by content match rather than assumed to be at the front. codex P2
+    ///   on PR #2360 (round 14, commit 8c2bc99ab): the queue is NOT always
+    ///   empty at the moment a new spawner claims it — the "second stall"
+    ///   path (`drain_queue_after_successful_spawn` with
+    ///   `allow_fallback_respawn: false`) deliberately releases
+    ///   `spawning_in_progress` while leaving genuinely leftover messages
+    ///   queued (see that function's own doc comment). A later
+    ///   `send_message` can then claim `BecomeSpawner` and `push_back` its
+    ///   own message BEHIND those leftovers. Assuming "front == my own
+    ///   message" in that case discarded an OLDER, unrelated, already-
+    ///   accepted prompt instead of the actually-failed one — silent data
+    ///   loss, plus handing the wrong (already-failed) message to the
+    ///   fallback respawn. Matching by content instead of position fixes
+    ///   this whenever the two differ, which is the overwhelming common
+    ///   case; the narrow residual case of two GENUINELY DIFFERENT messages
+    ///   sharing identical content (e.g. two "yes" replies) is the same
+    ///   content-identity-ambiguity gap already tracked in #2365 — this fix
+    ///   doesn't need to (and doesn't try to) close that, since either
+    ///   duplicate is content-equivalent to discard here. codex P1 on PR
+    ///   #2360 (sixth review pass): leaving this message queued let an
+    ///   unrelated LATER successful spawn silently execute a prompt the
+    ///   caller was already told had failed (`send_message`/
+    ///   `retry_after_resume_failure` already report the failure),
+    ///   sometimes duplicating a message the user had re-sent by hand.
+    ///   Anything else queued (from other callers who got
+    ///   `SendAction::Queued` and were already told "accepted") is left in
+    ///   place for the next successful spawn.
     /// - **Successful spawn**: hands the drain off to a background task
     ///   that delivers everything queued, in order, via `Sender::send`
     ///   (which awaits free capacity) rather than `try_send`. codex P2 on
@@ -694,14 +710,14 @@ impl PersistentSubprocessController {
     /// frontend the turn ended — the ORIGINAL exit deliberately suppressed
     /// its own terminal-status publish expecting the retry to eventually
     /// publish one.
-    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool, retry_config: PersistentSpawnConfig) {
+    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool, retry_config: PersistentSpawnConfig, own_message: &str) {
         if !spawn_succeeded {
-            // Discard only the front item — the caller's OWN message (see
-            // this function's own doc comment above for why it's
-            // guaranteed to be at the front). If anything else is queued
-            // behind it (from other callers already told "accepted"),
-            // hand off to a bounded fallback respawn rather than
-            // stranding it with nobody responsible for delivering it.
+            // Discard only `own_message` — see this function's own doc
+            // comment above for why position (front) is not a safe
+            // assumption. If anything else is queued (from other callers
+            // already told "accepted"), hand off to a bounded fallback
+            // respawn rather than stranding it with nobody responsible for
+            // delivering it.
             //
             // codex P2 on PR #2360 (round 13, commit e9678091f): clearing
             // `spawning_in_progress` in a SEPARATE, later lock acquisition
@@ -720,7 +736,16 @@ impl PersistentSubprocessController {
             // leave the claim held and hand off to the fallback respawn.
             let leftovers = {
                 let mut inner = self.inner.lock().unwrap();
-                inner.pending_send_messages.pop_front();
+                if let Some(idx) = inner.pending_send_messages.iter().position(|m| m == own_message) {
+                    inner.pending_send_messages.remove(idx);
+                } else {
+                    // Shouldn't normally happen — defensively log rather
+                    // than guess which OTHER entry to discard instead.
+                    tracing::warn!(
+                        block_id = %self.block_id,
+                        "failed spawn's own message was not found in the queue to discard"
+                    );
+                }
                 if inner.pending_send_messages.is_empty() {
                     inner.spawning_in_progress = false;
                     false
@@ -1069,6 +1094,7 @@ impl PersistentSubprocessController {
                 // `--resume`, which is what the retry payload is for.
                 let message_id = config.message_id.clone();
                 let retry_config = config.clone();
+                let own_message = json_str.clone();
                 let spawn_result = self.spawn_process(config, Some(json_str));
                 // Only emit "accepted" on success — codex P2 on PR #2360
                 // (sixth review pass, round 4): an earlier cut of this fix
@@ -1085,7 +1111,7 @@ impl PersistentSubprocessController {
                     self.mark_turn_active_and_publish();
                     self.emit_message_accepted(message_id.as_deref());
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config, &own_message);
                 spawn_result
             }
         }
@@ -1222,7 +1248,7 @@ impl PersistentSubprocessController {
                         "failed to respawn after a stale --resume session id"
                     ),
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config, &first);
                 if spawn_result.is_err() {
                     // Surface this, or the pane hangs forever with NO
                     // signal at all — codex P2 on PR #2360 (fifth review
@@ -3055,8 +3081,9 @@ mod send_input_tests {
         }
 
         // Never used for a fallback spawn in this test — the drain fully
-        // succeeds without ever stalling.
-        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config());
+        // succeeds without ever stalling. `own_message` is only consulted
+        // on the failed-spawn path, so its value doesn't matter here.
+        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config(), "first");
 
         assert_eq!(rx.recv().await.unwrap(), "first");
         assert_eq!(rx.recv().await.unwrap(), "second");
@@ -3123,7 +3150,7 @@ mod send_input_tests {
             // spawning for having already died before the drain ran.
         }
 
-        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config());
+        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config(), "stuck-one");
         // Let the spawned background task, and the fallback respawn
         // attempt it triggers, run to completion.
         tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
@@ -3166,7 +3193,7 @@ mod send_input_tests {
             inner.pending_send_messages.push_back(QueuedMessage::fresh("queued-by-someone-else".to_string()));
         }
 
-        c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config());
+        c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config(), "the-one-that-failed");
 
         let inner = c.inner.lock().unwrap();
         assert!(
@@ -3182,6 +3209,51 @@ mod send_input_tests {
             inner.pending_send_messages[0],
             "queued-by-someone-else",
             "a message queued by a DIFFERENT caller (already told \"accepted\") must survive for the next spawn"
+        );
+    }
+
+    /// codex P2 on PR #2360 (round 14, commit 8c2bc99ab): the queue is NOT
+    /// always empty at the moment a new spawner claims `BecomeSpawner` — the
+    /// "second stall" path (`drain_queue_after_successful_spawn` with
+    /// `allow_fallback_respawn: false`) deliberately releases
+    /// `spawning_in_progress` while leaving genuine leftover messages
+    /// queued. A later `send_message` can then claim `BecomeSpawner` and
+    /// `push_back` its own message BEHIND those leftovers — so the failed
+    /// spawner's own message is NOT at the front. Confirms
+    /// `release_spawn_claim_and_drain_queue`'s failed-spawn path finds and
+    /// discards the correct (content-matched) entry regardless of where it
+    /// sits, instead of assuming the front and silently destroying an
+    /// older, unrelated, already-accepted prompt.
+    #[test]
+    fn release_spawn_claim_and_drain_queue_discards_the_right_entry_when_it_is_not_at_the_front() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            // Simulates leftovers surviving a prior "second stall" release
+            // (queue non-empty, claim already given up by that path) plus a
+            // later BecomeSpawner appending its own message behind them.
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("older-leftover-from-a-different-caller".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh("this-spawners-own-message-that-just-failed".to_string()));
+        }
+
+        c.release_spawn_claim_and_drain_queue(
+            false,
+            unreachable_fallback_config(),
+            "this-spawners-own-message-that-just-failed",
+        );
+
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            1,
+            "only the actually-failed spawner's own message must be discarded"
+        );
+        assert_eq!(
+            inner.pending_send_messages[0],
+            "older-leftover-from-a-different-caller",
+            "an older, unrelated, already-accepted prompt must survive — not be silently destroyed \
+             because it happened to be sitting at the front"
         );
     }
 
@@ -3233,7 +3305,7 @@ mod send_input_tests {
                 })
                 .collect();
 
-            c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config());
+            c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config(), "the-one-that-failed");
 
             for h in handles {
                 h.join().unwrap();

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -138,10 +138,24 @@ struct PersistentInner {
     resume_poisoned: Option<String>,
     /// TENTATIVE: set synchronously inside `spawn_process`, before any
     /// background task exists, right after a FRESH spawn attaches
-    /// `--resume <sid>` — captures the exact spawn config + already-
-    /// formatted stdin line for the message that triggered it. This alone
-    /// does NOT mean a retry will happen: it only means "IF the CLI goes on
-    /// to confirm this exact sid unreachable, here is what to retry."
+    /// `--resume <sid>` — captures the exact spawn config + the already-
+    /// formatted stdin line for the message that triggered it, as the
+    /// first entry of a growing list. This alone does NOT mean a retry
+    /// will happen: it only means "IF the CLI goes on to confirm this
+    /// exact sid unreachable, here is what to retry."
+    ///
+    /// The list, not a single line: codex P1 on PR #2360 (sixth review
+    /// pass, round 5): once other callers can queue additional messages
+    /// behind this same spawn attempt (see `spawning_in_progress`), the
+    /// background drain (`drain_queue_after_successful_spawn`) can
+    /// successfully hand SEVERAL of them to this process's stdin channel
+    /// before it turns out to be doomed — the channel accepting a message
+    /// is not proof the CLI ever read it. Tracking only the first would
+    /// silently lose every later-accepted input the moment this process
+    /// dies; the drain appends each one it delivers here (while this is
+    /// still `Some`) so a confirmed retry can redeliver ALL of them, in
+    /// order, on the fresh respawn.
+    ///
     /// `poison_resume` is what promotes this to `confirmed_stale_resume_retry`
     /// (the only thing the process-waiter task actually acts on) — see its
     /// doc comment for why the two are kept separate. Cleared by
@@ -151,7 +165,7 @@ struct PersistentInner {
     /// anymore; also cleared on kill and on a normal exit so a reused
     /// controller instance never carries a tentative retry into an
     /// unrelated later lifetime.
-    pending_resume_retry: Option<(String, PersistentSpawnConfig, String)>,
+    pending_resume_retry: Option<(String, PersistentSpawnConfig, Vec<String>)>,
     /// CONFIRMED: only `poison_resume` ever sets this, and only when the
     /// sid it just confirmed unreachable is the exact one
     /// `pending_resume_retry` was captured for. This is the ONLY field the
@@ -164,7 +178,7 @@ struct PersistentInner {
     /// have seen instead of the confirmed case this mechanism exists for.
     /// Cleared on kill and on a normal exit for the same
     /// reused-instance reason as `pending_resume_retry`.
-    confirmed_stale_resume_retry: Option<(String, PersistentSpawnConfig, String)>,
+    confirmed_stale_resume_retry: Option<(String, PersistentSpawnConfig, Vec<String>)>,
     /// True from the moment a caller commits to calling `spawn_process`
     /// (in `send_message` or `retry_after_resume_failure`) until it has
     /// delivered every message enqueued for that spawn — see
@@ -654,6 +668,15 @@ impl PersistentSubprocessController {
         let block_id = self.block_id.clone();
         let self_ref = self.self_ref.lock().unwrap().clone().unwrap_or_default();
         tokio::spawn(async move {
+            // The very FIRST message this drain delivers is always the
+            // one that triggered the spawn — `spawn_process` already
+            // stashed it into `pending_resume_retry` synchronously,
+            // before this task even existed (necessary so a process that
+            // dies before this task's first poll can't lose it — see
+            // `pending_resume_retry`'s own doc comment). Appending it
+            // again below would duplicate that exact entry; only messages
+            // delivered AFTER it are genuinely new to the retry list.
+            let mut is_first_delivery = true;
             let stalled_with_leftovers = loop {
                 let next = {
                     let mut inner = inner_arc.lock().unwrap();
@@ -684,6 +707,9 @@ impl PersistentSubprocessController {
                     }
                     break stalled;
                 };
+                let delivered_copy = json_str.clone();
+                let was_first_delivery = is_first_delivery;
+                is_first_delivery = false;
                 if let Err(e) = tx.send(json_str).await {
                     tracing::warn!(
                         block_id = %block_id,
@@ -700,6 +726,29 @@ impl PersistentSubprocessController {
                         inner.spawning_in_progress = false;
                     }
                     break stalled;
+                }
+                // codex P1 on PR #2360 (sixth review pass, round 5): track
+                // every message actually handed to this process's stdin
+                // channel beyond the first — not just the one that
+                // triggered the spawn — so a confirmed stale-resume retry
+                // redelivers all of them (see `pending_resume_retry`'s own
+                // doc comment), since channel acceptance is not proof the
+                // CLI ever read it.
+                if !was_first_delivery {
+                    let mut inner = inner_arc.lock().unwrap();
+                    if let Some((_, _, ref mut delivered)) = inner.pending_resume_retry {
+                        delivered.push(delivered_copy.clone());
+                    }
+                }
+                // Persist in actual delivery order — codex P2 on PR #2360
+                // (sixth review pass, round 5): persisting at the
+                // `decide_send_action` call site instead let two callers'
+                // own synchronous code run (and thus persist) in a
+                // different order than their messages are actually
+                // delivered, producing a blockfile transcript that
+                // doesn't match what the agent received.
+                if let Some(ctrl) = self_ref.upgrade() {
+                    ctrl.persist_message_to_blockfile(&delivered_copy);
                 }
             };
             if stalled_with_leftovers {
@@ -808,12 +857,17 @@ impl PersistentSubprocessController {
 
         match self.decide_send_action(&json_str, false) {
             SendAction::Queued => {
-                // Persisted unconditionally: this caller was already told
-                // "accepted" (below) and a spawn/drain genuinely IS
-                // working through the queue this just joined, so — unlike
-                // the BecomeSpawner case — there is no "rejected before
-                // ever really being attempted" outcome to guard against.
-                self.persist_message_to_blockfile(&json_str);
+                // Persistence happens later, inside the drain, at the
+                // exact moment this message is actually delivered — see
+                // `drain_queue_after_successful_spawn`. codex P2 on PR
+                // #2360 (sixth review pass, round 5): persisting
+                // immediately here instead let whichever caller's
+                // synchronous code happened to run first persist first,
+                // even when queue position said a DIFFERENT message
+                // (already sitting there, from a caller further along in
+                // its own `BecomeSpawner` spawn_process call) is actually
+                // delivered first — producing a blockfile transcript that
+                // doesn't match delivery order.
                 self.emit_message_accepted(config.message_id.as_deref());
                 Ok(())
             }
@@ -860,20 +914,19 @@ impl PersistentSubprocessController {
                 // `--resume`, which is what the retry payload is for.
                 let message_id = config.message_id.clone();
                 let retry_config = config.clone();
-                let spawn_result = self.spawn_process(config, Some(json_str.clone()));
-                // Only persist/emit "accepted" on success — codex P2 on PR
-                // #2360 (sixth review pass, round 4): persisting
-                // unconditionally (an earlier cut of this fix did) let a
-                // rejected spawn (missing executable, bad launch config)
-                // leave a "user_message" line in the blockfile for a
-                // prompt that was NEVER actually delivered — reopening the
-                // pane would reconstruct it as if it had been sent, and a
-                // manual retry then produced a misleading duplicate.
-                // Matches this function's pre-queue behavior, which
-                // propagated a spawn failure via `?` before ever reaching
-                // either the persist or the "accepted" emission.
+                let spawn_result = self.spawn_process(config, Some(json_str));
+                // Only emit "accepted" on success — codex P2 on PR #2360
+                // (sixth review pass, round 4): an earlier cut of this fix
+                // persisted unconditionally here, letting a rejected spawn
+                // (missing executable, bad launch config) leave a
+                // "user_message" line in the blockfile for a prompt that
+                // was NEVER actually delivered. Persistence itself now
+                // happens later, inside the drain, at the exact moment
+                // this message is actually delivered (round 5 — see
+                // `drain_queue_after_successful_spawn`) — which already
+                // only runs on a successful spawn, so the same guarantee
+                // holds without needing a persist call here at all.
                 if spawn_result.is_ok() {
-                    self.persist_message_to_blockfile(&json_str);
                     self.mark_turn_active_and_publish();
                     self.emit_message_accepted(message_id.as_deref());
                 }
@@ -893,95 +946,104 @@ impl PersistentSubprocessController {
     /// unrelated exit.
     ///
     /// Spawns fresh with `session_id` cleared, so no `--resume` is attempted
-    /// again. Explicitly clears `inner.session_id` itself rather than
-    /// relying on `poison_resume` having already done so — reagentx P0 on PR
-    /// #2360: `poison_resume` runs on the stderr-reader task, this runs on
-    /// the process-waiter task; the two are independently scheduled with no
-    /// ordering guarantee, so this function cannot assume the former has
-    /// already completed by the time it runs. Redelivers the EXACT
-    /// already-formatted stdin line directly on the new process — does NOT
-    /// re-persist to the blockfile or re-emit `agent-message-accepted`,
-    /// since both already happened correctly on the original (failed)
-    /// attempt; only the underlying CLI process needed a fresh, resume-less
-    /// start.
-    fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_str: String) {
+    /// again. Redelivers EVERY message the doomed process's stdin channel
+    /// had accepted (see `pending_resume_retry`'s own doc comment for why
+    /// this is a batch, not just the one that triggered the spawn) — does
+    /// NOT re-persist to the blockfile or re-emit `agent-message-accepted`
+    /// for any of them, since both already happened correctly on each
+    /// message's original (failed) attempt; only the underlying CLI
+    /// process needed a fresh, resume-less start.
+    ///
+    /// This is itself a spawn attempt, and must not race a genuinely
+    /// concurrent `send_message` call the same way the ORIGINAL doomed
+    /// spawn could — see `PersistentInner::spawning_in_progress`'s doc
+    /// comment. By the time this runs, the original `send_message` call
+    /// that triggered the doomed process has long since returned (its own
+    /// spawn-claim-and-deliver sequence completed synchronously, well
+    /// before this process even exited), so each message here can safely
+    /// go through the SAME decision function `send_message` uses — with
+    /// dedup-by-content enabled (see `decide_send_action`'s doc comment),
+    /// since every entry in `json_strs` is a known re-delivery of content
+    /// already accepted for the ORIGINAL spawn, not an independent new
+    /// message. Only the FIRST message in the batch can ever resolve to
+    /// `BecomeSpawner` (it's the only one that can see
+    /// `spawning_in_progress == false`); everything after it necessarily
+    /// resolves to `Queued` (behind that same claim) or `DeliverDirect`
+    /// (if some OTHER caller's process happened to come up in the
+    /// meantime) — looping the exact same per-message decision naturally
+    /// preserves delivery order without needing special-case handling for
+    /// "the rest of the batch."
+    fn retry_after_resume_failure(&self, mut config: PersistentSpawnConfig, json_strs: Vec<String>) {
         config.session_id = String::new();
 
-        // This retry is itself a spawn attempt, and must not race a
-        // genuinely concurrent `send_message` call the same way the
-        // ORIGINAL doomed spawn could — see `PersistentInner::
-        // spawning_in_progress`'s doc comment. By the time this runs, the
-        // original `send_message` call that triggered the doomed process
-        // has long since returned (its own spawn-claim-and-deliver
-        // sequence completed synchronously, well before this process even
-        // exited), so this can safely go through the SAME decision
-        // function `send_message` uses — with dedup-by-content enabled
-        // (see `decide_send_action`'s doc comment), since `json_str` here
-        // is a known re-delivery of the ORIGINAL spawn's own payload, not
-        // an independent new message.
-        match self.decide_send_action(&json_str, true) {
-            SendAction::DeliverDirect => {
-                // Another caller's own spawn already installed a running
-                // process by the time this retry got scheduled — no need
-                // for a dedicated respawn; deliver straight to it.
-                self.mark_turn_active_and_publish();
-                let inner = self.inner.lock().unwrap();
-                if let Some(tx) = inner.stdin_tx.as_ref() {
-                    if let Err(e) = tx.try_send(json_str) {
-                        tracing::warn!(
-                            block_id = %self.block_id,
-                            error = %e,
-                            "failed to redeliver message after stale-resume retry (already-running path)"
-                        );
+        for json_str in json_strs {
+            match self.decide_send_action(&json_str, true) {
+                SendAction::DeliverDirect => {
+                    // Another caller's own spawn already installed a
+                    // running process by the time this retry got
+                    // scheduled — no need for a dedicated respawn; deliver
+                    // straight to it.
+                    self.mark_turn_active_and_publish();
+                    let inner = self.inner.lock().unwrap();
+                    if let Some(tx) = inner.stdin_tx.as_ref() {
+                        if let Err(e) = tx.try_send(json_str) {
+                            tracing::warn!(
+                                block_id = %self.block_id,
+                                error = %e,
+                                "failed to redeliver message after stale-resume retry (already-running path)"
+                            );
+                        }
                     }
                 }
-            }
-            SendAction::Queued => {
-                // Someone else is already spawning — their own
-                // `release_spawn_claim_and_drain_queue` will deliver this
-                // (or, if their process turns out to already be dead, its
-                // own bounded fallback respawn will).
-            }
-            SendAction::BecomeSpawner => {
-                // Only clear inner.session_id now that THIS retry is
-                // actually about to spawn — codex P2 on PR #2360 (sixth
-                // review pass, round 3): clearing it unconditionally at
-                // the top of this function (the previous cut) could erase
-                // a session id a DIFFERENT, concurrently-installed process
-                // had already legitimately captured, if this retry
-                // instead resolved via `DeliverDirect` or `Queued` above —
-                // breaking in-memory session tracking and turn-end
-                // subagent reconciliation for that process's remaining
-                // lifetime.
-                self.inner.lock().unwrap().session_id = None;
-                let retry_config = config.clone();
-                let spawn_result = self.spawn_process(config, None);
-                match &spawn_result {
-                    Ok(_) => self.mark_turn_active_and_publish(),
-                    Err(e) => tracing::error!(
-                        block_id = %self.block_id,
-                        error = %e,
-                        "failed to respawn after a stale --resume session id"
-                    ),
+                SendAction::Queued => {
+                    // Someone else is already spawning — their own
+                    // `release_spawn_claim_and_drain_queue` will deliver
+                    // this (or, if their process turns out to already be
+                    // dead, its own bounded fallback respawn will).
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
-                if spawn_result.is_err() {
-                    // Surface this, or the pane hangs forever with NO
-                    // signal at all — codex P2 on PR #2360 (fifth review
-                    // pass): the outer process-waiter already suppressed
-                    // its own terminal-status publish for the ORIGINAL
-                    // exit specifically because a retry was in flight, and
-                    // send_message already returned success (possibly
-                    // emitting agent-message-accepted) for the message
-                    // this retry was supposed to deliver. If this respawn
-                    // attempt ALSO fails, nothing else will ever tell the
-                    // frontend this turn is over. `inner.proc_status`/
-                    // `turn_active` are already `STATUS_DONE`/`false` (set
-                    // by the original exit's own cleanup before this
-                    // function was ever called) — this just actually
-                    // broadcasts that state, which the original exit
-                    // deliberately withheld pending this retry's outcome.
-                    self.publish_status();
+                SendAction::BecomeSpawner => {
+                    // Only clear inner.session_id now that THIS retry is
+                    // actually about to spawn — codex P2 on PR #2360
+                    // (sixth review pass, round 3): clearing it
+                    // unconditionally up front could erase a session id a
+                    // DIFFERENT, concurrently-installed process had
+                    // already legitimately captured, if this retry
+                    // instead resolved via `DeliverDirect` or `Queued`
+                    // above — breaking in-memory session tracking and
+                    // turn-end subagent reconciliation for that process's
+                    // remaining lifetime.
+                    self.inner.lock().unwrap().session_id = None;
+                    let retry_config = config.clone();
+                    let spawn_result = self.spawn_process(config.clone(), None);
+                    match &spawn_result {
+                        Ok(_) => self.mark_turn_active_and_publish(),
+                        Err(e) => tracing::error!(
+                            block_id = %self.block_id,
+                            error = %e,
+                            "failed to respawn after a stale --resume session id"
+                        ),
+                    }
+                    self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config);
+                    if spawn_result.is_err() {
+                        // Surface this, or the pane hangs forever with NO
+                        // signal at all — codex P2 on PR #2360 (fifth
+                        // review pass): the outer process-waiter already
+                        // suppressed its own terminal-status publish for
+                        // the ORIGINAL exit specifically because a retry
+                        // was in flight, and send_message already
+                        // returned success (possibly emitting
+                        // agent-message-accepted) for the message this
+                        // retry was supposed to deliver. If this respawn
+                        // attempt ALSO fails, nothing else will ever tell
+                        // the frontend this turn is over.
+                        // `inner.proc_status`/`turn_active` are already
+                        // `STATUS_DONE`/`false` (set by the original
+                        // exit's own cleanup before this function was
+                        // ever called) — this just actually broadcasts
+                        // that state, which the original exit deliberately
+                        // withheld pending this retry's outcome.
+                        self.publish_status();
+                    }
                 }
             }
         }
@@ -1319,7 +1381,7 @@ impl PersistentSubprocessController {
         {
             let mut inner = self.inner.lock().unwrap();
             if let (Some(sid), Some(retry_json)) = (attempted_resume_sid.clone(), resume_retry_payload) {
-                inner.pending_resume_retry = Some((sid, config.clone(), retry_json));
+                inner.pending_resume_retry = Some((sid, config.clone(), vec![retry_json]));
             }
         }
 
@@ -1858,6 +1920,21 @@ impl PersistentSubprocessController {
                     // lifetime.
                     inner.pending_resume_retry = None;
                     inner.confirmed_stale_resume_retry = None;
+                    // codex P1 on PR #2360 (sixth review pass, round 5):
+                    // an active spawn claim's own background drain
+                    // (`drain_queue_after_successful_spawn`) is a
+                    // SEPARATE, independently-scheduled task — killing
+                    // this process does not cancel it. Left untouched, its
+                    // next check would see `stdin_tx` gone with messages
+                    // still queued, treat that as a stall, and hand off to
+                    // `respawn_once_for_leftover_queue` — silently
+                    // reviving the agent moments after the user explicitly
+                    // stopped it. Clearing the queue AND releasing the
+                    // claim here means that same check instead sees an
+                    // empty queue and just concludes normally, with no
+                    // fallback respawn triggered.
+                    inner.pending_send_messages.clear();
+                    inner.spawning_in_progress = false;
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
 
@@ -2200,7 +2277,7 @@ mod send_input_tests {
             session_id: "dead-sid".to_string(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, "{}".to_string());
+        c.retry_after_resume_failure(config, vec!["{}".to_string()]);
 
         assert_eq!(
             c.inner.lock().unwrap().session_id,
@@ -2645,12 +2722,96 @@ mod send_input_tests {
             session_id: "dead-sid".to_string(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, "{}".to_string());
+        c.retry_after_resume_failure(config, vec!["{}".to_string()]);
 
         assert_eq!(
             c.inner.lock().unwrap().session_id.as_deref(),
             Some("fresh-concurrently-installed-sid"),
             "must not erase a session id a concurrent spawn already legitimately captured"
+        );
+    }
+
+    /// codex P1 on PR #2360 (sixth review pass, round 5): a doomed
+    /// process's stdin channel can have accepted MULTIPLE messages before
+    /// it turned out to be unreachable — not just the one that triggered
+    /// the spawn. `retry_after_resume_failure` now takes the whole batch
+    /// and must redeliver every one of them, in order. Uses an
+    /// already-running process (`DeliverDirect` for each) so this is
+    /// deterministic without needing a real subprocess spawn.
+    #[tokio::test]
+    async fn retry_after_resume_failure_redelivers_every_message_in_the_batch() {
+        let c = controller();
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+
+        let config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(
+            config,
+            vec!["msg-1".to_string(), "msg-2".to_string(), "msg-3".to_string()],
+        );
+
+        assert_eq!(rx.recv().await.unwrap(), "msg-1");
+        assert_eq!(rx.recv().await.unwrap(), "msg-2");
+        assert_eq!(rx.recv().await.unwrap(), "msg-3");
+    }
+
+    /// codex P1 on PR #2360 (sixth review pass, round 5): the drain must
+    /// track every message it successfully delivers beyond the first
+    /// (which `spawn_process` already stashed synchronously — see
+    /// `pending_resume_retry`'s own doc comment) into
+    /// `pending_resume_retry`'s own list, so a confirmed stale-resume
+    /// retry redelivers the WHOLE batch rather than just the message that
+    /// triggered the spawn.
+    #[tokio::test]
+    async fn drain_appends_later_messages_to_the_pending_resume_retry_without_duplicating_the_first() {
+        let c = controller();
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let retry_config = PersistentSpawnConfig {
+            cli_command: "unused".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.spawning_in_progress = true;
+            inner.pending_send_messages.push_back("first".to_string());
+            inner.pending_send_messages.push_back("second".to_string());
+            // Simulates spawn_process's own synchronous stash for "first"
+            // — the message that triggered this spawn.
+            inner.pending_resume_retry =
+                Some(("sid".to_string(), retry_config.clone(), vec!["first".to_string()]));
+        }
+
+        c.drain_queue_after_successful_spawn(retry_config, true);
+
+        assert_eq!(rx.recv().await.unwrap(), "first");
+        assert_eq!(rx.recv().await.unwrap(), "second");
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+
+        let inner = c.inner.lock().unwrap();
+        let (_, _, delivered) = inner
+            .pending_resume_retry
+            .as_ref()
+            .expect("must still be tracking this spawn's delivered messages");
+        assert_eq!(
+            delivered,
+            &vec!["first".to_string(), "second".to_string()],
+            "must contain the ORIGINAL message exactly once plus every later delivery, in order"
         );
     }
 }
@@ -2755,7 +2916,7 @@ mod resume_poison_tests {
     fn pending_resume_retry_is_cleared_once_the_resume_actually_succeeds() {
         let mut inner = inner_with_session_id(None);
         inner.pending_resume_retry =
-            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+            Some(("dead-sid".to_string(), dummy_spawn_config(), vec!["{}".to_string()]));
 
         // The CLI echoes back the SAME sid it was given, confirming --resume
         // actually worked — this is genuine progress, so the retry safety
@@ -2773,7 +2934,7 @@ mod resume_poison_tests {
     fn pending_resume_retry_is_cleared_when_the_cli_starts_a_fresh_conversation_on_its_own() {
         let mut inner = inner_with_session_id(None);
         inner.pending_resume_retry =
-            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+            Some(("dead-sid".to_string(), dummy_spawn_config(), vec!["{}".to_string()]));
 
         // A DIFFERENT (fresh) sid — the CLI gave up on --resume internally
         // and started its own new conversation without ever hitting the
@@ -2795,7 +2956,7 @@ mod resume_poison_tests {
     fn poison_resume_promotes_a_matching_pending_retry_to_confirmed() {
         let mut inner = inner_with_session_id(Some("dead-sid"));
         inner.pending_resume_retry =
-            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+            Some(("dead-sid".to_string(), dummy_spawn_config(), vec!["{}".to_string()]));
 
         inner.poison_resume("dead-sid");
 
@@ -2816,7 +2977,7 @@ mod resume_poison_tests {
     fn confirmed_retry_survives_a_subsequent_refused_capture() {
         let mut inner = inner_with_session_id(Some("dead-sid"));
         inner.pending_resume_retry =
-            Some(("dead-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+            Some(("dead-sid".to_string(), dummy_spawn_config(), vec!["{}".to_string()]));
         inner.poison_resume("dead-sid");
         assert!(inner.confirmed_stale_resume_retry.is_some());
 
@@ -2836,7 +2997,7 @@ mod resume_poison_tests {
     fn poison_resume_does_not_promote_a_retry_captured_for_a_different_sid() {
         let mut inner = inner_with_session_id(None);
         inner.pending_resume_retry =
-            Some(("other-sid".to_string(), dummy_spawn_config(), "{}".to_string()));
+            Some(("other-sid".to_string(), dummy_spawn_config(), vec!["{}".to_string()]));
 
         inner.poison_resume("dead-sid");
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -992,8 +992,16 @@ impl PersistentSubprocessController {
             .ok_or_else(|| format!("[persistent] stdout not captured for block {}", self.block_id))?;
         let stderr = child.stderr.take();
 
-        // Drain stderr in background — log lines for debugging
-        if let Some(stderr_pipe) = stderr {
+        // Drain stderr in background — log lines for debugging. The
+        // JoinHandle is kept (not discarded) so the process-waiter task
+        // can await this task's full completion before deciding whether a
+        // stale-resume retry was confirmed — codex P1/P2 on PR #2360
+        // (second review pass): `child.wait()` resolving is NOT proof this
+        // task has already seen and reacted to a "No conversation found"
+        // line, or finished its OWN subsequent `persist_session_id("")`
+        // call below. See the process-waiter's own comment for the two
+        // failure modes this closes.
+        let stderr_reader_handle: Option<tokio::task::JoinHandle<()>> = stderr.map(|stderr_pipe| {
             let block_id_stderr = self.block_id.clone();
             let inner_stderr = Arc::clone(&self.inner);
             let wstore_stderr = self.wstore.clone();
@@ -1046,8 +1054,8 @@ impl PersistentSubprocessController {
                         }
                     }
                 }
-            });
-        }
+            })
+        });
 
         // Create stdin writer channel
         let (msg_tx, mut msg_rx) = mpsc::channel::<String>(32);
@@ -1314,6 +1322,37 @@ impl PersistentSubprocessController {
                         "persistent process exited"
                     );
 
+                    // Give the stderr reader a bounded chance to fully
+                    // drain and react to whatever it saw right before this
+                    // process exited — codex P1/P2 on PR #2360 (second
+                    // review pass): `child.wait()` resolving does NOT mean
+                    // the stderr reader (an independently-scheduled task)
+                    // has already called `poison_resume` for a "No
+                    // conversation found" line, or finished ITS OWN
+                    // subsequent `persist_session_id("")` call. Without
+                    // this, two failure modes were possible: (1) this task
+                    // could clear `pending_resume_retry` below before the
+                    // stderr reader ever promotes it, permanently losing
+                    // the retry for the exact case it exists to catch, and
+                    // (2) a confirmed retry's fresh session id (persisted
+                    // by the NEW process's own stdout reader once
+                    // respawned) could be silently overwritten by this
+                    // exiting process's stderr task finally getting around
+                    // to persisting an empty one, corrupting continuity
+                    // despite the retry having succeeded. 500ms is
+                    // generous — the stderr pipe closes and drains almost
+                    // immediately once the process has genuinely exited —
+                    // and only ever delays shutdown handling, never blocks
+                    // it indefinitely.
+                    if let Some(handle) = stderr_reader_handle {
+                        if tokio::time::timeout(std::time::Duration::from_millis(500), handle).await.is_err() {
+                            tracing::warn!(
+                                block_id = %block_id_wait,
+                                "stderr reader did not finish within 500ms of process exit"
+                            );
+                        }
+                    }
+
                     // Notify health monitor so Stalled/Dead watchdog stops.
                     health_wait.set_exited(exit_code);
 
@@ -1328,9 +1367,11 @@ impl PersistentSubprocessController {
                     // see its doc comment and reagentx P1 on PR #2360. Taken
                     // (not just read) so it can only ever fire once. Any
                     // still-tentative `pending_resume_retry` is also
-                    // dropped here — this process (successful or not) is
-                    // done, so it can never be confirmed either way, and a
-                    // reused controller instance must not carry it into an
+                    // dropped here — by now the stderr reader has already
+                    // had its bounded chance to promote it above, so this
+                    // process (successful or not) is genuinely done: it
+                    // can never be confirmed either way, and a reused
+                    // controller instance must not carry it into an
                     // unrelated later lifetime.
                     let retry_after_resume = inner.confirmed_stale_resume_retry.take();
                     inner.pending_resume_retry = None;
@@ -1339,7 +1380,11 @@ impl PersistentSubprocessController {
 
                     // Deregister from muxbus so later sends fall through to the
                     // lower tiers instead of resolving to a dead block. Mirrors
-                    // the shell controller's exit path.
+                    // the shell controller's exit path. Done regardless of
+                    // whether a retry follows — this exact process's
+                    // resources are gone either way, and spawn_process's own
+                    // fresh registration (if a retry follows) doesn't clean
+                    // up state belonging to THIS dying process.
                     crate::backend::reactive::get_global_handler()
                         .unregister_block(&block_id_wait);
                     if let Some(ref agent_id) = agent_id_wait {
@@ -1355,8 +1400,29 @@ impl PersistentSubprocessController {
                         super::session_recovery::clear_active_pid(wstore, &block_id_wait);
                     }
 
-                    // Publish status
-                    if let Some(ref broker) = broker_wait {
+                    // A stale `--resume <sid>` is exactly what killed this
+                    // process (`retry_after_resume_failure`'s doc comment) —
+                    // retry the same message once, fresh, WITHOUT publishing
+                    // this transient failure as a completed turn first.
+                    // codex P2 on PR #2360 (second review pass): publishing
+                    // "done"/turn_active:false here would let the mounted
+                    // UI (trackTurnJustEnded, a deferred controller refresh)
+                    // treat this failed attempt as the real end of the
+                    // user's turn before the retry's own fresh "running"
+                    // status ever lands. reagentx/codex never reviewed this
+                    // controller type in PR #2338 (see docs/retros/
+                    // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md).
+                    if let Some((_attempted_sid, retry_config, retry_json)) = retry_after_resume {
+                        if let Some(ctrl) = self_ref_wait.upgrade() {
+                            tracing::warn!(
+                                block_id = %block_id_wait,
+                                "stale --resume session id caused this exit — retrying fresh, without --resume"
+                            );
+                            ctrl.retry_after_resume_failure(retry_config, retry_json);
+                        }
+                    } else if let Some(ref broker) = broker_wait {
+                        // Genuinely done, not retrying — publish the
+                        // terminal status.
                         let status = BlockControllerRuntimeStatus {
                             blockid: block_id_wait.clone(),
                             version: 0,
@@ -1368,25 +1434,6 @@ impl PersistentSubprocessController {
                             turn_active: false,
                         };
                         super::publish_controller_status(broker, &status);
-                    }
-
-                    // A stale `--resume <sid>` is exactly what killed this
-                    // process (`retry_after_resume_failure`'s doc comment) —
-                    // retry the same message once, fresh, before this exit
-                    // is ever treated as a completed/failed turn from the
-                    // frontend's point of view. reagentx/codex never
-                    // reviewed this path (see docs/retros/
-                    // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md) —
-                    // it's a different controller type than PR #2338's own
-                    // ACP-controller review surface.
-                    if let Some((_attempted_sid, retry_config, retry_json)) = retry_after_resume {
-                        if let Some(ctrl) = self_ref_wait.upgrade() {
-                            tracing::warn!(
-                                block_id = %block_id_wait,
-                                "stale --resume session id caused this exit — retrying fresh, without --resume"
-                            );
-                            ctrl.retry_after_resume_failure(retry_config, retry_json);
-                        }
                     }
                 }
                 Ok(force) = kill_rx => {
@@ -1774,6 +1821,39 @@ mod send_input_tests {
             c.inner.lock().unwrap().session_id,
             None,
             "must clear inner.session_id directly, not rely on poison_resume having already done so"
+        );
+    }
+
+    /// codex P1/P2 on PR #2360 (second review pass): the process-waiter
+    /// task now awaits the stderr reader's `JoinHandle` (bounded by a
+    /// timeout) before deciding whether a stale-resume retry was
+    /// confirmed, and before publishing a terminal status — otherwise
+    /// `child.wait()` resolving first could (1) wipe the tentative retry
+    /// before the stderr reader ever promotes it, and (2) let a
+    /// confirmed retry's fresh session id get overwritten by the stderr
+    /// task's own delayed `persist_session_id("")` call. This isn't a
+    /// full subprocess integration test (this module's established
+    /// precedent — see its own doc comment — avoids spawning a real CLI
+    /// process for this exact subsystem); it confirms the underlying
+    /// synchronization primitive itself: a task that completes well
+    /// within the bound is FULLY awaited — its side effect is guaranteed
+    /// observable — before the timeout could possibly race it.
+    #[tokio::test]
+    async fn a_join_handle_completing_within_the_bound_is_fully_awaited_first() {
+        let flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag_clone = Arc::clone(&flag);
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            flag_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        let result = tokio::time::timeout(std::time::Duration::from_millis(500), handle).await;
+
+        assert!(result.is_ok(), "a task well within the bound must not be treated as timed out");
+        assert!(
+            flag.load(std::sync::atomic::Ordering::SeqCst),
+            "awaiting the handle must observe the task's side effect having already happened, \
+             not race ahead of it"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -873,6 +873,23 @@ impl PersistentSubprocessController {
     /// later, unrelated send will still eventually pick it up.
     fn respawn_once_for_leftover_queue(&self, mut config: PersistentSpawnConfig) {
         config.session_id = String::new();
+        // reagentx P0 on PR #2360 (sixth review pass, round 11): clearing
+        // `config.session_id` alone does nothing — `spawn_process`'s own
+        // `--resume` decision reads `inner.session_id` directly (see its
+        // own doc comment), never `config.session_id` (that field is only
+        // consulted to HYDRATE `inner.session_id` when it's still `None`,
+        // which is skipped here anyway since it's now empty). If the
+        // doomed process's stderr reader hasn't cleared `inner.session_id`
+        // yet (poison_resume races the drain's own `tx.send()` failure —
+        // exactly the fast-fail case this whole mechanism targets), this
+        // fallback respawn would reattach `--resume <stale-sid>` and
+        // reproduce the identical failure — and since this call passes
+        // `resume_retry_payload: None`, nothing re-arms to catch the
+        // repeat, so the process-waiter finds no confirmed retry and
+        // silently drops the message for good. Mirrors
+        // `retry_after_resume_failure`'s own explicit clear for the exact
+        // same reason.
+        self.inner.lock().unwrap().session_id = None;
         let retry_config = config.clone();
         let spawn_result = self.spawn_process(config, None);
         match &spawn_result {
@@ -2549,6 +2566,38 @@ mod send_input_tests {
             c.inner.lock().unwrap().session_id,
             None,
             "must clear inner.session_id directly, not rely on poison_resume having already done so"
+        );
+    }
+
+    /// reagentx P0 on PR #2360 (sixth review pass, round 11): same class
+    /// of bug as the test above, in a sibling fallback path added later —
+    /// `respawn_once_for_leftover_queue` cleared only `config.session_id`,
+    /// which `spawn_process`'s own `--resume` decision never reads (it
+    /// reads `inner.session_id` directly). If the doomed process's stderr
+    /// reader hasn't cleared `inner.session_id` yet, this fallback would
+    /// reattach `--resume` to the same dead sid and reproduce the
+    /// identical failure, with nothing left to catch the repeat.
+    #[test]
+    fn respawn_once_for_leftover_queue_clears_inner_session_id_even_when_poison_resume_has_not_run_yet() {
+        let c = controller();
+        c.inner.lock().unwrap().session_id = Some("dead-sid".to_string());
+
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        c.respawn_once_for_leftover_queue(config);
+
+        assert_eq!(
+            c.inner.lock().unwrap().session_id,
+            None,
+            "must clear inner.session_id directly, not rely on config.session_id alone"
         );
     }
 

--- a/docs/retros/RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md
+++ b/docs/retros/RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md
@@ -1,0 +1,47 @@
+# Retro: first message to a globally-known agent from a brand-new build/channel failed with a generic "Agent encountered an error"
+
+**Date:** 2026-07-29
+**Severity:** Medium (message is lost and must be resent; the agent recovers on the very next send, but the failure is visible and unexplained)
+**Affected versions:** any persistent-controller agent (`agentmux-srv/src/backend/blockcontroller/persistent.rs`), any time its session is first resumed under a build/channel whose CLI install has never locally seen that session. First observed on the freshly-built `0.54.7+g38cc9ac99` portable, immediately after PR #2338 (fast-fail-send-while-unauthenticated) merged.
+
+---
+
+## What happened
+
+Live-tested the fresh `0.54.7` portable build. Logged into the "Lzop" agent successfully (`✓ Login successful`), then sent the message `u there`. The agent immediately failed with a generic **"Agent encountered an error"** banner — no response, message effectively lost.
+
+This is **not** a regression from PR #2338 or any of its ~39 review rounds. That PR's entire review surface was the ACP-controller's `outstanding_prompt_ids` tracking, `useAgentCommands.ts`'s deferred-controller-refresh machinery, and the frontend fast-fail auth guard — all of which sit in front of, and are agnostic to, the controller-type-specific code that actually failed here. "Lzop" is a **persistent**-type controller (`persistent.rs`), and the failure is in that file's session-resume path, a codepath PR #2338 never touched. The user *did* log in successfully and *was* authenticated — the auth guard worked exactly as designed; the failure is a completely separate, pre-existing gap in an unrelated subsystem.
+
+## Root cause
+
+Traced via `~/.agentmux/logs/agentmuxsrv-v0.54.7.log.2026-07-29`:
+
+1. On pane open, the backend backfills the pane's subagents from a session id already on record for this agent: `session_id: 2b75fd90-e509-4b09-b98f-6a190d6c707e` (`subagent_watcher::scan`, "backfilling session subagents on pane (re)open").
+2. Sending `u there` spawns the persistent CLI with `--resume 2b75fd90-e509-4b09-b98f-6a190d6c707e` against the **v0.54.7 channel's own, brand-new `npm install`** of `@anthropic-ai/claude-code` at `~/.agentmux/instances/v0.54.7/cli/claude` — a directory that had never run before this exact build.
+3. The CLI process immediately writes to stderr: `No conversation found with session ID: 2b75fd90-e509-4b09-b98f-6a190d6c707e`, then **exits with code 1** — it never produces a response to `u there` at all.
+4. `persistent.rs`'s stderr reader recognizes this exact line (this is a known, previously-encountered failure mode — see the code's own extensive comments referencing `SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.2`), clears the stale session id (`poison_resume` + `persist_session_id(..., "")`), and calls `session_recovery::mark_resume_failed`, which sets `session:resume_failed` on the block so `AgentControlBar.tsx` can show a distinct disclosure banner ("Couldn't resume the previous conversation — started a new one.").
+5. But this recovery only prepares the **next** send to succeed (fresh conversation, no `--resume` flag). The **current** send — the message the user actually typed — was already lost when the process exited with code 1. That bare non-zero exit with no output falls through to the generic fallback error string, which is literally `"Agent encountered an error"` (`agentmux-srv/src/agents/translator/claude.rs:299`, mirrored in `frontend/app/view/agent/providers/claude-translator.ts:84`) — exactly what appeared.
+
+The deeper architectural cause (documented the same day in a sibling investigation, `docs/retros/RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md`): **agent identity, definitions, and conversation transcripts are deliberately global** — resolved via `resolve_global_shared_root()` under `~/.agentmux/shared/...`, independent of build/channel, specifically so an agent and its history follow the user across every build. But the actual CLI **binary + its own native session/project storage** are provisioned **per version/channel** (`~/.agentmux/instances/v<version>/cli/claude`, a fresh `npm install` per channel, confirmed in this log by `"running npm install"` firing on first use of v0.54.7). A session id recorded while the conversation last ran under a *different* channel's CLI install is therefore unreachable the first time it's resumed under a brand-new channel — the global "this agent's last session" pointer and the per-channel "what conversations does this CLI installation actually know about" state can disagree, and nothing checks that they agree before spawning with `--resume`.
+
+This is the same root shape as the sibling retro (global agent state vs. a boundary-scoped execution layer that isn't aware of it) but manifests in a different layer: that retro was about **cross-process turn ownership** (two live srv processes resuming the same session concurrently); this one is about **cross-channel CLI-install session reachability** (one srv process, but a session id that only one specific channel's CLI install can actually resolve).
+
+## Why the existing mitigation didn't fully cover this
+
+The `resume_failed` disclosure mechanism (§4.2) was *already built* for exactly this failure signature (the code comment predates this incident: "a permanent 'Agent encountered an error' with no path to recovery" was the exact scenario it exists to close for *future* sends). It does close the loop for every send **after** the first — the poisoned session id is cleared, so the next message starts a fresh conversation and succeeds normally. The gap is narrower than "no recovery at all": it's that the **triggering send itself** still visibly fails and its content is lost, because the CLI process has to actually exit before the stderr line proving "this session is unreachable" can be observed — there's no way to know in advance, before spawning, that this particular `--resume` will fail.
+
+## Fix
+
+None shipped as part of this retro — this is a pre-existing gap in a different subsystem than the one just reviewed, not a defect in PR #2338 or the v0.54.7 release. Filed as follow-up rather than fixed inline, matching this session's own established practice of not bundling unrelated architectural fixes onto a merged/shipped change.
+
+## Explicit follow-ups (not fixed here)
+
+- **Don't lose the triggering message.** When `persistent.rs`'s stderr reader detects `"No conversation found with session ID"` on the very first spawn attempt for a message, it already knows this exact failure is recoverable by respawning without `--resume`. Instead of letting the process exit and surfacing a generic error, it could transparently retry the same send once, without `--resume`, before ever reporting failure to the user — turning this into a silent (or disclosed-but-non-error) fresh-conversation start rather than a lost message the user must notice and resend.
+- **Validate reachability before spawning, not after.** If there's a cheap way to check whether a given channel's CLI install actually has a given session id on record (e.g. a lightweight local lookup) before ever passing `--resume`, the stale case could be detected and handled pre-spawn instead of via a stderr-pattern-match post-mortem.
+- **Reconcile with the sibling retro's proposed fix.** If cross-process turn ownership ever gains a durable per-session lock/lease (that retro's proposed fix), consider whether the same lease record could also carry "last channel this session actually ran under," letting a new channel's first resume attempt know in advance that a fresh conversation is required, rather than discovering it via a failed spawn.
+
+## Lessons
+
+1. **A merged PR's review scope is not the whole app's error surface.** ~39 rounds of adversarial review on the auth-guard/deferred-refresh machinery correctly hardened *that* subsystem — but a completely different controller type's completely different session-management code was never in scope, and a first-use-of-a-new-channel failure mode there was always going to surface independently of how thorough that other review was.
+2. **"Global by design" state needs a matching-scope reachability check.** This is the second same-day finding (after the sibling retro) where a deliberately-global piece of agent state (identity/session pointer) outran the awareness of a narrower-scoped layer (a live process; a per-channel CLI install) that has to actually act on it. Both times, the global state was the right design choice — the gap was assuming the narrower layer could always successfully act on whatever the global layer handed it.
+3. **A "first attempt after this" fix isn't a "no user impact" fix.** The `resume_failed` mitigation is genuinely good engineering — it closes an infinite-failure loop — but recovering by the *second* attempt still means the *first* attempt visibly fails from the user's point of view. Worth distinguishing, when writing a retro or judging a fix's completeness, between "this can't happen forever" and "this never happens."


### PR DESCRIPTION
## Summary
- Fixes a live-testing find on the fresh `0.54.7` portable build: sending the first message to an already-logged-in, globally-known agent ("Lzop") failed with a generic **"Agent encountered an error"** and the message was lost.
- Root cause: agent session ids are deliberately global (follow the user across every build/channel), but each channel's CLI binary + its own native session storage are provisioned fresh per version. The very first resume of an existing session under a brand-new channel's CLI install fails immediately (`No conversation found with session ID: ...`, exit code 1) before producing any response. The backend already detects this exact case and clears the stale id — but only the *next* send benefited; the triggering message itself was lost.
- Adds a transparent retry: `send_message` stashes the (config, formatted stdin line) for a fresh spawn's resume attempt. If the stderr reader confirms that session id unreachable, the process-waiter task (via a new weak self-reference, mirroring `SubprocessController`'s existing queued-message-drain pattern) respawns fresh with no `--resume` and redelivers the exact same message — without re-persisting it or re-emitting `agent-message-accepted` (both already happened correctly on the original attempt).
- Full investigation write-up: `docs/retros/RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md` (a sibling finding to `RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md` from the same day — same root tension: agent identity/session data is deliberately global, but a narrower-scoped execution layer isn't always aware of it).
- Unrelated to PR #2338 (fast-fail-send-while-unauthenticated, merged earlier today) — that PR's entire review surface was the ACP controller's auth-guard/deferred-refresh machinery; this is the **persistent** controller's session-resume path, a completely different codepath that PR never touched.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv blockcontroller::persistent` — 19/19 passed, including 3 new tests covering `pending_resume_retry`'s set/clear lifecycle
- [x] Revert-and-verify: temporarily reverted `try_capture_session_id`'s new clearing line, confirmed both new "cleared on success" tests fail with the exact expected assertion, restored, confirmed all 19 pass again
- [x] `cargo test -p agentmux-srv --bin agentmux-srv blockcontroller` — 119/119 passed (no regressions across the whole module)
- [x] `cargo build -p agentmux-srv` — clean, no new warnings
- [ ] Fresh portable build + live resend of the exact failing scenario (first message to a globally-known agent from a brand-new channel)