### PR TITLE
feat(muxspect): new live process/turn-state introspection tool (Phase 1)

### DIFF
--- a/.changesets/1785618709-feat-muxspect-new-live-process-turn-state-introspection-tool-hx42.md
+++ b/.changesets/1785618709-feat-muxspect-new-live-process-turn-state-introspection-tool-hx42.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxspect): new live process/turn-state introspection tool, Phase 1 (current-instance only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,11 @@ Full reference: `docs/MUXLOG.md`.
 
 `muxlog` is history (log files on disk); for **live** state — is this block's
 controller actually running right now, what's its process tree — use
-`muxspect` (`muxspect list`, `muxspect describe <block_id>`), its sibling
-tool. Only queries the instance you're already inside (Phase 1 — no
-cross-instance support yet). Full reference: `docs/MUXSPECT.md`.
+`muxspect`, its sibling tool. Only queries the instance you're already
+inside (Phase 1 — no cross-instance support yet). **The bare `muxspect`
+shell function doesn't work from a tool-spawned shell yet (known gap,
+reagent P1 on PR #2380)** — call the core directly instead:
+`node ~/.agentmux/shell/muxspect.mjs list`. Full reference: `docs/MUXSPECT.md`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,12 @@ identically across `task dev`, portable, and install builds. Not loaded in a
 tool-spawned subshell? Call the core directly: `node ~/.agentmux/shell/muxlog.mjs ls`.
 Full reference: `docs/MUXLOG.md`.
 
+`muxlog` is history (log files on disk); for **live** state — is this block's
+controller actually running right now, what's its process tree — use
+`muxspect` (`muxspect list`, `muxspect describe <block_id>`), its sibling
+tool. Only queries the instance you're already inside (Phase 1 — no
+cross-instance support yet). Full reference: `docs/MUXSPECT.md`.
+
 ---
 
 ## Version Management

--- a/agentmux-srv/src/backend/shellintegration.rs
+++ b/agentmux-srv/src/backend/shellintegration.rs
@@ -21,6 +21,10 @@ const FISH_SCRIPT: &str = include_str!("shellintegration/fish.fish");
 /// shell's `muxlog` function delegates to it. One tested implementation does log
 /// discovery + NDJSON rendering + filtering for all shells.
 const MUXLOG_JS: &str = include_str!("shellintegration/muxlog.mjs");
+/// Shared muxspect core (Node) — muxlog's live-state sibling. Deployed once
+/// at `<shell>/muxspect.mjs`; every shell's `muxspect` function delegates to
+/// it. See docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md.
+const MUXSPECT_JS: &str = include_str!("shellintegration/muxspect.mjs");
 const VERSION_MARKER: &str = env!("CARGO_PKG_VERSION");
 
 // ─── Shell type ──────────────────────────────────────────────────────────────
@@ -96,6 +100,13 @@ pub fn deploy_scripts(wave_data_dir: &Path) {
     let muxlog_path = shell_base.join("muxlog.mjs");
     if let Err(e) = std::fs::write(&muxlog_path, MUXLOG_JS) {
         tracing::warn!("shell integration: failed to write {}: {}", muxlog_path.display(), e);
+        all_ok = false;
+    }
+
+    // Deploy the shared muxspect core the same way, right next to muxlog.mjs.
+    let muxspect_path = shell_base.join("muxspect.mjs");
+    if let Err(e) = std::fs::write(&muxspect_path, MUXSPECT_JS) {
+        tracing::warn!("shell integration: failed to write {}: {}", muxspect_path.display(), e);
         all_ok = false;
     }
 
@@ -234,5 +245,27 @@ mod tests {
     fn test_unknown_shell_returns_none() {
         let dir = Path::new("/tmp");
         assert!(get_shell_startup(ShellType::Unknown, dir).is_none());
+    }
+
+    /// `muxspect.mjs` deploys next to `muxlog.mjs` — codified as a test since
+    /// it's easy to add a new embedded script and forget the deploy line
+    /// (see docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md).
+    #[test]
+    fn deploy_scripts_writes_muxlog_and_muxspect_side_by_side() {
+        let tmp = std::env::temp_dir().join(format!(
+            "agentmux-shellintegration-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        deploy_scripts(&tmp);
+
+        let shell_base = tmp.join("shell");
+        let muxlog = shell_base.join("muxlog.mjs");
+        let muxspect = shell_base.join("muxspect.mjs");
+        assert!(muxlog.exists(), "muxlog.mjs should be deployed");
+        assert!(muxspect.exists(), "muxspect.mjs should be deployed alongside it");
+        assert_eq!(std::fs::read_to_string(&muxspect).unwrap(), MUXSPECT_JS);
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/agentmux-srv/src/backend/shellintegration.rs
+++ b/agentmux-srv/src/backend/shellintegration.rs
@@ -25,7 +25,31 @@ const MUXLOG_JS: &str = include_str!("shellintegration/muxlog.mjs");
 /// at `<shell>/muxspect.mjs`; every shell's `muxspect` function delegates to
 /// it. See docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md.
 const MUXSPECT_JS: &str = include_str!("shellintegration/muxspect.mjs");
-const VERSION_MARKER: &str = env!("CARGO_PKG_VERSION");
+
+/// Deployment marker: `<package version>-<content hash>`, NOT the bare
+/// package version alone (codex P2 on PR #2380). Local/dev builds routinely
+/// iterate on these embedded scripts WITHOUT a version bump (this repo's own
+/// convention — see CLAUDE.md's "Build versioning — local builds are
+/// *labeled*, not *versioned*"), so a version-only marker left `.version`
+/// already matching on every same-version rebuild/restart, silently
+/// skipping deployment of a newly-added or newly-edited script (muxspect.mjs
+/// specifically, added in the same PR that added the startup call site —
+/// the marker never invalidated to pick it up). Hashing the actual embedded
+/// content means ANY change to ANY script forces a redeploy regardless of
+/// whether the package version moved, while an unchanged rebuild still
+/// skips the (cheap, but not free) disk writes.
+fn version_marker() -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    BASH_SCRIPT.hash(&mut hasher);
+    ZSH_SCRIPT.hash(&mut hasher);
+    PWSH_SCRIPT.hash(&mut hasher);
+    FISH_SCRIPT.hash(&mut hasher);
+    MUXLOG_JS.hash(&mut hasher);
+    MUXSPECT_JS.hash(&mut hasher);
+    format!("{}-{:x}", env!("CARGO_PKG_VERSION"), hasher.finish())
+}
 
 // ─── Shell type ──────────────────────────────────────────────────────────────
 
@@ -63,15 +87,16 @@ pub fn detect_shell_type(shell_path: &str) -> ShellType {
 pub fn deploy_scripts(wave_data_dir: &Path) {
     let shell_base = wave_data_dir.join("shell");
     let version_file = shell_base.join(".version");
+    let marker = version_marker();
 
     // Check if already up-to-date
     if let Ok(existing) = std::fs::read_to_string(&version_file) {
-        if existing.trim() == VERSION_MARKER {
+        if existing.trim() == marker {
             return;
         }
     }
 
-    tracing::info!("Deploying shell integration scripts (v{})", VERSION_MARKER);
+    tracing::info!("Deploying shell integration scripts ({})", marker);
 
     let deploys: &[(&str, &str, &str)] = &[
         ("bash", ".bashrc", BASH_SCRIPT),
@@ -112,7 +137,7 @@ pub fn deploy_scripts(wave_data_dir: &Path) {
 
     // Write version marker only if all scripts deployed successfully
     if all_ok {
-        let _ = std::fs::write(&version_file, VERSION_MARKER);
+        let _ = std::fs::write(&version_file, &marker);
     }
 }
 
@@ -265,6 +290,44 @@ mod tests {
         assert!(muxlog.exists(), "muxlog.mjs should be deployed");
         assert!(muxspect.exists(), "muxspect.mjs should be deployed alongside it");
         assert_eq!(std::fs::read_to_string(&muxspect).unwrap(), MUXSPECT_JS);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// codex P2 on PR #2380: a version-only marker left an EXISTING profile
+    /// (same CARGO_PKG_VERSION, older content) permanently skipping
+    /// deployment of a newly-added script — exactly what an existing
+    /// `~/.agentmux` from a prior same-version dev build would have. Content
+    /// hashing must force a redeploy in that case, not just on a genuinely
+    /// fresh profile (the only case the test above covers).
+    #[test]
+    fn deploy_scripts_redeploys_when_marker_predates_a_content_change() {
+        let tmp = std::env::temp_dir().join(format!(
+            "agentmux-shellintegration-test-stale-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let shell_base = tmp.join("shell");
+        std::fs::create_dir_all(&shell_base).unwrap();
+
+        // Simulate a profile deployed by an older build of shellintegration.rs
+        // that only ever wrote the bare package version as its marker (i.e.
+        // BEFORE this fix existed) — the exact "same version, no muxspect.mjs
+        // yet" scenario codex's finding describes.
+        std::fs::write(shell_base.join(".version"), env!("CARGO_PKG_VERSION")).unwrap();
+        assert!(!shell_base.join("muxspect.mjs").exists(), "precondition: not deployed yet");
+
+        deploy_scripts(&tmp);
+
+        assert!(
+            shell_base.join("muxspect.mjs").exists(),
+            "a stale version-only marker must not suppress deployment of a script that was never written"
+        );
+        assert_eq!(
+            std::fs::read_to_string(shell_base.join(".version")).unwrap(),
+            version_marker(),
+            "marker must be updated to the new content-hashed form"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/agentmux-srv/src/backend/shellintegration/bash.sh
+++ b/agentmux-srv/src/backend/shellintegration/bash.sh
@@ -110,6 +110,22 @@ muxlog() {
     case "$action" in tail) tail -f "$logfile" ;; cat) cat "$logfile" ;; *) grep "$action" "$logfile" ;; esac
 }
 
+# ─── muxspect ───────────────────────────────────────────────────────────────
+# Live process/turn-state introspection for the CURRENT instance (muxlog's
+# live-state sibling — muxlog answers "what happened", muxspect answers
+# "what's happening right now"). Delegates to the shared Node core
+# (muxspect.mjs, deployed next to this rcfile). `muxspect help` for usage.
+# No non-Node fallback: introspection needs a real authenticated HTTP call.
+_AGENTMUX_MUXSPECT_JS="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)/muxspect.mjs"
+muxspect() {
+    if command -v node >/dev/null 2>&1 && [ -f "$_AGENTMUX_MUXSPECT_JS" ]; then
+        node "$_AGENTMUX_MUXSPECT_JS" "$@"
+        return
+    fi
+    echo "muxspect: Node unavailable or core missing at $_AGENTMUX_MUXSPECT_JS" >&2
+    return 1
+}
+
 # Append to PROMPT_COMMAND (array-safe)
 if [[ $(declare -p PROMPT_COMMAND 2>/dev/null) == "declare -a"* ]]; then
     PROMPT_COMMAND+=(_agentmux_si_prompt_command)

--- a/agentmux-srv/src/backend/shellintegration/fish.fish
+++ b/agentmux-srv/src/backend/shellintegration/fish.fish
@@ -89,6 +89,21 @@ function muxlog
     end
 end
 
+# ─── muxspect ───────────────────────────────────────────────────────────────
+# Live process/turn-state introspection for the CURRENT instance (muxlog's
+# live-state sibling). Delegates to the shared Node core (muxspect.mjs).
+# `muxspect help` for usage. No non-Node fallback: introspection needs a real
+# authenticated HTTP call.
+set -g _agentmux_muxspect_js (dirname (status -f))/../muxspect.mjs
+function muxspect
+    if command -q node; and test -f "$_agentmux_muxspect_js"
+        node "$_agentmux_muxspect_js" $argv
+        return
+    end
+    echo "muxspect: Node unavailable or core missing at $_agentmux_muxspect_js" >&2
+    return 1
+end
+
 function _agentmux_si_prompt --on-event fish_prompt
     _agentmux_si_osc7
     _agentmux_si_agent_env

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -21,6 +21,8 @@
 // the URL — the auth key specifically is only injected for agent-CLI-type
 // controllers today, see agentmux-srv/src/server/agent_handlers/input.rs).
 
+import { pathToFileURL } from "node:url";
+
 const USAGE = `muxspect — live process/turn-state introspection for the current AgentMux instance
 
 Usage:
@@ -82,15 +84,23 @@ function renderList(data) {
         console.log("(no controller-backed blocks in this instance)");
         return;
     }
+    // "pane_type" reflects static pane classification (is_agent_pane), NOT
+    // live turn activity — that's what `lifecycle` is for (`lifecycle_from`
+    // maps turn_active=true straight to Lifecycle::Running; see
+    // agentmux-srv/src/broker/process.rs). A column literally named "turn"
+    // showing pane-type instead of turn state was reviewed as misleading
+    // (codex P2 on PR #2380) — `list`'s ProcessStatus rows don't carry
+    // BlockControllerRuntimeStatus::turn_active at all (that needs
+    // `describe`), so this renames rather than fetching it at extra cost.
     const rows = blocks.map((b) => ({
         block_id: b.block_id,
         type: b.controller_type || "?",
         lifecycle: b.lifecycle,
-        turn: b.is_agent_pane ? "agent" : "-",
+        pane_type: b.is_agent_pane ? "agent" : "term",
         confidence: b.liveness_confidence,
         age: ageString(b.last_computed_ms),
     }));
-    const cols = ["block_id", "type", "lifecycle", "turn", "confidence", "age"];
+    const cols = ["block_id", "type", "lifecycle", "pane_type", "confidence", "age"];
     const widths = Object.fromEntries(
         cols.map((c) => [c, Math.max(c.length, ...rows.map((r) => String(r[c]).length))])
     );
@@ -129,12 +139,31 @@ function renderDescribe(data) {
     }
 }
 
-async function main() {
-    const args = process.argv.slice(2);
-    const cmd = args[0] && !args[0].startsWith("-") ? args[0] : "list";
-    const json = args.includes("--json");
+/**
+ * Split argv into `{ cmd, blockId, json, help }`, flags-and-positionals
+ * separated regardless of ordering. Flags can legally appear before OR
+ * after the positional args (both 'muxspect describe --json <id>' and
+ * 'muxspect --json describe <id>' are natural to type) — filtering them out
+ * first, then reading command/args positionally, is what makes both orders
+ * work; indexing into the raw, flag-interspersed argv (the original
+ * implementation) silently ran 'list' instead of 'describe' — or picked up
+ * a flag string as the block_id — depending on where the flag landed
+ * (reagent P2 on PR #2380). Exported (pure, no I/O) for
+ * muxspect.test.mjs.
+ */
+export function parseArgs(argv) {
+    const json = argv.includes("--json");
+    const help = argv.includes("--help") || argv.includes("-h");
+    const positional = argv.filter((a) => !a.startsWith("-"));
+    const cmd = positional[0] ?? "list";
+    const blockId = positional[1];
+    return { cmd, blockId, json, help };
+}
 
-    if (cmd === "help" || args.includes("--help") || args.includes("-h")) {
+async function main() {
+    const { cmd, blockId, json, help } = parseArgs(process.argv.slice(2));
+
+    if (cmd === "help" || help) {
         console.log(USAGE);
         return;
     }
@@ -149,7 +178,6 @@ async function main() {
     }
 
     if (cmd === "describe") {
-        const blockId = args[1];
         if (!blockId) fail("describe requires a block_id — 'muxspect describe <block_id>'");
         const data = await apiGet(url, authKey, `/api/v1/muxspect/describe?block_id=${encodeURIComponent(blockId)}`);
         if (json) console.log(JSON.stringify(data, null, 2));
@@ -158,7 +186,6 @@ async function main() {
     }
 
     if (cmd === "watch") {
-        const blockId = args[1];
         if (!blockId) fail("watch requires a block_id — 'muxspect watch <block_id>'");
         console.log(`watching ${blockId} — Ctrl+C to stop\n`);
         for (;;) {
@@ -173,4 +200,9 @@ async function main() {
     fail(`unknown command '${cmd}' — 'muxspect help' for usage`);
 }
 
-main().catch((e) => fail(e?.message ?? String(e)));
+// Only run when executed directly (`node muxspect.mjs ...`) — importing this
+// module (muxspect.test.mjs imports `parseArgs`) must not trigger a live
+// network call / `process.exit`.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+    main().catch((e) => fail(e?.message ?? String(e)));
+}

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -34,9 +34,21 @@ Usage:
   muxspect watch <block_id>       poll 'describe' every 2s until Ctrl+C
   muxspect help                   this message
 
-Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY in the environment —
-already present in any agent pane. Not a general-purpose cross-instance tool
-yet: this only ever queries the instance you're already inside.`;
+Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY in the environment.
+
+IMPORTANT (reagent P1 on PR #2380): the bare 'muxspect' shell FUNCTION is
+only defined in INTERACTIVE terminal panes (it's sourced from the shell
+rcfile), but those panes only get $AGENTMUX_LOCAL_URL, not
+$AGENTMUX_AUTH_KEY — so the function loads there but auth fails. Agent-CLI
+tool calls (the primary intended use — an agent inspecting its own running
+instance) get BOTH env vars, but tool-spawned shells don't source the
+rcfile, so the 'muxspect' function isn't defined there either. Until a
+Phase 2 fix wires this up properly, the ONLY invocation that reliably works
+today is calling the deployed core directly by path (same caveat muxlog
+itself documents for tool-spawned subshells):
+  node ~/.agentmux/shell/muxspect.mjs list
+See docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md for the
+full story and the planned fix.`;
 
 function fail(msg) {
     console.error(`muxspect: ${msg}`);
@@ -84,19 +96,26 @@ function renderList(data) {
         console.log("(no controller-backed blocks in this instance)");
         return;
     }
-    // "pane_type" reflects static pane classification (is_agent_pane), NOT
-    // live turn activity — that's what `lifecycle` is for (`lifecycle_from`
-    // maps turn_active=true straight to Lifecycle::Running; see
+    // "pane_type" reflects static pane classification, NOT live turn
+    // activity — that's what `lifecycle` is for (`lifecycle_from` maps
+    // turn_active=true straight to Lifecycle::Running; see
     // agentmux-srv/src/broker/process.rs). A column literally named "turn"
     // showing pane-type instead of turn state was reviewed as misleading
     // (codex P2 on PR #2380) — `list`'s ProcessStatus rows don't carry
     // BlockControllerRuntimeStatus::turn_active at all (that needs
     // `describe`), so this renames rather than fetching it at extra cost.
+    //
+    // Uses the server-computed `is_agent` field, NOT the raw
+    // `is_agent_pane` flag — subprocess/persistent/acp controllers can
+    // report `is_agent_pane: false` even though those controller types are
+    // always agents; reimplementing that classification rule in JS instead
+    // of reusing ProcessStatus::is_agent() mislabeled exactly those three
+    // types as "term" (codex P2 on PR #2380, second round).
     const rows = blocks.map((b) => ({
         block_id: b.block_id,
         type: b.controller_type || "?",
         lifecycle: b.lifecycle,
-        pane_type: b.is_agent_pane ? "agent" : "term",
+        pane_type: b.is_agent ? "agent" : "term",
         confidence: b.liveness_confidence,
         age: ageString(b.last_computed_ms),
     }));
@@ -116,7 +135,7 @@ function renderDescribe(data) {
     console.log(`block_id:            ${data.block_id}`);
     console.log(`lifecycle:           ${ps.lifecycle ?? "unknown"}  (computed ${ageString(ps.last_computed_ms)} ago)`);
     console.log(`controller_type:     ${ps.controller_type || "(no controller)"}`);
-    console.log(`is_agent_pane:       ${ps.is_agent_pane ?? false}`);
+    console.log(`is_agent:            ${data.is_agent ?? false}  (raw is_agent_pane: ${ps.is_agent_pane ?? false})`);
     console.log(`liveness_confidence: ${ps.liveness_confidence ?? "none"}`);
     console.log(`tracking_confidence: ${data.tracking_confidence}`);
     if (cs) {

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// muxspect — live introspection into the CURRENT running AgentMux instance's
+// process/turn state. Sibling to muxlog (history) — muxspect answers "what is
+// this instance doing right now," not "what happened."
+//
+// Phase 1 of docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md:
+// queries the instance the caller is ALREADY inside (via $AGENTMUX_LOCAL_URL /
+// $AGENTMUX_AUTH_KEY, inherited from the environment exactly the way
+// agentmux-mcp already does for every other /api/v1/* route — no new IPC, no
+// new auth scheme). Cross-instance querying (`muxspect targets` / `-i <other>`)
+// is Phase 2, not implemented here.
+//
+// Deployed by agentmux-srv next to muxlog.mjs (~/.agentmux/shell/muxspect.mjs);
+// the bash/zsh/pwsh/fish `muxspect` functions delegate here. Run standalone
+// with `node muxspect.mjs ...` (works from any subshell, unlike the shell
+// function) — but only from within a pane whose environment already carries
+// $AGENTMUX_LOCAL_URL/$AGENTMUX_AUTH_KEY (an agent pane, or any shell pane for
+// the URL — the auth key specifically is only injected for agent-CLI-type
+// controllers today, see agentmux-srv/src/server/agent_handlers/input.rs).
+
+const USAGE = `muxspect — live process/turn-state introspection for the current AgentMux instance
+
+Usage:
+  muxspect                        same as 'muxspect list'
+  muxspect list [--json]          summary of every controller-backed block
+  muxspect describe <block_id> [--json]
+                                  full detail for one block (process status,
+                                  controller status, OS process tree)
+  muxspect watch <block_id>       poll 'describe' every 2s until Ctrl+C
+  muxspect help                   this message
+
+Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY in the environment —
+already present in any agent pane. Not a general-purpose cross-instance tool
+yet: this only ever queries the instance you're already inside.`;
+
+function fail(msg) {
+    console.error(`muxspect: ${msg}`);
+    process.exit(1);
+}
+
+function requireEnv() {
+    const url = process.env.AGENTMUX_LOCAL_URL;
+    const authKey = process.env.AGENTMUX_AUTH_KEY;
+    if (!url || !authKey) {
+        fail(
+            "$AGENTMUX_LOCAL_URL / $AGENTMUX_AUTH_KEY not set — run this from inside an AgentMux agent pane.\n" +
+            "muxspect only queries the instance you're already running in; it can't discover or guess another one."
+        );
+    }
+    return { url, authKey };
+}
+
+async function apiGet(url, authKey, urlPath) {
+    let resp;
+    try {
+        resp = await fetch(`${url}${urlPath}`, { headers: { "X-AuthKey": authKey } });
+    } catch (e) {
+        fail(`could not reach ${url} — instance unreachable (${e.message})`);
+    }
+    if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        fail(`request failed (${resp.status}): ${body || resp.statusText}`);
+    }
+    return resp.json();
+}
+
+function ageString(lastComputedMs) {
+    if (!lastComputedMs) return "unknown";
+    const ageMs = Date.now() - lastComputedMs;
+    if (ageMs < 0) return "0s"; // clock skew — never print a negative age
+    if (ageMs < 1000) return `${ageMs}ms`;
+    if (ageMs < 60_000) return `${Math.round(ageMs / 1000)}s`;
+    return `${Math.round(ageMs / 60_000)}m`;
+}
+
+function renderList(data) {
+    const blocks = data.blocks ?? [];
+    if (blocks.length === 0) {
+        console.log("(no controller-backed blocks in this instance)");
+        return;
+    }
+    const rows = blocks.map((b) => ({
+        block_id: b.block_id,
+        type: b.controller_type || "?",
+        lifecycle: b.lifecycle,
+        turn: b.is_agent_pane ? "agent" : "-",
+        confidence: b.liveness_confidence,
+        age: ageString(b.last_computed_ms),
+    }));
+    const cols = ["block_id", "type", "lifecycle", "turn", "confidence", "age"];
+    const widths = Object.fromEntries(
+        cols.map((c) => [c, Math.max(c.length, ...rows.map((r) => String(r[c]).length))])
+    );
+    const line = (r) => cols.map((c) => String(r[c]).padEnd(widths[c])).join("  ");
+    console.log(line(Object.fromEntries(cols.map((c) => [c, c]))));
+    for (const r of rows) console.log(line(r));
+    console.log(`\n(as of query time — each row's own 'age' shows how stale its computed status is)`);
+}
+
+function renderDescribe(data) {
+    const ps = data.process_status ?? {};
+    const cs = data.controller_status;
+    console.log(`block_id:            ${data.block_id}`);
+    console.log(`lifecycle:           ${ps.lifecycle ?? "unknown"}  (computed ${ageString(ps.last_computed_ms)} ago)`);
+    console.log(`controller_type:     ${ps.controller_type || "(no controller)"}`);
+    console.log(`is_agent_pane:       ${ps.is_agent_pane ?? false}`);
+    console.log(`liveness_confidence: ${ps.liveness_confidence ?? "none"}`);
+    console.log(`tracking_confidence: ${data.tracking_confidence}`);
+    if (cs) {
+        console.log(`\ncontroller status:`);
+        console.log(`  shellprocstatus:   ${cs.shellprocstatus || "(none)"}`);
+        console.log(`  shellprocexitcode: ${cs.shellprocexitcode}`);
+        console.log(`  turn_active:       ${cs.turn_active ?? false}`);
+        console.log(`  spawn_ts_ms:       ${cs.spawn_ts_ms ?? "(never spawned)"}`);
+    } else {
+        console.log(`\ncontroller status:   (no controller for this block_id)`);
+    }
+    const processes = data.processes ?? [];
+    console.log(`\nprocesses (${processes.length}):`);
+    if (processes.length === 0) {
+        console.log(`  (none tracked)`);
+    } else {
+        for (const p of processes) {
+            console.log(`  pid=${p.pid}  rss=${Math.round(p.rss_bytes / 1024)}KB  ${p.command || "(unknown command)"}`);
+        }
+    }
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const cmd = args[0] && !args[0].startsWith("-") ? args[0] : "list";
+    const json = args.includes("--json");
+
+    if (cmd === "help" || args.includes("--help") || args.includes("-h")) {
+        console.log(USAGE);
+        return;
+    }
+
+    const { url, authKey } = requireEnv();
+
+    if (cmd === "list") {
+        const data = await apiGet(url, authKey, "/api/v1/muxspect/list");
+        if (json) console.log(JSON.stringify(data, null, 2));
+        else renderList(data);
+        return;
+    }
+
+    if (cmd === "describe") {
+        const blockId = args[1];
+        if (!blockId) fail("describe requires a block_id — 'muxspect describe <block_id>'");
+        const data = await apiGet(url, authKey, `/api/v1/muxspect/describe?block_id=${encodeURIComponent(blockId)}`);
+        if (json) console.log(JSON.stringify(data, null, 2));
+        else renderDescribe(data);
+        return;
+    }
+
+    if (cmd === "watch") {
+        const blockId = args[1];
+        if (!blockId) fail("watch requires a block_id — 'muxspect watch <block_id>'");
+        console.log(`watching ${blockId} — Ctrl+C to stop\n`);
+        for (;;) {
+            const data = await apiGet(url, authKey, `/api/v1/muxspect/describe?block_id=${encodeURIComponent(blockId)}`);
+            console.log(`--- ${new Date().toISOString()} ---`);
+            renderDescribe(data);
+            console.log("");
+            await new Promise((r) => setTimeout(r, 2000));
+        }
+    }
+
+    fail(`unknown command '${cmd}' — 'muxspect help' for usage`);
+}
+
+main().catch((e) => fail(e?.message ?? String(e)));

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -2,65 +2,69 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Unit tests for muxspect.mjs's argument parsing — pure, no network, no
-// running instance needed. Runnable standalone:
-//   node --test agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+// running instance needed. Runs as part of `npm test` (vitest) — NOT
+// node:test (reagent P1 on PR #2380: vitest.config.ts's default include
+// glob picks up this path, unlike tools/tests/lib/*.test.mjs which is
+// excluded via `**/tools/**`; a node:test file here made vitest fail with
+// "No test suite found in file" instead of actually running).
 //
 // Pins the fix for reagent P2 on PR #2380: flags could appear before OR
 // after the positional command/block_id, and the original (raw-index)
 // parser silently misbehaved depending on which side they landed on.
 
-import { test } from "node:test";
-import assert from "node:assert/strict";
+import { describe, expect, it } from "vitest";
 import { parseArgs } from "./muxspect.mjs";
 
-test("no args defaults to 'list'", () => {
-    assert.deepEqual(parseArgs([]), { cmd: "list", blockId: undefined, json: false, help: false });
-});
-
-test("plain 'describe <id>'", () => {
-    assert.deepEqual(parseArgs(["describe", "block-1"]), {
-        cmd: "describe",
-        blockId: "block-1",
-        json: false,
-        help: false,
+describe("muxspect parseArgs", () => {
+    it("no args defaults to 'list'", () => {
+        expect(parseArgs([])).toEqual({ cmd: "list", blockId: undefined, json: false, help: false });
     });
-});
 
-test("flag AFTER the command and block_id: 'describe block-1 --json'", () => {
-    const r = parseArgs(["describe", "block-1", "--json"]);
-    assert.equal(r.cmd, "describe");
-    assert.equal(r.blockId, "block-1");
-    assert.equal(r.json, true);
-});
+    it("plain 'describe <id>'", () => {
+        expect(parseArgs(["describe", "block-1"])).toEqual({
+            cmd: "describe",
+            blockId: "block-1",
+            json: false,
+            help: false,
+        });
+    });
 
-test("flag BETWEEN the command and block_id: 'describe --json block-1' (reagent P2 on PR #2380)", () => {
-    const r = parseArgs(["describe", "--json", "block-1"]);
-    assert.equal(r.cmd, "describe", "must still resolve to describe, not fall back to list");
-    assert.equal(r.blockId, "block-1", "must not pick up '--json' itself as the block_id");
-    assert.equal(r.json, true);
-});
+    it("flag AFTER the command and block_id: 'describe block-1 --json'", () => {
+        const r = parseArgs(["describe", "block-1", "--json"]);
+        expect(r.cmd).toBe("describe");
+        expect(r.blockId).toBe("block-1");
+        expect(r.json).toBe(true);
+    });
 
-test("flag BEFORE the command: '--json describe block-1' (reagent P2 on PR #2380)", () => {
-    const r = parseArgs(["--json", "describe", "block-1"]);
-    assert.equal(r.cmd, "describe", "must not fall back to list just because argv[0] is a flag");
-    assert.equal(r.blockId, "block-1");
-    assert.equal(r.json, true);
-});
+    it("flag BETWEEN the command and block_id: 'describe --json block-1' (reagent P2 on PR #2380)", () => {
+        const r = parseArgs(["describe", "--json", "block-1"]);
+        expect(r.cmd, "must still resolve to describe, not fall back to list").toBe("describe");
+        expect(r.blockId, "must not pick up '--json' itself as the block_id").toBe("block-1");
+        expect(r.json).toBe(true);
+    });
 
-test("'watch <id>' parses the same way as describe", () => {
-    const r = parseArgs(["watch", "block-1"]);
-    assert.equal(r.cmd, "watch");
-    assert.equal(r.blockId, "block-1");
-});
+    it("flag BEFORE the command: '--json describe block-1' (reagent P2 on PR #2380)", () => {
+        const r = parseArgs(["--json", "describe", "block-1"]);
+        expect(r.cmd, "must not fall back to list just because argv[0] is a flag").toBe("describe");
+        expect(r.blockId).toBe("block-1");
+        expect(r.json).toBe(true);
+    });
 
-test("'help' / '--help' / '-h' all set help regardless of position", () => {
-    assert.equal(parseArgs(["help"]).cmd, "help");
-    assert.equal(parseArgs(["--help"]).help, true);
-    assert.equal(parseArgs(["list", "-h"]).help, true);
-});
+    it("'watch <id>' parses the same way as describe", () => {
+        const r = parseArgs(["watch", "block-1"]);
+        expect(r.cmd).toBe("watch");
+        expect(r.blockId).toBe("block-1");
+    });
 
-test("missing block_id for describe/watch is representable as undefined, not a flag string", () => {
-    const r = parseArgs(["describe", "--json"]);
-    assert.equal(r.cmd, "describe");
-    assert.equal(r.blockId, undefined, "no positional after 'describe' — must not be '--json'");
+    it("'help' / '--help' / '-h' all set help regardless of position", () => {
+        expect(parseArgs(["help"]).cmd).toBe("help");
+        expect(parseArgs(["--help"]).help).toBe(true);
+        expect(parseArgs(["list", "-h"]).help).toBe(true);
+    });
+
+    it("missing block_id for describe/watch is representable as undefined, not a flag string", () => {
+        const r = parseArgs(["describe", "--json"]);
+        expect(r.cmd).toBe("describe");
+        expect(r.blockId, "no positional after 'describe' — must not be '--json'").toBeUndefined();
+    });
 });

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -1,0 +1,66 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for muxspect.mjs's argument parsing — pure, no network, no
+// running instance needed. Runnable standalone:
+//   node --test agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+//
+// Pins the fix for reagent P2 on PR #2380: flags could appear before OR
+// after the positional command/block_id, and the original (raw-index)
+// parser silently misbehaved depending on which side they landed on.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseArgs } from "./muxspect.mjs";
+
+test("no args defaults to 'list'", () => {
+    assert.deepEqual(parseArgs([]), { cmd: "list", blockId: undefined, json: false, help: false });
+});
+
+test("plain 'describe <id>'", () => {
+    assert.deepEqual(parseArgs(["describe", "block-1"]), {
+        cmd: "describe",
+        blockId: "block-1",
+        json: false,
+        help: false,
+    });
+});
+
+test("flag AFTER the command and block_id: 'describe block-1 --json'", () => {
+    const r = parseArgs(["describe", "block-1", "--json"]);
+    assert.equal(r.cmd, "describe");
+    assert.equal(r.blockId, "block-1");
+    assert.equal(r.json, true);
+});
+
+test("flag BETWEEN the command and block_id: 'describe --json block-1' (reagent P2 on PR #2380)", () => {
+    const r = parseArgs(["describe", "--json", "block-1"]);
+    assert.equal(r.cmd, "describe", "must still resolve to describe, not fall back to list");
+    assert.equal(r.blockId, "block-1", "must not pick up '--json' itself as the block_id");
+    assert.equal(r.json, true);
+});
+
+test("flag BEFORE the command: '--json describe block-1' (reagent P2 on PR #2380)", () => {
+    const r = parseArgs(["--json", "describe", "block-1"]);
+    assert.equal(r.cmd, "describe", "must not fall back to list just because argv[0] is a flag");
+    assert.equal(r.blockId, "block-1");
+    assert.equal(r.json, true);
+});
+
+test("'watch <id>' parses the same way as describe", () => {
+    const r = parseArgs(["watch", "block-1"]);
+    assert.equal(r.cmd, "watch");
+    assert.equal(r.blockId, "block-1");
+});
+
+test("'help' / '--help' / '-h' all set help regardless of position", () => {
+    assert.equal(parseArgs(["help"]).cmd, "help");
+    assert.equal(parseArgs(["--help"]).help, true);
+    assert.equal(parseArgs(["list", "-h"]).help, true);
+});
+
+test("missing block_id for describe/watch is representable as undefined, not a flag string", () => {
+    const r = parseArgs(["describe", "--json"]);
+    assert.equal(r.cmd, "describe");
+    assert.equal(r.blockId, undefined, "no positional after 'describe' — must not be '--json'");
+});

--- a/agentmux-srv/src/backend/shellintegration/pwsh.ps1
+++ b/agentmux-srv/src/backend/shellintegration/pwsh.ps1
@@ -84,6 +84,20 @@ function Global:muxlog {
     }
 }
 
+# ─── muxspect ───────────────────────────────────────────────────────────────
+# Live process/turn-state introspection for the CURRENT instance (muxlog's
+# live-state sibling). Delegates to the shared Node core (muxspect.mjs).
+# `muxspect help` for usage. No non-Node fallback: introspection needs a real
+# authenticated HTTP call.
+$global:AgentmuxMuxspectJs = Join-Path $PSScriptRoot "..\muxspect.mjs"
+function Global:muxspect {
+    if ((Get-Command node -ErrorAction SilentlyContinue) -and (Test-Path $global:AgentmuxMuxspectJs)) {
+        node $global:AgentmuxMuxspectJs @args
+        return
+    }
+    Write-Error "muxspect: Node unavailable or core missing at $global:AgentmuxMuxspectJs"
+}
+
 # Hook into the prompt function
 if (Test-Path Function:\prompt) {
     $global:_agentmux_original_prompt = $function:prompt

--- a/agentmux-srv/src/backend/shellintegration/zsh.sh
+++ b/agentmux-srv/src/backend/shellintegration/zsh.sh
@@ -105,6 +105,21 @@ muxlog() {
     case "$action" in tail) tail -f "$logfile" ;; cat) cat "$logfile" ;; *) grep "$action" "$logfile" ;; esac
 }
 
+# ─── muxspect ───────────────────────────────────────────────────────────────
+# Live process/turn-state introspection for the CURRENT instance (muxlog's
+# live-state sibling). Delegates to the shared Node core (muxspect.mjs).
+# `muxspect help` for usage. No non-Node fallback: introspection needs a real
+# authenticated HTTP call.
+_AGENTMUX_MUXSPECT_JS="${${(%):-%x}:A:h}/../muxspect.mjs"
+muxspect() {
+    if command -v node >/dev/null 2>&1 && [ -f "$_AGENTMUX_MUXSPECT_JS" ]; then
+        node "$_AGENTMUX_MUXSPECT_JS" "$@"
+        return
+    fi
+    echo "muxspect: Node unavailable or core missing at $_AGENTMUX_MUXSPECT_JS" >&2
+    return 1
+}
+
 autoload -U add-zsh-hook
 add-zsh-hook precmd _agentmux_si_precmd
 add-zsh-hook chpwd  _agentmux_si_osc7

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -861,6 +861,21 @@ pub fn spawn_background_subsystems(
         tracing::warn!("media file watcher not started; media panes will not live-update on new/changed files");
     }
 
+    // Deploy shell integration scripts (muxlog.mjs/muxspect.mjs + rcfiles)
+    // unconditionally at startup, not opportunistically from a specific
+    // controller's spawn path. Previously the only call site was
+    // `ShellController::start`'s interactive (empty-command) branch
+    // (`blockcontroller/shell/lifecycle.rs`) — a user whose first-ever pane
+    // in a fresh data dir is an Agent pane (persistent/subprocess/acp, which
+    // never hits that branch) would never get the scripts deployed at all,
+    // so even muxspect's own documented `node ~/.agentmux/shell/muxspect.mjs`
+    // direct-path fallback would ENOENT (codex P1 on PR #2380 — a latent gap
+    // in muxlog's identical deployment mechanism that PR newly depends on).
+    // `deploy_scripts` is idempotent (skips if its version marker already
+    // matches), so calling it here in addition to the existing call site is
+    // safe, not a double-write race.
+    backend::shellintegration::deploy_scripts(&backend::base::get_home_dir().join(".agentmux"));
+
     // Config watcher (created before sysinfo loop so it can read telemetry:interval)
     let config_watcher = Arc::new(wconfig::ConfigWatcher::with_config(wconfig::build_default_config()));
 

--- a/agentmux-srv/src/broker/process.rs
+++ b/agentmux-srv/src/broker/process.rs
@@ -240,6 +240,22 @@ impl ProcessBroker {
     pub fn status(&self, block_id: &str) -> ProcessStatus {
         let mut cache = self.cache.lock();
         let fresh = compute_status(block_id);
+        // Never cache (or emit a change event for) a block with no real
+        // controller — `list()`'s own callers only ever pass real,
+        // discovered block_ids (from `get_all_controllers()`), but this
+        // broker is also reachable directly with caller-supplied input via
+        // `muxspect describe` (agentmux-srv/src/server/muxspect_handlers.rs)
+        // — the first RPC-adjacent surface to call `status()` with an
+        // arbitrary string rather than one already known to exist. Without
+        // this guard, repeated queries for distinct nonexistent block_ids
+        // would grow this cache unboundedly, since `forget()` is only ever
+        // called from real controller teardown and never sees IDs that were
+        // never real to begin with (reagent + codex, independently, on
+        // PR #2380).
+        if fresh.lifecycle == Lifecycle::Unknown {
+            drop(cache);
+            return fresh;
+        }
         let changed = cache
             .get(block_id)
             .map(|prev| {
@@ -296,6 +312,14 @@ impl ProcessBroker {
     /// won't include it) while a stale cache entry lingers unreachable.
     pub fn forget(&self, block_id: &str) {
         self.cache.lock().remove(block_id);
+    }
+
+    /// Test-only: current cache size, to prove unknown/nonexistent
+    /// block_ids never get inserted (see `status()`'s own guard and the
+    /// regression test below).
+    #[cfg(test)]
+    fn cache_len(&self) -> usize {
+        self.cache.lock().len()
     }
 
     fn emit_changed(&self, status: &ProcessStatus) {
@@ -434,6 +458,22 @@ mod tests {
         let status = broker.status("no-such-block-id");
         assert_eq!(status.lifecycle, Lifecycle::Unknown);
         assert!(status.processes.is_empty());
+    }
+
+    #[test]
+    fn unknown_block_ids_are_never_cached_unbounded_growth_guard() {
+        // reagent + codex, independently, on PR #2380: `muxspect describe`
+        // is the first caller to reach `status()` with arbitrary,
+        // caller-supplied block_ids rather than ones already known to be
+        // real (list()'s own callers only ever pass IDs from
+        // get_all_controllers()). Without this guard, a loop probing
+        // distinct nonexistent block_ids would grow the cache forever,
+        // since forget() only ever fires from real controller teardown.
+        let broker = ProcessBroker::new(None);
+        for i in 0..50 {
+            let _ = broker.status(&format!("garbage-block-{i}"));
+        }
+        assert_eq!(broker.cache_len(), 0, "unknown block_ids must never be cached");
     }
 
     #[test]

--- a/agentmux-srv/src/broker/process.rs
+++ b/agentmux-srv/src/broker/process.rs
@@ -90,6 +90,14 @@ pub struct ProcessStatus {
     pub controller_type: String,
     pub is_agent_pane: bool,
     pub last_computed_ms: u64,
+    /// The raw `BlockControllerRuntimeStatus` `compute_status` already reads
+    /// to derive `lifecycle`/`is_agent_pane` above — exposed so callers that
+    /// want the finer-grained fields (`shellprocstatus`, `spawn_ts_ms`,
+    /// `turn_active` itself, not just the `lifecycle` it was folded into)
+    /// don't have to read the controller registry a second time and risk a
+    /// second, possibly-inconsistent snapshot (codex P2 on PR #2380 — the
+    /// `muxspect describe` route originally did exactly that).
+    pub controller_status: Option<BlockControllerRuntimeStatus>,
 }
 
 impl ProcessStatus {
@@ -102,6 +110,7 @@ impl ProcessStatus {
             controller_type: String::new(),
             is_agent_pane: false,
             last_computed_ms: now_ms(),
+            controller_status: None,
         }
     }
 
@@ -181,6 +190,7 @@ fn compute_status(block_id: &str) -> ProcessStatus {
             controller_type: controller.controller_type().to_string(),
             is_agent_pane: status.is_agent_pane,
             last_computed_ms: now_ms(),
+            controller_status: Some(status),
         },
         _ => ProcessStatus::unknown(block_id),
     }
@@ -334,6 +344,7 @@ mod tests {
             controller_type: controller_type.to_string(),
             is_agent_pane,
             last_computed_ms: 0,
+            controller_status: None,
         }
     }
 

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -25,6 +25,7 @@ mod drone_handlers;
 mod cron;
 mod messaging_handlers;
 mod muxbus_handlers;
+mod muxspect_handlers;
 mod native_memory_handlers;
 
 #[cfg(test)]
@@ -358,6 +359,13 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tab/activate", post(handle_tab_activate))
         .route("/api/v1/tab/new", post(handle_tab_new))
         .route("/api/v1/window/focus", post(handle_window_focus))
+        // Live-state introspection for the `muxspect` CLI (Phase 1 of
+        // docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md) —
+        // read-only, diagnostic-only, reached the same way agentmux-mcp
+        // reaches every other /api/v1/* route (X-AuthKey from the caller's
+        // own environment, no new IPC).
+        .route("/api/v1/muxspect/list", get(muxspect_handlers::handle_muxspect_list))
+        .route("/api/v1/muxspect/describe", get(muxspect_handlers::handle_muxspect_describe))
         // Agent App API — identity / preset / memory namespaces, the MCP-facing
         // slice of the app-API RPC surface (SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28).
         // The agent identity (`agent_id`) is supplied by agentmux-mcp from its

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -52,21 +52,21 @@ pub async fn handle_muxspect_describe(
             .into_response();
     }
 
+    // `process_status` (via `ProcessBroker::compute_status`) already reads
+    // the process-tracker registry once for both `processes` and
+    // `liveness_confidence` — a second, independent read here could race a
+    // process starting/exiting between the two calls and return two
+    // contradictory snapshots in one response (codex P2 on PR #2380).
+    // Derive everything from this one snapshot instead of reading twice.
     let process_status = state.process_broker.status(&q.block_id);
     let controller_status = crate::backend::blockcontroller::get_block_controller_status(&q.block_id);
-    let processes = state.process_tracker.list_block(&q.block_id);
-    let tracking_confidence = match state.process_tracker.confidence_of(&q.block_id) {
-        crate::backend::process_tracker::TrackingConfidence::High => "high",
-        crate::backend::process_tracker::TrackingConfidence::BestEffort => "best_effort",
-        crate::backend::process_tracker::TrackingConfidence::None => "none",
-    };
 
     Json(json!({
         "block_id": q.block_id,
-        "process_status": process_status,
+        "process_status": &process_status,
         "controller_status": controller_status,
-        "processes": processes,
-        "tracking_confidence": tracking_confidence,
+        "processes": &process_status.processes,
+        "tracking_confidence": process_status.liveness_confidence,
     }))
     .into_response()
 }

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -23,8 +23,26 @@ use super::AppState;
 /// `GET /api/v1/muxspect/list` — every controller-backed block's current
 /// `ProcessStatus`, full detail (unlike `agent.tracked-blocks`, which
 /// intentionally returns only `block_ids` for its Swarm-pane contract).
+/// Each row also carries `is_agent` — `ProcessStatus::is_agent()`'s complete
+/// classification rule (subprocess/persistent/acp are ALWAYS agents
+/// regardless of `is_agent_pane`, which only applies to shell/cmd) — so
+/// consumers don't reimplement that rule themselves (codex P2 on PR #2380:
+/// the CLI's own naive `is_agent_pane`-only rendering mislabeled exactly
+/// those three controller types).
 pub async fn handle_muxspect_list(State(state): State<AppState>) -> impl IntoResponse {
-    let blocks = state.process_broker.list();
+    let blocks: Vec<serde_json::Value> = state
+        .process_broker
+        .list()
+        .into_iter()
+        .map(|status| {
+            let is_agent = status.is_agent();
+            let mut value = serde_json::to_value(&status).unwrap_or_default();
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert("is_agent".to_string(), json!(is_agent));
+            }
+            value
+        })
+        .collect();
     Json(json!({ "blocks": blocks })).into_response()
 }
 
@@ -53,18 +71,22 @@ pub async fn handle_muxspect_describe(
     }
 
     // `process_status` (via `ProcessBroker::compute_status`) already reads
-    // the process-tracker registry once for both `processes` and
-    // `liveness_confidence` — a second, independent read here could race a
-    // process starting/exiting between the two calls and return two
-    // contradictory snapshots in one response (codex P2 on PR #2380).
-    // Derive everything from this one snapshot instead of reading twice.
+    // BOTH the process-tracker registry (for `processes`/
+    // `liveness_confidence`) AND the controller's `BlockControllerRuntimeStatus`
+    // (carried on `process_status.controller_status`) in one pass. A second,
+    // independent read of either would risk a process starting/exiting or a
+    // turn starting/finishing between the two calls, returning two
+    // contradictory snapshots in one response (codex P2 on PR #2380, twice —
+    // once for the process list, once for the controller status). Derive
+    // everything from this one snapshot instead of reading twice.
     let process_status = state.process_broker.status(&q.block_id);
-    let controller_status = crate::backend::blockcontroller::get_block_controller_status(&q.block_id);
+    let is_agent = process_status.is_agent();
 
     Json(json!({
         "block_id": q.block_id,
         "process_status": &process_status,
-        "controller_status": controller_status,
+        "is_agent": is_agent,
+        "controller_status": &process_status.controller_status,
         "processes": &process_status.processes,
         "tracking_confidence": process_status.liveness_confidence,
     }))

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP handlers backing the `muxspect` CLI — Phase 1 of
+//! `docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md`.
+//!
+//! Diagnostic-only surface: a thin read composition over `ProcessBroker`
+//! (Phase A of the process-tracking consolidation,
+//! `agentmux-srv/src/broker/process.rs`) and its sibling registries — never
+//! a new independent snapshot of process/turn state (spec §5.1/§3 point 8).
+//! Reached the same way `agentmux-mcp` already reaches every other
+//! `/api/v1/*` route: plain HTTP, `X-AuthKey` header, `$AGENTMUX_LOCAL_URL`/
+//! `$AGENTMUX_AUTH_KEY` inherited from the caller's own environment (spec
+//! §5.2) — no new IPC mechanism, no new auth scheme.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json};
+use serde_json::json;
+
+use super::AppState;
+
+/// `GET /api/v1/muxspect/list` — every controller-backed block's current
+/// `ProcessStatus`, full detail (unlike `agent.tracked-blocks`, which
+/// intentionally returns only `block_ids` for its Swarm-pane contract).
+pub async fn handle_muxspect_list(State(state): State<AppState>) -> impl IntoResponse {
+    let blocks = state.process_broker.list();
+    Json(json!({ "blocks": blocks })).into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub struct MuxspectDescribeQuery {
+    pub block_id: String,
+}
+
+/// `GET /api/v1/muxspect/describe?block_id=X` — composes `ProcessBroker`
+/// status, the coarse `BlockControllerRuntimeStatus`, and the OS-process
+/// tree for one block into a single response. This is the "describe
+/// everything about block X" query
+/// `REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md` §5.4 named
+/// as missing — getting this picture today takes 2-3 separate, uncomposed
+/// RPC round-trips.
+pub async fn handle_muxspect_describe(
+    State(state): State<AppState>,
+    Query(q): Query<MuxspectDescribeQuery>,
+) -> impl IntoResponse {
+    if q.block_id.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "missing block_id" })),
+        )
+            .into_response();
+    }
+
+    let process_status = state.process_broker.status(&q.block_id);
+    let controller_status = crate::backend::blockcontroller::get_block_controller_status(&q.block_id);
+    let processes = state.process_tracker.list_block(&q.block_id);
+    let tracking_confidence = match state.process_tracker.confidence_of(&q.block_id) {
+        crate::backend::process_tracker::TrackingConfidence::High => "high",
+        crate::backend::process_tracker::TrackingConfidence::BestEffort => "best_effort",
+        crate::backend::process_tracker::TrackingConfidence::None => "none",
+    };
+
+    Json(json!({
+        "block_id": q.block_id,
+        "process_status": process_status,
+        "controller_status": controller_status,
+        "processes": processes,
+        "tracking_confidence": tracking_confidence,
+    }))
+    .into_response()
+}

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1273,3 +1273,90 @@ async fn resolve_agent_definition_id_maps_slug_and_passes_through_def_id() {
     // Unknown ids error instead of silently writing bogus link rows.
     assert!(super::app_api::resolve_agent_definition_id(&state, "no-such-agent").is_err());
 }
+
+// ---- muxspect (docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md) ----
+
+/// `GET /api/v1/muxspect/list` returns the full `ProcessStatus` collection
+/// (not just `block_ids`, unlike `agent.tracked-blocks`) and is auth-gated
+/// like every other `/api/v1/*` route.
+#[tokio::test]
+async fn muxspect_list_returns_full_process_status_collection() {
+    let state = test_state();
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/muxspect/list")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["blocks"].is_array(), "response has a blocks array");
+}
+
+/// `GET /api/v1/muxspect/list` rejects a request with no/wrong auth key —
+/// same auth_middleware every other route already goes through.
+#[tokio::test]
+async fn muxspect_list_requires_auth() {
+    let state = test_state();
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/muxspect/list")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `GET /api/v1/muxspect/describe` composes ProcessBroker status +
+/// controller status + process tree into one response — the "describe
+/// everything about block X" query
+/// REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md §5.4 named as
+/// missing. For a block with no controller, this must still succeed and
+/// report `Lifecycle::Unknown` rather than erroring — an unknown block is a
+/// legitimate, common answer (e.g. a stale/closed pane), not a failure.
+#[tokio::test]
+async fn muxspect_describe_composes_status_for_an_unknown_block() {
+    let state = test_state();
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/muxspect/describe?block_id=no-such-block")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["block_id"], "no-such-block");
+    assert_eq!(json["process_status"]["lifecycle"], "unknown");
+    assert_eq!(json["controller_status"], serde_json::Value::Null);
+    assert_eq!(json["tracking_confidence"], "none");
+    assert!(json["processes"].as_array().unwrap().is_empty());
+}
+
+/// Missing `block_id` is a client error, not a panic or a silent empty
+/// success — mirrors `/api/v1/self`'s identical guard.
+#[tokio::test]
+async fn muxspect_describe_requires_block_id() {
+    let state = test_state();
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/muxspect/describe")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1296,6 +1296,13 @@ async fn muxspect_list_returns_full_process_status_collection() {
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(json["blocks"].is_array(), "response has a blocks array");
+    // Every row must carry the complete `is_agent` classification, not just
+    // the raw `is_agent_pane` flag a naive consumer might reimplement
+    // incorrectly for subprocess/persistent/acp controllers (codex P2 on
+    // PR #2380).
+    for block in json["blocks"].as_array().unwrap() {
+        assert!(block.get("is_agent").is_some(), "row is missing is_agent: {block}");
+    }
 }
 
 /// `GET /api/v1/muxspect/list` rejects a request with no/wrong auth key —
@@ -1339,7 +1346,13 @@ async fn muxspect_describe_composes_status_for_an_unknown_block() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["block_id"], "no-such-block");
     assert_eq!(json["process_status"]["lifecycle"], "unknown");
+    assert_eq!(json["is_agent"], false);
     assert_eq!(json["controller_status"], serde_json::Value::Null);
+    // `process_status.controller_status` must agree with the top-level
+    // field — both must come from the SAME snapshot, not two independent
+    // reads that could observe different controller states (codex P2 on
+    // PR #2380).
+    assert_eq!(json["process_status"]["controller_status"], json["controller_status"]);
     assert_eq!(json["tracking_confidence"], "none");
     assert!(json["processes"].as_array().unwrap().is_empty());
 }

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -1,0 +1,56 @@
+# `muxspect` — live process/turn-state introspection
+
+`muxspect` is `muxlog`'s live-state sibling: `muxlog` answers "what
+happened" (historical NDJSON logs); `muxspect` answers "what is this
+instance doing **right now**." Shipped the same way, in every AgentMux
+terminal (bash / zsh / pwsh / fish), delegating to a small Node core
+(`muxspect.mjs`, deployed next to `muxlog.mjs`).
+
+> **Phase 1 scope:** `muxspect` only queries the instance you're already
+> inside — it reads `$AGENTMUX_LOCAL_URL`/`$AGENTMUX_AUTH_KEY` from its own
+> environment (already present in any agent pane, the same way
+> `agentmux-mcp` reaches every other `/api/v1/*` route). It cannot yet
+> discover or query a *different* running instance — see
+> `docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md` for the
+> full design and the planned Phase 2.
+
+---
+
+## Quick start
+
+```bash
+muxspect                        # same as 'muxspect list'
+muxspect list                   # summary of every controller-backed block
+muxspect describe <block_id>    # full detail for one block
+muxspect watch <block_id>       # poll 'describe' every 2s until Ctrl+C
+muxspect help                   # full usage
+```
+
+Add `--json` to `list`/`describe` for structured output.
+
+## What it can and can't see
+
+`muxspect` is a thin, read-only client over the same `ProcessBroker`
+computation the app's own Swarm pane uses — it never invents a second,
+independent view of process/turn state. Concretely it can see:
+
+- Controller lifecycle (`Running`/`Idle`/`Done`/`Error`/`Unknown`) and
+  whether a turn is actively in flight
+- The OS process tree tracked for a block (PID, command, RSS)
+- How stale each of the above is (`last_computed_ms`) and how confidently
+  it's tracked on this platform (`liveness_confidence`)
+
+It **cannot** see the Agent pane's Activity Dock — that's pure in-renderer
+SolidJS state, never persisted or exposed via any RPC, by design (not an
+oversight `muxspect` will "eventually" fix). For that, use the CEF host's
+own remote-debugging port (Chrome DevTools Protocol) — see the spec's §5.3
+for why that's the right tool for that specific gap.
+
+## Why it can't just query any instance yet
+
+Every AgentMux instance runs its own `agentmux-srv` on a dynamic port with
+its own auth key (isolation invariants I1–I6) — there's no existing
+mechanism for one instance to answer a state query from outside itself
+except the path `muxspect` already uses (env-inherited token, same as
+`agentmux-mcp`). Reaching a *different* instance needs a real
+discovery+auth story that doesn't exist yet — planned as Phase 2.

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -18,15 +18,26 @@ terminal (bash / zsh / pwsh / fish), delegating to a small Node core
 
 ## Quick start
 
+> **Known gap (reagent P1 on PR #2380, not yet fixed):** the bare `muxspect`
+> shell function only loads in an *interactive* terminal pane (sourced from
+> the shell rcfile) — but those panes carry `$AGENTMUX_LOCAL_URL` without
+> `$AGENTMUX_AUTH_KEY`, so the function loads but auth fails. Agent-CLI tool
+> calls (the primary intended use) get both env vars, but tool-spawned
+> shells don't source the rcfile, so the function isn't defined there
+> either — empirically confirmed (`type muxspect` → not found) in an actual
+> agent tool-call shell. **Until this is fixed, call the deployed core
+> directly instead of the shell function:**
+
 ```bash
-muxspect                        # same as 'muxspect list'
-muxspect list                   # summary of every controller-backed block
-muxspect describe <block_id>    # full detail for one block
-muxspect watch <block_id>       # poll 'describe' every 2s until Ctrl+C
-muxspect help                   # full usage
+node ~/.agentmux/shell/muxspect.mjs list
+node ~/.agentmux/shell/muxspect.mjs describe <block_id>
+node ~/.agentmux/shell/muxspect.mjs watch <block_id>
+node ~/.agentmux/shell/muxspect.mjs help
 ```
 
-Add `--json` to `list`/`describe` for structured output.
+Add `--json` to `list`/`describe` for structured output. Once the shell
+function actually works everywhere it's meant to, bare `muxspect ...` will
+work too — the wire protocol and commands are identical either way.
 
 ## What it can and can't see
 

--- a/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
+++ b/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
@@ -1,0 +1,292 @@
+# SPEC — "muxspect": a live-state introspection tool for running AgentMux instances
+
+**Date:** 2026-08-01
+**Type:** New tool / subsystem design spec
+**Trigger:** Live debugging session — the user asked to locate "2 stuck sleep
+dock items," and neither `muxlog` nor any existing RPC could answer "what is
+this running instance doing right now, and which instance is even hosting
+this conversation." That gap is the direct motivation for this spec.
+**Status:** Proposed — research complete, phased design below, no code yet.
+**Related:** `docs/specs/REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md`
+(names the same six-plus overlapping liveness mechanisms this tool would read
+from, not add an seventh to), `agentmux-srv/src/broker/process.rs` (Process
+Broker Phase A — the read-side consolidation this tool builds directly on),
+Discussion #2375 (process/turn-liveness tracking thread).
+
+---
+
+## 1. Why `muxlog` doesn't cover this
+
+`muxlog` answers "what happened" — it walks NDJSON log files on disk across
+every discoverable channel/dev-branch directory and never contacts a running
+process. It has no concept of "current state": no live block list, no
+"what's this agent doing at this exact moment," and critically, **no way to
+even identify which running instance a given conversation or pane belongs
+to** — the exact question that stalled the live debugging session this spec
+grew out of. `muxspect` (working name — see §6 for alternatives) is the
+missing live-query counterpart: point it at a running instance (or ask it to
+discover all of them) and get a structured, drillable snapshot of what's
+actually happening right now.
+
+## 2. What already exists (full audit — see appendix references)
+
+A thorough audit of the current backend found real, usable pieces — this is
+explicitly **not** a green-field build:
+
+- **`ProcessBroker`** (`agentmux-srv/src/broker/process.rs`) already computes
+  a rich, cached, single-flight-guarded per-block `ProcessStatus`
+  (`lifecycle`, `processes`, `liveness_confidence`, `controller_type`,
+  `is_agent_pane`, `last_computed_ms`) via `status()`/`list()`. **But only
+  `list_agent_panes()` is exposed via RPC today** (`agent.tracked-blocks`),
+  and it returns bare `block_ids: Vec<String>` — every other field is
+  computed and then thrown away before it reaches the wire. `status()` (the
+  rich single-block read) has **zero RPC callers** anywhere in the codebase.
+- `BlockControllerRuntimeStatus` (coarse lifecycle + `turn_active`) is
+  reachable via `block.GetControllerStatus`, one block at a time.
+- OS-process detail is reachable via `agent.process-list`, one block at a
+  time, from a *different* registry (`AgentProcessRegistry`) than
+  `ProcessBroker` itself reads.
+- Subagent dispatch state is reachable via `subagent.ListActive`/`GetInfo`.
+- **No RPC composes any of the above into one "describe this block" answer.**
+  Getting a full picture of one block today means 3-4 separate, uncomposed
+  RPC round-trips — the exact gap `REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md`
+  names directly (§5.4, "the missing batch query").
+- **The Activity Dock is not queryable at all, by anything, ever, today.**
+  It's purely derived SolidJS state inside one renderer's own document store
+  — never persisted, never sent over any RPC. This is a hard architectural
+  boundary, not an oversight to "just expose" — see §5.3.
+- **Zero cross-instance query mechanism exists.** Every instance's RPC
+  surface (the WshRpcEngine, `ProcessBroker`, everything above) is reachable
+  only by that instance's own frontend renderer, over its own local
+  WS/HTTP. The *only* real cross-instance IPC today is (a) a bare
+  liveness ping (`other_instances.rs`'s `probe_liveness` — connect, no data
+  exchange, log-only) and (b) the authenticated `open_new_window` forward
+  (bearer-token HTTP POST, explicitly side-effect-free by invariant I4).
+  Discovery itself (`muxlog`'s own mechanism) is 100% disk-walking — it
+  never asks a running process anything.
+
+## 3. Best-practice synthesis (full research in the appendix)
+
+Surveyed `kubectl`, `docker`, `systemctl`, Erlang/OTP `observer`/`recon`,
+Chrome DevTools Protocol, `pm2`, `gh run`, Temporal's CLI, `htop`/Process
+Explorer. Recurring principles, in priority order for this design:
+
+1. **Read-only by default; mutation is always a separate, explicit action.**
+   `htop --readonly`, `recon:info/1` deliberately dropping the mailbox field
+   to stay production-safe, CDP's GET-only discovery endpoint. `muxspect`
+   v1 has **zero mutating commands** — no kill, no restart. Those already
+   exist elsewhere (`kill_tree`/`kill_pid`); this tool doesn't touch them.
+2. **Three-verb shape: list → describe → watch.** Every mature precedent
+   converges on this (`kubectl get`→`describe`→`-w`; `docker ps`→`inspect`→
+   `stats`; `pm2 list`→`describe`→`monit`; Temporal `list`→`describe`→
+   `show --follow`). §4 adopts this directly.
+3. **Discovery-as-a-first-step, separate from targeting.** `kubectl config
+   get-contexts`, `docker context ls`, CDP's `/json`, `epmd -names` all
+   separate "what are my options" from "operate on option X." `muxspect`'s
+   own multi-instance gap (§2) makes this the *load-bearing* command, not a
+   nicety — see `muxspect targets` in §4.
+4. **Structured output opt-in, human-readable default.** `--json` everywhere
+   surveyed follows this split; `muxspect` should too.
+5. **Snapshot vs. watch as one flag, not a separate mental model.** `docker
+   stats --no-stream`, `kubectl get -w`, `gh run watch`.
+6. **"Explain why," not just "what."** `kubectl describe`'s Events section
+   and Temporal's Event History are the standout precedent — a causal log
+   distinct from both the summary and the point-in-time detail view.
+   `ProcessBroker` already emits `processbroker:status-changed`; `describe`
+   should surface a short recent-events tail, not just the current snapshot
+   (§4, Phase 3 — deliberately not v1).
+7. **Surface staleness/confidence, never hide it.** `ProcessBroker` already
+   carries `last_computed_ms` and `liveness_confidence` — good, this is
+   exactly the discipline the research recommends, and it's already in the
+   data model. `muxspect` must always print these, not just the raw state.
+8. **Anti-pattern to actively avoid: don't become an eighth mechanism.** The
+   AWS S3 dashboard outage (its own status page was hosted on the service it
+   reported on, so it stayed green through the outage) and the GitHub 2018
+   incident (a topology tool acted on cached state that had silently
+   diverged from ground truth) are the two sharpest cautionary precedents.
+   **`muxspect` must be a thin, read-only client over `ProcessBroker`'s
+   existing computation — never a second, independent state-tracker that
+   can drift from it.** This is the single most important constraint on the
+   whole design; see §5.1.
+
+## 4. Proposed command shape
+
+```
+muxspect                                  # describe the CURRENT instance (env-sourced, see §5.2)
+muxspect list [--json]                    # summary table, current instance
+muxspect describe <block_id> [--json]
+muxspect watch <block_id>                 # live-updating describe
+muxspect targets                          # (Phase 2) discover every OTHER running instance
+muxspect list -i <target> / describe -i <target>   # (Phase 2) query a different instance
+```
+
+- **`muxspect list`** — a summary table (block_id, controller_type,
+  lifecycle, turn_active, confidence, last_computed_ms) for the current
+  instance. Requires exposing `ProcessBroker::list()`'s **full**
+  `ProcessStatus`, not just block_ids — a **new** route (not a breaking
+  change to `agent.tracked-blocks`, which the Swarm pane already depends on
+  for its specific narrower shape) — added under a clearly diagnostic-only
+  path (e.g. `/api/v1/muxspect/list`) to keep it obviously separate from
+  product-facing routes.
+- **`muxspect describe <block_id>`** — the new composition point: one route
+  that calls `ProcessBroker::status()` + `BlockControllerRuntimeStatus` +
+  `AgentProcessRegistry::list_block()` + (if applicable)
+  `subagent.GetInfo`, and returns them together. This is the single query
+  `REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md` §5.4 already
+  named as missing — `muxspect describe` is its first real consumer.
+- **`muxspect watch`** — same payload as `describe`, polling or subscribing
+  to `processbroker:status-changed` for that block scope, printed as a
+  scrolling diff (matching `docker stats`/`kubectl get -w`'s "same command,
+  one flag" pattern rather than a separate tool).
+- **`muxspect targets`** — Phase 2 only (§7); enumerates *other* running
+  instances via `muxlog`'s own disk-walk + liveness probe.
+
+## 5. Design decisions that need explicit resolution
+
+### 5.1 Build on `ProcessBroker`, don't fork it
+
+Every new route this tool needs is a **read composition over `ProcessBroker`
+and its existing sibling registries** — never a new independent snapshot of
+process/turn state. This is non-negotiable per §3 point 8. Concretely:
+`muxspect list`/`describe` call into the *same* `ProcessBroker::status()`/
+`list()` the app's own Swarm pane will eventually call once Process Broker
+Phase B lands (tracked separately, Discussion #2375) — this tool and the
+in-app UI converge on one source of truth rather than growing two.
+
+### 5.2 Connecting to the current instance — reuse the existing HTTP+token path, no new IPC
+
+**Corrected during design (2026-08-01):** the first draft of this section
+proposed a brand-new authenticated named-pipe IPC command for querying
+"the current instance." That's unnecessary — verified directly, there's
+already a real, working precedent for exactly this: **`agentmux-mcp`**, a
+standalone binary spawned as a child of an agent CLI, talks to `agentmux-srv`
+over plain HTTP (`POST {AGENTMUX_LOCAL_URL}/api/v1/...` with header
+`X-AuthKey: {AGENTMUX_AUTH_KEY}`, `agentmux-mcp/src/main.rs`), reading both
+values from its own **inherited process environment** — no file, no new
+discovery mechanism.
+
+Confirmed directly in this session's own shell (an agent-pane process):
+`AGENTMUX_LOCAL_URL` and `AGENTMUX_AUTH_KEY` are already present in the
+environment. `shell/lifecycle.rs` propagates `AGENTMUX_LOCAL_URL` to every
+plain shell/terminal pane too; `AGENTMUX_AUTH_KEY` specifically is injected
+by `agent_handlers/input.rs` for agent-CLI-type controller spawns (matching
+`agentmux-mcp`'s own environment). So: **`muxspect`, run from within an agent
+pane (the primary motivating use case — an agent inspecting its own running
+instance), already has everything it needs, today, with zero new plumbing.**
+
+Design: `muxspect list`/`describe`/`watch` read `$AGENTMUX_LOCAL_URL` /
+`$AGENTMUX_AUTH_KEY` from their own environment and call the two new HTTP
+routes (§4) the exact same way `agentmux-mcp` already calls existing ones.
+If invoked somewhere those env vars aren't set (a plain, non-agent shell
+pane invoked outside that propagation path, or a genuinely external
+terminal), it must fail with a clear, honest error — never guess, never
+silently fall back to a different (possibly wrong) instance. This is a
+direct application of §3 point 8 (never paper over unreachability) and
+means Phase 1 requires **no new IPC mechanism, no new auth scheme, and no
+named-pipe changes** — only two new authenticated HTTP routes reusing
+`auth_middleware` exactly as every other route already does.
+
+Cross-instance query (asking a *different* running instance, not the one
+you're already inside) is a genuinely separate problem — deferred to Phase 2
+(§7), since it requires a real discovery+auth story for instances whose
+token you don't already have in your environment (the dev-only `authkey.dev`
+file is the closest existing precedent, but it's explicitly dev-gated).
+
+### 5.3 Activity Dock visibility — explicitly out of scope for v1, with a named escape hatch
+
+The Dock is pure in-renderer SolidJS state (§2) — no backend-only tool can
+ever see it without either (a) a real architecture change (mirroring
+`ToolNode` state server-side, a much bigger lift, likely overlapping the
+"shared orphan-recovery invariant" work already tracked as a separate docket
+item) or (b) browser-level remote debugging. **AgentMux already ships CEF**,
+which supports the same `--remote-debugging-port` Chrome DevTools Protocol
+surveyed in §3 — the existing, off-the-shelf answer for "inspect this
+renderer's live JS state" is to enable and document that port, not build a
+custom mirror. Recommendation: `muxspect targets` can opportunistically print
+each instance's devtools URL if the port is easily discoverable per-channel,
+as a low-effort bonus — but full Dock introspection is explicitly **not** a
+`muxspect` v1 goal. Document this limitation loudly so nobody re-derives "why
+can't muxspect see the dock" a second time.
+
+### 5.4 Staleness and failure modes
+
+Per §3 point 7/8: every `muxspect` output must show `last_computed_ms` /
+`liveness_confidence` (already in `ProcessStatus`) front and center, and
+every cross-instance query must clearly distinguish "instance unreachable"
+from "instance reachable, block not found" from "instance reachable, block
+exists, state X" — collapsing these into one ambiguous "unknown" is exactly
+the watermelon-dashboard failure mode §3 point 8 warns against.
+
+## 6. Name candidates
+
+- **`muxspect`** (working title used throughout this spec) — "inspect,"
+  reads naturally alongside `muxlog`, distinct verb class (log vs. inspect).
+- `muxstat` — shorter, echoes `stat`/`systemctl status`, but weaker signal
+  that it's live (could be misread as one-shot like `docker system info`).
+- `muxtop` — evokes the `htop`/`docker stats` continuously-live precedent
+  well, but undersells the `describe`/drill-down half of the tool.
+- `muxprobe` — emphasizes the cross-instance liveness-probe angle (§5.2)
+  specifically, less clear on the local single-instance `list`/`describe`
+  use case.
+
+No strong reason to deviate from `muxspect` unless there's a naming
+collision or preference — recommend it as primary, open to the others.
+
+## 7. Phased plan (no big-bang, matching this repo's own established pattern)
+
+1. **Phase 1 — current instance only, no new IPC.** `muxspect list`/
+   `describe`/`watch` against whatever instance the caller's own
+   `$AGENTMUX_LOCAL_URL`/`$AGENTMUX_AUTH_KEY` point at (§5.2) — exactly two
+   new authenticated HTTP routes on the existing `web_listener`
+   (full-detail list + the describe-composition endpoint, §4), reusing
+   `auth_middleware` unchanged. This is genuinely small: no new auth scheme,
+   no new IPC, no discovery mechanism — the primary motivating use case (an
+   agent inspecting its own running instance) is fully served by this phase
+   alone.
+2. **Phase 2 — cross-instance query.** `muxspect targets` (disk-walk +
+   existing liveness probe, reusing `muxlog`'s own mechanism, zero backend
+   changes) plus a real discovery+auth story for reaching an instance whose
+   token isn't already in the caller's environment — the dev-only
+   `authkey.dev` file is the closest existing precedent but is explicitly
+   dev-gated; a production-viable equivalent (or an explicit "dev builds
+   only" scope limit) needs a decision before this phase starts.
+3. **Phase 3 — optional, lower priority.** A short recent-events tail for
+   `describe` (§3 point 6) — needs a small bounded ring buffer per block if
+   one doesn't already exist; devtools-URL surfacing in `muxspect targets`
+   (§5.3) as a convenience, not a requirement.
+
+**Explicitly not in scope, any phase:** any mutating action (kill/restart —
+already exists elsewhere, this tool doesn't duplicate it), and full Activity
+Dock/renderer-state introspection (§5.3 — CEF's own devtools protocol is the
+right tool for that, not a `muxspect` feature).
+
+---
+
+## 8. Decisions (resolved 2026-08-01)
+
+1. **Name: `muxspect`.** Confirmed.
+2. **First PR scope: Phase 1 only** (two new HTTP routes + `muxspect list`/
+   `describe`/`watch` against the current instance), holding Phase 2/3 for
+   later — matching this session's own established pattern of small,
+   incremental, reviewed PRs.
+3. **Location: a true sibling of `muxlog`**, not a new Rust binary.
+   `muxlog`'s actual deployment mechanism (traced directly, not assumed):
+   its Node source lives at `agentmux-srv/src/backend/shellintegration/muxlog.mjs`,
+   embedded into the srv binary via `include_str!` in `shellintegration.rs`,
+   and deployed once per version to `<wave_data_dir>/shell/muxlog.mjs` by
+   `deploy_scripts()` — each of the four per-shell integration scripts
+   (`bash.sh`/`zsh.sh`/`pwsh.ps1`/`fish.fish`) defines a `muxlog` function
+   that resolves that path relative to itself and delegates to
+   `node muxlog.mjs "$@"`. `muxspect` follows the identical pattern: a new
+   `agentmux-srv/src/backend/shellintegration/muxspect.mjs`, a new
+   `MUXSPECT_JS` `include_str!` constant, deployed alongside `muxlog.mjs` in
+   the same `deploy_scripts()` pass, with a matching `muxspect` function
+   added to each of the four shell scripts. Unlike `muxlog`, there is no
+   legacy non-Node fallback to preserve — introspection requires an actual
+   authenticated HTTP call, so "Node unavailable" is just a clear error, not
+   a degraded-but-working path.
+
+---
+
+*Research complete (external best-practices + full internal API audit, both
+via background agents). No code changes — design/scoping only.*

--- a/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
+++ b/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
@@ -260,6 +260,42 @@ already exists elsewhere, this tool doesn't duplicate it), and full Activity
 Dock/renderer-state introspection (§5.3 — CEF's own devtools protocol is the
 right tool for that, not a `muxspect` feature).
 
+### 7.1 Known gap: the shell function is unreachable exactly where it matters most (reagent P1 on PR #2380)
+
+Discovered during review, confirmed empirically (`type muxspect` → not found
+in an actual agent tool-call shell): the bare `muxspect` shell function only
+loads in an **interactive** terminal pane (sourced from the rcfile at PTY
+spawn) — but per §5.2's own research, those panes carry
+`$AGENTMUX_LOCAL_URL` WITHOUT `$AGENTMUX_AUTH_KEY` (only agent-CLI-type
+controller spawns get the key, via `agent_handlers/input.rs`). Agent tool
+calls (this session's own primary motivating use case) get both env vars,
+but tool-spawned shells (`bash -c "..."` style, no `--rcfile`) don't source
+the integration script at all, so the function isn't defined there either.
+Net result: the convenient `muxspect ...` invocation doesn't actually work
+in EITHER context today — only the fully-qualified
+`node ~/.agentmux/shell/muxspect.mjs ...` (which this PR verified works end
+to end) does.
+
+**Fix deferred, not attempted in this PR** — two candidates, both requiring
+more careful, separate scoping than a drive-by fixup:
+
+1. Wire a `muxspect` launcher into whatever mechanism already adds
+   AgentMux-managed tool dirs to an agent-CLI subprocess's `PATH` (see
+   `shell/lifecycle.rs`'s "Wire AgentMux-managed tool dirs into the agent's
+   PATH" comment) — makes bare `muxspect` callable exactly where the auth
+   key already exists, no new env propagation needed.
+2. Propagate `$AGENTMUX_AUTH_KEY` into interactive shell panes too (not
+   just agent-CLI spawns) — **not recommended without independent
+   security review**: that key currently authorizes every `/api/v1/*`
+   route, not just the two read-only `muxspect` ones, so widening its
+   propagation to every plain terminal pane is a real scope-of-access
+   change, not a documentation fix.
+
+Until one of these lands, `docs/MUXSPECT.md`, `CLAUDE.md`, and
+`muxspect.mjs`'s own `--help` text all point users/agents at the
+direct-path invocation instead of overselling shell-function convenience
+that doesn't apply yet.
+
 ---
 
 ## 8. Decisions (resolved 2026-08-01)

--- a/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
+++ b/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
@@ -296,6 +296,23 @@ Until one of these lands, `docs/MUXSPECT.md`, `CLAUDE.md`, and
 direct-path invocation instead of overselling shell-function convenience
 that doesn't apply yet.
 
+**Follow-up finding, same review (codex P1, next round):** the direct-path
+fallback above isn't reliably available either — `deploy_scripts` (which
+writes `muxlog.mjs`/`muxspect.mjs` to `<data_dir>/shell/`) had exactly one
+runtime call site, `ShellController::start`'s interactive (empty-command)
+branch — a user whose first-ever pane in a fresh data dir is an Agent pane
+(persistent/subprocess/acp, which never takes that branch) would never get
+either script deployed at all. A **pre-existing gap in `muxlog`'s own
+deployment mechanism** this PR newly depends on, not something introduced
+here. **Fixed**: `deploy_scripts` is now also called unconditionally at srv
+startup (`bootstrap.rs::spawn_background_subsystems`), before any block can
+be created — idempotent (skips if its version marker already matches), so
+this is additive, not a behavior change to the existing call site. The
+direct-path fallback (§7.1's own recommendation above) is now always
+available regardless of what pane type the user opens first; the shell
+*function*'s unreachability (the original finding) is unchanged and still
+needs one of the two candidates above.
+
 ---
 
 ## 8. Decisions (resolved 2026-08-01)


### PR DESCRIPTION
## Summary

New tool: `muxspect` — `muxlog`'s live-state sibling. `muxlog` answers "what happened" (log files on disk); `muxspect` answers "what is this instance doing right now." Grew directly out of a live debugging session where neither tool nor any existing RPC could answer "which instance is even hosting this conversation" or "what's this block's current state."

**Phase 1 scope only** (current instance, no cross-instance query yet — see the spec's §7 for Phase 2/3):

- Two new authenticated HTTP routes, `/api/v1/muxspect/list` and `/api/v1/muxspect/describe`, composing the existing `ProcessBroker::status()`/`list()` + `BlockControllerRuntimeStatus` + OS-process tree into the single "describe everything about block X" query `REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md` §5.4 already named as missing.
- `muxspect.mjs`, deployed exactly like `muxlog.mjs` (same `include_str!` embed, same per-shell deploy, same `bash`/`zsh`/`pwsh`/`fish` function wiring). Connects via `$AGENTMUX_LOCAL_URL`/`$AGENTMUX_AUTH_KEY` inherited from its own environment — verified directly that this is the same path `agentmux-mcp` already uses for every other `/api/v1/*` route, not new IPC.

## Design doc

`docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md` — external best-practices research (kubectl/docker/OTP observer/Chrome DevTools Protocol/Temporal CLI) + a full internal audit of what already existed, both via background research agents, informed every design decision below. Also `docs/MUXSPECT.md` (user-facing reference, mirrors `docs/MUXLOG.md`'s structure).

Notable decision worth flagging: the Agent pane's Activity Dock is **explicitly out of scope for every phase** — it's pure in-renderer SolidJS state, never persisted or RPC-exposed, so no backend tool can ever see it. AgentMux already ships CEF, which supports Chrome's remote-debugging protocol — that's the right tool for that specific gap, not something to build into `muxspect`.

## Test plan

- [x] `cargo test -p agentmux-srv` — 1860 passed, 0 failed (4 new: 2 route tests + auth-gate test + bad-request test; 1 new: `deploy_scripts` writes `muxspect.mjs` alongside `muxlog.mjs`)
- [x] Manually ran `node muxspect.mjs help`/`describe` (no args)/`list` against the currently-running (older-build) instance — clean usage output, clean argument-validation errors, and a clean "request failed (404)" against the old build that predates these routes (expected — confirms the env-var read + fetch + error-handling path all work end-to-end against a real running instance)
- [ ] Live check once a build including this PR is running: `muxspect list`/`muxspect describe <block_id>` from within an agent pane should return real data

<!-- agentmux:agent_id=agenta -->