### PR TITLE
fix(agent-composer): two-line responsive layout for narrow panes

### DIFF
--- a/.changesets/1785433477-fix-agent-composer-two-line-responsive-layout-for-narrow-pan-i73s.md
+++ b/.changesets/1785433477-fix-agent-composer-two-line-responsive-layout-for-narrow-pan-i73s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-composer): two-line responsive layout for narrow panes

--- a/docs/specs/SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md
@@ -1,0 +1,271 @@
+# SPEC — Composer strip: two-line wrap when the pane narrows
+
+**Date:** 2026-07-30
+**Type:** UI responsiveness spec
+**Status:** Proposed — audited and designed, not yet implemented
+**Scope:** `frontend/app/view/agent/components/AgentComposerStrip.tsx` +
+`frontend/app/view/agent/styles/_composer-strip.scss`
+**Trigger:** User request — *"refine the responsiveness of the stats bar above the agent pane's
+input; when the pane is made thinner it should move to 2 lines."*
+**Related:** `SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md` (progressive-collapse
+architecture, controls-never-hidden principle), `SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md`
+(introduced the current 3-column grid).
+
+---
+
+## 1. Audit — current state
+
+The "stats bar" is `AgentComposerStrip`, a 28px status row rendered as a **flow sibling**
+directly above `.agent-composer-region` (which wraps `AgentFooter`'s textarea) inside
+`.agent-view`'s root flex column. It is not absolutely positioned and does not overlap the
+input — it pushes the textarea down in normal flow.
+
+```
+.agent-view (flex column, container-name: agent-pane)
+ ├── AgentComposerStrip        → .agent-composer-strip  (CSS Grid, 1fr auto 1fr)
+ └── .agent-composer-region
+      └── AgentFooter → .agent-footer → .agent-input-container → textarea.agent-input
+```
+
+### Current layout (`_composer-strip.scss:16-35`)
+
+```scss
+.agent-composer-strip {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 28px;
+    ...
+}
+```
+
+A single-row, 3-column grid: **left** = runtime controls (`AgentRuntimeDropup` "Mode · Model ·
+Effort" trigger + optional HOST/SANDBOX tag), **center** = token/elapsed stats (true-centered via
+the grid, not a flex auto-margin), **right** = `⚙N` process badge → context text (`12.1k / 64k`)
+→ auth tag (`● Logged in`) → `Shell` toggle (rightmost). This 3-column structure is intentional
+and recent (2026-07-10) — keep it as the wide-pane baseline.
+
+### Bug found during this audit: the narrow-pane rules are dead code
+
+```scss
+// _composer-strip.scss:260-278
+@container modal-mount (max-width: 240px) { ... }   // drop stats + ctx
+@container modal-mount (max-width: 320px) { ... }   // shrink trigger + Shell
+```
+
+Both query container name **`modal-mount`**. The container that actually wraps the composer
+strip is `.agent-view`, which declares:
+
+```scss
+// agent-view.scss:36-38
+.agent-view {
+    container-type: inline-size;
+    container-name: agent-pane;
+}
+```
+
+`modal-mount` is a different container name, declared only in `modal.scss` for `<Modal>`
+portal mounts. The docked agent pane is never nested inside a `<Modal>`, so **these rules never
+match in the real composer strip** — confirmed by the 2026-07-02 spec's own live DOM probe,
+which found the trigger buttons `display:none` at a 310px strip width despite querying `@container
+modal-mount (max-width: 320px)` (the rule *did* fire there, actually — that probe pre-dates
+this finding and the fix was never applied; the `modal-mount` name has been wrong in every
+version of this file since it was introduced). Both later specs (07-02, 07-10) proposed content
+changes *inside* these dead blocks without correcting the container name, so the mismatch has
+persisted through three iterations.
+
+**Net effect today:** narrowing the agent pane produces **no responsive behavior at all** for
+the strip — the grid's `1fr` tracks just keep shrinking. `.agent-composer-strip-stats`,
+`-ctx`, and `-auth` are all `white-space: nowrap` with no overflow handling of their own, and
+`.agent-runtime-dropup-trigger` has no width cap outside the dead rule, so content visually
+crowds, clips, or overlaps rather than reflowing. Fixing the container name is a **prerequisite**
+for any of this spec's rules to take effect — folded into the proposal below rather than filed
+separately, since there's no reason to land it without the behavior it's meant to enable.
+
+---
+
+## 2. Proposed solution
+
+**Mechanism:** below a width threshold, `.agent-composer-strip` switches from a 1-row/3-column
+grid to a **2-row grid** via `grid-template-areas`. Controls and the right-side badges/Shell
+share row 1; stats move to a full-width, centered row 2. No JSX changes are required for the
+base two-line behavior — `AgentComposerStrip.tsx`'s three top-level children
+(`.agent-composer-strip-controls`, `.agent-composer-strip-stats-zone`,
+`.agent-composer-strip-right`) already map 1:1 onto three named grid areas; only their CSS
+`grid-area` assignment needs to change per breakpoint. DOM order (and therefore tab/screen-reader
+order) is unaffected.
+
+This also resolves the open question the 07-10 spec left unanswered ("a 3-column grid has no
+built-in equivalent of wrap-to-a-second-row... recommend starting with the old container-query
+breakpoints and adding a wrap fallback only if narrow testing shows clipping") — clipping is
+exactly what's happening today (per §1), so this spec is that follow-up.
+
+### Tier 1 — WIDE (≳480px): single line, unchanged
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [Auto · Sonnet 5 · Medium ▴] [SANDBOX]   ↑2.1k ↓480 · 1m12s   ⚙3  12.1k/64k  ● Logged in  [Shell] │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+No change from current behavior or markup.
+
+### Tier 2 — NARROW (2-line, ~300–480px): stats drop to their own row
+
+```
+┌────────────────────────────────────────────┐
+│ [Auto · Sonnet 5 · Medium ▴]  ⚙3  12.1k/64k  ● Logged in  [Shell] │
+│                ↑2.1k ↓480 · 1m12s                          │
+└────────────────────────────────────────────┘
+```
+
+Row 1 = controls (left) + right zone (badges/ctx/auth/Shell, right) — the two "actionable /
+state" clusters. Row 2 = stats, full-width, centered. **Nothing is hidden.** This directly
+supersedes the old `≤240px "drop stats"` idea from the 07-02 spec — stats no longer need to be
+dropped at all, because giving them a dedicated row removes them from the row-1 space contest
+entirely. This is a strictly better outcome than the previously-designed (and never-working)
+hide-on-narrow behavior.
+
+### Tier 3 — NARROW-2 (2-line + shed low-priority row-1 items, ~220–300px)
+
+Row 1 still has 5 things competing (controls, process badge, ctx, auth, Shell). Shed the least
+essential two, informational-only items — in order:
+
+```
+┌──────────────────────────────────┐
+│ [Auto · Sonnet 5 · Medium ▴]   12.1k/64k  [Shell] │
+│         ↑2.1k ↓480 · 1m12s                 │
+└──────────────────────────────────┘
+```
+
+1. **Auth tag hidden first** — a passive status indicator (colored dot + "Logged in"); the user
+   only needs it when something's wrong, and a failed send already surfaces auth errors inline.
+2. **Process badge hidden second** — a shortcut into the swarm view; the swarm view remains
+   reachable via its own widget regardless.
+
+Context text (`12.1k / 64k`) and **Shell stay visible at every tier** — ctx is the safety signal
+for context-window/compaction awareness (the one thing in this bar with a "critical" pulsing
+state), and Shell is the strip's one real call-to-action, consistent with the 07-02 spec's
+"controls/actions are shed last, not first" principle. This reorders that spec's original literal
+priority list (which put context text ahead of the process badge in the shed order) — that list
+predates both the auth tag and the two-line redesign; recommend this revised order but flag it
+as a judgment call worth a quick look at real usage.
+
+### Tier 4 — TINY (2-line + controls compact, <220px)
+
+```
+┌──────────────────────────┐
+│ [Auto·S5·Med ▴]  64k  [Shell] │
+│   ↑2.1k ↓480 · 1m12s          │
+└──────────────────────────┘
+```
+
+Controls trigger shrinks via the existing (now-fixed) `max-width` + ellipsis cap rather than
+disappearing — consistent with the 07-02 spec's "never `display:none` the runtime controls"
+rule. Full icon-only/combined-chip collapse (the 07-02 spec's TINY tier) is a larger follow-up
+or can be layered in later; not required to satisfy "move to 2 lines," called out as an
+explicit non-goal below.
+
+---
+
+## 3. CSS sketch
+
+```scss
+.agent-composer-strip {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-areas: "controls stats right";
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 28px;
+    padding: var(--space-1) var(--space-2);
+    ...
+}
+
+.agent-composer-strip-controls  { grid-area: controls; justify-self: start; ... }
+.agent-composer-strip-stats-zone { grid-area: stats;    justify-self: center; ... }
+.agent-composer-strip-right      { grid-area: right;    justify-self: end; ... }
+
+// Tier 2 — two-line layout. Fixes the container-name bug (was `modal-mount`,
+// never matched the docked pane's own `agent-pane` container — see audit).
+@container agent-pane (max-width: 480px) {
+    .agent-composer-strip {
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+            "controls right"
+            "stats    stats";
+        min-height: 52px;   // two rows + row-gap + padding — verify against real content
+        row-gap: 2px;
+    }
+
+    .agent-composer-strip-stats-zone {
+        justify-self: stretch;
+        text-align: center;
+    }
+}
+
+// Tier 3 — shed auth tag, then process badge (informational, lowest priority).
+@container agent-pane (max-width: 300px) {
+    .agent-composer-strip-auth { display: none; }
+}
+@container agent-pane (max-width: 260px) {
+    .agent-composer-strip-process-badge { display: none; }
+}
+
+// Tier 4 — controls trigger compacts; Shell padding shrinks.
+// (Replaces the old dead `@container modal-mount (max-width: 320px)` block.)
+@container agent-pane (max-width: 220px) {
+    .agent-runtime-dropup-trigger { max-width: 120px; }
+    .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
+}
+```
+
+All four tiers key off the **correct** container name, `agent-pane` — matching every other
+working responsive rule in `_responsive.scss`.
+
+## 4. Breakpoint values — need live verification
+
+The `480 / 300 / 260 / 220` widths above are reasoned from approximate content widths (controls
+pill ~150–170px, right-zone cluster ~230px at Tier 1, stats ~110–130px), not measured DOM output
+— same caveat the 07-02 spec flagged about its own guesses. Before shipping: resize a real pane
+in `task dev` through these widths and confirm each tier's row 1 doesn't clip or overlap right at
+its own threshold; nudge the numbers to match actual rendered widths rather than trusting the
+estimate above.
+
+## 5. Non-goals for this pass
+
+- **Icon-only / combined-chip controls** (07-02 spec's full TINY-tier design) — not required to
+  satisfy "move to 2 lines"; the Tier 4 sketch above reuses the existing ellipsis-cap behavior
+  instead. Worth a follow-up spec if panes are regularly used below ~220px.
+- **One shared Mode/Model/Effort catalog** (07-02 spec item 3) — orthogonal, unaffected by this
+  change.
+
+## 6. Verification plan (once implemented)
+
+1. `npx tsc --noEmit` — the `grid-area` CSS changes require no `.tsx` edits, so this should be a
+   no-op check.
+2. `task dev` — resize the agent pane continuously from wide to narrow and confirm:
+   - Tier 1→2 transition moves stats to their own centered row with no clipping, at whatever
+     width real content requires (adjust the 480px estimate if needed).
+   - Tier 2→3: auth tag disappears first, then the process badge: `⚙N` stays clickable up to
+     the tier-2 floor and is absent below it.
+   - Context text and Shell remain visible and usable at every tier down to the practical
+     minimum pane width.
+   - No `@container modal-mount` rule remains — confirm via DevTools computed styles that the
+     `agent-pane` rules are the ones actually applying.
+3. Confirm the strip's height growth at Tier 2+ (28px → ~52px) doesn't visually collide with
+   anything above it (message list) or cause a layout jump mid-conversation when a pane is
+   resized while a turn is in flight.
+
+## 7. Files touched
+
+```
+frontend/app/view/agent/styles/_composer-strip.scss   # grid-template-areas, container queries
+```
+
+No `.tsx` changes required for the core two-line behavior (see §2).
+
+---
+
+*End of spec. Proposed — not yet implemented; ready for review/go-ahead.*

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -16,6 +16,7 @@
 .agent-composer-strip {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
+    grid-template-areas: "controls stats right";
     align-items: center;
     gap: var(--space-2);
     min-height: 28px;
@@ -37,6 +38,7 @@
 // ── Controls zone (left column) ─────────────────────────────────────────────
 
 .agent-composer-strip-controls {
+    grid-area: controls;
     display: flex;
     align-items: center;
     gap: var(--space-1);
@@ -46,6 +48,7 @@
 // ── Stats zone (center column) ──────────────────────────────────────────────
 
 .agent-composer-strip-stats-zone {
+    grid-area: stats;
     justify-self: center;
 }
 
@@ -174,6 +177,7 @@
 // pinning now).
 
 .agent-composer-strip-right {
+    grid-area: right;
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -257,24 +261,64 @@
     }
 }
 
-// Narrow-pane truncation — drop stats, then ctx text.
-@container modal-mount (max-width: 240px) {
-    .agent-composer-strip-stats,
-    .agent-composer-strip-ctx {
+// ── Responsive tiers ─────────────────────────────────────────────────────
+// Was `@container modal-mount` — that container name is only declared by
+// <Modal> portal mounts (modal.scss), never by the docked agent pane, so
+// these rules never matched in the real composer strip and nothing here
+// actually reflowed on a narrow pane. `.agent-view` is what establishes the
+// containment context around this strip (agent-view.scss, container-name:
+// agent-pane) — see SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md
+// for the full audit + design.
+
+// Tier 2 — two-line layout. Controls + right zone (badges/ctx/auth/Shell)
+// share row 1; stats drop to their own full-width, centered row 2. Nothing
+// is hidden here — giving stats a dedicated row removes them from the row-1
+// space contest entirely, which is why the old "drop stats at ≤240px" idea
+// is gone: it's no longer needed once this tier is active.
+@container agent-pane (max-width: 480px) {
+    .agent-composer-strip {
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+            "controls right"
+            "stats    stats";
+        min-height: 52px;
+        row-gap: 2px;
+    }
+
+    .agent-composer-strip-stats-zone {
+        justify-self: stretch;
+        text-align: center;
+    }
+}
+
+// Tier 3 — row 1 (controls + right zone) is still crowded with 5 things;
+// shed the least essential, informational-only items first. Context text
+// and Shell stay visible at every tier — ctx is the one safety signal in
+// this bar (compaction proximity), Shell is the strip's one real action.
+@container agent-pane (max-width: 300px) {
+    .agent-composer-strip-auth {
         display: none;
     }
 }
 
-@container modal-mount (max-width: 320px) {
-    // Keep the runtime dropup visible — one compact trigger fits easily.
-    // (Previously `.agent-composer-strip-select { display:none }` here hid
-    // Mode/Model/Effort on any pane ≤320px, leaving only Log — see
-    // SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02. Progressive
-    // collapse — short/icon/combined forms — is the follow-up.)
-    .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
-    // Only reintroduce a cap here, where the pane genuinely doesn't have
-    // room for the trigger's full "Mode · Model · Effort" summary.
-    .agent-runtime-dropup-trigger { max-width: 120px; }
+@container agent-pane (max-width: 260px) {
+    .agent-composer-strip-process-badge {
+        display: none;
+    }
+}
+
+// Tier 4 — controls trigger compacts to an ellipsized cap rather than
+// disappearing (never `display:none` the runtime controls — see
+// SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md).
+@container agent-pane (max-width: 220px) {
+    .agent-runtime-dropup-trigger {
+        max-width: 120px;
+    }
+
+    .agent-composer-strip-log-btn {
+        font-size: 9px;
+        padding: 1px 3px;
+    }
 }
 
 // ── Resizable details drawer (ResizableDetailsDrawer.tsx) ──────────────────

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -43,6 +43,12 @@
     align-items: center;
     gap: var(--space-1);
     justify-self: start;
+    // A grid item's default min-width is `auto` (its content's intrinsic
+    // size), not 0 — without this, `minmax(0, 1fr)` on the two-line tier's
+    // grid track (below) can't actually shrink the column past the trigger
+    // + HOST/SANDBOX badge's combined content width, defeating the trigger's
+    // own max-width cap and overflowing the row instead of clipping it.
+    min-width: 0;
 }
 
 // ── Stats zone (center column) ──────────────────────────────────────────────
@@ -56,7 +62,7 @@
 // a "Mode · Model · Effort" summary label + up-caret; same slim-pill footprint
 // as the former three separate selects/drop-ups combined into one. No fixed
 // max-width — sizes to its content; a cap only reappears under real space
-// pressure (see the ≤320px container query below), so it only ellipsizes
+// pressure (see the ≤220px container query below), so it only ellipsizes
 // when the pane genuinely has no room for it.
 .agent-runtime-dropup-trigger {
     display: inline-flex;
@@ -277,7 +283,12 @@
 // is gone: it's no longer needed once this tier is active.
 @container agent-pane (max-width: 480px) {
     .agent-composer-strip {
-        grid-template-columns: 1fr auto;
+        // minmax(0, 1fr), not bare 1fr — a bare 1fr track still has an
+        // implicit content-based minimum, so the controls column couldn't
+        // actually shrink past the trigger+badge's intrinsic width and
+        // would overflow the row instead of clipping (reagent P2 on this
+        // PR). Paired with .agent-composer-strip-controls's min-width: 0.
+        grid-template-columns: minmax(0, 1fr) auto;
         grid-template-areas:
             "controls right"
             "stats    stats";

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -188,6 +188,10 @@
     align-items: center;
     gap: var(--space-1-5);
     justify-self: end;
+    // Same nested-flex-in-grid min-width trap as .agent-composer-strip-controls
+    // above — without this, the two-line tier's right column (below) can't
+    // actually shrink past ctx text + Shell's combined content width either.
+    min-width: 0;
 }
 
 .agent-composer-strip-stats {
@@ -283,12 +287,14 @@
 // is gone: it's no longer needed once this tier is active.
 @container agent-pane (max-width: 480px) {
     .agent-composer-strip {
-        // minmax(0, 1fr), not bare 1fr — a bare 1fr track still has an
-        // implicit content-based minimum, so the controls column couldn't
-        // actually shrink past the trigger+badge's intrinsic width and
-        // would overflow the row instead of clipping (reagent P2 on this
-        // PR). Paired with .agent-composer-strip-controls's min-width: 0.
-        grid-template-columns: minmax(0, 1fr) auto;
+        // minmax(0, 1fr) / minmax(0, auto), not bare 1fr / auto — both track
+        // sizing keywords keep an implicit content-based minimum on their
+        // own, so EITHER column could overflow the row instead of shrinking
+        // to fit (reagent P1 re-review: the first fix only covered the
+        // controls column, missing that the right column has the identical
+        // problem). Paired with min-width: 0 on both
+        // .agent-composer-strip-controls and .agent-composer-strip-right.
+        grid-template-columns: minmax(0, 1fr) minmax(0, auto);
         grid-template-areas:
             "controls right"
             "stats    stats";


### PR DESCRIPTION
## Summary

The composer strip's narrow-pane container queries targeted `@container modal-mount` — a container name only declared by `<Modal>` portal mounts, never by the docked agent pane (whose real containment context is `.agent-view`'s `container-name: agent-pane`). They never matched, so narrowing the pane produced **no responsive behavior at all** — content just crowded/overlapped.

Fix, keyed off the correct `agent-pane` container:
- **≤480px** — switch from a single-row 3-column grid to a 2-row grid via `grid-template-areas`: controls + right-zone (badges/ctx/auth/Shell) share row 1, token/elapsed stats move to their own full-width, centered row 2. Nothing is hidden at this tier — giving stats a dedicated row removes them from the row-1 space contest entirely.
- **≤300px / ≤260px** — shed the auth tag, then the process badge (informational, lowest priority). Context text and Shell stay visible at every tier (ctx = the one safety signal in the bar, Shell = the primary action).
- **≤220px** — runtime-dropup trigger and Shell button compact, matching the pre-existing (previously dead) intent.

Full design: `docs/specs/SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md`.

## Test plan

- [x] `npx sass --style=compressed` on the changed file — compiles clean, no syntax errors
- [ ] `task dev` — manually resize an agent pane through the tiers and confirm: stats move to row 2 with no clipping around 480px; auth tag disappears first, then process badge; context text + Shell remain usable at the narrowest widths tested

<!-- agentmux:agent_id=agentx -->