### PR TITLE
fix(agent-pane): remove the model selector's misleading trailing caret

### DIFF
--- a/.changesets/1785807323-fix-agent-pane-remove-the-model-selector-s-misleading-traili-ucxu.md
+++ b/.changesets/1785807323-fix-agent-pane-remove-the-model-selector-s-misleading-traili-ucxu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): remove the model selector's misleading trailing caret

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -289,9 +289,6 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
                 onClick={() => toggleOpen()}
             >
                 <span class="agent-runtime-dropup-trigger-label">{compactSummary()}</span>
-                <span class="agent-runtime-dropup-trigger-caret" aria-hidden="true">
-                    ▴
-                </span>
             </button>
             <Show when={open()}>
                 <Portal>

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -87,16 +87,14 @@
 }
 
 // The consolidated Mode/Model/Effort trigger — a single <button> laying out
-// a "Mode · Model · Effort" summary label + up-caret; same slim-pill footprint
-// as the former three separate selects/drop-ups combined into one. No fixed
+// a "Mode · Model · Effort" summary label; same slim-pill footprint as the
+// former three separate selects/drop-ups combined into one. No fixed
 // max-width — sizes to its content; a cap only reappears under real space
 // pressure (see the ≤150px container query below), so it only ellipsizes
 // when the pane genuinely has no room for it.
 .agent-runtime-dropup-trigger {
     display: inline-flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 3px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
     border-radius: 0;
@@ -122,13 +120,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-}
-
-.agent-runtime-dropup-trigger-caret {
-    font-size: 8px;
-    line-height: 1;
-    opacity: 0.7;
-    flex-shrink: 0;
 }
 
 // The panel itself (portaled to <body>, so this is a top-level global rule).


### PR DESCRIPTION
## Summary
- User-reported: the collapsed model selector ("Mode · Model · Effort" trigger pill) shows an extra dot separator at the end that isn't needed.
- Root-caused via screenshot: `compactSummary()` (`AgentRuntimeDropup.tsx`) is a plain `.join(" · ")` over 3 always-non-empty values -- provably correct, no stray separator possible. The "extra dot" is actually the trigger's own expand/collapse caret (`▴`, `font-size: 8px`, `opacity: 0.7`) sitting right after the label, small/faint enough to read as a 4th separator dot.
- Per explicit user direction: removed the caret entirely rather than just restyling it -- the whole pill is already clickable, so no dedicated indicator glyph is needed.
- Cleaned up the now-dead `.agent-runtime-dropup-trigger-caret` CSS rule and `justify-content: space-between` (irrelevant with a single remaining child).

## Test plan
- [x] `npx tsc --noEmit` -- clean.
- [x] `npx vitest run frontend/app/view/agent` -- 954/954 pass.
- [ ] Manual: open an agent pane, confirm the model selector pill shows "Mode · Model · Effort" with no trailing mark, and still opens the panel on click.

<!-- agentmux:agent_id=agenty -->