### PR TITLE
fix(frontend): consolidate 5 duplicated elapsed-time formatters, fix negative-duration gap

### DIFF
--- a/.changesets/1785718937-fix-frontend-consolidate-5-duplicated-elapsed-time-formatter-p6ed.md
+++ b/.changesets/1785718937-fix-frontend-consolidate-5-duplicated-elapsed-time-formatter-p6ed.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(frontend): consolidate 5 duplicated elapsed-time formatters, fix negative-duration gap

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -12,6 +12,7 @@
 import clsx from "clsx";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
+import { formatElapsedClock } from "@/util/format-time";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import {
@@ -57,13 +58,6 @@ const KIND_CLASS: Record<string, string> = {
     system: "agent-tool-log-line--system",
 };
 
-function formatElapsed(ms: number): string {
-    const totalSec = Math.max(0, Math.floor(ms / 1000));
-    const m = Math.floor(totalSec / 60);
-    const s = totalSec % 60;
-    return `${m}:${String(s).padStart(2, "0")}`;
-}
-
 interface ActivityRowProps {
     /** Reactive accessor — returns undefined if the activity just left. */
     activity: () => PinnedActivity | undefined;
@@ -93,7 +87,7 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
         const a = props.activity();
         if (!a) return "";
         const end = a.endedAt ?? (tick(), Date.now());
-        return formatElapsed(end - a.startedAt);
+        return formatElapsedClock(end - a.startedAt);
     });
 
     // Terminal statuses override the kind sigil with a result glyph.

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -24,6 +24,7 @@ import { useTick } from "@/app/hook/useTick";
 import { compactionThreshold } from "@/app/store/agent-pane-state/context-window";
 import type { CompactionState } from "@/app/store/agent-pane-state/types";
 import { formatCompactNumber, formatExactNumber } from "@/util/format-count";
+import { formatElapsedCompact } from "@/util/format-time";
 import { Show, createEffect, createMemo, createSignal, type JSX } from "solid-js";
 import type { SessionStats, TurnTokens } from "../types";
 import { AgentRuntimeDropup } from "./AgentRuntimeDropup";
@@ -33,11 +34,6 @@ import { RuntimeBadge } from "./RuntimeBadge";
 
 function fmtTokens(t: TurnTokens): string {
     return `↑${formatCompactNumber(t.input)} ↓${formatCompactNumber(t.output)}`;
-}
-
-function fmtElapsed(ms: number): string {
-    const s = Math.floor(ms / 1000);
-    return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
 type CtxBand = "low" | "mid" | "high" | "critical";
@@ -148,19 +144,19 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
 
     const rightText = createMemo((): string => {
         if (props.compacting) {
-            return `Compacting…  ${fmtElapsed(compactingElapsedMs())}`;
+            return `Compacting…  ${formatElapsedCompact(compactingElapsedMs())}`;
         }
         const parts: string[] = [];
         if (props.loading) {
             if (props.turnTokens) parts.push(fmtTokens(props.turnTokens));
-            parts.push(fmtElapsed(elapsedMs()));
+            parts.push(formatElapsedCompact(elapsedMs()));
         } else if (props.sessionTotals) {
             const s = props.sessionTotals;
             if (s.input_tokens != null || s.output_tokens != null) {
                 parts.push(fmtTokens({ input: s.input_tokens ?? 0, output: s.output_tokens ?? 0 }));
             }
             if (s.duration_ms != null) {
-                parts.push(fmtElapsed(s.duration_ms));
+                parts.push(formatElapsedCompact(s.duration_ms));
             }
         }
         return parts.join("  ·  ");

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -14,6 +14,7 @@ import { atoms } from "@/app/store/global";
 import { ObjectService } from "@/app/store/services";
 import { fireAndForget } from "@/util/util";
 import { formatCompactNumber } from "@/util/format-count";
+import { formatElapsedCompact } from "@/util/format-time";
 import { MicButton } from "@/app/element/MicButton";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
@@ -27,11 +28,6 @@ function pickThinkingPhrase(_exclude?: string): string {
 
 function ingToEd(_phrase: string): string {
     return "Worked";
-}
-
-function fmtElapsed(ms: number): string {
-    const s = Math.floor(ms / 1000);
-    return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
 function fmtTokens(t: TurnTokens): string {
@@ -236,7 +232,7 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     const rightText = createMemo((): string => {
         const right: string[] = [];
         if (props.turnTokens) right.push(fmtTokens(props.turnTokens));
-        right.push(fmtElapsed(elapsedMs()));
+        right.push(formatElapsedCompact(elapsedMs()));
         return right.join("  ·  ");
     });
 

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -14,6 +14,7 @@
 import clsx from "clsx";
 import { For, Show, createMemo, createSignal, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
+import { formatElapsedClock } from "@/util/format-time";
 import { capChars, createChunkCapper, createSpinnerCollapser, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { LinkifiedText } from "@/app/element/linkified-text";
@@ -33,19 +34,12 @@ const KIND_CLASS: Record<string, string> = {
     system: "agent-tool-log-line--system",
 };
 
-function formatElapsed(ms: number): string {
-    const totalSec = Math.floor(ms / 1000);
-    const m = Math.floor(totalSec / 60);
-    const s = totalSec % 60;
-    return `${m}:${String(s).padStart(2, "0")}`;
-}
-
 export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Element => {
     const tick = useTick(1000);
 
     const elapsed = createMemo(() => {
         const end = props.node.exitedAt ?? (tick(), Date.now());
-        return formatElapsed(end - props.node.spawnedAt);
+        return formatElapsedClock(end - props.node.spawnedAt);
     });
 
     const lastLine = createMemo((): string | undefined => {

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -15,6 +15,7 @@ import { WorkspaceService } from "@/app/store/services";
 import { recordTurn } from "@/app/store/token-usage";
 import { useTick } from "@/app/hook/useTick";
 import { formatCompactNumber } from "@/util/format-count";
+import { formatElapsedClock } from "@/util/format-time";
 import "./swarm-view.scss";
 
 // Navigate to the pane for a given block ID, switching tabs and windows as needed.
@@ -378,18 +379,11 @@ function ShellBucket({ rows }: { rows: ActiveShell[] }): JSX.Element {
     );
 }
 
-function formatElapsed(ms: number): string {
-    const totalSec = Math.max(0, Math.floor(ms / 1000));
-    const m = Math.floor(totalSec / 60);
-    const s = totalSec % 60;
-    return `${m}:${String(s).padStart(2, "0")}`;
-}
-
 function ShellRow({ shell }: { shell: ActiveShell }): JSX.Element {
     const tick = useTick(1000);
     const elapsed = createMemo(() => {
         tick();
-        return formatElapsed(Date.now() - shell.started_at);
+        return formatElapsedClock(Date.now() - shell.started_at);
     });
 
     const handleStop = (e: MouseEvent) => {

--- a/frontend/util/format-time.test.ts
+++ b/frontend/util/format-time.test.ts
@@ -1,0 +1,37 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { formatElapsedClock, formatElapsedCompact } from "./format-time";
+
+describe("formatElapsedCompact", () => {
+    it("renders seconds only under a minute", () => {
+        expect(formatElapsedCompact(0)).toBe("0s");
+        expect(formatElapsedCompact(999)).toBe("0s");
+        expect(formatElapsedCompact(1_000)).toBe("1s");
+        expect(formatElapsedCompact(42_000)).toBe("42s");
+        expect(formatElapsedCompact(59_000)).toBe("59s");
+    });
+
+    it("renders minutes + seconds at/above a minute", () => {
+        expect(formatElapsedCompact(60_000)).toBe("1m 0s");
+        expect(formatElapsedCompact(185_000)).toBe("3m 5s");
+    });
+
+    it("floors negative durations to 0s", () => {
+        expect(formatElapsedCompact(-500)).toBe("0s");
+    });
+});
+
+describe("formatElapsedClock", () => {
+    it("renders mm:ss, zero-padded", () => {
+        expect(formatElapsedClock(0)).toBe("0:00");
+        expect(formatElapsedClock(5_000)).toBe("0:05");
+        expect(formatElapsedClock(185_000)).toBe("3:05");
+        expect(formatElapsedClock(600_000)).toBe("10:00");
+    });
+
+    it("floors negative durations to 0:00 (fixes the PersistentShellBlock gap)", () => {
+        expect(formatElapsedClock(-65_000)).toBe("0:00");
+    });
+});

--- a/frontend/util/format-time.ts
+++ b/frontend/util/format-time.ts
@@ -1,0 +1,36 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared elapsed-time display formatting — consolidates 5 independently-
+ * duplicated implementations found across the composer strip, footer,
+ * activity dock, persistent shell block, and swarm pane.
+ *
+ * Two genuinely different conventions were already live in the product, so
+ * this exports both rather than forcing one on every call site:
+ *   - `formatElapsedCompact` — prose form ("42s", "3m 5s"), used in the
+ *     composer strip and footer.
+ *   - `formatElapsedClock`   — mm:ss form ("3:05"), used in the activity
+ *     dock, persistent shell block, and swarm pane.
+ *
+ * See docs/specs/SPEC_TOKEN_STATS_NUMBER_FORMATTING_2026_08_02.md §7.1.
+ */
+
+/** Prose form: "42s" under a minute, "3m 5s" at/above a minute. */
+export function formatElapsedCompact(ms: number): string {
+    const s = Math.max(0, Math.floor(ms / 1000));
+    return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+/**
+ * Clock form: "M:SS", zero-padded seconds. Floors negative durations to 0 —
+ * one of the 5 original copies (`PersistentShellBlock.tsx`) was missing this
+ * guard and could render e.g. "-1:05" on a clock-skew edge case; the other
+ * clock-style copies already had it.
+ */
+export function formatElapsedClock(ms: number): string {
+    const totalSec = Math.max(0, Math.floor(ms / 1000));
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- Consolidates 5 independently-duplicated elapsed-time formatters (`AgentComposerStrip.tsx`, `AgentFooter.tsx`, `ActivityRow.tsx`, `PersistentShellBlock.tsx`, `swarm-view.tsx`) into `frontend/util/format-time.ts`.
- Two genuinely different display conventions were already live in the product — prose ("3m 5s") vs clock ("3:05") — so this exports both (`formatElapsedCompact`, `formatElapsedClock`) rather than forcing one everywhere. See `docs/specs/SPEC_TOKEN_STATS_NUMBER_FORMATTING_2026_08_02.md` §7.1.
- Fixes a real bug along the way: `PersistentShellBlock.tsx`'s copy was missing the `Math.max(0, ...)` floor guard the other clock-style copies already had — it could render a negative duration (e.g. `-1:05`) on a clock-skew edge case.
- Second PR in the display-formatting consolidation sequence (follows #2385, format-count.ts — merged).

## Test plan
- [x] New `frontend/util/format-time.test.ts` — 5 tests covering both formatters, boundary values, and negative-duration flooring.
- [x] Full frontend suite: 2216/2216 passing (verified with a real `npm install`, not a dev-worktree node_modules junction).
- [x] `tsc --noEmit` clean, project-wide.

<!-- agentmux:agent_id=agenta-07017 -->