### PR TITLE
chore: release v0.54.8

### DIFF
--- a/.changesets/1785284522-feat-muxbus-same-host-cross-channel-reactive-delivery-tier-2-8d9c.md
+++ b/.changesets/1785284522-feat-muxbus-same-host-cross-channel-reactive-delivery-tier-2-8d9c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(muxbus): same-host cross-channel reactive delivery (Tier 2b, issue #1916)

--- a/.changesets/1785333760-docs-specs-archive-2-superseded-specs-doc-008-doc-009-p39l.md
+++ b/.changesets/1785333760-docs-specs-archive-2-superseded-specs-doc-008-doc-009-p39l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(specs): archive 2 superseded specs (DOC-008, DOC-009)

--- a/.changesets/1785335800-feat-srv-enforce-cross-process-session-lease-on-host-mode-ag-7h8c.md
+++ b/.changesets/1785335800-feat-srv-enforce-cross-process-session-lease-on-host-mode-ag-7h8c.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): enforce cross-process session lease on host-mode agent turns

--- a/.changesets/1785340373-fix-agent-transparently-retry-a-stale-resume-session-id-on-a-gx9b.md
+++ b/.changesets/1785340373-fix-agent-transparently-retry-a-stale-resume-session-id-on-a-gx9b.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): transparently retry a stale --resume session id on a persistent controller's first message

--- a/.changesets/1785341697-fix-agent-backfill-cross-channel-agent-definitions-before-in-mn26.md
+++ b/.changesets/1785341697-fix-agent-backfill-cross-channel-agent-definitions-before-in-mn26.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): backfill cross-channel agent definitions before instance create, filter legacy identity sentinels

--- a/.changesets/1785398290-fix-agent-pane-pin-scroll-from-content-resizeobserver-not-an-98kb.md
+++ b/.changesets/1785398290-fix-agent-pane-pin-scroll-from-content-resizeobserver-not-an-98kb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): pin scroll from content ResizeObserver, not an itemized signal whitelist

--- a/.changesets/1785419249-fix-agent-stream-require-real-explanation-text-before-ending-od56.md
+++ b/.changesets/1785419249-fix-agent-stream-require-real-explanation-text-before-ending-od56.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-stream): require real explanation text before ending a persistent-mode turn

--- a/.changesets/1785422369-fix-agent-suppress-the-visible-error-bubble-a-stale-resume-r-0zep.md
+++ b/.changesets/1785422369-fix-agent-suppress-the-visible-error-bubble-a-stale-resume-r-0zep.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): suppress the visible error bubble a stale --resume retry leaves behind

--- a/.changesets/1785433477-fix-agent-composer-two-line-responsive-layout-for-narrow-pan-i73s.md
+++ b/.changesets/1785433477-fix-agent-composer-two-line-responsive-layout-for-narrow-pan-i73s.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-composer): two-line responsive layout for narrow panes

--- a/.changesets/1785437872-refactor-agent-replace-ad-hoc-resume-retry-fields-with-an-ex-lgdl.md
+++ b/.changesets/1785437872-refactor-agent-replace-ad-hoc-resume-retry-fields-with-an-ex-lgdl.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-refactor(agent): replace ad-hoc resume-retry fields with an explicit event-driven state machine

--- a/.changesets/1785533841-fix-agent-auth-mount-time-auth-check-resolves-the-linked-acc-ygxy.md
+++ b/.changesets/1785533841-fix-agent-auth-mount-time-auth-check-resolves-the-linked-acc-ygxy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-auth): mount-time auth check resolves the linked account's own dir, not the generic default

--- a/.changesets/1785538036-feat-agent-detect-and-surface-context-compaction-in-real-tim-rbf3.md
+++ b/.changesets/1785538036-feat-agent-detect-and-surface-context-compaction-in-real-tim-rbf3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): detect and surface context compaction in real time

--- a/.changesets/1785618688-feat-armory-abf-single-file-abf-zip-format-importer-phase-2-bvcf.md
+++ b/.changesets/1785618688-feat-armory-abf-single-file-abf-zip-format-importer-phase-2-bvcf.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): ABF single-file (.abf zip) format + importer (Phase 2)

--- a/.changesets/1785618709-feat-muxspect-new-live-process-turn-state-introspection-tool-hx42.md
+++ b/.changesets/1785618709-feat-muxspect-new-live-process-turn-state-introspection-tool-hx42.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxspect): new live process/turn-state introspection tool, Phase 1 (current-instance only)

--- a/.changesets/1785660132-feat-armory-abf-import-ui-phase-3-selective-import-collision-2z7d.md
+++ b/.changesets/1785660132-feat-armory-abf-import-ui-phase-3-selective-import-collision-2z7d.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): ABF import UI (Phase 3) -- selective import + collision handling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.7"
+version = "0.54.8"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.7"
+version = "0.54.8"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.7"
+version = "0.54.8"
 dependencies = [
  "dirs",
  "serde",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.7"
+version = "0.54.8"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.7"
+version = "0.54.8"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.7"
+version = "0.54.8"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.7"
+version = "0.54.8"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,24 @@
 # AgentMux Version History
 
+## 0.54.8 — 2026-08-02
+
+- feat(muxbus): same-host cross-channel reactive delivery (Tier 2b, issue #1916)
+- docs(specs): archive 2 superseded specs (DOC-008, DOC-009)
+- feat(srv): enforce cross-process session lease on host-mode agent turns
+- fix(agent): transparently retry a stale --resume session id on a persistent controller's first message
+- fix(agent): backfill cross-channel agent definitions before instance create, filter legacy identity sentinels
+- fix(agent-pane): pin scroll from content ResizeObserver, not an itemized signal whitelist
+- fix(agent-stream): require real explanation text before ending a persistent-mode turn
+- fix(agent): suppress the visible error bubble a stale --resume retry leaves behind
+- fix(agent-composer): two-line responsive layout for narrow panes
+- refactor(agent): replace ad-hoc resume-retry fields with an explicit event-driven state machine
+- fix(agent-auth): mount-time auth check resolves the linked account's own dir, not the generic default
+- feat(agent): detect and surface context compaction in real time
+- feat(armory): ABF single-file (.abf zip) format + importer (Phase 2)
+- feat(muxspect): new live process/turn-state introspection tool, Phase 1 (current-instance only)
+- feat(armory): ABF import UI (Phase 3) -- selective import + collision handling
+
+
 ## 0.54.7 — 2026-07-29
 
 - feat(telemetry): [wave-turn] diagnostic logging for the turn-phase state machine + watchdog reasoning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.7",
+      "version": "0.54.8",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Consumes 15 pending changesets into v0.54.8.
- **Forced patch bump** (`--as patch`) per explicit request, overriding the computed `minor` (8 of the 15 pending changesets are `feat`-typed) — those features ship under this patch version rather than waiting for a minor release.
- All 5 version-consistency locations verified in agreement at 0.54.8 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md top section).

## Test plan
- [x] `scripts/release.sh --as patch` completed with the loud "forcing a LOWER bump" warning acknowledged (expected — deliberate override)
- [x] Reviewed `git diff --staged` — only version files + changeset deletions touched
- [ ] CI green
- [ ] reagent's release-consistency invariant check passes

<!-- agentmux:agent_id=agenta-07017 -->