### PR TITLE
chore: release v0.54.9

### DIFF
--- a/.changesets/1785717705-fix-frontend-consolidate-7-duplicated-token-count-formatters-ojje.md
+++ b/.changesets/1785717705-fix-frontend-consolidate-7-duplicated-token-count-formatters-ojje.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(frontend): consolidate 7 duplicated token-count formatters, add k/m/b rollover

--- a/.changesets/1785718937-fix-frontend-consolidate-5-duplicated-elapsed-time-formatter-p6ed.md
+++ b/.changesets/1785718937-fix-frontend-consolidate-5-duplicated-elapsed-time-formatter-p6ed.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(frontend): consolidate 5 duplicated elapsed-time formatters, fix negative-duration gap

--- a/.changesets/1785719802-fix-frontend-consolidate-string-truncation-formatters-remove-jdnv.md
+++ b/.changesets/1785719802-fix-frontend-consolidate-string-truncation-formatters-remove-jdnv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(frontend): consolidate string-truncation formatters, remove dead code

--- a/.changesets/1785720162-fix-frontend-consolidate-12-duplicated-sleep-promise-express-x9kd.md
+++ b/.changesets/1785720162-fix-frontend-consolidate-12-duplicated-sleep-promise-express-x9kd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(frontend): consolidate 12 duplicated sleep-promise expressions into a shared helper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.8"
+version = "0.54.9"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.8"
+version = "0.54.9"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.8"
+version = "0.54.9"
 dependencies = [
  "dirs",
  "serde",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.8"
+version = "0.54.9"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.8"
+version = "0.54.9"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.8"
+version = "0.54.9"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.8"
+version = "0.54.9"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.54.9 — 2026-08-02
+
+- fix(frontend): consolidate 7 duplicated token-count formatters, add k/m/b rollover
+- fix(frontend): consolidate 5 duplicated elapsed-time formatters, fix negative-duration gap
+- fix(frontend): consolidate string-truncation formatters, remove dead code
+- fix(frontend): consolidate 12 duplicated sleep-promise expressions into a shared helper
+
+
 ## 0.54.8 — 2026-08-02
 
 - feat(muxbus): same-host cross-channel reactive delivery (Tier 2b, issue #1916)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.8",
+  "version": "0.54.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.8",
+      "version": "0.54.9",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.8",
+  "version": "0.54.9",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Consumes 4 pending changesets into v0.54.9 — all `fix`-typed, so this is a natural patch bump (no override needed this time).
- All 4 changesets come from the display-formatting-utility consolidation sequence (#2385-#2388): format-count.ts, format-time.ts, format-text.ts, and the sleep-promise consolidation.
- All 5 version-consistency locations verified in agreement at 0.54.9.

## Test plan
- [x] `scripts/release.sh --as patch` completed cleanly
- [x] Reviewed `git diff --staged` — only version files + changeset deletions touched
- [ ] CI green
- [ ] reagent's release-consistency invariant check passes

<!-- agentmux:agent_id=agenta-07017 -->