### PR TITLE
fix(editor): remove dead editor:source_hidden meta

### DIFF
--- a/.changesets/1785786365-fix-editor-remove-dead-editor-source-hidden-meta-y2sl.md
+++ b/.changesets/1785786365-fix-editor-remove-dead-editor-source-hidden-meta-y2sl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): remove dead editor:source_hidden meta

--- a/agentmux-srv/src/server/app_api/pane.rs
+++ b/agentmux-srv/src/server/app_api/pane.rs
@@ -224,12 +224,6 @@ pub(super) fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, 
             } else if is_markdown {
                 meta.insert("editor:tree_expanded".to_string(), json!(false));
             }
-
-            // Markdown files default to preview-only (source editor hidden).
-            // Agents open .md files to surface documentation, not to edit.
-            if is_markdown {
-                meta.insert("editor:source_hidden".to_string(), json!(true));
-            }
         }
         "term" => {
             meta.insert("view".to_string(), json!("term"));

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -1023,7 +1023,7 @@ export class EditorViewModel implements ViewModel {
                     meta: {
                         view: "editor",
                         file: filePath,
-                        ...(isMarkdown ? { "editor:tree_expanded": false, "editor:source_hidden": true } : {}),
+                        ...(isMarkdown ? { "editor:tree_expanded": false } : {}),
                     },
                 },
                 null,


### PR DESCRIPTION
## Summary
- `build_pane_meta` and the "open to the side" flow both still wrote `editor:source_hidden: true` for markdown files, but the frontend stopped reading it back on 2026-07-01 (the PR that introduced `editorMode()`/`_tabModes` replaced the old meta-driven read, and its own fallback already defaults `.md` to `"preview"` independent of any meta).
- Confirmed via a fresh repo-wide grep immediately before removing that no reader was missed.
- Per `docs/specs/SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md` (#2402) Part 1's action item -- orthogonal to that plan's still-open blank-preview investigation, safe to land independently.

## Test plan
- [x] `cargo check -p agentmux-srv` -- clean.
- [x] `npx tsc --noEmit` -- clean.
- [x] `cargo test -p agentmux-srv pane` -- 11/11 pass, unaffected.

<!-- agentmux:agent_id=agenty -->