### PR TITLE
ABF import UI (Phase 3): selective import + collision handling

### DIFF
--- a/.changesets/1785660132-feat-armory-abf-import-ui-phase-3-selective-import-collision-2z7d.md
+++ b/.changesets/1785660132-feat-armory-abf-import-ui-phase-3-selective-import-collision-2z7d.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): ABF import UI (Phase 3) -- selective import + collision handling

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -704,6 +704,30 @@ pub async fn show_open_file_dialog(
     })
 }
 
+/// File picker for Armory Bundle Format (`.abf`) files — Phase 3 of
+/// docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4 Step 1.
+/// `show_open_file_dialog` can't be reused: it takes no filter argument and
+/// its own filter list is hard-coded to image/video/audio extensions, with
+/// no generic filter mechanism elsewhere in this module — this mirrors its
+/// shape with an `.abf` filter instead. The filter is advisory only (a
+/// non-`.abf` file picked here still just fails `unzip_bundle_import`'s
+/// "not a valid zip archive" check server-side, same as today).
+pub async fn show_open_bundle_dialog(
+    _args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let path = tokio::task::spawn_blocking(|| {
+        rfd::FileDialog::new()
+            .add_filter("Armory Bundle", &["abf"])
+            .pick_file()
+    })
+    .await
+    .map_err(|e| format!("show_open_bundle_dialog: task join error: {e}"))?;
+    Ok(match path {
+        Some(p) => serde_json::json!(p.to_string_lossy()),
+        None => serde_json::Value::Null,
+    })
+}
+
 fn extract_commented_setting_key(line: &str) -> Option<&str> {
     let trimmed = line.trim_start();
     let rest = trimmed.strip_prefix("//")?;

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -273,6 +273,7 @@ async fn route_command(
         "open_external" => commands::platform::open_external(args),
         "reveal_in_file_explorer" => commands::platform::reveal_in_file_explorer(args),
         "show_open_file_dialog" => commands::platform::show_open_file_dialog(args).await,
+        "show_open_bundle_dialog" => commands::platform::show_open_bundle_dialog(args).await,
         "set_window_transparency" => commands::window::set_window_transparency(state, args),
         "set_window_opacity" => commands::window::set_window_opacity(state, args),
         "get_window_opacity" => commands::window::get_window_opacity(state, args).await,

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -271,14 +271,6 @@ pub struct ParsedBundleImport {
     pub warnings: Vec<String>,
 }
 
-/// Parse and validate a bundle's files into [`ParsedBundleImport`].
-/// Structural failures (missing/malformed `armory.json`) reject the whole
-/// import — `Err` — since there is nothing safe to partially write.
-/// Per-entry problems (a missing referenced file, an unsafe path, a
-/// malformed SKILL.md) degrade to a warning and that entry is skipped —
-/// matches `bundle_export.rs`'s own philosophy, and lets a lossy import
-/// still produce a usable bundle rather than an all-or-nothing failure on
-/// e.g. one corrupt skill among five good ones.
 /// Normalize every input file's path and reduce to a first-wins,
 /// deduped `(path -> content)` map — the exact effective representation
 /// `parse_bundle_import` builds internally before doing anything else.
@@ -286,9 +278,19 @@ pub struct ParsedBundleImport {
 /// can compute over the IDENTICAL order-resolved representation the parser
 /// itself uses, rather than a naive raw-input sort that could disagree
 /// with which entry the parser's own first-wins rule actually keeps.
-/// Enforces the accounts/ allowlist (only `accounts/requirements.json` is
-/// ever readable from that directory) the same as every other caller of
-/// this map.
+///
+/// Also enforces the accounts/ allowlist (§4.3.5): only
+/// `accounts/requirements.json` is ever readable from that directory,
+/// checked against every file actually present (not just what the
+/// manifest references, since a malformed bundle's `components` object
+/// isn't a trustworthy inventory of its own contents), and normalized the
+/// same way regardless of intake source (zip or raw `files` list) so
+/// neither can bypass the check with a non-canonical spelling
+/// (codex P1, PR #2379 rounds 1–2). A rejected file is excluded from the
+/// returned map entirely, not merely warned about — otherwise a
+/// `components.*` reference pointing at it (e.g.
+/// `accounts/secrets.json`) would still resolve and leak its content into
+/// the imported bundle.
 fn dedup_files_by_path<'a>(files: &'a [BundleImportFile], warnings: &mut WarningSink) -> HashMap<String, &'a str> {
     let mut by_path: HashMap<String, &str> = HashMap::new();
     for f in files {
@@ -385,6 +387,14 @@ pub fn content_digest_files(files: &[BundleImportFile]) -> String {
     hex::encode(hasher.finalize())
 }
 
+/// Parse and validate a bundle's files into [`ParsedBundleImport`].
+/// Structural failures (missing/malformed `armory.json`) reject the whole
+/// import — `Err` — since there is nothing safe to partially write.
+/// Per-entry problems (a missing referenced file, an unsafe path, a
+/// malformed SKILL.md) degrade to a warning and that entry is skipped —
+/// matches `bundle_export.rs`'s own philosophy, and lets a lossy import
+/// still produce a usable bundle rather than an all-or-nothing failure on
+/// e.g. one corrupt skill among five good ones.
 pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImport, String> {
     parse_bundle_import_with_budget(files, WarningBudget::unbounded())
 }
@@ -401,32 +411,9 @@ pub fn parse_bundle_import_with_budget(
 ) -> Result<ParsedBundleImport, String> {
     let mut warnings = WarningSink::new(budget);
 
-    // §4.3.5: reject anything under accounts/ other than requirements.json
-    // outright — never read, never write, never even acknowledged beyond a
-    // warning. Checked against every file actually present, not just what
-    // the manifest references, since a malicious/malformed bundle's
-    // `components` object is not a trustworthy inventory of its own
-    // contents.
-    //
-    // Codex P1, PR #2379: a rejected file must be excluded from `by_path`
-    // entirely, not merely warned about — otherwise a malicious bundle
-    // whose `components.instructions`/`components.mcpServers` REFERENCES
-    // `accounts/secrets.json` would still have that content looked up and
-    // folded into the imported bundle by the code below (and, on a later
-    // re-export of that same bundle, written unredacted straight into
-    // `instructions/AGENTS.md`) — defeating the accounts/ allowlist this
-    // exact loop exists to enforce.
-    // Codex P1, PR #2379 (round 2): the accounts/ allowlist check above
-    // only ever saw a ZIP entry's already-normalized path (unzip_bundle_import
-    // runs every entry through `sanitize_context_relative_path` first). The
-    // raw `files` RPC input skips that step entirely, so a spelling like
-    // `./accounts/secrets.json` or `accounts\secrets.json` doesn't match the
-    // literal `starts_with("accounts/")` check and sails through unrejected
-    // — while a manifest `components.*` entry using the exact same raw
-    // spelling still resolves it via `by_path.get(path)` below. Normalize
-    // every file's path the same way regardless of source (zip or raw
-    // list) before the allowlist check and before it becomes a lookup key,
-    // so both intake paths enforce the same rule on the same canonical form.
+    // Path normalization, first-wins dedup, and accounts/ allowlist
+    // enforcement (§4.3.5) all live in dedup_files_by_path — see its own
+    // doc comment.
     let by_path = dedup_files_by_path(files, &mut warnings);
 
     let manifest_raw = by_path

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -433,14 +433,12 @@ pub fn parse_bundle_import_with_budget(
         .get("name")
         .and_then(|v| v.as_str())
         .unwrap_or("imported-bundle");
-    let name = if raw_name.chars().count() > MAX_BUNDLE_NAME_CHARS {
+    if raw_name.chars().count() > MAX_BUNDLE_NAME_CHARS {
         warnings.push(format!(
             "armory.json: name exceeds {MAX_BUNDLE_NAME_CHARS} characters; truncated"
         ));
-        raw_name.chars().take(MAX_BUNDLE_NAME_CHARS).collect()
-    } else {
-        raw_name.to_string()
-    };
+    }
+    let name = bound_bundle_name(raw_name);
     let description = manifest
         .get("description")
         .and_then(|v| v.as_str())
@@ -868,7 +866,13 @@ const MAX_ACCOUNT_REQUIREMENTS: usize = 1_000;
 /// (well within the size caps) could otherwise monopolize the handler and
 /// pollute the installation's skill catalog. A real bundle needs a
 /// handful to a few dozen skills at most.
-const MAX_IMPORTED_SKILLS: usize = 200;
+///
+/// Also reused by `bundle.import.commit` (Phase 3 spec §3.2, round 3) as
+/// the cap on `include_skills`'s length — the same reasoning applies to a
+/// client-supplied selection array as to the parser's own component list:
+/// neither may drive more Store-write attempts than a real bundle could
+/// ever need.
+pub const MAX_IMPORTED_SKILLS: usize = 200;
 
 /// Maximum character length of a bundle's manifest `name`, enforced at
 /// parse time (Phase 3 spec §3.1, round 13) rather than at a later display
@@ -876,7 +880,22 @@ const MAX_IMPORTED_SKILLS: usize = 200;
 /// doesn't edit the preview's suggested value, so the canonical, bounded
 /// value must be what both `preview` and `commit` converge on from the
 /// moment parsing completes. Generous for any real bundle name.
-const MAX_BUNDLE_NAME_CHARS: usize = 200;
+pub const MAX_BUNDLE_NAME_CHARS: usize = 200;
+
+/// Bounds a bundle name to [`MAX_BUNDLE_NAME_CHARS`] via plain truncation
+/// (no ellipsis, unlike [`truncate_display`]) — this IS the canonical
+/// value, not a display abbreviation of a longer "real" one. Shared by
+/// `parse_bundle_import`'s own manifest-`name` bounding and the Phase 3
+/// `bundle.import.commit` RPC's `bundle_name` override (round 3), so a
+/// client-supplied override can't bypass the same bound `parsed.name` is
+/// already held to.
+pub fn bound_bundle_name(name: &str) -> String {
+    if name.chars().count() > MAX_BUNDLE_NAME_CHARS {
+        name.chars().take(MAX_BUNDLE_NAME_CHARS).collect()
+    } else {
+        name.to_string()
+    }
+}
 
 /// Single choke point for the per-entry/aggregate size caps, shared by
 /// BOTH intake paths (zip decompression and the raw `files` RPC list) —

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -35,6 +35,12 @@ pub struct BundleImportFile {
 /// `agent_config::render_skill_md`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ParsedSkill {
+    /// The exact `components.skills` directory reference that produced this
+    /// entry (Phase 3 spec §3.0) — a stable, always-unique selection key,
+    /// independent of `slug` (which two entries can share; see the
+    /// `"duplicate_in_bundle"` collision case). Never displayed truncated;
+    /// only used to match a preview row to a commit selection.
+    pub source_dir: String,
     /// The slug from SKILL.md's own `name` field (Agent Skills spec:
     /// must match the parent directory) — reused as both the imported
     /// skill's display name and its `trigger`. Agent-skill-type skills
@@ -44,6 +50,17 @@ pub struct ParsedSkill {
     pub slug: String,
     pub description: String,
     pub content: String,
+}
+
+/// An MCP server parsed out of a `components.mcpServers` reference — Phase
+/// 3 spec §3.0. `source_path` is the stable, always-unique selection key
+/// (the manifest path reference, distinct from whatever `"name"` field
+/// happens to appear inside `config`'s arbitrary JSON, which has no
+/// uniqueness guarantee and isn't even required to be present).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ParsedMcpServer {
+    pub source_path: String,
+    pub config: Value,
 }
 
 /// One `accounts/requirements.json` entry — mirrors the shape
@@ -64,6 +81,13 @@ pub struct AccountRequirement {
 /// `db_bundles.context_files` stores.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ImportedContextFile {
+    /// 0-based index within this parse's `context_files` list (Phase 3
+    /// spec §3.1, round 13) — the stable selection key `bundle.import.commit`'s
+    /// `include_context_files` uses. Deterministic and reusable across
+    /// `preview`/`commit` because `expected_content_digest` already
+    /// guarantees both calls parse identical content, so the same index
+    /// always means the same entry. Never used for display.
+    pub id: usize,
     pub path: String,
     pub content: String,
 }
@@ -80,7 +104,7 @@ pub struct ParsedBundleImport {
     pub description: String,
     pub instructions: String,
     pub context_files: Vec<ImportedContextFile>,
-    pub mcp_servers: Vec<Value>,
+    pub mcp_servers: Vec<ParsedMcpServer>,
     pub skills: Vec<ParsedSkill>,
     pub skipped_skills: Vec<String>,
     pub requirements: Vec<AccountRequirement>,
@@ -165,11 +189,25 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     let manifest: Value = serde_json::from_str(manifest_raw)
         .map_err(|e| format!("armory.json: malformed JSON ({e})"))?;
 
-    let name = manifest
+    // Phase 3 spec §3.1, round 13: bound at the parse source, not at a
+    // later response boundary — `name` is re-submitted verbatim as
+    // `bundle_name` when a user doesn't edit the preview's suggested value
+    // (§3.2, round 11), so `preview` and `commit` (which independently
+    // re-parse) must converge on the identical canonical value
+    // deterministically. There is no separate "full" name anywhere for a
+    // display-only truncation to lose.
+    let raw_name = manifest
         .get("name")
         .and_then(|v| v.as_str())
-        .unwrap_or("imported-bundle")
-        .to_string();
+        .unwrap_or("imported-bundle");
+    let name = if raw_name.chars().count() > MAX_BUNDLE_NAME_CHARS {
+        warnings.push(format!(
+            "armory.json: name exceeds {MAX_BUNDLE_NAME_CHARS} characters; truncated"
+        ));
+        raw_name.chars().take(MAX_BUNDLE_NAME_CHARS).collect()
+    } else {
+        raw_name.to_string()
+    };
     let description = manifest
         .get("description")
         .and_then(|v| v.as_str())
@@ -268,6 +306,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
             if let Some(rel) = path.strip_prefix("instructions/context/") {
                 match sanitize_context_relative_path(rel) {
                     Some(safe_rel) => context_files.push(ImportedContextFile {
+                        id: context_files.len(),
                         path: safe_rel,
                         content: content.to_string(),
                     }),
@@ -324,7 +363,10 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
                 continue;
             };
             match parse_skill_md(content) {
-                Some(skill) => skills.push(skill),
+                Some(mut skill) => {
+                    skill.source_dir = dir.clone();
+                    skills.push(skill);
+                }
                 None => {
                     warnings.push(format!("{skill_md_path}: malformed SKILL.md frontmatter; skipped"));
                     skipped_skills.push(dir.clone());
@@ -352,7 +394,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
     // verbatim (still containing ${VAR} placeholders; resolution is the
     // RPC handler's job, §4.5).
     // ------------------------------------------------------------------
-    let mut mcp_servers: Vec<Value> = Vec::new();
+    let mut mcp_servers: Vec<ParsedMcpServer> = Vec::new();
     let mut seen_mcp_paths: HashSet<String> = HashSet::new();
     let mut duplicate_mcp_refs: u32 = 0;
     {
@@ -393,7 +435,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
                 continue;
             };
             match serde_json::from_str::<Value>(content) {
-                Ok(v) => mcp_servers.push(v),
+                Ok(config) => mcp_servers.push(ParsedMcpServer { source_path: path.clone(), config }),
                 Err(e) => warnings.push(format!("{path}: malformed JSON ({e}); skipped")),
             }
         }
@@ -540,6 +582,9 @@ fn parse_skill_md(content: &str) -> Option<ParsedSkill> {
         }
     }
     Some(ParsedSkill {
+        // Filled in by the caller (parse_bundle_import), which alone knows
+        // the components.skills directory reference that led here.
+        source_dir: String::new(),
         slug: name?,
         // Required, not defaulted: render_skill_md always writes both
         // fields (falling back to a placeholder string, never omitting
@@ -591,6 +636,14 @@ const MAX_ACCOUNT_REQUIREMENTS: usize = 1_000;
 /// pollute the installation's skill catalog. A real bundle needs a
 /// handful to a few dozen skills at most.
 const MAX_IMPORTED_SKILLS: usize = 200;
+
+/// Maximum character length of a bundle's manifest `name`, enforced at
+/// parse time (Phase 3 spec §3.1, round 13) rather than at a later display
+/// boundary — `name` is re-submitted verbatim as `bundle_name` when a user
+/// doesn't edit the preview's suggested value, so the canonical, bounded
+/// value must be what both `preview` and `commit` converge on from the
+/// moment parsing completes. Generous for any real bundle name.
+const MAX_BUNDLE_NAME_CHARS: usize = 200;
 
 /// Single choke point for the per-entry/aggregate size caps, shared by
 /// BOTH intake paths (zip decompression and the raw `files` RPC list) —
@@ -909,6 +962,7 @@ mod tests {
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.instructions, "Main instructions.");
         assert_eq!(result.context_files, vec![ImportedContextFile {
+            id: 0,
             path: "notes.md".to_string(),
             content: "Extra context.".to_string(),
         }]);
@@ -942,6 +996,7 @@ mod tests {
         ];
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].source_dir, "skills/deploy-checklist");
         assert_eq!(result.skills[0].slug, "deploy-checklist");
         assert_eq!(result.skills[0].description, "Runs the checklist");
         assert_eq!(result.skills[0].content, "1. Test\n2. Deploy");
@@ -984,7 +1039,8 @@ mod tests {
         ];
         let result = parse_bundle_import(&files).unwrap();
         assert_eq!(result.mcp_servers.len(), 1);
-        assert_eq!(result.mcp_servers[0]["env"]["GITHUB_TOKEN"], "${GITHUB_TOKEN}");
+        assert_eq!(result.mcp_servers[0].source_path, "mcp/github.server.json");
+        assert_eq!(result.mcp_servers[0].config["env"]["GITHUB_TOKEN"], "${GITHUB_TOKEN}");
     }
 
     #[test]
@@ -1373,6 +1429,26 @@ mod tests {
             }
         }
         assert!(warnings.iter().filter(|w| w.contains("exceeds the per-entry limit")).count() >= 4);
+    }
+
+    #[test]
+    fn bounds_an_oversized_manifest_name_at_parse_time() {
+        // Phase 3 spec §3.1, round 13: name must be bounded at the parse
+        // source (not at a later response boundary) so preview and commit
+        // -- which independently re-parse -- always converge on the exact
+        // same canonical value.
+        let oversized_name = "n".repeat(MAX_BUNDLE_NAME_CHARS + 50);
+        let manifest = serde_json::to_string(&serde_json::json!({
+            "name": oversized_name,
+            "version": "0.1.0",
+            "components": {},
+        })).unwrap();
+        let files = vec![file("armory.json", &manifest)];
+        let result_a = parse_bundle_import(&files).unwrap();
+        let result_b = parse_bundle_import(&files).unwrap();
+        assert_eq!(result_a.name.chars().count(), MAX_BUNDLE_NAME_CHARS);
+        assert_eq!(result_a.name, result_b.name, "two independent parses of the same bytes must converge on the identical truncated name");
+        assert!(result_a.warnings.iter().any(|w| w.contains("name exceeds") && w.contains("truncated")));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -23,6 +23,166 @@ use serde_json::Value;
 
 use super::bundle_export::sanitize_context_relative_path;
 
+/// Bounds how many warnings a parse call accumulates, and how long each
+/// individual warning string may be — Phase 3 spec
+/// (`SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md`) §3.1, round 11: the cap must
+/// live at the point warnings are actually PRODUCED, not only at a later
+/// RPC-response-serialization boundary, or a hostile archive can still
+/// force the parser itself to build an unbounded `Vec<String>` in memory
+/// before any cap ever runs. `unbounded()` preserves today's existing
+/// `bundle.import` route's real, already-shipped behavior exactly — this is
+/// a capability the parser gains, not a behavior change forced onto Phase 2's
+/// existing caller.
+#[derive(Debug, Clone, Copy)]
+pub struct WarningBudget {
+    max_count: Option<usize>,
+    max_len: Option<usize>,
+}
+
+impl WarningBudget {
+    pub fn unbounded() -> Self {
+        Self { max_count: None, max_len: None }
+    }
+
+    pub fn bounded(max_count: usize, max_len: usize) -> Self {
+        Self { max_count: Some(max_count), max_len: Some(max_len) }
+    }
+}
+
+/// Accumulates warnings against a [`WarningBudget`]. Exposes `.push(String)`
+/// so every existing `warnings.push(format!(...))` call site in this module
+/// keeps working unchanged after its binding's type changes from
+/// `Vec<String>` to this — only construction (`WarningSink::new`) and
+/// extraction (`.into_vec()`) differ.
+#[derive(Debug, Clone)]
+struct WarningSink {
+    budget: WarningBudget,
+    warnings: Vec<String>,
+    dropped: usize,
+}
+
+impl WarningSink {
+    fn new(budget: WarningBudget) -> Self {
+        Self { budget, warnings: Vec::new(), dropped: 0 }
+    }
+
+    fn push(&mut self, message: String) {
+        if let Some(max_count) = self.budget.max_count {
+            if self.warnings.len() >= max_count {
+                self.dropped += 1;
+                return;
+            }
+        }
+        let message = match self.budget.max_len {
+            Some(max_len) => truncate_display(&message, max_len),
+            None => message,
+        };
+        self.warnings.push(message);
+    }
+
+    fn into_vec(mut self) -> Vec<String> {
+        if self.dropped > 0 {
+            self.warnings.push(format!("... {} more warning(s) not shown", self.dropped));
+        }
+        self.warnings
+    }
+}
+
+/// Fixed-character truncation shared by every bounded-display projection
+/// this module (and its RPC callers, Phase 3 spec §3.1/§3.2) define —
+/// stated once so `preview` and `commit` always apply IDENTICAL bounds to
+/// the equivalent field, rather than independent per-endpoint copies
+/// drifting apart (the exact class of gap codex found and re-found across
+/// rounds 9 and 12).
+pub fn truncate_display(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let mut truncated: String = s.chars().take(max_chars).collect();
+        truncated.push_str("...");
+        truncated
+    }
+}
+
+/// Cap on `instructions_preview` (Phase 3 spec §3.1, round 5) — generous for
+/// a glance-and-decide preview; bounds worst-case JSON-escaped response size
+/// to roughly 300 KB rather than the ~300 MB a maximally-adversarial,
+/// unbounded `instructions` string could otherwise force.
+pub const MAX_INSTRUCTIONS_PREVIEW_CHARS: usize = 50_000;
+
+/// Fixed-character display cap shared by every "meant to be short" bounded
+/// field this spec defines: skill `description`/`slug` (rounds 10/12),
+/// requirement `id`/`provider`/`env` (round 11), context-file
+/// `display_path` (round 13), and bundle `description` (round 12 self-audit).
+pub const MAX_DISPLAY_FIELD_CHARS: usize = 300;
+
+/// Fixed-character display cap for an MCP server's projected `name`/
+/// `command` (Phase 3 spec §3.1, round 7) — smaller than
+/// [`MAX_DISPLAY_FIELD_CHARS`] since these are meant to be short
+/// identifiers/executable names, not free-form text.
+pub const MAX_MCP_DISPLAY_FIELD_CHARS: usize = 200;
+
+/// Bounds `instructions_preview` for the RPC response — returns
+/// `(preview, truncated, total_chars)`. The full, untruncated `instructions`
+/// value is unaffected; this only bounds what's echoed back for display
+/// (Phase 3 spec §3.1, rounds 5 and 8).
+pub fn bounded_instructions_preview(instructions: &str) -> (String, bool, usize) {
+    let total_chars = instructions.chars().count();
+    if total_chars <= MAX_INSTRUCTIONS_PREVIEW_CHARS {
+        (instructions.to_string(), false, total_chars)
+    } else {
+        (instructions.chars().take(MAX_INSTRUCTIONS_PREVIEW_CHARS).collect(), true, total_chars)
+    }
+}
+
+/// Bounded `{name, command}` projection of an MCP server's full `config`
+/// (Phase 3 spec §3.1, round 7) — the full `config` is never returned in
+/// preview/commit responses, only this small, defensively-extracted
+/// projection. Falls back to `null` for either field when absent or not a
+/// string, since MCP JSON has no required shape (§3.0).
+pub fn mcp_server_display(config: &Value) -> Value {
+    let field = |key: &str| -> Value {
+        match config.get(key).and_then(|v| v.as_str()) {
+            Some(s) => Value::String(truncate_display(s, MAX_MCP_DISPLAY_FIELD_CHARS)),
+            None => Value::Null,
+        }
+    };
+    serde_json::json!({ "name": field("name"), "command": field("command") })
+}
+
+/// Every parsed skill slug that appears more than once across the WHOLE
+/// bundle — the `"duplicate_in_bundle"` collision pass (Phase 3 spec §3.1,
+/// codex P1 round 2), computed independently of any external global-catalog
+/// state so it's pure and directly testable.
+pub fn duplicate_in_bundle_slugs(skills: &[ParsedSkill]) -> HashSet<String> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut dupes: HashSet<String> = HashSet::new();
+    for skill in skills {
+        if !seen.insert(skill.slug.as_str()) {
+            dupes.insert(skill.slug.clone());
+        }
+    }
+    dupes
+}
+
+/// `"none"` / `"name_conflict"` / `"duplicate_in_bundle"` — Phase 3 spec
+/// §3.1's two-pass skill collision classification. `global_slugs` is
+/// whatever the caller already fetched from `skill.catalog.list`'s
+/// underlying `skill_list_global()` (Store access lives in the RPC
+/// handler, not here — this stays a pure function so it's testable with a
+/// seeded fake global-skill list, per the spec's own §6 testing notes).
+/// Pass 1 (global catalog) takes priority over pass 2 (intra-bundle
+/// duplicate) when both apply, matching §3.1's stated precedence.
+pub fn classify_skill_collision(slug: &str, global_slugs: &HashSet<String>, in_bundle_dupes: &HashSet<String>) -> &'static str {
+    if global_slugs.contains(slug) {
+        "name_conflict"
+    } else if in_bundle_dupes.contains(slug) {
+        "duplicate_in_bundle"
+    } else {
+        "none"
+    }
+}
+
 /// One file read from an import source (zip or raw list), path relative
 /// to the bundle root. Mirrors `bundle_export::BundleExportFile`.
 #[derive(Debug, Clone)]
@@ -120,7 +280,20 @@ pub struct ParsedBundleImport {
 /// still produce a usable bundle rather than an all-or-nothing failure on
 /// e.g. one corrupt skill among five good ones.
 pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImport, String> {
-    let mut warnings: Vec<String> = Vec::new();
+    parse_bundle_import_with_budget(files, WarningBudget::unbounded())
+}
+
+/// Same as [`parse_bundle_import`], but with an explicit [`WarningBudget`]
+/// enforced at every warning-push site inside this function (Phase 3 spec
+/// §3.1, round 11) — the new `bundle.import.preview`/`.commit` RPC handlers
+/// call this directly with a tight budget; [`parse_bundle_import`] passes
+/// [`WarningBudget::unbounded`], preserving today's existing `bundle.import`
+/// route's behavior exactly.
+pub fn parse_bundle_import_with_budget(
+    files: &[BundleImportFile],
+    budget: WarningBudget,
+) -> Result<ParsedBundleImport, String> {
+    let mut warnings = WarningSink::new(budget);
 
     // §4.3.5: reject anything under accounts/ other than requirements.json
     // outright — never read, never write, never even acknowledged beyond a
@@ -518,7 +691,7 @@ pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImp
         skills,
         skipped_skills,
         requirements,
-        warnings,
+        warnings: warnings.into_vec(),
     })
 }
 
@@ -545,7 +718,7 @@ fn is_requirements_json(path: &str) -> bool {
 /// amplification effect. Reuses [`MAX_ENTRY_COUNT`] — a manifest
 /// component array legitimately needs the same "more entries than any
 /// real bundle uses" ceiling a zip archive's entry count does.
-fn capped_component_array<'a>(arr: Option<&'a Vec<Value>>, key: &str, warnings: &mut Vec<String>) -> &'a [Value] {
+fn capped_component_array<'a>(arr: Option<&'a Vec<Value>>, key: &str, warnings: &mut WarningSink) -> &'a [Value] {
     let Some(arr) = arr else { return &[] };
     let len = arr.len();
     if len > MAX_ENTRY_COUNT {
@@ -677,7 +850,7 @@ fn check_entry_size(
     safe_name: &str,
     content_len: u64,
     total_uncompressed: &mut u64,
-    warnings: &mut Vec<String>,
+    warnings: &mut WarningSink,
 ) -> Result<bool, String> {
     *total_uncompressed = total_uncompressed.saturating_add(content_len);
     if *total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES {
@@ -702,13 +875,22 @@ fn check_entry_size(
 /// bound), so this only needs the shared per-entry/aggregate check, no
 /// backstop-read machinery.
 pub fn enforce_raw_files_caps(files: Vec<BundleImportFile>) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
+    enforce_raw_files_caps_with_budget(files, WarningBudget::unbounded())
+}
+
+/// Same as [`enforce_raw_files_caps`], but with an explicit [`WarningBudget`]
+/// (Phase 3 spec §3.1, round 11).
+pub fn enforce_raw_files_caps_with_budget(
+    files: Vec<BundleImportFile>,
+    budget: WarningBudget,
+) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
     if files.len() > MAX_ENTRY_COUNT {
         return Err(format!(
             "{} entries exceeds the limit ({MAX_ENTRY_COUNT}) — rejecting the whole import",
             files.len()
         ));
     }
-    let mut warnings = Vec::new();
+    let mut warnings = WarningSink::new(budget);
     let mut total_uncompressed: u64 = 0;
     let mut out = Vec::new();
     for f in files {
@@ -717,7 +899,7 @@ pub fn enforce_raw_files_caps(files: Vec<BundleImportFile>) -> Result<(Vec<Bundl
             out.push(f);
         }
     }
-    Ok((out, warnings))
+    Ok((out, warnings.into_vec()))
 }
 
 /// Unpack a `.abf` zip archive into a flat file list, applying the same
@@ -738,6 +920,15 @@ pub fn enforce_raw_files_caps(files: Vec<BundleImportFile>) -> Result<(Vec<Bundl
 /// more confusing than useful, and hitting the aggregate cap at all
 /// already indicates a genuinely abusive archive rather than one bad file.
 pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
+    unzip_bundle_import_with_budget(zip_bytes, WarningBudget::unbounded())
+}
+
+/// Same as [`unzip_bundle_import`], but with an explicit [`WarningBudget`]
+/// (Phase 3 spec §3.1, round 11).
+pub fn unzip_bundle_import_with_budget(
+    zip_bytes: &[u8],
+    budget: WarningBudget,
+) -> Result<(Vec<BundleImportFile>, Vec<String>), String> {
     use std::io::Read;
     let cursor = std::io::Cursor::new(zip_bytes);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| format!("not a valid zip archive: {e}"))?;
@@ -784,7 +975,7 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
     let strip_len: Option<usize> = common_wrapper.map(|w| w.len() + 1); // +1 for the '/'
 
     let mut out = Vec::new();
-    let mut warnings = Vec::new();
+    let mut warnings = WarningSink::new(budget);
     let mut seen: HashSet<String> = HashSet::new();
     let mut total_uncompressed: u64 = 0;
     for i in 0..archive.len() {
@@ -862,7 +1053,7 @@ pub fn unzip_bundle_import(zip_bytes: &[u8]) -> Result<(Vec<BundleImportFile>, V
         };
         out.push(BundleImportFile { path: safe_name, content });
     }
-    Ok((out, warnings))
+    Ok((out, warnings.into_vec()))
 }
 
 #[cfg(test)]
@@ -1230,7 +1421,7 @@ mod tests {
         // before the read-error branch) since forging a CRC mismatch
         // through the public ZipWriter API isn't practical.
         let mut total: u64 = 0;
-        let mut warnings = Vec::new();
+        let mut warnings = WarningSink::new(WarningBudget::unbounded());
         // Simulates: read_to_end returned Err, but buf still holds
         // MAX_ENTRY_UNCOMPRESSED_BYTES bytes of real decompressed data.
         let keep = check_entry_size("corrupt.md", MAX_ENTRY_UNCOMPRESSED_BYTES, &mut total, &mut warnings);
@@ -1417,7 +1608,7 @@ mod tests {
         // the invariant is verified directly at its actual implementation
         // site instead.)
         let mut total: u64 = 0;
-        let mut warnings = Vec::new();
+        let mut warnings = WarningSink::new(WarningBudget::unbounded());
         let oversized = MAX_ENTRY_UNCOMPRESSED_BYTES + 1;
         for i in 0..5 {
             let name = format!("f{i}.md");
@@ -1428,7 +1619,7 @@ mod tests {
                 assert!(result.is_err(), "5th entry should trip the aggregate cap now that all 5 discarded entries' bytes were counted (total={total})");
             }
         }
-        assert!(warnings.iter().filter(|w| w.contains("exceeds the per-entry limit")).count() >= 4);
+        assert!(warnings.into_vec().iter().filter(|w| w.contains("exceeds the per-entry limit")).count() >= 4);
     }
 
     #[test]
@@ -1721,5 +1912,127 @@ mod tests {
         let zip_bytes = build_zip(&refs);
         let err = unzip_bundle_import(&zip_bytes).unwrap_err();
         assert!(err.contains("entries exceeds the limit"));
+    }
+
+    // ── Phase 3 shared helpers (SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md) ──
+
+    #[test]
+    fn warning_budget_bounds_accumulation_during_parsing_itself() {
+        // codex P2, PR #2381, round 11: the cap must live at the parser's
+        // own warning-push sites, not just at a later response-boundary
+        // projection -- called directly here (not through an RPC response
+        // serializer) to prove the returned Vec is bounded regardless of
+        // any downstream projection.
+        let many_junk: Vec<Value> = (0..5_000).map(|i| serde_json::json!(i)).collect();
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({ "instructions": many_junk }))),
+        ];
+        let result = parse_bundle_import_with_budget(&files, WarningBudget::bounded(50, 40)).unwrap();
+        assert!(result.warnings.len() <= 51, "expected at most 50 warnings plus one summary, got {}", result.warnings.len());
+        assert!(result.warnings.iter().any(|w| w.contains("more warning(s) not shown")));
+        for w in &result.warnings {
+            // truncate_display appends "..." after taking max_chars, so the
+            // hard ceiling is max_len + 3, not max_len exactly.
+            assert!(w.chars().count() <= 43, "warning exceeded the budget's max length: {w:?}");
+        }
+    }
+
+    #[test]
+    fn warning_budget_unbounded_matches_todays_existing_route_behavior() {
+        // parse_bundle_import (no budget arg) must behave identically to
+        // parse_bundle_import_with_budget(files, WarningBudget::unbounded())
+        // -- the existing bundle.import route's real, already-shipped
+        // behavior must not change.
+        let many_junk: Vec<Value> = (0..500).map(|i| serde_json::json!(i)).collect();
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({ "instructions": many_junk.clone() }))),
+        ];
+        let a = parse_bundle_import(&files).unwrap();
+        let b = parse_bundle_import_with_budget(&files, WarningBudget::unbounded()).unwrap();
+        assert_eq!(a.warnings, b.warnings);
+        assert_eq!(a.warnings.len(), 500);
+    }
+
+    #[test]
+    fn duplicate_in_bundle_slugs_flags_only_slugs_appearing_more_than_once() {
+        let skills = vec![
+            ParsedSkill { source_dir: "skills/a".to_string(), slug: "code-review".to_string(), description: String::new(), content: String::new() },
+            ParsedSkill { source_dir: "skills/b".to_string(), slug: "code-review".to_string(), description: String::new(), content: String::new() },
+            ParsedSkill { source_dir: "skills/c".to_string(), slug: "unique".to_string(), description: String::new(), content: String::new() },
+        ];
+        let dupes = duplicate_in_bundle_slugs(&skills);
+        assert!(dupes.contains("code-review"));
+        assert!(!dupes.contains("unique"));
+        assert_eq!(dupes.len(), 1);
+    }
+
+    #[test]
+    fn classify_skill_collision_prioritizes_global_catalog_over_intra_bundle_duplicate() {
+        // Phase 3 spec §3.1: pass 1 (global catalog) takes priority over
+        // pass 2 (intra-bundle duplicate) when both apply.
+        let mut global: HashSet<String> = HashSet::new();
+        global.insert("taken".to_string());
+        let mut dupes: HashSet<String> = HashSet::new();
+        dupes.insert("taken".to_string());
+        dupes.insert("dupe-only".to_string());
+        assert_eq!(classify_skill_collision("taken", &global, &dupes), "name_conflict");
+        assert_eq!(classify_skill_collision("dupe-only", &global, &dupes), "duplicate_in_bundle");
+        assert_eq!(classify_skill_collision("free", &global, &dupes), "none");
+    }
+
+    #[test]
+    fn truncate_display_truncates_only_when_over_the_cap() {
+        assert_eq!(truncate_display("short", 100), "short");
+        let long = "a".repeat(150);
+        let truncated = truncate_display(&long, 100);
+        assert_eq!(truncated.chars().count(), 103); // 100 chars + "..."
+        assert!(truncated.ends_with("..."));
+    }
+
+    #[test]
+    fn bounded_instructions_preview_reports_truncation_and_true_total_length() {
+        let long = "x".repeat(MAX_INSTRUCTIONS_PREVIEW_CHARS + 500);
+        let (preview, truncated, total) = bounded_instructions_preview(&long);
+        assert!(truncated);
+        assert_eq!(total, MAX_INSTRUCTIONS_PREVIEW_CHARS + 500);
+        assert_eq!(preview.chars().count(), MAX_INSTRUCTIONS_PREVIEW_CHARS);
+
+        let short = "short instructions";
+        let (preview2, truncated2, total2) = bounded_instructions_preview(short);
+        assert!(!truncated2);
+        assert_eq!(total2, short.chars().count());
+        assert_eq!(preview2, short);
+    }
+
+    #[test]
+    fn mcp_server_display_never_returns_the_full_config() {
+        let config = serde_json::json!({
+            "name": "github",
+            "command": "npx",
+            "args": ["-y", "gh-mcp"],
+            "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" },
+        });
+        let display = mcp_server_display(&config);
+        assert_eq!(display["name"], "github");
+        assert_eq!(display["command"], "npx");
+        assert!(display.get("args").is_none());
+        assert!(display.get("env").is_none());
+    }
+
+    #[test]
+    fn mcp_server_display_bounds_an_oversized_name_or_command() {
+        let oversized = "n".repeat(MAX_MCP_DISPLAY_FIELD_CHARS + 50);
+        let config = serde_json::json!({ "name": oversized, "command": "npx" });
+        let display = mcp_server_display(&config);
+        let name = display["name"].as_str().unwrap();
+        assert!(name.chars().count() <= MAX_MCP_DISPLAY_FIELD_CHARS + 3);
+    }
+
+    #[test]
+    fn mcp_server_display_falls_back_to_null_when_fields_absent_or_wrong_type() {
+        let config = serde_json::json!({ "command": 123 });
+        let display = mcp_server_display(&config);
+        assert!(display["name"].is_null());
+        assert!(display["command"].is_null());
     }
 }

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -279,6 +279,112 @@ pub struct ParsedBundleImport {
 /// matches `bundle_export.rs`'s own philosophy, and lets a lossy import
 /// still produce a usable bundle rather than an all-or-nothing failure on
 /// e.g. one corrupt skill among five good ones.
+/// Normalize every input file's path and reduce to a first-wins,
+/// deduped `(path -> content)` map — the exact effective representation
+/// `parse_bundle_import` builds internally before doing anything else.
+/// Extracted so the Phase 3 `files`-mode content digest (§3.0.5, round 6)
+/// can compute over the IDENTICAL order-resolved representation the parser
+/// itself uses, rather than a naive raw-input sort that could disagree
+/// with which entry the parser's own first-wins rule actually keeps.
+/// Enforces the accounts/ allowlist (only `accounts/requirements.json` is
+/// ever readable from that directory) the same as every other caller of
+/// this map.
+fn dedup_files_by_path<'a>(files: &'a [BundleImportFile], warnings: &mut WarningSink) -> HashMap<String, &'a str> {
+    let mut by_path: HashMap<String, &str> = HashMap::new();
+    for f in files {
+        let Some(safe_path) = sanitize_context_relative_path(&f.path) else {
+            warnings.push(format!("{}: not a safe path; skipped", f.path));
+            continue;
+        };
+        // reagent P1, PR #2379 round 4: case-insensitive on the DIRECTORY
+        // check -- sanitize_context_relative_path never case-folds, so
+        // `ACCOUNTS/secrets.json` (or any other-case variant) previously
+        // sailed past the literal lowercase `starts_with` check while a
+        // manifest reference using the identical casing would still
+        // resolve it. The exception itself stays exact-match against the
+        // canonical lowercase spelling the exporter always emits — an
+        // other-case "requirements.json" is still inside the rejected
+        // directory, just not recognized as the one allowed file.
+        if safe_path.to_ascii_lowercase().starts_with("accounts/") && safe_path != "accounts/requirements.json" {
+            warnings.push(format!(
+                "{safe_path}: rejected — only accounts/requirements.json is ever read from the accounts/ directory"
+            ));
+            continue;
+        }
+        // reagent P2, PR #2379 round 5: `unzip_bundle_import` explicitly
+        // detects and warns on a duplicate entry within a zip ("first
+        // occurrence kept"), but the raw `files` RPC list reaches this
+        // shared loop directly, bypassing that pass entirely — two input
+        // entries normalizing to the same safe_path silently resolved
+        // last-write-wins with no warning, so a caller inspecting the
+        // input couldn't tell which content actually got imported.
+        if by_path.contains_key(&safe_path) {
+            warnings.push(format!("{safe_path}: duplicate path in input; first occurrence kept"));
+            continue;
+        }
+        by_path.insert(safe_path, f.content.as_str());
+    }
+    by_path
+}
+
+/// Which of the three `bundle.import.preview`/`.commit` input fields
+/// produced a given payload — mixed into the content-digest hash domain
+/// itself (Phase 3 spec §3.0.5, round 7) so a `file_path` preview can never
+/// be satisfied by a `zip_base64` commit of the identical underlying bytes
+/// (both canonicalize to the same raw zip bytes and would otherwise hash
+/// identically), closing the gap a bare byte-digest comparison left open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportInputMode {
+    FilePath,
+    ZipBase64,
+    Files,
+}
+
+impl ImportInputMode {
+    fn mode_byte(self) -> u8 {
+        match self {
+            ImportInputMode::FilePath => 0x01,
+            ImportInputMode::ZipBase64 => 0x02,
+            ImportInputMode::Files => 0x03,
+        }
+    }
+}
+
+/// SHA-256 content digest for `file_path`/`zip_base64` input — both
+/// canonicalize to the same thing (raw zip bytes), differentiated only by
+/// the mode tag mixed into the hash domain (§3.0.5, round 7).
+pub fn content_digest_raw_bytes(mode: ImportInputMode, zip_bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update([mode.mode_byte()]);
+    hasher.update(zip_bytes);
+    hex::encode(hasher.finalize())
+}
+
+/// SHA-256 content digest for `files`-mode input (§3.0.5, round 6) — hashes
+/// `parse_bundle_import`'s own effective, order-resolved representation
+/// ([`dedup_files_by_path`]'s normalize-then-first-wins reduction, sorted
+/// by normalized key), not the raw input array. This makes the digest
+/// order-independent for genuinely equivalent inputs while remaining
+/// sensitive to any reordering that would actually change which entry the
+/// parser's first-wins rule keeps.
+pub fn content_digest_files(files: &[BundleImportFile]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut discard = WarningSink::new(WarningBudget::unbounded());
+    let deduped = dedup_files_by_path(files, &mut discard);
+    let mut entries: Vec<(&String, &&str)> = deduped.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    let mut hasher = Sha256::new();
+    hasher.update([ImportInputMode::Files.mode_byte()]);
+    for (path, content) in entries {
+        hasher.update((path.len() as u64).to_le_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update((content.len() as u64).to_le_bytes());
+        hasher.update(content.as_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
 pub fn parse_bundle_import(files: &[BundleImportFile]) -> Result<ParsedBundleImport, String> {
     parse_bundle_import_with_budget(files, WarningBudget::unbounded())
 }
@@ -321,40 +427,7 @@ pub fn parse_bundle_import_with_budget(
     // every file's path the same way regardless of source (zip or raw
     // list) before the allowlist check and before it becomes a lookup key,
     // so both intake paths enforce the same rule on the same canonical form.
-    let mut by_path: HashMap<String, &str> = HashMap::new();
-    for f in files {
-        let Some(safe_path) = sanitize_context_relative_path(&f.path) else {
-            warnings.push(format!("{}: not a safe path; skipped", f.path));
-            continue;
-        };
-        // reagent P1, PR #2379 round 4: case-insensitive on the DIRECTORY
-        // check -- sanitize_context_relative_path never case-folds, so
-        // `ACCOUNTS/secrets.json` (or any other-case variant) previously
-        // sailed past the literal lowercase `starts_with` check while a
-        // manifest reference using the identical casing would still
-        // resolve it. The exception itself stays exact-match against the
-        // canonical lowercase spelling the exporter always emits — an
-        // other-case "requirements.json" is still inside the rejected
-        // directory, just not recognized as the one allowed file.
-        if safe_path.to_ascii_lowercase().starts_with("accounts/") && safe_path != "accounts/requirements.json" {
-            warnings.push(format!(
-                "{safe_path}: rejected — only accounts/requirements.json is ever read from the accounts/ directory"
-            ));
-            continue;
-        }
-        // reagent P2, PR #2379 round 5: `unzip_bundle_import` explicitly
-        // detects and warns on a duplicate entry within a zip ("first
-        // occurrence kept"), but the raw `files` RPC list reaches this
-        // shared loop directly, bypassing that pass entirely — two input
-        // entries normalizing to the same safe_path silently resolved
-        // last-write-wins with no warning, so a caller inspecting the
-        // input couldn't tell which content actually got imported.
-        if by_path.contains_key(&safe_path) {
-            warnings.push(format!("{safe_path}: duplicate path in input; first occurrence kept"));
-            continue;
-        }
-        by_path.insert(safe_path, f.content.as_str());
-    }
+    let by_path = dedup_files_by_path(files, &mut warnings);
 
     let manifest_raw = by_path
         .get("armory.json")
@@ -2034,5 +2107,42 @@ mod tests {
         let display = mcp_server_display(&config);
         assert!(display["name"].is_null());
         assert!(display["command"].is_null());
+    }
+
+    #[test]
+    fn content_digest_raw_bytes_differs_by_mode_for_identical_bytes() {
+        // Phase 3 spec §3.0.5, round 7: file_path and zip_base64 both
+        // canonicalize to the same raw zip bytes -- without a mode tag
+        // mixed into the hash domain, a file_path preview would be
+        // satisfiable by a zip_base64 commit of the same underlying
+        // archive, defeating the round-6 same-mode-required fix.
+        let bytes = b"identical zip bytes";
+        let a = content_digest_raw_bytes(ImportInputMode::FilePath, bytes);
+        let b = content_digest_raw_bytes(ImportInputMode::ZipBase64, bytes);
+        assert_ne!(a, b);
+        // Same mode, same bytes -> identical digest, deterministically.
+        assert_eq!(a, content_digest_raw_bytes(ImportInputMode::FilePath, bytes));
+    }
+
+    #[test]
+    fn content_digest_files_is_order_independent_for_genuinely_equivalent_inputs() {
+        let a = vec![file("armory.json", "{}"), file("instructions/AGENTS.md", "Be concise.")];
+        let b = vec![file("instructions/AGENTS.md", "Be concise."), file("armory.json", "{}")];
+        assert_eq!(content_digest_files(&a), content_digest_files(&b));
+    }
+
+    #[test]
+    fn content_digest_files_changes_when_reordering_changes_the_first_wins_outcome() {
+        // codex P1, PR #2381, round 6: a naive raw-input sort would make
+        // two differently-ordered request bodies hash identically even
+        // when the parser's own first-wins rule would actually import
+        // DIFFERENT content from each (whichever happened to be first).
+        let a = vec![file("instructions/AGENTS.md", "first wins"), file("instructions/AGENTS.md", "second, discarded")];
+        let b = vec![file("instructions/AGENTS.md", "second, discarded"), file("instructions/AGENTS.md", "first wins")];
+        assert_ne!(
+            content_digest_files(&a),
+            content_digest_files(&b),
+            "reordering which entry wins the normalize-then-first-wins reduction must change the digest"
+        );
     }
 }

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -319,6 +319,11 @@ pub const COMMAND_BUNDLE_EXPORT: &str = "bundle.export";
 // file list. No `preset.*` alias — importer postdates the preset->bundle
 // rename, nothing legacy to keep compatible with.
 pub const COMMAND_BUNDLE_IMPORT: &str = "bundle.import";
+// Phase 3 of SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md -- selective import +
+// collision handling. preview is a pure parse (zero Store writes); commit
+// takes the same file plus a selection and writes only what was chosen.
+pub const COMMAND_BUNDLE_IMPORT_PREVIEW: &str = "bundle.import.preview";
+pub const COMMAND_BUNDLE_IMPORT_COMMIT: &str = "bundle.import.commit";
 // Deprecated `preset.*` aliases — kept wired for one release (remove in Phase 4).
 pub const COMMAND_PRESET_LIST: &str = "preset.list";
 pub const COMMAND_PRESET_GET: &str = "preset.get";

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -505,8 +505,17 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     instructions: parsed.instructions,
                     context_files: serde_json::to_string(&parsed.context_files)
                         .unwrap_or_else(|_| "[]".to_string()),
-                    mcp_servers: serde_json::to_string(&parsed.mcp_servers)
-                        .unwrap_or_else(|_| "[]".to_string()),
+                    // Phase 3 spec §3.0, round 2: `parsed.mcp_servers` is now
+                    // `Vec<ParsedMcpServer>{source_path, config}` (a stable
+                    // selection key alongside the raw config) — every write
+                    // site must project to `.config` before serializing, or
+                    // this would persist the wrapper object instead of the
+                    // raw MCP config every consumer of `Memory.mcp_servers`
+                    // expects.
+                    mcp_servers: serde_json::to_string(
+                        &parsed.mcp_servers.iter().map(|m| &m.config).collect::<Vec<_>>(),
+                    )
+                    .unwrap_or_else(|_| "[]".to_string()),
                     skills: serde_json::to_string(&imported_skill_ids)
                         .unwrap_or_else(|_| "[]".to_string()),
                     sort_order: 0,

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -1079,7 +1079,21 @@ async fn bundle_import_commit_impl(
                         Err(crate::backend::storage::error::StoreError::Other(msg))
                             if msg.contains("already exists") =>
                         {
-                            warnings.push(format!("skill \"{effective_slug}\": {msg}"));
+                            // codex P2, PR #2382 round 2: effective_slug can be
+                            // the caller-supplied import_as, which has no
+                            // length bound anywhere before this point (unlike
+                            // a parsed skill.slug, implicitly bounded by the
+                            // per-entry decompression cap) -- and msg's own
+                            // text embeds the identical unbounded value a
+                            // second time (StoreError::Other's own format!
+                            // interpolates skill.name). Use a fixed message
+                            // instead of msg's text (its only informative
+                            // content, "already exists", is already implied by
+                            // the branch guard) and the shared bounded_display
+                            // projection every other warning in this handler
+                            // already uses, closing both unbounded paths at
+                            // once rather than truncating msg's text in place.
+                            warnings.push(format!("skill \"{}\": already exists", bounded_display(&effective_slug)));
                             skipped_skills.push(bounded_display(&effective_slug));
                         }
                         Err(e) => {
@@ -1441,6 +1455,82 @@ mod import_preview_commit_tests {
         let imported_id = resp["imported_skill_ids"][0].as_str().unwrap();
         let saved_skill = state.wstore.skill_get(imported_id).unwrap().unwrap();
         assert_eq!(saved_skill.name, "deploy-team-x");
+    }
+
+    #[tokio::test]
+    async fn commit_bounds_an_oversized_import_as_in_the_already_exists_warning() {
+        // codex P2, PR #2382 round 2: effective_slug (from caller-supplied
+        // import_as) has no length bound before reaching the "already
+        // exists" warning push -- unlike a parsed skill.slug, which is at
+        // least implicitly bounded by the per-entry decompression cap.
+        // StoreError::Other's own message text ALSO embeds the identical
+        // unbounded value a second time.
+        let state = test_state();
+        let oversized_name = "n".repeat(bi::MAX_DISPLAY_FIELD_CHARS + 500);
+        state
+            .wstore
+            .skill_upsert_unique_global(&crate::backend::storage::Skill {
+                id: "existing-1".to_string(),
+                name: "deploy".to_string(),
+                trigger: "deploy".to_string(),
+                skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                description: "pre-existing".to_string(),
+                content: "pre-existing body".to_string(),
+                is_global: true,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+        state
+            .wstore
+            .skill_upsert_unique_global(&crate::backend::storage::Skill {
+                id: "existing-2".to_string(),
+                name: oversized_name.clone(),
+                trigger: oversized_name.clone(),
+                skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                description: "pre-existing".to_string(),
+                content: "pre-existing body".to_string(),
+                is_global: true,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({ "skills": ["skills/deploy"] }))),
+            entry("skills/deploy/SKILL.md", &skill_md("deploy", "d", "body")),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![SkillSelection {
+                source_dir: "skills/deploy".to_string(),
+                import_as: Some(oversized_name),
+            }],
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        assert!(resp["imported_skill_ids"].as_array().unwrap().is_empty());
+        let warnings = resp["warnings"].as_array().unwrap();
+        assert!(!warnings.is_empty(), "expected an already-exists warning");
+        for w in warnings {
+            let s = w.as_str().unwrap();
+            assert!(
+                s.chars().count() <= bi::MAX_DISPLAY_FIELD_CHARS + 3 + 40,
+                "warning not bounded ({} chars): {s:?}",
+                s.chars().count()
+            );
+        }
+        let skipped = resp["skipped_skills"][0].as_str().unwrap();
+        assert!(skipped.chars().count() <= bi::MAX_DISPLAY_FIELD_CHARS + 3);
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -8,6 +8,16 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_bundle_self_get(engine, state);
     register_bundle_export(engine, state);
     register_bundle_import(engine, state);
+    register_bundle_import_preview(engine, state);
+    register_bundle_import_commit(engine, state);
+}
+
+/// Raw `[{path, content}]` entry shape, shared by `bundle.import`'s `files`
+/// input and the Phase 3 `bundle.import.preview`/`.commit` handlers.
+#[derive(serde::Deserialize, Default)]
+struct FileEntry {
+    path: String,
+    content: String,
 }
 
 /// Normalize a `bundle.upsert` request body into the shape the `Memory` struct
@@ -297,21 +307,27 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// `bundle.import.preview`/`.commit` handlers share the exact same
 /// resolution logic rather than duplicating it in a second place where it
 /// could drift.
-struct ResolvedRequirements {
-    resolved_requirement_ids: Vec<String>,
-    /// (id, provider, env, match_count) — full, untruncated values; the
-    /// RPC handler's own response construction applies the shared
-    /// bounded-display projection (Phase 3 spec §3.1, round 11) before
-    /// this is ever serialized.
-    unresolved: Vec<(String, String, String, usize)>,
+/// Full, untruncated values — callers apply the shared bounded-display
+/// projection ([`bounded_display`]) to `id`/`provider`/`env` before ever
+/// serializing these into an RPC response (Phase 3 spec §3.1, round 11).
+struct RequirementResolution {
+    id: String,
+    provider: String,
+    env: String,
+    match_count: usize,
+}
+
+impl RequirementResolution {
+    fn resolved(&self) -> bool {
+        self.match_count == 1
+    }
 }
 
 fn resolve_account_requirements(
     id_store: &crate::backend::storage::store::Store,
     requirements: &[crate::backend::bundle_import::AccountRequirement],
-) -> Result<ResolvedRequirements, String> {
-    let mut resolved_requirement_ids: Vec<String> = Vec::new();
-    let mut unresolved: Vec<(String, String, String, usize)> = Vec::new();
+) -> Result<Vec<RequirementResolution>, String> {
+    let mut results: Vec<RequirementResolution> = Vec::new();
     let mut match_count_by_provider: std::collections::HashMap<&str, usize> =
         std::collections::HashMap::new();
     for requirement in requirements {
@@ -329,13 +345,25 @@ fn resolve_account_requirements(
                 n
             }
         };
-        if match_count == 1 {
-            resolved_requirement_ids.push(requirement.id.clone());
-        } else {
-            unresolved.push((requirement.id.clone(), requirement.provider.clone(), requirement.env.clone(), match_count));
-        }
+        results.push(RequirementResolution {
+            id: requirement.id.clone(),
+            provider: requirement.provider.clone(),
+            env: requirement.env.clone(),
+            match_count,
+        });
     }
-    Ok(ResolvedRequirements { resolved_requirement_ids, unresolved })
+    Ok(results)
+}
+
+/// Shared bounded-display projection (Phase 3 spec, round 12's governing
+/// rule) for every "meant to be short" field both `preview` and `commit`
+/// echo back: skill slug/description, requirement `id`/`provider`/`env`,
+/// context-file `display_path`, bundle `description`, and commit's
+/// `skipped_skills`/`resolved_requirement_ids` entries. `bundle.name` is
+/// NOT projected through this — it's bounded at parse time instead
+/// (round 13), since it's re-submitted verbatim as `bundle_name`.
+fn bounded_display(s: &str) -> String {
+    crate::backend::bundle_import::truncate_display(s, crate::backend::bundle_import::MAX_DISPLAY_FIELD_CHARS)
 }
 
 /// `bundle.import` — ABF importer, Phase 2 of
@@ -361,11 +389,6 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let wstore = wstore.clone();
             let broker = broker.clone();
             Box::pin(async move {
-                #[derive(serde::Deserialize, Default)]
-                struct FileEntry {
-                    path: String,
-                    content: String,
-                }
                 #[derive(serde::Deserialize, Default)]
                 struct Req {
                     #[serde(default)]
@@ -427,17 +450,22 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // account, never writes anything derived from a match.
                 // Phase 3 spec §3.1: extracted into resolve_account_requirements,
                 // shared with the new preview/commit RPC handlers.
+                // Today's existing route keeps its response shape exactly
+                // as before -- unbounded, matching its own already-shipped
+                // behavior. The bounded-display projection below is a
+                // Phase 3 preview/commit-only requirement.
                 let resolved = resolve_account_requirements(&id_store, &parsed.requirements)
                     .map_err(|e| format!("bundle.import: {e}"))?;
-                let resolved_requirement_ids = resolved.resolved_requirement_ids;
+                let resolved_requirement_ids: Vec<String> =
+                    resolved.iter().filter(|r| r.resolved()).map(|r| r.id.clone()).collect();
                 let unresolved_requirements: Vec<serde_json::Value> = resolved
-                    .unresolved
-                    .into_iter()
-                    .map(|(id, provider, env, match_count)| json!({
-                        "id": id,
-                        "provider": provider,
-                        "env": env,
-                        "match_count": match_count,
+                    .iter()
+                    .filter(|r| !r.resolved())
+                    .map(|r| json!({
+                        "id": r.id,
+                        "provider": r.provider,
+                        "env": r.env,
+                        "match_count": r.match_count,
                     }))
                     .collect();
 
@@ -528,8 +556,15 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     provider: String::new(),
                     model: String::new(),
                     instructions: parsed.instructions,
-                    context_files: serde_json::to_string(&parsed.context_files)
-                        .unwrap_or_else(|_| "[]".to_string()),
+                    // Phase 3 spec §3.0: ImportedContextFile gained a
+                    // stable `id` selection key alongside `path`/`content`
+                    // -- project it away before persisting, matching
+                    // `Memory.context_files`'s existing documented
+                    // `[{path, content}]` shape.
+                    context_files: serde_json::to_string(
+                        &parsed.context_files.iter().map(|cf| json!({"path": cf.path, "content": cf.content})).collect::<Vec<_>>(),
+                    )
+                    .unwrap_or_else(|_| "[]".to_string()),
                     // Phase 3 spec §3.0, round 2: `parsed.mcp_servers` is now
                     // `Vec<ParsedMcpServer>{source_path, config}` (a stable
                     // selection key alongside the raw config) — every write
@@ -585,4 +620,933 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+/// On-disk size ceiling for `file_path` input (Phase 3 spec §3.0.5, rounds
+/// 4/5) — generous headroom above `MAX_TOTAL_UNCOMPRESSED_BYTES`'s 50 MiB
+/// for compression/container overhead and imperfectly-compressed content.
+const MAX_ABF_FILE_SIZE_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Reads a `file_path` input server-side (Phase 3 spec §3.0.5). Opens the
+/// path with a no-follow mechanism so a symlink fails to open at all
+/// rather than being silently resolved to its target (round 6) — one
+/// handle, one continuous read, no second path resolution for anything to
+/// race against (round 5's TOCTOU fix): metadata comes from that SAME open
+/// handle and is checked against `MAX_ABF_FILE_SIZE_BYTES` BEFORE any read
+/// (round 4); the actual read is still hard-bounded via `.take(...)`
+/// regardless of what the metadata claimed.
+fn read_abf_file_path(path: &str) -> Result<Vec<u8>, String> {
+    use std::io::Read;
+
+    #[cfg(unix)]
+    let mut file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .map_err(|e| format!("{path}: failed to open: {e}"))?
+    };
+    #[cfg(windows)]
+    let mut file = {
+        use std::os::windows::fs::OpenOptionsExt;
+        // FILE_FLAG_OPEN_REPARSE_POINT (0x0020_0000): opens a symlink/
+        // junction AS the reparse point itself, rather than transparently
+        // following it to its target — the Windows equivalent of Unix's
+        // O_NOFOLLOW, in a single atomic CreateFileW call (no separate
+        // path resolution for a TOCTOU window to open in). The metadata
+        // check immediately below then rejects the handle outright if it
+        // turns out to be a reparse point. Windows symlinks require
+        // elevated privileges to create by default, narrowing (not
+        // eliminating) the practical risk this guards against.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+            .map_err(|e| format!("{path}: failed to open: {e}"))?
+    };
+    #[cfg(not(any(unix, windows)))]
+    let mut file = std::fs::File::open(path).map_err(|e| format!("{path}: failed to open: {e}"))?;
+
+    let metadata = file.metadata().map_err(|e| format!("{path}: failed to stat: {e}"))?;
+    #[cfg(windows)]
+    if metadata.file_type().is_symlink() {
+        return Err(format!("{path}: refusing to follow a symlink"));
+    }
+    if !metadata.is_file() {
+        return Err(format!("{path}: not a regular file"));
+    }
+    if metadata.len() > MAX_ABF_FILE_SIZE_BYTES {
+        return Err(format!(
+            "{path}: size ({} bytes) exceeds the limit ({MAX_ABF_FILE_SIZE_BYTES} bytes)",
+            metadata.len()
+        ));
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut limited = (&mut file).take(MAX_ABF_FILE_SIZE_BYTES + 1);
+    limited.read_to_end(&mut buf).map_err(|e| format!("{path}: failed to read: {e}"))?;
+    if buf.len() as u64 > MAX_ABF_FILE_SIZE_BYTES {
+        return Err(format!("{path}: exceeds the size limit while reading"));
+    }
+    Ok(buf)
+}
+
+/// Bounded warning budget shared by `bundle.import.preview`/`.commit`
+/// (Phase 3 spec §3.1, round 11) — unlike the existing `bundle.import`
+/// route's effectively-unbounded budget, preserved unchanged above.
+fn preview_commit_warning_budget() -> crate::backend::bundle_import::WarningBudget {
+    crate::backend::bundle_import::WarningBudget::bounded(200, 300)
+}
+
+/// Final combined-list bound applied to a preview/commit response's
+/// `warnings` (Phase 3 spec §3.1 round 8 / round 9's commit-response
+/// generalization) — cheap defense-in-depth over an already
+/// per-source-bounded list (each of `resolve_import_input`'s intake
+/// warnings and `parse_bundle_import_with_budget`'s own warnings is
+/// already individually bounded; concatenating two independently-bounded
+/// lists can still exceed either bound alone, so one more pass caps the
+/// combined total before it's ever serialized).
+fn bound_warnings_for_response(warnings: Vec<String>) -> (Vec<String>, bool) {
+    const MAX_COMBINED_WARNINGS: usize = 200;
+    if warnings.len() <= MAX_COMBINED_WARNINGS {
+        (warnings, false)
+    } else {
+        let mut kept: Vec<String> = warnings.into_iter().take(MAX_COMBINED_WARNINGS).collect();
+        kept.push("... additional warnings not shown".to_string());
+        (kept, true)
+    }
+}
+
+/// The outcome of resolving one of `file_path`/`zip_base64`/`files` into
+/// intake-ready files plus the Phase 3 content digest (§3.0.5) — shared by
+/// `bundle.import.preview` and `.commit` so both compute the digest
+/// identically. The mode tag baked into `content_digest` (round 7) means a
+/// plain digest-equality check at commit is sufficient to enforce "same
+/// input mode as preview" (round 6) — no separate mode field is needed.
+#[derive(Debug)]
+struct ResolvedImportInput {
+    files: Vec<crate::backend::bundle_import::BundleImportFile>,
+    intake_warnings: Vec<String>,
+    content_digest: String,
+}
+
+fn resolve_import_input(
+    file_path: Option<String>,
+    zip_base64: Option<String>,
+    files: Option<Vec<FileEntry>>,
+    warning_budget: crate::backend::bundle_import::WarningBudget,
+) -> Result<ResolvedImportInput, String> {
+    use crate::backend::bundle_import as bi;
+    let provided = [file_path.is_some(), zip_base64.is_some(), files.is_some()]
+        .iter()
+        .filter(|p| **p)
+        .count();
+    if provided != 1 {
+        return Err(format!(
+            "exactly one of file_path/zip_base64/files must be present, got {provided}"
+        ));
+    }
+    if let Some(path) = file_path {
+        let raw = read_abf_file_path(&path)?;
+        let content_digest = bi::content_digest_raw_bytes(bi::ImportInputMode::FilePath, &raw);
+        let (files, intake_warnings) = bi::unzip_bundle_import_with_budget(&raw, warning_budget)?;
+        return Ok(ResolvedImportInput { files, intake_warnings, content_digest });
+    }
+    if let Some(b64) = zip_base64 {
+        use base64::Engine as _;
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .map_err(|e| format!("invalid zip_base64: {e}"))?;
+        let content_digest = bi::content_digest_raw_bytes(bi::ImportInputMode::ZipBase64, &raw);
+        let (files, intake_warnings) = bi::unzip_bundle_import_with_budget(&raw, warning_budget)?;
+        return Ok(ResolvedImportInput { files, intake_warnings, content_digest });
+    }
+    let files = files.expect("exactly one input already validated present");
+    let raw_files: Vec<bi::BundleImportFile> = files
+        .into_iter()
+        .map(|f| bi::BundleImportFile { path: f.path, content: f.content })
+        .collect();
+    let (capped_files, intake_warnings) = bi::enforce_raw_files_caps_with_budget(raw_files, warning_budget)?;
+    let content_digest = bi::content_digest_files(&capped_files);
+    Ok(ResolvedImportInput { files: capped_files, intake_warnings, content_digest })
+}
+
+#[derive(serde::Deserialize, Default)]
+struct PreviewReq {
+    #[serde(default)]
+    file_path: Option<String>,
+    #[serde(default)]
+    zip_base64: Option<String>,
+    #[serde(default)]
+    files: Option<Vec<FileEntry>>,
+}
+
+/// `bundle.import.preview` — Phase 3 of
+/// docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §3.1. Pure parse plus
+/// read-only collision/name-collision lookups — zero Store writes. Window-
+/// scoped like the rest of `bundle.*`. Extracted from the RPC closure into
+/// a directly-callable, directly-testable function (the closure itself
+/// only deserializes the request and forwards).
+async fn bundle_import_preview_impl(
+    id_store: &crate::backend::storage::store::Store,
+    wstore: &crate::backend::storage::store::Store,
+    req: PreviewReq,
+) -> Result<serde_json::Value, String> {
+    use crate::backend::bundle_import as bi;
+
+    let resolved = resolve_import_input(req.file_path, req.zip_base64, req.files, preview_commit_warning_budget())
+        .map_err(|e| format!("bundle.import.preview: {e}"))?;
+
+    let parsed = bi::parse_bundle_import_with_budget(&resolved.files, preview_commit_warning_budget())
+        .map_err(|e| format!("bundle.import.preview: {e}"))?;
+
+    let mut all_warnings = resolved.intake_warnings;
+    all_warnings.extend(parsed.warnings);
+
+    // Skill collision detection (§3.1, two-pass).
+    let global_slugs: std::collections::HashSet<String> = wstore
+        .skill_list_global()
+        .map_err(|e| format!("bundle.import.preview: {e}"))?
+        .into_iter()
+        .map(|item| item.skill.name)
+        .collect();
+    let in_bundle_dupes = bi::duplicate_in_bundle_slugs(&parsed.skills);
+
+    let skills_json: Vec<serde_json::Value> = parsed
+        .skills
+        .iter()
+        .map(|skill| {
+            let collision = bi::classify_skill_collision(&skill.slug, &global_slugs, &in_bundle_dupes);
+            json!({
+                "source_dir": skill.source_dir,
+                "slug": bounded_display(&skill.slug),
+                "description": bounded_display(&skill.description),
+                "collision": collision,
+            })
+        })
+        .collect();
+
+    let mcp_servers_json: Vec<serde_json::Value> = parsed
+        .mcp_servers
+        .iter()
+        .map(|m| json!({
+            "source_path": m.source_path,
+            "display": bi::mcp_server_display(&m.config),
+        }))
+        .collect();
+
+    let (instructions_preview, instructions_truncated, instructions_total_chars) =
+        bi::bounded_instructions_preview(&parsed.instructions);
+
+    let context_files_json: Vec<serde_json::Value> = parsed
+        .context_files
+        .iter()
+        .map(|cf| json!({
+            "id": cf.id,
+            "display_path": bounded_display(&cf.path),
+            "size_bytes": cf.content.len(),
+        }))
+        .collect();
+
+    let resolved_requirements = resolve_account_requirements(id_store, &parsed.requirements)
+        .map_err(|e| format!("bundle.import.preview: {e}"))?;
+    let requirements_json: Vec<serde_json::Value> = resolved_requirements
+        .iter()
+        .map(|r| json!({
+            "id": bounded_display(&r.id),
+            "provider": bounded_display(&r.provider),
+            "env": bounded_display(&r.env),
+            "resolved": r.resolved(),
+            "match_count": r.match_count,
+        }))
+        .collect();
+
+    // Bundle name collision -- soft, informational (§2: bundle_memory_upsert
+    // has no name uniqueness constraint, so this never blocks).
+    let existing_names: std::collections::HashSet<String> = id_store
+        .bundle_memory_list()
+        .map_err(|e| format!("bundle.import.preview: {e}"))?
+        .into_iter()
+        .map(|b| b.name)
+        .collect();
+    let name_collision = existing_names.contains(&parsed.name);
+
+    let (warnings, warnings_truncated) = bound_warnings_for_response(all_warnings);
+
+    Ok(json!({
+        "name": parsed.name,
+        "description": bounded_display(&parsed.description),
+        "instructions_preview": instructions_preview,
+        "instructions_truncated": instructions_truncated,
+        "instructions_total_chars": instructions_total_chars,
+        "context_files": context_files_json,
+        "skills": skills_json,
+        "mcp_servers": mcp_servers_json,
+        "requirements": requirements_json,
+        "warnings": warnings,
+        "warnings_truncated": warnings_truncated,
+        "name_collision": name_collision,
+        "content_digest": resolved.content_digest,
+    }))
+}
+
+fn register_bundle_import_preview(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_BUNDLE_IMPORT_PREVIEW,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let req: PreviewReq = serde_json::from_value(data)
+                    .map_err(|e| format!("bundle.import.preview: {e}"))?;
+                Ok(Some(bundle_import_preview_impl(&id_store, &wstore, req).await?))
+            })
+        }),
+    );
+}
+
+#[derive(serde::Deserialize)]
+struct SkillSelection {
+    source_dir: String,
+    #[serde(default)]
+    import_as: Option<String>,
+}
+#[derive(serde::Deserialize, Default)]
+struct CommitReq {
+    #[serde(default)]
+    file_path: Option<String>,
+    #[serde(default)]
+    zip_base64: Option<String>,
+    #[serde(default)]
+    files: Option<Vec<FileEntry>>,
+    #[serde(default)]
+    expected_content_digest: String,
+    #[serde(default)]
+    bundle_name: Option<String>,
+    #[serde(default)]
+    include_instructions: bool,
+    #[serde(default)]
+    include_context_files: Vec<usize>,
+    #[serde(default)]
+    include_skills: Vec<SkillSelection>,
+    #[serde(default)]
+    include_mcp_servers: Vec<String>,
+}
+
+/// `bundle.import.commit` — Phase 3 §3.2. Re-resolves and re-parses the
+/// same input fresh (never trusts client-supplied preview data for
+/// anything written), rejects on a content-digest mismatch, then writes
+/// only the selected items. Shares `bundle.import`'s existing skill-write/
+/// rollback logic; the differences are selection filtering, the
+/// `bundle_name`/`import_as` overrides, and the digest gate. Extracted
+/// from the RPC closure into a directly-callable, directly-testable
+/// function (the closure itself only deserializes the request and
+/// forwards).
+async fn bundle_import_commit_impl(
+    id_store: &crate::backend::storage::store::Store,
+    wstore: &crate::backend::storage::store::Store,
+    broker: &crate::backend::wps::Broker,
+    req: CommitReq,
+) -> Result<serde_json::Value, String> {
+    use crate::backend::bundle_import as bi;
+
+                let resolved = resolve_import_input(req.file_path, req.zip_base64, req.files, preview_commit_warning_budget())
+                    .map_err(|e| format!("bundle.import.commit: {e}"))?;
+
+                // §3.0.5: reject BEFORE doing anything else on a mismatch --
+                // never a partial import against whatever content was
+                // actually given. The mode tag baked into content_digest
+                // (round 7) means this single comparison also enforces
+                // "same input mode as preview" (round 6) with no separate
+                // mode field needed.
+                if resolved.content_digest != req.expected_content_digest {
+                    return Err(
+                        "bundle.import.commit: content changed since preview (digest mismatch) — re-select and preview again"
+                            .to_string(),
+                    );
+                }
+
+                let parsed = bi::parse_bundle_import_with_budget(&resolved.files, preview_commit_warning_budget())
+                    .map_err(|e| format!("bundle.import.commit: {e}"))?;
+
+                let mut warnings = resolved.intake_warnings;
+                warnings.extend(parsed.warnings.clone());
+
+                // codex P2, PR #2381 round 11: bundle_name must actually be
+                // substituted for parsed.name, never silently ignored.
+                let bundle_name = req.bundle_name.unwrap_or_else(|| parsed.name.clone());
+
+                let instructions = if req.include_instructions { parsed.instructions.clone() } else { String::new() };
+
+                // include_context_files selects by the stable `id` (round
+                // 13), never by (truncatable) display_path.
+                let selected_context_files: Vec<serde_json::Value> = parsed
+                    .context_files
+                    .iter()
+                    .filter(|cf| req.include_context_files.contains(&cf.id))
+                    .map(|cf| json!({ "path": cf.path, "content": cf.content }))
+                    .collect();
+
+                // include_mcp_servers selects by source_path (§3.0), never
+                // by a JSON "name" field. The write path projects to
+                // .config, matching the §3.0 amendment.
+                let include_mcp: std::collections::HashSet<&str> =
+                    req.include_mcp_servers.iter().map(|s| s.as_str()).collect();
+                let selected_mcp_servers: Vec<&serde_json::Value> = parsed
+                    .mcp_servers
+                    .iter()
+                    .filter(|m| include_mcp.contains(m.source_path.as_str()))
+                    .map(|m| &m.config)
+                    .collect();
+
+                let resolved_reqs = resolve_account_requirements(id_store, &parsed.requirements)
+                    .map_err(|e| format!("bundle.import.commit: {e}"))?;
+                // codex P2, PR #2381 round 12: commit's response reuses the
+                // exact same bounded-display projection preview's
+                // equivalent fields use, via the shared bounded_display fn.
+                let resolved_requirement_ids: Vec<String> =
+                    resolved_reqs.iter().filter(|r| r.resolved()).map(|r| bounded_display(&r.id)).collect();
+                let unresolved_requirements: Vec<serde_json::Value> = resolved_reqs
+                    .iter()
+                    .filter(|r| !r.resolved())
+                    .map(|r| json!({
+                        "id": bounded_display(&r.id),
+                        "provider": bounded_display(&r.provider),
+                        "env": bounded_display(&r.env),
+                        "match_count": r.match_count,
+                    }))
+                    .collect();
+
+                // Two-pass skill collision, recomputed server-side --
+                // §4.1 point 4's "empty rename on a colliding skill = skip"
+                // rule is enforced authoritatively here, not left to a
+                // possibly-buggy/malicious client to have honored: without
+                // this, a "duplicate_in_bundle" collision (not yet in the
+                // global catalog) would let the FIRST of two same-slug
+                // skills write successfully under its own slug even with
+                // an empty rename, since skill_upsert_unique_global alone
+                // wouldn't reject it until the second attempt.
+                let global_slugs: std::collections::HashSet<String> = wstore
+                    .skill_list_global()
+                    .map_err(|e| format!("bundle.import.commit: {e}"))?
+                    .into_iter()
+                    .map(|item| item.skill.name)
+                    .collect();
+                let in_bundle_dupes = bi::duplicate_in_bundle_slugs(&parsed.skills);
+
+                let rollback_skills = |ids: &[String]| -> Vec<String> {
+                    ids.iter()
+                        .filter_map(|id| wstore.skill_delete(id).err().map(|e| format!("{id}: {e}")))
+                        .collect()
+                };
+
+                let now = now_ms();
+                let mut imported_skill_ids: Vec<String> = Vec::new();
+                let mut skipped_skills: Vec<String> = Vec::new();
+
+                for selection in &req.include_skills {
+                    let Some(skill) = parsed.skills.iter().find(|s| s.source_dir == selection.source_dir) else {
+                        continue; // source_dir not present in this parse -- nothing to import
+                    };
+                    let collision = bi::classify_skill_collision(&skill.slug, &global_slugs, &in_bundle_dupes);
+                    let non_empty_rename = selection.import_as.as_deref().filter(|s| !s.is_empty());
+
+                    if collision != "none" && non_empty_rename.is_none() {
+                        // §4.1 point 4: never silently sent through with
+                        // its original, known-conflicting slug.
+                        skipped_skills.push(bounded_display(&skill.slug));
+                        continue;
+                    }
+                    let effective_slug = non_empty_rename.map(|s| s.to_string()).unwrap_or_else(|| skill.slug.clone());
+
+                    let row = crate::backend::storage::Skill {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name: effective_slug.clone(),
+                        trigger: effective_slug.clone(),
+                        skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                        description: skill.description.clone(),
+                        content: skill.content.clone(),
+                        is_global: true,
+                        created_at: now,
+                        updated_at: now,
+                    };
+                    match wstore.skill_upsert_unique_global(&row) {
+                        Ok(()) => imported_skill_ids.push(row.id),
+                        Err(crate::backend::storage::error::StoreError::Other(msg))
+                            if msg.contains("already exists") =>
+                        {
+                            warnings.push(format!("skill \"{effective_slug}\": {msg}"));
+                            skipped_skills.push(bounded_display(&effective_slug));
+                        }
+                        Err(e) => {
+                            let rollback_errors = rollback_skills(&imported_skill_ids);
+                            let mut msg = format!(
+                                "bundle.import.commit: failed to create skill \"{effective_slug}\": {e}"
+                            );
+                            if !rollback_errors.is_empty() {
+                                msg.push_str(&format!(
+                                    "; additionally, rollback of {} previously-created skill(s) failed and may have left orphaned global skill row(s): {}",
+                                    rollback_errors.len(),
+                                    rollback_errors.join("; ")
+                                ));
+                            }
+                            return Err(msg);
+                        }
+                    }
+                }
+
+                let memory = Memory {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name: bundle_name,
+                    description: parsed.description,
+                    is_blank: false,
+                    is_global: false,
+                    provider: String::new(),
+                    model: String::new(),
+                    instructions,
+                    context_files: serde_json::to_string(&selected_context_files)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    mcp_servers: serde_json::to_string(&selected_mcp_servers)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    skills: serde_json::to_string(&imported_skill_ids)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    sort_order: 0,
+                    created_at: now,
+                    updated_at: now,
+                };
+                if let Err(e) = id_store.bundle_memory_upsert(&memory) {
+                    let rollback_errors = rollback_skills(&imported_skill_ids);
+                    let mut msg = format!("bundle.import.commit: {e}");
+                    if !rollback_errors.is_empty() {
+                        msg.push_str(&format!(
+                            "; additionally, rollback of {} previously-created skill(s) failed and may have left orphaned global skill row(s): {}",
+                            rollback_errors.len(),
+                            rollback_errors.join("; ")
+                        ));
+                    }
+                    return Err(msg);
+                }
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "memories:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                if !imported_skill_ids.is_empty() {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "skills:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+
+                // codex P1, PR #2381 round 9: bounded the same as preview's
+                // response, not left unbounded like today's bundle.import.
+                let (bounded_warnings, warnings_truncated) = bound_warnings_for_response(warnings);
+
+    Ok(json!({
+        "bundle_id": memory.id,
+        "imported_skill_ids": imported_skill_ids,
+        "skipped_skills": skipped_skills,
+        "resolved_requirement_ids": resolved_requirement_ids,
+        "unresolved_requirements": unresolved_requirements,
+        "warnings": bounded_warnings,
+        "warnings_truncated": warnings_truncated,
+    }))
+}
+
+fn register_bundle_import_commit(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_BUNDLE_IMPORT_COMMIT,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let req: CommitReq = serde_json::from_value(data)
+                    .map_err(|e| format!("bundle.import.commit: {e}"))?;
+                Ok(Some(bundle_import_commit_impl(&id_store, &wstore, &broker, req).await?))
+            })
+        }),
+    );
+}
+
+#[cfg(test)]
+mod import_preview_commit_tests {
+    use super::*;
+    use crate::backend::bundle_import as bi;
+    use crate::server::tests::test_state;
+
+    fn manifest(components: serde_json::Value) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "$schema": "https://docs.agentmux.ai/schemas/armory-bundle/v0.1/bundle.schema.json",
+            "name": "test-bundle",
+            "version": "0.1.0",
+            "description": "A test bundle",
+            "components": components,
+            "metadata": {},
+        }))
+        .unwrap()
+    }
+
+    fn entry(path: &str, content: &str) -> FileEntry {
+        FileEntry { path: path.to_string(), content: content.to_string() }
+    }
+
+    fn skill_md(name: &str, description: &str, body: &str) -> String {
+        crate::backend::agent_config::render_skill_md(name, description, body)
+    }
+
+    #[tokio::test]
+    async fn preview_returns_parsed_bundle_with_digest() {
+        let state = test_state();
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md", "instructions/context/notes.md"],
+                "skills": ["skills/deploy"],
+            }))),
+            entry("instructions/AGENTS.md", "Be concise."),
+            entry("instructions/context/notes.md", "Extra context."),
+            entry("skills/deploy/SKILL.md", &skill_md("deploy", "Runs the checklist", "1. Test\n2. Deploy")),
+        ];
+        let req = PreviewReq { file_path: None, zip_base64: None, files: Some(files) };
+        let resp = bundle_import_preview_impl(&state.id_store, &state.wstore, req).await.unwrap();
+
+        assert_eq!(resp["name"], "test-bundle");
+        assert_eq!(resp["instructions_preview"], "Be concise.");
+        assert_eq!(resp["context_files"][0]["id"], 0);
+        assert_eq!(resp["context_files"][0]["display_path"], "notes.md");
+        assert_eq!(resp["skills"][0]["source_dir"], "skills/deploy");
+        assert_eq!(resp["skills"][0]["slug"], "deploy");
+        assert_eq!(resp["skills"][0]["collision"], "none");
+        assert!(resp["content_digest"].as_str().unwrap().len() > 0);
+        assert_eq!(resp["name_collision"], false);
+    }
+
+    #[tokio::test]
+    async fn preview_flags_name_conflict_against_existing_global_skill() {
+        let state = test_state();
+        // Seed an existing global skill named "deploy".
+        state
+            .wstore
+            .skill_upsert_unique_global(&crate::backend::storage::Skill {
+                id: "existing-1".to_string(),
+                name: "deploy".to_string(),
+                trigger: "deploy".to_string(),
+                skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                description: "pre-existing".to_string(),
+                content: "pre-existing body".to_string(),
+                is_global: true,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({ "skills": ["skills/deploy"] }))),
+            entry("skills/deploy/SKILL.md", &skill_md("deploy", "d", "body")),
+        ];
+        let req = PreviewReq { file_path: None, zip_base64: None, files: Some(files) };
+        let resp = bundle_import_preview_impl(&state.id_store, &state.wstore, req).await.unwrap();
+        assert_eq!(resp["skills"][0]["collision"], "name_conflict");
+    }
+
+    #[tokio::test]
+    async fn preview_flags_duplicate_in_bundle_when_two_parsed_skills_share_a_slug() {
+        // Phase 3 spec §3.1, codex P1 round 2: two skills within the same
+        // bundle sharing a slug that ISN'T yet global must both be flagged,
+        // not silently passed as "none".
+        let state = test_state();
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({
+                "skills": ["skills/code-review-v2", "skills/code-review-old"],
+            }))),
+            entry("skills/code-review-v2/SKILL.md", &skill_md("code-review", "new", "body-new")),
+            entry("skills/code-review-old/SKILL.md", &skill_md("code-review", "old", "body-old")),
+        ];
+        let req = PreviewReq { file_path: None, zip_base64: None, files: Some(files) };
+        let resp = bundle_import_preview_impl(&state.id_store, &state.wstore, req).await.unwrap();
+        let skills = resp["skills"].as_array().unwrap();
+        assert_eq!(skills.len(), 2);
+        assert!(skills.iter().all(|s| s["collision"] == "duplicate_in_bundle"));
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_on_digest_mismatch_and_writes_nothing() {
+        let state = test_state();
+        let files = vec![entry("armory.json", &manifest(serde_json::json!({})))];
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: "not-the-real-digest".to_string(),
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![],
+            include_mcp_servers: vec![],
+        };
+        let err = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req)
+            .await
+            .unwrap_err();
+        assert!(err.contains("digest mismatch"));
+        assert!(state.id_store.bundle_memory_list().unwrap().iter().all(|b| b.name != "test-bundle"));
+    }
+
+    #[tokio::test]
+    async fn commit_applies_bundle_name_override_not_parsed_name() {
+        // codex P2, PR #2381 round 11: bundle_name must actually be
+        // substituted for Memory.name, never silently ignored.
+        let state = test_state();
+        let files = vec![entry("armory.json", &manifest(serde_json::json!({})))];
+        let digest = bi::content_digest_files(&files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect::<Vec<_>>());
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: Some("Renamed Bundle".to_string()),
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![],
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let bundle_id = resp["bundle_id"].as_str().unwrap();
+        let saved = state.id_store.bundle_memory_get(bundle_id).unwrap().unwrap();
+        assert_eq!(saved.name, "Renamed Bundle");
+    }
+
+    #[tokio::test]
+    async fn commit_selects_context_files_by_id_not_display_path() {
+        let state = test_state();
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({
+                "instructions": ["instructions/context/a.md", "instructions/context/b.md"],
+            }))),
+            entry("instructions/context/a.md", "content A"),
+            entry("instructions/context/b.md", "content B"),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+        // Only select id 1 (b.md) -- verify a.md (id 0) is excluded.
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![1],
+            include_skills: vec![],
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let bundle_id = resp["bundle_id"].as_str().unwrap();
+        let saved = state.id_store.bundle_memory_get(bundle_id).unwrap().unwrap();
+        assert!(saved.context_files.contains("content B"));
+        assert!(!saved.context_files.contains("content A"));
+    }
+
+    #[tokio::test]
+    async fn commit_skips_colliding_skill_left_with_an_empty_rename() {
+        // §4.1 point 4: never silently sent through under its original,
+        // known-conflicting slug.
+        let state = test_state();
+        state
+            .wstore
+            .skill_upsert_unique_global(&crate::backend::storage::Skill {
+                id: "existing-1".to_string(),
+                name: "deploy".to_string(),
+                trigger: "deploy".to_string(),
+                skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                description: "pre-existing".to_string(),
+                content: "pre-existing body".to_string(),
+                is_global: true,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({ "skills": ["skills/deploy"] }))),
+            entry("skills/deploy/SKILL.md", &skill_md("deploy", "d", "body")),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![SkillSelection { source_dir: "skills/deploy".to_string(), import_as: None }],
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        assert!(resp["imported_skill_ids"].as_array().unwrap().is_empty());
+        assert_eq!(resp["skipped_skills"][0], "deploy");
+    }
+
+    #[tokio::test]
+    async fn commit_imports_colliding_skill_under_a_non_empty_rename() {
+        let state = test_state();
+        state
+            .wstore
+            .skill_upsert_unique_global(&crate::backend::storage::Skill {
+                id: "existing-1".to_string(),
+                name: "deploy".to_string(),
+                trigger: "deploy".to_string(),
+                skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+                description: "pre-existing".to_string(),
+                content: "pre-existing body".to_string(),
+                is_global: true,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({ "skills": ["skills/deploy"] }))),
+            entry("skills/deploy/SKILL.md", &skill_md("deploy", "d", "body")),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![SkillSelection {
+                source_dir: "skills/deploy".to_string(),
+                import_as: Some("deploy-team-x".to_string()),
+            }],
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        assert_eq!(resp["imported_skill_ids"].as_array().unwrap().len(), 1);
+        let imported_id = resp["imported_skill_ids"][0].as_str().unwrap();
+        let saved_skill = state.wstore.skill_get(imported_id).unwrap().unwrap();
+        assert_eq!(saved_skill.name, "deploy-team-x");
+    }
+
+    #[tokio::test]
+    async fn commit_persists_raw_mcp_config_not_the_source_path_wrapper() {
+        // Phase 3 spec §3.0, round 2: every write site touching
+        // parsed.mcp_servers must project to .config before serializing.
+        let state = test_state();
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({ "mcpServers": ["mcp/github.server.json"] }))),
+            entry("mcp/github.server.json", r#"{"command":"npx","args":["-y","gh-mcp"]}"#),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![],
+            include_mcp_servers: vec!["mcp/github.server.json".to_string()],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let bundle_id = resp["bundle_id"].as_str().unwrap();
+        let saved = state.id_store.bundle_memory_get(bundle_id).unwrap().unwrap();
+        let mcp_servers: serde_json::Value = serde_json::from_str(&saved.mcp_servers).unwrap();
+        assert_eq!(mcp_servers[0]["command"], "npx");
+        assert!(mcp_servers[0].get("source_path").is_none(), "must not persist the {{source_path, config}} wrapper");
+    }
+
+    #[tokio::test]
+    async fn read_abf_file_path_rejects_a_missing_path() {
+        let err = read_abf_file_path("C:\\definitely\\not\\a\\real\\path.abf").unwrap_err();
+        assert!(err.contains("failed to open") || err.contains("failed to stat"));
+    }
+
+    #[tokio::test]
+    async fn read_abf_file_path_rejects_a_directory() {
+        let dir = std::env::temp_dir();
+        let err = read_abf_file_path(dir.to_str().unwrap()).unwrap_err();
+        assert!(err.contains("not a regular file") || err.contains("failed to open"));
+    }
+
+    #[tokio::test]
+    async fn read_abf_file_path_reads_a_small_file_correctly() {
+        let path = std::env::temp_dir().join(format!("abf-test-{}.bin", std::process::id()));
+        std::fs::write(&path, b"hello abf").unwrap();
+        let result = read_abf_file_path(path.to_str().unwrap());
+        std::fs::remove_file(&path).ok();
+        assert_eq!(result.unwrap(), b"hello abf".to_vec());
+    }
+
+    #[tokio::test]
+    async fn read_abf_file_path_rejects_a_file_over_the_size_cap_via_sparse_file() {
+        // Verified via a sparse/pre-allocated file (metadata-based rejection,
+        // before any read) rather than actually writing 100MB+ to disk.
+        let path = std::env::temp_dir().join(format!("abf-test-oversized-{}.bin", std::process::id()));
+        {
+            let file = std::fs::File::create(&path).unwrap();
+            file.set_len(MAX_ABF_FILE_SIZE_BYTES + 1).unwrap();
+        }
+        let result = read_abf_file_path(path.to_str().unwrap());
+        std::fs::remove_file(&path).ok();
+        let err = result.unwrap_err();
+        assert!(err.contains("exceeds the limit"), "expected a size-limit error, got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_abf_file_path_rejects_a_symlink() {
+        let target = std::env::temp_dir().join(format!("abf-symlink-target-{}.bin", std::process::id()));
+        let link = std::env::temp_dir().join(format!("abf-symlink-{}.bin", std::process::id()));
+        std::fs::write(&target, b"real content").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let result = read_abf_file_path(link.to_str().unwrap());
+        std::fs::remove_file(&target).ok();
+        std::fs::remove_file(&link).ok();
+        assert!(result.is_err(), "opening a symlink via file_path must fail, not silently follow it");
+    }
+
+    #[test]
+    fn bound_warnings_for_response_caps_the_combined_list() {
+        let many: Vec<String> = (0..500).map(|i| format!("warning {i}")).collect();
+        let (bounded, truncated) = bound_warnings_for_response(many);
+        assert!(truncated);
+        assert!(bounded.len() <= 201);
+        assert!(bounded.last().unwrap().contains("not shown"));
+    }
+
+    #[test]
+    fn bound_warnings_for_response_leaves_a_short_list_untouched() {
+        let few = vec!["a".to_string(), "b".to_string()];
+        let (bounded, truncated) = bound_warnings_for_response(few.clone());
+        assert!(!truncated);
+        assert_eq!(bounded, few);
+    }
+
+    #[test]
+    fn resolve_import_input_rejects_when_zero_or_multiple_inputs_given() {
+        let budget = bi::WarningBudget::unbounded();
+        let none = resolve_import_input(None, None, None, budget).unwrap_err();
+        assert!(none.contains("exactly one"));
+        let both = resolve_import_input(Some("x".to_string()), Some("y".to_string()), None, budget).unwrap_err();
+        assert!(both.contains("exactly one"));
+    }
 }

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -978,7 +978,12 @@ async fn bundle_import_commit_impl(
 
                 // codex P2, PR #2381 round 11: bundle_name must actually be
                 // substituted for parsed.name, never silently ignored.
-                let bundle_name = req.bundle_name.unwrap_or_else(|| parsed.name.clone());
+                // reagentx P2, PR #2382 round 3: unlike parsed.name (bounded
+                // at parse time), a client-supplied override had no length
+                // cap at all -- bound_bundle_name closes that gap the same
+                // way for both paths (a no-op when bundle_name is already
+                // parsed.name, since that's already within the cap).
+                let bundle_name = bi::bound_bundle_name(&req.bundle_name.unwrap_or_else(|| parsed.name.clone()));
 
                 let instructions = if req.include_instructions { parsed.instructions.clone() } else { String::new() };
 
@@ -1048,7 +1053,25 @@ async fn bundle_import_commit_impl(
                 let mut imported_skill_ids: Vec<String> = Vec::new();
                 let mut skipped_skills: Vec<String> = Vec::new();
 
-                for selection in &req.include_skills {
+                // reagentx P1, PR #2382 round 3: req.include_skills is
+                // client-supplied with no length cap and no dedup by
+                // source_dir -- an unbounded/repeated array could otherwise
+                // drive an unbounded number of skill_upsert_unique_global
+                // Store writes regardless of how many skills the archive
+                // itself actually parsed to (parsed.skills is already
+                // bounded by MAX_IMPORTED_SKILLS). First occurrence wins per
+                // source_dir (matches this module's existing duplicate-
+                // reference convention elsewhere), then capped at the same
+                // MAX_IMPORTED_SKILLS the parser itself enforces.
+                let mut seen_source_dirs: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                let deduped_skill_selections: Vec<&SkillSelection> = req
+                    .include_skills
+                    .iter()
+                    .filter(|s| seen_source_dirs.insert(s.source_dir.as_str()))
+                    .take(bi::MAX_IMPORTED_SKILLS)
+                    .collect();
+
+                for selection in deduped_skill_selections {
                     let Some(skill) = parsed.skills.iter().find(|s| s.source_dir == selection.source_dir) else {
                         continue; // source_dir not present in this parse -- nothing to import
                     };
@@ -1334,6 +1357,115 @@ mod import_preview_commit_tests {
         let bundle_id = resp["bundle_id"].as_str().unwrap();
         let saved = state.id_store.bundle_memory_get(bundle_id).unwrap().unwrap();
         assert_eq!(saved.name, "Renamed Bundle");
+    }
+
+    #[tokio::test]
+    async fn commit_bounds_an_oversized_bundle_name_override() {
+        // reagentx P2, PR #2382 round 3: unlike parsed.name (bounded at
+        // parse time), req.bundle_name had no length cap of its own before
+        // being used verbatim as Memory.name.
+        let state = test_state();
+        let files = vec![entry("armory.json", &manifest(serde_json::json!({})))];
+        let digest = bi::content_digest_files(&files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect::<Vec<_>>());
+        let oversized_name = "n".repeat(bi::MAX_BUNDLE_NAME_CHARS + 500);
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: Some(oversized_name),
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills: vec![],
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let bundle_id = resp["bundle_id"].as_str().unwrap();
+        let saved = state.id_store.bundle_memory_get(bundle_id).unwrap().unwrap();
+        assert_eq!(saved.name.chars().count(), bi::MAX_BUNDLE_NAME_CHARS);
+    }
+
+    #[tokio::test]
+    async fn commit_dedupes_repeated_source_dirs_in_include_skills_first_occurrence_wins() {
+        // reagentx P1, PR #2382 round 3: a client repeating the same
+        // source_dir with a different import_as each time must not drive
+        // one Store write per repetition.
+        let state = test_state();
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({ "skills": ["skills/deploy"] }))),
+            entry("skills/deploy/SKILL.md", &skill_md("deploy", "d", "body")),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+        let include_skills: Vec<SkillSelection> = (0..50)
+            .map(|i| SkillSelection { source_dir: "skills/deploy".to_string(), import_as: Some(format!("deploy-{i}")) })
+            .collect();
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills,
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let imported = resp["imported_skill_ids"].as_array().unwrap();
+        assert_eq!(imported.len(), 1, "expected only the first occurrence of the repeated source_dir to be written");
+        let saved_skill = state.wstore.skill_get(imported[0].as_str().unwrap()).unwrap().unwrap();
+        assert_eq!(saved_skill.name, "deploy-0");
+    }
+
+    #[tokio::test]
+    async fn commit_caps_include_skills_at_max_imported_skills() {
+        // reagentx P1, PR #2382 round 3: an include_skills array longer
+        // than MAX_IMPORTED_SKILLS must not drive more than that many
+        // skill_upsert_unique_global write attempts. Distinct-but-bogus
+        // source_dirs (each a cheap no-op "continue") occupy the first
+        // MAX_IMPORTED_SKILLS positions; three genuinely resolvable
+        // selections are placed AFTER that boundary. If the cap truncates
+        // the selection list itself (not just deduping), those three are
+        // silently dropped -- proving the cap applies before resolution,
+        // not just as an incidental side effect of the dedup fix.
+        let state = test_state();
+        let files = vec![
+            entry("armory.json", &manifest(serde_json::json!({
+                "skills": ["skills/a", "skills/b", "skills/c"],
+            }))),
+            entry("skills/a/SKILL.md", &skill_md("a", "d", "body")),
+            entry("skills/b/SKILL.md", &skill_md("b", "d", "body")),
+            entry("skills/c/SKILL.md", &skill_md("c", "d", "body")),
+        ];
+        let bi_files: Vec<bi::BundleImportFile> =
+            files.iter().map(|f| bi::BundleImportFile { path: f.path.clone(), content: f.content.clone() }).collect();
+        let digest = bi::content_digest_files(&bi_files);
+
+        let mut include_skills: Vec<SkillSelection> = (0..bi::MAX_IMPORTED_SKILLS)
+            .map(|i| SkillSelection { source_dir: format!("skills/nonexistent-{i}"), import_as: None })
+            .collect();
+        include_skills.push(SkillSelection { source_dir: "skills/a".to_string(), import_as: None });
+        include_skills.push(SkillSelection { source_dir: "skills/b".to_string(), import_as: None });
+        include_skills.push(SkillSelection { source_dir: "skills/c".to_string(), import_as: None });
+
+        let req = CommitReq {
+            file_path: None,
+            zip_base64: None,
+            files: Some(files),
+            expected_content_digest: digest,
+            bundle_name: None,
+            include_instructions: false,
+            include_context_files: vec![],
+            include_skills,
+            include_mcp_servers: vec![],
+        };
+        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        assert!(
+            resp["imported_skill_ids"].as_array().unwrap().is_empty(),
+            "the three real selections beyond the MAX_IMPORTED_SKILLS boundary must be dropped by the cap, not imported"
+        );
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -288,6 +288,56 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
+/// Read-only account-requirement resolution (spec §4.5) — one identity
+/// lookup per DISTINCT provider, not per requirement row (codex P1, PR
+/// #2379 round 4: `bundle_import.rs` bounds the requirements array length,
+/// but even at that bound many rows commonly share a handful of
+/// providers). Extracted here (Phase 3 spec §3.1's account-resolution
+/// implementation note) so the existing `bundle.import` route and the new
+/// `bundle.import.preview`/`.commit` handlers share the exact same
+/// resolution logic rather than duplicating it in a second place where it
+/// could drift.
+struct ResolvedRequirements {
+    resolved_requirement_ids: Vec<String>,
+    /// (id, provider, env, match_count) — full, untruncated values; the
+    /// RPC handler's own response construction applies the shared
+    /// bounded-display projection (Phase 3 spec §3.1, round 11) before
+    /// this is ever serialized.
+    unresolved: Vec<(String, String, String, usize)>,
+}
+
+fn resolve_account_requirements(
+    id_store: &crate::backend::storage::store::Store,
+    requirements: &[crate::backend::bundle_import::AccountRequirement],
+) -> Result<ResolvedRequirements, String> {
+    let mut resolved_requirement_ids: Vec<String> = Vec::new();
+    let mut unresolved: Vec<(String, String, String, usize)> = Vec::new();
+    let mut match_count_by_provider: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::new();
+    for requirement in requirements {
+        let match_count = match match_count_by_provider.get(requirement.provider.as_str()) {
+            Some(&n) => n,
+            None => {
+                // Codex P2, PR #2379 round 2: account CRUD routes through
+                // id_store (shared/store.db when available), not wstore
+                // (the per-channel database).
+                let n = id_store
+                    .identity_list(Some(&requirement.provider))
+                    .map_err(|e| format!("account lookup failed: {e}"))?
+                    .len();
+                match_count_by_provider.insert(requirement.provider.as_str(), n);
+                n
+            }
+        };
+        if match_count == 1 {
+            resolved_requirement_ids.push(requirement.id.clone());
+        } else {
+            unresolved.push((requirement.id.clone(), requirement.provider.clone(), requirement.env.clone(), match_count));
+        }
+    }
+    Ok(ResolvedRequirements { resolved_requirement_ids, unresolved })
+}
+
 /// `bundle.import` — ABF importer, Phase 2 of
 /// docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md. Window-
 /// scoped like `bundle.export` (bundles aren't agent-specific). Accepts
@@ -375,46 +425,21 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // Account requirement resolution (§4.5) — read-only lookup
                 // by provider, purely informational. Never creates an
                 // account, never writes anything derived from a match.
-                let mut resolved_requirement_ids: Vec<String> = Vec::new();
-                let mut unresolved_requirements: Vec<serde_json::Value> = Vec::new();
-                // codex P1, PR #2379 round 4: query each distinct provider
-                // ONCE, not once per requirement row -- bundle_import.rs
-                // bounds the requirements array length, but even at that
-                // bound many rows commonly share a handful of providers
-                // (or an attacker can repeat one provider many times), and
-                // each identity_list call is a synchronous store query.
-                let mut match_count_by_provider: std::collections::HashMap<&str, usize> =
-                    std::collections::HashMap::new();
-                for requirement in &parsed.requirements {
-                    let match_count = match match_count_by_provider.get(requirement.provider.as_str()) {
-                        Some(&n) => n,
-                        None => {
-                            // Codex P2, PR #2379 round 2: account CRUD routes
-                            // through id_store (shared/store.db when available), not
-                            // wstore (the per-channel database) -- see identity.rs's
-                            // own handler registrations. Querying wstore here would
-                            // report zero/stale matches for accounts that actually
-                            // exist, incorrectly placing requirements in
-                            // unresolved_requirements.
-                            let n = id_store
-                                .identity_list(Some(&requirement.provider))
-                                .map_err(|e| format!("bundle.import: account lookup failed: {e}"))?
-                                .len();
-                            match_count_by_provider.insert(requirement.provider.as_str(), n);
-                            n
-                        }
-                    };
-                    if match_count == 1 {
-                        resolved_requirement_ids.push(requirement.id.clone());
-                    } else {
-                        unresolved_requirements.push(json!({
-                            "id": requirement.id,
-                            "provider": requirement.provider,
-                            "env": requirement.env,
-                            "match_count": match_count,
-                        }));
-                    }
-                }
+                // Phase 3 spec §3.1: extracted into resolve_account_requirements,
+                // shared with the new preview/commit RPC handlers.
+                let resolved = resolve_account_requirements(&id_store, &parsed.requirements)
+                    .map_err(|e| format!("bundle.import: {e}"))?;
+                let resolved_requirement_ids = resolved.resolved_requirement_ids;
+                let unresolved_requirements: Vec<serde_json::Value> = resolved
+                    .unresolved
+                    .into_iter()
+                    .map(|(id, provider, env, match_count)| json!({
+                        "id": id,
+                        "provider": provider,
+                        "env": env,
+                        "match_count": match_count,
+                    }))
+                    .collect();
 
                 // Skills — global, not bound to any agent (mirrors
                 // skill.catalog.upsert's own is_global: true convention for

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -19,11 +19,15 @@ import { BrowserAuthModalPanel } from "@/app/view/browser/components/BrowserAuth
 import { AgentIdentityModalPanel } from "@/app/view/agent/components/AgentIdentityModal";
 import { AgentNativeMemoryModal } from "@/app/view/agent/components/AgentNativeMemoryModal";
 import { AgentStashModal } from "@/app/view/agent/components/AgentStashModal";
+import { BundleImportSelectModalPanel } from "@/app/view/memory/components/BundleImportSelectModal";
+import { BundleImportPreviewModalPanel } from "@/app/view/memory/components/BundleImportPreviewModal";
+import { BundleImportConfirmModalPanel } from "@/app/view/memory/components/BundleImportConfirmModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
 import "@/app/view/agent/components/AgentIdentityModal.scss";
 import "@/app/view/agent/components/AgentStashModal.scss";
 import "@/app/view/browser/components/BrowserAuthModal.scss";
+import "@/app/view/memory/components/BundleImportModal.scss";
 
 import type { ModalLayerApi, ModalLayerRequest } from "./modal-layer";
 
@@ -49,6 +53,12 @@ export function requestLabel(req: ModalLayerRequest): string {
             return `Memory — ${req.agentName}`;
         case "agent-stash":
             return "Stash";
+        case "bundle-import-select":
+            return "Import Bundle";
+        case "bundle-import-preview":
+            return "Preview & Select";
+        case "bundle-import-confirm":
+            return "Confirm Import";
     }
 }
 
@@ -289,6 +299,41 @@ export function renderRequest(
                         workingDirectory={req.workingDirectory}
                         initialTab={req.initialTab}
                         onClose={api.close}
+                    />
+                ),
+            };
+        case "bundle-import-select":
+            return {
+                label: requestLabel(req),
+                panel: (
+                    <BundleImportSelectModalPanel
+                        onPreviewed={req.onPreviewed}
+                        onCancel={req.onCancel}
+                    />
+                ),
+            };
+        case "bundle-import-preview":
+            return {
+                label: requestLabel(req),
+                panel: (
+                    <BundleImportPreviewModalPanel
+                        preview={req.preview}
+                        onNext={req.onNext}
+                        onCancel={req.onCancel}
+                    />
+                ),
+            };
+        case "bundle-import-confirm":
+            return {
+                label: requestLabel(req),
+                panel: (
+                    <BundleImportConfirmModalPanel
+                        filePath={req.filePath}
+                        contentDigest={req.contentDigest}
+                        bundleDisplayName={req.bundleDisplayName}
+                        selection={req.selection}
+                        onImported={req.onImported}
+                        onCancel={req.onCancel}
                     />
                 ),
             };

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -25,7 +25,10 @@ export type ModalLayerRequest =
     | BrowserAuthRequest
     | AgentIdentityRequest
     | AgentMemoryRequest
-    | AgentStashRequest;
+    | AgentStashRequest
+    | BundleImportSelectRequest
+    | BundleImportPreviewRequest
+    | BundleImportConfirmRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -313,6 +316,78 @@ export interface AgentStashRequest {
     workingDirectory: string;
     /** Which tab to open on. Defaults to "accounts". */
     initialTab?: "accounts" | "memory";
+}
+
+/**
+ * Armory Bundle Format (ABF) import — Phase 3
+ * (docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4). Three chained
+ * modal-layer requests, following the same `ModalLayerApi.replace()`
+ * sequential pattern as the install→launch chain above — this codebase has
+ * no wizard-panel component, and threading step state through this
+ * request-kind union keeps each step's props typed and testable
+ * independently.
+ */
+
+/** Step 1 — pick a `.abf` file and preview it. Has almost no UI of its own:
+ *  it triggers the native file dialog on mount, shows a spinner while
+ *  `bundle.import.preview` runs, and surfaces a parse/validation error
+ *  inline (with a retry) rather than advancing. */
+export interface BundleImportSelectRequest {
+    kind: "bundle-import-select";
+    /** Preview succeeded — caller does
+     *  `modalLayer.replace(previewRequest)`. */
+    onPreviewed: (filePath: string, preview: BundleImportPreviewResponse) => void;
+    onCancel: () => void;
+}
+
+/** One skill row's selection state — every parsed skill gets an entry,
+ *  including non-colliding ones (checked by default). For a colliding
+ *  row, `renameValue` starts empty (§4.1 point 5) and is the ONLY value
+ *  ever submitted as `import_as`; leaving it empty at commit time is
+ *  treated as skip regardless of the checkbox (§4.1 point 4). */
+export interface BundleImportSkillSelectionState {
+    sourceDir: string;
+    checked: boolean;
+    renameValue: string;
+}
+
+/** Built by Step 2, consumed by Step 3 — the user's full selection,
+ *  independent of the (possibly truncated) preview display values. */
+export interface BundleImportSelectionState {
+    bundleName: string;
+    includeInstructions: boolean;
+    includeContextFileIds: number[];
+    skills: BundleImportSkillSelectionState[];
+    includeMcpServerPaths: string[];
+}
+
+/** Step 2 — preview & select. Renders the checklist described in §4 Step
+ *  2: editable bundle name, instructions checkbox + preview, context
+ *  files, skills (with collision UI per §4.1), MCP servers, a read-only
+ *  requirements summary, and a dismissible warnings banner. */
+export interface BundleImportPreviewRequest {
+    kind: "bundle-import-preview";
+    filePath: string;
+    preview: BundleImportPreviewResponse;
+    /** "Next" — caller does
+     *  `modalLayer.replace(confirmRequest)`. */
+    onNext: (selection: BundleImportSelectionState) => void;
+    onCancel: () => void;
+}
+
+/** Step 3 — confirm & import. Calls `bundle.import.commit`; a digest
+ *  mismatch (the file changed since preview) surfaces as a distinct
+ *  "re-select and preview again" error rather than a generic failure. */
+export interface BundleImportConfirmRequest {
+    kind: "bundle-import-confirm";
+    filePath: string;
+    contentDigest: string;
+    bundleDisplayName: string;
+    selection: BundleImportSelectionState;
+    /** Commit succeeded — caller does `modalLayer.close()` (+ any
+     *  post-import navigation). */
+    onImported: (result: BundleImportCommitResponse) => void;
+    onCancel: () => void;
 }
 
 // ── Context API ──────────────────────────────────────────────────────────────

--- a/frontend/app/store/rpc-api/bundle.ts
+++ b/frontend/app/store/rpc-api/bundle.ts
@@ -1,0 +1,35 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Armory Bundle Format (ABF) import — Phase 3
+// (agentmux-srv/src/server/app_api/bundle.rs). Window-scoped, no agent_id
+// gate, same as the rest of `bundle.*`. See
+// docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md.
+
+import { RpcClient } from "../rpc-client";
+
+export const BundleImportApi = {
+    BundleImportPreviewCommand(
+        client: RpcClient,
+        data: { file_path: string },
+        opts?: RpcOpts,
+    ): Promise<BundleImportPreviewResponse> {
+        return client.rpcCall("bundle.import.preview", data, opts);
+    },
+
+    BundleImportCommitCommand(
+        client: RpcClient,
+        data: {
+            file_path: string;
+            expected_content_digest: string;
+            bundle_name?: string;
+            include_instructions: boolean;
+            include_context_files: number[];
+            include_skills: { source_dir: string; import_as?: string }[];
+            include_mcp_servers: string[];
+        },
+        opts?: RpcOpts,
+    ): Promise<BundleImportCommitResponse> {
+        return client.rpcCall("bundle.import.commit", data, opts);
+    },
+};

--- a/frontend/app/store/rpc-api/index.ts
+++ b/frontend/app/store/rpc-api/index.ts
@@ -13,6 +13,7 @@
 
 import { AgentApi } from "./agent";
 import { BlockApi } from "./block";
+import { BundleImportApi } from "./bundle";
 import { FileApi } from "./file";
 import { IdentityApi } from "./identity";
 import { McpApi } from "./mcp";
@@ -36,4 +37,5 @@ export const RpcApi = {
     ...SessionApi,
     ...McpApi,
     ...SkillApi,
+    ...BundleImportApi,
 };

--- a/frontend/app/view/memory/components/BundleImportConfirmModal.tsx
+++ b/frontend/app/view/memory/components/BundleImportConfirmModal.tsx
@@ -1,0 +1,160 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleImportConfirmModalPanel — Step 3 of the ABF import flow
+ * (docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4 Step 3).
+ *
+ * Shows a summary of the current selection and calls `bundle.import.commit`
+ * on "Import". A digest mismatch (the file changed since preview) surfaces
+ * as a distinct, clearly-worded error directing the user back to step 1 —
+ * not a generic failure. A partial failure (a skill skipped server-side
+ * because of a last-second name conflict) is a real, expected outcome, not
+ * an error state — it's surfaced via `warnings`/`skipped_skills` instead.
+ */
+
+import { createSignal, For, Show, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import type { BundleImportSelectionState } from "@/app/element/modal-layer";
+
+interface BundleImportConfirmModalPanelProps {
+    filePath: string;
+    contentDigest: string;
+    bundleDisplayName: string;
+    selection: BundleImportSelectionState;
+    onImported: (result: BundleImportCommitResponse) => void;
+    onCancel: () => void;
+}
+
+function summaryLine(selection: BundleImportSelectionState): string {
+    const parts: string[] = [];
+    if (selection.includeInstructions) parts.push("instructions");
+    if (selection.includeContextFileIds.length > 0) {
+        parts.push(`${selection.includeContextFileIds.length} context file${selection.includeContextFileIds.length === 1 ? "" : "s"}`);
+    }
+    const includedSkills = selection.skills.filter((s) => s.checked && s.renameValue.trim().length >= 0);
+    // A colliding-but-blank-rename row still shows as "selected" in the
+    // checkbox UI but will be skipped server-side -- the summary counts
+    // checked rows, matching what the user sees checked, not the final
+    // server-side outcome (which the result screen reports separately).
+    if (includedSkills.length > 0) {
+        parts.push(`${includedSkills.length} skill${includedSkills.length === 1 ? "" : "s"}`);
+    }
+    if (selection.includeMcpServerPaths.length > 0) {
+        parts.push(`${selection.includeMcpServerPaths.length} MCP server${selection.includeMcpServerPaths.length === 1 ? "" : "s"}`);
+    }
+    return parts.length > 0 ? `Importing: ${parts.join(", ")}.` : "Nothing selected to import.";
+}
+
+export const BundleImportConfirmModalPanel = (
+    props: BundleImportConfirmModalPanelProps,
+): JSX.Element => {
+    const [submitting, setSubmitting] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+    const [digestMismatch, setDigestMismatch] = createSignal(false);
+    const [result, setResult] = createSignal<BundleImportCommitResponse | null>(null);
+
+    const commit = async () => {
+        setSubmitting(true);
+        setError(null);
+        setDigestMismatch(false);
+        try {
+            const res = await RpcApi.BundleImportCommitCommand(TabRpcClient, {
+                file_path: props.filePath,
+                expected_content_digest: props.contentDigest,
+                bundle_name: props.selection.bundleName,
+                include_instructions: props.selection.includeInstructions,
+                include_context_files: props.selection.includeContextFileIds,
+                include_skills: props.selection.skills
+                    .filter((s) => s.checked)
+                    .map((s) => ({
+                        source_dir: s.sourceDir,
+                        ...(s.renameValue.trim() ? { import_as: s.renameValue.trim() } : {}),
+                    })),
+                include_mcp_servers: props.selection.includeMcpServerPaths,
+            });
+            setSubmitting(false);
+            if (res.skipped_skills.length > 0 || res.warnings.length > 0) {
+                // Real, expected partial-failure outcome -- show the
+                // result inline rather than closing immediately.
+                setResult(res);
+            } else {
+                props.onImported(res);
+            }
+        } catch (e) {
+            setSubmitting(false);
+            const message = (e as Error)?.message ?? String(e);
+            if (message.includes("digest mismatch")) {
+                setDigestMismatch(true);
+            } else {
+                setError(message);
+            }
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">Confirm Import</h2>
+                <p class="modal-panel-description">
+                    Importing as <strong>{props.bundleDisplayName}</strong>.
+                </p>
+            </header>
+            <div class="modal-panel-body bundle-import-confirm-body">
+                <Show
+                    when={!result()}
+                    fallback={
+                        <div class="bundle-import-result">
+                            <p>Bundle imported.</p>
+                            <Show when={result()!.skipped_skills.length > 0}>
+                                <div class="bundle-import-hint bundle-import-hint-warn">
+                                    Skipped skill(s): {result()!.skipped_skills.join(", ")}
+                                </div>
+                            </Show>
+                            <Show when={result()!.warnings.length > 0}>
+                                <div class="bundle-import-warnings-banner">
+                                    <For each={result()!.warnings}>
+                                        {(w) => <div class="bundle-import-warning-line">{w}</div>}
+                                    </For>
+                                </div>
+                            </Show>
+                        </div>
+                    }
+                >
+                    <p class="bundle-import-summary-line">{summaryLine(props.selection)}</p>
+                </Show>
+
+                <Show when={digestMismatch()}>
+                    <div class="bundle-import-error">
+                        The file changed since it was previewed. Please cancel and re-select it.
+                    </div>
+                </Show>
+                <Show when={error()}>
+                    <div class="bundle-import-error">{error()}</div>
+                </Show>
+            </div>
+            <footer class="modal-panel-footer">
+                <Show
+                    when={!result()}
+                    fallback={
+                        <Button onClick={() => props.onImported(result()!)} className="green solid">
+                            Done
+                        </Button>
+                    }
+                >
+                    <Button onClick={() => props.onCancel()} disabled={submitting()} data-modal-dismiss>
+                        Cancel
+                    </Button>
+                    <Button onClick={() => void commit()} className="green solid" disabled={submitting()}>
+                        {submitting() ? "Importing…" : "Import"}
+                    </Button>
+                </Show>
+            </footer>
+        </>
+    );
+};
+
+BundleImportConfirmModalPanel.displayName = "BundleImportConfirmModalPanel";

--- a/frontend/app/view/memory/components/BundleImportConfirmModal.tsx
+++ b/frontend/app/view/memory/components/BundleImportConfirmModal.tsx
@@ -35,11 +35,11 @@ function summaryLine(selection: BundleImportSelectionState): string {
     if (selection.includeContextFileIds.length > 0) {
         parts.push(`${selection.includeContextFileIds.length} context file${selection.includeContextFileIds.length === 1 ? "" : "s"}`);
     }
-    const includedSkills = selection.skills.filter((s) => s.checked && s.renameValue.trim().length >= 0);
     // A colliding-but-blank-rename row still shows as "selected" in the
     // checkbox UI but will be skipped server-side -- the summary counts
     // checked rows, matching what the user sees checked, not the final
     // server-side outcome (which the result screen reports separately).
+    const includedSkills = selection.skills.filter((s) => s.checked);
     if (includedSkills.length > 0) {
         parts.push(`${includedSkills.length} skill${includedSkills.length === 1 ? "" : "s"}`);
     }

--- a/frontend/app/view/memory/components/BundleImportModal.scss
+++ b/frontend/app/view/memory/components/BundleImportModal.scss
@@ -1,0 +1,194 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared styling for the three ABF import modal steps (BundleImportSelect/
+// Preview/ConfirmModal.tsx). Reuses the app's shared .modal-panel-* shell
+// classes; everything here is scoped under .bundle-import-*.
+
+.bundle-import-select-body,
+.bundle-import-preview-body,
+.bundle-import-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.bundle-import-select-status {
+    opacity: 0.75;
+}
+
+.bundle-import-select-error,
+.bundle-import-error {
+    color: var(--color-error, #e5484d);
+    white-space: pre-wrap;
+}
+
+.bundle-import-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bundle-import-field-label {
+    font-weight: 600;
+    opacity: 0.85;
+}
+
+.bundle-import-input {
+    padding: 6px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border, #444);
+    background: var(--color-input-bg, transparent);
+}
+
+.bundle-import-hint {
+    font-size: 0.85em;
+    opacity: 0.75;
+}
+
+.bundle-import-hint-warn {
+    color: var(--color-warning, #f5a524);
+    opacity: 1;
+}
+
+.bundle-import-link-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--color-accent, #4d9de5);
+    text-decoration: underline;
+    cursor: pointer;
+    font: inherit;
+}
+
+.bundle-import-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.bundle-import-section-title {
+    font-size: 0.95em;
+    font-weight: 600;
+    margin: 0;
+    opacity: 0.85;
+}
+
+.bundle-import-checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.bundle-import-item-name {
+    font-weight: 500;
+}
+
+.bundle-import-item-name-readonly {
+    opacity: 0.6;
+    text-decoration: line-through;
+    font-size: 0.9em;
+}
+
+.bundle-import-item-meta {
+    opacity: 0.6;
+    font-size: 0.85em;
+    margin-left: auto;
+}
+
+.bundle-import-item-description {
+    margin: 0 0 0 24px;
+    font-size: 0.85em;
+    opacity: 0.75;
+}
+
+.bundle-import-skill-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bundle-import-skill-collision {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.bundle-import-collision-badge {
+    font-size: 0.75em;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--color-warning-bg, rgba(245, 165, 36, 0.15));
+    color: var(--color-warning, #f5a524);
+}
+
+.bundle-import-rename-input {
+    flex: 1;
+    min-width: 160px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border, #444);
+    background: var(--color-input-bg, transparent);
+}
+
+.bundle-import-instructions-preview {
+    margin-left: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bundle-import-instructions-text {
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    font-size: 0.85em;
+    padding: 8px;
+    border-radius: 4px;
+    background: var(--color-code-bg, rgba(128, 128, 128, 0.1));
+}
+
+.bundle-import-requirements-summary {
+    font-size: 0.9em;
+    opacity: 0.85;
+}
+
+.bundle-import-warnings-banner {
+    position: relative;
+    padding: 8px 28px 8px 8px;
+    border-radius: 4px;
+    background: var(--color-warning-bg, rgba(245, 165, 36, 0.1));
+    font-size: 0.85em;
+}
+
+.bundle-import-warning-line {
+    opacity: 0.85;
+}
+
+.bundle-import-warnings-dismiss {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.1em;
+    opacity: 0.6;
+
+    &:hover {
+        opacity: 1;
+    }
+}
+
+.bundle-import-summary-line {
+    font-weight: 500;
+}
+
+.bundle-import-result {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}

--- a/frontend/app/view/memory/components/BundleImportPreviewModal.test.tsx
+++ b/frontend/app/view/memory/components/BundleImportPreviewModal.test.tsx
@@ -1,0 +1,91 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins the reagentx P2 finding on PR #2382 round 2: the rename-conflict
+ * hint must check the FULL global skill catalog (fetched via
+ * skill.catalog.list per SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4.1
+ * point 2), not just the subset of skills the preview response already
+ * flagged "name_conflict" against itself -- a rename to some OTHER,
+ * unrelated existing global skill name previously showed no client-side
+ * warning at all.
+ */
+
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BundleImportPreviewModalPanel } from "./BundleImportPreviewModal";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        SkillCatalogListCommand: vi.fn(),
+    },
+}));
+
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+
+afterEach(() => {
+    cleanup();
+});
+
+function makePreview(): BundleImportPreviewResponse {
+    return {
+        name: "test-bundle",
+        description: "",
+        instructions_preview: "",
+        instructions_truncated: false,
+        instructions_total_chars: 0,
+        context_files: [],
+        skills: [
+            {
+                source_dir: "skills/deploy",
+                slug: "deploy",
+                description: "d",
+                collision: "duplicate_in_bundle",
+            },
+        ],
+        mcp_servers: [],
+        requirements: [],
+        warnings: [],
+        warnings_truncated: false,
+        name_collision: false,
+        content_digest: "abc123",
+    };
+}
+
+describe("BundleImportPreviewModalPanel — rename conflict check", () => {
+    it("warns when a rename matches a global skill name outside this bundle's own flagged rows", async () => {
+        vi.mocked(RpcApi.SkillCatalogListCommand).mockResolvedValue([
+            { id: "x", name: "taken-elsewhere", trigger: "taken-elsewhere", skill_type: "agent_skill", description: "", content: "", is_global: true, created_at: 0, updated_at: 0, bound_count: 0 },
+        ]);
+
+        render(() => (
+            <BundleImportPreviewModalPanel preview={makePreview()} onNext={() => {}} onCancel={() => {}} />
+        ));
+
+        await waitFor(() => expect(RpcApi.SkillCatalogListCommand).toHaveBeenCalled());
+
+        const renameInput = screen.getByPlaceholderText("rename to import (leave blank to skip)");
+        await userEvent.type(renameInput, "taken-elsewhere");
+
+        expect(await screen.findByText("This name is also taken — pick another.")).toBeInTheDocument();
+    });
+
+    it("shows no conflict hint for a rename that matches nothing in the fetched catalog", async () => {
+        vi.mocked(RpcApi.SkillCatalogListCommand).mockResolvedValue([]);
+
+        render(() => (
+            <BundleImportPreviewModalPanel preview={makePreview()} onNext={() => {}} onCancel={() => {}} />
+        ));
+
+        await waitFor(() => expect(RpcApi.SkillCatalogListCommand).toHaveBeenCalled());
+
+        const renameInput = screen.getByPlaceholderText("rename to import (leave blank to skip)");
+        await userEvent.type(renameInput, "genuinely-free-name");
+
+        expect(screen.queryByText("This name is also taken — pick another.")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/app/view/memory/components/BundleImportPreviewModal.tsx
+++ b/frontend/app/view/memory/components/BundleImportPreviewModal.tsx
@@ -10,9 +10,11 @@
  * this panel makes no RPC calls of its own.
  */
 
-import { createSignal, For, Show, type JSX } from "solid-js";
+import { createSignal, For, onMount, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import type { BundleImportSelectionState, BundleImportSkillSelectionState } from "@/app/element/modal-layer";
 
 interface BundleImportPreviewModalPanelProps {
@@ -46,14 +48,24 @@ export const BundleImportPreviewModalPanel = (
     );
     const [warningsDismissed, setWarningsDismissed] = createSignal(false);
 
+    // §4.1 point 2: the modal fetches the full existing global skill-name
+    // list ONCE, up front, via skill.catalog.list -- not just the subset
+    // preview.skills already flagged "name_conflict" against itself (a
+    // rename to some OTHER, unrelated existing global skill name would
+    // otherwise show no client-side warning and silently be skipped at
+    // commit, since skill_upsert_unique_global still rejects it there).
+    const [globalSlugs, setGlobalSlugs] = createSignal<Set<string>>(new Set());
+    onMount(() => {
+        void RpcApi.SkillCatalogListCommand(TabRpcClient, {})
+            .then((items) => setGlobalSlugs(new Set(items.map((i) => i.name))))
+            .catch(() => {}); // advisory only -- a failed fetch just means no client-side hint; commit is still authoritative.
+    });
+
     // Live union of the global catalog + every OTHER selected skill's
     // current slug/rename (§4.1 point 2) -- advisory client-side check
     // only; skill_upsert_unique_global is the real authority at commit.
     const takenSlugsFor = (sourceDir: string): Set<string> => {
-        const taken = new Set<string>();
-        for (const s of preview.skills) {
-            if (s.collision === "name_conflict") taken.add(s.slug);
-        }
+        const taken = new Set<string>(globalSlugs());
         for (const row of skills()) {
             if (row.sourceDir === sourceDir || !row.checked) continue;
             const other = preview.skills.find((s) => s.source_dir === row.sourceDir);

--- a/frontend/app/view/memory/components/BundleImportPreviewModal.tsx
+++ b/frontend/app/view/memory/components/BundleImportPreviewModal.tsx
@@ -1,0 +1,305 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleImportPreviewModalPanel — Step 2 of the ABF import flow
+ * (docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4 Step 2 / §4.1).
+ *
+ * Renders the `bundle.import.preview` response as a selection checklist.
+ * All selection state is built here and handed to Step 3 via `onNext` —
+ * this panel makes no RPC calls of its own.
+ */
+
+import { createSignal, For, Show, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import type { BundleImportSelectionState, BundleImportSkillSelectionState } from "@/app/element/modal-layer";
+
+interface BundleImportPreviewModalPanelProps {
+    preview: BundleImportPreviewResponse;
+    onNext: (selection: BundleImportSelectionState) => void;
+    onCancel: () => void;
+}
+
+function formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const BundleImportPreviewModalPanel = (
+    props: BundleImportPreviewModalPanelProps,
+): JSX.Element => {
+    const { preview } = props;
+
+    const [bundleName, setBundleName] = createSignal(preview.name);
+    const [includeInstructions, setIncludeInstructions] = createSignal(true);
+    const [instructionsExpanded, setInstructionsExpanded] = createSignal(false);
+    const [contextChecked, setContextChecked] = createSignal<Record<number, boolean>>(
+        Object.fromEntries(preview.context_files.map((cf) => [cf.id, true])),
+    );
+    const [skills, setSkills] = createSignal<BundleImportSkillSelectionState[]>(
+        preview.skills.map((s) => ({ sourceDir: s.source_dir, checked: true, renameValue: "" })),
+    );
+    const [mcpChecked, setMcpChecked] = createSignal<Record<string, boolean>>(
+        Object.fromEntries(preview.mcp_servers.map((m) => [m.source_path, true])),
+    );
+    const [warningsDismissed, setWarningsDismissed] = createSignal(false);
+
+    // Live union of the global catalog + every OTHER selected skill's
+    // current slug/rename (§4.1 point 2) -- advisory client-side check
+    // only; skill_upsert_unique_global is the real authority at commit.
+    const takenSlugsFor = (sourceDir: string): Set<string> => {
+        const taken = new Set<string>();
+        for (const s of preview.skills) {
+            if (s.collision === "name_conflict") taken.add(s.slug);
+        }
+        for (const row of skills()) {
+            if (row.sourceDir === sourceDir || !row.checked) continue;
+            const other = preview.skills.find((s) => s.source_dir === row.sourceDir);
+            const effective = row.renameValue.trim() || other?.slug;
+            if (effective) taken.add(effective);
+        }
+        return taken;
+    };
+
+    const updateSkill = (sourceDir: string, patch: Partial<BundleImportSkillSelectionState>) => {
+        setSkills((prev) => prev.map((s) => (s.sourceDir === sourceDir ? { ...s, ...patch } : s)));
+    };
+
+    const toggleContext = (id: number) => {
+        setContextChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+    };
+
+    const toggleMcp = (path: string) => {
+        setMcpChecked((prev) => ({ ...prev, [path]: !prev[path] }));
+    };
+
+    const suggestedAltName = () => {
+        const m = bundleName().match(/^(.*) \((\d+)\)$/);
+        if (m) return `${m[1]} (${Number(m[2]) + 1})`;
+        return `${bundleName()} (2)`;
+    };
+
+    const next = () => {
+        props.onNext({
+            bundleName: bundleName().trim() || preview.name,
+            includeInstructions: includeInstructions(),
+            includeContextFileIds: preview.context_files
+                .filter((cf) => contextChecked()[cf.id])
+                .map((cf) => cf.id),
+            skills: skills(),
+            includeMcpServerPaths: preview.mcp_servers
+                .filter((m) => mcpChecked()[m.source_path])
+                .map((m) => m.source_path),
+        });
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">Preview &amp; Select</h2>
+                <p class="modal-panel-description">
+                    Choose what to bring in from <strong>{preview.name}</strong>.
+                </p>
+            </header>
+            <div class="modal-panel-body bundle-import-preview-body">
+                <label class="bundle-import-field">
+                    <span class="bundle-import-field-label">Bundle name</span>
+                    <input
+                        type="text"
+                        class="bundle-import-input"
+                        value={bundleName()}
+                        onInput={(e) => setBundleName(e.currentTarget.value)}
+                    />
+                    <Show when={preview.name_collision}>
+                        <div class="bundle-import-hint">
+                            A bundle named this already exists.{" "}
+                            <button
+                                type="button"
+                                class="bundle-import-link-btn"
+                                onClick={() => setBundleName(suggestedAltName())}
+                            >
+                                Use "{suggestedAltName()}" instead
+                            </button>
+                        </div>
+                    </Show>
+                </label>
+
+                <section class="bundle-import-section">
+                    <label class="bundle-import-checkbox-row">
+                        <input
+                            type="checkbox"
+                            checked={includeInstructions()}
+                            onChange={(e) => setIncludeInstructions(e.currentTarget.checked)}
+                        />
+                        <span>Include instructions</span>
+                    </label>
+                    <Show when={includeInstructions() && preview.instructions_preview}>
+                        <div class="bundle-import-instructions-preview">
+                            <button
+                                type="button"
+                                class="bundle-import-link-btn"
+                                onClick={() => setInstructionsExpanded((v) => !v)}
+                            >
+                                {instructionsExpanded() ? "Hide" : "Show"} preview
+                            </button>
+                            <Show when={instructionsExpanded()}>
+                                <pre class="bundle-import-instructions-text">{preview.instructions_preview}</pre>
+                                <Show when={preview.instructions_truncated}>
+                                    <div class="bundle-import-hint">
+                                        Preview truncated — {preview.instructions_total_chars} characters total,
+                                        the full instructions are still imported.
+                                    </div>
+                                </Show>
+                            </Show>
+                        </div>
+                    </Show>
+                </section>
+
+                <Show when={preview.context_files.length > 0}>
+                    <section class="bundle-import-section">
+                        <h3 class="bundle-import-section-title">Context files</h3>
+                        <For each={preview.context_files}>
+                            {(cf) => (
+                                <label class="bundle-import-checkbox-row">
+                                    <input
+                                        type="checkbox"
+                                        checked={!!contextChecked()[cf.id]}
+                                        onChange={() => toggleContext(cf.id)}
+                                    />
+                                    <span class="bundle-import-item-name">{cf.display_path}</span>
+                                    <span class="bundle-import-item-meta">{formatBytes(cf.size_bytes)}</span>
+                                </label>
+                            )}
+                        </For>
+                    </section>
+                </Show>
+
+                <Show when={preview.skills.length > 0}>
+                    <section class="bundle-import-section">
+                        <h3 class="bundle-import-section-title">Skills</h3>
+                        <For each={preview.skills}>
+                            {(skill) => {
+                                const row = () => skills().find((s) => s.sourceDir === skill.source_dir)!;
+                                const colliding = skill.collision !== "none";
+                                const renameConflict = () =>
+                                    colliding &&
+                                    row().renameValue.trim().length > 0 &&
+                                    takenSlugsFor(skill.source_dir).has(row().renameValue.trim());
+                                return (
+                                    <div class="bundle-import-skill-row">
+                                        <label class="bundle-import-checkbox-row">
+                                            <input
+                                                type="checkbox"
+                                                checked={row().checked}
+                                                onChange={(e) =>
+                                                    updateSkill(skill.source_dir, { checked: e.currentTarget.checked })
+                                                }
+                                            />
+                                            <Show
+                                                when={!colliding}
+                                                fallback={
+                                                    <span class="bundle-import-skill-collision">
+                                                        <span class="bundle-import-collision-badge">
+                                                            {skill.collision === "name_conflict"
+                                                                ? "already exists in your library"
+                                                                : "another skill in this import uses this name"}
+                                                        </span>
+                                                        <span class="bundle-import-item-name-readonly">{skill.slug}</span>
+                                                        <input
+                                                            type="text"
+                                                            class="bundle-import-rename-input"
+                                                            placeholder="rename to import (leave blank to skip)"
+                                                            value={row().renameValue}
+                                                            disabled={!row().checked}
+                                                            onInput={(e) =>
+                                                                updateSkill(skill.source_dir, { renameValue: e.currentTarget.value })
+                                                            }
+                                                        />
+                                                    </span>
+                                                }
+                                            >
+                                                <span class="bundle-import-item-name">{skill.slug}</span>
+                                            </Show>
+                                        </label>
+                                        <Show when={skill.description}>
+                                            <p class="bundle-import-item-description">{skill.description}</p>
+                                        </Show>
+                                        <Show when={renameConflict()}>
+                                            <div class="bundle-import-hint bundle-import-hint-warn">
+                                                This name is also taken — pick another.
+                                            </div>
+                                        </Show>
+                                    </div>
+                                );
+                            }}
+                        </For>
+                    </section>
+                </Show>
+
+                <Show when={preview.mcp_servers.length > 0}>
+                    <section class="bundle-import-section">
+                        <h3 class="bundle-import-section-title">MCP servers</h3>
+                        <For each={preview.mcp_servers}>
+                            {(m) => (
+                                <label class="bundle-import-checkbox-row">
+                                    <input
+                                        type="checkbox"
+                                        checked={!!mcpChecked()[m.source_path]}
+                                        onChange={() => toggleMcp(m.source_path)}
+                                    />
+                                    <span class="bundle-import-item-name">
+                                        {m.display.name ?? m.source_path.split("/").pop()}
+                                    </span>
+                                    <Show when={m.display.command}>
+                                        <span class="bundle-import-item-meta">{m.display.command}</span>
+                                    </Show>
+                                </label>
+                            )}
+                        </For>
+                    </section>
+                </Show>
+
+                <Show when={preview.requirements.length > 0}>
+                    <section class="bundle-import-section">
+                        <h3 class="bundle-import-section-title">Account requirements</h3>
+                        <p class="bundle-import-requirements-summary">
+                            Depends on {preview.requirements.length} account(s):{" "}
+                            {preview.requirements
+                                .map((r) => `${r.provider} (${r.resolved ? "resolved" : "not connected"})`)
+                                .join(", ")}
+                        </p>
+                    </section>
+                </Show>
+
+                <Show when={preview.warnings.length > 0 && !warningsDismissed()}>
+                    <div class="bundle-import-warnings-banner">
+                        <button
+                            type="button"
+                            class="bundle-import-warnings-dismiss"
+                            onClick={() => setWarningsDismissed(true)}
+                            aria-label="Dismiss warnings"
+                        >
+                            ×
+                        </button>
+                        <For each={preview.warnings}>{(w) => <div class="bundle-import-warning-line">{w}</div>}</For>
+                        <Show when={preview.warnings_truncated}>
+                            <div class="bundle-import-warning-line">…more warnings not shown</div>
+                        </Show>
+                    </div>
+                </Show>
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} data-modal-dismiss>
+                    Cancel
+                </Button>
+                <Button onClick={next} className="green solid">
+                    Next
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+BundleImportPreviewModalPanel.displayName = "BundleImportPreviewModalPanel";

--- a/frontend/app/view/memory/components/BundleImportSelectModal.tsx
+++ b/frontend/app/view/memory/components/BundleImportSelectModal.tsx
@@ -1,0 +1,92 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleImportSelectModalPanel — Step 1 of the ABF import flow
+ * (docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4 Step 1).
+ *
+ * Has almost no UI of its own: it triggers the native `.abf` file dialog
+ * on mount, calls `bundle.import.preview` with the picked path, and
+ * either advances (`onPreviewed`) or shows the parse/validation error
+ * inline with a "Choose a different file" retry — per the spec, an error
+ * here surfaces on THIS step rather than advancing.
+ */
+
+import { createSignal, onMount, Show, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { getApi } from "@/app/store/app-api";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+interface BundleImportSelectModalPanelProps {
+    onPreviewed: (filePath: string, preview: BundleImportPreviewResponse) => void;
+    onCancel: () => void;
+}
+
+export const BundleImportSelectModalPanel = (
+    props: BundleImportSelectModalPanelProps,
+): JSX.Element => {
+    const [busy, setBusy] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+    // Once the user picks a file (or explicitly cancels the OS dialog
+    // twice with nothing chosen), we don't want to keep re-firing the
+    // native dialog on every render -- track whether we've prompted yet.
+    const [awaitingPick, setAwaitingPick] = createSignal(true);
+
+    const pickAndPreview = async () => {
+        setError(null);
+        setAwaitingPick(false);
+        const path = await getApi()?.showOpenBundleDialog?.();
+        if (!path) {
+            // User cancelled the OS dialog with nothing chosen -- close
+            // the whole flow rather than leaving an empty modal open.
+            props.onCancel();
+            return;
+        }
+        setBusy(true);
+        try {
+            const preview = await RpcApi.BundleImportPreviewCommand(TabRpcClient, { file_path: path });
+            setBusy(false);
+            props.onPreviewed(path, preview);
+        } catch (e) {
+            setBusy(false);
+            setError((e as Error)?.message ?? String(e));
+        }
+    };
+
+    onMount(() => {
+        void pickAndPreview();
+    });
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">Import Bundle</h2>
+                <p class="modal-panel-description">
+                    Pick an Armory Bundle (<code>.abf</code>) file to see what's inside before importing.
+                </p>
+            </header>
+            <div class="modal-panel-body bundle-import-select-body">
+                <Show when={busy()}>
+                    <div class="bundle-import-select-status">Reading bundle…</div>
+                </Show>
+                <Show when={error()}>
+                    <div class="bundle-import-select-error">{error()}</div>
+                </Show>
+                <Show when={!busy() && !awaitingPick()}>
+                    <Button onClick={() => void pickAndPreview()} className="green">
+                        Choose a different file
+                    </Button>
+                </Show>
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} disabled={busy()} data-modal-dismiss>
+                    Cancel
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+BundleImportSelectModalPanel.displayName = "BundleImportSelectModalPanel";

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -20,6 +20,7 @@
 import { For, onCleanup, Show, type JSX } from "solid-js";
 
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
+import { useModalLayer } from "@/app/element/modal-layer";
 import { type MemoryDraft, MemoryViewModel } from "./memory-model";
 
 import "./memory-view.scss";
@@ -38,6 +39,39 @@ interface MemoryManagerBodyProps {
  */
 export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
     const { model } = props;
+    const modalLayer = useModalLayer();
+
+    // Starts the 3-step ABF import chain (SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md
+    // §4) -- each step's request builds the next via modalLayer.replace(),
+    // mirroring the install→launch chain precedent. The commit RPC
+    // publishes `memories:changed`, which this model already subscribes
+    // to, so the newly-imported bundle appears in the list with no extra
+    // glue here.
+    const handleImportBundle = () => {
+        modalLayer.open({
+            kind: "bundle-import-select",
+            onPreviewed: (filePath, preview) => {
+                modalLayer.replace({
+                    kind: "bundle-import-preview",
+                    filePath,
+                    preview,
+                    onNext: (selection) => {
+                        modalLayer.replace({
+                            kind: "bundle-import-confirm",
+                            filePath,
+                            contentDigest: preview.content_digest,
+                            bundleDisplayName: selection.bundleName,
+                            selection,
+                            onImported: () => modalLayer.close(),
+                            onCancel: modalLayer.close,
+                        });
+                    },
+                    onCancel: modalLayer.close,
+                });
+            },
+            onCancel: modalLayer.close,
+        });
+    };
 
     // Clicking a list item SELECTS the memory so the read-only detail
     // view appears (including for the blank singleton, which can't be
@@ -102,6 +136,9 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
             <div class="memory-view-rail-header">
                 <button class="memory-view-new-btn" onClick={handleNew}>
                     + New Preset
+                </button>
+                <button class="memory-view-new-btn" onClick={handleImportBundle}>
+                    Import Bundle
                 </button>
             </div>
             <ul class="memory-view-list">

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -178,6 +178,11 @@ declare global {
          *  or null if the user cancelled. See
          *  docs/specs/SPEC_MEDIA_PANE_2026_07_26.md. */
         showOpenFileDialog(): Promise<string | null>;
+        /** Native "open file" dialog filtered to `.abf` (Armory Bundle
+         *  Format) files. Resolves to the chosen absolute path, or null if
+         *  the user cancelled. See
+         *  docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md §4 Step 1. */
+        showOpenBundleDialog(): Promise<string | null>;
         captureScreenshot(rect: { x: number; y: number; width: number; height: number }): Promise<string>;
         setKeyboardChordMode: () => void;
         openAgent: (agentId: string) => Promise<void>;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -388,6 +388,71 @@ declare global {
         updated_at: number;
     };
 
+    // ── Armory Bundle Format (ABF) import, Phase 3 ──────────────────────
+    // agentmux-srv/src/server/app_api/bundle.rs — bundle.import.preview /
+    // bundle.import.commit. See docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md.
+
+    type BundleImportContextFilePreview = {
+        /** Stable selection key (0-based index within this parse) — never
+         *  the (possibly truncated) display_path. */
+        id: number;
+        display_path: string;
+        size_bytes: number;
+    };
+
+    /** "none" | "name_conflict" | "duplicate_in_bundle". */
+    type BundleImportSkillCollision = "none" | "name_conflict" | "duplicate_in_bundle";
+
+    type BundleImportSkillPreview = {
+        /** Stable selection key — never the (possibly truncated) slug. */
+        source_dir: string;
+        slug: string;
+        description: string;
+        collision: BundleImportSkillCollision;
+    };
+
+    type BundleImportMcpServerPreview = {
+        /** Stable selection key. */
+        source_path: string;
+        display: { name: string | null; command: string | null };
+    };
+
+    type BundleImportRequirementPreview = {
+        id: string;
+        provider: string;
+        env: string;
+        resolved: boolean;
+        match_count: number;
+    };
+
+    type BundleImportPreviewResponse = {
+        name: string;
+        description: string;
+        instructions_preview: string;
+        instructions_truncated: boolean;
+        instructions_total_chars: number;
+        context_files: BundleImportContextFilePreview[];
+        skills: BundleImportSkillPreview[];
+        mcp_servers: BundleImportMcpServerPreview[];
+        requirements: BundleImportRequirementPreview[];
+        warnings: string[];
+        warnings_truncated: boolean;
+        name_collision: boolean;
+        /** Required back at commit as expected_content_digest — proves the
+         *  file hasn't changed since preview. */
+        content_digest: string;
+    };
+
+    type BundleImportCommitResponse = {
+        bundle_id: string;
+        imported_skill_ids: string[];
+        skipped_skills: string[];
+        resolved_requirement_ids: string[];
+        unresolved_requirements: { id: string; provider: string; env: string; match_count: number }[];
+        warnings: string[];
+        warnings_truncated: boolean;
+    };
+
     // ── v1 composable model — standalone MCP Server + Skill primitives ─────
     // Mirrors agentmux-srv/src/backend/storage/mcp_servers.rs::McpServer and
     // skills.rs::Skill (the v1 struct, not the legacy agent-scoped AgentSkill).

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -392,6 +392,9 @@ export function buildCefApi(): AppApi {
         showOpenFileDialog: () => {
             return invokeCommand<string | null>("show_open_file_dialog");
         },
+        showOpenBundleDialog: () => {
+            return invokeCommand<string | null>("show_open_bundle_dialog");
+        },
         onQuicklook: (filePath: string) => {
             invokeCommand("quicklook", { filePath }).catch(console.error);
         },

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -296,8 +296,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "bundle.export",
     "bundle.get",
     "bundle.import",
-    "bundle.import.commit",
-    "bundle.import.preview",
     "bundle.list",
     "bundle.self.get",
     "bundle.upsert",

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -296,6 +296,8 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "bundle.export",
     "bundle.get",
     "bundle.import",
+    "bundle.import.commit",
+    "bundle.import.preview",
     "bundle.list",
     "bundle.self.get",
     "bundle.upsert",


### PR DESCRIPTION
Implements docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md end to end -- the spec merged via #2381 after 14 review rounds.

## Summary

- **Backend struct amendments** (`bundle_import.rs`): `ParsedSkill.source_dir`, `ParsedMcpServer{source_path, config}`, `ImportedContextFile.id`, parse-time bundle-name length bounding -- stable selection keys distinct from truncatable display values, per §3.0/§3.1.
- **Shared helpers**: `WarningBudget`/`WarningSink` (parser-level warning bounding, unbounded default preserving today's `bundle.import` route exactly), bounded-display-projection helpers (`truncate_display`, `bounded_instructions_preview`, `mcp_server_display`), two-pass skill collision classification (`duplicate_in_bundle_slugs`/`classify_skill_collision`), and `resolve_account_requirements` extracted out of the existing `bundle.import` handler for reuse.
- **`bundle.import.preview` / `bundle.import.commit` RPC handlers**: `file_path` input support (no-follow single-handle bounded read -- `O_NOFOLLOW` on Unix, `FILE_FLAG_OPEN_REPARSE_POINT` + `is_symlink()` on Windows), mode-tagged SHA-256 content digest for all three input modes (`file_path`/`zip_base64`/`files`), digest-gated commit, `bundle_name` actually applied to `Memory.name`, context files selected by stable `id` not truncatable path, skills server-side-authoritatively skipped when left with an empty rename on a collision.
- **`show_open_bundle_dialog`** host command (agentmux-cef) + `cef-api.ts` binding, mirroring `show_open_file_dialog` with an `.abf` filter.
- **Frontend 3-step modal** (select → preview/select → confirm), following the existing `ModalLayerApi.replace()` chain pattern (install→launch precedent), wired into the Armory Bundles tab's new "Import Bundle" button.

## Testing

- 68 new/updated Rust unit + integration-style tests (`bundle_import.rs` + a new `bundle::import_preview_commit_tests` module using the existing `test_state()` harness) -- collision classification against both a seeded global skill and an intra-bundle duplicate, digest-mismatch rejection writing nothing, `bundle_name` override, context-file id-based selection survives truncation, skip-vs-rename skill collision handling, raw MCP config persistence (not the `{source_path, config}` wrapper), `read_abf_file_path`'s missing-path/directory/oversized-via-sparse-file/symlink(Unix) rejection paths, and the digest mode-tag differentiation. Full backend suite: 1940 passed, 0 failed.
- `tsc --noEmit` and the full `vitest` suite pass (one unrelated pre-existing flaky timeout in `tool-renderers/registry.test.ts`, confirmed clean in isolation).
- `agentmux-cef` builds clean.

<!-- agentmux:agent_id=lazo -->