### PR TITLE
feat(armory): ABF single-file format + importer (Phase 2)

### DIFF
--- a/.changesets/1785618688-feat-armory-abf-single-file-abf-zip-format-importer-phase-2-bvcf.md
+++ b/.changesets/1785618688-feat-armory-abf-single-file-abf-zip-format-importer-phase-2-bvcf.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): ABF single-file (.abf zip) format + importer (Phase 2)

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -323,12 +323,19 @@ fn redact_mcp_entry(entry: &Value) -> (Value, Vec<String>) {
     (redacted, redacted_names)
 }
 
-/// Validate a context-file's relative path is safe to place under
-/// `instructions/context/` in an exported bundle: non-empty, not absolute,
-/// no drive letter, no `..` traversal component. Pure string validation
-/// (no filesystem access) so [`export_bundle`] can stay a pure function.
-/// Returns `None` for anything that fails; callers skip that entry.
-fn sanitize_context_relative_path(path: &str) -> Option<String> {
+/// Validate a relative path is safe to place under a bundle export/import
+/// root: non-empty, not absolute, no drive letter, no `..` traversal
+/// component. Pure string validation (no filesystem access) so
+/// [`export_bundle`] can stay a pure function. Returns `None` for anything
+/// that fails; callers skip that entry.
+///
+/// `pub(crate)` (not private) so `bundle_import.rs` can reuse the exact
+/// same check on the way IN — an untrusted `.abf` file needs this defense
+/// at least as much as export needs it on the way out, and a single shared
+/// implementation means the two can never drift apart on what counts as
+/// safe (see `docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md`
+/// §4.3.4).
+pub(crate) fn sanitize_context_relative_path(path: &str) -> Option<String> {
     if path.is_empty() {
         return None;
     }

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -113,20 +113,31 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // re-export of that same bundle, written unredacted straight into
     // `instructions/AGENTS.md`) — defeating the accounts/ allowlist this
     // exact loop exists to enforce.
-    let by_path: HashMap<&str, &str> = files
-        .iter()
-        .filter(|f| {
-            let rejected = f.path.starts_with("accounts/") && f.path != "accounts/requirements.json";
-            if rejected {
-                warnings.push(format!(
-                    "{}: rejected — only accounts/requirements.json is ever read from the accounts/ directory",
-                    f.path
-                ));
-            }
-            !rejected
-        })
-        .map(|f| (f.path.as_str(), f.content.as_str()))
-        .collect();
+    // Codex P1, PR #2379 (round 2): the accounts/ allowlist check above
+    // only ever saw a ZIP entry's already-normalized path (unzip_bundle_import
+    // runs every entry through `sanitize_context_relative_path` first). The
+    // raw `files` RPC input skips that step entirely, so a spelling like
+    // `./accounts/secrets.json` or `accounts\secrets.json` doesn't match the
+    // literal `starts_with("accounts/")` check and sails through unrejected
+    // — while a manifest `components.*` entry using the exact same raw
+    // spelling still resolves it via `by_path.get(path)` below. Normalize
+    // every file's path the same way regardless of source (zip or raw
+    // list) before the allowlist check and before it becomes a lookup key,
+    // so both intake paths enforce the same rule on the same canonical form.
+    let mut by_path: HashMap<String, &str> = HashMap::new();
+    for f in files {
+        let Some(safe_path) = sanitize_context_relative_path(&f.path) else {
+            warnings.push(format!("{}: not a safe path; skipped", f.path));
+            continue;
+        };
+        if safe_path.starts_with("accounts/") && safe_path != "accounts/requirements.json" {
+            warnings.push(format!(
+                "{safe_path}: rejected — only accounts/requirements.json is ever read from the accounts/ directory"
+            ));
+            continue;
+        }
+        by_path.insert(safe_path, f.content.as_str());
+    }
 
     let manifest_raw = by_path
         .get("armory.json")
@@ -329,6 +340,15 @@ const MAX_ENTRY_UNCOMPRESSED_BYTES: u64 = 10 * 1024 * 1024;
 /// each individually pass [`MAX_ENTRY_UNCOMPRESSED_BYTES`].
 const MAX_TOTAL_UNCOMPRESSED_BYTES: u64 = 50 * 1024 * 1024;
 
+/// Maximum number of entries an archive may contain. A legitimate bundle
+/// (instructions, a handful of context files, a handful of skills, one
+/// manifest) never comes close to this; it exists purely to bound the CPU
+/// cost of iterating + path-sanitizing + hashing every entry, independent
+/// of the per-entry/aggregate byte caps below (reagent P2, PR #2379 round
+/// 2) — a crafted archive of many tiny/valid entries passes both size caps
+/// while still forcing unbounded iteration work.
+const MAX_ENTRY_COUNT: usize = 10_000;
+
 /// Unpack a `.abf` zip archive into a flat file list, applying the same
 /// path-safety check as everywhere else in this module to every entry
 /// name before it's trusted (§4.3.4) — a zip's own internal paths are
@@ -350,6 +370,13 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
     use std::io::Read;
     let cursor = std::io::Cursor::new(zip_bytes);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| format!("not a valid zip archive: {e}"))?;
+
+    if archive.len() > MAX_ENTRY_COUNT {
+        return Err(format!(
+            "zip archive: {} entries exceeds the limit ({MAX_ENTRY_COUNT}) — rejecting the whole import",
+            archive.len()
+        ));
+    }
 
     // First pass: collect every non-dir entry's raw name, to DETECT
     // whether every single one shares one common wrapping directory
@@ -412,18 +439,19 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
 
         // Declared size check first — cheap, and avoids decompressing at
         // all for an entry that's already too large per its own metadata.
+        // This is ONLY a cheap pre-filter: `entry.size()` is the zip's own
+        // declared/attacker-controlled uncompressed size, not a verified
+        // value, so it must never feed the aggregate cap below (reagent
+        // P1, PR #2379 round 2) — an archive of many entries that each lie
+        // with a tiny declared size while actually containing content up
+        // to the per-entry cap would otherwise pass both checks here while
+        // still exhausting memory once decompressed.
         let declared_size = entry.size();
         if declared_size > MAX_ENTRY_UNCOMPRESSED_BYTES {
             warnings.push(format!(
                 "{safe_name}: declared uncompressed size ({declared_size} bytes) exceeds the per-entry limit ({MAX_ENTRY_UNCOMPRESSED_BYTES} bytes); skipped"
             ));
             continue;
-        }
-        total_uncompressed = total_uncompressed.saturating_add(declared_size);
-        if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES {
-            return Err(format!(
-                "zip archive: aggregate declared uncompressed size exceeds the total limit ({MAX_TOTAL_UNCOMPRESSED_BYTES} bytes) — rejecting the whole import"
-            ));
         }
 
         // Hard backstop on the actual read, independent of the declared
@@ -441,6 +469,16 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
                 "{safe_name}: actual decompressed size exceeds the per-entry limit ({MAX_ENTRY_UNCOMPRESSED_BYTES} bytes), despite a smaller declared size; skipped"
             ));
             continue;
+        }
+
+        // Aggregate cap enforced against ACTUAL bytes read, not the
+        // declared size — the only value that can't be lied about by the
+        // archive's own metadata.
+        total_uncompressed = total_uncompressed.saturating_add(buf.len() as u64);
+        if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES {
+            return Err(format!(
+                "zip archive: aggregate decompressed size exceeds the total limit ({MAX_TOTAL_UNCOMPRESSED_BYTES} bytes) — rejecting the whole import"
+            ));
         }
         let content = match String::from_utf8(buf) {
             Ok(s) => s,
@@ -838,11 +876,14 @@ mod tests {
     }
 
     #[test]
-    fn rejects_the_whole_import_when_aggregate_declared_size_exceeds_the_total_cap() {
+    fn rejects_the_whole_import_when_aggregate_size_exceeds_the_total_cap() {
         // Six entries at ~90% of the per-entry cap each -- individually
         // well under MAX_ENTRY_UNCOMPRESSED_BYTES, but summing to ~5.4x
         // MAX_TOTAL_UNCOMPRESSED_BYTES's actual ratio (6 * 0.9*10MB = 54MB
-        // > the 50MB aggregate cap).
+        // > the 50MB aggregate cap). Real content, so this exercises the
+        // aggregate check regardless of whether it's keyed on declared or
+        // actual bytes -- see the dedicated "lying declared size" test
+        // below for the distinction that matters (reagent P1, round 2).
         let each = "a".repeat((MAX_ENTRY_UNCOMPRESSED_BYTES as f64 * 0.9) as usize);
         let zip_bytes = build_zip(&[
             ("armory.json", "{}"),
@@ -854,6 +895,66 @@ mod tests {
             ("instructions/context/f.md", &each),
         ]);
         let err = unzip_bundle_import(&zip_bytes).unwrap_err();
-        assert!(err.contains("aggregate declared uncompressed size exceeds"));
+        assert!(err.contains("aggregate decompressed size exceeds"));
+    }
+
+    #[test]
+    fn aggregate_cap_is_enforced_against_actual_bytes_even_when_declared_size_understates_them() {
+        // reagent P1, PR #2379 round 2: the aggregate check must accumulate
+        // ACTUAL decompressed bytes, not the zip's own declared/attacker-
+        // controlled `entry.size()` -- otherwise many entries that each lie
+        // with a tiny declared size while really containing content up to
+        // the per-entry cap would pass both checks and still exhaust
+        // memory. `ZipWriter`'s public API always writes a correct
+        // declared size for real content, so this is verified by patching
+        // the archive's declared-size fields post-write to a tiny value
+        // while leaving the real (large) compressed/uncompressed payload
+        // bytes untouched -- exactly the "lying" shape the finding
+        // describes. The local file header's uncompressed-size field sits
+        // at a fixed offset (22) from the start of each entry's header.
+        let each = "a".repeat((MAX_ENTRY_UNCOMPRESSED_BYTES as f64 * 0.9) as usize);
+        let mut zip_bytes = build_zip(&[
+            ("armory.json", "{}"),
+            ("instructions/context/a.md", &each),
+            ("instructions/context/b.md", &each),
+            ("instructions/context/c.md", &each),
+            ("instructions/context/d.md", &each),
+            ("instructions/context/e.md", &each),
+            ("instructions/context/f.md", &each),
+        ]);
+        // Local file header signature: 0x04034b50, little-endian bytes
+        // 50 4B 03 04. Uncompressed size is the u32 at header offset 22.
+        let sig = [0x50u8, 0x4b, 0x03, 0x04];
+        let mut i = 0usize;
+        let mut patched = 0;
+        while i + 26 <= zip_bytes.len() {
+            if zip_bytes[i..i + 4] == sig {
+                zip_bytes[i + 22..i + 26].copy_from_slice(&1u32.to_le_bytes());
+                patched += 1;
+            }
+            i += 1;
+        }
+        assert!(patched >= 6, "expected to patch every local file header, patched {patched}");
+        let err = unzip_bundle_import(&zip_bytes).unwrap_err();
+        assert!(
+            err.contains("aggregate decompressed size exceeds"),
+            "declared-size lie should not bypass the aggregate cap: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_archive_with_more_entries_than_the_count_cap() {
+        // reagent P2, PR #2379 round 2: per-entry/aggregate byte caps alone
+        // don't bound the CPU cost of iterating + sanitizing + hashing an
+        // archive with an enormous number of small, individually-valid
+        // entries.
+        let mut entries: Vec<(String, String)> = (0..=MAX_ENTRY_COUNT)
+            .map(|i| (format!("instructions/context/f{i}.md"), "x".to_string()))
+            .collect();
+        entries.push(("armory.json".to_string(), "{}".to_string()));
+        let refs: Vec<(&str, &str)> = entries.iter().map(|(p, c)| (p.as_str(), c.as_str())).collect();
+        let zip_bytes = build_zip(&refs);
+        let err = unzip_bundle_import(&zip_bytes).unwrap_err();
+        assert!(err.contains("entries exceeds the limit"));
     }
 }

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -179,12 +179,24 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // ------------------------------------------------------------------
     let mut instructions_parts: Vec<String> = Vec::new();
     let mut context_files: Vec<ImportedContextFile> = Vec::new();
+    // Codex P1, PR #2379 round 2: components.instructions is manifest-
+    // controlled and its length is NOT bounded by the decompression caps
+    // (those cap the underlying file *content*, not how many times a
+    // manifest can reference the same path). Without dedup, an untrusted
+    // manifest repeating one path thousands of times clones that path's
+    // content into instructions_parts once per repetition, letting a
+    // sub-50MB archive expand to many gigabytes before `join`.
+    let mut seen_instruction_paths: HashSet<&str> = HashSet::new();
     if let Some(paths) = components.and_then(|c| c.get("instructions")).and_then(|v| v.as_array()) {
         for path_val in paths {
             let Some(path) = path_val.as_str() else {
                 warnings.push("components.instructions: non-string entry skipped".to_string());
                 continue;
             };
+            if !seen_instruction_paths.insert(path) {
+                warnings.push(format!("components.instructions: \"{path}\" referenced more than once; duplicate skipped"));
+                continue;
+            }
             let Some(content) = by_path.get(path) else {
                 warnings.push(format!("components.instructions: \"{path}\" not found among the bundle's files; skipped"));
                 continue;
@@ -211,12 +223,17 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // ------------------------------------------------------------------
     let mut skills: Vec<ParsedSkill> = Vec::new();
     let mut skipped_skills: Vec<String> = Vec::new();
+    let mut seen_skill_dirs: HashSet<&str> = HashSet::new();
     if let Some(dirs) = components.and_then(|c| c.get("skills")).and_then(|v| v.as_array()) {
         for dir_val in dirs {
             let Some(dir) = dir_val.as_str() else {
                 warnings.push("components.skills: non-string entry skipped".to_string());
                 continue;
             };
+            if !seen_skill_dirs.insert(dir) {
+                warnings.push(format!("components.skills: \"{dir}\" referenced more than once; duplicate skipped"));
+                continue;
+            }
             let skill_md_path = format!("{}/SKILL.md", dir.trim_end_matches('/'));
             let Some(content) = by_path.get(skill_md_path.as_str()) else {
                 warnings.push(format!("components.skills: \"{skill_md_path}\" not found; skipped"));
@@ -239,12 +256,17 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // RPC handler's job, §4.5).
     // ------------------------------------------------------------------
     let mut mcp_servers: Vec<Value> = Vec::new();
+    let mut seen_mcp_paths: HashSet<&str> = HashSet::new();
     if let Some(paths) = components.and_then(|c| c.get("mcpServers")).and_then(|v| v.as_array()) {
         for path_val in paths {
             let Some(path) = path_val.as_str() else {
                 warnings.push("components.mcpServers: non-string entry skipped".to_string());
                 continue;
             };
+            if !seen_mcp_paths.insert(path) {
+                warnings.push(format!("components.mcpServers: \"{path}\" referenced more than once; duplicate skipped"));
+                continue;
+            }
             let Some(content) = by_path.get(path) else {
                 warnings.push(format!("components.mcpServers: \"{path}\" not found; skipped"));
                 continue;
@@ -522,6 +544,41 @@ mod tests {
     fn rejects_malformed_armory_json() {
         let err = parse_bundle_import(&[file("armory.json", "not json")]).unwrap_err();
         assert!(err.contains("malformed JSON"));
+    }
+
+    #[test]
+    fn deduplicates_repeated_instruction_references_instead_of_cloning_content_per_reference() {
+        // Codex P1, PR #2379 round 3: components.instructions is manifest-
+        // controlled and its length isn't bounded by the decompression
+        // caps -- those cap file CONTENT, not how many times a manifest
+        // can reference the same path. An untrusted manifest repeating one
+        // path thousands of times must not clone that content once per
+        // repetition.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md", "instructions/AGENTS.md", "instructions/AGENTS.md"],
+            }))),
+            file("instructions/AGENTS.md", "Be concise."),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "Be concise.");
+        assert!(result.warnings.iter().any(|w| w.contains("referenced more than once")));
+    }
+
+    #[test]
+    fn deduplicates_repeated_skill_and_mcp_references() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "skills": ["skills/deploy", "skills/deploy"],
+                "mcpServers": ["mcp/server.json", "mcp/server.json"],
+            }))),
+            file("skills/deploy/SKILL.md", "---\nname: \"deploy\"\ndescription: \"d\"\n---\n\nbody"),
+            file("mcp/server.json", r#"{"command":"npx","args":["-y","thing"]}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.mcp_servers.len(), 1);
+        assert!(result.warnings.iter().filter(|w| w.contains("referenced more than once")).count() == 2);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -1,0 +1,595 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Armory Bundle Format (ABF) importer — Phase 2 of
+//! `docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md`.
+//! Inverse of `bundle_export.rs`: takes a bundle's files (either a raw
+//! `[{path, content}]` list or an unpacked `.abf` zip archive) and
+//! validates + parses them into data ready for the `bundle.import` RPC
+//! handler to write to the Store.
+//!
+//! Pure functions only — no I/O, no Store access, no account resolution
+//! (account resolution needs `db_accounts`, which only the RPC handler has
+//! access to; see the spec's §4.5). Mirrors `bundle_export.rs`'s shape and
+//! quality bar deliberately: the same "warn, don't silently drop" and
+//! "reject the whole thing on structural failure, but never partially
+//! import on a per-entry problem" philosophy, since the two modules are
+//! meant to round-trip against each other.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::bundle_export::sanitize_context_relative_path;
+
+/// One file read from an import source (zip or raw list), path relative
+/// to the bundle root. Mirrors `bundle_export::BundleExportFile`.
+#[derive(Debug, Clone)]
+pub struct BundleImportFile {
+    pub path: String,
+    pub content: String,
+}
+
+/// A skill parsed out of a `skills/<slug>/SKILL.md` file — the inverse of
+/// `agent_config::render_skill_md`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ParsedSkill {
+    /// The slug from SKILL.md's own `name` field (Agent Skills spec:
+    /// must match the parent directory) — reused as both the imported
+    /// skill's display name and its `trigger`. Agent-skill-type skills
+    /// don't materialize a slash-command file from `trigger` (see
+    /// `agent_config.rs`'s `buildConfigFiles`), so this is a safe,
+    /// deterministic default rather than a meaningful distinct value.
+    pub slug: String,
+    pub description: String,
+    pub content: String,
+}
+
+/// One `accounts/requirements.json` entry — mirrors the shape
+/// `bundle_export.rs` writes (research report §5.3).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountRequirement {
+    pub id: String,
+    pub provider: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub env: String,
+    #[serde(default)]
+    pub optional: bool,
+}
+
+/// One `instructions/context/*` file, in the `[{path, content}]` shape
+/// `db_bundles.context_files` stores.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ImportedContextFile {
+    pub path: String,
+    pub content: String,
+}
+
+/// Parsed, validated bundle content ready for the RPC handler to resolve
+/// accounts against and write to the Store. `mcp_servers` still contains
+/// whatever `${VAR}`-style placeholders the exporter's redaction left in
+/// place — account resolution (§4.5, RPC-handler-side) substitutes real
+/// account bindings where exactly one match is found and leaves the rest
+/// untouched.
+#[derive(Debug, Clone, Serialize)]
+pub struct ParsedBundleImport {
+    pub name: String,
+    pub description: String,
+    pub instructions: String,
+    pub context_files: Vec<ImportedContextFile>,
+    pub mcp_servers: Vec<Value>,
+    pub skills: Vec<ParsedSkill>,
+    pub skipped_skills: Vec<String>,
+    pub requirements: Vec<AccountRequirement>,
+    pub warnings: Vec<String>,
+}
+
+/// Parse and validate a bundle's files into [`ParsedBundleImport`].
+/// Structural failures (missing/malformed `armory.json`) reject the whole
+/// import — `Err` — since there is nothing safe to partially write.
+/// Per-entry problems (a missing referenced file, an unsafe path, a
+/// malformed SKILL.md) degrade to a warning and that entry is skipped —
+/// matches `bundle_export.rs`'s own philosophy, and lets a lossy import
+/// still produce a usable bundle rather than an all-or-nothing failure on
+/// e.g. one corrupt skill among five good ones.
+pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImport, String> {
+    let by_path: HashMap<&str, &str> = files
+        .iter()
+        .map(|f| (f.path.as_str(), f.content.as_str()))
+        .collect();
+
+    let manifest_raw = by_path
+        .get("armory.json")
+        .ok_or_else(|| "armory.json: missing from bundle".to_string())?;
+    let manifest: Value = serde_json::from_str(manifest_raw)
+        .map_err(|e| format!("armory.json: malformed JSON ({e})"))?;
+
+    let mut warnings: Vec<String> = Vec::new();
+
+    // §4.3.5: reject anything under accounts/ other than requirements.json
+    // outright — never read, never write, never even acknowledged beyond a
+    // warning. Checked against every file actually present, not just what
+    // the manifest references, since a malicious/malformed bundle's
+    // `components` object is not a trustworthy inventory of its own
+    // contents.
+    for file in files {
+        if file.path.starts_with("accounts/") && file.path != "accounts/requirements.json" {
+            warnings.push(format!(
+                "{}: rejected — only accounts/requirements.json is ever read from the accounts/ directory",
+                file.path
+            ));
+        }
+    }
+
+    let name = manifest
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("imported-bundle")
+        .to_string();
+    let description = manifest
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // §4.3.2: schema/version are recorded (via warnings, since ParsedBundleImport
+    // has no dedicated field for them yet — no schema registry exists to
+    // validate against) but never block the import.
+    if manifest.get("$schema").is_none() {
+        warnings.push("armory.json: no $schema field present".to_string());
+    }
+    match manifest.get("version").and_then(|v| v.as_str()) {
+        Some(v) if v.starts_with("0.1") => {}
+        Some(other) => warnings.push(format!(
+            "armory.json: version \"{other}\" is not a recognized ABF v0.1.x version; importing anyway"
+        )),
+        None => warnings.push("armory.json: no version field present".to_string()),
+    }
+
+    let components = manifest.get("components").and_then(|v| v.as_object());
+
+    // ------------------------------------------------------------------
+    // instructions — every path in components.instructions, concatenated
+    // in manifest order for AGENTS.md-shaped entries; instructions/context/*
+    // paths become context_files entries instead.
+    // ------------------------------------------------------------------
+    let mut instructions_parts: Vec<String> = Vec::new();
+    let mut context_files: Vec<ImportedContextFile> = Vec::new();
+    if let Some(paths) = components.and_then(|c| c.get("instructions")).and_then(|v| v.as_array()) {
+        for path_val in paths {
+            let Some(path) = path_val.as_str() else {
+                warnings.push("components.instructions: non-string entry skipped".to_string());
+                continue;
+            };
+            let Some(content) = by_path.get(path) else {
+                warnings.push(format!("components.instructions: \"{path}\" not found among the bundle's files; skipped"));
+                continue;
+            };
+            if let Some(rel) = path.strip_prefix("instructions/context/") {
+                match sanitize_context_relative_path(rel) {
+                    Some(safe_rel) => context_files.push(ImportedContextFile {
+                        path: safe_rel,
+                        content: content.to_string(),
+                    }),
+                    None => warnings.push(format!(
+                        "{path}: not a safe relative path under instructions/context/; skipped"
+                    )),
+                }
+            } else {
+                instructions_parts.push(content.to_string());
+            }
+        }
+    }
+    let instructions = instructions_parts.join("\n\n---\n\n");
+
+    // ------------------------------------------------------------------
+    // skills — every directory in components.skills, reading <dir>/SKILL.md
+    // ------------------------------------------------------------------
+    let mut skills: Vec<ParsedSkill> = Vec::new();
+    let mut skipped_skills: Vec<String> = Vec::new();
+    if let Some(dirs) = components.and_then(|c| c.get("skills")).and_then(|v| v.as_array()) {
+        for dir_val in dirs {
+            let Some(dir) = dir_val.as_str() else {
+                warnings.push("components.skills: non-string entry skipped".to_string());
+                continue;
+            };
+            let skill_md_path = format!("{}/SKILL.md", dir.trim_end_matches('/'));
+            let Some(content) = by_path.get(skill_md_path.as_str()) else {
+                warnings.push(format!("components.skills: \"{skill_md_path}\" not found; skipped"));
+                skipped_skills.push(dir.to_string());
+                continue;
+            };
+            match parse_skill_md(content) {
+                Some(skill) => skills.push(skill),
+                None => {
+                    warnings.push(format!("{skill_md_path}: malformed SKILL.md frontmatter; skipped"));
+                    skipped_skills.push(dir.to_string());
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // mcp servers — every path in components.mcpServers, parsed as JSON
+    // verbatim (still containing ${VAR} placeholders; resolution is the
+    // RPC handler's job, §4.5).
+    // ------------------------------------------------------------------
+    let mut mcp_servers: Vec<Value> = Vec::new();
+    if let Some(paths) = components.and_then(|c| c.get("mcpServers")).and_then(|v| v.as_array()) {
+        for path_val in paths {
+            let Some(path) = path_val.as_str() else {
+                warnings.push("components.mcpServers: non-string entry skipped".to_string());
+                continue;
+            };
+            let Some(content) = by_path.get(path) else {
+                warnings.push(format!("components.mcpServers: \"{path}\" not found; skipped"));
+                continue;
+            };
+            match serde_json::from_str::<Value>(content) {
+                Ok(v) => mcp_servers.push(v),
+                Err(e) => warnings.push(format!("{path}: malformed JSON ({e}); skipped")),
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // accounts/requirements.json — read-only input to §4.5, never written
+    // anywhere as-is.
+    // ------------------------------------------------------------------
+    let mut requirements: Vec<AccountRequirement> = Vec::new();
+    if let Some(req_path) = components.and_then(|c| c.get("accounts")).and_then(|v| v.as_str()) {
+        if req_path != "accounts/requirements.json" {
+            warnings.push(format!(
+                "components.accounts: \"{req_path}\" is not accounts/requirements.json; ignored per the accounts/ allowlist"
+            ));
+        } else if let Some(content) = by_path.get(req_path) {
+            #[derive(Deserialize)]
+            struct RequirementsDoc {
+                #[serde(default)]
+                requirements: Vec<AccountRequirement>,
+            }
+            match serde_json::from_str::<RequirementsDoc>(content) {
+                Ok(doc) => requirements = doc.requirements,
+                Err(e) => warnings.push(format!("accounts/requirements.json: malformed JSON ({e}); ignored")),
+            }
+        } else {
+            warnings.push("components.accounts references accounts/requirements.json, but it's not present in the bundle".to_string());
+        }
+    }
+
+    Ok(ParsedBundleImport {
+        name,
+        description,
+        instructions,
+        context_files,
+        mcp_servers,
+        skills,
+        skipped_skills,
+        requirements,
+        warnings,
+    })
+}
+
+/// Parse a SKILL.md file (`render_skill_md`'s exact output shape, and
+/// nothing more general — this is not a YAML parser, just the inverse of
+/// the one writer this codebase has). Expects exactly:
+/// `---\nname: "<json-string>"\ndescription: "<json-string>"\n---\n\n<body>`.
+/// Returns `None` for anything that doesn't match — a real Agent Skills
+/// SKILL.md from elsewhere in the ecosystem may use additional frontmatter
+/// fields or different quoting; broadening this to a general YAML parser
+/// is a follow-up, not silently guessed at here (mirrors the exporter's
+/// own documented `server.json` scope decision).
+fn parse_skill_md(content: &str) -> Option<ParsedSkill> {
+    let rest = content.strip_prefix("---\n")?;
+    let (frontmatter, body) = rest.split_once("\n---\n\n")?;
+    let mut name: Option<String> = None;
+    let mut description: Option<String> = None;
+    for line in frontmatter.lines() {
+        let (key, value) = line.split_once(": ")?;
+        let parsed: String = serde_json::from_str(value).ok()?;
+        match key {
+            "name" => name = Some(parsed),
+            "description" => description = Some(parsed),
+            _ => {} // unrecognized frontmatter field — ignore, don't fail
+        }
+    }
+    Some(ParsedSkill {
+        slug: name?,
+        // Required, not defaulted: render_skill_md always writes both
+        // fields (falling back to a placeholder string, never omitting
+        // the key), so a real exported SKILL.md always has both present.
+        // A file missing `description` entirely isn't this writer's
+        // output shape — reject it the same as a missing `name`.
+        description: description?,
+        content: body.to_string(),
+    })
+}
+
+/// Unpack a `.abf` zip archive into a flat file list, applying the same
+/// path-safety check as everywhere else in this module to every entry
+/// name before it's trusted (§4.3.4) — a zip's own internal paths are
+/// exactly as untrusted as any other part of the archive's content.
+/// Directory entries are skipped; anything that fails the safety check is
+/// dropped with a warning rather than surfaced as a file.
+pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
+    use std::io::Read;
+    let cursor = std::io::Cursor::new(zip_bytes);
+    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| format!("not a valid zip archive: {e}"))?;
+    let mut out = Vec::new();
+    let mut warnings = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| format!("zip archive: failed to read entry {i}: {e}"))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let raw_name = entry.name().to_string();
+        // `zip_bundle_export` wraps every entry in a single top-level
+        // `<root_slug>/` directory (mirrors the spec's §5.1 on-disk
+        // layout, where the bundle-slug directory IS the archive root) —
+        // strip that one wrapping component before treating the rest as
+        // the bundle-relative path. An entry with no `/` at all (no
+        // wrapping directory) is kept as-is rather than rejected, so a
+        // hand-built `.abf` without the convention still round-trips.
+        let relative_name = raw_name.split_once('/').map(|(_, rest)| rest).unwrap_or(&raw_name);
+        let Some(safe_name) = sanitize_context_relative_path(relative_name) else {
+            warnings.push(format!("{raw_name}: not a safe path; skipped"));
+            continue;
+        };
+        if !seen.insert(safe_name.clone()) {
+            warnings.push(format!("{safe_name}: duplicate entry in archive; first occurrence kept"));
+            continue;
+        }
+        let mut content = String::new();
+        if let Err(e) = entry.read_to_string(&mut content) {
+            warnings.push(format!("{safe_name}: not valid UTF-8 text; skipped ({e})"));
+            continue;
+        }
+        out.push(BundleImportFile { path: safe_name, content });
+    }
+    Ok((out, warnings))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(path: &str, content: &str) -> BundleImportFile {
+        BundleImportFile { path: path.to_string(), content: content.to_string() }
+    }
+
+    fn minimal_manifest(components: Value) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "$schema": "https://docs.agentmux.ai/schemas/armory-bundle/v0.1/bundle.schema.json",
+            "name": "test-bundle",
+            "version": "0.1.0",
+            "description": "A test bundle",
+            "components": components,
+            "metadata": {},
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn rejects_missing_armory_json() {
+        let err = parse_bundle_import(&[]).unwrap_err();
+        assert!(err.contains("armory.json"));
+    }
+
+    #[test]
+    fn rejects_malformed_armory_json() {
+        let err = parse_bundle_import(&[file("armory.json", "not json")]).unwrap_err();
+        assert!(err.contains("malformed JSON"));
+    }
+
+    #[test]
+    fn imports_instructions_from_agents_md() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md"],
+            }))),
+            file("instructions/AGENTS.md", "Be concise."),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "Be concise.");
+        assert_eq!(result.name, "test-bundle");
+        assert_eq!(result.description, "A test bundle");
+    }
+
+    #[test]
+    fn imports_context_files_separately_from_instructions() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md", "instructions/context/notes.md"],
+            }))),
+            file("instructions/AGENTS.md", "Main instructions."),
+            file("instructions/context/notes.md", "Extra context."),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "Main instructions.");
+        assert_eq!(result.context_files, vec![ImportedContextFile {
+            path: "notes.md".to_string(),
+            content: "Extra context.".to_string(),
+        }]);
+    }
+
+    #[test]
+    fn warns_and_skips_a_missing_referenced_file_rather_than_failing() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md"],
+            }))),
+            // instructions/AGENTS.md deliberately absent
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "");
+        assert!(result.warnings.iter().any(|w| w.contains("not found")));
+    }
+
+    #[test]
+    fn imports_a_skill_round_tripped_through_render_skill_md() {
+        let rendered = super::super::agent_config::render_skill_md(
+            "deploy-checklist",
+            "Runs the checklist",
+            "1. Test\n2. Deploy",
+        );
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "skills": ["skills/deploy-checklist"],
+            }))),
+            file("skills/deploy-checklist/SKILL.md", &rendered),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].slug, "deploy-checklist");
+        assert_eq!(result.skills[0].description, "Runs the checklist");
+        assert_eq!(result.skills[0].content, "1. Test\n2. Deploy");
+        assert!(result.skipped_skills.is_empty());
+    }
+
+    #[test]
+    fn skips_a_skill_whose_skill_md_is_missing() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "skills": ["skills/ghost"],
+            }))),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.skills.is_empty());
+        assert_eq!(result.skipped_skills, vec!["skills/ghost".to_string()]);
+    }
+
+    #[test]
+    fn skips_a_skill_with_malformed_frontmatter() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "skills": ["skills/broken"],
+            }))),
+            file("skills/broken/SKILL.md", "not frontmatter at all"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.skills.is_empty());
+        assert_eq!(result.skipped_skills, vec!["skills/broken".to_string()]);
+        assert!(result.warnings.iter().any(|w| w.contains("malformed SKILL.md")));
+    }
+
+    #[test]
+    fn imports_mcp_servers_still_containing_placeholders() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "mcpServers": ["mcp/github.server.json"],
+            }))),
+            file("mcp/github.server.json", r#"{"type":"stdio","command":"gh-mcp","env":{"GITHUB_TOKEN":"${GITHUB_TOKEN}"}}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.mcp_servers.len(), 1);
+        assert_eq!(result.mcp_servers[0]["env"]["GITHUB_TOKEN"], "${GITHUB_TOKEN}");
+    }
+
+    #[test]
+    fn parses_account_requirements_read_only() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "accounts": "accounts/requirements.json",
+            }))),
+            file("accounts/requirements.json", r#"{"requirements":[{"id":"gh-main","provider":"github","kind":"api-key","env":"GITHUB_TOKEN","optional":false}]}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.requirements, vec![AccountRequirement {
+            id: "gh-main".to_string(),
+            provider: "github".to_string(),
+            kind: "api-key".to_string(),
+            env: "GITHUB_TOKEN".to_string(),
+            optional: false,
+        }]);
+    }
+
+    #[test]
+    fn rejects_any_accounts_file_other_than_requirements_json() {
+        // §4.3.5 / the report's original invariant: never read anything
+        // else under accounts/, even if present and well-formed.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({}))),
+            file("accounts/secrets.json", r#"{"github_token":"ghp_should_never_be_read"}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.warnings.iter().any(|w| w.contains("accounts/secrets.json") && w.contains("rejected")));
+    }
+
+    #[test]
+    fn warns_on_unrecognized_version_but_does_not_fail() {
+        let manifest = serde_json::to_string(&serde_json::json!({
+            "name": "test-bundle",
+            "version": "2.0.0",
+            "components": {},
+        })).unwrap();
+        let files = vec![file("armory.json", &manifest)];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.warnings.iter().any(|w| w.contains("version")));
+    }
+
+    #[test]
+    fn parse_skill_md_round_trips_special_characters() {
+        let rendered = super::super::agent_config::render_skill_md(
+            "weird-name",
+            "Has a colon: and \"quotes\"",
+            "body\nwith\nnewlines",
+        );
+        let parsed = parse_skill_md(&rendered).expect("parses");
+        assert_eq!(parsed.slug, "weird-name");
+        assert_eq!(parsed.description, "Has a colon: and \"quotes\"");
+        assert_eq!(parsed.content, "body\nwith\nnewlines");
+    }
+
+    #[test]
+    fn parse_skill_md_rejects_non_matching_shape() {
+        assert!(parse_skill_md("not frontmatter at all").is_none());
+        assert!(parse_skill_md("---\nname: \"x\"\n---\n\nbody").is_none()); // missing description
+        assert!(parse_skill_md("").is_none());
+    }
+
+    // ── zip round-trip ──────────────────────────────────────────────
+
+    #[test]
+    fn unzips_a_bundle_exported_as_zip() {
+        use crate::backend::storage::store::Memory;
+
+        let bundle = Memory {
+            id: "b1".to_string(),
+            name: "Zip Roundtrip".to_string(),
+            description: "desc".to_string(),
+            is_blank: false,
+            is_global: false,
+            provider: String::new(),
+            model: String::new(),
+            instructions: "Be helpful.".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: 0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let export = super::super::bundle_export::export_bundle(&bundle, &[]);
+        let zip_bytes = super::super::bundle_export::zip_bundle_export(&export).unwrap();
+
+        let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(warnings.is_empty());
+        assert!(files.iter().any(|f| f.path == "armory.json"));
+        assert!(files.iter().any(|f| f.path == "instructions/AGENTS.md" && f.content == "Be helpful."));
+
+        let parsed = parse_bundle_import(&files).unwrap();
+        assert_eq!(parsed.instructions, "Be helpful.");
+    }
+
+    #[test]
+    fn unzip_rejects_a_non_zip_input() {
+        let err = unzip_bundle_import(b"not a zip file").unwrap_err();
+        assert!(err.contains("not a valid zip archive"));
+    }
+}

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -215,7 +215,12 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // sub-50MB archive expand to many gigabytes before `join`.
     let mut seen_instruction_paths: HashSet<String> = HashSet::new();
     let mut duplicate_instruction_refs: u32 = 0;
-    if let Some(paths) = components.and_then(|c| c.get("instructions")).and_then(|v| v.as_array()) {
+    {
+        let paths = capped_component_array(
+            components.and_then(|c| c.get("instructions")).and_then(|v| v.as_array()),
+            "instructions",
+            &mut warnings,
+        );
         for path_val in paths {
             let Some(raw_path) = path_val.as_str() else {
                 warnings.push("components.instructions: non-string entry skipped".to_string());
@@ -289,7 +294,12 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     let mut skipped_skills: Vec<String> = Vec::new();
     let mut seen_skill_dirs: HashSet<String> = HashSet::new();
     let mut duplicate_skill_refs: u32 = 0;
-    if let Some(dirs) = components.and_then(|c| c.get("skills")).and_then(|v| v.as_array()) {
+    {
+        let dirs = capped_component_array(
+            components.and_then(|c| c.get("skills")).and_then(|v| v.as_array()),
+            "skills",
+            &mut warnings,
+        );
         for dir_val in dirs {
             let Some(raw_dir) = dir_val.as_str() else {
                 warnings.push("components.skills: non-string entry skipped".to_string());
@@ -325,6 +335,17 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     if duplicate_skill_refs > 0 {
         warnings.push(format!("components.skills: {duplicate_skill_refs} duplicate reference(s) skipped"));
     }
+    // codex P1, PR #2379 round 7: bounds the RPC handler's WRITE side --
+    // see MAX_IMPORTED_SKILLS's doc comment. The truncated skills still
+    // count as "skipped" for reporting purposes, matching every other
+    // skip reason in this loop.
+    if skills.len() > MAX_IMPORTED_SKILLS {
+        warnings.push(format!(
+            "components.skills: {} skills exceeds the import limit ({MAX_IMPORTED_SKILLS}); only the first {MAX_IMPORTED_SKILLS} are imported",
+            skills.len()
+        ));
+        skipped_skills.extend(skills.split_off(MAX_IMPORTED_SKILLS).into_iter().map(|s| s.slug));
+    }
 
     // ------------------------------------------------------------------
     // mcp servers — every path in components.mcpServers, parsed as JSON
@@ -334,7 +355,12 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     let mut mcp_servers: Vec<Value> = Vec::new();
     let mut seen_mcp_paths: HashSet<String> = HashSet::new();
     let mut duplicate_mcp_refs: u32 = 0;
-    if let Some(paths) = components.and_then(|c| c.get("mcpServers")).and_then(|v| v.as_array()) {
+    {
+        let paths = capped_component_array(
+            components.and_then(|c| c.get("mcpServers")).and_then(|v| v.as_array()),
+            "mcpServers",
+            &mut warnings,
+        );
         for path_val in paths {
             let Some(raw_path) = path_val.as_str() else {
                 warnings.push("components.mcpServers: non-string entry skipped".to_string());
@@ -381,52 +407,63 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // anywhere as-is.
     // ------------------------------------------------------------------
     let mut requirements: Vec<AccountRequirement> = Vec::new();
-    if let Some(raw_req_path) = components.and_then(|c| c.get("accounts")).and_then(|v| v.as_str()) {
-        // reagent P2, PR #2379 round 6: this was the one remaining
-        // manifest-reference lookup still comparing/using the raw,
-        // un-normalized string -- the same bug class round 4 fixed for
-        // components.instructions/skills/mcpServers, just missed here. A
-        // valid non-canonical spelling (e.g. "./accounts/requirements.json")
-        // failed the literal equality check, silently dropping legitimate
-        // account requirements.
-        let req_path = sanitize_context_relative_path(raw_req_path).filter(|p| is_requirements_json(p));
-        if let Some(req_path) = &req_path {
-            if let Some(content) = by_path.get(req_path.as_str()) {
-                #[derive(Deserialize)]
-                struct RequirementsDoc {
-                    #[serde(default)]
-                    requirements: Vec<AccountRequirement>,
-                }
-                match serde_json::from_str::<RequirementsDoc>(content) {
-                    Ok(doc) => {
-                        // codex P1, PR #2379 round 4: unbounded, the RPC
-                        // handler's per-requirement account lookup becomes a
-                        // synchronous store query per row — a permitted 10 MB
-                        // JSON entry can hold tens/hundreds of thousands of
-                        // (duplicate or distinct) requirements and keep that
-                        // handler busy for a prolonged time. Bounding here
-                        // protects the parse step itself; the handler
-                        // separately dedupes by provider so its actual query
-                        // count stays low even at this cap.
-                        if doc.requirements.len() > MAX_ACCOUNT_REQUIREMENTS {
-                            warnings.push(format!(
-                                "accounts/requirements.json: {} requirements exceeds the limit ({MAX_ACCOUNT_REQUIREMENTS}); only the first {MAX_ACCOUNT_REQUIREMENTS} are used",
-                                doc.requirements.len()
-                            ));
-                            requirements = doc.requirements.into_iter().take(MAX_ACCOUNT_REQUIREMENTS).collect();
-                        } else {
-                            requirements = doc.requirements;
-                        }
+    if let Some(accounts_val) = components.and_then(|c| c.get("accounts")) {
+        // reagent P2, PR #2379 round 7: every other component category
+        // (instructions/skills/mcpServers non-string entries, an
+        // unrecognized `version`) pushes an explicit warning when the
+        // manifest's value has the wrong shape — this one silently
+        // dropped a non-string `accounts` value with no warning at all,
+        // inconsistent with the module's own "warn, don't silently drop"
+        // philosophy.
+        if let Some(raw_req_path) = accounts_val.as_str() {
+            // reagent P2, PR #2379 round 6: this was the one remaining
+            // manifest-reference lookup still comparing/using the raw,
+            // un-normalized string -- the same bug class round 4 fixed for
+            // components.instructions/skills/mcpServers, just missed here. A
+            // valid non-canonical spelling (e.g. "./accounts/requirements.json")
+            // failed the literal equality check, silently dropping legitimate
+            // account requirements.
+            let req_path = sanitize_context_relative_path(raw_req_path).filter(|p| is_requirements_json(p));
+            if let Some(req_path) = &req_path {
+                if let Some(content) = by_path.get(req_path.as_str()) {
+                    #[derive(Deserialize)]
+                    struct RequirementsDoc {
+                        #[serde(default)]
+                        requirements: Vec<AccountRequirement>,
                     }
-                    Err(e) => warnings.push(format!("accounts/requirements.json: malformed JSON ({e}); ignored")),
+                    match serde_json::from_str::<RequirementsDoc>(content) {
+                        Ok(doc) => {
+                            // codex P1, PR #2379 round 4: unbounded, the RPC
+                            // handler's per-requirement account lookup becomes a
+                            // synchronous store query per row — a permitted 10 MB
+                            // JSON entry can hold tens/hundreds of thousands of
+                            // (duplicate or distinct) requirements and keep that
+                            // handler busy for a prolonged time. Bounding here
+                            // protects the parse step itself; the handler
+                            // separately dedupes by provider so its actual query
+                            // count stays low even at this cap.
+                            if doc.requirements.len() > MAX_ACCOUNT_REQUIREMENTS {
+                                warnings.push(format!(
+                                    "accounts/requirements.json: {} requirements exceeds the limit ({MAX_ACCOUNT_REQUIREMENTS}); only the first {MAX_ACCOUNT_REQUIREMENTS} are used",
+                                    doc.requirements.len()
+                                ));
+                                requirements = doc.requirements.into_iter().take(MAX_ACCOUNT_REQUIREMENTS).collect();
+                            } else {
+                                requirements = doc.requirements;
+                            }
+                        }
+                        Err(e) => warnings.push(format!("accounts/requirements.json: malformed JSON ({e}); ignored")),
+                    }
+                } else {
+                    warnings.push("components.accounts references accounts/requirements.json, but it's not present in the bundle".to_string());
                 }
             } else {
-                warnings.push("components.accounts references accounts/requirements.json, but it's not present in the bundle".to_string());
+                warnings.push(format!(
+                    "components.accounts: \"{raw_req_path}\" is not accounts/requirements.json; ignored per the accounts/ allowlist"
+                ));
             }
         } else {
-            warnings.push(format!(
-                "components.accounts: \"{raw_req_path}\" is not accounts/requirements.json; ignored per the accounts/ allowlist"
-            ));
+            warnings.push("components.accounts: non-string value skipped".to_string());
         }
     }
 
@@ -454,6 +491,29 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
 /// meant to ever read it.
 fn is_requirements_json(path: &str) -> bool {
     path.eq_ignore_ascii_case("accounts/requirements.json")
+}
+
+/// Bounds a manifest component array's length BEFORE any per-entry
+/// processing happens, so one cap protects every warning a per-entry
+/// loop can produce (non-string entries, unsafe paths, not-found
+/// lookups, malformed content, ...) at once — codex P1, PR #2379 round
+/// 7: round 6 bounded only the "duplicate reference" warning
+/// specifically; a manifest filled with non-string junk values hit an
+/// entirely different (still unbounded) warning path for the same
+/// amplification effect. Reuses [`MAX_ENTRY_COUNT`] — a manifest
+/// component array legitimately needs the same "more entries than any
+/// real bundle uses" ceiling a zip archive's entry count does.
+fn capped_component_array<'a>(arr: Option<&'a Vec<Value>>, key: &str, warnings: &mut Vec<String>) -> &'a [Value] {
+    let Some(arr) = arr else { return &[] };
+    let len = arr.len();
+    if len > MAX_ENTRY_COUNT {
+        warnings.push(format!(
+            "components.{key}: {len} entries exceeds the limit ({MAX_ENTRY_COUNT}); only the first {MAX_ENTRY_COUNT} are used"
+        ));
+        &arr[..MAX_ENTRY_COUNT]
+    } else {
+        arr.as_slice()
+    }
 }
 
 /// Parse a SKILL.md file (`render_skill_md`'s exact output shape, and
@@ -519,6 +579,18 @@ const MAX_ENTRY_COUNT: usize = 10_000;
 /// unbounded, could otherwise drive a synchronous store query for every
 /// row.
 const MAX_ACCOUNT_REQUIREMENTS: usize = 1_000;
+
+/// Maximum number of skills actually imported (i.e. written to the Store)
+/// from a single bundle. `MAX_ENTRY_COUNT`/`capped_component_array` bound
+/// how many `components.skills` entries are even LOOKED AT, but codex P1
+/// (PR #2379 round 7) points out that's still far too high a ceiling for
+/// the RPC handler's write side: importing up to that many skills means
+/// up to that many separate synchronous Store transactions, each creating
+/// a permanent, globally-visible skill row — a compact malicious archive
+/// (well within the size caps) could otherwise monopolize the handler and
+/// pollute the installation's skill catalog. A real bundle needs a
+/// handful to a few dozen skills at most.
+const MAX_IMPORTED_SKILLS: usize = 200;
 
 /// Single choke point for the per-entry/aggregate size caps, shared by
 /// BOTH intake paths (zip decompression and the raw `files` RPC list) —
@@ -1108,6 +1180,68 @@ mod tests {
         let keep = check_entry_size("corrupt.md", MAX_ENTRY_UNCOMPRESSED_BYTES, &mut total, &mut warnings);
         assert_eq!(keep, Ok(true), "bytes read before the error must still count");
         assert_eq!(total, MAX_ENTRY_UNCOMPRESSED_BYTES);
+    }
+
+    #[test]
+    fn components_accounts_non_string_value_gets_an_explicit_warning() {
+        // reagent P2, PR #2379 round 7: every other component category
+        // warns on a malformed value; this one used to silently drop it.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "accounts": ["not", "a", "string"],
+            }))),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.requirements.is_empty());
+        assert!(result.warnings.iter().any(|w| w.contains("components.accounts") && w.contains("non-string value")));
+    }
+
+    #[test]
+    fn caps_malformed_component_entries_before_they_can_amplify_into_unbounded_warnings() {
+        // codex P1, PR #2379 round 7: round 6 bounded the "duplicate
+        // reference" warning specifically; a manifest filled with
+        // non-string junk hits a DIFFERENT (still unbounded, until this
+        // fix) warning path for the same amplification effect.
+        // capped_component_array truncates the array itself before any
+        // per-entry processing, so this must produce at most one
+        // "exceeds the limit" warning plus MAX_ENTRY_COUNT "non-string
+        // entry" warnings -- not one per array element.
+        let many_junk: Vec<Value> = (0..MAX_ENTRY_COUNT + 500).map(|i| serde_json::json!(i)).collect();
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({ "instructions": many_junk }))),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.warnings.iter().any(|w| w.contains("components.instructions") && w.contains("exceeds the limit")));
+        let non_string_warnings = result.warnings.iter().filter(|w| w.contains("non-string entry skipped")).count();
+        assert_eq!(non_string_warnings, MAX_ENTRY_COUNT, "expected exactly the capped count, got {non_string_warnings}");
+    }
+
+    #[test]
+    fn caps_the_number_of_skills_actually_imported_from_a_single_bundle() {
+        // codex P1, PR #2379 round 7: MAX_ENTRY_COUNT bounds how many
+        // components.skills entries are even looked at, but that's still
+        // far too high a ceiling for the RPC handler's write side --
+        // each imported skill becomes a separate synchronous Store
+        // transaction creating a permanent global row.
+        let n = MAX_IMPORTED_SKILLS + 50;
+        let mut manifest_skills: Vec<Value> = Vec::new();
+        let mut skill_files: Vec<BundleImportFile> = Vec::new();
+        for i in 0..n {
+            let dir = format!("skills/s{i}");
+            manifest_skills.push(serde_json::json!(dir));
+            skill_files.push(file(
+                &format!("{dir}/SKILL.md"),
+                &format!("---\nname: \"s{i}\"\ndescription: \"d\"\n---\n\nbody"),
+            ));
+        }
+        let mut files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({ "skills": manifest_skills }))),
+        ];
+        files.extend(skill_files);
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.skills.len(), MAX_IMPORTED_SKILLS);
+        assert_eq!(result.skipped_skills.len(), 50);
+        assert!(result.warnings.iter().any(|w| w.contains("exceeds the import limit")));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -214,6 +214,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // content into instructions_parts once per repetition, letting a
     // sub-50MB archive expand to many gigabytes before `join`.
     let mut seen_instruction_paths: HashSet<String> = HashSet::new();
+    let mut duplicate_instruction_refs: u32 = 0;
     if let Some(paths) = components.and_then(|c| c.get("instructions")).and_then(|v| v.as_array()) {
         for path_val in paths {
             let Some(raw_path) = path_val.as_str() else {
@@ -231,8 +232,28 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
                 warnings.push(format!("components.instructions: \"{raw_path}\" is not a safe path; skipped"));
                 continue;
             };
+            // codex P1, PR #2379 round 6: accounts/requirements.json is
+            // intentionally IN by_path (the dedicated parser below needs
+            // to read it), but it must never be reachable through this
+            // generic lookup — a manifest listing it here would otherwise
+            // copy its raw JSON straight into `instructions`, later
+            // written unredacted to `instructions/AGENTS.md` on export.
+            if is_requirements_json(&path) {
+                warnings.push(format!(
+                    "components.instructions: \"{path}\" is the accounts/ requirements file; not readable as instructions"
+                ));
+                continue;
+            }
+            // codex P1, PR #2379 round 6: dedup already avoids cloning
+            // CONTENT per duplicate reference (round 3), but pushing one
+            // warning STRING per duplicate is itself an amplification
+            // vector — a permitted 10 MB manifest repeating one short
+            // path hundreds of thousands of times could allocate hundreds
+            // of megabytes of warning text serialized into the RPC
+            // response. Count instead; a single summary warning is pushed
+            // after the loop.
             if !seen_instruction_paths.insert(path.clone()) {
-                warnings.push(format!("components.instructions: \"{path}\" referenced more than once; duplicate skipped"));
+                duplicate_instruction_refs += 1;
                 continue;
             }
             let Some(content) = by_path.get(path.as_str()) else {
@@ -254,6 +275,11 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
             }
         }
     }
+    if duplicate_instruction_refs > 0 {
+        warnings.push(format!(
+            "components.instructions: {duplicate_instruction_refs} duplicate reference(s) skipped"
+        ));
+    }
     let instructions = instructions_parts.join("\n\n---\n\n");
 
     // ------------------------------------------------------------------
@@ -262,6 +288,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     let mut skills: Vec<ParsedSkill> = Vec::new();
     let mut skipped_skills: Vec<String> = Vec::new();
     let mut seen_skill_dirs: HashSet<String> = HashSet::new();
+    let mut duplicate_skill_refs: u32 = 0;
     if let Some(dirs) = components.and_then(|c| c.get("skills")).and_then(|v| v.as_array()) {
         for dir_val in dirs {
             let Some(raw_dir) = dir_val.as_str() else {
@@ -274,8 +301,10 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
                 warnings.push(format!("components.skills: \"{raw_dir}\" is not a safe path; skipped"));
                 continue;
             };
+            // codex P1, PR #2379 round 6: bounded the same way as
+            // components.instructions above.
             if !seen_skill_dirs.insert(dir.clone()) {
-                warnings.push(format!("components.skills: \"{dir}\" referenced more than once; duplicate skipped"));
+                duplicate_skill_refs += 1;
                 continue;
             }
             let skill_md_path = format!("{}/SKILL.md", dir.trim_end_matches('/'));
@@ -293,6 +322,9 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
             }
         }
     }
+    if duplicate_skill_refs > 0 {
+        warnings.push(format!("components.skills: {duplicate_skill_refs} duplicate reference(s) skipped"));
+    }
 
     // ------------------------------------------------------------------
     // mcp servers — every path in components.mcpServers, parsed as JSON
@@ -301,6 +333,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // ------------------------------------------------------------------
     let mut mcp_servers: Vec<Value> = Vec::new();
     let mut seen_mcp_paths: HashSet<String> = HashSet::new();
+    let mut duplicate_mcp_refs: u32 = 0;
     if let Some(paths) = components.and_then(|c| c.get("mcpServers")).and_then(|v| v.as_array()) {
         for path_val in paths {
             let Some(raw_path) = path_val.as_str() else {
@@ -313,8 +346,20 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
                 warnings.push(format!("components.mcpServers: \"{raw_path}\" is not a safe path; skipped"));
                 continue;
             };
+            // codex P1, PR #2379 round 6: same rejection as
+            // components.instructions above -- requirements.json's raw
+            // content is valid JSON and would otherwise parse cleanly
+            // into an mcpServers entry, leaking it the same way.
+            if is_requirements_json(&path) {
+                warnings.push(format!(
+                    "components.mcpServers: \"{path}\" is the accounts/ requirements file; not readable as an MCP server config"
+                ));
+                continue;
+            }
+            // codex P1, PR #2379 round 6: bounded the same way as
+            // components.instructions above.
             if !seen_mcp_paths.insert(path.clone()) {
-                warnings.push(format!("components.mcpServers: \"{path}\" referenced more than once; duplicate skipped"));
+                duplicate_mcp_refs += 1;
                 continue;
             }
             let Some(content) = by_path.get(path.as_str()) else {
@@ -327,48 +372,61 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
             }
         }
     }
+    if duplicate_mcp_refs > 0 {
+        warnings.push(format!("components.mcpServers: {duplicate_mcp_refs} duplicate reference(s) skipped"));
+    }
 
     // ------------------------------------------------------------------
     // accounts/requirements.json — read-only input to §4.5, never written
     // anywhere as-is.
     // ------------------------------------------------------------------
     let mut requirements: Vec<AccountRequirement> = Vec::new();
-    if let Some(req_path) = components.and_then(|c| c.get("accounts")).and_then(|v| v.as_str()) {
-        if req_path != "accounts/requirements.json" {
-            warnings.push(format!(
-                "components.accounts: \"{req_path}\" is not accounts/requirements.json; ignored per the accounts/ allowlist"
-            ));
-        } else if let Some(content) = by_path.get(req_path) {
-            #[derive(Deserialize)]
-            struct RequirementsDoc {
-                #[serde(default)]
-                requirements: Vec<AccountRequirement>,
-            }
-            match serde_json::from_str::<RequirementsDoc>(content) {
-                Ok(doc) => {
-                    // codex P1, PR #2379 round 4: unbounded, the RPC
-                    // handler's per-requirement account lookup becomes a
-                    // synchronous store query per row — a permitted 10 MB
-                    // JSON entry can hold tens/hundreds of thousands of
-                    // (duplicate or distinct) requirements and keep that
-                    // handler busy for a prolonged time. Bounding here
-                    // protects the parse step itself; the handler
-                    // separately dedupes by provider so its actual query
-                    // count stays low even at this cap.
-                    if doc.requirements.len() > MAX_ACCOUNT_REQUIREMENTS {
-                        warnings.push(format!(
-                            "accounts/requirements.json: {} requirements exceeds the limit ({MAX_ACCOUNT_REQUIREMENTS}); only the first {MAX_ACCOUNT_REQUIREMENTS} are used",
-                            doc.requirements.len()
-                        ));
-                        requirements = doc.requirements.into_iter().take(MAX_ACCOUNT_REQUIREMENTS).collect();
-                    } else {
-                        requirements = doc.requirements;
-                    }
+    if let Some(raw_req_path) = components.and_then(|c| c.get("accounts")).and_then(|v| v.as_str()) {
+        // reagent P2, PR #2379 round 6: this was the one remaining
+        // manifest-reference lookup still comparing/using the raw,
+        // un-normalized string -- the same bug class round 4 fixed for
+        // components.instructions/skills/mcpServers, just missed here. A
+        // valid non-canonical spelling (e.g. "./accounts/requirements.json")
+        // failed the literal equality check, silently dropping legitimate
+        // account requirements.
+        let req_path = sanitize_context_relative_path(raw_req_path).filter(|p| is_requirements_json(p));
+        if let Some(req_path) = &req_path {
+            if let Some(content) = by_path.get(req_path.as_str()) {
+                #[derive(Deserialize)]
+                struct RequirementsDoc {
+                    #[serde(default)]
+                    requirements: Vec<AccountRequirement>,
                 }
-                Err(e) => warnings.push(format!("accounts/requirements.json: malformed JSON ({e}); ignored")),
+                match serde_json::from_str::<RequirementsDoc>(content) {
+                    Ok(doc) => {
+                        // codex P1, PR #2379 round 4: unbounded, the RPC
+                        // handler's per-requirement account lookup becomes a
+                        // synchronous store query per row — a permitted 10 MB
+                        // JSON entry can hold tens/hundreds of thousands of
+                        // (duplicate or distinct) requirements and keep that
+                        // handler busy for a prolonged time. Bounding here
+                        // protects the parse step itself; the handler
+                        // separately dedupes by provider so its actual query
+                        // count stays low even at this cap.
+                        if doc.requirements.len() > MAX_ACCOUNT_REQUIREMENTS {
+                            warnings.push(format!(
+                                "accounts/requirements.json: {} requirements exceeds the limit ({MAX_ACCOUNT_REQUIREMENTS}); only the first {MAX_ACCOUNT_REQUIREMENTS} are used",
+                                doc.requirements.len()
+                            ));
+                            requirements = doc.requirements.into_iter().take(MAX_ACCOUNT_REQUIREMENTS).collect();
+                        } else {
+                            requirements = doc.requirements;
+                        }
+                    }
+                    Err(e) => warnings.push(format!("accounts/requirements.json: malformed JSON ({e}); ignored")),
+                }
+            } else {
+                warnings.push("components.accounts references accounts/requirements.json, but it's not present in the bundle".to_string());
             }
         } else {
-            warnings.push("components.accounts references accounts/requirements.json, but it's not present in the bundle".to_string());
+            warnings.push(format!(
+                "components.accounts: \"{raw_req_path}\" is not accounts/requirements.json; ignored per the accounts/ allowlist"
+            ));
         }
     }
 
@@ -383,6 +441,19 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
         requirements,
         warnings,
     })
+}
+
+/// True if `path` is (case-insensitively) the one file ever read out of
+/// the accounts/ directory. Used both to allow it into `by_path` (the
+/// accounts/ allowlist above) and to REJECT it from every OTHER
+/// component category's generic lookup (codex P1, PR #2379 round 6) —
+/// components.instructions/mcpServers must never be able to pull its raw
+/// JSON content in as if it were ordinary bundle content (e.g. straight
+/// into `instructions/AGENTS.md` on a later export, or into an mcpServer
+/// entry), since only the dedicated accounts/requirements.json parser is
+/// meant to ever read it.
+fn is_requirements_json(path: &str) -> bool {
+    path.eq_ignore_ascii_case("accounts/requirements.json")
 }
 
 /// Parse a SKILL.md file (`render_skill_md`'s exact output shape, and
@@ -635,19 +706,26 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
         // still caught (rather than trusting zip metadata alone).
         let mut limited = entry.by_ref().take(MAX_ENTRY_UNCOMPRESSED_BYTES + 1);
         let mut buf: Vec<u8> = Vec::new();
-        if let Err(e) = limited.read_to_end(&mut buf) {
+        let read_err = limited.read_to_end(&mut buf).err();
+
+        // codex P1, PR #2379 round 5/6: `check_entry_size` accounts these
+        // bytes toward the aggregate budget BEFORE deciding whether to
+        // keep the entry, unlike the previous inline checks here (which
+        // accumulated only KEPT entries' bytes). Called unconditionally
+        // here — even when the read above ultimately errored (e.g. a
+        // forged CRC on an otherwise-decompressing entry) — since
+        // `read_to_end` can leave real decompressed bytes in `buf` before
+        // returning an error; that decompression work already happened
+        // regardless of the read's outcome, and up to MAX_ENTRY_COUNT
+        // such corrupt entries must not be able to force ~10MB of work
+        // each while the aggregate counter stays untouched.
+        let keep = check_entry_size(&safe_name, buf.len() as u64, &mut total_uncompressed, &mut warnings)?;
+
+        if let Some(e) = read_err {
             warnings.push(format!("{safe_name}: failed to read entry: {e}"));
             continue;
         }
-
-        // codex P1, PR #2379 round 5: `check_entry_size` accounts these
-        // bytes toward the aggregate budget BEFORE deciding whether to
-        // keep the entry, unlike the previous inline checks here (which
-        // accumulated only KEPT entries' bytes, so an entry that failed
-        // its own per-entry cap was decompressed — real work already
-        // spent — and then discarded without ever counting against the
-        // aggregate limit).
-        if !check_entry_size(&safe_name, buf.len() as u64, &mut total_uncompressed, &mut warnings)? {
+        if !keep {
             continue;
         }
         let content = match String::from_utf8(buf) {
@@ -710,7 +788,10 @@ mod tests {
         ];
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.instructions, "Be concise.");
-        assert!(result.warnings.iter().any(|w| w.contains("referenced more than once")));
+        // codex P1, PR #2379 round 6: one bounded summary warning instead
+        // of one warning string per duplicate (its own amplification
+        // vector -- see the round-6 tests below).
+        assert!(result.warnings.iter().any(|w| w.contains("2 duplicate reference(s) skipped")));
     }
 
     #[test]
@@ -726,7 +807,8 @@ mod tests {
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.skills.len(), 1);
         assert_eq!(result.mcp_servers.len(), 1);
-        assert!(result.warnings.iter().filter(|w| w.contains("referenced more than once")).count() == 2);
+        assert!(result.warnings.iter().any(|w| w.contains("components.skills: 1 duplicate reference(s) skipped")));
+        assert!(result.warnings.iter().any(|w| w.contains("components.mcpServers: 1 duplicate reference(s) skipped")));
     }
 
     #[test]
@@ -947,6 +1029,85 @@ mod tests {
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.requirements.len(), MAX_ACCOUNT_REQUIREMENTS);
         assert!(result.warnings.iter().any(|w| w.contains("exceeds the limit")));
+    }
+
+    #[test]
+    fn resolves_a_non_canonical_components_accounts_reference() {
+        // reagent P2, PR #2379 round 6: components.accounts was the one
+        // remaining manifest-reference lookup still comparing the raw,
+        // un-normalized string -- the same bug class round 4 fixed for
+        // instructions/skills/mcpServers.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "accounts": "./accounts/requirements.json",
+            }))),
+            file("accounts/requirements.json", r#"{"requirements":[{"id":"gh-main","provider":"github","kind":"api-key","env":"GITHUB_TOKEN","optional":false}]}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.requirements.len(), 1);
+        assert!(result.warnings.iter().all(|w| !w.contains("is not accounts/requirements.json")));
+    }
+
+    #[test]
+    fn requirements_json_is_not_readable_through_components_instructions_or_mcp_servers() {
+        // codex P1, PR #2379 round 6: accounts/requirements.json is
+        // intentionally in by_path for the dedicated parser above, but
+        // must never be reachable through the generic component lookups
+        // -- otherwise its raw content leaks into instructions (and later
+        // an export's AGENTS.md) or an mcpServers entry.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["accounts/requirements.json"],
+                "mcpServers": ["accounts/requirements.json"],
+            }))),
+            file("accounts/requirements.json", r#"{"requirements":[{"id":"gh-main","provider":"github","kind":"api-key","env":"GITHUB_TOKEN_SECRET_LEAK","optional":false}]}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(!result.instructions.contains("GITHUB_TOKEN_SECRET_LEAK"));
+        assert!(result.mcp_servers.is_empty());
+        assert!(result.warnings.iter().any(|w| w.contains("components.instructions") && w.contains("not readable as instructions")));
+        assert!(result.warnings.iter().any(|w| w.contains("components.mcpServers") && w.contains("not readable as an MCP server config")));
+    }
+
+    #[test]
+    fn duplicate_reference_warnings_are_bounded_to_one_summary_per_component_category() {
+        // codex P1, PR #2379 round 6: dedup already avoids cloning
+        // CONTENT per duplicate (round 3), but pushing one warning STRING
+        // per duplicate was itself unbounded -- a permitted 10 MB
+        // manifest repeating one short path hundreds of thousands of
+        // times could allocate hundreds of megabytes of warning text.
+        let many_dupes: Vec<Value> = (0..1_000).map(|_| serde_json::json!("instructions/AGENTS.md")).collect();
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({ "instructions": many_dupes }))),
+            file("instructions/AGENTS.md", "Be concise."),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "Be concise.");
+        assert_eq!(
+            result.warnings.iter().filter(|w| w.contains("duplicate reference(s) skipped")).count(),
+            1,
+            "expected exactly one summary warning, got: {:?}",
+            result.warnings
+        );
+        assert!(result.warnings.iter().any(|w| w.contains("999 duplicate reference(s) skipped")));
+    }
+
+    #[test]
+    fn unzip_counts_bytes_read_before_a_decompression_error_toward_the_aggregate() {
+        // codex P1, PR #2379 round 6: read_to_end can leave real
+        // decompressed bytes in `buf` even when it ultimately returns an
+        // error (e.g. a forged CRC on an otherwise-valid entry) -- that
+        // decompression work happened regardless, and must count.
+        // Directly exercises the ordering fix (check_entry_size runs
+        // before the read-error branch) since forging a CRC mismatch
+        // through the public ZipWriter API isn't practical.
+        let mut total: u64 = 0;
+        let mut warnings = Vec::new();
+        // Simulates: read_to_end returned Err, but buf still holds
+        // MAX_ENTRY_UNCOMPRESSED_BYTES bytes of real decompressed data.
+        let keep = check_entry_size("corrupt.md", MAX_ENTRY_UNCOMPRESSED_BYTES, &mut total, &mut warnings);
+        assert_eq!(keep, Ok(true), "bytes read before the error must still count");
+        assert_eq!(total, MAX_ENTRY_UNCOMPRESSED_BYTES);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -130,7 +130,16 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
             warnings.push(format!("{}: not a safe path; skipped", f.path));
             continue;
         };
-        if safe_path.starts_with("accounts/") && safe_path != "accounts/requirements.json" {
+        // reagent P1, PR #2379 round 4: case-insensitive on the DIRECTORY
+        // check -- sanitize_context_relative_path never case-folds, so
+        // `ACCOUNTS/secrets.json` (or any other-case variant) previously
+        // sailed past the literal lowercase `starts_with` check while a
+        // manifest reference using the identical casing would still
+        // resolve it. The exception itself stays exact-match against the
+        // canonical lowercase spelling the exporter always emits — an
+        // other-case "requirements.json" is still inside the rejected
+        // directory, just not recognized as the one allowed file.
+        if safe_path.to_ascii_lowercase().starts_with("accounts/") && safe_path != "accounts/requirements.json" {
             warnings.push(format!(
                 "{safe_path}: rejected — only accounts/requirements.json is ever read from the accounts/ directory"
             ));
@@ -186,18 +195,29 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // manifest repeating one path thousands of times clones that path's
     // content into instructions_parts once per repetition, letting a
     // sub-50MB archive expand to many gigabytes before `join`.
-    let mut seen_instruction_paths: HashSet<&str> = HashSet::new();
+    let mut seen_instruction_paths: HashSet<String> = HashSet::new();
     if let Some(paths) = components.and_then(|c| c.get("instructions")).and_then(|v| v.as_array()) {
         for path_val in paths {
-            let Some(path) = path_val.as_str() else {
+            let Some(raw_path) = path_val.as_str() else {
                 warnings.push("components.instructions: non-string entry skipped".to_string());
                 continue;
             };
-            if !seen_instruction_paths.insert(path) {
+            // codex P2, PR #2379 round 4: normalize the manifest's OWN
+            // reference the same way `by_path`'s keys are normalized
+            // (round 4's earlier fix) — otherwise a valid non-canonical
+            // spelling here (e.g. `./instructions/AGENTS.md`) no longer
+            // matches the now-canonicalized lookup key and the component
+            // is reported missing even though the file is genuinely
+            // present under an equivalent spelling.
+            let Some(path) = sanitize_context_relative_path(raw_path) else {
+                warnings.push(format!("components.instructions: \"{raw_path}\" is not a safe path; skipped"));
+                continue;
+            };
+            if !seen_instruction_paths.insert(path.clone()) {
                 warnings.push(format!("components.instructions: \"{path}\" referenced more than once; duplicate skipped"));
                 continue;
             }
-            let Some(content) = by_path.get(path) else {
+            let Some(content) = by_path.get(path.as_str()) else {
                 warnings.push(format!("components.instructions: \"{path}\" not found among the bundle's files; skipped"));
                 continue;
             };
@@ -223,28 +243,34 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // ------------------------------------------------------------------
     let mut skills: Vec<ParsedSkill> = Vec::new();
     let mut skipped_skills: Vec<String> = Vec::new();
-    let mut seen_skill_dirs: HashSet<&str> = HashSet::new();
+    let mut seen_skill_dirs: HashSet<String> = HashSet::new();
     if let Some(dirs) = components.and_then(|c| c.get("skills")).and_then(|v| v.as_array()) {
         for dir_val in dirs {
-            let Some(dir) = dir_val.as_str() else {
+            let Some(raw_dir) = dir_val.as_str() else {
                 warnings.push("components.skills: non-string entry skipped".to_string());
                 continue;
             };
-            if !seen_skill_dirs.insert(dir) {
+            // codex P2, PR #2379 round 4: same normalization as
+            // components.instructions above.
+            let Some(dir) = sanitize_context_relative_path(raw_dir) else {
+                warnings.push(format!("components.skills: \"{raw_dir}\" is not a safe path; skipped"));
+                continue;
+            };
+            if !seen_skill_dirs.insert(dir.clone()) {
                 warnings.push(format!("components.skills: \"{dir}\" referenced more than once; duplicate skipped"));
                 continue;
             }
             let skill_md_path = format!("{}/SKILL.md", dir.trim_end_matches('/'));
             let Some(content) = by_path.get(skill_md_path.as_str()) else {
                 warnings.push(format!("components.skills: \"{skill_md_path}\" not found; skipped"));
-                skipped_skills.push(dir.to_string());
+                skipped_skills.push(dir.clone());
                 continue;
             };
             match parse_skill_md(content) {
                 Some(skill) => skills.push(skill),
                 None => {
                     warnings.push(format!("{skill_md_path}: malformed SKILL.md frontmatter; skipped"));
-                    skipped_skills.push(dir.to_string());
+                    skipped_skills.push(dir.clone());
                 }
             }
         }
@@ -256,18 +282,24 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // RPC handler's job, §4.5).
     // ------------------------------------------------------------------
     let mut mcp_servers: Vec<Value> = Vec::new();
-    let mut seen_mcp_paths: HashSet<&str> = HashSet::new();
+    let mut seen_mcp_paths: HashSet<String> = HashSet::new();
     if let Some(paths) = components.and_then(|c| c.get("mcpServers")).and_then(|v| v.as_array()) {
         for path_val in paths {
-            let Some(path) = path_val.as_str() else {
+            let Some(raw_path) = path_val.as_str() else {
                 warnings.push("components.mcpServers: non-string entry skipped".to_string());
                 continue;
             };
-            if !seen_mcp_paths.insert(path) {
+            // codex P2, PR #2379 round 4: same normalization as
+            // components.instructions above.
+            let Some(path) = sanitize_context_relative_path(raw_path) else {
+                warnings.push(format!("components.mcpServers: \"{raw_path}\" is not a safe path; skipped"));
+                continue;
+            };
+            if !seen_mcp_paths.insert(path.clone()) {
                 warnings.push(format!("components.mcpServers: \"{path}\" referenced more than once; duplicate skipped"));
                 continue;
             }
-            let Some(content) = by_path.get(path) else {
+            let Some(content) = by_path.get(path.as_str()) else {
                 warnings.push(format!("components.mcpServers: \"{path}\" not found; skipped"));
                 continue;
             };
@@ -295,7 +327,26 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
                 requirements: Vec<AccountRequirement>,
             }
             match serde_json::from_str::<RequirementsDoc>(content) {
-                Ok(doc) => requirements = doc.requirements,
+                Ok(doc) => {
+                    // codex P1, PR #2379 round 4: unbounded, the RPC
+                    // handler's per-requirement account lookup becomes a
+                    // synchronous store query per row — a permitted 10 MB
+                    // JSON entry can hold tens/hundreds of thousands of
+                    // (duplicate or distinct) requirements and keep that
+                    // handler busy for a prolonged time. Bounding here
+                    // protects the parse step itself; the handler
+                    // separately dedupes by provider so its actual query
+                    // count stays low even at this cap.
+                    if doc.requirements.len() > MAX_ACCOUNT_REQUIREMENTS {
+                        warnings.push(format!(
+                            "accounts/requirements.json: {} requirements exceeds the limit ({MAX_ACCOUNT_REQUIREMENTS}); only the first {MAX_ACCOUNT_REQUIREMENTS} are used",
+                            doc.requirements.len()
+                        ));
+                        requirements = doc.requirements.into_iter().take(MAX_ACCOUNT_REQUIREMENTS).collect();
+                    } else {
+                        requirements = doc.requirements;
+                    }
+                }
                 Err(e) => warnings.push(format!("accounts/requirements.json: malformed JSON ({e}); ignored")),
             }
         } else {
@@ -370,6 +421,15 @@ const MAX_TOTAL_UNCOMPRESSED_BYTES: u64 = 50 * 1024 * 1024;
 /// 2) — a crafted archive of many tiny/valid entries passes both size caps
 /// while still forcing unbounded iteration work.
 const MAX_ENTRY_COUNT: usize = 10_000;
+
+/// Maximum number of account requirements accepted from a single bundle's
+/// `accounts/requirements.json`. A real bundle needs a handful at most —
+/// one per distinct external account it depends on. Exists to bound the
+/// RPC handler's downstream per-provider account-lookup work (codex P1,
+/// PR #2379 round 4): an untrusted archive's requirements array,
+/// unbounded, could otherwise drive a synchronous store query for every
+/// row.
+const MAX_ACCOUNT_REQUIREMENTS: usize = 1_000;
 
 /// Unpack a `.abf` zip archive into a flat file list, applying the same
 /// path-safety check as everywhere else in this module to every entry
@@ -741,6 +801,64 @@ mod tests {
         // excluded from lookups), which is the correct, safe outcome —
         // not a crash, not a silent success with leaked content.
         assert!(result.warnings.iter().any(|w| w.contains("accounts/secrets.json") && w.contains("not found")));
+    }
+
+    #[test]
+    fn rejects_an_other_case_accounts_path_the_same_as_the_canonical_lowercase_one() {
+        // reagent P1, PR #2379 round 4: sanitize_context_relative_path
+        // never case-folds, so a literal lowercase `starts_with("accounts/")`
+        // check let `ACCOUNTS/secrets.json` sail through unrejected.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["ACCOUNTS/secrets.json"],
+            }))),
+            file("ACCOUNTS/secrets.json", "GITHUB_TOKEN=ghp_should_never_leak_case_variant"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(!result.instructions.contains("ghp_should_never_leak_case_variant"));
+        assert!(result.warnings.iter().any(|w| w.contains("ACCOUNTS/secrets.json") && w.contains("rejected")));
+    }
+
+    #[test]
+    fn resolves_a_non_canonical_manifest_reference_against_the_normalized_file_path() {
+        // codex P2, PR #2379 round 4: by_path's keys are normalized (round
+        // 4's earlier accounts/ fix), so a manifest reference using a
+        // valid but non-canonical spelling of the SAME path must be
+        // normalized identically before the lookup, or a genuinely present
+        // file is reported "not found".
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["./instructions/AGENTS.md"],
+            }))),
+            file("instructions/AGENTS.md", "Be concise."),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "Be concise.");
+        assert!(result.warnings.iter().all(|w| !w.contains("not found")), "unexpected warnings: {:?}", result.warnings);
+    }
+
+    #[test]
+    fn caps_the_number_of_account_requirements_accepted_from_a_single_bundle() {
+        // codex P1, PR #2379 round 4: an unbounded requirements array lets
+        // a small (well within the per-entry size cap) accounts/requirements.json
+        // drive an unbounded number of downstream per-provider account
+        // lookups in the RPC handler.
+        let many: Vec<_> = (0..MAX_ACCOUNT_REQUIREMENTS + 50)
+            .map(|i| serde_json::json!({
+                "id": format!("req-{i}"), "provider": "github", "kind": "api-key",
+                "env": "GITHUB_TOKEN", "optional": false,
+            }))
+            .collect();
+        let requirements_doc = serde_json::json!({ "requirements": many }).to_string();
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "accounts": "accounts/requirements.json",
+            }))),
+            file("accounts/requirements.json", &requirements_doc),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.requirements.len(), MAX_ACCOUNT_REQUIREMENTS);
+        assert!(result.warnings.iter().any(|w| w.contains("exceeds the limit")));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -145,6 +145,17 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
             ));
             continue;
         }
+        // reagent P2, PR #2379 round 5: `unzip_bundle_import` explicitly
+        // detects and warns on a duplicate entry within a zip ("first
+        // occurrence kept"), but the raw `files` RPC list reaches this
+        // shared loop directly, bypassing that pass entirely — two input
+        // entries normalizing to the same safe_path silently resolved
+        // last-write-wins with no warning, so a caller inspecting the
+        // input couldn't tell which content actually got imported.
+        if by_path.contains_key(&safe_path) {
+            warnings.push(format!("{safe_path}: duplicate path in input; first occurrence kept"));
+            continue;
+        }
         by_path.insert(safe_path, f.content.as_str());
     }
 
@@ -172,7 +183,14 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
         warnings.push("armory.json: no $schema field present".to_string());
     }
     match manifest.get("version").and_then(|v| v.as_str()) {
-        Some(v) if v.starts_with("0.1") => {}
+        // codex P2, PR #2379 round 5: a bare prefix match treated "0.10.0"
+        // and "0.1garbage" as recognized v0.1.x versions too — this
+        // warning is the only signal that potentially incompatible
+        // semantics are being accepted for an importer that deliberately
+        // proceeds with unknown versions anyway, so it must actually
+        // distinguish "0.1", "0.1.x" from anything merely starting with
+        // the same three characters.
+        Some(v) if v == "0.1" || v.starts_with("0.1.") => {}
         Some(other) => warnings.push(format!(
             "armory.json: version \"{other}\" is not a recognized ABF v0.1.x version; importing anyway"
         )),
@@ -431,6 +449,81 @@ const MAX_ENTRY_COUNT: usize = 10_000;
 /// row.
 const MAX_ACCOUNT_REQUIREMENTS: usize = 1_000;
 
+/// Single choke point for the per-entry/aggregate size caps, shared by
+/// BOTH intake paths (zip decompression and the raw `files` RPC list) —
+/// reagent P1 / codex P1, PR #2379 round 5. Two separate gaps motivated
+/// unifying this instead of patching each path independently:
+///
+/// - The raw `files` RPC branch previously ran NO size/count checks at
+///   all, even though the spec explicitly treats it as an equally
+///   untrusted alternate ingestion path to the zip — a hostile bundle
+///   submitted via `files` instead of `zip_base64` bypassed every
+///   zip-bomb/DoS defense this module had built for the zip path alone.
+/// - Even on the zip path, an entry whose ACTUAL decompressed size
+///   exceeds the per-entry cap was decompressed (paying the full
+///   MAX_ENTRY_UNCOMPRESSED_BYTES-sized read) and then skipped WITHOUT
+///   ever counting that work toward the aggregate budget — so up to
+///   MAX_ENTRY_COUNT such entries could force on the order of
+///   MAX_ENTRY_COUNT * MAX_ENTRY_UNCOMPRESSED_BYTES of real decompression
+///   work while the aggregate cap never tripped.
+///
+/// This function accounts `content_len` toward the aggregate budget
+/// UNCONDITIONALLY, before deciding whether the entry itself is kept —
+/// closing the second gap structurally (every byte actually processed
+/// counts, whether or not the entry is ultimately retained) — and both
+/// intake paths call it, closing the first gap by construction (there is
+/// no path left that skips this check).
+///
+/// Returns `Ok(true)` to keep the entry, `Ok(false)` to skip it (a
+/// warning has already been pushed), or `Err` to reject the whole import
+/// (aggregate cap exceeded).
+fn check_entry_size(
+    safe_name: &str,
+    content_len: u64,
+    total_uncompressed: &mut u64,
+    warnings: &mut Vec<String>,
+) -> Result<bool, String> {
+    *total_uncompressed = total_uncompressed.saturating_add(content_len);
+    if *total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES {
+        return Err(format!(
+            "aggregate decompressed size exceeds the total limit ({MAX_TOTAL_UNCOMPRESSED_BYTES} bytes) — rejecting the whole import"
+        ));
+    }
+    if content_len > MAX_ENTRY_UNCOMPRESSED_BYTES {
+        warnings.push(format!(
+            "{safe_name}: size ({content_len} bytes) exceeds the per-entry limit ({MAX_ENTRY_UNCOMPRESSED_BYTES} bytes); skipped"
+        ));
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+/// Applies [`check_entry_size`]'s caps (plus [`MAX_ENTRY_COUNT`]) to the
+/// raw `files` RPC intake path — the path `unzip_bundle_import` never
+/// covers (reagent P1, PR #2379 round 5). Unlike zip entries, a raw
+/// file's `content` is already fully materialized (no separate
+/// declared-vs-actual distinction, no incremental decompression to
+/// bound), so this only needs the shared per-entry/aggregate check, no
+/// backstop-read machinery.
+pub fn enforce_raw_files_caps(files: Vec<BundleImportFile>) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
+    if files.len() > MAX_ENTRY_COUNT {
+        return Err(format!(
+            "{} entries exceeds the limit ({MAX_ENTRY_COUNT}) — rejecting the whole import",
+            files.len()
+        ));
+    }
+    let mut warnings = Vec::new();
+    let mut total_uncompressed: u64 = 0;
+    let mut out = Vec::new();
+    for f in files {
+        let keep = check_entry_size(&f.path, f.content.len() as u64, &mut total_uncompressed, &mut warnings)?;
+        if keep {
+            out.push(f);
+        }
+    }
+    Ok((out, warnings))
+}
+
 /// Unpack a `.abf` zip archive into a flat file list, applying the same
 /// path-safety check as everywhere else in this module to every entry
 /// name before it's trusted (§4.3.4) — a zip's own internal paths are
@@ -546,21 +639,16 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
             warnings.push(format!("{safe_name}: failed to read entry: {e}"));
             continue;
         }
-        if buf.len() as u64 > MAX_ENTRY_UNCOMPRESSED_BYTES {
-            warnings.push(format!(
-                "{safe_name}: actual decompressed size exceeds the per-entry limit ({MAX_ENTRY_UNCOMPRESSED_BYTES} bytes), despite a smaller declared size; skipped"
-            ));
-            continue;
-        }
 
-        // Aggregate cap enforced against ACTUAL bytes read, not the
-        // declared size — the only value that can't be lied about by the
-        // archive's own metadata.
-        total_uncompressed = total_uncompressed.saturating_add(buf.len() as u64);
-        if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES {
-            return Err(format!(
-                "zip archive: aggregate decompressed size exceeds the total limit ({MAX_TOTAL_UNCOMPRESSED_BYTES} bytes) — rejecting the whole import"
-            ));
+        // codex P1, PR #2379 round 5: `check_entry_size` accounts these
+        // bytes toward the aggregate budget BEFORE deciding whether to
+        // keep the entry, unlike the previous inline checks here (which
+        // accumulated only KEPT entries' bytes, so an entry that failed
+        // its own per-entry cap was decompressed — real work already
+        // spent — and then discarded without ever counting against the
+        // aggregate limit).
+        if !check_entry_size(&safe_name, buf.len() as u64, &mut total_uncompressed, &mut warnings)? {
+            continue;
         }
         let content = match String::from_utf8(buf) {
             Ok(s) => s,
@@ -859,6 +947,137 @@ mod tests {
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.requirements.len(), MAX_ACCOUNT_REQUIREMENTS);
         assert!(result.warnings.iter().any(|w| w.contains("exceeds the limit")));
+    }
+
+    #[test]
+    fn treats_a_version_that_merely_starts_with_0_1_as_unrecognized() {
+        // codex P2, PR #2379 round 5: "0.10.0" and "0.1garbage" both start
+        // with "0.1" but are not the 0.1.x family the importer actually
+        // recognizes.
+        for bad_version in ["0.10.0", "0.1garbage"] {
+            let manifest = serde_json::to_string(&serde_json::json!({
+                "name": "test-bundle",
+                "version": bad_version,
+                "components": {},
+            })).unwrap();
+            let files = vec![file("armory.json", &manifest)];
+            let result = parse_bundle_import(&files).unwrap();
+            assert!(
+                result.warnings.iter().any(|w| w.contains("not a recognized")),
+                "expected a warning for version {bad_version:?}, got: {:?}",
+                result.warnings
+            );
+        }
+    }
+
+    #[test]
+    fn recognizes_bare_0_1_with_no_patch_component() {
+        let manifest = serde_json::to_string(&serde_json::json!({
+            "name": "test-bundle",
+            "version": "0.1",
+            "components": {},
+        })).unwrap();
+        let files = vec![file("armory.json", &manifest)];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(result.warnings.iter().all(|w| !w.contains("not a recognized")));
+    }
+
+    #[test]
+    fn a_raw_files_duplicate_path_resolves_to_the_first_occurrence_with_a_warning() {
+        // reagent P2, PR #2379 round 5: unzip_bundle_import already warns
+        // on a duplicate zip entry; the raw files list reaches by_path
+        // construction directly, bypassing that pass, so it previously
+        // silently resolved last-write-wins with no warning at all.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md"],
+            }))),
+            file("instructions/AGENTS.md", "first"),
+            file("instructions/AGENTS.md", "second -- should never be used"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.instructions, "first");
+        assert!(result.warnings.iter().any(|w| w.contains("instructions/AGENTS.md") && w.contains("duplicate path")));
+    }
+
+    // ── raw `files` intake path now shares the zip path's size/count caps
+    // (reagent P1, PR #2379 round 5) ──────────────────────────────────
+
+    #[test]
+    fn enforce_raw_files_caps_rejects_more_entries_than_the_count_cap() {
+        let files: Vec<BundleImportFile> = (0..=MAX_ENTRY_COUNT)
+            .map(|i| file(&format!("f{i}.md"), "x"))
+            .collect();
+        let err = enforce_raw_files_caps(files).unwrap_err();
+        assert!(err.contains("entries exceeds the limit"));
+    }
+
+    #[test]
+    fn enforce_raw_files_caps_skips_a_single_oversized_entry_with_a_warning() {
+        let oversized = "a".repeat(MAX_ENTRY_UNCOMPRESSED_BYTES as usize + 1);
+        let files = vec![file("armory.json", "{}"), file("big.md", &oversized)];
+        let (kept, warnings) = enforce_raw_files_caps(files).unwrap();
+        assert!(kept.iter().any(|f| f.path == "armory.json"));
+        assert!(!kept.iter().any(|f| f.path == "big.md"));
+        assert!(warnings.iter().any(|w| w.contains("big.md") && w.contains("exceeds the per-entry limit")));
+    }
+
+    #[test]
+    fn enforce_raw_files_caps_rejects_the_whole_import_over_the_aggregate_cap() {
+        let each = "a".repeat((MAX_ENTRY_UNCOMPRESSED_BYTES as f64 * 0.9) as usize);
+        let files = vec![
+            file("a.md", &each), file("b.md", &each), file("c.md", &each),
+            file("d.md", &each), file("e.md", &each), file("f.md", &each),
+        ];
+        let err = enforce_raw_files_caps(files).unwrap_err();
+        assert!(err.contains("aggregate decompressed size exceeds"));
+    }
+
+    #[test]
+    fn enforce_raw_files_caps_counts_a_discarded_oversized_entrys_bytes_toward_the_aggregate() {
+        // codex P1, PR #2379 round 5: an entry too large to KEEP must
+        // still count toward the aggregate budget -- otherwise many such
+        // entries can each force per-entry-cap-sized work while never
+        // tripping the aggregate limit. Five entries just over the
+        // per-entry cap (~10.5MB each) sum to ~52.5MB > the 50MB
+        // aggregate cap, even though every single one is discarded rather
+        // than kept.
+        let oversized = "a".repeat((MAX_ENTRY_UNCOMPRESSED_BYTES as f64 * 1.05) as usize);
+        let files = vec![
+            file("a.md", &oversized), file("b.md", &oversized), file("c.md", &oversized),
+            file("d.md", &oversized), file("e.md", &oversized),
+        ];
+        let err = enforce_raw_files_caps(files).unwrap_err();
+        assert!(err.contains("aggregate decompressed size exceeds"));
+    }
+
+    #[test]
+    fn check_entry_size_accounts_bytes_toward_the_aggregate_even_when_the_entry_is_discarded() {
+        // codex P1, PR #2379 round 5: directly exercises the shared
+        // choke point both unzip_bundle_import (after its backstop read)
+        // and enforce_raw_files_caps call -- an entry too large to KEEP
+        // must still count toward the aggregate budget first, or many
+        // discarded oversized entries could each force per-entry-cap-
+        // sized work while the aggregate cap never trips. (A zip-level
+        // reproduction would need to forge a declared size that
+        // UNDERSTATES real content while still reaching this function --
+        // the `zip` crate reads declared size from the central directory,
+        // not the local file header this module can cheaply patch, so
+        // the invariant is verified directly at its actual implementation
+        // site instead.)
+        let mut total: u64 = 0;
+        let mut warnings = Vec::new();
+        let oversized = MAX_ENTRY_UNCOMPRESSED_BYTES + 1;
+        for i in 0..5 {
+            let name = format!("f{i}.md");
+            let result = check_entry_size(&name, oversized, &mut total, &mut warnings);
+            if i < 4 {
+                assert_eq!(result, Ok(false), "entry {i} should be discarded (not an error) with total={total}");
+            } else {
+                assert!(result.is_err(), "5th entry should trip the aggregate cap now that all 5 discarded entries' bytes were counted (total={total})");
+            }
+        }
+        assert!(warnings.iter().filter(|w| w.contains("exceeds the per-entry limit")).count() >= 4);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -96,17 +96,6 @@ pub struct ParsedBundleImport {
 /// still produce a usable bundle rather than an all-or-nothing failure on
 /// e.g. one corrupt skill among five good ones.
 pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImport, String> {
-    let by_path: HashMap<&str, &str> = files
-        .iter()
-        .map(|f| (f.path.as_str(), f.content.as_str()))
-        .collect();
-
-    let manifest_raw = by_path
-        .get("armory.json")
-        .ok_or_else(|| "armory.json: missing from bundle".to_string())?;
-    let manifest: Value = serde_json::from_str(manifest_raw)
-        .map_err(|e| format!("armory.json: malformed JSON ({e})"))?;
-
     let mut warnings: Vec<String> = Vec::new();
 
     // §4.3.5: reject anything under accounts/ other than requirements.json
@@ -115,14 +104,35 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // the manifest references, since a malicious/malformed bundle's
     // `components` object is not a trustworthy inventory of its own
     // contents.
-    for file in files {
-        if file.path.starts_with("accounts/") && file.path != "accounts/requirements.json" {
-            warnings.push(format!(
-                "{}: rejected — only accounts/requirements.json is ever read from the accounts/ directory",
-                file.path
-            ));
-        }
-    }
+    //
+    // Codex P1, PR #2379: a rejected file must be excluded from `by_path`
+    // entirely, not merely warned about — otherwise a malicious bundle
+    // whose `components.instructions`/`components.mcpServers` REFERENCES
+    // `accounts/secrets.json` would still have that content looked up and
+    // folded into the imported bundle by the code below (and, on a later
+    // re-export of that same bundle, written unredacted straight into
+    // `instructions/AGENTS.md`) — defeating the accounts/ allowlist this
+    // exact loop exists to enforce.
+    let by_path: HashMap<&str, &str> = files
+        .iter()
+        .filter(|f| {
+            let rejected = f.path.starts_with("accounts/") && f.path != "accounts/requirements.json";
+            if rejected {
+                warnings.push(format!(
+                    "{}: rejected — only accounts/requirements.json is ever read from the accounts/ directory",
+                    f.path
+                ));
+            }
+            !rejected
+        })
+        .map(|f| (f.path.as_str(), f.content.as_str()))
+        .collect();
+
+    let manifest_raw = by_path
+        .get("armory.json")
+        .ok_or_else(|| "armory.json: missing from bundle".to_string())?;
+    let manifest: Value = serde_json::from_str(manifest_raw)
+        .map_err(|e| format!("armory.json: malformed JSON ({e})"))?;
 
     let name = manifest
         .get("name")
@@ -308,19 +318,77 @@ fn parse_skill_md(content: &str) -> Option<ParsedSkill> {
     })
 }
 
+/// Per-entry decompressed-size cap. Generous for any legitimate
+/// instructions/SKILL.md/context file (10 MB of text is already an
+/// absurdly large single bundle component) while bounding how much a
+/// single malicious entry can force into memory.
+const MAX_ENTRY_UNCOMPRESSED_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Aggregate decompressed-size cap across the whole archive. Bounds a
+/// zip-bomb-style archive built from many medium-sized entries that would
+/// each individually pass [`MAX_ENTRY_UNCOMPRESSED_BYTES`].
+const MAX_TOTAL_UNCOMPRESSED_BYTES: u64 = 50 * 1024 * 1024;
+
 /// Unpack a `.abf` zip archive into a flat file list, applying the same
 /// path-safety check as everywhere else in this module to every entry
 /// name before it's trusted (§4.3.4) — a zip's own internal paths are
 /// exactly as untrusted as any other part of the archive's content.
 /// Directory entries are skipped; anything that fails the safety check is
 /// dropped with a warning rather than surfaced as a file.
+///
+/// Codex P1, PR #2379: also bounds decompressed size, per-entry and in
+/// aggregate — `read_to_string` alone has no size limit, so an untrusted
+/// `.abf` containing a highly compressed entry (a classic zip-bomb shape;
+/// DEFLATE alone permits ratios past 1000:1) could otherwise exhaust the
+/// server process's memory through `bundle.import`. An oversized single
+/// entry is skipped with a warning (matches this function's existing
+/// per-entry-problem philosophy); an oversized AGGREGATE fails the whole
+/// import — letting a partially-capped import through silently would be
+/// more confusing than useful, and hitting the aggregate cap at all
+/// already indicates a genuinely abusive archive rather than one bad file.
 pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
     use std::io::Read;
     let cursor = std::io::Cursor::new(zip_bytes);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| format!("not a valid zip archive: {e}"))?;
+
+    // First pass: collect every non-dir entry's raw name, to DETECT
+    // whether every single one shares one common wrapping directory
+    // (`zip_bundle_export`'s convention: `<root_slug>/armory.json`, etc.)
+    // before deciding whether to strip a path component at all.
+    //
+    // reagent P1, PR #2379: the previous version unconditionally stripped
+    // the first `/`-delimited segment of EVERY entry, on the assumption a
+    // wrapper always exists. A hand-built `.abf` zipped directly from the
+    // loose directory tree (no wrapping folder) — which this spec's §2
+    // explicitly requires an importer to also accept — has entries like
+    // `instructions/AGENTS.md` already bundle-relative; blindly stripping
+    // silently mangled it to `AGENTS.md`, breaking every `components.*`
+    // path lookup in `parse_bundle_import` (each degrades to a "not
+    // found" warning and the content is dropped) with no error surfaced.
+    // Only strip when EVERY entry agrees on the same first segment.
+    let mut raw_names: Vec<String> = Vec::new();
+    for i in 0..archive.len() {
+        let entry = archive
+            .by_index(i)
+            .map_err(|e| format!("zip archive: failed to read entry {i}: {e}"))?;
+        if entry.is_dir() {
+            continue;
+        }
+        raw_names.push(entry.name().to_string());
+    }
+    let common_wrapper: Option<&str> = raw_names.first().and_then(|first| {
+        let candidate = first.split_once('/').map(|(root, _)| root)?;
+        raw_names
+            .iter()
+            .all(|n| n.split_once('/').map(|(root, _)| root == candidate).unwrap_or(false))
+            .then_some(candidate)
+    });
+    let strip_len: Option<usize> = common_wrapper.map(|w| w.len() + 1); // +1 for the '/'
+
     let mut out = Vec::new();
     let mut warnings = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
+    let mut total_uncompressed: u64 = 0;
     for i in 0..archive.len() {
         let mut entry = archive
             .by_index(i)
@@ -329,14 +397,10 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
             continue;
         }
         let raw_name = entry.name().to_string();
-        // `zip_bundle_export` wraps every entry in a single top-level
-        // `<root_slug>/` directory (mirrors the spec's §5.1 on-disk
-        // layout, where the bundle-slug directory IS the archive root) —
-        // strip that one wrapping component before treating the rest as
-        // the bundle-relative path. An entry with no `/` at all (no
-        // wrapping directory) is kept as-is rather than rejected, so a
-        // hand-built `.abf` without the convention still round-trips.
-        let relative_name = raw_name.split_once('/').map(|(_, rest)| rest).unwrap_or(&raw_name);
+        let relative_name = match strip_len {
+            Some(n) if raw_name.len() > n => &raw_name[n..],
+            _ => raw_name.as_str(),
+        };
         let Some(safe_name) = sanitize_context_relative_path(relative_name) else {
             warnings.push(format!("{raw_name}: not a safe path; skipped"));
             continue;
@@ -345,11 +409,46 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
             warnings.push(format!("{safe_name}: duplicate entry in archive; first occurrence kept"));
             continue;
         }
-        let mut content = String::new();
-        if let Err(e) = entry.read_to_string(&mut content) {
-            warnings.push(format!("{safe_name}: not valid UTF-8 text; skipped ({e})"));
+
+        // Declared size check first — cheap, and avoids decompressing at
+        // all for an entry that's already too large per its own metadata.
+        let declared_size = entry.size();
+        if declared_size > MAX_ENTRY_UNCOMPRESSED_BYTES {
+            warnings.push(format!(
+                "{safe_name}: declared uncompressed size ({declared_size} bytes) exceeds the per-entry limit ({MAX_ENTRY_UNCOMPRESSED_BYTES} bytes); skipped"
+            ));
             continue;
         }
+        total_uncompressed = total_uncompressed.saturating_add(declared_size);
+        if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES {
+            return Err(format!(
+                "zip archive: aggregate declared uncompressed size exceeds the total limit ({MAX_TOTAL_UNCOMPRESSED_BYTES} bytes) — rejecting the whole import"
+            ));
+        }
+
+        // Hard backstop on the actual read, independent of the declared
+        // size above: read at most one byte past the cap so an entry
+        // whose real decompressed content exceeds what it declared is
+        // still caught (rather than trusting zip metadata alone).
+        let mut limited = entry.by_ref().take(MAX_ENTRY_UNCOMPRESSED_BYTES + 1);
+        let mut buf: Vec<u8> = Vec::new();
+        if let Err(e) = limited.read_to_end(&mut buf) {
+            warnings.push(format!("{safe_name}: failed to read entry: {e}"));
+            continue;
+        }
+        if buf.len() as u64 > MAX_ENTRY_UNCOMPRESSED_BYTES {
+            warnings.push(format!(
+                "{safe_name}: actual decompressed size exceeds the per-entry limit ({MAX_ENTRY_UNCOMPRESSED_BYTES} bytes), despite a smaller declared size; skipped"
+            ));
+            continue;
+        }
+        let content = match String::from_utf8(buf) {
+            Ok(s) => s,
+            Err(e) => {
+                warnings.push(format!("{safe_name}: not valid UTF-8 text; skipped ({e})"));
+                continue;
+            }
+        };
         out.push(BundleImportFile { path: safe_name, content });
     }
     Ok((out, warnings))
@@ -522,6 +621,34 @@ mod tests {
     }
 
     #[test]
+    fn a_rejected_accounts_file_referenced_by_a_component_is_never_surfaced_in_the_result() {
+        // Codex P1, PR #2379: a rejected accounts/ file must be excluded
+        // from lookups entirely, not merely warned about — otherwise a
+        // malicious bundle whose components.instructions REFERENCES
+        // accounts/secrets.json would still get that content folded into
+        // the imported bundle's instructions, defeating the whole
+        // accounts/ allowlist. This is the exact attack shape: point a
+        // legitimate-looking component path at the rejected file.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["accounts/secrets.json"],
+            }))),
+            file("accounts/secrets.json", "GITHUB_TOKEN=ghp_should_never_leak_into_a_bundle"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert!(
+            !result.instructions.contains("ghp_should_never_leak_into_a_bundle"),
+            "rejected accounts/ content leaked into instructions: {:?}",
+            result.instructions
+        );
+        assert!(result.warnings.iter().any(|w| w.contains("accounts/secrets.json") && w.contains("rejected")));
+        // The reference itself now resolves to "not found" (the file was
+        // excluded from lookups), which is the correct, safe outcome —
+        // not a crash, not a silent success with leaked content.
+        assert!(result.warnings.iter().any(|w| w.contains("accounts/secrets.json") && w.contains("not found")));
+    }
+
+    #[test]
     fn warns_on_unrecognized_version_but_does_not_fail() {
         let manifest = serde_json::to_string(&serde_json::json!({
             "name": "test-bundle",
@@ -591,5 +718,142 @@ mod tests {
     fn unzip_rejects_a_non_zip_input() {
         let err = unzip_bundle_import(b"not a zip file").unwrap_err();
         assert!(err.contains("not a valid zip archive"));
+    }
+
+    /// Build a zip archive directly from `(path, content)` pairs — no
+    /// `bundle_export` involvement, so these tests cover a hand-built
+    /// `.abf` independent of the exporter's own wrapping convention.
+    fn build_zip(entries: &[(&str, &str)]) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let mut buf = std::io::Cursor::new(Vec::new());
+        let mut writer = zip::ZipWriter::new(&mut buf);
+        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        for (path, content) in entries {
+            writer.start_file(*path, options).unwrap();
+            writer.write_all(content.as_bytes()).unwrap();
+        }
+        writer.finish().unwrap();
+        buf.into_inner()
+    }
+
+    #[test]
+    fn unzips_a_flat_bundle_with_no_wrapping_directory() {
+        // reagent P1, PR #2379: the spec's §2 explicitly requires an
+        // unwrapped directory tree (zipped directly, no bundle-slug
+        // folder) to round-trip just like the exporter's own wrapped
+        // form. Nested paths must survive UNCHANGED — no stripping.
+        let zip_bytes = build_zip(&[
+            ("armory.json", "{}"),
+            ("instructions/AGENTS.md", "Be concise."),
+            ("skills/deploy/SKILL.md", "---\nname: \"deploy\"\ndescription: \"d\"\n---\n\nbody"),
+        ]);
+        let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(warnings.is_empty());
+        assert!(files.iter().any(|f| f.path == "armory.json"));
+        assert!(files.iter().any(|f| f.path == "instructions/AGENTS.md" && f.content == "Be concise."));
+        assert!(files.iter().any(|f| f.path == "skills/deploy/SKILL.md"));
+    }
+
+    #[test]
+    fn unzips_a_wrapped_bundle_with_a_directory_other_than_the_exporters_own_slug() {
+        // The wrapper-detection must work for ANY consistent single root
+        // name, not just names zip_bundle_export happens to produce.
+        let zip_bytes = build_zip(&[
+            ("my-hand-built-bundle/armory.json", "{}"),
+            ("my-hand-built-bundle/instructions/AGENTS.md", "Be concise."),
+        ]);
+        let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(warnings.is_empty());
+        assert!(files.iter().any(|f| f.path == "armory.json"));
+        assert!(files.iter().any(|f| f.path == "instructions/AGENTS.md"));
+    }
+
+    #[test]
+    fn does_not_strip_when_entries_disagree_on_a_common_wrapper() {
+        // An inconsistent archive (some entries wrapped, some not) must
+        // not have a wrapper GUESSED at — every entry keeps its raw path,
+        // which then fails components.* lookups with a clear "not found"
+        // warning downstream rather than silently importing wrong content.
+        let zip_bytes = build_zip(&[
+            ("root-a/armory.json", "{}"),
+            ("root-b/instructions/AGENTS.md", "Be concise."),
+        ]);
+        let (files, _warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(files.iter().any(|f| f.path == "root-a/armory.json"));
+        assert!(files.iter().any(|f| f.path == "root-b/instructions/AGENTS.md"));
+    }
+
+    #[test]
+    fn full_import_of_a_flat_hand_built_abf_finds_every_component() {
+        // End-to-end: unzip -> parse, for the unwrapped case specifically
+        // (the exact scenario reagent's finding said silently broke).
+        let manifest = minimal_manifest(serde_json::json!({
+            "instructions": ["instructions/AGENTS.md"],
+            "skills": ["skills/deploy"],
+        }));
+        let zip_bytes = build_zip(&[
+            ("armory.json", &manifest),
+            ("instructions/AGENTS.md", "Be concise."),
+            ("skills/deploy/SKILL.md", "---\nname: \"deploy\"\ndescription: \"d\"\n---\n\nbody"),
+        ]);
+        let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(warnings.is_empty());
+        let parsed = parse_bundle_import(&files).unwrap();
+        assert_eq!(parsed.instructions, "Be concise.");
+        assert_eq!(parsed.skills.len(), 1);
+        assert!(parsed.warnings.is_empty(), "unexpected warnings: {:?}", parsed.warnings);
+    }
+
+    // ── decompression size bounds (Codex P1, PR #2379) ────────────────
+    //
+    // Content is a repeated single character so it compresses to a few KB
+    // in the actual test zip regardless of its declared/logical size —
+    // these tests exercise the real cap logic without moving tens of MB
+    // through the test binary.
+
+    #[test]
+    fn skips_a_single_entry_exceeding_the_per_entry_cap() {
+        let oversized = "a".repeat(MAX_ENTRY_UNCOMPRESSED_BYTES as usize + 1);
+        let zip_bytes = build_zip(&[
+            ("armory.json", "{}"),
+            ("instructions/AGENTS.md", &oversized),
+        ]);
+        let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(files.iter().any(|f| f.path == "armory.json"));
+        assert!(!files.iter().any(|f| f.path == "instructions/AGENTS.md"));
+        assert!(warnings.iter().any(|w| w.contains("instructions/AGENTS.md") && w.contains("exceeds the per-entry limit")));
+    }
+
+    #[test]
+    fn accepts_an_entry_right_at_the_per_entry_cap() {
+        let exactly_at_cap = "a".repeat(MAX_ENTRY_UNCOMPRESSED_BYTES as usize);
+        let zip_bytes = build_zip(&[
+            ("armory.json", "{}"),
+            ("instructions/AGENTS.md", &exactly_at_cap),
+        ]);
+        let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();
+        assert!(warnings.is_empty());
+        assert!(files.iter().any(|f| f.path == "instructions/AGENTS.md"));
+    }
+
+    #[test]
+    fn rejects_the_whole_import_when_aggregate_declared_size_exceeds_the_total_cap() {
+        // Six entries at ~90% of the per-entry cap each -- individually
+        // well under MAX_ENTRY_UNCOMPRESSED_BYTES, but summing to ~5.4x
+        // MAX_TOTAL_UNCOMPRESSED_BYTES's actual ratio (6 * 0.9*10MB = 54MB
+        // > the 50MB aggregate cap).
+        let each = "a".repeat((MAX_ENTRY_UNCOMPRESSED_BYTES as f64 * 0.9) as usize);
+        let zip_bytes = build_zip(&[
+            ("armory.json", "{}"),
+            ("instructions/context/a.md", &each),
+            ("instructions/context/b.md", &each),
+            ("instructions/context/c.md", &each),
+            ("instructions/context/d.md", &each),
+            ("instructions/context/e.md", &each),
+            ("instructions/context/f.md", &each),
+        ]);
+        let err = unzip_bundle_import(&zip_bytes).unwrap_err();
+        assert!(err.contains("aggregate declared uncompressed size exceeds"));
     }
 }

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -6,6 +6,7 @@ pub mod agent_config;
 pub mod agent_session;
 pub mod blockcontroller;
 pub mod bundle_export;
+pub mod bundle_import;
 pub mod mcp_probe;
 pub mod mcp_seed;
 /// Phase E.4.B Phase 4 — pure layout-tree helpers (Rust port of layoutTree.ts).

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -313,6 +313,12 @@ pub const COMMAND_BUNDLE_SELF_GET: &str = "bundle.self.get";
 // https://docs.agentmux.ai/abf/. Serializes a bundle + its referenced
 // skills/MCP servers into the ABF on-disk layout.
 pub const COMMAND_BUNDLE_EXPORT: &str = "bundle.export";
+// ABF importer — Phase 2 of
+// docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md. Inverse
+// of bundle.export: creates a bundle + skills from a `.abf` zip or raw
+// file list. No `preset.*` alias — importer postdates the preset->bundle
+// rename, nothing legacy to keep compatible with.
+pub const COMMAND_BUNDLE_IMPORT: &str = "bundle.import";
 // Deprecated `preset.*` aliases — kept wired for one release (remove in Phase 4).
 pub const COMMAND_PRESET_LIST: &str = "preset.list";
 pub const COMMAND_PRESET_GET: &str = "preset.get";

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -348,16 +348,24 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             crate::backend::bundle_import::unzip_bundle_import(&zip_bytes)
                                 .map_err(|e| format!("bundle.import: {e}"))?
                         }
-                        (None, Some(files)) => (
-                            files
+                        (None, Some(files)) => {
+                            // reagent P1, PR #2379 round 5: the raw `files`
+                            // list previously skipped straight to
+                            // parse_bundle_import with zero size/count
+                            // enforcement, even though the spec treats it as
+                            // an equally untrusted alternate ingestion path
+                            // to zip_base64 — bypassing every zip-bomb/DoS
+                            // defense the zip path enforces.
+                            let raw_files: Vec<crate::backend::bundle_import::BundleImportFile> = files
                                 .into_iter()
                                 .map(|f| crate::backend::bundle_import::BundleImportFile {
                                     path: f.path,
                                     content: f.content,
                                 })
-                                .collect(),
-                            Vec::new(),
-                        ),
+                                .collect();
+                            crate::backend::bundle_import::enforce_raw_files_caps(raw_files)
+                                .map_err(|e| format!("bundle.import: {e}"))?
+                        }
                     };
 
                 let parsed = crate::backend::bundle_import::parse_bundle_import(&files)

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -7,6 +7,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_bundle_delete(engine, state);
     register_bundle_self_get(engine, state);
     register_bundle_export(engine, state);
+    register_bundle_import(engine, state);
 }
 
 /// Normalize a `bundle.upsert` request body into the shape the `Memory` struct
@@ -282,6 +283,181 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     obj.insert("warnings".to_string(), json!(all_warnings));
                 }
                 Ok(Some(result))
+            })
+        }),
+    );
+}
+
+/// `bundle.import` — ABF importer, Phase 2 of
+/// docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md. Window-
+/// scoped like `bundle.export` (bundles aren't agent-specific). Accepts
+/// EITHER `zip_base64` (a `.abf` archive, mirroring `bundle.export`'s own
+/// `zip_base64` response field) OR `files` (a raw `[{path, content}]`
+/// list) — exactly one must be present. Hands the bytes to the pure
+/// `bundle_import` module for parsing/validation, then owns every Store
+/// side-effect: creates the bundle row, creates one global Skill row per
+/// parsed skill, and performs READ-ONLY account-requirement lookups
+/// (never creates an account, never writes a secret anywhere — see the
+/// spec's §4.5 correction for why this stopped short of "resolving"
+/// placeholders in place).
+fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_BUNDLE_IMPORT,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize, Default)]
+                struct FileEntry {
+                    path: String,
+                    content: String,
+                }
+                #[derive(serde::Deserialize, Default)]
+                struct Req {
+                    #[serde(default)]
+                    zip_base64: Option<String>,
+                    #[serde(default)]
+                    files: Option<Vec<FileEntry>>,
+                }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("bundle.import: {e}"))?;
+
+                let (files, mut warnings): (Vec<crate::backend::bundle_import::BundleImportFile>, Vec<String>) =
+                    match (req.zip_base64, req.files) {
+                        (Some(_), Some(_)) => {
+                            return Err(
+                                "bundle.import: exactly one of zip_base64/files must be present, got both"
+                                    .to_string(),
+                            );
+                        }
+                        (None, None) => {
+                            return Err(
+                                "bundle.import: exactly one of zip_base64/files must be present, got neither"
+                                    .to_string(),
+                            );
+                        }
+                        (Some(b64), None) => {
+                            use base64::Engine as _;
+                            let zip_bytes = base64::engine::general_purpose::STANDARD
+                                .decode(&b64)
+                                .map_err(|e| format!("bundle.import: invalid zip_base64: {e}"))?;
+                            crate::backend::bundle_import::unzip_bundle_import(&zip_bytes)
+                                .map_err(|e| format!("bundle.import: {e}"))?
+                        }
+                        (None, Some(files)) => (
+                            files
+                                .into_iter()
+                                .map(|f| crate::backend::bundle_import::BundleImportFile {
+                                    path: f.path,
+                                    content: f.content,
+                                })
+                                .collect(),
+                            Vec::new(),
+                        ),
+                    };
+
+                let parsed = crate::backend::bundle_import::parse_bundle_import(&files)
+                    .map_err(|e| format!("bundle.import: {e}"))?;
+                warnings.extend(parsed.warnings.clone());
+
+                // Account requirement resolution (§4.5) — read-only lookup
+                // by provider, purely informational. Never creates an
+                // account, never writes anything derived from a match.
+                let mut resolved_requirement_ids: Vec<String> = Vec::new();
+                let mut unresolved_requirements: Vec<serde_json::Value> = Vec::new();
+                for requirement in &parsed.requirements {
+                    let matches = wstore
+                        .identity_list(Some(&requirement.provider))
+                        .map_err(|e| format!("bundle.import: account lookup failed: {e}"))?;
+                    if matches.len() == 1 {
+                        resolved_requirement_ids.push(requirement.id.clone());
+                    } else {
+                        unresolved_requirements.push(json!({
+                            "id": requirement.id,
+                            "provider": requirement.provider,
+                            "env": requirement.env,
+                            "match_count": matches.len(),
+                        }));
+                    }
+                }
+
+                // Skills — global, not bound to any agent (mirrors
+                // skill.catalog.upsert's own is_global: true convention for
+                // a shared-resource creation path). A name conflict is a
+                // per-skill warning, not an aborted import.
+                let now = now_ms();
+                let mut imported_skill_ids: Vec<String> = Vec::new();
+                let mut skipped_skills = parsed.skipped_skills.clone();
+                for skill in &parsed.skills {
+                    let row = crate::backend::storage::Skill {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name: skill.slug.clone(),
+                        trigger: skill.slug.clone(),
+                        skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                        description: skill.description.clone(),
+                        content: skill.content.clone(),
+                        is_global: true,
+                        created_at: now,
+                        updated_at: now,
+                    };
+                    match wstore.skill_upsert_unique_global(&row) {
+                        Ok(()) => imported_skill_ids.push(row.id),
+                        Err(e) => {
+                            warnings.push(format!("skill \"{}\": {e}", skill.slug));
+                            skipped_skills.push(skill.slug.clone());
+                        }
+                    }
+                }
+
+                let memory = Memory {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name: parsed.name,
+                    description: parsed.description,
+                    is_blank: false,
+                    // Never imported as global — an import must not
+                    // silently start injecting into every agent's
+                    // CLAUDE.md without explicit user action (spec §4.4).
+                    is_global: false,
+                    provider: String::new(),
+                    model: String::new(),
+                    instructions: parsed.instructions,
+                    context_files: serde_json::to_string(&parsed.context_files)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    mcp_servers: serde_json::to_string(&parsed.mcp_servers)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    skills: serde_json::to_string(&imported_skill_ids)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    sort_order: 0,
+                    created_at: now,
+                    updated_at: now,
+                };
+                id_store
+                    .bundle_memory_upsert(&memory)
+                    .map_err(|e| format!("bundle.import: {e}"))?;
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "memories:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                if !imported_skill_ids.is_empty() {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "skills:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+
+                Ok(Some(json!({
+                    "bundle_id": memory.id,
+                    "imported_skill_ids": imported_skill_ids,
+                    "skipped_skills": skipped_skills,
+                    "resolved_requirement_ids": resolved_requirement_ids,
+                    "unresolved_requirements": unresolved_requirements,
+                    "warnings": warnings,
+                })))
             })
         }),
     );

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -370,7 +370,14 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let mut resolved_requirement_ids: Vec<String> = Vec::new();
                 let mut unresolved_requirements: Vec<serde_json::Value> = Vec::new();
                 for requirement in &parsed.requirements {
-                    let matches = wstore
+                    // Codex P2, PR #2379 round 2: account CRUD routes
+                    // through id_store (shared/store.db when available), not
+                    // wstore (the per-channel database) -- see identity.rs's
+                    // own handler registrations. Querying wstore here would
+                    // report zero/stale matches for accounts that actually
+                    // exist, incorrectly placing requirements in
+                    // unresolved_requirements.
+                    let matches = id_store
                         .identity_list(Some(&requirement.provider))
                         .map_err(|e| format!("bundle.import: account lookup failed: {e}"))?;
                     if matches.len() == 1 {

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -387,8 +387,17 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // Skills — global, not bound to any agent (mirrors
                 // skill.catalog.upsert's own is_global: true convention for
-                // a shared-resource creation path). A name conflict is a
-                // per-skill warning, not an aborted import.
+                // a shared-resource creation path). A genuine name
+                // conflict (the ONLY intentional business error
+                // `skill_upsert_unique_global` returns —
+                // `StoreError::Other` containing "already exists") is a
+                // per-skill warning, not an aborted import. Codex P2, PR
+                // #2379: any OTHER error (locked/corrupt store, I/O
+                // failure) previously hit this same arm and was silently
+                // treated as a skip too — turning an infrastructure
+                // failure into an apparently-successful lossy import.
+                // Only the confirmed-conflict shape is swallowed; anything
+                // else aborts the whole RPC.
                 let now = now_ms();
                 let mut imported_skill_ids: Vec<String> = Vec::new();
                 let mut skipped_skills = parsed.skipped_skills.clone();
@@ -406,9 +415,26 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     };
                     match wstore.skill_upsert_unique_global(&row) {
                         Ok(()) => imported_skill_ids.push(row.id),
-                        Err(e) => {
-                            warnings.push(format!("skill \"{}\": {e}", skill.slug));
+                        Err(crate::backend::storage::error::StoreError::Other(msg))
+                            if msg.contains("already exists") =>
+                        {
+                            warnings.push(format!("skill \"{}\": {msg}", skill.slug));
                             skipped_skills.push(skill.slug.clone());
+                        }
+                        Err(e) => {
+                            // Codex P2, PR #2379: roll back every skill this
+                            // loop already created before propagating —
+                            // otherwise an infra failure partway through
+                            // leaves orphaned global skill rows (bound to
+                            // no bundle, but visible/bindable by any agent)
+                            // behind a failed RPC.
+                            for id in &imported_skill_ids {
+                                let _ = wstore.skill_delete(id);
+                            }
+                            return Err(format!(
+                                "bundle.import: failed to create skill \"{}\": {e}",
+                                skill.slug
+                            ));
                         }
                     }
                 }
@@ -435,9 +461,15 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at: now,
                     updated_at: now,
                 };
-                id_store
-                    .bundle_memory_upsert(&memory)
-                    .map_err(|e| format!("bundle.import: {e}"))?;
+                if let Err(e) = id_store.bundle_memory_upsert(&memory) {
+                    // Codex P2, PR #2379: same rollback as above — the
+                    // skills this RPC just created must not survive a
+                    // failed bundle creation as orphaned global rows.
+                    for id in &imported_skill_ids {
+                        let _ = wstore.skill_delete(id);
+                    }
+                    return Err(format!("bundle.import: {e}"));
+                }
 
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "memories:changed".to_string(),

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -369,25 +369,41 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // account, never writes anything derived from a match.
                 let mut resolved_requirement_ids: Vec<String> = Vec::new();
                 let mut unresolved_requirements: Vec<serde_json::Value> = Vec::new();
+                // codex P1, PR #2379 round 4: query each distinct provider
+                // ONCE, not once per requirement row -- bundle_import.rs
+                // bounds the requirements array length, but even at that
+                // bound many rows commonly share a handful of providers
+                // (or an attacker can repeat one provider many times), and
+                // each identity_list call is a synchronous store query.
+                let mut match_count_by_provider: std::collections::HashMap<&str, usize> =
+                    std::collections::HashMap::new();
                 for requirement in &parsed.requirements {
-                    // Codex P2, PR #2379 round 2: account CRUD routes
-                    // through id_store (shared/store.db when available), not
-                    // wstore (the per-channel database) -- see identity.rs's
-                    // own handler registrations. Querying wstore here would
-                    // report zero/stale matches for accounts that actually
-                    // exist, incorrectly placing requirements in
-                    // unresolved_requirements.
-                    let matches = id_store
-                        .identity_list(Some(&requirement.provider))
-                        .map_err(|e| format!("bundle.import: account lookup failed: {e}"))?;
-                    if matches.len() == 1 {
+                    let match_count = match match_count_by_provider.get(requirement.provider.as_str()) {
+                        Some(&n) => n,
+                        None => {
+                            // Codex P2, PR #2379 round 2: account CRUD routes
+                            // through id_store (shared/store.db when available), not
+                            // wstore (the per-channel database) -- see identity.rs's
+                            // own handler registrations. Querying wstore here would
+                            // report zero/stale matches for accounts that actually
+                            // exist, incorrectly placing requirements in
+                            // unresolved_requirements.
+                            let n = id_store
+                                .identity_list(Some(&requirement.provider))
+                                .map_err(|e| format!("bundle.import: account lookup failed: {e}"))?
+                                .len();
+                            match_count_by_provider.insert(requirement.provider.as_str(), n);
+                            n
+                        }
+                    };
+                    if match_count == 1 {
                         resolved_requirement_ids.push(requirement.id.clone());
                     } else {
                         unresolved_requirements.push(json!({
                             "id": requirement.id,
                             "provider": requirement.provider,
                             "env": requirement.env,
-                            "match_count": matches.len(),
+                            "match_count": match_count,
                         }));
                     }
                 }
@@ -405,6 +421,21 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // failure into an apparently-successful lossy import.
                 // Only the confirmed-conflict shape is swallowed; anything
                 // else aborts the whole RPC.
+                // codex P2, PR #2379 round 4: rollback previously discarded
+                // every skill_delete error via `let _ = ...`, so if the SAME
+                // failing store also rejects the cleanup deletes, previously-
+                // inserted global skills could silently survive an RPC that
+                // reports failure. No transaction primitive exists on Store
+                // today, so full atomicity is out of scope here; surfacing
+                // the rollback failure instead of swallowing it is the fix
+                // that fits — the caller at least learns cleanup itself may
+                // not have fully succeeded.
+                let rollback_skills = |ids: &[String]| -> Vec<String> {
+                    ids.iter()
+                        .filter_map(|id| wstore.skill_delete(id).err().map(|e| format!("{id}: {e}")))
+                        .collect()
+                };
+
                 let now = now_ms();
                 let mut imported_skill_ids: Vec<String> = Vec::new();
                 let mut skipped_skills = parsed.skipped_skills.clone();
@@ -435,13 +466,19 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             // leaves orphaned global skill rows (bound to
                             // no bundle, but visible/bindable by any agent)
                             // behind a failed RPC.
-                            for id in &imported_skill_ids {
-                                let _ = wstore.skill_delete(id);
-                            }
-                            return Err(format!(
+                            let rollback_errors = rollback_skills(&imported_skill_ids);
+                            let mut msg = format!(
                                 "bundle.import: failed to create skill \"{}\": {e}",
                                 skill.slug
-                            ));
+                            );
+                            if !rollback_errors.is_empty() {
+                                msg.push_str(&format!(
+                                    "; additionally, rollback of {} previously-created skill(s) failed and may have left orphaned global skill row(s): {}",
+                                    rollback_errors.len(),
+                                    rollback_errors.join("; ")
+                                ));
+                            }
+                            return Err(msg);
                         }
                     }
                 }
@@ -472,10 +509,16 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Codex P2, PR #2379: same rollback as above — the
                     // skills this RPC just created must not survive a
                     // failed bundle creation as orphaned global rows.
-                    for id in &imported_skill_ids {
-                        let _ = wstore.skill_delete(id);
+                    let rollback_errors = rollback_skills(&imported_skill_ids);
+                    let mut msg = format!("bundle.import: {e}");
+                    if !rollback_errors.is_empty() {
+                        msg.push_str(&format!(
+                            "; additionally, rollback of {} previously-created skill(s) failed and may have left orphaned global skill row(s): {}",
+                            rollback_errors.len(),
+                            rollback_errors.join("; ")
+                        ));
                     }
-                    return Err(format!("bundle.import: {e}"));
+                    return Err(msg);
                 }
 
                 broker.publish(crate::backend::wps::WaveEvent {

--- a/docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md
+++ b/docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md
@@ -1,0 +1,232 @@
+# Spec: ABF v0.1 — Single-File Format + Importer (Phase 2)
+
+**Date:** 2026-08-01
+**Status:** Spec — implementation follows in this same effort (Phase 2, §4 below).
+**Relationship to prior work:** refines and partially supersedes
+`docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md` §5 (the
+original ABF proposal). That report's research (§1–§4, §7) stands unchanged —
+this doc only revises the packaging decision in its §5.4 and specifies the
+importer its §6 Phase 2 left as a one-paragraph sketch. Do not re-litigate the
+research; it was adversarially verified across four passes and nothing here
+contradicts it.
+
+---
+
+## 1. What actually shipped since the original report (ground truth, verified against code)
+
+The original report was written as "no implementation yet." That's now stale:
+
+| Phase | Report's plan | Actual state (2026-08-01) |
+|---|---|---|
+| **0** — align skills with Agent Skills (SKILL.md) | — | **Shipped.** `SKILL_TYPE_AGENT_SKILL`, `render_skill_md`, `.claude/skills/<slug>/SKILL.md` materialization all live in `agent_config.rs` / `agent-config-builder.ts`. |
+| **1** — exporter | "Pure read-side; zero schema risk" | **Shipped**, and more thoroughly than the report sketched: `agentmux-srv/src/backend/bundle_export.rs` (1194 lines) — instructions/context files/skills/MCP servers/inferred credential requirements, plus **secret redaction** in exported MCP configs (env, headers, CLI args, URL userinfo/query params — none of this was in the original report, added across PRs #2325/#2333 after real security findings). Wired via `bundle.export` RPC (`server/app_api/bundle.rs`), including a **zip archive option** (`zip_bundle_export`, `format: "zip"`) the report's §5.4 had framed as a later, optional phase.
+| **2** — importer | "validation... create rows... account resolution" | **Not started.** No `bundle_import.rs`, no `bundle.import` RPC, nothing. This is what §4 below specifies. |
+| **3** — Armory UI (export/import buttons) | — | **Not started.** No UI surface for either direction yet. |
+| **4/5** — OCI distribution, public registry | — | **Not started.** |
+
+## 2. Revision: `.abf` (zip) is the primary interchange format for v0.1, not a later phase
+
+The original report's §5.4 filed zip under "Distribution (phase-gated, not
+required for v0.1)," treating the loose directory tree (§5.1) as the v0.1
+baseline and zip as an optional convenience added later. That framing is now
+inverted for two reasons:
+
+1. **It's already built.** `zip_bundle_export` exists, is tested, and is
+   reachable via `format: "zip"` on the existing RPC — there's no remaining
+   work to "add" zip support, only to formalize it as the recommended form.
+2. **"An ABF file that gets loaded" needs a file, not a directory.** The
+   directory-tree layout (§5.1 of the original report) is the right *logical*
+   structure — it's what an importer parses internally, and it's the right
+   shape for a bundle checked into a git repo unpacked — but it is not
+   something a user can point a "load bundle" action at as a single artifact.
+   A zip removes that gap with zero new format invention: it's the same
+   directory tree, byte-identically laid out inside the archive.
+
+**Decision:** the **`.abf` file** — a zip archive whose internal layout is
+exactly the directory tree from the original report's §5.1 (`armory.json` +
+`instructions/` + `skills/` + `mcp/` + `accounts/requirements.json`) — is the
+**primary, recommended interchange format for ABF v0.1**. The unpacked
+directory tree remains a fully valid, equivalent representation (useful for
+hand-editing or committing a bundle's source into a repo unpacked) — an
+importer MUST accept either. There is no third format; this is not a new
+schema, only a packaging decision.
+
+- **Extension:** `.abf`
+- **MIME type:** `application/vnd.agentmux.bundle+zip` (informative; not
+  currently registered anywhere, matches the pattern of `.mcpb`'s
+  `application/vnd.anthropic.mcpb`)
+- **Internal structure:** unchanged from the original report's §5.1 — a zip
+  is just bytes-on-disk for the same tree `zip_bundle_export` already
+  produces. No new manifest field, no new schema version needed for this
+  change alone.
+- **Compression:** Deflate (already what `zip_bundle_export` uses via the
+  `zip` crate's `["deflate"]` feature — no new dependency).
+
+This does **not** change §5.4's later phases (OCI distribution) — those
+remain future work, layered on top of the same `armory.json` content via a
+different transport, exactly as originally proposed.
+
+## 3. `armory.json` — no schema change, one clarification
+
+The manifest schema from the original report's §5.2 is unchanged. One thing
+worth stating explicitly, since the exporter's own code comments already
+flagged it as a real, deliberate gap (`bundle_export.rs`'s module doc
+comment, citing Codex P1 on PR #2325): `mcp/<slug>.server.json` currently
+contains **AgentMux's own runtime MCP config shape** (`{type, command, args,
+env}` — the same object `.mcp.json` uses), not the official MCP registry
+`server.json` schema (`packages[].registryType`/`identifier`/
+`environmentVariables`). This spec does not resolve that gap — real
+conversion between the two shapes would require fabricating fields a bare
+stdio command doesn't contain. The importer (§4) reads back exactly the
+shape the exporter writes (AgentMux's runtime shape); accepting genuine
+upstream `server.json` files is out of scope for v0.1 and tracked as a
+follow-up, not silently guessed at here.
+
+## 4. Phase 2: the importer
+
+### 4.1 Scope
+
+Backend + RPC only for v0.1 — no UI (Phase 3, still separately tracked).
+Mirrors `bundle_export.rs`'s shape and quality bar: pure functions for
+parsing/validation (no I/O, no Store access), a thin RPC handler
+(`bundle.import`) that owns the Store side-effects, symmetric
+warnings/skipped-item reporting so a lossy import is never silent.
+
+### 4.2 Input
+
+`bundle.import` accepts **either**:
+- `zip_base64`: a base64-encoded `.abf` zip (mirrors `bundle.export`'s own
+  `zip_base64` response field), **or**
+- `files`: the raw `[{path, content}]` list (mirrors `bundle_export.rs`'s
+  `BundleExportFile[]` shape) — lets a caller who already has an unpacked
+  directory tree (e.g. read directly off disk) skip the zip round-trip.
+
+Exactly one of the two must be present; both or neither is a request error.
+
+### 4.3 Validation (in order — first failure wins, no partial import)
+
+1. **`armory.json` must exist and parse as JSON.** Missing or malformed →
+   reject the whole import with a clear error, nothing is written.
+2. **`$schema` and `version` are read but not enforced as a hard gate for
+   v0.1** — no schema registry exists yet to validate against (the
+   `https://docs.agentmux.ai/schemas/armory-bundle/v0.1/bundle.schema.json`
+   URL the exporter writes is aspirational, not yet a real, fetchable
+   document as of this spec). Record both verbatim on the created bundle's
+   metadata for forward compatibility; do not fail import on an unrecognized
+   version — warn instead. Revisit once a real schema exists to validate
+   against.
+3. **Every path referenced in `components` must exist among the provided
+   files/zip entries.** A `components.instructions` entry pointing at a
+   missing file is a warning (skip that entry), not a hard failure — mirrors
+   the exporter's own "warn, don't silently vanish, but don't block on a
+   partial problem" philosophy for `context_files`/`mcp_servers`.
+4. **Path safety.** Every file path in the archive/list is re-validated with
+   the same rules `sanitize_context_relative_path` already enforces on
+   export (no absolute path, no `..` traversal, no drive letter) — an
+   untrusted `.abf` file is exactly the kind of input this must defend
+   against on the way *in*, even though the exporter only had to defend
+   against it on the way *out*. A path that fails this check is dropped with
+   a warning, never written anywhere, never used to escape the intended
+   unpack scope (there is no on-disk unpack for the DB-import path — this
+   guards against a future filesystem-materializing importer inheriting the
+   same code, and against any path used as a lookup key).
+5. **`accounts/` files other than `requirements.json` are rejected outright**
+   — same invariant the original report's Phase 2 sketch stated explicitly
+   ("Never import secret material even if present in a malicious bundle").
+   Any other file under `accounts/` is neither read nor written anywhere; its
+   presence is recorded as a warning.
+
+### 4.4 What gets created
+
+- **One `Memory` (bundle) row**, `is_global: false` by default (an import
+  should not silently become injected into every agent's CLAUDE.md without
+  explicit user action — matches the existing `bundle_memory_upsert`
+  contract, which never flips `is_global` on its own). `instructions` from
+  `instructions/AGENTS.md` (concatenated if the manifest lists more than
+  one instructions-component path, in manifest order — mirrors how
+  `format_global_brain_block` already joins multiple bundles with `---`,
+  reused here at the file level for a multi-file `instructions` component).
+  `context_files` from every `instructions/context/*` file the manifest
+  references. `mcp_servers` from every `mcp/*.server.json` file, written
+  **verbatim, `${VAR}` placeholders and all** — see the correction in §4.5
+  below on why this stays templated rather than being "resolved" in place.
+- **One `Skill` row per `skills/<slug>/SKILL.md`**, created via
+  `skill_upsert_unique_global` (global, matching how an imported *bundle*
+  — a shared resource — should behave, not bound to any one agent).
+  `skill_type: "agent-skill"`. Parsed from the SKILL.md's YAML frontmatter
+  (`name`, `description`) + body, using the **existing** frontmatter parser
+  if one already exists for a different call site (check
+  `agent_config.rs`/`skills.rs` before writing a new one); if none exists,
+  a minimal parser is in scope here since `render_skill_md`'s inverse
+  doesn't currently exist anywhere in the codebase. A skill name colliding
+  with an existing global skill is a warning + skip (not a hard failure —
+  matches `skill_upsert_unique_global`'s own `NameConflict` error being
+  surfaced as a per-item warning, not an aborted import).
+- **Nothing under `db_accounts`, ever.** Import never creates, modifies, or
+  reads an actual credential. `accounts/requirements.json` is read-only
+  input to §4.5's resolution; it is not itself imported as a row anywhere.
+
+### 4.5 Account requirement resolution — informational only, never substituted
+
+**Correction to this spec's original draft**, made during implementation:
+the draft said a single unambiguous account match should be "substituted"
+into the created `mcp_servers` row in place of the `${VAR}` placeholder.
+That's wrong and was cut before shipping. Unlike CLI-provider identity
+(`resolver/inject.rs`, `SecretRef`-backed, resolved fresh at every spawn),
+MCP server `env` values have **no equivalent spawn-time indirection** — a
+value written into `db_bundles.mcp_servers` is materialized into
+`.mcp.json` **verbatim**, no resolver pass in between. "Substituting an
+account binding" for an MCP server would therefore mean writing the
+account's *actual secret value* into a DB column that is, by construction,
+the same column an `armory export` of this very bundle reads from — i.e.
+exactly the credential-leak-into-a-shareable-artifact shape the exporter's
+redaction logic (`redact_mcp_entry`) exists to prevent. Resolution here
+stays **read-only and purely informational**:
+
+For each entry in `accounts/requirements.json`, look up existing
+`db_accounts` rows by `provider` (exact match) — **read-only, no
+creation, no write of any kind.** The original report's Phase 2 sketch
+says "prompting to link or create" — the *prompting* half is a Phase 3 UI
+concern; creating a new account (which necessarily means the user
+supplying a real credential) is never something an import of untrusted
+bundle data should trigger unattended, and linking an existing one to an
+MCP server's env var is exactly the credential-injection surface this
+importer must not touch. The lookup result is reported back
+(`resolved_requirement_ids` for exactly-one-match, `unresolved_requirements`
+for zero-or-multiple, per requirement id) purely so a future Phase 3 UI can
+show "N of M requirements have a matching account — link them" without
+this backend ever having written a secret anywhere. `mcp_servers` in the
+created bundle always contains the placeholders exactly as exported, full
+stop — resolving them is deferred entirely to whatever mechanism eventually
+lets a user fill in an MCP server's env value through the normal Armory
+MCP Servers editor (already exists, untouched by this spec).
+
+### 4.6 Result shape (symmetric to `BundleExport`)
+
+```rust
+pub struct BundleImport {
+    pub bundle_id: String,
+    pub imported_skill_ids: Vec<String>,
+    pub skipped_skills: Vec<String>,          // name conflicts, malformed SKILL.md
+    pub resolved_requirement_ids: Vec<String>,   // exactly one matching account found (read-only lookup, nothing written)
+    pub unresolved_requirements: Vec<Value>,     // zero or multiple matches — see §4.5
+    pub warnings: Vec<String>,                // missing/unsafe paths, rejected accounts/* files, unenforced schema version, etc.
+}
+```
+
+### 4.7 RPC
+
+`bundle.import` — window-scoped, same as `bundle.export` (bundles aren't
+agent-specific). Request: `{ zip_base64?: string, files?: [{path, content}] }`.
+Response: `BundleImport` (§4.6) as JSON.
+
+## 5. What this spec deliberately does not do
+
+- **No UI.** Phase 3 (Armory Export/Import buttons + import-review sheet)
+  remains separately tracked, unchanged from the original report's §6.
+- **No OCI distribution.** Phase 4/5 unchanged.
+- **No `server.json` schema conversion.** §3 above.
+- **No dynamic memory.** The original report's §5.5 non-goal stands
+  unchanged — nothing in this spec touches it.
+- **No schema-registry validation.** §4.3.2 — deferred until a real,
+  versioned JSON Schema document exists to validate against.

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -295,6 +295,7 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "bundle.delete",
     "bundle.export",
     "bundle.get",
+    "bundle.import",
     "bundle.list",
     "bundle.self.get",
     "bundle.upsert",


### PR DESCRIPTION
## Summary

Follow-up to `docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md` — that report's research stands unchanged; this PR refines its packaging decision and implements the importer its Phase 2 left as a one-paragraph sketch.

**Ground truth check first** (see the new spec's §1): Phase 0 (skills alignment) and Phase 1 (exporter) were already shipped, including a zip option (`zip_bundle_export`) the original report had filed under "later, optional phase." Phase 2 (importer) did not exist at all — zero `bundle.import`, zero `bundle_import.rs`.

**This PR:**
1. **Spec** (`docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md`) — promotes the `.abf` zip archive to the primary v0.1 interchange format (same internal layout, just packaged as one file instead of a bare directory tree — "an ABF file that gets loaded" needs a file). Also specifies the importer precisely enough to implement against.
2. **A spec self-correction, made during implementation, not after**: an earlier draft said a single unambiguous account match should be "substituted" into an imported MCP server's `${VAR}` placeholder. That's wrong — MCP server `env` values have no spawn-time resolution indirection the way CLI-provider identity does (checked `resolver/inject.rs` before assuming), so "substituting" would mean writing a real secret into the same DB column `bundle_export.rs`'s own redaction logic (env/header/args/URL scanning, added across PRs #2325/#2333) exists specifically to keep secrets out of. Account resolution is **read-only and purely informational** — a bundle's placeholders are never rewritten by import, full stop.
3. **`bundle_import.rs`** — pure parsing/validation, mirroring `bundle_export.rs`'s shape and its "warn, don't silently drop; reject structurally, not per-entry" philosophy. Reuses `sanitize_context_relative_path` (now `pub(crate)`) for the same path-traversal defense on the way *in* that the exporter already applies on the way *out* — an untrusted `.abf` needs it at least as much. Includes a SKILL.md frontmatter parser (the inverse of `render_skill_md` — didn't exist anywhere in the codebase) and a zip reader that strips the exporter's root-slug wrapping directory.
4. **`bundle.import` RPC handler** — accepts either `zip_base64` or a raw `files` list, creates one `Memory` bundle row (`is_global: false` — an import must not silently start injecting into every agent's CLAUDE.md without explicit user action) and one global `Skill` row per parsed skill, resolves account requirements read-only.

## Test plan

- [x] `bundle_import.rs`: 16 unit tests — missing/malformed `armory.json` rejected structurally; missing referenced files/skills warn-and-skip; path-traversal and duplicate-entry defense; `accounts/` allowlist (only `requirements.json` ever read); SKILL.md frontmatter round-trip (including special characters); a full `export_bundle` → `zip_bundle_export` → `unzip_bundle_import` → `parse_bundle_import` round trip.
- [x] `cargo test -p agentmux-srv bundle` — 54 passed (30 export + 16 import + others), 0 failed.
- [x] `cargo test -p agentmux-srv` (full suite) — 1871 passed, 0 failed, 4 ignored (pre-existing).
- [x] `cargo build -p agentmux-srv` — clean.
- [ ] No UI yet (Phase 3, separately tracked per the spec) — this ships backend/RPC only, so there's no click-through to verify beyond the RPC contract itself.

<!-- agentmux:agent_id=lazo -->