### PR TITLE
feat(mcp): implement OpenMedia tool for the Media pane

### DIFF
--- a/.changesets/1785780984-feat-mcp-add-openmedia-tool-for-opening-the-media-pane-b12h.md
+++ b/.changesets/1785780984-feat-mcp-add-openmedia-tool-for-opening-the-media-pane-b12h.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): add OpenMedia tool for opening the Media pane

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -221,6 +221,21 @@ const OPEN_EDITOR_TOOL: &str = r#"{
   }
 }"#;
 
+const OPEN_MEDIA_TOOL: &str = r#"{
+  "name": "OpenMedia",
+  "description": "Open an image, video, or audio file in an AgentMux media pane next to this conversation. Use when you want the user to see/watch generated media you're discussing. Pass an absolute host path. Fire-and-forget: returns once the pane is opened.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "file":     { "type": "string", "description": "Absolute path to the media file to open" },
+      "title":    { "type": "string", "description": "Optional tab/pane title (defaults to the file name)" },
+      "split":    { "type": "string", "enum": ["right", "left", "down", "up"], "description": "Where to place the new pane relative to this agent pane (default: right). Ignored when floating is true." },
+      "floating": { "type": "boolean", "description": "Open the file in a floating window (a chromeless pane over the app) instead of a docked split. Default: false." }
+    },
+    "required": ["file"]
+  }
+}"#;
+
 const LOOP_TOOL: &str = r#"{
   "name": "Loop",
   "description": "Run a prompt or slash command on a recurring interval by re-injecting it into a conversation. AgentMux's analogue of Claude's /loop. Returns immediately with a loop_id; the prompt is injected on a fixed schedule until you call LoopStop(loop_id) or it exhausts max_iterations. Use for polling/babysitting tasks ('check the deploy every 5m', 'keep running /babysit-prs'). Loops stop automatically when the agent pane closes. Do NOT use for one-off tasks — use ScheduleWakeup for that.",
@@ -479,6 +494,7 @@ async fn main() {
                 let shell_input: Value = serde_json::from_str(SHELL_INPUT_TOOL).expect("static json");
                 let shell_status: Value = serde_json::from_str(SHELL_STATUS_TOOL).expect("static json");
                 let open_editor: Value = serde_json::from_str(OPEN_EDITOR_TOOL).expect("static json");
+                let open_media: Value = serde_json::from_str(OPEN_MEDIA_TOOL).expect("static json");
                 let send_message: Value = serde_json::from_str(SEND_MESSAGE_TOOL).expect("static json");
                 let discover_agents: Value =
                     serde_json::from_str(DISCOVER_AGENTS_TOOL).expect("static json");
@@ -510,7 +526,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -865,6 +881,76 @@ async fn call_tool(
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
 
             Ok(format!("Opened {file} in editor pane (block {})", result.block_id))
+        }
+        "OpenMedia" => {
+            let file = arguments
+                .get("file")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: file"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let split = arguments
+                .get("split")
+                .and_then(|v| v.as_str())
+                .filter(|s| matches!(*s, "right" | "left" | "down" | "up"))
+                .unwrap_or("right");
+
+            let url = format!("{}/api/v1/pane/open", local_url.trim_end_matches('/'));
+            // Place the media pane relative to the calling agent pane when we
+            // know its block id (AGENTMUX_BLOCKID); otherwise the sidecar
+            // inserts it at the tab root.
+            let (split_direction, split_reference_block_id) = if block_id.is_empty() {
+                (None, None)
+            } else {
+                (Some(split.to_string()), Some(block_id.to_string()))
+            };
+            let req = PaneOpenRequest {
+                view: "media".to_string(),
+                file: Some(file.to_string()),
+                focus: Some(true),
+                split_direction,
+                split_reference_block_id,
+                title: arguments.get("title").and_then(|v| v.as_str()).map(str::to_string),
+                // The Media pane has no file-tree sidebar, unlike Editor.
+                tree_expanded: None,
+                // `floating: true` → open in a floating window instead of a docked split.
+                floating: if arguments.get("floating").and_then(|v| v.as_bool()) == Some(true) {
+                    Some(true)
+                } else {
+                    None
+                },
+                url: None,
+                cwd: None,
+                tab_id: None,
+            };
+
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&req)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("pane.open failed: HTTP {status} — {text}");
+            }
+
+            let result: PaneOpenResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
+            Ok(format!("Opened {file} in media pane (block {})", result.block_id))
         }
         "SendMessage" => {
             let to = arguments
@@ -1720,6 +1806,7 @@ mod tests {
             SHELL_TOOL,
             SHELL_STOP_TOOL,
             OPEN_EDITOR_TOOL,
+            OPEN_MEDIA_TOOL,
             SEND_MESSAGE_TOOL,
             DISCOVER_AGENTS_TOOL,
             WHOAMI_TOOL,
@@ -1744,7 +1831,7 @@ mod tests {
             IDENTITY_ACCOUNTS_TOOL,
             IDENTITY_VALIDATE_TOOL,
         ];
-        assert_eq!(defs.len(), 26, "tools/list advertises 26 tools (11 original + 3 Loop + 5 Cron + 7 agent-API)");
+        assert_eq!(defs.len(), 27, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API)");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-srv/src/server/app_api/pane.rs
+++ b/agentmux-srv/src/server/app_api/pane.rs
@@ -250,9 +250,15 @@ pub(super) fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, 
         "help" => {
             meta.insert("view".to_string(), json!("help"));
         }
+        "media" => {
+            let file = cmd.file.as_deref().filter(|s| !s.is_empty())
+                .ok_or_else(|| "MISSING_ARG: view=media requires 'file'".to_string())?;
+            meta.insert("view".to_string(), json!("media"));
+            meta.insert("media:path".to_string(), json!(file));
+        }
         other => {
             return Err(format!(
-                "INVALID_VIEW: unsupported view '{other}' (expected editor/term/browser/sysinfo/help)"
+                "INVALID_VIEW: unsupported view '{other}' (expected editor/term/browser/sysinfo/help/media)"
             ));
         }
     }

--- a/frontend/app/view/media/media.test.ts
+++ b/frontend/app/view/media/media.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { dirnameOf, extOf } from "./media";
+import { basenameOf, dirnameOf, extOf } from "./media";
 
 describe("extOf", () => {
     it("returns the lowercase extension without a dot", () => {
@@ -31,5 +31,19 @@ describe("dirnameOf", () => {
 
     it("returns empty string when there's no separator", () => {
         expect(dirnameOf("shot.webm")).toBe("");
+    });
+});
+
+describe("basenameOf", () => {
+    it("returns the last posix segment", () => {
+        expect(basenameOf("/home/user/clips/shot.webm")).toBe("shot.webm");
+    });
+
+    it("returns the last windows segment", () => {
+        expect(basenameOf("C:\\Users\\asafe\\clips\\shot.webm")).toBe("shot.webm");
+    });
+
+    it("returns the path unchanged when there's no separator", () => {
+        expect(basenameOf("shot.webm")).toBe("shot.webm");
     });
 });

--- a/frontend/app/view/media/media.tsx
+++ b/frontend/app/view/media/media.tsx
@@ -11,6 +11,7 @@
 
 import { getApi } from "@/app/store/app-api";
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import { useBlockAtom } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
@@ -19,7 +20,7 @@ import { WpsEvent } from "@/app/store/wps-events";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { fetch } from "@/util/fetchutil";
 import { fireAndForget } from "@/util/util";
-import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type Accessor, type JSX } from "solid-js";
 
 const META_PATH = "media:path" as const;
 
@@ -48,6 +49,14 @@ export function extOf(path: string): string {
 export function dirnameOf(path: string): string {
     const lastSlash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
     return lastSlash === -1 ? "" : path.slice(0, lastSlash);
+}
+
+// File name of `path` (the part after the last separator), matching
+// whichever separator style it uses. Returns `path` unchanged if it has no
+// separator.
+export function basenameOf(path: string): string {
+    const lastSlash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+    return lastSlash === -1 ? path : path.slice(lastSlash + 1);
 }
 
 // Surfaces the browser's actual MediaError code/message instead of a
@@ -97,10 +106,26 @@ async function fetchMediaBlob(path: string): Promise<Blob> {
 class MediaViewModel implements ViewModel {
     viewType: string;
     blockId: string;
+    viewName: Accessor<string>;
 
     constructor(blockId: string) {
         this.viewType = "media";
         this.blockId = blockId;
+
+        // Header title — file basename of the persisted path, so an
+        // OpenMedia call's default (untitled) pane is distinguishable from
+        // another rather than showing a generic "Media" label for all of
+        // them. Mirrors EditorViewModel.viewName's pattern exactly
+        // (editor-model.ts:290-296): wrapped in useBlockAtom (creates a
+        // tracking root) rather than a bare createMemo, so block-frame
+        // subscribers reliably see updates.
+        this.viewName = useBlockAtom(blockId, "media-view-name", () =>
+            createMemo<string>(() => {
+                const blockData = getWaveObjectAtom<Block>(makeORef("block", blockId))();
+                const path = blockData?.meta?.[META_PATH];
+                return typeof path === "string" && path.length > 0 ? basenameOf(path) : "Media";
+            }),
+        );
     }
 
     get viewComponent(): ViewComponent {


### PR DESCRIPTION
## Summary
- Implements `docs/specs/SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03.md` (#2395).
- `build_pane_meta` (`agentmux-srv/src/server/app_api/pane.rs`) whitelists a `"media"` view, writing `media:path` meta — the actual server-side gap the spec's own review process caught (view was a closed whitelist, not an unvalidated passthrough).
- New `OpenMedia` MCP tool (`agentmux-mcp/src/main.rs`) mirrors `OpenEditor`'s shape/handler exactly (minus `collapse_tree`, which has no Media-pane equivalent). Registered in both the real production `tools/list` array (`main.rs:513`) and the test-only `defs`/count-pinning array (now 27 tools).
- `MediaViewModel` gains a path-derived `viewName` (mirrors `EditorViewModel.viewName`'s exact pattern) so the tool's own "defaults to the file name" description promise actually holds — plus a `basenameOf` helper and unit tests.

## Test plan
- [x] `cargo test -p agentmux-mcp` — all 4 tests pass, including the tool-def validity/count test at the new count of 27.
- [x] `cargo test -p agentmux-srv pane` — all 11 existing pane tests pass unaffected.
- [x] `npx vitest run frontend/app/view/media/media.test.ts` — 9/9 pass (6 existing + 3 new `basenameOf` cases).
- [x] `npx tsc --noEmit` — clean, zero errors across the whole frontend.
- [ ] Manual: call `OpenMedia` from an agent pane once this ships, confirm the pane opens with a filename-derived default title.

<!-- agentmux:agent_id=agenty -->