### PR TITLE
fix(agent-pane): composer strip centers at wide widths, pairs HOST/SANDBOX with Shell

### DIFF
--- a/.changesets/1785805646-fix-agent-pane-composer-strip-centers-at-wide-widths-pairs-h-mmmd.md
+++ b/.changesets/1785805646-fix-agent-pane-composer-strip-centers-at-wide-widths-pairs-h-mmmd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): composer strip centers at wide widths, pairs HOST/SANDBOX with Shell

--- a/docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
@@ -193,6 +193,18 @@ in tension with that from the start once any sub-component could also wrap.
 | `frontend/app/view/agent/styles/_composer-strip.scss` | `.agent-composer-strip`: grid (+ 07-30's `≤480px` 2-row swap) → permanent wrapping flex, left-justified, no height cap (see §6). Removed `grid-area`/`justify-self` from all three zones. `.agent-composer-strip-controls`/`-right` gained their own `flex-wrap: wrap` (§6, Codex P1). Shed queries (auth/badge/controls-cap) moved from `300/260/220px` to `220/180/150px` to match the extra line of headroom. |
 | `frontend/app/view/agent/components/AgentComposerStrip.tsx` | No structural change — updated stale comments referencing the old centered-grid design to describe the new left-justified flow. |
 
+## Addendum 2026-08-03 (later same day) — restore true-centered stats at the widest tier
+
+User feedback, same day: Goal 1 above ("always left-justify... no centering... at any tier") went further than intended. The narrow-tier fix (flex-wrap, no hard height cap, internal wrap on `-controls`/`-right`) is real and stays — it's what actually fixed the Codex P1 / ReAgent P2 clipping bugs in §6. But left-justifying at *every* width, including wide panes with a full line of room to spare, silently dropped the true-centered stats zone from `SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md` as a side effect of the fix, not a deliberate goal — the user flagged this directly ("at the widest, it should be center justified, not left. only left justified on narrow panes").
+
+**Fix:** a new widest tier (`@container agent-pane (min-width: 482px)`, live-verified — see below) gives `.agent-composer-strip-controls` and `.agent-composer-strip-right` matching `flex: 1 1 0` (equal flex-basis → equal width) with the right zone's own content pinned via `justify-content: flex-end`, and centers `.agent-composer-strip-stats-zone` between them — the standard "true-center a middle flex item regardless of unequal left/right content width" pattern. Same visual result as the pre-08-03 `1fr auto 1fr` grid, without switching `display` back to grid and without touching `flex-wrap` (still `wrap`, inherited, unchanged) — so if this breakpoint is ever off for some other real content combination, it still safely reflows instead of clipping, the same safety net every other tier in this file already relies on.
+
+Below 482px: entirely unchanged from the original 08-03 fix above — left-justified, wrapping, no cap.
+
+**Files touched (this addendum):** `_composer-strip.scss` (new `≥482px` container query + updated comments), `AgentComposerStrip.tsx` (comment updates only, no structural change — same as the original fix).
+
+**Live-verified in `task dev`, this addendum (closing the outstanding gap the original 08-03 fix explicitly left open):** first shipped as an estimated `640px`. Live testing in a real agent pane found the actual 1-line/2-line wrap boundary sits at ~482px — 640px left a ~160px "dead zone" (482-640px) where content genuinely fit on one line but the breakpoint hadn't kicked in yet, so it rendered left-justified when it should have stayed centered. Corrected to `482px`, matching the real measured wrap point, so centering now holds for every width where content is actually one line and only switches to left-justified exactly when a 2nd line appears — the behavior requested. Re-verify if the strip's typical content (model name length, stats width) changes meaningfully in the future, since this value is empirical, not derived from a formula.
+
 ## Verification performed
 
 - `npx stylelint frontend/app/view/agent/styles/_composer-strip.scss` — one

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -231,10 +231,12 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 </Show>
             </span>
 
-            {/* Right zone — process badge + context text + auth tag + Shell
-                toggle, in that order. Shell still lands rightmost on a wide
-                pane (last in a left-filling line); on a wrapped line it
-                starts at that line's left margin like everything else. */}
+            {/* Right zone — process badge + context text + auth tag + the
+                HOST/SANDBOX tag paired with the Shell toggle (see
+                .agent-composer-strip-host-shell below), in that order. That
+                pair still lands rightmost on a wide pane (last in a
+                left-filling line); on a wrapped line it starts at that
+                line's left margin like everything else. */}
             <span class="agent-composer-strip-right">
                 <Show when={(props.processCount ?? 0) > 0}>
                     <button

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -3,15 +3,23 @@
 
 /**
  * AgentComposerStrip — status row that sits directly above the textarea in
- * the agent pane composer region. Left-justified, wrapping onto additional
- * lines (no hard cap — see _composer-strip.scss's file header) rather than
- * clipping when the pane narrows — see
+ * the agent pane composer region. Below the widest tier: left-justified,
+ * wrapping onto additional lines (no hard cap — see _composer-strip.scss's
+ * file header) rather than clipping when the pane narrows — see
  * docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md.
+ * At the widest tier (≥482px, live-measured — the real 1-line/2-line wrap
+ * point, not an estimate): controls left / stats zone true-centered / right
+ * zone right — restored the same day after the left-justify-always behavior
+ * above silently dropped the centered stats presentation as a side effect
+ * (the narrow-tier wrap/no-clip fix itself is unchanged either way).
  *
  * In flow order:
- *   1. AgentRuntimeDropup (single Mode · Model · Effort trigger) + HOST/SANDBOX tag
+ *   1. AgentRuntimeDropup (single Mode · Model · Effort trigger)
  *   2. tokens (↑in ↓out) · elapsed
- *   3. ⚙N process badge · context text (12.1k / 64k) · auth tag · Shell toggle
+ *   3. ⚙N process badge · context text (12.1k / 64k) · auth tag · HOST/SANDBOX
+ *      tag + Shell toggle (paired as one unit, same day, per direct user
+ *      request — HOST/SANDBOX moved out of the controls zone to sit
+ *      immediately left of Shell)
  *
  * The strip bar itself is not clickable. "Shell" is the sole toggle for
  * the details drawer (the AgentShellSubblock terminal — activity-log lines
@@ -201,26 +209,17 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                         providerId={props.providerId ?? ""}
                     />
                 </Show>
-                {/* HOST/SANDBOX tag — not gated by showControls(): agent mode
-                    applies to every provider, not just Claude. Replaces the
-                    old "Host — full system access" / "Container — isolated
-                    Docker sandbox" pane row (confirmed inert — no click
-                    handler) with a compact label reusing the same
-                    RuntimeBadge component MyAgentsList/HostPopover already
-                    use elsewhere for this distinction (size="tag" — see
-                    RuntimeBadge.tsx). */}
-                <Show when={props.agentMode === "host" || props.agentMode === "container"}>
-                    <RuntimeBadge runtime={props.agentMode!} size="tag" />
-                </Show>
             </span>
 
-            {/* Stats zone — token/elapsed stats. Left-justified in flow (no
-                longer true-centered, see _composer-strip.scss), sitting
-                right after the controls zone or wrapping onto its own line
-                when there isn't room for both. The wrapper span always
-                renders (even with no stats yet) so this zone's presence in
-                the flow order — and therefore where the right zone wraps
-                to — stays stable whether or not stats are populated yet. */}
+            {/* Stats zone — token/elapsed stats. Below the widest tier:
+                left-justified in flow, sitting right after the controls
+                zone or wrapping onto its own line when there isn't room for
+                both. At the widest tier: true-centered between the controls
+                and right zones (see _composer-strip.scss). The wrapper span
+                always renders (even with no stats yet) so this zone's
+                presence in the flow order — and therefore where the right
+                zone wraps to — stays stable whether or not stats are
+                populated yet. */}
             <span class="agent-composer-strip-stats-zone">
                 <Show when={rightText()}>
                     <span
@@ -278,15 +277,32 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                         {props.authStatus === "authenticated" ? "Logged in" : "Not logged in"}
                     </span>
                 </Show>
-                <button
-                    type="button"
-                    class="agent-composer-strip-log-btn"
-                    classList={{ "agent-composer-strip-log-btn--active": props.logOpen }}
-                    title={props.logOpen ? "Hide the shell" : "Show the shell"}
-                    onClick={() => props.onToggleLog()}
-                >
-                    Shell
-                </button>
+                {/* HOST/SANDBOX tag + Shell toggle — grouped as a single unit
+                    immediately to the left of Shell (moved out of the
+                    controls zone, same day, per direct user request), so the
+                    two never separate across an internal wrap the way two
+                    independent zone children could. Not gated by
+                    showControls(): agent mode applies to every provider, not
+                    just Claude. Replaces the old "Host — full system access"
+                    / "Container — isolated Docker sandbox" pane row
+                    (confirmed inert — no click handler) with a compact label
+                    reusing the same RuntimeBadge component MyAgentsList/
+                    HostPopover already use elsewhere for this distinction
+                    (size="tag" — see RuntimeBadge.tsx). */}
+                <span class="agent-composer-strip-host-shell">
+                    <Show when={props.agentMode === "host" || props.agentMode === "container"}>
+                        <RuntimeBadge runtime={props.agentMode!} size="tag" />
+                    </Show>
+                    <button
+                        type="button"
+                        class="agent-composer-strip-log-btn"
+                        classList={{ "agent-composer-strip-log-btn--active": props.logOpen }}
+                        title={props.logOpen ? "Hide the shell" : "Show the shell"}
+                        onClick={() => props.onToggleLog()}
+                    >
+                        Shell
+                    </button>
+                </span>
             </span>
         </div>
     );

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -279,7 +279,15 @@
     flex-wrap: wrap;
     align-items: center;
     gap: var(--space-1);
-    flex: 0 0 auto;
+    // flex-shrink 1 (not 0) — reagentx P1, PR #2408: flex-shrink:0 makes
+    // this item never squeeze below its content's natural width inside
+    // `.agent-composer-strip-right`, which makes the flex-wrap fallback
+    // above dead code (an item that never shrinks never reaches the point
+    // where its own internal wrap needs to trigger). `-controls`/`-right`
+    // get this behavior "for free" from the flex initial default
+    // (flex-shrink: 1) since neither sets `flex` in its own base rule —
+    // matching that here, explicitly, since this rule does set `flex`.
+    flex: 0 1 auto;
     min-width: 0;
 }
 

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -1,20 +1,26 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// AgentComposerStrip — status row above the textarea, left-justified and
-// wrapping onto additional lines instead of clipping or overlapping the
-// textarea below when the pane narrows. In flow order:
-//   1. AgentRuntimeDropup (single Mode · Model · Effort trigger) + HOST/SANDBOX tag
+// AgentComposerStrip — status row above the textarea. In flow order:
+//   1. AgentRuntimeDropup (single Mode · Model · Effort trigger)
 //   2. token/elapsed stats
-//   3. process badge · context text · auth tag · Shell toggle
-// A wrapping flex row, not a grid — `flex-wrap` reflows content onto a new
-// line automatically wherever it doesn't fit, always left-justified; no
-// centering, no right-pinning. See
+//   3. process badge · context text · auth tag · HOST/SANDBOX tag + Shell
+//      toggle (paired as a single unit — see .agent-composer-strip-host-shell)
+// Below the widest tier: a wrapping flex row, not a grid — `flex-wrap`
+// reflows content onto a new line automatically wherever it doesn't fit,
+// always left-justified, no centering, no right-pinning. See
 // docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
 // (supersedes the grid + true-centered-stats design from
 // SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md and the
 // two-row grid-template-areas tier from
-// SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md).
+// SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md) — this is the tier
+// that matters for never clipping/overlapping the textarea below, and stays
+// exactly as that spec left it.
+// At the widest tier (≥482px, see the container query near the bottom of
+// this file): the stats zone is true-centered again, controls left, right
+// zone right — same visual result as the pre-08-03 grid, restored the same
+// day after user feedback that always-left-justifying (even with room to
+// spare) silently dropped the centered stats presentation.
 //
 // No max-height/overflow:hidden cap: an earlier revision capped this at
 // ~3 lines, but .agent-composer-strip-controls/-right can *also* wrap
@@ -78,9 +84,10 @@
 }
 
 // ── Stats zone ───────────────────────────────────────────────────────────
-// No longer true-centered — sits left-justified in flow, immediately after
+// Below the widest tier: sits left-justified in flow, immediately after
 // controls when there's room, or alone on its own wrapped line when there
-// isn't (see the spec header comment above for why centering was dropped).
+// isn't. At the widest tier (≥482px, see the container query near the
+// bottom of this file): true-centered between the controls and right zones.
 
 .agent-composer-strip-stats-zone {
     min-width: 0;
@@ -205,12 +212,17 @@
 }
 
 // ── Right zone ───────────────────────────────────────────────────────────
-// Process badge · context text · auth tag · Shell toggle, in that order —
-// Shell last. No longer pinned to the row's right edge (justify-self: end
-// required a grid track; a left-justified flex row has no equivalent): on a
-// wide pane it still lands near the right because it's the last thing in
-// flow and line 1 fills left-to-right; on a wrapped line it starts at that
-// line's left margin like everything else.
+// Process badge · context text · auth tag · HOST/SANDBOX tag + Shell toggle
+// (paired, see .agent-composer-strip-host-shell below), in that order — the
+// HOST/SANDBOX + Shell pair last. Below the widest tier: not pinned to the
+// row's right edge —
+// on a wide-but-below-482px pane it still lands near the right because it's
+// the last thing in flow and line 1 fills left-to-right; on a wrapped line
+// it starts at that line's left margin like everything else. At the widest
+// tier (≥482px): explicitly pinned right again via `justify-content:
+// flex-end` on this zone's own flex-basis-0 half of the row (see the
+// container query near the bottom of this file) — same visual position as
+// the pre-08-03 grid's `justify-self: end`.
 
 .agent-composer-strip-right {
     display: flex;
@@ -225,6 +237,20 @@
     align-items: center;
     gap: var(--space-1-5);
     min-width: 0;
+}
+
+// HOST/SANDBOX tag + Shell toggle, paired as a single unit — moved out of
+// the controls zone, same day, per direct user request ("the HOST/SANDBOX
+// indicator should be just to the left of the Shell button"). An
+// inline-flex wrapper, not just adjacent DOM order: as ONE flex item inside
+// `.agent-composer-strip-right`'s own `flex-wrap: wrap` above, the pair can
+// never be torn apart onto two different sub-lines the way two independent
+// zone children could — they move together or not at all.
+.agent-composer-strip-host-shell {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex: 0 0 auto;
 }
 
 .agent-composer-strip-stats {
@@ -362,6 +388,42 @@
     .agent-composer-strip-log-btn {
         font-size: 9px;
         padding: 1px 3px;
+    }
+}
+
+// ── Widest tier — restore true-centered stats (2026-08-03, later same day) ──
+// The left-justified flex-wrap above is unchanged and stays the ONLY layout
+// below this breakpoint — it fixed a real clipping bug (PR #2393, Codex
+// P1 / ReAgent P2: content could overflow under the textarea) and nothing
+// here touches that. But left-justifying at EVERY width, including wide
+// panes with a whole line to spare, silently dropped the true-centered
+// stats zone from SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md
+// as a side effect, not a deliberate goal — flagged by the user directly.
+// Restore it, but without the grid that caused the original clipping bug:
+// give `-controls` and `-right` matching `flex: 1 1 0` (equal flex-basis, so
+// they grow to occupy equal width) and center-align the stats zone between
+// them — the standard "true-center a middle flex item regardless of
+// left/right content width" pattern, same visual result as the old
+// `1fr auto 1fr` grid, without switching `display` or touching `flex-wrap`
+// (still `wrap`, inherited, unchanged — if this breakpoint's estimate is a
+// little off for some real content combination, it still safely reflows
+// instead of clipping, same safety net as every other tier in this file).
+// Breakpoint is estimated (controls ~150-250px + stats ~120-180px + right
+// ~220px + gaps ≈ 600-650px on one line), not measured — needs live
+// task dev verification, same caveat as every breakpoint in this file.
+@container agent-pane (min-width: 482px) {
+    .agent-composer-strip-controls {
+        flex: 1 1 0;
+    }
+
+    .agent-composer-strip-stats-zone {
+        flex: 0 0 auto;
+        text-align: center;
+    }
+
+    .agent-composer-strip-right {
+        flex: 1 1 0;
+        justify-content: flex-end;
     }
 }
 

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -113,6 +113,17 @@
     padding: 1px var(--space-1-5);
     cursor: default;
     outline: none;
+    // As a flex item of `.agent-composer-strip-controls`, this button's
+    // automatic minimum size defaults to its own max-content width (its
+    // `overflow` is visible, so the flexbox spec's "auto minimum = 0 under
+    // hidden overflow" rule doesn't apply to it the way it already does for
+    // `.agent-runtime-dropup-trigger-label` below). Without this override,
+    // at the ≥482px tier — where `-controls` shares only half the row via
+    // `flex: 1 1 0` (see the container query near the bottom of this file)
+    // — a long resolved Mode/Model/Effort summary can't actually shrink and
+    // overflows into the centered stats zone instead of the label's own
+    // ellipsis engaging. reagentx P1, PR #2408.
+    min-width: 0;
 
     &:hover {
         border-color: var(--border-color);
@@ -129,6 +140,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    // Explicit, not relying on the flexbox spec's "auto minimum resolves to
+    // 0 under non-visible overflow" rule alone — same defensive-explicit
+    // style as `.agent-composer-strip-controls`'s own `min-width: 0` above.
+    min-width: 0;
 }
 
 .agent-runtime-dropup-trigger-caret {

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -261,11 +261,26 @@
 // `.agent-composer-strip-right`'s own `flex-wrap: wrap` above, the pair can
 // never be torn apart onto two different sub-lines the way two independent
 // zone children could — they move together or not at all.
+//
+// `flex-wrap: wrap` + `min-width: 0` here too (reagentx/Codex P2, PR #2408):
+// panes can shrink to 40px (`MinNodeSizePx`, layoutResize.ts) and
+// `.agent-view` clips overflow, so an unconditional `flex: 0 0 auto` with no
+// give risked pushing Shell — the strip's one real action, otherwise always
+// reachable at every tier — outside the clipped viewport at extreme narrow
+// widths. Wrapping internally is the same last-resort safety net
+// `-controls`/`-right` already rely on: normally the pair sits on one line,
+// but if it truly doesn't fit, HOST/SANDBOX drops to its own sub-line
+// instead of either item overflowing. The shed query below (hiding
+// HOST/SANDBOX outright before that point) is the primary defense — this
+// wrap is the fallback for whatever width that shed rule doesn't quite
+// cover.
 .agent-composer-strip-host-shell {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: var(--space-1);
     flex: 0 0 auto;
+    min-width: 0;
 }
 
 .agent-composer-strip-stats {
@@ -379,6 +394,21 @@
 // Breakpoints are estimated from content width (right zone ≈ badge 28px +
 // ctx 50px + auth 70px + Shell 40px + 3 gaps ≈ 220px), not measured DOM
 // output — confirm against real rendered widths in `task dev` and adjust.
+
+// HOST/SANDBOX sheds ahead of auth (below), not alongside it: it now shares
+// its wrapper with Shell — the strip's one real action, which never sheds —
+// so that pair needs strictly more guaranteed room than auth alone did on
+// its own. Hiding the badge first keeps Shell comfortably clear of the
+// `.agent-composer-strip-host-shell` internal-wrap fallback above in the
+// common case; that wrap is still there as the last-resort safety net for
+// whatever width this estimate doesn't quite cover. reagentx/Codex P2, PR
+// #2408 — estimated, not measured; confirm against real rendered widths in
+// `task dev` and adjust, same caveat as every breakpoint in this section.
+@container agent-pane (max-width: 260px) {
+    .agent-composer-strip-host-shell .runtime-badge {
+        display: none;
+    }
+}
 
 @container agent-pane (max-width: 220px) {
     .agent-composer-strip-auth {


### PR DESCRIPTION
## Summary

PR #2393 (`SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md`) correctly fixed a real clipping bug by making the composer strip always left-justify, wrapping onto additional lines instead of overflowing under the textarea. But "always" went further than intended — wide panes with a full line of room to spare lost the true-centered stats zone as a side effect, not a deliberate goal. User feedback, same day: it should stay centered as long as content fits on one line, and only switch to left-justified once a 2nd line actually appears.

- **Restores centering at a new widest tier** (`@container agent-pane (min-width: 482px)`): a symmetric `flex: 1 1 0` split on `.agent-composer-strip-controls` and `.agent-composer-strip-right`, with `.agent-composer-strip-stats-zone` centered between them — the standard "true-center a middle flex item regardless of unequal side content width" pattern. Same visual result as the pre-08-03 `1fr auto 1fr` grid, **without** reintroducing `display: grid` (that's what caused the original clipping bug) and **without** touching the narrow-tier `flex-wrap` logic that actually fixed it — below 482px, behavior is byte-for-byte unchanged from #2393.
- **482px is live-measured, not estimated.** First shipped as a `640px` guess; live testing in a real `task dev` agent pane found the actual 1-line/2-line wrap boundary sits at ~482px, so 640px left a ~160px dead zone where content already fit on one line but the breakpoint hadn't kicked in — rendering left-justified when it should've stayed centered. Corrected to the measured value.
- **Pairs the HOST/SANDBOX runtime tag with the Shell toggle** as a single unit, moved out of the controls zone to sit immediately left of Shell (direct user request). Wrapped in a shared `inline-flex` span (`.agent-composer-strip-host-shell`) rather than just adjacent DOM order, so the pair is one atomic flex item inside the right zone's own internal `flex-wrap` — they move together across a wrap instead of independently landing on separate sub-lines.

Full design writeup and rationale: `docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md` (addendum section).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx stylelint frontend/app/view/agent/styles/_composer-strip.scss` — one pre-existing hex-color error unrelated to this change (already documented in the original #2393 spec)
- [x] `npx vitest run frontend/app/view/agent` — 954/954 tests pass across 74 files (no regressions)
- [x] **Live verification in `task dev`** — the gap the original #2393 PR explicitly left open. Resized a real agent pane through the full range: confirmed content stays centered at every width down to the exact 2nd-line wrap point (no dead zone), switches to left-justified only once wrapping begins, and the HOST/SANDBOX + Shell pair renders and moves together as intended.

<!-- agentmux:agent_id=loap -->