### PR TITLE
fix(agent-pane): composer strip always left-justified, wraps up to 3 lines

### DIFF
--- a/.changesets/1785768648-fix-agent-pane-composer-strip-always-left-justified-wraps-up-ldth.md
+++ b/.changesets/1785768648-fix-agent-pane-composer-strip-always-left-justified-wraps-up-ldth.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): composer strip always left-justified, wraps up to 3 lines

--- a/docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
@@ -1,0 +1,167 @@
+# SPEC — Composer strip: left-justified, tiered wrap (up to 3 levels)
+
+**Date:** 2026-08-03
+**Type:** Responsive layout fix
+**Status:** Implemented
+**Owner:** Agent3
+**Scope:** `frontend/app/view/agent/components/AgentComposerStrip.tsx` +
+`frontend/app/view/agent/styles/_composer-strip.scss`
+
+## Related history
+
+- `SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md` — root-caused the
+  strip force-hiding the runtime controls (Mode/Model/Effort) via
+  `display:none`; established the standing rule that controls are shed last,
+  informational content first.
+- `SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md` —
+  introduced the 3-column grid (`1fr auto 1fr`) with the stats zone
+  true-centered in the middle column.
+- `SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md` — **already merged**
+  as of this spec. Found the narrow-pane container queries were dead code
+  (wrong container name, `modal-mount` instead of `agent-pane`) and landed a
+  fix: a `grid-template-areas` swap at `≤480px` that moved the strip to a
+  fixed 2-row layout (row 1 = controls + right zone, row 2 = stats,
+  centered), plus shed queries at `≤300px`/`≤260px`/`≤220px` for the auth
+  tag, process badge, and control-trigger cap. This is the baseline this
+  spec starts from — not the 07-10 single-row grid.
+
+## Problem
+
+Following the 07-30 two-line fix, the strip still had two issues the user
+flagged directly:
+
+1. **Not always left-justified.** The stats zone was centered in Tier 1 (grid
+   middle column) and centered again in Tier 2 (`justify-self: stretch;
+   text-align: center`). The right zone was pinned to the row's right edge
+   via `justify-self: end`. Centering/right-pinning via a grid is also what
+   made the two-line fix a fixed, hardcoded 2-row `grid-template-areas` swap
+   rather than something that reflows naturally — the grid has no built-in
+   notion of "wrap to a 3rd line only if needed."
+2. **Only ever 2 lines, hard-capped.** The 07-30 fix bought exactly one extra
+   line (row 2 for stats). At widths where row 1 (controls + right zone)
+   still didn't fit, the only remaining lever was to hide content (auth tag,
+   then process badge) — there was no 3rd line to fall back on first.
+
+## Goal
+
+1. **Always left-justify.** No centering, no right-pinning, at any tier.
+   Content flows left-to-right in DOM order (controls → stats → right zone)
+   and starts at the strip's left edge on every line, including wrapped
+   ones.
+2. **Wrap up to 3 levels before shedding content.** Let the browser reflow
+   content onto additional lines as needed — capped at 3 — before falling
+   back to hiding informational content (auth tag, then process badge) or
+   compacting the runtime controls trigger.
+
+## Design (as implemented)
+
+### 1. Grid → wrapping flex
+
+`.agent-composer-strip` changed from `display: grid` (with the 07-30 fix's
+`≤480px` `grid-template-areas` swap) to a single, permanent `display: flex;
+flex-wrap: wrap; justify-content: flex-start`. This removes the fixed 2-row
+breakpoint entirely — the browser wraps `agent-composer-strip-controls`,
+`agent-composer-strip-stats-zone`, and `agent-composer-strip-right` (still
+the same three top-level children, no TSX structure change) onto as many
+lines as the content needs, always left-justified, with no explicit
+width-keyed rule required for the wrapping itself.
+
+```scss
+.agent-composer-strip {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    justify-content: flex-start;
+    align-items: center;
+    row-gap: 2px;
+    column-gap: var(--space-2);
+    min-height: 28px;
+    max-height: 84px;   // ~3 lines — the cap
+    overflow: hidden;   // a 4th line would clip; shed queries below prevent
+                         // real content from ever reaching one
+    ...
+}
+```
+
+### 2. Zone rules: drop grid-only properties
+
+`agent-composer-strip-controls`/`-stats-zone`/`-right` all lose their
+`grid-area`/`justify-self` declarations (meaningless on flex children); they
+keep `min-width: 0` so the runtime-trigger max-width cap can still shrink
+the controls zone under real pressure. No `justify-content: center` or
+`justify-self: end` remains anywhere in the file.
+
+### 3. Height cap = the "3 levels"
+
+There's no discrete per-line breakpoint list — `flex-wrap` reflows
+automatically at whatever width the content needs. The tiering that matters
+is the **height cap**: `max-height: 84px` (~3 lines at this font-size/
+padding) with `overflow: hidden`, so the strip can grow from 1 → 2 → 3
+lines as needed but never past that into unbounded vertical growth that
+would eat space from the transcript above it.
+
+### 4. Shed order — revised breakpoints, informational-first (unchanged principle)
+
+The 07-30 shed breakpoints (auth `≤300px`, process badge `≤260px`, controls
+cap `≤220px`) were tuned for a layout with only 2 available lines. With 3
+lines available — in the worst case, one zone per line — the right zone
+(badge + ctx + auth + Shell, none of which wrap internally) has much more
+total width budget before it needs to shed anything, so the breakpoints
+move narrower:
+
+```scss
+@container agent-pane (max-width: 220px) {
+    .agent-composer-strip-auth { display: none; }
+}
+@container agent-pane (max-width: 180px) {
+    .agent-composer-strip-process-badge { display: none; }
+}
+@container agent-pane (max-width: 150px) {
+    .agent-runtime-dropup-trigger { max-width: 120px; }
+    .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
+}
+```
+
+Order and reasoning unchanged from 07-30/07-02: auth tag first (passive
+status, least essential), then process badge (a shortcut, swarm view stays
+reachable elsewhere), controls last and never `display:none` (07-02's
+standing rule) — only compacted via the existing ellipsis cap. Context text
+and Shell remain visible at every tier.
+
+**Breakpoint values are estimated from content width** (right zone ≈ badge
+28px + ctx 50px + auth 70px + Shell 40px + 3 gaps ≈ 220px), not measured DOM
+output — same caveat every prior composer-strip spec has flagged about its
+own numbers. Needs live verification in `task dev`.
+
+### 5. Shell button
+
+Stays the last child in DOM order — no TSX structural change. On a wide
+pane it's still visually rightmost (last in a left-filling line); on a
+narrow, wrapped pane it may be the sole item on its own line, left-justified
+like every other line. This is the expected consequence of Goal 1, not a
+regression.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/styles/_composer-strip.scss` | `.agent-composer-strip`: grid (+ 07-30's `≤480px` 2-row swap) → permanent wrapping flex, left-justified, `max-height`/`overflow:hidden` cap at ~3 lines. Removed `grid-area`/`justify-self` from all three zones. Shed queries (auth/badge/controls-cap) moved from `300/260/220px` to `220/180/150px` to match the extra line of headroom. |
+| `frontend/app/view/agent/components/AgentComposerStrip.tsx` | No structural change — updated stale comments referencing the old centered-grid design to describe the new left-justified flow. |
+
+## Verification performed
+
+- `npx stylelint frontend/app/view/agent/styles/_composer-strip.scss` — one
+  pre-existing hex-color lint error at line ~217 (`--warning-color,
+  #d9a441` fallback), unrelated to this change and present before it.
+- `npx tsc --noEmit` — clean.
+- `npx vitest run frontend/app/view/agent` — 72 files / 954 tests passed
+  (no test exercises this component's layout directly; this is a
+  no-regression check, not layout coverage).
+- **Not performed:** a live `task dev` visual check of the actual wrap/shed
+  behavior at real pane widths. The breakpoint values above are estimated,
+  not measured — resize a real agent pane through ~250px → ~120px and
+  confirm: (a) stats/right zone wrap onto line 2/3 with no clipping or
+  overlap with the textarea below, (b) content is always left-justified at
+  every width, (c) the shed order (auth → process badge → controls cap)
+  fires in that order and only as a last resort, (d) resizing back to full
+  width returns cleanly to one line with no leftover height.

--- a/docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
@@ -49,9 +49,11 @@ flagged directly:
    and starts at the strip's left edge on every line, including wrapped
    ones.
 2. **Wrap up to 3 levels before shedding content.** Let the browser reflow
-   content onto additional lines as needed — capped at 3 — before falling
-   back to hiding informational content (auth tag, then process badge) or
-   compacting the runtime controls trigger.
+   content onto additional lines as needed — normally 1-3, see the
+   "revised during review" note below — before falling back to hiding
+   informational content (auth tag, then process badge) or compacting the
+   runtime controls trigger. **Never clip or overlap** — this is the harder
+   requirement and the one that changed the design mid-review (§6).
 
 ## Design (as implemented)
 
@@ -76,9 +78,9 @@ width-keyed rule required for the wrapping itself.
     row-gap: 2px;
     column-gap: var(--space-2);
     min-height: 28px;
-    max-height: 84px;   // ~3 lines — the cap
-    overflow: hidden;   // a 4th line would clip; shed queries below prevent
-                         // real content from ever reaching one
+    // No max-height/overflow:hidden — see §6, this was in the first
+    // version of the fix and removed after review found it could clip
+    // Shell again once the zones below wrap internally.
     ...
 }
 ```
@@ -91,23 +93,25 @@ keep `min-width: 0` so the runtime-trigger max-width cap can still shrink
 the controls zone under real pressure. No `justify-content: center` or
 `justify-self: end` remains anywhere in the file.
 
-### 3. Height cap = the "3 levels"
+### 3. No hard line cap — see §6
 
-There's no discrete per-line breakpoint list — `flex-wrap` reflows
-automatically at whatever width the content needs. The tiering that matters
-is the **height cap**: `max-height: 84px` (~3 lines at this font-size/
-padding) with `overflow: hidden`, so the strip can grow from 1 → 2 → 3
-lines as needed but never past that into unbounded vertical growth that
-would eat space from the transcript above it.
+The first version of this fix added `max-height: 84px; overflow: hidden`
+(~3 lines) to enforce "up to 3 levels" as a hard ceiling. Review found this
+reintroduced clipping once `.agent-composer-strip-controls`/`-right` could
+also wrap internally (§6), so the cap was removed: `flex-wrap` reflows
+content onto as many lines as it actually needs, with no upper bound
+enforced by CSS. In practice the shed-content queries below keep real
+content to ~1-3 lines by shrinking/hiding it as width drops; "3 levels" is
+the normal-case outcome of that shedding, not a mechanism that clips a 4th
+line into existence.
 
 ### 4. Shed order — revised breakpoints, informational-first (unchanged principle)
 
 The 07-30 shed breakpoints (auth `≤300px`, process badge `≤260px`, controls
 cap `≤220px`) were tuned for a layout with only 2 available lines. With 3
 lines available — in the worst case, one zone per line — the right zone
-(badge + ctx + auth + Shell, none of which wrap internally) has much more
-total width budget before it needs to shed anything, so the breakpoints
-move narrower:
+(badge + ctx + auth + Shell) has much more total width budget before it
+needs to shed anything, so the breakpoints move narrower:
 
 ```scss
 @container agent-pane (max-width: 220px) {
@@ -141,11 +145,52 @@ narrow, wrapped pane it may be the sole item on its own line, left-justified
 like every other line. This is the expected consequence of Goal 1, not a
 regression.
 
+## 6. Revised during review (PR #2393)
+
+Two rounds of automated review on the PR found real problems in the first
+version of this fix — both are the same underlying tension (a hard clip
+boundary vs. content that can legitimately need more room) resurfacing at
+a different layer:
+
+1. **Codex (P1):** `.agent-composer-strip-right` moved as a single,
+   non-internally-wrapping flex item. When it landed alone on a wrapped
+   line narrower than its full content (badge + ctx + auth + Shell), the
+   strip's `overflow: hidden` clipped the trailing **Shell button** —
+   breaking the "Shell always reachable" invariant from
+   `SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md`/
+   `SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md`. Same latent risk
+   on `.agent-composer-strip-controls` (a long resolved model name before
+   the `≤150px` trigger cap applies).
+   **Fix:** both zones gained their own `flex-wrap: wrap`, so a zone's
+   content reflows onto an internal sub-line instead of overflowing past
+   the strip's edge.
+2. **ReAgent (P2), on the fix above:** adding internal wrap converts
+   *horizontal* overflow into *vertical* growth — which competes with the
+   outer strip's `max-height: 84px; overflow: hidden` from §1/§3. If two
+   zones each need an internal sub-line at once (e.g. controls wraps the
+   HOST/SANDBOX tag under a long model name while right zone wraps Shell
+   under badge+ctx+auth, at the same narrow width), total height can
+   exceed 84px and the outer `overflow: hidden` clips Shell again — same
+   failure mode, triggered by height instead of width, and not covered by
+   the "not performed" live-verification caveat below (it's a structural
+   interaction, not a tuning issue).
+   **Fix:** removed `max-height`/`overflow: hidden` from
+   `.agent-composer-strip` entirely (§3). There is no longer any
+   mechanism in this component that can clip content; the shed-content
+   queries are the only thing keeping real-world height to ~1-3 lines, and
+   they do so by shrinking/hiding content, not by force.
+
+Net effect: "up to three levels" is now the *expected outcome* of the shed
+order under normal content, not a *ceiling enforced by clipping*. That's a
+one-word-sounding but real distinction — the goal was always "never
+overlay/clip," and enforcing a numeric line cap via `overflow: hidden` was
+in tension with that from the start once any sub-component could also wrap.
+
 ## Files changed
 
 | File | Change |
 |---|---|
-| `frontend/app/view/agent/styles/_composer-strip.scss` | `.agent-composer-strip`: grid (+ 07-30's `≤480px` 2-row swap) → permanent wrapping flex, left-justified, `max-height`/`overflow:hidden` cap at ~3 lines. Removed `grid-area`/`justify-self` from all three zones. Shed queries (auth/badge/controls-cap) moved from `300/260/220px` to `220/180/150px` to match the extra line of headroom. |
+| `frontend/app/view/agent/styles/_composer-strip.scss` | `.agent-composer-strip`: grid (+ 07-30's `≤480px` 2-row swap) → permanent wrapping flex, left-justified, no height cap (see §6). Removed `grid-area`/`justify-self` from all three zones. `.agent-composer-strip-controls`/`-right` gained their own `flex-wrap: wrap` (§6, Codex P1). Shed queries (auth/badge/controls-cap) moved from `300/260/220px` to `220/180/150px` to match the extra line of headroom. |
 | `frontend/app/view/agent/components/AgentComposerStrip.tsx` | No structural change — updated stale comments referencing the old centered-grid design to describe the new left-justified flow. |
 
 ## Verification performed
@@ -157,11 +202,14 @@ regression.
 - `npx vitest run frontend/app/view/agent` — 72 files / 954 tests passed
   (no test exercises this component's layout directly; this is a
   no-regression check, not layout coverage).
+- Two rounds of automated PR review (Codex, ReAgent) — findings applied,
+  see §6.
 - **Not performed:** a live `task dev` visual check of the actual wrap/shed
   behavior at real pane widths. The breakpoint values above are estimated,
   not measured — resize a real agent pane through ~250px → ~120px and
-  confirm: (a) stats/right zone wrap onto line 2/3 with no clipping or
-  overlap with the textarea below, (b) content is always left-justified at
-  every width, (c) the shed order (auth → process badge → controls cap)
-  fires in that order and only as a last resort, (d) resizing back to full
-  width returns cleanly to one line with no leftover height.
+  confirm: (a) content wraps (outer and, if needed, internal) with no
+  clipping or overlap with the textarea below, (b) content is always
+  left-justified at every width, (c) the shed order (auth → process badge
+  → controls cap) fires in that order and only as a last resort, (d)
+  resizing back to full width returns cleanly to one line with no leftover
+  height.

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentComposerStrip — slim 28-32px status row that sits directly above
- * the textarea in the agent pane composer region.
+ * AgentComposerStrip — status row that sits directly above the textarea in
+ * the agent pane composer region. Left-justified, wrapping onto additional
+ * lines (capped at 3) rather than clipping when the pane narrows — see
+ * docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md.
  *
- * LEFT:   AgentRuntimeDropup (single Mode · Model · Effort trigger)
- * CENTER: tokens (↑in ↓out) · elapsed — true-centered in the bar
- * RIGHT:  ⚙N process badge · context text (12.1k / 64k) · Shell toggle
- *         (Shell is rightmost — SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md)
+ * In flow order:
+ *   1. AgentRuntimeDropup (single Mode · Model · Effort trigger) + HOST/SANDBOX tag
+ *   2. tokens (↑in ↓out) · elapsed
+ *   3. ⚙N process badge · context text (12.1k / 64k) · auth tag · Shell toggle
  *
  * The strip bar itself is not clickable. "Shell" is the sole toggle for
  * the details drawer (the AgentShellSubblock terminal — activity-log lines
@@ -211,11 +213,13 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 </Show>
             </span>
 
-            {/* Center zone — token/elapsed stats, true-centered in the bar via
-                the grid's middle column (see _composer-strip.scss). The
-                wrapper span always renders (even with no stats yet) so the
-                grid keeps 3 children and the right zone stays in the
-                rightmost column instead of sliding into the middle one. */}
+            {/* Stats zone — token/elapsed stats. Left-justified in flow (no
+                longer true-centered, see _composer-strip.scss), sitting
+                right after the controls zone or wrapping onto its own line
+                when there isn't room for both. The wrapper span always
+                renders (even with no stats yet) so this zone's presence in
+                the flow order — and therefore where the right zone wraps
+                to — stays stable whether or not stats are populated yet. */}
             <span class="agent-composer-strip-stats-zone">
                 <Show when={rightText()}>
                     <span
@@ -227,8 +231,10 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 </Show>
             </span>
 
-            {/* Right zone — process badge + context text + Shell toggle, in
-                that order so Shell is the rightmost element in the bar. */}
+            {/* Right zone — process badge + context text + auth tag + Shell
+                toggle, in that order. Shell still lands rightmost on a wide
+                pane (last in a left-filling line); on a wrapped line it
+                starts at that line's left margin like everything else. */}
             <span class="agent-composer-strip-right">
                 <Show when={(props.processCount ?? 0) > 0}>
                     <button

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -4,7 +4,8 @@
 /**
  * AgentComposerStrip — status row that sits directly above the textarea in
  * the agent pane composer region. Left-justified, wrapping onto additional
- * lines (capped at 3) rather than clipping when the pane narrows — see
+ * lines (no hard cap — see _composer-strip.scss's file header) rather than
+ * clipping when the pane narrows — see
  * docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md.
  *
  * In flow order:

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -51,6 +51,14 @@
 
 .agent-composer-strip-controls {
     display: flex;
+    // Internal wrap, not just the outer strip's — a zone that only ever
+    // moves as one atomic flex item can still be wider than the line it
+    // lands on (e.g. a long resolved model name before the ≤150px trigger
+    // cap applies), and the strip's own `overflow: hidden` would silently
+    // clip whatever doesn't fit instead of reflowing it. Reagent P1 (PR
+    // #2393): the equivalent gap on .agent-composer-strip-right could clip
+    // the Shell toggle itself — same fix applied to both zones.
+    flex-wrap: wrap;
     align-items: center;
     gap: var(--space-1);
     // A flex item's default min-width is `auto` (its content's intrinsic
@@ -197,6 +205,14 @@
 
 .agent-composer-strip-right {
     display: flex;
+    // Internal wrap so Shell (the last, and only real actionable, item in
+    // this zone) reflows onto its own line instead of being clipped by the
+    // strip's `overflow: hidden` when the zone lands on a wrapped line
+    // narrower than its full content (badge + ctx + auth + Shell) — the
+    // shed-content queries below reduce that content as width shrinks, but
+    // shouldn't be the only thing standing between "fits" and "Shell is
+    // silently unreachable." Reagent P1, PR #2393.
+    flex-wrap: wrap;
     align-items: center;
     gap: var(--space-1-5);
     min-width: 0;

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // AgentComposerStrip — status row above the textarea, left-justified and
-// wrapping onto additional lines (capped at 3) instead of clipping or
-// overlapping the textarea below when the pane narrows. In flow order:
+// wrapping onto additional lines instead of clipping or overlapping the
+// textarea below when the pane narrows. In flow order:
 //   1. AgentRuntimeDropup (single Mode · Model · Effort trigger) + HOST/SANDBOX tag
 //   2. token/elapsed stats
 //   3. process badge · context text · auth tag · Shell toggle
@@ -15,6 +15,18 @@
 // SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md and the
 // two-row grid-template-areas tier from
 // SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md).
+//
+// No max-height/overflow:hidden cap: an earlier revision capped this at
+// ~3 lines, but .agent-composer-strip-controls/-right can *also* wrap
+// internally (below) so a zone doesn't get clipped when it alone doesn't
+// fit its wrapped line — and a height cap paired with internal wrapping
+// reintroduces the exact bug it was meant to fix (two zones each needing
+// their own sub-line can together exceed the cap, clipping Shell again,
+// just via the vertical axis instead of the horizontal one — reagent P2,
+// PR #2393). The shed-content queries further down keep real-world content
+// to ~1-3 lines by shrinking/hiding informational content as width drops;
+// growing taller than that is only possible in combinations those queries
+// don't cover, and growing is always preferable to silently clipping Shell.
 
 @use "../../../mixins.scss";
 
@@ -27,9 +39,6 @@
     row-gap: 2px;
     column-gap: var(--space-2);
     min-height: 28px;
-    max-height: 84px; // ~3 lines at this font-size/padding — the shed-content
-                       // queries below exist so real content never needs a 4th
-    overflow: hidden;
     padding: var(--space-1) var(--space-2);
     font-size: 11px;
     line-height: 1.4;
@@ -306,9 +315,11 @@
 
 // ── Responsive tiers ─────────────────────────────────────────────────────
 // The wrap itself needs no width-keyed rules — `flex-wrap: wrap` on
-// `.agent-composer-strip` reflows controls/stats/right onto additional
-// lines automatically as the pane narrows, always left-justified, up to
-// the 3-line cap set above. That alone is the fix for the clipping/overlap
+// `.agent-composer-strip` (outer lines) plus on `-controls`/`-right`
+// (internal sub-lines) reflows content onto additional lines automatically
+// as the pane narrows, always left-justified, with no hard cap — see the
+// file-header comment for why there's no `max-height`/`overflow:hidden`
+// here. That alone is the fix for the clipping/overlap
 // `SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md` documented (the
 // grid this replaced had no wrap path at all — its `@container modal-mount`
 // rules never matched the docked pane's own `agent-pane` container, so
@@ -316,15 +327,14 @@
 // grid-template-areas tier it landed only ever bought a 2nd line).
 //
 // What still needs a width-keyed rule is the *last-resort* shed order
-// below, for widths where even 3 outer lines — one zone per line, in the
-// worst case — plus the right zone's own internal wrap (badge, ctx, auth,
-// Shell can now reflow onto a sub-line of their own, see above) isn't
-// enough headroom to keep the strip within its 3-line cap without
-// resorting to an extra sub-line per zone. Content and Shell stay visible
-// at every tier — ctx is the one safety signal in this bar (compaction
-// proximity), Shell is the strip's one real action — so shedding starts
-// with the least essential, informational-only items, trimming content
-// before the internal wrap needs to add sub-lines at all.
+// below — not to prevent clipping (nothing clips now) but to keep the
+// strip's real-world height to ~1-3 lines instead of growing tall enough
+// to noticeably eat into the transcript above it. Content and Shell stay
+// visible at every tier — ctx is the one safety signal in this bar
+// (compaction proximity), Shell is the strip's one real action — so
+// shedding starts with the least essential, informational-only items,
+// trimming content before either zone would otherwise need an internal
+// sub-line.
 // Breakpoints are estimated from content width (right zone ≈ badge 28px +
 // ctx 50px + auth 70px + Shell 40px + 3 gaps ≈ 220px), not measured DOM
 // output — confirm against real rendered widths in `task dev` and adjust.

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -316,12 +316,15 @@
 // grid-template-areas tier it landed only ever bought a 2nd line).
 //
 // What still needs a width-keyed rule is the *last-resort* shed order
-// below, for widths where even 3 lines — one zone per line, in the worst
-// case — leaves the right zone's own content (badge, ctx, auth, Shell; none
-// of which wrap internally) too wide for its single line. Content and
-// Shell stay visible at every tier — ctx is the one safety signal in this
-// bar (compaction proximity), Shell is the strip's one real action — so
-// shedding starts with the least essential, informational-only items.
+// below, for widths where even 3 outer lines — one zone per line, in the
+// worst case — plus the right zone's own internal wrap (badge, ctx, auth,
+// Shell can now reflow onto a sub-line of their own, see above) isn't
+// enough headroom to keep the strip within its 3-line cap without
+// resorting to an extra sub-line per zone. Content and Shell stay visible
+// at every tier — ctx is the one safety signal in this bar (compaction
+// proximity), Shell is the strip's one real action — so shedding starts
+// with the least essential, informational-only items, trimming content
+// before the internal wrap needs to add sub-lines at all.
 // Breakpoints are estimated from content width (right zone ≈ badge 28px +
 // ctx 50px + auth 70px + Shell 40px + 3 gaps ≈ 220px), not measured DOM
 // output — confirm against real rendered widths in `task dev` and adjust.

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -1,25 +1,35 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// AgentComposerStrip — slim 28-32px status row above the textarea.
-//   LEFT:   AgentRuntimeDropup (single Mode · Model · Effort trigger)
-//   CENTER: token/elapsed stats, true-centered in the bar
-//   RIGHT:  process badge · context text · Shell toggle (Shell is rightmost)
-// 3-column grid (1fr auto 1fr) so the center column sits at the bar's
-// mathematical center regardless of how wide the left/right content is —
-// a flex row with one auto-margin zone can't do that once something sits
-// to the right of the auto-margin zone too (Shell used to be left-most in
-// that zone; now it's the last child of the right column instead).
+// AgentComposerStrip — status row above the textarea, left-justified and
+// wrapping onto additional lines (capped at 3) instead of clipping or
+// overlapping the textarea below when the pane narrows. In flow order:
+//   1. AgentRuntimeDropup (single Mode · Model · Effort trigger) + HOST/SANDBOX tag
+//   2. token/elapsed stats
+//   3. process badge · context text · auth tag · Shell toggle
+// A wrapping flex row, not a grid — `flex-wrap` reflows content onto a new
+// line automatically wherever it doesn't fit, always left-justified; no
+// centering, no right-pinning. See
+// docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
+// (supersedes the grid + true-centered-stats design from
+// SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md and the
+// two-row grid-template-areas tier from
+// SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md).
 
 @use "../../../mixins.scss";
 
 .agent-composer-strip {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    grid-template-areas: "controls stats right";
+    display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start; // stack wrapped lines from the top
+    justify-content: flex-start; // always left
     align-items: center;
-    gap: var(--space-2);
+    row-gap: 2px;
+    column-gap: var(--space-2);
     min-height: 28px;
+    max-height: 84px; // ~3 lines at this font-size/padding — the shed-content
+                       // queries below exist so real content never needs a 4th
+    overflow: hidden;
     padding: var(--space-1) var(--space-2);
     font-size: 11px;
     line-height: 1.4;
@@ -35,34 +45,35 @@
     }
 }
 
-// ── Controls zone (left column) ─────────────────────────────────────────────
+// ── Controls zone ────────────────────────────────────────────────────────
+// First in flow — wraps onto its own line if it and the stats zone don't
+// both fit on line 1.
 
 .agent-composer-strip-controls {
-    grid-area: controls;
     display: flex;
     align-items: center;
     gap: var(--space-1);
-    justify-self: start;
-    // A grid item's default min-width is `auto` (its content's intrinsic
-    // size), not 0 — without this, `minmax(0, 1fr)` on the two-line tier's
-    // grid track (below) can't actually shrink the column past the trigger
-    // + HOST/SANDBOX badge's combined content width, defeating the trigger's
-    // own max-width cap and overflowing the row instead of clipping it.
+    // A flex item's default min-width is `auto` (its content's intrinsic
+    // size), not 0 — without this the runtime trigger's own max-width cap
+    // (the ≤150px query below) can't actually shrink this zone below its
+    // content width.
     min-width: 0;
 }
 
-// ── Stats zone (center column) ──────────────────────────────────────────────
+// ── Stats zone ───────────────────────────────────────────────────────────
+// No longer true-centered — sits left-justified in flow, immediately after
+// controls when there's room, or alone on its own wrapped line when there
+// isn't (see the spec header comment above for why centering was dropped).
 
 .agent-composer-strip-stats-zone {
-    grid-area: stats;
-    justify-self: center;
+    min-width: 0;
 }
 
 // The consolidated Mode/Model/Effort trigger — a single <button> laying out
 // a "Mode · Model · Effort" summary label + up-caret; same slim-pill footprint
 // as the former three separate selects/drop-ups combined into one. No fixed
 // max-width — sizes to its content; a cap only reappears under real space
-// pressure (see the ≤220px container query below), so it only ellipsizes
+// pressure (see the ≤150px container query below), so it only ellipsizes
 // when the pane genuinely has no room for it.
 .agent-runtime-dropup-trigger {
     display: inline-flex;
@@ -176,21 +187,18 @@
     }
 }
 
-// ── Right zone (right column) ───────────────────────────────────────────────
-// Process badge · context text · Shell toggle, in that order — Shell last so
-// it's the rightmost element in the whole bar. justify-self:end pins the
-// column to the grid's right edge (the grid, not a margin trick, does the
-// pinning now).
+// ── Right zone ───────────────────────────────────────────────────────────
+// Process badge · context text · auth tag · Shell toggle, in that order —
+// Shell last. No longer pinned to the row's right edge (justify-self: end
+// required a grid track; a left-justified flex row has no equivalent): on a
+// wide pane it still lands near the right because it's the last thing in
+// flow and line 1 fills left-to-right; on a wrapped line it starts at that
+// line's left margin like everything else.
 
 .agent-composer-strip-right {
-    grid-area: right;
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
-    justify-self: end;
-    // Same nested-flex-in-grid min-width trap as .agent-composer-strip-controls
-    // above — without this, the two-line tier's right column (below) can't
-    // actually shrink past ctx text + Shell's combined content width either.
     min-width: 0;
 }
 
@@ -281,62 +289,43 @@
 }
 
 // ── Responsive tiers ─────────────────────────────────────────────────────
-// Was `@container modal-mount` — that container name is only declared by
-// <Modal> portal mounts (modal.scss), never by the docked agent pane, so
-// these rules never matched in the real composer strip and nothing here
-// actually reflowed on a narrow pane. `.agent-view` is what establishes the
-// containment context around this strip (agent-view.scss, container-name:
-// agent-pane) — see SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md
-// for the full audit + design.
+// The wrap itself needs no width-keyed rules — `flex-wrap: wrap` on
+// `.agent-composer-strip` reflows controls/stats/right onto additional
+// lines automatically as the pane narrows, always left-justified, up to
+// the 3-line cap set above. That alone is the fix for the clipping/overlap
+// `SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md` documented (the
+// grid this replaced had no wrap path at all — its `@container modal-mount`
+// rules never matched the docked pane's own `agent-pane` container, so
+// nothing reflowed in production before that spec, and the two-line
+// grid-template-areas tier it landed only ever bought a 2nd line).
+//
+// What still needs a width-keyed rule is the *last-resort* shed order
+// below, for widths where even 3 lines — one zone per line, in the worst
+// case — leaves the right zone's own content (badge, ctx, auth, Shell; none
+// of which wrap internally) too wide for its single line. Content and
+// Shell stay visible at every tier — ctx is the one safety signal in this
+// bar (compaction proximity), Shell is the strip's one real action — so
+// shedding starts with the least essential, informational-only items.
+// Breakpoints are estimated from content width (right zone ≈ badge 28px +
+// ctx 50px + auth 70px + Shell 40px + 3 gaps ≈ 220px), not measured DOM
+// output — confirm against real rendered widths in `task dev` and adjust.
 
-// Tier 2 — two-line layout. Controls + right zone (badges/ctx/auth/Shell)
-// share row 1; stats drop to their own full-width, centered row 2. Nothing
-// is hidden here — giving stats a dedicated row removes them from the row-1
-// space contest entirely, which is why the old "drop stats at ≤240px" idea
-// is gone: it's no longer needed once this tier is active.
-@container agent-pane (max-width: 480px) {
-    .agent-composer-strip {
-        // minmax(0, 1fr) / minmax(0, auto), not bare 1fr / auto — both track
-        // sizing keywords keep an implicit content-based minimum on their
-        // own, so EITHER column could overflow the row instead of shrinking
-        // to fit (reagent P1 re-review: the first fix only covered the
-        // controls column, missing that the right column has the identical
-        // problem). Paired with min-width: 0 on both
-        // .agent-composer-strip-controls and .agent-composer-strip-right.
-        grid-template-columns: minmax(0, 1fr) minmax(0, auto);
-        grid-template-areas:
-            "controls right"
-            "stats    stats";
-        min-height: 52px;
-        row-gap: 2px;
-    }
-
-    .agent-composer-strip-stats-zone {
-        justify-self: stretch;
-        text-align: center;
-    }
-}
-
-// Tier 3 — row 1 (controls + right zone) is still crowded with 5 things;
-// shed the least essential, informational-only items first. Context text
-// and Shell stay visible at every tier — ctx is the one safety signal in
-// this bar (compaction proximity), Shell is the strip's one real action.
-@container agent-pane (max-width: 300px) {
+@container agent-pane (max-width: 220px) {
     .agent-composer-strip-auth {
         display: none;
     }
 }
 
-@container agent-pane (max-width: 260px) {
+@container agent-pane (max-width: 180px) {
     .agent-composer-strip-process-badge {
         display: none;
     }
 }
 
-// Tier 4 — controls trigger compacts to an ellipsized cap rather than
-// disappearing (never `display:none` the runtime controls — see
+// Controls trigger compacts to an ellipsized cap rather than disappearing
+// (never `display:none` the runtime controls — see
 // SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md).
-@container agent-pane (max-width: 220px) {
+@container agent-pane (max-width: 150px) {
     .agent-runtime-dropup-trigger {
         max-width: 120px;
     }


### PR DESCRIPTION
## Summary

- The composer strip (stats dock above the agent pane's input) was a CSS
  grid with a true-centered stats column and a right-pinned zone, fixed to
  a hardcoded 2-row swap at ≤480px (`SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md`).
  Below that, once row 1 (controls + right zone) got crowded, content could
  still clip or overlap the textarea underneath it.
- Replaces the grid with a permanent `flex-wrap` row: content is always
  left-justified (no centering, no right-pinning) and reflows onto
  additional lines — capped at 3 — as the pane narrows, instead of clipping
  or overlapping.
- Shed-content breakpoints (auth tag → process badge → controls-trigger
  cap) move narrower (300/260/220px → 220/180/150px) to match the extra
  line of headroom 3 lines gives vs. the old 2-line cap.
- No `.tsx` structural changes — same three zones (controls/stats/right),
  only their CSS layout role changes. Comments referencing the old
  centered-grid design were updated to match.
- Full design writeup: `docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx stylelint frontend/app/view/agent/styles/_composer-strip.scss` —
      one pre-existing hex-color lint error unrelated to this change
- [x] `npx vitest run frontend/app/view/agent` — 72 files / 954 tests pass
- [ ] Live `task dev` visual check of wrap/shed behavior at real pane
      widths — breakpoint values are estimated from content width, not
      measured DOM output; needs a resize pass in a running pane to confirm
      and tune (called out explicitly in the spec)

<!-- agentmux:agent_id=agent3 -->