### PR TITLE
feat(launcher): detect srv hang-while-alive and force a recycle (#942)

### DIFF
--- a/.changesets/1785806209-feat-launcher-detect-srv-hang-while-alive-and-force-a-recycl-s606.md
+++ b/.changesets/1785806209-feat-launcher-detect-srv-hang-while-alive-and-force-a-recycl-s606.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launcher): detect srv hang-while-alive and force a recycle (#942)

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -56,6 +56,10 @@ mod splash_text;
 mod splash_config;
 mod splash_info;
 mod startup_events;
+// srv hang-while-alive detection plugs into srv recycle-on-exit
+// (SRV_RESTART_BUDGET, supervisor/mod.rs), which is Windows-only today.
+#[cfg(target_os = "windows")]
+mod srv_liveness;
 mod srv_spawner;
 mod state;
 mod wrr;

--- a/agentmux-launcher/src/srv_liveness.rs
+++ b/agentmux-launcher/src/srv_liveness.rs
@@ -122,23 +122,23 @@ pub fn should_recycle() -> bool {
 /// `select!`) for up to `timeout` on every hiccup.
 ///
 /// Success = a response starting with `HTTP/1.1 200`. `web_endpoint` is
-/// `srv_result.web_endpoint`, already in `http://127.0.0.1:{port}` form
-/// (see `srv_spawner::SrvSpawnResult`).
+/// `srv_result.web_endpoint` — a bare `host:port` (e.g. `127.0.0.1:54321`),
+/// NOT a URL: `emit_estart` (`agentmux-srv/src/bootstrap.rs`) writes
+/// `web:127.0.0.1:{port}` with no scheme, and `parse_estart`
+/// (`srv_spawner.rs`) carries that through verbatim — the same convention
+/// `host_spawn.rs` relies on when it passes this value straight through as
+/// `AGENTMUX_BACKEND_WEB`. (codex P1, PR #2411: an earlier version of this
+/// function stripped a `http://` prefix that never exists, so every probe
+/// silently failed and every healthy srv got recycled to death.)
 pub async fn probe(web_endpoint: &str, timeout: Duration) -> bool {
     tokio::time::timeout(timeout, probe_inner(web_endpoint))
         .await
         .unwrap_or(false)
 }
 
-async fn probe_inner(web_endpoint: &str) -> bool {
+async fn probe_inner(host_port: &str) -> bool {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let Some(host_port) = web_endpoint
-        .strip_prefix("http://")
-        .or_else(|| web_endpoint.strip_prefix("https://"))
-    else {
-        return false;
-    };
     let Ok(mut stream) = tokio::net::TcpStream::connect(host_port).await else {
         return false;
     };
@@ -216,7 +216,10 @@ mod tests {
                 .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
                 .await;
         });
-        let ok = super::probe(&format!("http://{}", addr), std::time::Duration::from_secs(2)).await;
+        // `addr` here matches the real shape of `srv_result.web_endpoint`
+        // (bare host:port, no scheme) — see the codex P1 fix this test
+        // guards against.
+        let ok = super::probe(&addr.to_string(), std::time::Duration::from_secs(2)).await;
         assert!(ok);
     }
 
@@ -231,7 +234,7 @@ mod tests {
             let (_sock, _) = listener.accept().await.unwrap();
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         });
-        let ok = super::probe(&format!("http://{}", addr), std::time::Duration::from_millis(200)).await;
+        let ok = super::probe(&addr.to_string(), std::time::Duration::from_millis(200)).await;
         assert!(!ok);
     }
 
@@ -241,7 +244,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
-        let ok = super::probe(&format!("http://{}", addr), std::time::Duration::from_secs(1)).await;
+        let ok = super::probe(&addr.to_string(), std::time::Duration::from_secs(1)).await;
         assert!(!ok);
     }
 }

--- a/agentmux-launcher/src/srv_liveness.rs
+++ b/agentmux-launcher/src/srv_liveness.rs
@@ -1,0 +1,247 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPEC_SRV_HANG_WHILE_ALIVE_DETECTION_2026_08_03 (#942 family) — srv
+//! liveness probing. Closes the named non-goal in
+//! `SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11.md`: that spec covers a
+//! crashed (exited) srv; this covers srv staying alive but wedged
+//! (deadlock, exhausted blocking pool, stuck await) so its process never
+//! exits and the existing crash-recycle machinery never triggers.
+//!
+//! Simpler than the host's `ui_liveness`/`teardown_backstop` pair, and
+//! deliberately so: the host's probe is fire-and-forget over a pipe (the
+//! reply arrives asynchronously from a posted CEF UI-thread task, which is
+//! why that side needs nonce-matching across ticks), and `teardown_backstop`
+//! needs an armed state machine because it must not fire during legitimate
+//! zero-window states. Neither applies here — srv already exposes a
+//! synchronous, unauthenticated HTTP health endpoint
+//! (`agentmux-srv/src/server/mod.rs::health_handler`, mounted outside
+//! `auth_middleware`), so a single bounded round-trip per tick gives a
+//! pass/fail answer within that same tick. No cross-tick reply matching, no
+//! "is zero absence legitimate" guard — srv is expected to answer whenever
+//! it is running.
+//!
+//! Recovery deliberately does NOT duplicate the existing crash-recycle
+//! logic: on `SRV_HANG_REQUIRED_MISSES` consecutive failed probes, the
+//! caller kills srv's process directly (`Child::start_kill()`) and resets
+//! this module's counters. The next loop iteration's existing
+//! `srv_status = srv_child.wait()` arm sees the exit and runs the
+//! already-shipped #2107 respawn/rebind/host-recycle path unmodified — this
+//! module's only job is deciding "treat this as a crash", never how to
+//! recover from one.
+//!
+//! Like `ui_liveness`, all logic lives on the struct (unit-testable without
+//! real I/O or a mock clock — there's no elapsed-time gate, just a
+//! consecutive-failure counter); the module-level functions delegate to one
+//! process-global instance, mirroring `ui_liveness`'s reasoning for why each
+//! test constructs its own instance instead of sharing the process-global
+//! cell (parallel test execution would otherwise interleave).
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Consecutive missed health probes before srv counts as wedged. At the
+/// `SRV_PROBE_INTERVAL` (10s) this bounds worst-case wedge→recycle latency
+/// to roughly 3 probe intervals plus their timeouts (~30s) — the same
+/// order of magnitude as the host teardown backstop's 30s grace.
+pub const SRV_HANG_REQUIRED_MISSES: u32 = 3;
+
+#[derive(Debug, Default)]
+pub struct SrvLiveness {
+    consecutive_misses: u32,
+    last_alive: Option<Instant>,
+}
+
+impl SrvLiveness {
+    /// Record a successful probe. Clears the miss streak — any answer
+    /// proves srv's async runtime is pumping right now.
+    pub fn record_success(&mut self, now: Instant) {
+        self.consecutive_misses = 0;
+        self.last_alive = Some(now);
+    }
+
+    /// Record a missed probe (timeout or connection failure). Returns the
+    /// new consecutive-miss count.
+    pub fn record_failure(&mut self) -> u32 {
+        self.consecutive_misses = self.consecutive_misses.saturating_add(1);
+        self.consecutive_misses
+    }
+
+    /// Clear all state. Called after every srv (re)spawn — a freshly
+    /// started srv must not inherit its predecessor's miss count.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// The recycle decision: pure read, caller executes.
+    pub fn should_recycle(&self, required_misses: u32) -> bool {
+        self.consecutive_misses >= required_misses
+    }
+
+    #[allow(dead_code)] // telemetry surface, mirrors ui_liveness::last_alive
+    pub fn last_alive(&self) -> Option<Instant> {
+        self.last_alive
+    }
+}
+
+fn cell() -> &'static Mutex<SrvLiveness> {
+    static S: OnceLock<Mutex<SrvLiveness>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(SrvLiveness::default()))
+}
+
+/// See [`SrvLiveness::record_success`]. Process-global instance.
+pub fn record_success() {
+    cell().lock().unwrap().record_success(Instant::now());
+}
+
+/// See [`SrvLiveness::record_failure`]. Process-global instance.
+pub fn record_failure() -> u32 {
+    cell().lock().unwrap().record_failure()
+}
+
+/// See [`SrvLiveness::reset`]. Process-global instance.
+pub fn reset() {
+    cell().lock().unwrap().reset();
+}
+
+/// See [`SrvLiveness::should_recycle`]. Process-global instance, evaluated
+/// against the spec constant.
+pub fn should_recycle() -> bool {
+    cell().lock().unwrap().should_recycle(SRV_HANG_REQUIRED_MISSES)
+}
+
+/// Hand-rolled HTTP `GET /` against srv's web endpoint, bounded end-to-end
+/// by `timeout`. Deliberately not reqwest — same reasoning as
+/// `second_instance::forward_open_new_window`: the launcher binary stays
+/// tiny and the request is fixed, so a hand-rolled request is the right
+/// tool. Unlike that function (a one-shot call before the supervisor loop
+/// starts), this runs every tick INSIDE the loop, so it uses `tokio::net`
+/// + `tokio::time::timeout` rather than blocking `std::net` calls — a
+/// blocking probe would stall the whole supervisor loop (host-exit
+/// detection, the teardown backstop, everything else in the same
+/// `select!`) for up to `timeout` on every hiccup.
+///
+/// Success = a response starting with `HTTP/1.1 200`. `web_endpoint` is
+/// `srv_result.web_endpoint`, already in `http://127.0.0.1:{port}` form
+/// (see `srv_spawner::SrvSpawnResult`).
+pub async fn probe(web_endpoint: &str, timeout: Duration) -> bool {
+    tokio::time::timeout(timeout, probe_inner(web_endpoint))
+        .await
+        .unwrap_or(false)
+}
+
+async fn probe_inner(web_endpoint: &str) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let Some(host_port) = web_endpoint
+        .strip_prefix("http://")
+        .or_else(|| web_endpoint.strip_prefix("https://"))
+    else {
+        return false;
+    };
+    let Ok(mut stream) = tokio::net::TcpStream::connect(host_port).await else {
+        return false;
+    };
+    let req = format!("GET / HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n", host_port);
+    if stream.write_all(req.as_bytes()).await.is_err() {
+        return false;
+    }
+    let mut buf = [0u8; 32];
+    match stream.read(&mut buf).await {
+        Ok(n) if n > 0 => buf[..n].starts_with(b"HTTP/1.1 200"),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SrvLiveness;
+    use std::time::Instant;
+
+    // Each test owns its OWN SrvLiveness instance — no process-global
+    // state, no parallel-execution interleaving (same reasoning as
+    // ui_liveness's tests).
+
+    #[test]
+    fn first_failure_does_not_recycle() {
+        let mut l = SrvLiveness::default();
+        l.record_failure();
+        assert!(!l.should_recycle(3));
+    }
+
+    #[test]
+    fn required_consecutive_failures_recycles() {
+        let mut l = SrvLiveness::default();
+        l.record_failure();
+        l.record_failure();
+        assert!(!l.should_recycle(3), "2 of 3 required misses must not recycle yet");
+        l.record_failure();
+        assert!(l.should_recycle(3));
+    }
+
+    #[test]
+    fn success_resets_miss_count() {
+        let mut l = SrvLiveness::default();
+        l.record_failure();
+        l.record_failure();
+        l.record_success(Instant::now());
+        assert!(l.last_alive().is_some());
+        l.record_failure();
+        l.record_failure();
+        assert!(!l.should_recycle(3), "streak must have reset on success");
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut l = SrvLiveness::default();
+        l.record_failure();
+        l.record_failure();
+        l.record_failure();
+        assert!(l.should_recycle(3));
+        l.reset();
+        assert!(!l.should_recycle(3));
+        assert!(l.last_alive().is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_succeeds_against_a_real_200_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 512];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .await;
+        });
+        let ok = super::probe(&format!("http://{}", addr), std::time::Duration::from_secs(2)).await;
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn probe_times_out_against_a_stalled_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // Accept and never respond — simulates a wedged srv whose
+            // listener still accepts connections but whose async runtime
+            // never gets around to running the handler.
+            let (_sock, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        });
+        let ok = super::probe(&format!("http://{}", addr), std::time::Duration::from_millis(200)).await;
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn probe_fails_against_nothing_listening() {
+        // Bind-then-drop to get a port that's guaranteed refused.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let ok = super::probe(&format!("http://{}", addr), std::time::Duration::from_secs(1)).await;
+        assert!(!ok);
+    }
+}

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -436,6 +436,9 @@ pub(crate) async fn run_windows(
     // (live-reproduced 2026-07-11: respawned srv logged "stdin closed,
     // shutting down" 7ms after binding its listeners).
     let mut srv_stdin_keepalive = srv_child.stdin.take();
+    // SPEC_SRV_HANG_WHILE_ALIVE_DETECTION_2026_08_03 — start the liveness
+    // prober's counters clean for this srv instance.
+    crate::srv_liveness::reset();
 
     // 4-6. Spawn the host (suspended) → assign to J0 → resume, via
     // spawn_host_supervised(). The splash event is passed on every launch
@@ -561,6 +564,20 @@ pub(crate) async fn run_windows(
     // Distinct exit code so the wedged-host teardown is unambiguous in any
     // log/exit-code triage (spec: "launcher exit with a distinct code").
     const TEARDOWN_BACKSTOP_EXIT_CODE: i32 = 86;
+    // SPEC_SRV_HANG_WHILE_ALIVE_DETECTION_2026_08_03 (#942 family) — srv
+    // liveness prober. Unlike the host's UI-thread probe, srv exposes a
+    // synchronous HTTP health endpoint, so each tick gets a pass/fail
+    // answer within that same tick — no cross-tick nonce matching needed.
+    // First tick delayed one interval for the same reason as
+    // `ui_probe_interval`: give a just-(re)spawned srv a moment before its
+    // first probe.
+    const SRV_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+    const SRV_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+    let mut srv_probe_interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + SRV_PROBE_INTERVAL,
+        SRV_PROBE_INTERVAL,
+    );
+    srv_probe_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let exit_code = loop {
         tokio::select! {
             _ = teardown_check_interval.tick() => {
@@ -619,6 +636,33 @@ pub(crate) async fn run_windows(
                         "[ui-liveness] probe send failed (transport, not liveness): {:?}",
                         e
                     ));
+                }
+            }
+            _ = srv_probe_interval.tick() => {
+                if crate::srv_liveness::probe(&srv_result.web_endpoint, SRV_PROBE_TIMEOUT).await {
+                    crate::srv_liveness::record_success();
+                } else {
+                    let misses = crate::srv_liveness::record_failure();
+                    log(&format!(
+                        "[srv-liveness] missed health probe ({} consecutive)",
+                        misses
+                    ));
+                    if crate::srv_liveness::should_recycle() {
+                        log(&format!(
+                            "[srv-liveness] srv wedged (alive, unresponsive to {} consecutive health \
+                             probes) — forcing recycle",
+                            misses
+                        ));
+                        crate::srv_liveness::reset();
+                        // Kill srv directly (not via J0/TerminateJobObject —
+                        // this is scoped to srv alone, not a whole-tree
+                        // teardown). The srv_status = srv_child.wait() arm
+                        // (next iteration) picks up the exit and runs the
+                        // already-shipped #2107 respawn/rebind/host-recycle
+                        // path unmodified — this arm's only job is deciding
+                        // "treat this as a crash".
+                        let _ = srv_child.start_kill();
+                    }
                 }
             }
             host_status = host_child.wait() => {
@@ -975,6 +1019,11 @@ pub(crate) async fn run_windows(
                         // milliseconds — live-reproduced on the first version
                         // of this arm.
                         srv_stdin_keepalive = srv_child.stdin.take();
+                        // A freshly respawned srv must not inherit its
+                        // predecessor's miss count (whether this respawn was
+                        // triggered by a real crash or by the liveness
+                        // prober's own recycle-kill above).
+                        crate::srv_liveness::reset();
                         log(&format!(
                             "srv respawned (pid {}) — new endpoints ws={} web={}; recycling host",
                             srv_result.pid, srv_result.ws_endpoint, srv_result.web_endpoint

--- a/docs/specs/SPEC_SRV_HANG_WHILE_ALIVE_DETECTION_2026_08_03.md
+++ b/docs/specs/SPEC_SRV_HANG_WHILE_ALIVE_DETECTION_2026_08_03.md
@@ -1,0 +1,120 @@
+# SPEC: srv hang-while-alive detection (#942 family)
+
+**Date:** 2026-08-03
+**Status:** Implemented
+**Tracking:** #942 ("Service Supervision & Recovery"); closes the named
+non-goal in `SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11.md`: *"srv
+hang-while-alive detection (this covers exits; liveness probing for srv is
+a separate follow-up in the #942 family)."*
+**Scope:** `agentmux-launcher/src/supervisor/windows.rs` (Windows only —
+see Non-goals)
+
+## Problem
+
+srv exit-triggered recycle (#2107) recovers cleanly from a crashed srv, but
+nothing detects srv staying **alive but wedged** — a deadlock, an exhausted
+blocking-thread pool, or a stuck `await` inside srv's own async runtime.
+`srv_child.wait()` never resolves in that case, so the existing
+crash-recycle machinery never fires, and the user is left with a session
+that silently stopped responding for no visible reason.
+
+## Design — probe, then reuse the existing recycle path
+
+The host solves the analogous problem (a wedged CEF UI thread) with a pair
+of modules: `ui_liveness.rs` (fire-and-forget pipe probe + nonce-matched
+reply tracking) and `teardown_backstop.rs` (an armed state machine guarding
+against legitimate zero-window states). Neither complication is needed for
+srv:
+
+- srv already exposes a **synchronous, unauthenticated HTTP health
+  endpoint** (`GET /` → `health_handler`, `agentmux-srv/src/server/mod.rs`,
+  mounted outside `auth_middleware`). A single bounded HTTP round-trip per
+  tick gives a pass/fail answer within that same tick — no cross-tick nonce
+  matching required.
+- There is no "legitimate absence" state to guard against the way
+  `teardown_backstop` must (host startup, crash-restart gap): srv is
+  expected to answer whenever its process is running.
+
+So this is one small module, `srv_liveness.rs`, with a single struct
+(`SrvLiveness`: `consecutive_misses` + `last_alive`) and a process-global
+singleton, following `ui_liveness.rs`'s exact conventions (same
+`OnceLock<Mutex<>>` pattern, same "each test owns its own instance" reason
+for avoiding cross-test interleaving).
+
+**Recovery reuses #2107 unmodified.** On `SRV_HANG_REQUIRED_MISSES` (3)
+consecutive missed probes, the new `select!` arm calls
+`srv_child.start_kill()` and resets its own counters. The very next loop
+iteration's existing `srv_status = srv_child.wait()` arm sees the exit and
+runs the already-shipped respawn/rebind/host-recycle path exactly as it
+would for a real crash. This module's only responsibility is deciding
+"treat this as a crash" — it does not touch recovery logic, matching the
+#942 program's prime directive that the supervisor stay "passive, bounded,
+and simpler than everything it supervises."
+
+No misclassification risk: `TerminateProcess` produces a generic non-zero
+exit code, not the specific OOM exception code `classify_host_exit` checks
+for, so a hang-triggered recycle naturally buckets as `Abnormal` and counts
+against `SRV_RESTART_BUDGET` — exactly like a real crash. No
+`srv_recycle_kill`-style flag is needed (that flag exists on the *host*
+side, to stop a deliberate srv-triggered host recycle from being misread as
+a GPU/OOM host fault — a different problem this doesn't touch).
+
+### Why `tokio::net` instead of the `second_instance.rs` blocking-`std::net`
+precedent
+
+`second_instance::forward_open_new_window` is the existing hand-rolled
+HTTP-over-loopback template (deliberately not `reqwest` — keeps the
+launcher binary tiny for a fixed one-line request). `srv_liveness::probe`
+follows the same request-construction style but uses `tokio::net::TcpStream`
++ `tokio::time::timeout` rather than blocking calls: `forward_open_new_window`
+runs once, before the supervisor loop starts; `probe` runs every 10s
+*inside* the same `select!` loop that also detects host/srv exit and the
+teardown backstop, so a blocking call would stall all of those for up to
+the probe timeout on every hiccup.
+
+## Constants
+
+- `SRV_PROBE_INTERVAL` = 10s (first tick delayed one interval, same
+  convention as `ui_probe_interval`)
+- `SRV_PROBE_TIMEOUT` = 3s
+- `SRV_HANG_REQUIRED_MISSES` = 3 — bounds worst-case wedge→recycle latency
+  to roughly 3 probe intervals plus timeouts (~30s), the same order of
+  magnitude as the host teardown backstop's 30s grace.
+
+`srv_liveness::reset()` is called at both `srv_spawner::spawn_srv` call
+sites (cold boot and the exit-triggered recycle branch) so a freshly
+spawned srv never inherits its predecessor's miss count.
+
+## Non-goals
+
+- **Unix.** `SRV_RESTART_BUDGET`/`SRV_RESTART_WINDOW` (the machinery this
+  plugs into) are `#[cfg(target_os = "windows")]` today — srv
+  crash-recycle itself isn't ported to Unix yet. Building hang detection on
+  top of a platform where the underlying recycle path doesn't exist would
+  be dead code; Unix parity is a follow-up once srv recycle lands there.
+- A new srv-side debug endpoint to simulate a wedge for testing. A real
+  process suspend (`pssuspend`, Sysinternals) is a more faithful test of
+  "alive but not scheduled" than a busy-loop handler, and avoids adding
+  permanent test-only surface to srv.
+
+## Verification
+
+- `cargo test -p agentmux-launcher` — `srv_liveness::tests` (pure
+  miss-count/recycle-decision unit tests + three `probe()` integration
+  tests against a local `tokio::net::TcpListener`: 200 response, stalled
+  response past timeout, connection refused). Full launcher suite (213
+  tests) green, no regressions.
+- Live, on `task dev` (Windows):
+  - Boot normally; confirm no `[srv-liveness]` miss logs during healthy
+    operation.
+  - `pssuspend <srv_pid>` to freeze srv without killing it.
+  - Launcher log shows miss logs every ~10s, then after 3 (~30s) `srv
+    wedged — forcing recycle`; srv is killed; the existing #2107
+    respawn/rebind/host-recycle sequence fires (same "Restoring session…"
+    splash as a real crash); windows reproject correctly; zero stray
+    processes afterward.
+  - Repeat to confirm `SRV_RESTART_BUDGET` (3/120s) still exhausts
+    correctly — this change must not regress #2107's already-verified
+    budget behavior.
+  - Regression: a genuine srv crash (kill by PID, not suspend) still
+    recycles exactly as before.


### PR DESCRIPTION
## Summary

Closes the named non-goal in `SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11.md`
(#2107): *"srv hang-while-alive detection ... is a separate follow-up in
the #942 family."*

srv exit-triggered recycle (#2107) already recovers cleanly from a crashed
srv, but nothing detected srv staying **alive but wedged** (deadlock,
exhausted blocking-thread pool, stuck `await`) — `srv_child.wait()` never
resolves in that case, so the existing crash-recycle machinery never fires
and the session silently stops responding.

- New `agentmux-launcher/src/srv_liveness.rs`: a 10s HTTP health-check probe
  against srv's existing unauthenticated `GET /` endpoint, 3-consecutive-miss
  threshold (~30s to detect, same order of magnitude as the host teardown
  backstop's 30s grace).
- On detecting a hang: kill srv directly (`start_kill`) and reset the
  counters. The existing `srv_status = srv_child.wait()` arm (next loop
  iteration) drives the already-shipped #2107 respawn/rebind/host-recycle
  path **unmodified** — this module's only job is deciding "treat this as a
  crash," not how to recover from one.
- Simpler by design than the host's `ui_liveness`/`teardown_backstop` pair:
  srv's health check is synchronous (pass/fail within one tick, no
  cross-tick nonce matching) and there's no "legitimate absence" state to
  guard against the way the host's zero-window backstop must.
- Uses `tokio::net` (not the `second_instance.rs` blocking-`std::net`
  precedent) since this probe runs every tick inside the same `select!`
  loop that also detects host/srv exit and the teardown backstop — a
  blocking call would stall all of those on every hiccup.

**Windows-only.** `SRV_RESTART_BUDGET`/`SRV_RESTART_WINDOW` (the machinery
this plugs into) are `#[cfg(target_os = "windows")]` today — srv
crash-recycle itself isn't ported to Unix yet, so building hang detection
on top of it there would be dead code. Unix parity is a natural follow-up
once srv recycle lands on that platform.

Full design writeup: `docs/specs/SPEC_SRV_HANG_WHILE_ALIVE_DETECTION_2026_08_03.md`.

## Test plan

- [x] `cargo test -p agentmux-launcher` — new `srv_liveness` unit tests
      (miss-count/recycle-decision, pure) + 3 `probe()` integration tests
      against a local `tokio::net::TcpListener` (200 response, stalled
      response past timeout, connection refused) — all pass.
- [x] Full launcher suite (213 tests) green, no regressions.
- [x] `cargo check -p agentmux-launcher` clean.
- [ ] Live verification on a Windows machine (needs Sysinternals `pssuspend`
      to freeze srv without killing it — not available in this sandbox):
      boot `task dev`, `pssuspend <srv_pid>`, confirm the launcher log shows
      3 missed probes (~30s) then "srv wedged — forcing recycle", srv is
      killed, the existing "Restoring session…" respawn/reproject sequence
      fires, windows come back, and `SRV_RESTART_BUDGET` (3/120s) still
      exhausts correctly on repeat.

<!-- agentmux:agent_id=agenta -->