### PR TITLE
feat(muxspect): surface last persisted spawn/execution error in list/describe

### DIFF
--- a/.changesets/1785721790-feat-muxspect-surface-last-persisted-spawn-execution-error-i-57kp.md
+++ b/.changesets/1785721790-feat-muxspect-surface-last-persisted-spawn-execution-error-i-57kp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(muxspect): surface last persisted spawn/execution error in list/describe

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -504,6 +504,13 @@ impl SubprocessController {
         let event_bus_wait = self.event_bus.clone();
         let lease_store_wait = self.lease_store.clone();
         let claimed_lease_wait = claimed_lease;
+        // For the queued-message-drain failure frame below — must be
+        // PERSISTED, not just live-broadcast (codex P1 on PR #2390: the
+        // call below previously passed None despite its own comment
+        // claiming parity with input.rs's persisted identity/container
+        // frames, so muxspect's last_error_frame could never see it after
+        // the live moment passed).
+        let filestore_wait = self.filestore.clone();
         tokio::spawn(async move {
             // Classified failure cause, surfaced to the pane after the readers drain.
             let mut run_failure: Option<crate::agents::failure::AgentFailure> = None;
@@ -741,7 +748,7 @@ impl SubprocessController {
                                 &block_id_wait,
                                 SUBPROCESS_OUTPUT_SUBJECT,
                                 format!("{error_frame}\n").as_bytes(),
-                                None,
+                                filestore_wait.as_ref(),
                                 None,
                             );
                         }

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -111,6 +111,13 @@ function renderList(data) {
     // always agents; reimplementing that classification rule in JS instead
     // of reusing ProcessStatus::is_agent() mislabeled exactly those three
     // types as "term" (codex P2 on PR #2380, second round).
+    // "last_error" — the last thing that happened to this block was an
+    // unrecovered spawn/execution error (muxspect_handlers.rs's
+    // last_error_frame). Distinct from lifecycle/confidence (liveness): a
+    // block can be `lifecycle: unknown` for perfectly healthy reasons
+    // (idle, never opened) — this column is what disambiguates "idle"
+    // from "wedged, fix available" at a glance, which is the whole point
+    // (docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md §3.2).
     const rows = blocks.map((b) => ({
         block_id: b.block_id,
         type: b.controller_type || "?",
@@ -118,8 +125,9 @@ function renderList(data) {
         pane_type: b.is_agent ? "agent" : "term",
         confidence: b.liveness_confidence,
         age: ageString(b.last_computed_ms),
+        last_error: b.last_error ? `yes (${ageString(b.last_error.written_ms)})` : "-",
     }));
-    const cols = ["block_id", "type", "lifecycle", "pane_type", "confidence", "age"];
+    const cols = ["block_id", "type", "lifecycle", "pane_type", "confidence", "age", "last_error"];
     const widths = Object.fromEntries(
         cols.map((c) => [c, Math.max(c.length, ...rows.map((r) => String(r[c]).length))])
     );
@@ -155,6 +163,18 @@ function renderDescribe(data) {
         for (const p of processes) {
             console.log(`  pid=${p.pid}  rss=${Math.round(p.rss_bytes / 1024)}KB  ${p.command || "(unknown command)"}`);
         }
+    }
+    // The actual "why" for a block with no live controller/process — see
+    // muxspect_handlers.rs's last_error_frame. Printed last, since it's
+    // usually the answer someone's here for precisely when everything
+    // above it is empty.
+    if (data.last_error) {
+        console.log(`\nlast_error:`);
+        console.log(`  message: ${data.last_error.message}`);
+        console.log(`  source:  ${data.last_error.source}`);
+        console.log(`  age:     ${ageString(data.last_error.written_ms)}`);
+    } else {
+        console.log(`\nlast_error:           (none)`);
     }
 }
 

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -384,12 +384,19 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                                 "subtype": "error_during_execution",
                                 "error": {"message": format!("[AgentMux] container ensure_running failed: {e}")}
                             }).to_string();
+                            // Some(&filestore_gate): PERSIST, not just live-broadcast —
+                            // same requirement as the identity spawn-gate frame above
+                            // (reagent P1, PR #2164 round 2). Previously passed None
+                            // here despite the comment above claiming parity with that
+                            // path — codex P1 on PR #2390: muxspect's last_error_frame
+                            // (which reads only the persisted `output` file) could
+                            // never see this failure after the live moment passed.
                             crate::backend::blockcontroller::shell::handle_append_block_file(
                                 &broker,
                                 &cmd.blockid,
                                 crate::backend::blockcontroller::subprocess::SUBPROCESS_OUTPUT_SUBJECT,
                                 format!("{error_frame}\n").as_bytes(),
-                                None,
+                                Some(&filestore_gate),
                                 None,
                             );
                             return Err(format!("container ensure_running failed: {e}"));

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -18,7 +18,115 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json};
 use serde_json::json;
 
+use crate::backend::storage::filestore::FileStore;
+
 use super::AppState;
+
+/// Bounded tail window read from a block's own persisted `output` file
+/// when looking for a trailing `error_during_execution` frame — see
+/// [`last_error_frame`]. Large enough to comfortably hold the frame itself
+/// (a single JSON line, typically well under 1KB) plus whatever partial
+/// line/chunking noise might precede it; small enough to stay O(1) and not
+/// turn `muxspect` into a log-walker (that's `muxlog`'s job, not this
+/// tool's — see the tool's own design spec §1).
+const LAST_ERROR_TAIL_BYTES: i64 = 8192;
+
+/// The most recent persisted `error_during_execution` frame at the tail of
+/// a block's own `output` file — populated ONLY when the very last
+/// non-blank line IS one (a block that errored once and then kept
+/// producing normal output afterward must NOT be flagged; only "the last
+/// thing that happened to this block was an unrecovered error" counts).
+///
+/// This reads a signal that already exists and is already durable: per
+/// `agent_handlers/input.rs`'s own comment, this exact frame shape is
+/// deliberately persisted to the block file (not just live-broadcast) so
+/// it survives pane reload — the same source the frontend itself renders
+/// as the pane's error bubble. Composing a second reader over that
+/// existing store, rather than adding a new independent tracker, follows
+/// this module's own design constraint (spec §5.1/§3 pt. 8).
+///
+/// See `docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md`
+/// for the incident this closes the diagnostic gap on: a block whose spawn
+/// was refused before any controller/process ever existed showed up as
+/// featureless "no controller, no processes" — indistinguishable from a
+/// healthy idle block — even though the actual, actionable reason was
+/// already sitting in this exact file.
+#[derive(serde::Serialize)]
+pub struct LastErrorFrame {
+    /// The frame's `error.message` verbatim (includes the `[AgentMux] `
+    /// prefix every construction site already writes).
+    pub message: String,
+    /// Best-effort tag for which pre-spawn failure path wrote the frame —
+    /// see [`classify_last_error_source`]. NOT a stable/tested taxonomy
+    /// like `agents::failure::FailureClass` (which only classifies
+    /// POST-spawn exit failures); building that properly for pre-spawn
+    /// refusals is real, separate follow-up work (report §3.3), not
+    /// attempted here.
+    pub source: &'static str,
+    /// Epoch ms the `output` file was last written — i.e. when this frame
+    /// (being the file's last line) was appended. Deliberately a raw
+    /// timestamp, not a precomputed "age," matching `last_computed_ms`'s
+    /// existing convention elsewhere in this response so `--json`
+    /// consumers get a stable value and the CLI renderer computes age the
+    /// same way it already does for every other timestamp.
+    pub written_ms: u64,
+}
+
+/// Best-effort classification of which pre-spawn failure path wrote a
+/// persisted `error_during_execution` frame, inferred from the message
+/// text itself (each construction site's message is distinct and stable —
+/// see `identity/resolver/errors.rs`'s `SpawnGateError::Display`,
+/// `subprocess/container_spawn.rs`, `subprocess/host_spawn.rs`, and
+/// `agent_handlers/input.rs`'s container `ensure_running` path, the only
+/// four call sites that build this frame today). `message` should have
+/// the `[AgentMux] ` prefix already stripped.
+fn classify_last_error_source(message: &str) -> &'static str {
+    if message.starts_with("no credentials for") || message.starts_with("credential injection could not run") {
+        "identity"
+    } else if message.starts_with("container exec failed") || message.starts_with("container ensure_running failed")
+    {
+        "container_spawn"
+    } else if message.starts_with("queued message could not be sent") {
+        "host_spawn"
+    } else {
+        "unknown"
+    }
+}
+
+/// Read the bounded tail of `block_id`'s `output` file and return the
+/// parsed [`LastErrorFrame`] if its last non-blank line is one. `None`
+/// covers every other case (no such block, empty file, last line is
+/// normal output, last line doesn't parse as this exact frame shape) —
+/// deliberately not distinguished further, since all of them mean the
+/// same thing to a caller: nothing actionable to surface here.
+fn last_error_frame(filestore: &FileStore, block_id: &str) -> Option<LastErrorFrame> {
+    let file = filestore.stat(block_id, "output").ok().flatten()?;
+    if file.size <= 0 {
+        return None;
+    }
+    let start = (file.size - LAST_ERROR_TAIL_BYTES).max(0);
+    let (_, bytes) = filestore
+        .read_at(block_id, "output", start, file.size - start)
+        .ok()?;
+    let text = String::from_utf8_lossy(&bytes);
+    let last_line = text.lines().rev().find(|l| !l.trim().is_empty())?;
+
+    let value: serde_json::Value = serde_json::from_str(last_line).ok()?;
+    if value.get("type").and_then(|v| v.as_str()) != Some("result")
+        || value.get("is_error").and_then(|v| v.as_bool()) != Some(true)
+        || value.get("subtype").and_then(|v| v.as_str()) != Some("error_during_execution")
+    {
+        return None;
+    }
+    let message = value.get("error")?.get("message")?.as_str()?.to_string();
+    let source = classify_last_error_source(message.strip_prefix("[AgentMux] ").unwrap_or(&message));
+
+    Some(LastErrorFrame {
+        message,
+        source,
+        written_ms: file.modts.max(0) as u64,
+    })
+}
 
 /// `GET /api/v1/muxspect/list` — every controller-backed block's current
 /// `ProcessStatus`, full detail (unlike `agent.tracked-blocks`, which
@@ -36,9 +144,11 @@ pub async fn handle_muxspect_list(State(state): State<AppState>) -> impl IntoRes
         .into_iter()
         .map(|status| {
             let is_agent = status.is_agent();
+            let last_error = last_error_frame(&state.filestore, &status.block_id);
             let mut value = serde_json::to_value(&status).unwrap_or_default();
             if let Some(obj) = value.as_object_mut() {
                 obj.insert("is_agent".to_string(), json!(is_agent));
+                obj.insert("last_error".to_string(), json!(last_error));
             }
             value
         })
@@ -81,6 +191,13 @@ pub async fn handle_muxspect_describe(
     // everything from this one snapshot instead of reading twice.
     let process_status = state.process_broker.status(&q.block_id);
     let is_agent = process_status.is_agent();
+    // Read unconditionally, not gated on "no live controller" — cheap
+    // (bounded tail read), and gating it would mean re-deriving exactly
+    // the liveness logic `process_status` already computes just to decide
+    // whether to bother. In practice this is only ever non-null for
+    // exactly the case it exists for: nothing has appended to this
+    // block's output since an unrecovered pre-spawn failure.
+    let last_error = last_error_frame(&state.filestore, &q.block_id);
 
     Json(json!({
         "block_id": q.block_id,
@@ -89,6 +206,124 @@ pub async fn handle_muxspect_describe(
         "controller_status": &process_status.controller_status,
         "processes": &process_status.processes,
         "tracking_confidence": process_status.liveness_confidence,
+        "last_error": last_error,
     }))
     .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::filestore::{FileMeta, FileOpts};
+
+    fn error_frame_line(message: &str) -> String {
+        json!({
+            "type": "result",
+            "is_error": true,
+            "subtype": "error_during_execution",
+            "error": {"message": message}
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn classify_last_error_source_matches_every_known_construction_site() {
+        // The exact message text each of the four call sites builds today
+        // (identity/resolver/errors.rs, container_spawn.rs, host_spawn.rs,
+        // agent_handlers/input.rs) — with the `[AgentMux] ` prefix already
+        // stripped, as the real caller does before classifying.
+        assert_eq!(
+            classify_last_error_source("no credentials for claude: the bound account was deleted or is unresolvable. Bind an account for this provider in the Armory."),
+            "identity"
+        );
+        assert_eq!(
+            classify_last_error_source("credential injection could not run (task join failed); the spawn was refused rather than falling back to the global CLI login. Retry, and check `muxlog auth` if it persists."),
+            "identity"
+        );
+        assert_eq!(
+            classify_last_error_source("container exec failed: no such container"),
+            "container_spawn"
+        );
+        assert_eq!(
+            classify_last_error_source("container ensure_running failed: image not found"),
+            "container_spawn"
+        );
+        assert_eq!(
+            classify_last_error_source("queued message could not be sent: lease held by another process"),
+            "host_spawn"
+        );
+        assert_eq!(classify_last_error_source("something nobody wrote yet"), "unknown");
+    }
+
+    #[test]
+    fn last_error_frame_none_for_missing_block() {
+        let filestore = FileStore::open_in_memory().unwrap();
+        assert!(last_error_frame(&filestore, "no-such-block").is_none());
+    }
+
+    #[test]
+    fn last_error_frame_none_for_empty_output() {
+        let filestore = FileStore::open_in_memory().unwrap();
+        filestore
+            .make_file("block-1", "output", FileMeta::new(), FileOpts::default())
+            .unwrap();
+        assert!(last_error_frame(&filestore, "block-1").is_none());
+    }
+
+    #[test]
+    fn last_error_frame_found_when_last_line_is_the_frame() {
+        let filestore = FileStore::open_in_memory().unwrap();
+        filestore
+            .make_file("block-1", "output", FileMeta::new(), FileOpts::default())
+            .unwrap();
+        let mut content = String::new();
+        content.push_str("{\"type\":\"assistant\",\"text\":\"normal turn output\"}\n");
+        content.push_str(&error_frame_line(
+            "[AgentMux] no credentials for claude: bind an account in the Armory.",
+        ));
+        content.push('\n');
+        filestore.write_file("block-1", "output", content.as_bytes()).unwrap();
+
+        let found = last_error_frame(&filestore, "block-1").expect("last line is an error frame");
+        assert_eq!(
+            found.message,
+            "[AgentMux] no credentials for claude: bind an account in the Armory."
+        );
+        assert_eq!(found.source, "identity");
+        assert!(found.written_ms > 0);
+    }
+
+    /// Pins the "only the LAST non-blank line counts" rule (see the
+    /// function's own doc comment): a block that errored once and then
+    /// recovered — kept producing normal output afterward — must NOT be
+    /// flagged. Only "the last thing that happened was an unrecovered
+    /// error" is what this exists to surface.
+    #[test]
+    fn last_error_frame_none_when_normal_output_follows_an_earlier_error() {
+        let filestore = FileStore::open_in_memory().unwrap();
+        filestore
+            .make_file("block-1", "output", FileMeta::new(), FileOpts::default())
+            .unwrap();
+        let mut content = String::new();
+        content.push_str(&error_frame_line("[AgentMux] container exec failed: transient"));
+        content.push('\n');
+        content.push_str("{\"type\":\"assistant\",\"text\":\"turn resumed fine after the retry\"}\n");
+        filestore.write_file("block-1", "output", content.as_bytes()).unwrap();
+
+        assert!(last_error_frame(&filestore, "block-1").is_none());
+    }
+
+    #[test]
+    fn last_error_frame_ignores_a_result_frame_that_is_not_an_error() {
+        let filestore = FileStore::open_in_memory().unwrap();
+        filestore
+            .make_file("block-1", "output", FileMeta::new(), FileOpts::default())
+            .unwrap();
+        let normal_result = json!({"type": "result", "is_error": false, "subtype": "success"}).to_string();
+        filestore
+            .write_file("block-1", "output", format!("{normal_result}\n").as_bytes())
+            .unwrap();
+
+        assert!(last_error_frame(&filestore, "block-1").is_none());
+    }
 }

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1373,3 +1373,78 @@ async fn muxspect_describe_requires_block_id() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
+
+/// `describe` on a block with NO controller (the exact "diagnostically
+/// empty" state `muxspect_describe_composes_status_for_an_unknown_block`
+/// pins above) must now also surface WHY, when the reason is knowable: a
+/// persisted `error_during_execution` frame as the last line of the
+/// block's own output — the durable signal `agent_handlers/input.rs`
+/// already writes for exactly this case (identity-gate spawn refusal,
+/// container-spawn failure, etc.). See
+/// `docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md`
+/// — this is the change that closes the gap the report was written about.
+#[tokio::test]
+async fn muxspect_describe_surfaces_last_error_for_a_wedged_block() {
+    use crate::backend::storage::filestore::{FileMeta, FileOpts};
+
+    let state = test_state();
+    let filestore = state.filestore.clone();
+    filestore
+        .make_file("wedged-block", "output", FileMeta::new(), FileOpts::default())
+        .unwrap();
+    let error_line = serde_json::json!({
+        "type": "result",
+        "is_error": true,
+        "subtype": "error_during_execution",
+        "error": {"message": "[AgentMux] no credentials for claude: bind an account for this provider in the Armory."}
+    })
+    .to_string();
+    filestore
+        .write_file("wedged-block", "output", format!("{error_line}\n").as_bytes())
+        .unwrap();
+
+    let app = build_router(state);
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/muxspect/describe?block_id=wedged-block")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    // Still correctly reports no live controller — this block never had one.
+    assert_eq!(json["process_status"]["lifecycle"], "unknown");
+    assert_eq!(json["controller_status"], serde_json::Value::Null);
+    // ...but is no longer diagnostically empty about why.
+    assert_eq!(
+        json["last_error"]["message"],
+        "[AgentMux] no credentials for claude: bind an account for this provider in the Armory."
+    );
+    assert_eq!(json["last_error"]["source"], "identity");
+    assert!(json["last_error"]["written_ms"].as_u64().unwrap() > 0);
+}
+
+/// A block with no `output` file at all (never opened, or genuinely
+/// healthy) must report `last_error: null`, not error or fabricate one —
+/// this is the common case and must stay silent.
+#[tokio::test]
+async fn muxspect_describe_last_error_is_null_for_a_block_with_no_output() {
+    let state = test_state();
+    let app = build_router(state);
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/muxspect/describe?block_id=never-opened")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["last_error"], serde_json::Value::Null);
+}

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -50,6 +50,20 @@ independent view of process/turn state. Concretely it can see:
 - The OS process tree tracked for a block (PID, command, RSS)
 - How stale each of the above is (`last_computed_ms`) and how confidently
   it's tracked on this platform (`liveness_confidence`)
+- **`last_error`** — if the very last line ever written to a block's own
+  transcript is a persisted `error_during_execution` frame (a spawn that
+  was refused before any process/controller existed — a bad identity
+  link, a container that wouldn't start, etc.), `describe` and `list` both
+  surface it directly: the message, a best-effort `source` tag, and when
+  it was written. This is what a block with `lifecycle: unknown` and zero
+  processes actually means — "healthy, idle" and "permanently wedged,
+  actionable fix available" look identical without it. Added to close
+  exactly that gap after a real incident where `muxspect describe` came
+  back diagnostically empty on a wedged agent — see
+  `docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md`.
+  Not a live/independent error tracker — it's a second reader over the
+  same durable frame the pane's own error bubble already comes from, so it
+  can never drift from what the UI shows.
 
 It **cannot** see the Agent pane's Activity Dock — that's pure in-renderer
 SolidJS state, never persisted or exposed via any RPC, by design (not an

--- a/docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md
+++ b/docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md
@@ -1,0 +1,199 @@
+# REPORT — Extending `muxspect` to diagnose pre-spawn refusals
+
+**Date:** 2026-08-03
+**Type:** Extension to `muxspect` (PR #2380, merged 2026-08-02) — implemented,
+this report is both the incident writeup and the design doc for the fix.
+**Status:** Implemented. `last_error` is now a field on both
+`/api/v1/muxspect/list` and `/api/v1/muxspect/describe`.
+
+---
+
+## 1. The incident that motivated this
+
+An agent's pane ("Agent1") sat showing "Agent encountered error" for over two
+hours. Closing/reopening the pane and resending messages did nothing.
+Root-causing it required three separate, manual investigations: grepping two
+days of srv logs for the block id, then a direct read-only query against the
+live `store.db`. `muxspect` — which already existed at the time — was checked
+*last*, and even then came back diagnostically empty:
+
+```
+$ node ~/.agentmux/shell/muxspect.mjs describe e913dc16-c0a6-4470-9acf-692dfc720f90
+controller_type:     (no controller)
+liveness_confidence: none
+processes (0):
+  (none tracked)
+```
+
+This is **correct** — there genuinely was no controller and no process for
+that block — but it's indistinguishable from a perfectly healthy idle block.
+The actual cause, reconstructed by hand from srv logs and `db_agent_identity_links`,
+was one line, entirely knowable at the time:
+
+```
+identity.spawn.blocked: no credentials for provider claude (definition
+938e343c-..., identity bundle-agenty-default) — no account bound for the
+agent's provider; spawn refused (single-point enforcement — use_ambient_login=true, ignored)
+```
+
+The agent definition had a `github` identity link but no `claude` link — so
+the v0.54.8 identity migration correctly classified it as fail-by-default
+(not ambient), and every spawn attempt was refused before a controller or
+process ever existed. Closing/reopening the pane could never have fixed this:
+there was nothing for the client to retry against.
+
+## 2. The signal already existed — nothing read it
+
+This is the load-bearing finding: **the fix here isn't new instrumentation,
+it's reading something that was already being written.**
+
+`agentmux-srv/src/identity/resolver/inject.rs`'s spawn gate
+(`gate_oauth_failure`) returns a `SpawnGateError` whose `Display` impl
+(`errors.rs`) is already a good, actionable, user-facing message:
+
+> "no credentials for claude: the bound account was deleted or is
+> unresolvable. Bind an account for this provider in the Armory."
+
+Per `agent_handlers/input.rs`'s own existing comment, that message is
+**deliberately persisted into the block's own `output` file** as an
+`error_during_execution` frame — the same frame shape the agent pane's
+frontend renders as its error bubble — specifically so *"the frame must be
+PERSISTED to the block file... otherwise the error vanishes on pane
+reload/reconnect"* (reagent P1, PR #2164 round 2). The same frame shape is
+also written by two other pre-spawn failure paths — `container_spawn.rs`'s
+`exec`/`ensure_running` failures and `host_spawn.rs`'s queued-message-drain
+failure — so this isn't identity-specific, it's the general "spawn never
+happened, here's why" signal for the whole app.
+
+The data `muxspect` needed already lived in exactly one place, was already
+durable, and was already the *same* source the frontend itself reads.
+Extending `muxspect` to read it is a direct application of its own design
+constraint (`SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md` §5.1/§3 pt.
+8 — "never a second, independent state-tracker"): a second reader over an
+existing durable store, not a new one.
+
+## 3. What was implemented
+
+### 3.1 `last_error_frame()` — `agentmux-srv/src/server/muxspect_handlers.rs`
+
+A bounded reverse-tail read (last 8KB, `LAST_ERROR_TAIL_BYTES`) of a block's
+`output` file via the existing `FileStore` (`stat` + `read_at` — the same
+store `blockfile.rs`'s `read_range`/`line_count` handlers already read).
+Deliberately only inspects the **last non-blank line** — a block that
+errored once and then kept producing normal output afterward must NOT be
+flagged; only "the last thing that happened to this block was an unrecovered
+error" is surfaced. If that line parses as
+`{"type":"result","is_error":true,"subtype":"error_during_execution",...}`,
+its `error.message` is extracted and classified (`classify_last_error_source`)
+into a best-effort `source` tag (`identity` / `container_spawn` / `host_spawn`
+/ `unknown`) by matching the message's own stable prefix — each of the four
+construction sites in the codebase writes a distinct, unambiguous phrasing.
+
+**Age, resolved:** the frame itself carries no wall-clock timestamp at
+write time. Rather than touching four call sites across two subsystems
+(identity, container/host spawn) to add one, this reads the `output` file's
+own `modts` (already tracked by `FileStore` on every write) — correct for
+exactly the case this feature exists for: nothing appends to a block's
+output after an unrecovered pre-spawn failure, so the file's last-modified
+time *is* the frame's timestamp. Returned as a raw epoch-ms `written_ms`
+(matching the existing `last_computed_ms` convention), not a precomputed
+duration — the CLI computes age with the same `ageString()` helper it
+already uses for every other timestamp in the response.
+
+### 3.2 Wired into both routes, unconditionally
+
+Both `handle_muxspect_list` and `handle_muxspect_describe` now call
+`last_error_frame()` for every block/`block_id` they already handle and add
+a `last_error` field (`null` when absent) — additive only, no change to the
+existing response shape. Computed unconditionally rather than gated on "no
+live controller": it's cheap (one bounded tail read), and gating it would
+mean re-deriving the same liveness logic `process_status` already computes
+just to decide whether to bother. In practice it's non-null only for the
+case it exists for.
+
+**A scope note on `list`:** `handle_muxspect_list` iterates
+`ProcessBroker::list()`, which is scoped to `get_all_controllers()` — blocks
+with a currently-registered controller. This PR decorates the rows `list()`
+already returns; it does not change what block_ids `list()` enumerates. A
+block whose spawn is refused *before* any controller is ever registered may
+still not appear as a `list()` row at all (independent of this change,
+matching the route's own existing "every controller-backed block" scope —
+see its doc comment). **`describe` has no such limitation** — it already
+accepts and correctly reports on any block_id string, controller-backed or
+not (see the existing `muxspect_describe_composes_status_for_an_unknown_block`
+test), so it's the reliable, primary fix for the diagnostic gap; `list`'s
+new column is a real improvement for whatever it already shows, not a
+guarantee that every wedged block will surface there. If a future incident
+shows blocks going wedged with no controller record at all, widening
+`list()`'s source of block_ids (e.g. to every known agent pane, not just
+currently-registered controllers) is a reasonable, separate follow-up — not
+attempted here.
+
+### 3.3 CLI rendering — `muxspect.mjs`
+
+- `muxspect list`: new `last_error` column, `yes (<age>)` or `-`.
+- `muxspect describe`: new `last_error:` section (message / source / age),
+  printed last since it's usually the answer someone's there for precisely
+  when everything above it is empty.
+- `--json` output carries the raw field for either command, unchanged
+  shape otherwise.
+
+### 3.4 Docs
+
+`docs/MUXSPECT.md`'s "what it can and can't see" section now documents
+`last_error` alongside the existing lifecycle/process-tree/staleness bullets.
+
+## 4. What this would have caught
+
+Re-running the actual incident with this change live:
+
+```
+$ muxspect describe e913dc16-...
+last_error:
+  message: [AgentMux] no credentials for claude: the bound account was
+           deleted or is unresolvable. Bind an account for this provider
+           in the Armory.
+  source:  identity
+  age:     2h14m
+```
+
+That's the entire investigation in one command, with the actual fix printed
+verbatim — the same conclusion that took a two-file srv-log grep plus a live
+`store.db` read to reconstruct by hand.
+
+## 5. Explicitly out of scope
+
+- **No mutation.** `muxspect` stays read-only — no auto-rebind, no
+  auto-retry. Same invariant as Phase 1.
+- **No stable pre-spawn failure taxonomy.** `source` is a best-effort tag
+  inferred from message text, not a tested enum like
+  `agents::failure::FailureClass` (which only classifies **post-spawn** exit
+  failures — `classify()` never runs for a spawn refused before a process
+  existed). Building that taxonomy properly is real, separate work belonging
+  to whoever owns `SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md`.
+- **Not fixing the frontend error bubble.** Whether the pane's own "Agent
+  encountered error" banner should show this message text is a product/UI
+  question, not addressed here.
+- **Not a general blockfile tail viewer.** Scoped to exactly one frame
+  shape, not "show me the last N lines of any block" — that's `muxlog`'s
+  job.
+- **Not widening `list()`'s block enumeration** — see §3.2's scope note.
+
+## 6. Testing
+
+- `agentmux-srv/src/server/muxspect_handlers.rs` — 6 new unit tests for
+  `last_error_frame`/`classify_last_error_source` directly (missing block,
+  empty output, frame present, frame present-then-recovered, non-error
+  result frame, every known message-prefix classification).
+- `agentmux-srv/src/server/tests.rs` — 2 new HTTP-level tests: `describe`
+  surfaces `last_error` for a block with a persisted identity-gate refusal
+  as its last output line; `describe` returns `last_error: null` for a
+  block with no output at all.
+- `cargo test -p agentmux-srv` — 1959 passed, 0 failed (full suite, not
+  just the new tests).
+- `npx vitest run muxspect.test.mjs` — 8/8 passing, unchanged (no
+  `parseArgs` changes in this PR).
+- Not run this pass: a live rebuild + manual `muxspect describe` against a
+  real wedged block in a running instance (same scope decision PR #2380 and
+  #2373 each made in their own test plans) — the unit + integration
+  coverage above exercises the exact code path directly.

--- a/docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md
+++ b/docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md
@@ -143,6 +143,36 @@ attempted here.
 `docs/MUXSPECT.md`'s "what it can and can't see" section now documents
 `last_error` alongside the existing lifecycle/process-tree/staleness bullets.
 
+### 3.5 Fixed during review: two of the four sources weren't actually persisted (codex P1)
+
+`classify_last_error_source` names four sources — `identity`,
+`container_spawn` (exec + ensure_running), `host_spawn` — but two of the
+four underlying construction sites (`agent_handlers/input.rs`'s container
+`ensure_running` failure, `subprocess/host_spawn.rs`'s queued-message-drain
+failure) were passing `None` for `handle_append_block_file`'s filestore
+argument, meaning those two frames were only ever live-broadcast, never
+durably written to `output`. `last_error_frame` only reads the persisted
+file, so `describe`/`list` could never have surfaced either of them after
+the live moment passed — silently contradicting §3.3's own claim that this
+"isn't identity-specific, it's the general signal for the whole app."
+
+Both call sites already had an `Arc<FileStore>`/`Option<Arc<FileStore>>`
+in scope (`filestore_gate` in `input.rs`, matching the identity-gate frame
+a few lines above it; a new `filestore_wait` clone added alongside
+`host_spawn.rs`'s other `_wait`-suffixed clones, matching the module's own
+existing naming convention) — both fixed to pass it through, exactly
+mirroring the pattern the identity-gate and container-`exec` call sites
+already used correctly. No new test added for either failure path directly
+(simulating a real Docker `ensure_running` failure or a lease-conflict
+queued-message failure would need mocking scaffolding that doesn't
+currently exist in these modules, disproportionate to a 2-line wiring
+fix) — the underlying persist mechanism itself
+(`handle_append_block_file`'s `Some`-vs-`None` behavior) already has
+direct unit coverage (`shell/tests.rs`'s
+`test_handle_append_block_file_writes_to_filestore` and siblings), and
+both fixes compile under the exact same call shape already proven at the
+other two, always-correct sites.
+
 ## 4. What this would have caught
 
 Re-running the actual incident with this change live:


### PR DESCRIPTION
## Summary

A block whose spawn was refused before any controller/process ever existed
(bad identity link, container that wouldn't start, etc.) showed up in
`muxspect describe`/`list` as featureless "no controller, no processes" —
indistinguishable from a healthy idle block.

Root-caused a real 2+ hour stuck-pane incident this way: it took a two-file
srv-log grep and a direct `store.db` read to find a one-line, entirely
knowable cause that was already sitting in the block's own persisted output
the whole time. `agent_handlers/input.rs` already durably persists an
`error_during_execution` frame into the block's `output` file specifically
so it survives pane reload/reconnect — the same frame the frontend renders
as the pane's error bubble. Nothing was reading it back out.

- New `last_error_frame()` (`muxspect_handlers.rs`): a bounded (8KB) tail
  read of a block's `output` file. Populated ONLY when the very last
  non-blank line is an `error_during_execution` frame — a block that
  errored once and recovered afterward is correctly left unflagged.
- Composed into both `/api/v1/muxspect/list` and `/api/v1/muxspect/describe`
  as an additive `last_error` field (`{message, source, written_ms}` or
  `null`) — no change to the existing response shape.
- `source` is a best-effort tag (`identity`/`container_spawn`/`host_spawn`/
  `unknown`) inferred from the message's own stable prefix — not a new
  stable taxonomy (that's real, separate follow-up work; see the report).
- `age`/`written_ms` comes from the `output` file's own `modts` rather than
  a new timestamp field on the frame — correct for exactly the case this
  exists for, and touches zero identity/spawn code paths.
- `muxspect.mjs` CLI: new `last_error` column in `list`, new `last_error:`
  section in `describe`.
- `docs/MUXSPECT.md` updated.

This is a second *reader* over an already-durable, already-existing store —
not a new independent tracker — matching the tool's own design constraint
(`SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md` §5.1/§3 pt. 8).

Full incident writeup + design rationale (including the `list()` scope
caveat — it decorates existing rows, doesn't widen what block_ids get
enumerated):
`docs/reports/REPORT_MUXSPECT_SPAWN_REFUSAL_DIAGNOSIS_EXTENSION_2026_08_03.md`

## Test plan

- [x] `cargo test -p agentmux-srv` — 1959 passed, 0 failed
- [x] 6 new unit tests (`muxspect_handlers.rs`) for `last_error_frame`/
      `classify_last_error_source`: missing block, empty output, frame
      present, frame present-then-recovered, non-error result frame, every
      known message-prefix classification
- [x] 2 new HTTP-level tests (`server/tests.rs`): `describe` surfaces
      `last_error` for a block with a persisted identity-gate refusal as
      its last output line; `describe` returns `last_error: null` for a
      block with no output at all
- [x] `npx vitest run muxspect.test.mjs` — 8/8 passing, unchanged
- [ ] Live rebuild + manual `muxspect describe` against a real wedged block
      not run this pass (same scope decision PR #2380/#2373 each made in
      their own test plans) — unit + integration coverage exercises the
      exact code path directly

<!-- agentmux:agent_id=agentx -->