### PR TITLE
fix(ci): Windows nightly build failed to extract codec CEF (backslash zip paths)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -139,24 +139,37 @@ jobs:
           path: ${{ env.CEF_RUNTIME_DIR_WINDOWS }}
           key: cef-runtime-windows-${{ steps.cef.outputs.tag }}
 
+      # `Expand-Archive`, not bash `unzip`: the release zip is produced by
+      # PowerShell's `Compress-Archive` (docs/cef-build/build-patched-cef-windows.md
+      # §7), which stores internal entries with backslash path separators.
+      # Info-ZIP's `unzip` (the bash job's prior tool here) can't parse those
+      # as nested directories — it silently flattens/mangles them, so the
+      # libcef.dll lookup below always failed with "not found in zip" on any
+      # cache miss. Extracting with the same .NET zip implementation that
+      # created the archive round-trips correctly. See
+      # docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md.
       - name: Download codec-enabled CEF runtime
         if: steps.cef-cache.outputs.cache-hit != 'true'
-        shell: bash
+        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
         run: |
-          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR_WINDOWS"
-          gh release download "${{ steps.cef.outputs.tag }}" \
-            --repo agentmuxai/cef \
-            --pattern "*.zip" \
-            --dir /tmp/cef-extract \
+          $extractDir = "$env:RUNNER_TEMP\cef-extract"
+          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+          New-Item -ItemType Directory -Force -Path $env:CEF_RUNTIME_DIR_WINDOWS | Out-Null
+          gh release download "${{ steps.cef.outputs.tag }}" `
+            --repo agentmuxai/cef `
+            --pattern "*.zip" `
+            --dir $extractDir `
             --clobber
-          unzip -q /tmp/cef-extract/*.zip -d /tmp/cef-extract/unpacked
+          $zip = Get-ChildItem "$extractDir\*.zip" | Select-Object -First 1
+          if (-not $zip) { Write-Error "ERROR: no .zip downloaded from release"; exit 1 }
+          Expand-Archive -Path $zip.FullName -DestinationPath "$extractDir\unpacked" -Force
           # Find libcef.dll regardless of whether the zip has a top-level dir
-          LIBCEF=$(find /tmp/cef-extract/unpacked -name "libcef.dll" | head -1)
-          if [ -z "$LIBCEF" ]; then echo "ERROR: libcef.dll not found in zip"; exit 1; fi
-          cp -r "$(dirname "$LIBCEF")/." "$CEF_RUNTIME_DIR_WINDOWS/"
-          rm -rf /tmp/cef-extract
+          $libcef = Get-ChildItem -Path "$extractDir\unpacked" -Filter "libcef.dll" -Recurse | Select-Object -First 1
+          if (-not $libcef) { Write-Error "ERROR: libcef.dll not found in zip"; exit 1 }
+          Copy-Item -Path "$($libcef.DirectoryName)\*" -Destination $env:CEF_RUNTIME_DIR_WINDOWS -Recurse -Force
+          Remove-Item -Recurse -Force $extractDir
 
       - name: Set AGENTMUX_CEF_RUNTIME_DIR_WINDOWS
         shell: bash

--- a/.github/workflows/ci-nightly-artifacts.yml
+++ b/.github/workflows/ci-nightly-artifacts.yml
@@ -65,21 +65,34 @@ jobs:
           path: ${{ env.CEF_RUNTIME_DIR_WINDOWS }}
           key: cef-runtime-windows-${{ steps.cef.outputs.tag }}
 
+      # `Expand-Archive`, not bash `unzip`: the release zip is produced by
+      # PowerShell's `Compress-Archive` (docs/cef-build/build-patched-cef-windows.md
+      # §7), which stores internal entries with backslash path separators.
+      # Info-ZIP's `unzip` (the bash job's prior tool here) can't parse those
+      # as nested directories — it silently flattens/mangles them, so the
+      # libcef.dll lookup below always failed with "not found in zip" on any
+      # cache miss. Extracting with the same .NET zip implementation that
+      # created the archive round-trips correctly. See
+      # docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md.
       - name: Download codec-enabled CEF runtime
         if: steps.cef-cache.outputs.cache-hit != 'true'
-        shell: bash
+        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
         run: |
-          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR_WINDOWS"
-          gh release download "${{ steps.cef.outputs.tag }}" \
-            --repo agentmuxai/cef --pattern "*.zip" \
-            --dir /tmp/cef-extract --clobber
-          unzip -q /tmp/cef-extract/*.zip -d /tmp/cef-extract/unpacked
-          LIBCEF=$(find /tmp/cef-extract/unpacked -name "libcef.dll" | head -1)
-          if [ -z "$LIBCEF" ]; then echo "ERROR: libcef.dll not found in zip"; exit 1; fi
-          cp -r "$(dirname "$LIBCEF")/." "$CEF_RUNTIME_DIR_WINDOWS/"
-          rm -rf /tmp/cef-extract
+          $extractDir = "$env:RUNNER_TEMP\cef-extract"
+          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+          New-Item -ItemType Directory -Force -Path $env:CEF_RUNTIME_DIR_WINDOWS | Out-Null
+          gh release download "${{ steps.cef.outputs.tag }}" `
+            --repo agentmuxai/cef --pattern "*.zip" `
+            --dir $extractDir --clobber
+          $zip = Get-ChildItem "$extractDir\*.zip" | Select-Object -First 1
+          if (-not $zip) { Write-Error "ERROR: no .zip downloaded from release"; exit 1 }
+          Expand-Archive -Path $zip.FullName -DestinationPath "$extractDir\unpacked" -Force
+          $libcef = Get-ChildItem -Path "$extractDir\unpacked" -Filter "libcef.dll" -Recurse | Select-Object -First 1
+          if (-not $libcef) { Write-Error "ERROR: libcef.dll not found in zip"; exit 1 }
+          Copy-Item -Path "$($libcef.DirectoryName)\*" -Destination $env:CEF_RUNTIME_DIR_WINDOWS -Recurse -Force
+          Remove-Item -Recurse -Force $extractDir
 
       - name: Set AGENTMUX_CEF_RUNTIME_DIR_WINDOWS
         shell: bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -676,13 +676,23 @@ tasks:
                   echo "" >&2
                 fi
                 mkdir -p dist/cef/locales
+                # Optional-file copies below use `[ -f src ] && cp` instead of
+                # `cp ... 2>/dev/null || true`: Task's shell (mvdan.cc/sh) runs
+                # `cp` as a native Go builtin, not a spawned cp.exe, and on
+                # Windows a missing SOURCE file surfaces as a hard
+                # GetFileAttributesEx task-engine error that bypasses the
+                # `2>/dev/null || true` shell-level suppression entirely —
+                # confirmed live when vulkan-1.dll was absent from a codec CEF
+                # runtime (docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md).
+                # An explicit existence check (already used below for the
+                # locale file) sidesteps the builtin's error path altogether.
                 # Core DLLs (required)
                 cp -f "$cefDir/libcef.dll" dist/cef/
-                cp -f "$cefDir/chrome_elf.dll" dist/cef/ 2>/dev/null || true
+                [ -f "$cefDir/chrome_elf.dll" ] && cp -f "$cefDir/chrome_elf.dll" dist/cef/
                 # GPU support (required — ANGLE + D3D compiler)
-                cp -f "$cefDir/libEGL.dll" dist/cef/ 2>/dev/null || true
-                cp -f "$cefDir/libGLESv2.dll" dist/cef/ 2>/dev/null || true
-                cp -f "$cefDir/d3dcompiler_47.dll" dist/cef/ 2>/dev/null || true
+                [ -f "$cefDir/libEGL.dll" ] && cp -f "$cefDir/libEGL.dll" dist/cef/
+                [ -f "$cefDir/libGLESv2.dll" ] && cp -f "$cefDir/libGLESv2.dll" dist/cef/
+                [ -f "$cefDir/d3dcompiler_47.dll" ] && cp -f "$cefDir/d3dcompiler_47.dll" dist/cef/
                 # Software-GL fallback (SwiftShader, ~6 MB). When the HARDWARE GPU process
                 # can't boot, Chromium falls back to SwiftShader for WebGL ONLY if these are
                 # present AND --enable-unsafe-swiftshader is set (app.rs). Without them, the
@@ -692,13 +702,15 @@ tasks:
                 # (GPU process STATUS_BREAKPOINTs at init — see issue / the DCHECK-build root
                 # cause). macOS/Linux bundles already ship SwiftShader; this restores parity.
                 # SAFETY NET ONLY — hardware GL is still preferred when it boots.
-                cp -f "$cefDir/vk_swiftshader.dll" dist/cef/ 2>/dev/null || true
-                cp -f "$cefDir/vulkan-1.dll" dist/cef/ 2>/dev/null || true
-                cp -f "$cefDir/vk_swiftshader_icd.json" dist/cef/ 2>/dev/null || true
+                [ -f "$cefDir/vk_swiftshader.dll" ] && cp -f "$cefDir/vk_swiftshader.dll" dist/cef/
+                [ -f "$cefDir/vulkan-1.dll" ] && cp -f "$cefDir/vulkan-1.dll" dist/cef/
+                [ -f "$cefDir/vk_swiftshader_icd.json" ] && cp -f "$cefDir/vk_swiftshader_icd.json" dist/cef/
                 # Data files (required)
-                cp -f "$cefDir/icudtl.dat" dist/cef/ 2>/dev/null || true
-                cp -f "$cefDir/v8_context_snapshot.bin" dist/cef/ 2>/dev/null || true
-                cp -f "$cefDir"/*.pak dist/cef/ 2>/dev/null || true
+                [ -f "$cefDir/icudtl.dat" ] && cp -f "$cefDir/icudtl.dat" dist/cef/
+                [ -f "$cefDir/v8_context_snapshot.bin" ] && cp -f "$cefDir/v8_context_snapshot.bin" dist/cef/
+                for pak in "$cefDir"/*.pak; do
+                  [ -f "$pak" ] && cp -f "$pak" dist/cef/
+                done
                 # Locales — en-US only (saves ~18 MB)
                 [ -f "$cefDir/locales/en-US.pak" ] && cp -f "$cefDir/locales/en-US.pak" dist/cef/locales/
                 # SKIPPED (not needed):

--- a/docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md
+++ b/docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md
@@ -1,0 +1,62 @@
+# Retro: nightly Windows build silently failing to extract codec-enabled CEF (backslash zip paths)
+
+**Date found:** 2026-07-29
+**Severity:** High — the Windows job of `ci-nightly-artifacts.yml` has failed
+outright on every run since at least 2026-07-28 whenever the CEF-runtime
+cache misses; no nightly Windows artifact (codec or otherwise) has been
+produced in that window.
+
+## TL;DR
+
+`docs/cef-build/build-patched-cef-windows.md` §7 instructs creating the
+codec-enabled CEF runtime release zip with PowerShell's `Compress-Archive`.
+That cmdlet stores internal zip entries with backslash (`\`) path separators
+for nested directories (notably `locales\*.pak`). Both `ci-nightly-artifacts.yml`
+and `build-windows.yml` extracted that zip with bash's `unzip` (Info-ZIP),
+which does not parse backslash-separated internal paths as nested
+directories — it treats each entry as a single flat (and effectively
+unusable) filename. The subsequent `find ... -name "libcef.dll"` lookup then
+always came up empty, and the step failed with `ERROR: libcef.dll not found
+in zip`.
+
+## Why it wasn't obvious
+
+The overall nightly workflow's pass/fail history looked mixed (some green,
+some red) rather than consistently red, which read as ordinary flakiness.
+The green runs were misleading: they hit a `rust-cache` restore where
+`cef-dll-sys`'s build script didn't need to re-run at all, so the
+CEF-runtime download/extract step was skipped entirely that day — not proof
+the extraction path worked, just proof it wasn't exercised. The two days
+this got caught (2026-07-28, 2026-07-29) both hit a genuine cache miss and
+failed identically.
+
+## Fix
+
+Switch the Windows-side extraction from bash `unzip` to PowerShell's
+`Expand-Archive` in both workflows — the same .NET zip implementation that
+created the archive, so it round-trips regardless of internal path
+separator style. No change needed to the zip-creation side
+(`build-patched-cef-windows.md` §7) and no need to rebuild/re-release the
+already-published CEF binary; this was purely a consumption-side bug.
+
+## Prevention
+
+When a CI step downloads an artifact produced by a *different* platform's
+native tooling than the one doing the extracting (here: a Windows-native
+`Compress-Archive` zip, consumed by a Linux-heritage `unzip` running under
+Git Bash on the same Windows runner), don't assume standard zip format
+compatibility — verify with an artifact actually produced by that exact tool,
+not a hand-crafted test zip. The macOS/Linux equivalents of this pipeline use
+`.tar.gz`, produced and consumed by the same POSIX toolchain end-to-end, so
+they never had this class of bug — worth keeping platform-native tool
+symmetry (create-with-X, extract-with-X) in mind for any future artifact
+pipeline crossing this same boundary.
+
+## Files
+
+- `.github/workflows/ci-nightly-artifacts.yml` — Windows job's CEF-runtime
+  download/extract step, switched to `pwsh`/`Expand-Archive`.
+- `.github/workflows/build-windows.yml` — same fix, same pattern.
+- `docs/cef-build/build-patched-cef-windows.md:208-228` — the
+  `Compress-Archive` step that produces the backslash-path zip (unchanged;
+  the fix is entirely on the consuming side).

--- a/docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md
+++ b/docs/retro/retro-nightly-windows-cef-zip-backslash-paths-2026-07-29.md
@@ -60,3 +60,41 @@ pipeline crossing this same boundary.
 - `docs/cef-build/build-patched-cef-windows.md:208-228` — the
   `Compress-Archive` step that produces the backslash-path zip (unchanged;
   the fix is entirely on the consuming side).
+- `Taskfile.yml`'s `bundle:windows` task — second, distinct bug found while
+  live-verifying the fix above (see addendum below).
+
+## Addendum (same day): a second, distinct bug surfaced once extraction was fixed
+
+With the zip extraction fixed, a live verification run
+(`gh workflow run ci-nightly-artifacts.yml --ref
+fix/windows-cef-zip-extract-backslash-paths`) confirmed the codec-enabled CEF
+runtime now resolves and version-matches correctly (`✓ CEF runtime OK:
+libcef.dll ... matches linked cef crate major 148`) — but the build then
+failed one step later, in `Taskfile.yml`'s `bundle:windows` task:
+
+```
+task: Failed to run task "bundle:windows": GetFileAttributesEx
+D:\a\agentmux\agentmux/cef-runtime-windows/vulkan-1.dll: The system cannot
+find the file specified.
+```
+
+`vulkan-1.dll` (part of the optional SwiftShader software-GL fallback trio)
+happens to be absent from this particular codec-enabled CEF build. The
+bundling script's copy line for it —
+`cp -f "$cefDir/vulkan-1.dll" dist/cef/ 2>/dev/null || true` — was written to
+tolerate exactly that (matching every other optional-file copy in the same
+block). It didn't: Task's shell (`mvdan.cc/sh`) runs `cp` as a native Go
+builtin rather than spawning a real `cp.exe`, and on Windows a missing
+*source* file surfaces as a hard task-engine error (a raw
+`GetFileAttributesEx` failure) that bypasses `2>/dev/null || true`
+entirely — that shell-level suppression only catches errors the builtin
+reports through normal stderr/exit-code channels, not this one.
+
+Fixed by replacing every `cp ... 2>/dev/null || true` in `bundle:windows`
+with an explicit `[ -f src ] && cp ...` existence check — the same pattern
+the block already used for the locale-file copy, which is why that one line
+never hit this bug. Scoped to `bundle:windows` only: `bundle:linux`'s
+identical-looking `cp ... 2>/dev/null || true` lines run on a Linux runner,
+where Task's builtin `cp` doesn't go through `GetFileAttributesEx` and the
+Linux job in the same run completed successfully — no evidence that side is
+affected, so left as-is rather than speculatively changed.


### PR DESCRIPTION
## Summary
- The Windows job of `ci-nightly-artifacts.yml` (and `build-windows.yml`) has failed outright on every run since at least 2026-07-28 whenever the CEF-runtime cache misses -- no nightly Windows artifact, codec or otherwise, has actually been produced in that window.
- Root cause: the codec-enabled CEF release zip is created with PowerShell's `Compress-Archive` (`docs/cef-build/build-patched-cef-windows.md` §7), which stores nested directory entries with backslash path separators. Info-ZIP's `unzip` (bash) can't parse those as nested directories, so the `libcef.dll` lookup always came up empty.
- Fixed by switching both workflows' extraction to PowerShell's `Expand-Archive` -- same .NET zip implementation that created the archive, so it round-trips correctly regardless of internal path separator style. No change needed to the zip-creation side, no need to rebuild/re-release the already-published CEF binary.
- Live-verifying that fix surfaced a second, distinct bug: `Taskfile.yml`'s `bundle:windows` task failed one step later on a missing optional file (`vulkan-1.dll`, absent from this particular codec CEF build) with a raw `GetFileAttributesEx` task-engine error -- Task's shell (`mvdan.cc/sh`) runs `cp` as a native Go builtin, and on Windows a missing *source* file bypasses the `2>/dev/null || true` suppression the script relied on. Fixed by switching every optional-file copy in that block to an explicit `[ -f src ] && cp` existence check (the pattern the locale-file copy already used successfully).
- Full root-cause writeup, live-verification evidence, and a note on scope (only `bundle:windows` touched -- `bundle:linux`'s lookalike lines are unaffected, confirmed by that job completing successfully in the same runs) in the included retro.

## Verification
- Triggered two live `workflow_dispatch` runs of `ci-nightly-artifacts.yml` against this branch:
  - First run (extraction fix only): CEF download/extract step succeeded, version-match confirmed (`✓ CEF runtime OK: libcef.dll ... matches linked cef crate major 148`); failed one step later on the `vulkan-1.dll` bug.
  - Second run (both fixes): **all three platform jobs succeeded**, including Windows.
- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files and `Taskfile.yml` after edits.

## Test plan
- [x] Live CI verification (see above) -- this is a CI-infrastructure fix, so the actual test *is* a green CI run, already done.
- [ ] Next scheduled nightly run (06:00 UTC) should now produce a Windows artifact for the first time since 2026-07-27.

<!-- agentmux:agent_id=agent2 -->