### PR TITLE
fix(wrr): bound quit-watchdog retries when reducer shows a live, non-draining window

### DIFF
--- a/.changesets/1785780064-fix-wrr-bound-quit-watchdog-retries-when-reducer-shows-a-liv-orxq.md
+++ b/.changesets/1785780064-fix-wrr-bound-quit-watchdog-retries-when-reducer-shows-a-liv-orxq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(wrr): bound quit-watchdog retries when reducer shows a live, non-draining window

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -234,6 +234,24 @@ static WATCHDOG_ARMED: std::sync::atomic::AtomicBool =
 /// an invisible zombie instance for long.
 const QUIT_WATCHDOG_GRACE: std::time::Duration = std::time::Duration::from_millis(3000);
 
+/// Bound on how many extra watchdog cycles the "reducer shows a live,
+/// non-draining window" desync gets before the code falls back to trusting
+/// the OS signal alone (docs/plans/PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md).
+/// Worst-case added grace is `WATCHDOG_LAG_RETRIES_MAX * QUIT_WATCHDOG_GRACE`,
+/// and only when a live, non-draining window is genuinely still registered —
+/// bounded so this stays "quit a few seconds late with a loud log", not a
+/// regression toward the invisible-zombie failure mode Step D exists to avoid.
+const WATCHDOG_LAG_RETRIES_MAX: u32 = 3;
+
+/// Consecutive re-arm cycles already granted to the `registered > 0 &&
+/// !draining` desync flavor (as opposed to the pre-existing `draining &&
+/// registered == 0` "post-drain debris" re-arm, which is unbounded by
+/// design — see its own comment in `QuitWatchdogRecheckTask::execute`).
+/// Reset to 0 whenever the watchdog stands down cleanly (a window is
+/// OS-visible again) or ultimately fires (fresh budget for next time).
+static WATCHDOG_LAG_RETRY_COUNT: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
 /// X-coordinate below which a top-level window is an off-screen warm-pool member
 /// (created at -32000), not a real user window. Mirrors
 /// `commands::window::lifecycle::OFFSCREEN_POOL_THRESHOLD_X`.
@@ -290,6 +308,52 @@ unsafe fn count_visible_user_windows() -> usize {
     ctx.count
 }
 
+/// Diagnostic-only: enumerate every app-class top-level window belonging to
+/// this process — regardless of visibility — and log hwnd/class/title/
+/// visible/iconic/rect for each. Called only from the watchdog's anomalous
+/// paths (a lag re-arm or the final quit-fire, PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md),
+/// never from the per-WINEVENT hot path, so the extra `EnumWindows` pass here
+/// doesn't matter. Turns the old "reducer desync, investigate" log line —
+/// which told you the *counts* disagreed but nothing about which window the
+/// reducer thought was still alive or what state the OS actually saw it in —
+/// into something a future investigation can actually use.
+unsafe fn diag_dump_app_windows(context: &str) {
+    use windows_sys::Win32::Foundation::{BOOL, LPARAM};
+    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+    use windows_sys::Win32::UI::WindowsAndMessaging::EnumWindows;
+
+    unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let pid_target = lparam as u32;
+        let mut pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, &mut pid);
+        if pid != pid_target {
+            return 1;
+        }
+        let class = read_class_name(hwnd);
+        if !classify::is_app_class(&class) {
+            return 1;
+        }
+        let title = read_window_text(hwnd);
+        let visible = IsWindowVisible(hwnd) != 0;
+        let iconic = IsIconic(hwnd) != 0;
+        let rect = read_window_rect(hwnd);
+        tracing::warn!(
+            target: "wrr",
+            "[wrr] diag hwnd={:#x} class={} title={:?} visible={} iconic={} rect={:?}",
+            hwnd as u64, class, title, visible, iconic, rect
+        );
+        1
+    }
+
+    let pid = GetCurrentProcessId();
+    tracing::warn!(
+        target: "wrr",
+        "[wrr] diag dump ({}) — enumerating all app-class windows for pid={}",
+        context, pid
+    );
+    EnumWindows(Some(enum_cb), pid as LPARAM);
+}
+
 /// Pure decision extracted for unit testing (SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md).
 ///
 /// Requires BOTH the OS-level `EnumWindows` count (`visible`) AND the reducer's own
@@ -329,6 +393,20 @@ fn should_quit_on_last_window(armed: bool, draining: bool, visible: usize, regis
 /// flavors are the failure mode Step D's watchdog exists to bound.
 fn is_reducer_lagging_os(armed: bool, draining: bool, visible: usize, registered: usize) -> bool {
     armed && visible == 0 && (registered > 0 || !draining)
+}
+
+/// Pure decision (PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md): should the
+/// watchdog grant one more re-arm cycle to the "reducer shows a live,
+/// non-draining window" desync flavor, instead of trusting the OS `visible ==
+/// 0` snapshot immediately? `registered > 0 && !draining` is the least
+/// ambiguous "do NOT quit" signal the reducer can produce — a window nobody
+/// has asked to close. `retries_used` is how many re-arms this flavor has
+/// already been granted (0 on its first watchdog fire). The
+/// `registered == 0 && !draining` flavor (a genuinely missed `request_drain`
+/// consumption site — no live window to protect) is deliberately excluded:
+/// it has nothing to wait for, so it still fires on the first cycle.
+fn should_extend_lag_retry(registered: usize, draining: bool, retries_used: u32) -> bool {
+    registered > 0 && !draining && retries_used < WATCHDOG_LAG_RETRIES_MAX
 }
 
 /// Step D — bounded fallback so a missed `UnregisterBrowser` path degrades to
@@ -413,6 +491,7 @@ cef::wrap_task! {
                     arm_quit_watchdog(registered);
                     return;
                 }
+                WATCHDOG_LAG_RETRY_COUNT.store(0, SeqCst);
                 tracing::info!(
                     target: "wrr",
                     "[wrr] quit watchdog: {} window(s) visible again — stand down",
@@ -420,18 +499,49 @@ cef::wrap_task! {
                 );
                 return;
             }
+            // PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md: `registered > 0
+            // && !draining` means the reducer still shows a live window that
+            // nobody has asked to close — the least ambiguous "do NOT quit"
+            // signal it can produce. A single 3s grace period isn't always
+            // enough to ride out a burst of window-pool HWND churn (drag/
+            // tear-off pool refill) landing in the same window as a pane
+            // close, which is exactly what a transient `EnumWindows` misread
+            // looks like (SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md §2).
+            // Grant this flavor a few bounded extra cycles before falling
+            // back to trusting the OS signal — the `registered == 0`
+            // flavor (a genuinely missed request_drain consumption site, no
+            // live window to protect) still falls through immediately below.
+            let retries_used = WATCHDOG_LAG_RETRY_COUNT.load(SeqCst);
+            if should_extend_lag_retry(registered, draining, retries_used) {
+                let retries = WATCHDOG_LAG_RETRY_COUNT.fetch_add(1, SeqCst) + 1;
+                tracing::warn!(
+                    target: "wrr",
+                    "[wrr] quit watchdog: 0 visible for {}ms but registered={} draining=false (live window, not draining) — re-arming ({}/{})",
+                    QUIT_WATCHDOG_GRACE.as_millis(),
+                    registered,
+                    retries,
+                    WATCHDOG_LAG_RETRIES_MAX
+                );
+                unsafe { diag_dump_app_windows("lag re-arm") };
+                arm_quit_watchdog(registered);
+                return;
+            }
+            WATCHDOG_LAG_RETRY_COUNT.store(0, SeqCst);
             if QUIT_INITIATED.swap(true, SeqCst) {
                 return;
             }
             // Trusting the OS signal alone (the pre-Step-B behavior). The
             // state logged here is a live bug report: registered > 0 means
-            // some close path failed to dispatch UnregisterBrowser;
-            // !draining means a request_drain consumption site was missed
-            // (Phase 2's sites, or a new close path) — find it.
+            // some close path failed to dispatch UnregisterBrowser (and the
+            // lag-retry budget above is now exhausted); !draining means a
+            // request_drain consumption site was missed (Phase 2's sites, or
+            // a new close path) — find it.
+            unsafe { diag_dump_app_windows("quit fire") };
             tracing::warn!(
                 target: "wrr",
-                "[wrr] quit watchdog fired: 0 visible for {}ms but reducer disagrees (registered={} draining={}) — quitting on OS signal alone (reducer desync, investigate)",
+                "[wrr] quit watchdog fired: 0 visible for {}ms (retries={}) but reducer disagrees (registered={} draining={}) — quitting on OS signal alone (reducer desync, investigate)",
                 QUIT_WATCHDOG_GRACE.as_millis(),
+                retries_used,
                 registered,
                 draining
             );
@@ -569,6 +679,40 @@ mod should_quit_tests {
         assert!(!is_reducer_lagging_os(true, false, 3, 1));
         // …or before any user window was ever shown (startup).
         assert!(!is_reducer_lagging_os(false, false, 0, 1));
+    }
+
+    #[test]
+    fn lag_retry_extends_for_live_nondraining_window_under_budget() {
+        use super::{should_extend_lag_retry, WATCHDOG_LAG_RETRIES_MAX};
+        // The exact desync this fix targets: a real, non-draining window is
+        // still registered — extend as long as the budget isn't exhausted.
+        assert!(should_extend_lag_retry(1, false, 0));
+        assert!(should_extend_lag_retry(1, false, WATCHDOG_LAG_RETRIES_MAX - 1));
+    }
+
+    #[test]
+    fn lag_retry_stops_once_budget_exhausted() {
+        use super::{should_extend_lag_retry, WATCHDOG_LAG_RETRIES_MAX};
+        assert!(!should_extend_lag_retry(1, false, WATCHDOG_LAG_RETRIES_MAX));
+        assert!(!should_extend_lag_retry(1, false, WATCHDOG_LAG_RETRIES_MAX + 5));
+    }
+
+    #[test]
+    fn lag_retry_does_not_extend_once_draining() {
+        use super::should_extend_lag_retry;
+        // Once the reducer has decided to drain, this is a different flavor
+        // (handled by the draining && registered == 0 re-arm above, or a
+        // clean quit) — not this desync.
+        assert!(!should_extend_lag_retry(1, true, 0));
+    }
+
+    #[test]
+    fn lag_retry_does_not_extend_with_no_live_window() {
+        use super::should_extend_lag_retry;
+        // registered == 0 && !draining is a genuinely missed request_drain
+        // consumption site — there's no live window to protect, so it
+        // should still fire on the first cycle, same as before this fix.
+        assert!(!should_extend_lag_retry(0, false, 0));
     }
 }
 

--- a/docs/plans/PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md
+++ b/docs/plans/PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md
@@ -1,0 +1,151 @@
+# PLAN — WRR quit watchdog kills the whole host on a live, non-draining window
+
+- **Status:** Draft → implementing
+- **Date:** 2026-08-03
+- **Reported by:** user (this machine), v0.54.9
+- **Scope:** A minimal, bounded extension of Step D from
+  `docs/specs/SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md`. Does not touch Steps A-C, the
+  `should_quit_on_last_window` gate itself, or any of the reducer/`reconcile_quit` machinery.
+  Deliberately does not attempt the larger L1 "retire the win_event parallel authority" effort
+  those specs reference — this is a targeted fix for one specific gap in the existing bounded
+  fallback.
+
+---
+
+## 1. Symptom
+
+AgentMux (v0.54.9) closed unexpectedly with the main window and ~9 open panes (agent panes,
+terminal panes, one Browser pane) all disappearing at once — not a crash (no dump, no Windows
+Event Log entry, no error in `agentmux-launcher.log`), just a clean process exit (code 0).
+
+## 2. Evidence
+
+Reconstructed from the per-session structured host log
+(`<channel>/versions/0.54.9/logs/agentmux-host-v0.54.9.log.<date>`, target `wrr`), all times UTC
+2026-08-03:
+
+| Time | Event |
+|---|---|
+| 14:51:08.43 | Browser pane navigates to `accounts.youtube.com/accounts/SetSID` |
+| 14:51:09.27 | → `accounts.google.com/signin/oauth/id` (Google OAuth handoff) |
+| 14:51:10.87 | → `accounts.google.com/signin/oauth/consent` |
+| 14:51:10.99 | `accounts.google.com/gsi/transform` request **aborted** (`ERR_ABORTED`) |
+| 14:51:11.03 | That pane's browser is torn down: `BrowserUnregistered` / `BrowserPaneClosed` |
+| 14:51:11.04 | `[wrr] arming 3000ms quit watchdog (reducer counts 1 live)` |
+| 14:51:11.04–14:51:14.07 | A burst of unrelated window-pool churn lands in the same window: multiple `PoolWindowLeft { reason: DestroyedBeforePromote }`, `DriftDetected { kind: Pool, host_count: 2, mirror_count: 3 }`, and repeated pool window spawn/destroy cycles (the drag/tear-off warm-pool refilling itself) |
+| 14:51:14.04 | `[wrr] quit watchdog fired: 0 visible for 3000ms but reducer disagrees (registered=1 draining=false) — quitting on OS signal alone (reducer desync, investigate)` |
+| 14:51:14.05 | `cef::quit_message_loop()` called — entire host exits |
+
+The layout at the time had ~10 blocks across multiple panes in a single `main` window — nowhere
+near an actual last-window-close. `registered=1 draining=false` is as unambiguous a "the reducer
+thinks a real, running window is still open and nobody asked to quit" signal as this codebase
+produces.
+
+## 3. Root cause
+
+`agentmux-cef/src/wrr/win_event.rs`'s `QuitWatchdogRecheckTask::execute` (Step D of
+`SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md`) has exactly **one** re-arm path today:
+
+```rust
+if visible != 0 {
+    if draining && registered == 0 {
+        // "post-drain debris" — re-arm
+        arm_quit_watchdog(registered);
+        return;
+    }
+    // stand down — a window is visible again
+    return;
+}
+// visible == 0 falls straight through to here — NO re-arm option at all,
+// regardless of what `registered`/`draining` say:
+if QUIT_INITIATED.swap(true, SeqCst) { return; }
+tracing::warn!(... "reducer desync, investigate" ...);
+cef::quit_message_loop();
+```
+
+The existing re-arm only covers the *mirror-image* desync (OS says something's still visible,
+reducer says drained-and-zero). There is **no equivalent retry budget** for the flavor that
+actually fired here: OS says zero visible, but the reducer says a live, non-draining window
+(`registered > 0 && !draining`) is still registered. That flavor gets exactly one 3-second grace
+period, then the code unconditionally trusts the OS `EnumWindows` snapshot and kills the whole
+process — even though the reducer's own bookkeeping is the *more* trustworthy signal in this
+specific case (a window nobody decided to close, still counted as live).
+
+`count_visible_user_windows` is a synchronous `EnumWindows` pass on the UI thread
+(win_event.rs:248-291); the same spec doc that introduced Step D already documents this pass as
+capable of transiently misreading during "window-pool refill/promote churn on the same UI
+thread" (§2 of `SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md`). The captured log shows exactly that
+churn (repeated `PoolWindowLeft`/`DriftDetected`/pool-respawn events) landing in the same 3-second
+window as the Browser pane's OAuth-triggered close — the same class of transient misread the
+spec already anticipated, just on the `visible == 0` side instead of the `visible != 0` side, and
+with no retry budget to absorb it.
+
+The Browser pane's close is the trigger (its underlying browser tore down right after the
+`gsi/transform` request aborted — consistent with Google's GSI/OAuth completion script closing
+its own popup-style frame), but it is not itself the bug: any pane close that happens to land
+inside a window-pool churn burst can hit this same one-shot fallback.
+
+## 4. Fix
+
+Give the `registered > 0 && !draining` desync flavor the same kind of bounded retry budget the
+`draining && registered == 0` flavor already has, instead of one immediate unconditional quit:
+
+1. **`should_extend_lag_retry(registered, draining, retries_used) -> bool`** — new pure decision
+   function (same style as `should_quit_on_last_window`/`is_reducer_lagging_os`, unit-testable
+   without Win32/CEF): `registered > 0 && !draining && retries_used < WATCHDOG_LAG_RETRIES_MAX`.
+2. **`WATCHDOG_LAG_RETRIES_MAX: u32 = 3`** — bounded, so this remains "quit a few seconds late
+   with a loud log" and not a regression back toward the invisible-zombie failure mode Step D was
+   built to avoid (must not regress #1676). Worst case adds
+   `WATCHDOG_LAG_RETRIES_MAX * QUIT_WATCHDOG_GRACE` = 9s of extra grace, only when a live,
+   non-draining window is genuinely still registered.
+3. **`WATCHDOG_LAG_RETRY_COUNT: AtomicU32`** — tracks consecutive re-arms granted to this flavor;
+   reset to 0 whenever the watchdog stands down cleanly (a window is OS-visible again) or when it
+   ultimately fires (fresh budget for the next occurrence).
+4. **Diagnostic dump on the anomalous paths only** (`diag_dump_app_windows`) — a one-off
+   `EnumWindows` pass (not the hot per-event path) that logs hwnd/class/title/visible/iconic/rect
+   for every app-class window belonging to the process, called right before each lag re-arm and
+   right before the final quit-fire. Turns "reducer desync, investigate" from a bare pair of
+   counts into an actual list of what the OS thinks exists, for the next time this fires.
+5. The `registered == 0 && !draining` flavor (a genuinely missed `request_drain` consumption
+   site — no live window to protect) is unchanged: it still fires on the first watchdog cycle,
+   same as today.
+
+## 5. Why this preserves the #1676 / Step-D guarantees
+
+- Still bounded — a genuinely stuck reducer (never updates `registered`/`draining` again) quits
+  after `WATCHDOG_LAG_RETRIES_MAX + 1` cycles instead of 1, not never.
+- Does not touch `should_quit_on_last_window` (the primary, non-watchdog quit gate) or the
+  `registered == 0` desync flavor.
+- Only extends grace for the specific case where the reducer reports a live window that nobody
+  asked to close — the one case where "quit anyway" is actively wrong, not just premature.
+
+## 6. Risks / things to verify live
+
+1. **Extra shutdown latency on a genuine last-window recycle-close that races this exact
+   condition** — bounded to +9s worst case; needs live verification it doesn't regress perceived
+   quit responsiveness for the common case (should be unaffected — the common case resolves on
+   the very first re-check, same as today).
+2. **The diagnostic dump's cost** — one extra `EnumWindows` + per-window property reads, only on
+   the already-anomalous path (at most a few times per occurrence), not the per-WINEVENT hot
+   path.
+3. Cannot live-repro the original Google-sign-in-timed pool-churn race in this environment
+   (requires a live Windows CEF build + an actual OAuth flow); this fix is verified by unit test
+   plus `cargo check -p agentmux-cef`, matching the verification bar the originating spec
+   (`SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` §7) used for its own initial land.
+
+## 7. Testing plan
+
+- Unit tests for `should_extend_lag_retry` covering: live+non-draining+under-budget (extend),
+  live+non-draining+at-budget (don't extend, fall through to fire), draining (don't extend —
+  that's the other flavor / straightforward quit), `registered == 0` (don't extend — no live
+  window to protect).
+- `cargo check -p agentmux-cef`.
+
+## 8. Sources
+
+- `docs/specs/SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` (Step D, the fallback this plan extends)
+- `docs/retro/retro-last-window-close-quit-race-2026-07-16.md` (related but distinct window-close
+  gap, same subsystem, confirms this area was still being hardened through mid-July)
+- Code read for this plan: `agentmux-cef/src/wrr/win_event.rs:196-573`
+- Log evidence: this session's incident triage (Google-sign-in-in-Browser-pane → full app exit),
+  cross-referenced against the current `agentmuxai/agentmux` `main` (`1899c5e`)


### PR DESCRIPTION
## Summary

Live incident (v0.54.9): AgentMux's whole host process quit (clean exit,
code 0 — not a crash) while a Browser pane was mid-Google-OAuth sign-in, in
a session with ~10 other open panes.

Root cause traced via the per-session structured host log
(`agentmux-host-v0.54.9.log.<date>`, target `wrr`) and cross-referenced
against `agentmux-cef/src/wrr/win_event.rs`: the Step D quit watchdog from
`docs/specs/SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` has exactly one
re-arm path (`visible != 0`, `draining && registered == 0`). When the OS
`EnumWindows` snapshot instead reads 0 visible while the reducer still
counts a real, non-draining window (`registered > 0 && !draining` — the
least ambiguous "don't quit" signal the reducer can produce), the watchdog
fires after a single 3s grace period and kills the whole host regardless of
what caused the transient misread.

In the captured incident, a Browser pane's browser tore down right after an
aborted `gsi/transform` request (consistent with Google's GSI/OAuth
completion script closing its own frame), landing in the same ~3s window as
an unrelated burst of window-pool HWND churn (drag/tear-off pool refill —
multiple `PoolWindowLeft`/`DriftDetected` events in the same log window).
That combination produced exactly the transient `EnumWindows` misread the
originating spec already anticipated (§2), just on the side with no retry
budget.

## Fix

- New pure decision `should_extend_lag_retry(registered, draining,
  retries_used)`, mirroring the existing `should_quit_on_last_window` /
  `is_reducer_lagging_os` style, unit-tested without Win32/CEF.
- Bounded retry budget (`WATCHDOG_LAG_RETRIES_MAX = 3`, same 3s cadence) for
  the `registered > 0 && !draining` desync flavor before falling back to the
  pre-existing "trust the OS signal" behavior — worst case +9s grace, only
  when a live, non-draining window is genuinely still registered. Still
  bounded, so this doesn't regress toward the invisible-zombie failure mode
  Step D exists to avoid (#1676).
- The `registered == 0 && !draining` flavor (a genuinely missed
  `request_drain` consumption site — no live window to protect) is
  unchanged and still fires on the first cycle.
- `diag_dump_app_windows` — a diagnostic-only `EnumWindows` pass (called
  only on the anomalous re-arm/fire paths, never the per-WINEVENT hot path)
  that logs hwnd/class/title/visible/iconic/rect for every app-class window,
  so a future occurrence of this log line is actually investigable instead
  of just a bare count mismatch.

Full evidence and design writeup:
`docs/plans/PLAN_WRR_QUIT_WATCHDOG_LAG_RETRY_2026_08_03.md`.

## Test plan

- [x] `cargo check -p agentmux-cef` — clean (pre-existing warnings only,
      unrelated to this change)
- [x] `cargo test -p agentmux-cef wrr::win_event` — 11/11 pass (7 existing +
      4 new: extends-under-budget, stops-at-budget, no-extend-once-draining,
      no-extend-with-no-live-window)
- [ ] Live verification on Windows (re-run the original repro path: close a
      Browser pane mid-navigation while triggering window-pool churn) — not
      done in this environment; flagged in the plan doc as a risk to verify
      live, matching the verification bar the originating spec used.

<!-- agentmux:agent_id=loap -->