### PR TITLE
feat(armory): connect/re-login Claude OAuth accounts from Armory and Agent Stash

### DIFF
--- a/.changesets/1785811191-feat-armory-connect-re-login-claude-oauth-accounts-from-armo-dit6.md
+++ b/.changesets/1785811191-feat-armory-connect-re-login-claude-oauth-accounts-from-armo-dit6.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): connect/re-login Claude OAuth accounts from Armory and Agent Stash

--- a/frontend/app/view/accounts/AccountsGallery.tsx
+++ b/frontend/app/view/accounts/AccountsGallery.tsx
@@ -23,6 +23,15 @@ export function AccountsGallery(props: {
     /** Open the dedicated AgentMux connect panel instead of the OAuth/Key
      *  chooser. Required for the agentmux tile to do anything. */
     onAgentMux?: () => void;
+    /** Open ClaudeLoginPanel (the in-app CLI login session, spec
+     *  SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 3) instead
+     *  of the generic Add-account form's OAuth path — Anthropic isn't in
+     *  oauth-catalog.ts's service-OAuth scaffold (no device/PKCE endpoint
+     *  an app-driven client could hit), so its "oauth" mode needs its own
+     *  panel the same way the agentmux tile needs its own connect flow.
+     *  Unlike agentmux, this fires from the chooser's OAuth button (the
+     *  anthropic tile still offers Key too), not at tile-click time. */
+    onClaudeConnect?: () => void;
 }): JSX.Element {
     const model = props.model;
     const [chooser, setChooser] = createSignal<ServiceTile | null>(null);
@@ -33,8 +42,12 @@ export function AccountsGallery(props: {
     };
 
     const pick = (tile: ServiceTile, mode: AuthMode) => {
-        const kind: AccountKind = mode === "oauth" ? "oauth" : tile.keyKind;
         setChooser(null);
+        if (tile.id === "anthropic" && mode === "oauth") {
+            props.onClaudeConnect?.();
+            return;
+        }
+        const kind: AccountKind = mode === "oauth" ? "oauth" : tile.keyKind;
         model.openAddFormFor(tile.id, kind);
     };
 

--- a/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
@@ -154,6 +154,43 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
         expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
     });
 
+    it("reagent P2 on PR #2414 (round 4): Retry after a link-verification failure reuses the account THIS panel already minted, instead of re-minting a second one", async () => {
+        // First attempt: Armory's bare-Connect shape (no existingAccountId
+        // prop) mints a NEW account and persists it, but the agent-link
+        // check fails — mirrors the test above, just with a Stash
+        // linkTarget added so there's an agent to (fail to) link to.
+        hub.runProviderLogin.mockImplementationOnce(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+        hub.listAgentIdentities.mockResolvedValueOnce([]); // link never landed
+
+        const { findByText } = render(() => (
+            <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
+        ));
+        const retryButton = await findByText("Retry");
+
+        // Second attempt (Retry): this time the link verification succeeds.
+        hub.runProviderLogin.mockImplementationOnce(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+        hub.listAgentIdentities.mockResolvedValueOnce([
+            { agent_id: "agent-1", account_id: "acct-new", provider: "claude" },
+        ]);
+        retryButton.click();
+
+        await findByText(/signed in to claude/i);
+        // The whole point: Retry must refresh the SAME account
+        // ("acct-new") the first attempt already minted and persisted, not
+        // mint a brand-new one under the still-undefined original prop —
+        // that would orphan "acct-new" as a real, credentialed, unlinked
+        // Claude account.
+        expect(hub.runProviderLogin).toHaveBeenLastCalledWith(
+            expect.objectContaining({ existingAccountId: "acct-new" }),
+        );
+    });
+
     it("shows success when the link IS confirmed present for this agent", async () => {
         hub.runProviderLogin.mockImplementation(async (opts: any) => {
             opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");

--- a/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
@@ -1,0 +1,121 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for ClaudeLoginPanel — specifically the staleAliasProvider
+ * cleanup (reagent P0 on PR #2414): a successful login here always links
+ * the CANONICAL "claude" provider (finalizeAccount's
+ * ON CONFLICT(agent_id, provider) key), so opening this panel from a
+ * legacy-aliased row ("claude-code") and succeeding must ALSO unlink the
+ * old alias — otherwise the orphaned alias row lingers and the resolver's
+ * inject.rs aborts every future spawn on it, even though a healthy
+ * canonical "claude" link now exists right alongside it.
+ */
+
+import { cleanup, render, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    runProviderLogin: vi.fn(),
+    resolveCliCommand: vi.fn(),
+    unlinkAgentIdentity: vi.fn(),
+    ensureAuthDir: vi.fn(),
+    refreshAccountCache: vi.fn(),
+}));
+
+vi.mock("@/app/store/global", () => ({
+    getApi: () => ({
+        ensureAuthDir: (...args: unknown[]) => hub.ensureAuthDir(...args),
+        cancelCliLogin: () => Promise.resolve(),
+    }),
+}));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ResolveCliCommand: (...args: unknown[]) => hub.resolveCliCommand(...args),
+        UnlinkAgentIdentityCommand: (...args: unknown[]) => hub.unlinkAgentIdentity(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/errors/translate", () => ({
+    translateError: (e: any) => ({ title: "Error", message: String(e?.message ?? e), retry: "" }),
+}));
+vi.mock("@/app/view/agent/flows/run-provider-login", () => ({
+    runProviderLogin: (...args: unknown[]) => hub.runProviderLogin(...args),
+}));
+vi.mock("@/app/view/agent/components/InAppLoginPanel", () => ({
+    InAppLoginPanel: () => null,
+}));
+vi.mock("@/app/view/identity/identity-model", () => ({
+    refreshAccountCache: (...args: unknown[]) => hub.refreshAccountCache(...args),
+}));
+
+import { ClaudeLoginPanel } from "./ClaudeLoginPanel";
+
+beforeEach(() => {
+    hub.runProviderLogin.mockReset();
+    hub.resolveCliCommand.mockReset().mockResolvedValue({ cli_path: "/usr/bin/claude" });
+    hub.unlinkAgentIdentity.mockReset().mockResolvedValue({ unlinked: true });
+    hub.ensureAuthDir.mockReset().mockResolvedValue("/tmp/claude-auth");
+    hub.refreshAccountCache.mockReset();
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("ClaudeLoginPanel — staleAliasProvider cleanup (reagent P0 on PR #2414)", () => {
+    it("unlinks the stale alias provider after a successful login, using linkTarget's agentDefinitionId", async () => {
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+
+        render(() => (
+            <ClaudeLoginPanel
+                onClose={() => {}}
+                existingAccountId="acc-claude-1"
+                linkTarget={{ agentDefinitionId: "agent-1" }}
+                staleAliasProvider="claude-code"
+            />
+        ));
+
+        await waitFor(() => {
+            expect(hub.unlinkAgentIdentity).toHaveBeenCalledWith(
+                {},
+                { agent_id: "agent-1", provider: "claude-code" },
+            );
+        });
+        expect(hub.refreshAccountCache).toHaveBeenCalled();
+    });
+
+    it("does NOT call UnlinkAgentIdentityCommand when staleAliasProvider is unset (canonical row, or Armory's bare Connect)", async () => {
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+
+        render(() => <ClaudeLoginPanel onClose={() => {}} />);
+
+        await waitFor(() => {
+            expect(hub.refreshAccountCache).toHaveBeenCalled();
+        });
+        expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
+    });
+
+    it("does NOT unlink on a failed/unregistered login — nothing to clean up if the new link never landed", async () => {
+        hub.runProviderLogin.mockResolvedValue("inapp-timeout");
+
+        render(() => (
+            <ClaudeLoginPanel
+                onClose={() => {}}
+                linkTarget={{ agentDefinitionId: "agent-1" }}
+                staleAliasProvider="claude-code"
+            />
+        ));
+
+        await waitFor(() => {
+            expect(hub.runProviderLogin).toHaveBeenCalled();
+        });
+        expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
@@ -19,20 +19,23 @@ const hub = vi.hoisted(() => ({
     runProviderLogin: vi.fn(),
     resolveCliCommand: vi.fn(),
     unlinkAgentIdentity: vi.fn(),
+    listAgentIdentities: vi.fn(),
     ensureAuthDir: vi.fn(),
     refreshAccountCache: vi.fn(),
+    cancelCliLogin: vi.fn(),
 }));
 
 vi.mock("@/app/store/global", () => ({
     getApi: () => ({
         ensureAuthDir: (...args: unknown[]) => hub.ensureAuthDir(...args),
-        cancelCliLogin: () => Promise.resolve(),
+        cancelCliLogin: (...args: unknown[]) => hub.cancelCliLogin(...args),
     }),
 }));
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ResolveCliCommand: (...args: unknown[]) => hub.resolveCliCommand(...args),
         UnlinkAgentIdentityCommand: (...args: unknown[]) => hub.unlinkAgentIdentity(...args),
+        ListAgentIdentitiesCommand: (...args: unknown[]) => hub.listAgentIdentities(...args),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -55,8 +58,15 @@ beforeEach(() => {
     hub.runProviderLogin.mockReset();
     hub.resolveCliCommand.mockReset().mockResolvedValue({ cli_path: "/usr/bin/claude" });
     hub.unlinkAgentIdentity.mockReset().mockResolvedValue({ unlinked: true });
+    // Confirms the link by default — matches onAccountRegistered("acct-new", …)
+    // used throughout these tests. Individual tests override to simulate a
+    // missing/failed link.
+    hub.listAgentIdentities.mockReset().mockResolvedValue([
+        { agent_id: "agent-1", account_id: "acct-new", provider: "claude" },
+    ]);
     hub.ensureAuthDir.mockReset().mockResolvedValue("/tmp/claude-auth");
     hub.refreshAccountCache.mockReset();
+    hub.cancelCliLogin.mockReset().mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -82,7 +92,10 @@ describe("ClaudeLoginPanel — staleAliasProvider cleanup (reagent P0 on PR #241
         await waitFor(() => {
             expect(hub.unlinkAgentIdentity).toHaveBeenCalledWith(
                 {},
-                { agent_id: "agent-1", provider: "claude-code" },
+                // silent: true (codex P2 on PR #2414) — this is an alias
+                // migration, not a real unbind; must not trigger the
+                // user-facing "Credentials revoked" broadcast.
+                { agent_id: "agent-1", provider: "claude-code", silent: true },
             );
         });
         expect(hub.refreshAccountCache).toHaveBeenCalled();
@@ -117,5 +130,97 @@ describe("ClaudeLoginPanel — staleAliasProvider cleanup (reagent P0 on PR #241
             expect(hub.runProviderLogin).toHaveBeenCalled();
         });
         expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
+    });
+});
+
+describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", () => {
+    it("does NOT show success for a Stash flow (linkTarget set) when the account was persisted but the agent link itself never landed", async () => {
+        // finalizeAccount (run-provider-login.ts) catches and only logs a
+        // LinkAgentIdentityCommand failure — onAccountRegistered still
+        // fires. This is exactly that: the account exists, but no link row
+        // for this agent shows up when we check.
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+        hub.listAgentIdentities.mockResolvedValue([]); // no link for this agent
+
+        const { findByText } = render(() => (
+            <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
+        ));
+
+        await findByText(/couldn't confirm the account was linked/i);
+        expect(hub.refreshAccountCache).not.toHaveBeenCalled();
+        expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
+    });
+
+    it("shows success when the link IS confirmed present for this agent", async () => {
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+
+        const { findByText } = render(() => (
+            <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
+        ));
+
+        await findByText(/signed in to claude/i);
+        expect(hub.refreshAccountCache).toHaveBeenCalled();
+    });
+
+    it("skips link verification entirely for Armory's bare Connect (no linkTarget) — nothing to verify", async () => {
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+
+        const { findByText } = render(() => <ClaudeLoginPanel onClose={() => {}} />);
+
+        await findByText(/signed in to claude/i);
+        expect(hub.listAgentIdentities).not.toHaveBeenCalled();
+    });
+});
+
+describe("ClaudeLoginPanel — unmount cleanup (codex P2 on PR #2414)", () => {
+    it("does NOT cancel the host's login when unmounting after already reaching success (inFlight is false)", async () => {
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");
+            return "inapp-success";
+        });
+
+        const { findByText, unmount } = render(() => (
+            <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
+        ));
+        await findByText(/signed in to claude/i);
+        hub.cancelCliLogin.mockClear(); // clear whatever the login flow itself called
+
+        unmount();
+
+        // The whole point: a lingering "✓ Signed in" panel that finally
+        // closes must not kill some OTHER, newer login the host's single
+        // global slot might hold by then.
+        expect(hub.cancelCliLogin).not.toHaveBeenCalled();
+    });
+
+    it("DOES cancel the host's login when unmounting while still genuinely in flight", async () => {
+        hub.runProviderLogin.mockImplementation(() => new Promise(() => {})); // never resolves
+
+        const { unmount } = render(() => <ClaudeLoginPanel onClose={() => {}} />);
+        await Promise.resolve();
+
+        unmount();
+
+        expect(hub.cancelCliLogin).toHaveBeenCalled();
+    });
+});
+
+describe("ClaudeLoginPanel — login-runner rejection (codex P2 on PR #2414)", () => {
+    it("surfaces a retryable error instead of leaving the panel stuck when runProviderLogin rejects outright", async () => {
+        hub.runProviderLogin.mockRejectedValue(new Error("PTY spawn failed"));
+
+        const { findByText } = render(() => <ClaudeLoginPanel onClose={() => {}} />);
+
+        await findByText(/PTY spawn failed/i);
+        expect(hub.cancelCliLogin).toHaveBeenCalled();
     });
 });

--- a/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
@@ -168,6 +168,37 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
         expect(hub.refreshAccountCache).toHaveBeenCalled();
     });
 
+    it("reagent P0 on PR #2414 (round 3): does NOT show success when the only matching row is the STALE ALIAS link, not the canonical 'claude' one — a Stash re-login refreshes the SAME account_id, so an account_id-only check is vacuously satisfied by the pre-existing alias row even when the new canonical link insert silently failed", async () => {
+        hub.runProviderLogin.mockImplementation(async (opts: any) => {
+            // A re-login: onAccountRegistered fires with the SAME account
+            // id the alias row already points at (registeredAccountId ===
+            // existingAccountId), exactly as run-provider-login.ts does for
+            // a refresh rather than a fresh mint.
+            opts.onAccountRegistered?.("acct-existing", "/tmp/acct-existing");
+            return "inapp-success";
+        });
+        // Only the OLD alias row is present — the canonical "claude" link
+        // insert silently failed (finalizeAccount swallows that error).
+        hub.listAgentIdentities.mockResolvedValue([
+            { agent_id: "agent-1", account_id: "acct-existing", provider: "claude-code" },
+        ]);
+
+        const { findByText } = render(() => (
+            <ClaudeLoginPanel
+                onClose={() => {}}
+                existingAccountId="acct-existing"
+                linkTarget={{ agentDefinitionId: "agent-1" }}
+                staleAliasProvider="claude-code"
+            />
+        ));
+
+        await findByText(/couldn't confirm the account was linked/i);
+        // Must NOT proceed to the stale-alias cleanup unlink — that would
+        // delete the one link that actually works, leaving zero links.
+        expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
+        expect(hub.refreshAccountCache).not.toHaveBeenCalled();
+    });
+
     it("skips link verification entirely for Armory's bare Connect (no linkTarget) — nothing to verify", async () => {
         hub.runProviderLogin.mockImplementation(async (opts: any) => {
             opts.onAccountRegistered?.("acct-new", "/tmp/acct-new");

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -188,7 +188,26 @@ export function ClaudeLoginPanel(props: {
                                 const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
                                     agent_id: props.linkTarget.agentDefinitionId,
                                 });
-                                linkConfirmed = links.some((l) => l.account_id === registeredAccountId);
+                                // reagent P0 on PR #2414 (round 3): must check
+                                // the CANONICAL "claude" provider specifically,
+                                // not just account_id. finalizeAccount only
+                                // warns/swallows a failed link insert (never
+                                // rethrows) — for a Stash re-login on a
+                                // legacy-aliased row, registeredAccountId
+                                // equals that SAME alias row's own account_id
+                                // (it's a refresh, not a fresh mint), so a bare
+                                // account_id match is vacuously satisfied by
+                                // the pre-existing alias link even when the
+                                // new canonical insert silently failed. That
+                                // false "confirmed" then fires the
+                                // staleAliasProvider unlink below, deleting
+                                // the one link that actually worked — leaving
+                                // the agent with ZERO identity links, worse
+                                // than the pre-PR orphaned-alias bug this
+                                // panel exists to fix.
+                                linkConfirmed = links.some(
+                                    (l) => l.account_id === registeredAccountId && l.provider === CLAUDE_PROVIDER.id,
+                                );
                             } catch (e) {
                                 console.warn(
                                     `[claude-login] failed to verify the agent link: ${(e as Error)?.message ?? String(e)}`,

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -17,7 +17,7 @@
  * staleness tracking needed.
  */
 
-import { createSignal, Show, type JSX } from "solid-js";
+import { createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { getApi } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -46,6 +46,26 @@ export function ClaudeLoginPanel(props: {
     let cancelled = false;
     let terminalRequested = false;
     let inFlight = false;
+    // Set by onAccountRegistered — run-provider-login.ts fires it ONLY once
+    // the account row is actually persisted (reagent P0 on #2263). A
+    // credential can be validly seeded/pasted on disk while that persist
+    // call itself fails (REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_
+    // 2026_07_27.md) — trusting the outcome string alone would show
+    // "Signed in" for a login the resolver's spawn gate then blocks on the
+    // agent's next spawn, with no account ever having existed. reagent P1
+    // on PR #2414: this panel omitted the check both PreLaunchAuthPanel and
+    // useAgentControllerStatus.ts's relogin() already make.
+    let registeredAccountId: string | undefined;
+
+    // Kill a genuinely orphaned login (in-flight up to 5 min) if the panel
+    // unmounts before it resolves — otherwise the spawned CLI child and
+    // this component's poll keep running detached, holding the host's
+    // singleton cli_login_* state and blocking any later login attempt
+    // from starting. reagent P1 on PR #2414.
+    onCleanup(() => {
+        cancelled = true;
+        getApi().cancelCliLogin().catch(() => {});
+    });
 
     const runAttempt = async (cliPath: string, authEnv: Record<string, string>, skipTier1: boolean) =>
         runProviderLogin({
@@ -64,6 +84,9 @@ export function ClaudeLoginPanel(props: {
             },
             log: (_cat, msg) => console.log(`[claude-login] ${msg}`),
             isCancelled: () => cancelled || terminalRequested,
+            onAccountRegistered: (accountId) => {
+                registeredAccountId = accountId;
+            },
             onTierChange: (event) => {
                 if (event.tier === "inapp-waiting") setPhase("waiting-authorize");
                 else if (event.tier === "fallback") setPhase("fallback");
@@ -121,8 +144,12 @@ export function ClaudeLoginPanel(props: {
                 case "inapp-success":
                 case "seeded":
                 case "terminal-success":
-                    void refreshAccountCache();
-                    setDone(true);
+                    if (registeredAccountId) {
+                        void refreshAccountCache();
+                        setDone(true);
+                    } else {
+                        setError("Login completed but the account couldn't be registered. Try again.");
+                    }
                     break;
                 case "inapp-timeout":
                     setError("The login link timed out. Complete it in your browser, then try again.");

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -98,7 +98,18 @@ export function ClaudeLoginPanel(props: {
             provider: CLAUDE_PROVIDER,
             cliPath,
             authEnv,
-            existingAccountId: props.existingAccountId,
+            // reagent P2 on PR #2414 (round 4): prefer the account THIS
+            // panel already minted/persisted (registeredAccountId, set by
+            // onAccountRegistered below) over the original prop. Without
+            // this, clicking Retry after a link-verification failure (the
+            // account persisted fine, but confirming its link to this
+            // agent failed) re-ran with the stale props.existingAccountId
+            // — undefined for Armory's bare Connect — minting a SECOND
+            // fresh account and orphaning the first one, which is already
+            // a real, credentialed Claude account. Falls back to
+            // props.existingAccountId when nothing has been registered yet
+            // (the ordinary first-attempt / non-persist-failure retries).
+            existingAccountId: registeredAccountId ?? props.existingAccountId,
             linkTarget: props.linkTarget,
             // See PreLaunchAuthPanel's identical rationale: the in-app tier 1
             // runs first; "Use terminal instead" re-runs with it skipped.

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -77,9 +77,20 @@ export function ClaudeLoginPanel(props: {
     // this component's poll keep running detached, holding the host's
     // singleton cli_login_* state and blocking any later login attempt
     // from starting. reagent P1 on PR #2414.
+    //
+    // Guarded on `inFlight` (codex P2 on PR #2414): this panel can also
+    // unmount AFTER reaching its success/error screen, while still counted
+    // as "mounted" for a moment (e.g. the user lingers on "✓ Signed in"
+    // before closing). cancelCliLogin() hits the host's SINGLE global
+    // login slot — if a different window/surface has since started its
+    // own login, an unconditional call here would kill that unrelated,
+    // newer attempt instead of a no-op cleanup of our own already-finished
+    // one.
     onCleanup(() => {
         cancelled = true;
-        getApi().cancelCliLogin().catch(() => {});
+        if (inFlight) {
+            getApi().cancelCliLogin().catch(() => {});
+        }
     });
 
     const runAttempt = async (cliPath: string, authEnv: Record<string, string>, skipTier1: boolean) =>
@@ -160,19 +171,55 @@ export function ClaudeLoginPanel(props: {
                 case "seeded":
                 case "terminal-success":
                     if (registeredAccountId) {
+                        // codex P1 on PR #2414: finalizeAccount (run-provider-
+                        // login.ts) catches and logs — does NOT rethrow — a
+                        // failed LinkAgentIdentityCommand, so
+                        // onAccountRegistered firing only proves the ACCOUNT
+                        // was persisted, not that it's actually linked to
+                        // this agent. For a Stash flow (linkTarget set),
+                        // that's the whole point of the click — confirm the
+                        // link is really there before showing success,
+                        // instead of "Signed in" for an agent whose next
+                        // spawn the resolver's gate still blocks.
+                        let linkConfirmed = true;
+                        if (props.linkTarget?.agentDefinitionId) {
+                            linkConfirmed = false;
+                            try {
+                                const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
+                                    agent_id: props.linkTarget.agentDefinitionId,
+                                });
+                                linkConfirmed = links.some((l) => l.account_id === registeredAccountId);
+                            } catch (e) {
+                                console.warn(
+                                    `[claude-login] failed to verify the agent link: ${(e as Error)?.message ?? String(e)}`,
+                                );
+                            }
+                        }
+                        if (!linkConfirmed) {
+                            setError(
+                                "Signed in, but AgentMux couldn't confirm the account was linked to this agent. Try again.",
+                            );
+                            break;
+                        }
                         void refreshAccountCache();
                         // See staleAliasProvider's own doc comment: the link
-                        // just written above used the canonical "claude" key,
-                        // never the alias — clean up the orphaned alias row
-                        // now so it can't abort a future spawn. Best-effort:
-                        // the new canonical link already succeeded and is
-                        // what matters for "signed in"; log and move on if
-                        // this fails rather than blocking the success state
-                        // on cleanup of an already-broken row.
+                        // just confirmed above used the canonical "claude"
+                        // key, never the alias — clean up the orphaned alias
+                        // row now so it can't abort a future spawn.
+                        // `silent: true` (codex P2 on PR #2414): a plain
+                        // unlink publishes agentcredentials:revoked, which
+                        // the agent pane shows as "Credentials revoked" —
+                        // misleading immediately after a successful
+                        // re-login where the credential and effective
+                        // binding are both fine; this is a migration, not a
+                        // real unbind. Best-effort either way: the new
+                        // canonical link already succeeded and is what
+                        // matters for "signed in".
                         if (props.staleAliasProvider && props.linkTarget?.agentDefinitionId) {
                             RpcApi.UnlinkAgentIdentityCommand(TabRpcClient, {
                                 agent_id: props.linkTarget.agentDefinitionId,
                                 provider: props.staleAliasProvider,
+                                silent: true,
                             }).catch((e) => {
                                 console.warn(
                                     `[claude-login] failed to unlink stale alias "${props.staleAliasProvider}": ${e?.message ?? String(e)}`,
@@ -194,6 +241,19 @@ export function ClaudeLoginPanel(props: {
                     setError("Couldn't start a browser login or open a terminal window on this platform.");
                     break;
             }
+        } catch (e) {
+            // codex P2 on PR #2414: runAttempt (runProviderLogin) can
+            // REJECT outright — e.g. the PTY child fails to spawn, or an
+            // IPC call errors — not just resolve to a failure outcome
+            // string. This try previously had no catch, only finally, so a
+            // rejection here escaped `void start()`'s fire-and-forget call
+            // (line ~208) as an unhandled rejection, leaving the panel
+            // stuck on its starting phase forever with no error shown and
+            // no Retry button (same class of bug as PreLaunchAuthPanel's
+            // identical gap, reagent P2 on PR #2410).
+            getApi().cancelCliLogin().catch(() => {});
+            const t = translateError(e);
+            setError(`${t.title}: ${t.message}${t.retry ? ` — ${t.retry}` : ""}`);
         } finally {
             inFlight = false;
         }

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -38,6 +38,21 @@ export function ClaudeLoginPanel(props: {
      *  launch/Stash bind). */
     existingAccountId?: string;
     linkTarget?: { blockId?: string; agentDefinitionId: string };
+    /** reagent P0 on PR #2414: set when the row this panel was opened from
+     *  carries a legacy-alias provider string (e.g. "claude-code") — a
+     *  successful login here links the CANONICAL "claude" provider
+     *  (finalizeAccount → agent_identity_link `ON CONFLICT(agent_id,
+     *  provider)`), which is a DIFFERENT key than the alias row, so it
+     *  INSERTS a second link instead of replacing the broken one. The old
+     *  alias row (pointing at a deleted/orphaned account) is left behind —
+     *  the resolver's `inject.rs` iterates ALL of an agent's bindings
+     *  ORDER BY provider and aborts the ENTIRE spawn on the first one that
+     *  fails to resolve, so the orphaned alias row (sorting after "claude")
+     *  silently blocks every future spawn even though the healthy "claude"
+     *  link now exists — "✓ Signed in" but the agent stays broken. On
+     *  success, this panel unlinks `staleAliasProvider` for the same
+     *  agent so only the canonical row remains. */
+    staleAliasProvider?: string;
 }): JSX.Element {
     const [phase, setPhase] = createSignal<InAppLoginPhase>("starting");
     const [authUrl, setAuthUrl] = createSignal<string | undefined>(undefined);
@@ -146,6 +161,24 @@ export function ClaudeLoginPanel(props: {
                 case "terminal-success":
                     if (registeredAccountId) {
                         void refreshAccountCache();
+                        // See staleAliasProvider's own doc comment: the link
+                        // just written above used the canonical "claude" key,
+                        // never the alias — clean up the orphaned alias row
+                        // now so it can't abort a future spawn. Best-effort:
+                        // the new canonical link already succeeded and is
+                        // what matters for "signed in"; log and move on if
+                        // this fails rather than blocking the success state
+                        // on cleanup of an already-broken row.
+                        if (props.staleAliasProvider && props.linkTarget?.agentDefinitionId) {
+                            RpcApi.UnlinkAgentIdentityCommand(TabRpcClient, {
+                                agent_id: props.linkTarget.agentDefinitionId,
+                                provider: props.staleAliasProvider,
+                            }).catch((e) => {
+                                console.warn(
+                                    `[claude-login] failed to unlink stale alias "${props.staleAliasProvider}": ${e?.message ?? String(e)}`,
+                                );
+                            });
+                        }
                         setDone(true);
                     } else {
                         setError("Login completed but the account couldn't be registered. Try again.");

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -1,0 +1,203 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ClaudeLoginPanel — the in-app Claude/Anthropic login session, driven from
+ * a context that has no agent block: the Armory Accounts gallery's "Connect"
+ * (fresh account, no `linkTarget`) and the Agent Stash's per-binding
+ * "Connect / Re-login" action (`linkTarget` + `existingAccountId`, refresh
+ * not mint). Both reuse the exact same session logic and UI
+ * (`InAppLoginPanel`) as the launch surface's `PreLaunchAuthPanel` — see
+ * docs/specs/SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 3.
+ *
+ * Deliberately simpler than PreLaunchAuthPanel's `AuthFlowController`: there
+ * is no provider dropdown to switch away from mid-login (this panel is
+ * Claude-only) and no launch sequence waiting on the result, so a plain
+ * boolean in-flight guard + a few signals is enough — no action-token
+ * staleness tracking needed.
+ */
+
+import { createSignal, Show, type JSX } from "solid-js";
+import { getApi } from "@/app/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { translateError } from "@/app/errors/translate";
+import { PROVIDERS } from "@/app/view/agent/providers/catalog";
+import { runProviderLogin, type ProviderLoginOutcome } from "@/app/view/agent/flows/run-provider-login";
+import { InAppLoginPanel, type InAppLoginPhase } from "@/app/view/agent/components/InAppLoginPanel";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
+
+const CLAUDE_PROVIDER = PROVIDERS["claude"];
+
+export function ClaudeLoginPanel(props: {
+    onClose: () => void;
+    /** Set for the Stash's per-binding re-login: refreshes THIS account's
+     *  isolated dir instead of minting a new one, and links the result back
+     *  to the agent. Omit for Armory's bare Connect (fresh account, no
+     *  agent to link yet — the account just needs to exist for a later
+     *  launch/Stash bind). */
+    existingAccountId?: string;
+    linkTarget?: { blockId?: string; agentDefinitionId: string };
+}): JSX.Element {
+    const [phase, setPhase] = createSignal<InAppLoginPhase>("starting");
+    const [authUrl, setAuthUrl] = createSignal<string | undefined>(undefined);
+    const [error, setError] = createSignal<string | null>(null);
+    const [done, setDone] = createSignal(false);
+    let cancelled = false;
+    let terminalRequested = false;
+    let inFlight = false;
+
+    const runAttempt = async (cliPath: string, authEnv: Record<string, string>, skipTier1: boolean) =>
+        runProviderLogin({
+            provider: CLAUDE_PROVIDER,
+            cliPath,
+            authEnv,
+            existingAccountId: props.existingAccountId,
+            linkTarget: props.linkTarget,
+            // See PreLaunchAuthPanel's identical rationale: the in-app tier 1
+            // runs first; "Use terminal instead" re-runs with it skipped.
+            skipTier1,
+            awaitTier1Completion: true,
+            setAuthUrl: (url) => {
+                setAuthUrl(url ?? undefined);
+                if (url) setPhase("waiting-authorize");
+            },
+            log: (_cat, msg) => console.log(`[claude-login] ${msg}`),
+            isCancelled: () => cancelled || terminalRequested,
+            onTierChange: (event) => {
+                if (event.tier === "inapp-waiting") setPhase("waiting-authorize");
+                else if (event.tier === "fallback") setPhase("fallback");
+                else setPhase("terminal-polling");
+            },
+        });
+
+    const start = async () => {
+        if (inFlight) return;
+        inFlight = true;
+        setError(null);
+        setPhase("starting");
+        try {
+            let cliPath: string;
+            try {
+                const r = await RpcApi.ResolveCliCommand(
+                    TabRpcClient,
+                    {
+                        provider_id: CLAUDE_PROVIDER.id,
+                        cli_command: CLAUDE_PROVIDER.cliCommand,
+                        npm_package: CLAUDE_PROVIDER.npmPackage,
+                        pinned_version: CLAUDE_PROVIDER.pinnedVersion,
+                        windows_install_command: CLAUDE_PROVIDER.windowsInstallCommand,
+                        unix_install_command: CLAUDE_PROVIDER.unixInstallCommand,
+                    },
+                    { timeout: 120000 },
+                );
+                cliPath = r.cli_path;
+            } catch (e) {
+                const t = translateError(e);
+                setError(`${t.title}: ${t.message}${t.retry ? ` — ${t.retry}` : ""}`);
+                return;
+            }
+            const authEnv: Record<string, string> = {};
+            if (CLAUDE_PROVIDER.authConfigDirEnvVar) {
+                try {
+                    authEnv[CLAUDE_PROVIDER.authConfigDirEnvVar] = await getApi().ensureAuthDir(CLAUDE_PROVIDER.id);
+                } catch (e) {
+                    setError((e as Error)?.message ?? String(e));
+                    return;
+                }
+            }
+            if (cancelled) return;
+
+            let outcome: ProviderLoginOutcome = await runAttempt(cliPath, authEnv, false);
+            if (outcome === "inapp-timeout" && terminalRequested && !cancelled) {
+                // Same release/reset dance as PreLaunchAuthPanel's identical
+                // "Use terminal instead" handling — see its comment.
+                terminalRequested = false;
+                setPhase("fallback");
+                outcome = await runAttempt(cliPath, authEnv, true);
+            }
+            if (cancelled) return;
+            switch (outcome) {
+                case "inapp-success":
+                case "seeded":
+                case "terminal-success":
+                    void refreshAccountCache();
+                    setDone(true);
+                    break;
+                case "inapp-timeout":
+                    setError("The login link timed out. Complete it in your browser, then try again.");
+                    break;
+                case "terminal-timeout":
+                    setError("Opened a terminal window, but no login was detected within 5 minutes.");
+                    break;
+                case "terminal-unavailable":
+                    setError("Couldn't start a browser login or open a terminal window on this platform.");
+                    break;
+            }
+        } finally {
+            inFlight = false;
+        }
+    };
+
+    const onCancel = () => {
+        cancelled = true;
+        getApi().cancelCliLogin().catch(() => {});
+        props.onClose();
+    };
+
+    void start();
+
+    return (
+        <div
+            class="accounts-chooser-overlay"
+            onClick={(e) => e.target === e.currentTarget && !inFlight && props.onClose()}
+        >
+            <div class="accounts-chooser" role="dialog" aria-label="Connect Anthropic">
+                <Show
+                    when={!done()}
+                    fallback={
+                        <div class="accounts-chooser-modes">
+                            <div class="oauth-byo-note">✓ Signed in to Claude.</div>
+                            <div class="identity-key-actions">
+                                <button class="identity-btn identity-btn-primary" onClick={() => props.onClose()}>
+                                    Done
+                                </button>
+                            </div>
+                        </div>
+                    }
+                >
+                    <Show
+                        when={!error()}
+                        fallback={
+                            <div class="accounts-chooser-modes">
+                                <div class="oauth-byo-note">{error()}</div>
+                                <div class="identity-key-actions">
+                                    <button class="identity-btn identity-btn-primary" onClick={() => void start()}>
+                                        Retry
+                                    </button>
+                                    <button class="identity-btn identity-btn-secondary" onClick={() => props.onClose()}>
+                                        Close
+                                    </button>
+                                </div>
+                            </div>
+                        }
+                    >
+                        <InAppLoginPanel
+                            providerId={CLAUDE_PROVIDER.id}
+                            providerLabel={CLAUDE_PROVIDER.displayName}
+                            authUrl={authUrl()}
+                            phase={phase()}
+                            onCancel={onCancel}
+                            onUseTerminal={() => {
+                                terminalRequested = true;
+                                setPhase("fallback");
+                            }}
+                        />
+                    </Show>
+                </Show>
+            </div>
+        </div>
+    );
+}
+
+ClaudeLoginPanel.displayName = "ClaudeLoginPanel";

--- a/frontend/app/view/accounts/accounts-catalog.ts
+++ b/frontend/app/view/accounts/accounts-catalog.ts
@@ -39,7 +39,15 @@ export const SERVICE_CATALOG: ServiceTile[] = [
     // yet — key-only for v1 so the chooser never offers a dead-end OAuth path.
     { id: "aws", displayName: "AWS", authModes: ["key"], keyKind: "role", blurb: "IAM, deploy" },
     { id: "openai", displayName: "OpenAI", authModes: ["key"], keyKind: "api_key", blurb: "API key" },
-    { id: "anthropic", displayName: "Anthropic", authModes: ["key"], keyKind: "api_key", blurb: "API key" },
+    // "oauth" here is Claude's own in-app CLI login (spec
+    // SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 3), NOT the
+    // service-OAuth scaffold (oauth-catalog.ts's OAUTH_SERVICES) the
+    // github/google/slack tiles above use — Anthropic has no device/PKCE
+    // endpoint an app-driven client could hit (auth-broker Phase D
+    // decision), so the gallery intercepts this tile's "oauth" pick the
+    // same way it intercepts the AgentMux tile above, opening
+    // ClaudeLoginPanel instead of the generic OAuthConnectPanel form path.
+    { id: "anthropic", displayName: "Anthropic", authModes: ["oauth", "key"], keyKind: "api_key", blurb: "Claude Code sign-in, or API key" },
     { id: "slack", displayName: "Slack", authModes: ["oauth"], keyKind: "api_key", blurb: "Messaging" },
     { id: "custom", displayName: "Custom", authModes: ["key"], keyKind: "api_key", blurb: "Any bearer token" },
 ];

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -29,6 +29,7 @@ import { AccountForm } from "@/app/view/identity/identity-account-form";
 import { ProviderLogo } from "@/element/ProviderLogo";
 import { AccountsGallery } from "./AccountsGallery";
 import { AgentMuxConnectPanel, useMuxBusStatus } from "./AgentMuxConnectPanel";
+import { ClaudeLoginPanel } from "./ClaudeLoginPanel";
 import "@/app/view/identity/identity-view.scss";
 
 export function AccountsManager(): JSX.Element {
@@ -46,6 +47,7 @@ export function AccountsManager(): JSX.Element {
     onMount(() => void muxbus.refresh());
 
     const [muxPanelOpen, setMuxPanelOpen] = createSignal(false);
+    const [claudePanelOpen, setClaudePanelOpen] = createSignal(false);
     const agentMuxConnected = () => muxbus.status()?.connected === true;
 
     const muxStatusDot = (): string => {
@@ -74,6 +76,7 @@ export function AccountsManager(): JSX.Element {
                     model={model}
                     agentMuxConnected={agentMuxConnected}
                     onAgentMux={() => setMuxPanelOpen(true)}
+                    onClaudeConnect={() => setClaudePanelOpen(true)}
                 />
                 {/* Connected accounts (manage existing). Shown when there is any
                     stored account OR an AgentMux Cloud session is connected.
@@ -128,6 +131,10 @@ export function AccountsManager(): JSX.Element {
 
             <Show when={muxPanelOpen()}>
                 <AgentMuxConnectPanel muxbus={muxbus} onClose={() => setMuxPanelOpen(false)} />
+            </Show>
+
+            <Show when={claudePanelOpen()}>
+                <ClaudeLoginPanel onClose={() => setClaudePanelOpen(false)} />
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/InAppLoginPanel.test.tsx
+++ b/frontend/app/view/agent/components/InAppLoginPanel.test.tsx
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for InAppLoginPanel — specifically the phase-gating fix (reagent
+ * P1 on PR #2410): the URL/paste box must disappear once "Use terminal
+ * instead" moves the session past waiting-authorize, not just when
+ * authUrl itself is cleared. Before this fix, the box stayed mounted
+ * showing a dead authorize link — a paste at that point silently wrote
+ * the code as a plain auth_token via the host's non-CLI fallback path
+ * (cli_login_stdin already cleared), misleading the user while the real
+ * login ran in the separately-opened terminal.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/global", () => ({
+    getApi: () => ({ openExternal: vi.fn(), setProviderAuth: vi.fn() }),
+}));
+vi.mock("@/util/clipboard", () => ({
+    readText: vi.fn(),
+    writeText: vi.fn(),
+}));
+
+import { InAppLoginPanel, type InAppLoginPhase } from "./InAppLoginPanel";
+
+afterEach(() => {
+    cleanup();
+});
+
+const AUTH_URL = "https://claude.com/cai/oauth/authorize?code=true";
+
+function renderPanel(phase: InAppLoginPhase) {
+    render(() => (
+        <InAppLoginPanel
+            providerId="claude"
+            providerLabel="Claude"
+            authUrl={AUTH_URL}
+            phase={phase}
+            onCancel={() => {}}
+            onUseTerminal={() => {}}
+        />
+    ));
+}
+
+describe("InAppLoginPanel — URL/paste box gated on phase, not just authUrl (reagent P1 on PR #2410)", () => {
+    it("shows the URL/paste box while phase is 'starting'", () => {
+        renderPanel("starting");
+        expect(screen.getByText(/authorize in your browser/i)).toBeInTheDocument();
+    });
+
+    it("shows the URL/paste box while phase is 'waiting-authorize'", () => {
+        renderPanel("waiting-authorize");
+        expect(screen.getByText(/authorize in your browser/i)).toBeInTheDocument();
+    });
+
+    it("hides the URL/paste box once phase moves to 'fallback' (Use terminal instead was clicked), even though authUrl is still set", () => {
+        renderPanel("fallback");
+        expect(screen.queryByText(/authorize in your browser/i)).not.toBeInTheDocument();
+        expect(screen.queryByPlaceholderText(/paste the authorization code/i)).not.toBeInTheDocument();
+    });
+
+    it("hides the URL/paste box once phase moves to 'terminal-polling'", () => {
+        renderPanel("terminal-polling");
+        expect(screen.queryByText(/authorize in your browser/i)).not.toBeInTheDocument();
+    });
+
+    it("hides the \"Use terminal instead\" button once already in fallback/terminal-polling (nothing left to fall back from)", () => {
+        renderPanel("terminal-polling");
+        expect(screen.queryByRole("button", { name: /use terminal instead/i })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/app/view/agent/components/InAppLoginPanel.tsx
+++ b/frontend/app/view/agent/components/InAppLoginPanel.tsx
@@ -1,0 +1,201 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * InAppLoginPanel — the in-app OAuth login UI (spec §3.1's session, rendered):
+ * URL + Open/Copy, a paste-code box wired to `setProviderAuth`, a live phase
+ * line, and Cancel / "Use terminal instead" actions.
+ *
+ * Extracted from `PreLaunchAuthPanel.tsx` (its original and still-primary
+ * caller — the launch surface, spec §3.3 surface 1) so the Armory/Stash
+ * surface (§3.3 surface 3) can reuse the identical UI instead of a second
+ * hand-rolled copy. Decoupled from `PreLaunchAuthPanel`'s own
+ * `AuthFlowController`/`AuthState` reducer — callers pass `authUrl` directly
+ * (the only field of that reducer's state this component ever read).
+ *
+ * See docs/specs/SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md.
+ */
+
+import { Button } from "@/element/button";
+import { getApi } from "@/app/store/global";
+import { readText as clipboardReadText, writeText as clipboardWriteText } from "@/util/clipboard";
+import { createEffect, createSignal, Show, type JSX } from "solid-js";
+
+/** Live phase of the in-app login session, surfaced as a status line. */
+export type InAppLoginPhase = "starting" | "waiting-authorize" | "fallback" | "terminal-polling";
+
+export interface InAppLoginPanelProps {
+    providerId: string;
+    providerLabel: string;
+    authUrl: string | undefined;
+    phase: InAppLoginPhase;
+    onCancel: () => void;
+    onUseTerminal: () => void;
+}
+
+export const InAppLoginPanel = (p: InAppLoginPanelProps): JSX.Element => {
+    const [pasteCode, setPasteCode] = createSignal("");
+    const [pasting, setPasting] = createSignal(false);
+    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
+    let inputRef: HTMLInputElement | undefined;
+
+    // Grab focus when the paste input appears (same rationale as
+    // AuthUrlBox/AgentDocumentView: a pasted code must land HERE, not
+    // whatever field held focus before). Deferred a frame so it wins the
+    // host's own focus management; fires once per URL appearance.
+    createEffect(() => {
+        if (p.authUrl) {
+            requestAnimationFrame(() => inputRef?.focus());
+        }
+    });
+
+    const submitCode = async (explicit?: string): Promise<void> => {
+        // Read from the live input element as a fallback (mirrors
+        // AuthUrlBox): if focus desynced and the controlled signal missed
+        // the paste, the DOM value still holds it.
+        const code = (explicit ?? inputRef?.value ?? pasteCode()).trim();
+        if (!code) return;
+        setPasting(true);
+        setPasteResult(null);
+        try {
+            // Delivered to the login child's stdin via the host's
+            // set_provider_auth → CliLoginStdin::write_line plumbing; the
+            // session's completion poll (inside runProviderLogin) then
+            // observes the CLI finishing. SECURITY: the code is single-use
+            // and PKCE-bound to the spawned process (spec §5) — never logged.
+            await getApi().setProviderAuth(p.providerId, code);
+            setPasteResult("Code accepted — signing you in…");
+            setPasteCode("");
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            setPasteResult(`Error: ${msg}`);
+        } finally {
+            setPasting(false);
+        }
+    };
+
+    const phaseText = (): string => {
+        switch (p.phase) {
+            case "starting":
+                return `Starting ${p.providerLabel} sign-in — requesting a sign-in link…`;
+            case "waiting-authorize":
+                return "Waiting for you to authorize in the browser — we'll detect it automatically.";
+            case "fallback":
+                return "No sign-in link appeared — trying your existing login, then a terminal…";
+            case "terminal-polling":
+                return "A terminal window opened — finish the login there.";
+        }
+    };
+
+    return (
+        <div class="pre-launch-auth-panel-waiting">
+            <div class="pre-launch-auth-panel-waiting-title">
+                🔐 Sign in to {p.providerLabel}
+            </div>
+            <div class="pre-launch-auth-panel-hint">{phaseText()}</div>
+            <Show when={p.authUrl}>
+                {(url) => (
+                    <>
+                        <div class="pre-launch-auth-panel-url-label">
+                            1 · Authorize in your browser (it should have opened — if not, use this link):
+                        </div>
+                        <div class="pre-launch-auth-panel-url-row">
+                            <code class="pre-launch-auth-panel-url-text" title={url()}>
+                                {url()}
+                            </code>
+                            <Button
+                                className="grey solid"
+                                onClick={() => {
+                                    try {
+                                        getApi().openExternal(url());
+                                    } catch (e) {
+                                        console.warn(`[auth-diag] openExternal failed: ${(e as Error)?.message ?? String(e)}`);
+                                    }
+                                }}
+                            >
+                                Open
+                            </Button>
+                            <Button
+                                className="grey solid"
+                                onClick={() => {
+                                    // CEF clipboard wrapper, not navigator.clipboard —
+                                    // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
+                                    void clipboardWriteText(url()).catch((err) =>
+                                        console.log("clipboard write failed", err),
+                                    );
+                                }}
+                            >
+                                Copy
+                            </Button>
+                        </div>
+                        <div class="pre-launch-auth-panel-url-label">
+                            2 · If the page shows an authorization code, paste it here:
+                        </div>
+                        <div class="pre-launch-auth-panel-callback-row">
+                            <input
+                                ref={inputRef}
+                                class="pre-launch-auth-panel-url-input"
+                                type="text"
+                                placeholder="Paste the authorization code…"
+                                value={pasteCode()}
+                                onInput={(e) => setPasteCode(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") void submitCode();
+                                }}
+                                onPaste={(e) => {
+                                    // Auto-submit on paste — pasting the code IS the
+                                    // intent to submit (same UX as AuthUrlBox).
+                                    const text = (e.clipboardData?.getData("text") ?? "").trim();
+                                    if (text) {
+                                        setPasteCode(text);
+                                        void submitCode(text);
+                                    }
+                                }}
+                            />
+                            <Button
+                                className="grey solid"
+                                title="Paste from clipboard and submit"
+                                onClick={() => {
+                                    clipboardReadText()
+                                        .then((text) => {
+                                            const trimmed = (text ?? "").trim();
+                                            if (trimmed) {
+                                                setPasteCode(trimmed);
+                                                void submitCode(trimmed);
+                                            }
+                                        })
+                                        .catch(() => {
+                                            setPasteResult("Could not read clipboard — paste manually");
+                                        });
+                                }}
+                            >
+                                Paste &amp; submit
+                            </Button>
+                            <Button
+                                className="grey solid"
+                                onClick={() => void submitCode()}
+                                disabled={pasting()}
+                            >
+                                {pasting() ? "…" : "Submit"}
+                            </Button>
+                        </div>
+                        <Show when={pasteResult()}>
+                            <div class="pre-launch-auth-panel-hint">{pasteResult()}</div>
+                        </Show>
+                    </>
+                )}
+            </Show>
+            <div class="pre-launch-auth-panel-inapp-actions">
+                <Button onClick={() => p.onCancel()}>Cancel login</Button>
+                {/* Explicit terminal fallback — never auto-launched (spec
+                    §3.2). Hidden once the flow is already in the terminal
+                    tiers, where the request would only abort a live poll. */}
+                <Show when={p.phase === "starting" || p.phase === "waiting-authorize"}>
+                    <Button className="grey" onClick={() => p.onUseTerminal()}>
+                        Use terminal instead
+                    </Button>
+                </Show>
+            </div>
+        </div>
+    );
+};

--- a/frontend/app/view/agent/components/InAppLoginPanel.tsx
+++ b/frontend/app/view/agent/components/InAppLoginPanel.tsx
@@ -93,7 +93,24 @@ export const InAppLoginPanel = (p: InAppLoginPanelProps): JSX.Element => {
                 🔐 Sign in to {p.providerLabel}
             </div>
             <div class="pre-launch-auth-panel-hint">{phaseText()}</div>
-            <Show when={p.authUrl}>
+            {/* reagent P1 on PR #2410: gate on phase too, not just authUrl's
+                presence. "Use terminal instead" kills the tier-1 login child
+                (cancelCliLogin) and moves phase to "fallback"/"terminal-
+                polling" WITHOUT clearing the now-dead authUrl — without this
+                gate, the URL/paste box stayed visible for a session that no
+                longer exists. Pasting a code at that point would call
+                setProviderAuth, whose host handler falls through to the
+                non-CLI config-file branch (cli_login_stdin already cleared)
+                and silently writes the code as a plain auth_token while
+                showing "Code accepted…", misleading the user while the real
+                login runs in the separately-opened terminal instead. */}
+            <Show
+                when={
+                    p.phase === "starting" || p.phase === "waiting-authorize"
+                        ? p.authUrl
+                        : undefined
+                }
+            >
                 {(url) => (
                     <>
                         <div class="pre-launch-auth-panel-url-label">

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -25,7 +25,7 @@ import { translateError } from "@/app/errors/translate";
 import { getApi } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { readText as clipboardReadText, writeText as clipboardWriteText } from "@/util/clipboard";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
 import {
     createEffect,
     createSignal,

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -43,6 +43,7 @@ import {
     type SelectionOutcome,
 } from "../auth";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
+import { InAppLoginPanel, type InAppLoginPhase } from "./InAppLoginPanel";
 import { registerSeededAccount } from "../flows/register-seeded-account";
 import { runProviderLogin } from "../flows/run-provider-login";
 import type { ProviderDefinition } from "../providers";
@@ -98,12 +99,6 @@ export interface PreLaunchAuthPanelProps {
  *  generic `WaitingPanel` (whose paste row submits a redirect URL to
  *  `auth.submitcallback` — a backend session this flow doesn't have). */
 const PROVIDER_LOGIN_SESSION_ID = "provider-login";
-
-/** Live phase of the in-app login session, surfaced in `InAppLoginPanel`'s
- *  status line. Driven by `startConnect`'s `onTierChange`/`setAuthUrl`
- *  wiring off `runProviderLogin`'s real transitions (spec §3.1's
- *  `spawning → url_captured → waiting_for_authorize → …` states). */
-type InAppLoginPhase = "starting" | "waiting-authorize" | "fallback" | "terminal-polling";
 
 /** UI hooks `startConnect` (a module-level function) uses to drive the
  *  panel-owned in-app-login signals: the live phase line, and the
@@ -297,7 +292,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                     <InAppLoginPanel
                         providerId={props.provider?.id ?? ""}
                         providerLabel={props.provider?.displayName ?? "this provider"}
-                        state={controller.state()}
+                        authUrl={controller.state().authUrl}
                         phase={inAppPhase()}
                         onCancel={() => void controller.cancel()}
                         onUseTerminal={() => {
@@ -860,200 +855,6 @@ const WaitingPanel = (p: {
                 </div>
             </Show>
             <Button onClick={() => p.onCancel()}>Cancel login</Button>
-        </div>
-    );
-};
-
-/** The in-app login session panel (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md
- *  §3.1 / §3.3 surface 1) — the launch-modal sibling of AgentDocumentView's
- *  `AuthUrlBox` (same 2-step authorize-then-paste pattern, same
- *  `setProviderAuth` → login-child-stdin code delivery), plus the pieces the
- *  modal flow needs that the composer box doesn't have: a live phase line
- *  (fed from `runProviderLogin`'s real tier transitions), and the explicit
- *  "Use terminal instead" secondary action that replaces the old
- *  auto-launched terminal. The paste step is the FALLBACK — when the user
- *  authorizes in the browser, the CLI detects completion on its own and the
- *  session resolves with nothing pasted (spec §2 item 3). */
-const InAppLoginPanel = (p: {
-    providerId: string;
-    providerLabel: string;
-    state: AuthState;
-    phase: InAppLoginPhase;
-    onCancel: () => void;
-    onUseTerminal: () => void;
-}): JSX.Element => {
-    const [pasteCode, setPasteCode] = createSignal("");
-    const [pasting, setPasting] = createSignal(false);
-    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
-    let inputRef: HTMLInputElement | undefined;
-
-    // Grab focus when the paste input appears (same rationale as
-    // AuthUrlBox: a pasted code must land HERE, not whatever field held
-    // focus before). Deferred a frame so it wins the modal's own focus
-    // management; fires once per URL appearance.
-    createEffect(() => {
-        if (p.state.authUrl) {
-            requestAnimationFrame(() => inputRef?.focus());
-        }
-    });
-
-    const submitCode = async (explicit?: string): Promise<void> => {
-        // Read from the live input element as a fallback (mirrors
-        // AuthUrlBox): if focus desynced and the controlled signal missed
-        // the paste, the DOM value still holds it.
-        const code = (explicit ?? inputRef?.value ?? pasteCode()).trim();
-        if (!code) return;
-        setPasting(true);
-        setPasteResult(null);
-        try {
-            // Delivered to the login child's stdin via the host's
-            // set_provider_auth → CliLoginStdin::write_line plumbing; the
-            // session's completion poll (inside runProviderLogin) then
-            // observes the CLI finishing. SECURITY: the code is single-use
-            // and PKCE-bound to the spawned process (spec §5) — never logged.
-            await getApi().setProviderAuth(p.providerId, code);
-            setPasteResult("Code accepted — signing you in…");
-            setPasteCode("");
-        } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            setPasteResult(`Error: ${msg}`);
-        } finally {
-            setPasting(false);
-        }
-    };
-
-    const phaseText = (): string => {
-        switch (p.phase) {
-            case "starting":
-                return `Starting ${p.providerLabel} sign-in — requesting a sign-in link…`;
-            case "waiting-authorize":
-                return "Waiting for you to authorize in the browser — we'll detect it automatically.";
-            case "fallback":
-                return "No sign-in link appeared — trying your existing login, then a terminal…";
-            case "terminal-polling":
-                return "A terminal window opened — finish the login there.";
-        }
-    };
-
-    return (
-        <div class="pre-launch-auth-panel-waiting">
-            <div class="pre-launch-auth-panel-waiting-title">
-                🔐 Sign in to {p.providerLabel}
-            </div>
-            <div class="pre-launch-auth-panel-hint">{phaseText()}</div>
-            {/* reagent P1 on PR #2410: gate on phase too, not just authUrl's
-                presence. "Use terminal instead" kills the tier-1 login child
-                (cancelCliLogin) and moves phase to "fallback"/"terminal-
-                polling" WITHOUT clearing the now-dead authUrl — without this
-                gate, the URL/paste box stayed visible for a session that no
-                longer exists. Pasting a code at that point would call
-                setProviderAuth, whose host handler falls through to the
-                non-CLI config-file branch (cli_login_stdin already cleared)
-                and silently writes the code as a plain auth_token while
-                showing "Code accepted…", misleading the user while the real
-                login runs in the separately-opened terminal instead. */}
-            <Show when={p.state.authUrl && (p.phase === "starting" || p.phase === "waiting-authorize")}>
-                <div class="pre-launch-auth-panel-url-label">
-                    1 · Authorize in your browser (it should have opened — if not, use this link):
-                </div>
-                <div class="pre-launch-auth-panel-url-row">
-                    <code
-                        class="pre-launch-auth-panel-url-text"
-                        title={p.state.authUrl}
-                    >
-                        {p.state.authUrl}
-                    </code>
-                    <Button
-                        className="grey solid"
-                        onClick={() => {
-                            try {
-                                getApi().openExternal(p.state.authUrl);
-                            } catch (e) {
-                                console.warn(`[auth-diag] openExternal failed: ${(e as Error)?.message ?? String(e)}`);
-                            }
-                        }}
-                    >
-                        Open
-                    </Button>
-                    <Button
-                        className="grey solid"
-                        onClick={() => {
-                            // CEF clipboard wrapper, not navigator.clipboard —
-                            // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
-                            void clipboardWriteText(p.state.authUrl).catch((err) =>
-                                console.log("clipboard write failed", err),
-                            );
-                        }}
-                    >
-                        Copy
-                    </Button>
-                </div>
-                <div class="pre-launch-auth-panel-url-label">
-                    2 · If the page shows an authorization code, paste it here:
-                </div>
-                <div class="pre-launch-auth-panel-callback-row">
-                    <input
-                        ref={inputRef}
-                        class="pre-launch-auth-panel-url-input"
-                        type="text"
-                        placeholder="Paste the authorization code…"
-                        value={pasteCode()}
-                        onInput={(e) => setPasteCode(e.currentTarget.value)}
-                        onKeyDown={(e) => {
-                            if (e.key === "Enter") void submitCode();
-                        }}
-                        onPaste={(e) => {
-                            // Auto-submit on paste — pasting the code IS the
-                            // intent to submit (same UX as AuthUrlBox).
-                            const text = (e.clipboardData?.getData("text") ?? "").trim();
-                            if (text) {
-                                setPasteCode(text);
-                                void submitCode(text);
-                            }
-                        }}
-                    />
-                    <Button
-                        className="grey solid"
-                        title="Paste from clipboard and submit"
-                        onClick={() => {
-                            clipboardReadText()
-                                .then((text) => {
-                                    const trimmed = (text ?? "").trim();
-                                    if (trimmed) {
-                                        setPasteCode(trimmed);
-                                        void submitCode(trimmed);
-                                    }
-                                })
-                                .catch(() => {
-                                    setPasteResult("Could not read clipboard — paste manually");
-                                });
-                        }}
-                    >
-                        Paste &amp; submit
-                    </Button>
-                    <Button
-                        className="grey solid"
-                        onClick={() => void submitCode()}
-                        disabled={pasting()}
-                    >
-                        {pasting() ? "…" : "Submit"}
-                    </Button>
-                </div>
-                <Show when={pasteResult()}>
-                    <div class="pre-launch-auth-panel-hint">{pasteResult()}</div>
-                </Show>
-            </Show>
-            <div class="pre-launch-auth-panel-inapp-actions">
-                <Button onClick={() => p.onCancel()}>Cancel login</Button>
-                {/* Explicit terminal fallback — never auto-launched (spec
-                    §3.2). Hidden once the flow is already in the terminal
-                    tiers, where the request would only abort a live poll. */}
-                <Show when={p.phase === "starting" || p.phase === "waiting-authorize"}>
-                    <Button className="grey" onClick={() => p.onUseTerminal()}>
-                        Use terminal instead
-                    </Button>
-                </Show>
-            </div>
         </div>
     );
 };

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -281,6 +281,28 @@ describe("runProviderLogin", () => {
         });
     });
 
+    it("links the account but skips the block-meta update when linkTarget has no blockId (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 3: Armory/Stash callers with no live pane)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            linkTarget: { agentDefinitionId: "def-1" },
+        });
+
+        expect(outcome).toBe("seeded");
+        expect(hub.linkAgentIdentity).toHaveBeenCalledWith({}, {
+            agent_id: "def-1",
+            account_id: MINTED.accountId,
+            provider: "claude",
+        });
+        expect(hub.setMeta).not.toHaveBeenCalled();
+    });
+
     it("skips tier 2 for non-claude providers (host rejects seed-from-global for them) but STILL mints an account dir and points the terminal at it directly (not stripped — codex has no seed-from-global to copy back from)", async () => {
         hub.runCliLogin.mockResolvedValue(null);
         hub.checkCliAuthCommand.mockResolvedValue({ authenticated: false });

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -102,12 +102,18 @@ export interface RunProviderLoginParams extends ForceLoginParams {
     };
     /** Polled during the tier-3 wait; return true to abort early (e.g. the user hit Cancel). */
     isCancelled?: () => boolean;
-    /** When set, a newly-registered account (tier 2 or 3) is linked to this
-     *  agent definition and the block's `cmd:env` is updated to point at
-     *  its isolated dir — the pane-level recovery case (an already-running
-     *  agent). Omit for a pre-launch flow with no agent yet; that flow's own
-     *  launch-time reconcile links the account once one is created. */
-    linkTarget?: { blockId: string; agentDefinitionId: string };
+    /** When set, a newly-registered account (tier 2 or 3, or the awaited
+     *  tier-1 session) is linked to this agent definition. Omit for a
+     *  pre-launch flow with no agent yet; that flow's own launch-time
+     *  reconcile links the account once one is created.
+     *  `blockId` is optional (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md
+     *  §3.3 surface 3): when present, the block's `cmd:env` is ALSO updated
+     *  to point at the isolated dir — the pane-level recovery case (an
+     *  already-running agent that needs its live env refreshed right now).
+     *  Callers with no live pane (Armory's bare Connect, or the Stash's
+     *  per-binding re-login when the agent has no open pane) still get the
+     *  account linked; the next spawn resolves the dir fresh regardless. */
+    linkTarget?: { blockId?: string; agentDefinitionId: string };
     /** Reconnect (not fresh-connect) into this account id, if set — threaded
      *  through to tier 2/3's account-dir minting so the SAME account's
      *  isolated dir is reused/refreshed instead of a new one being minted.
@@ -199,6 +205,12 @@ async function finalizeAccount(
         );
         return;
     }
+    // Best-effort live-pane env refresh — only when a block actually exists
+    // (the pane-level recovery case). Armory's bare Connect and the Stash's
+    // re-login for an agent with no open pane have nothing to refresh here;
+    // the link above is already durable, and the next spawn resolves the
+    // account's dir fresh regardless of this pane-local cache.
+    if (!p.linkTarget.blockId) return;
     try {
         const oref = WOS.makeORef("block", p.linkTarget.blockId);
         await RpcApi.SetMetaCommand(TabRpcClient, {

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -178,7 +178,30 @@ describe("AgentIdentityLinksPanel", () => {
             button.click();
 
             expect(claudeLoginPanel).toHaveBeenCalledWith(
-                expect.objectContaining({ existingAccountId: "acc-claude-1" }),
+                expect.objectContaining({
+                    existingAccountId: "acc-claude-1",
+                    // reagent P0 on PR #2414: opening from an aliased row
+                    // must tell the panel which alias to clean up on
+                    // success — otherwise the login links the canonical
+                    // "claude" provider while this orphaned "claude-code"
+                    // row lingers and aborts every future spawn.
+                    staleAliasProvider: "claude-code",
+                }),
+            );
+        });
+
+        it("does NOT set staleAliasProvider when the row is already canonical \"claude\" — nothing to clean up", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-claude-1", provider: "claude" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            const button = await screen.findByRole("button", { name: "Re-login" });
+            button.click();
+
+            expect(claudeLoginPanel).toHaveBeenCalledWith(
+                expect.objectContaining({ staleAliasProvider: undefined }),
             );
         });
 

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -48,9 +48,29 @@ vi.mock("./identity-model", () => ({
             display_name: "Agent Two's GitHub",
             status: "valid",
         },
+        {
+            id: "acc-claude-1",
+            name: "claude-work",
+            provider: "claude",
+            kind: "oauth",
+            display_name: "Claude Work",
+            status: "valid",
+        },
     ],
     subscribeAccountChanges: () => () => {},
     PROVIDER_LABELS: { github: "GitHub", claude: "Claude" },
+}));
+
+const claudeLoginPanel = vi.fn();
+vi.mock("@/app/view/accounts/ClaudeLoginPanel", () => ({
+    // Stub: records the props it was opened with instead of driving a real
+    // login session (that flow is ClaudeLoginPanel's own concern) — this
+    // file only tests that AgentIdentityLinksPanel opens it with the right
+    // existingAccountId/linkTarget from the right row.
+    ClaudeLoginPanel: (props: any) => {
+        claudeLoginPanel(props);
+        return <div data-testid="claude-login-panel" />;
+    },
 }));
 
 import { AgentIdentityLinksPanel } from "./agent-identity-links-panel";
@@ -67,6 +87,7 @@ function mkLink(overrides: Partial<AgentDefinitionIdentity>): AgentDefinitionIde
 describe("AgentIdentityLinksPanel", () => {
     beforeEach(() => {
         listAllAgentIdentities.mockReset();
+        claudeLoginPanel.mockReset();
     });
 
     afterEach(() => {
@@ -112,5 +133,54 @@ describe("AgentIdentityLinksPanel", () => {
 
         expect(screen.getByText(/isn't attached to a specific agent/i)).toBeInTheDocument();
         expect(screen.queryByText("Linked accounts")).not.toBeInTheDocument();
+    });
+
+    describe("Claude Connect/Re-login (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 3)", () => {
+        it("shows a Re-login button on a bound claude row and opens ClaudeLoginPanel with that row's account + this agent as linkTarget", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-claude-1", provider: "claude" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            const button = await screen.findByRole("button", { name: "Re-login" });
+            expect(claudeLoginPanel).not.toHaveBeenCalled();
+
+            button.click();
+
+            expect(claudeLoginPanel).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    existingAccountId: "acc-claude-1",
+                    linkTarget: { agentDefinitionId: "agent-1" },
+                }),
+            );
+        });
+
+        it("does NOT show a Connect/Re-login button on a non-claude row (github) — only Claude has an in-app session today", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-1", provider: "github" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            await waitFor(() => expect(screen.getByText("Work GitHub")).toBeInTheDocument());
+            expect(screen.queryByRole("button", { name: /re-login|connect/i })).not.toBeInTheDocument();
+        });
+
+        it("empty state offers 'Connect Claude account' for an agent with NO links at all (the v0.54.9 stuck-instance case — no row exists to attach a per-row button to)", async () => {
+            listAllAgentIdentities.mockResolvedValue([]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            button.click();
+
+            expect(claudeLoginPanel).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    existingAccountId: undefined,
+                    linkTarget: { agentDefinitionId: "agent-1" },
+                }),
+            );
+        });
     });
 });

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -26,8 +26,9 @@ vi.mock("@/app/store/wps", () => ({
 }));
 vi.mock("@/app/view/agent/components/AgentPicker", () => ({
     useAgentDefinitions: () => () => [
-        { id: "agent-1", name: "Agent One" },
-        { id: "agent-2", name: "Agent Two" },
+        { id: "agent-1", name: "Agent One", provider: "claude" },
+        { id: "agent-2", name: "Agent Two", provider: "claude" },
+        { id: "agent-3", name: "Agent Three (codex)", provider: "codex" },
     ],
 }));
 vi.mock("./identity-model", () => ({
@@ -219,6 +220,30 @@ describe("AgentIdentityLinksPanel", () => {
                     linkTarget: { agentDefinitionId: "agent-1" },
                 }),
             );
+        });
+
+        it("reagent P2 on PR #2414 (round 3): does NOT offer 'Connect Claude account' for an agent whose own provider isn't claude — that would link an unrelated Claude account instead of the agent's actual provider", async () => {
+            listAllAgentIdentities.mockResolvedValue([]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-3" />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/no linked accounts yet/i)).toBeInTheDocument();
+            });
+            expect(screen.queryByRole("button", { name: "Connect Claude account" })).not.toBeInTheDocument();
+        });
+
+        it("reagent P2 on PR #2414 (round 3): does NOT offer 'Connect Claude account' before the initial load resolves or after it fails — only once genuinely confirmed empty", async () => {
+            let resolveLoad!: (v: unknown[]) => void;
+            listAllAgentIdentities.mockReturnValue(new Promise((res) => { resolveLoad = res; }));
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            expect(screen.queryByRole("button", { name: "Connect Claude account" })).not.toBeInTheDocument();
+
+            resolveLoad([]);
+            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            expect(button).toBeInTheDocument();
         });
     });
 });

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -157,6 +157,29 @@ describe("AgentIdentityLinksPanel", () => {
             );
         });
 
+        it("reagent P2 on PR #2414 (round 5): passes the link row's own account id, not the (possibly cache-lagging) joined Account's, so a click while the local accounts cache hasn't caught up still refreshes the RIGHT account instead of minting a new one", async () => {
+            // "acc-not-yet-cached" has no matching entry in the mocked
+            // loadAccounts() list (acc-1/acc-2/acc-claude-1 only) — this is
+            // exactly what a real cache-lag looks like: the link row exists,
+            // but subscribeAccountChanges() hasn't delivered the matching
+            // Account yet, so joinAgentIdentityRows's `account` field is
+            // null even though `accountId` (from the link row itself) is
+            // real. The button must still show "Connect" (row.account is
+            // null) but must NOT drop the account id on the floor.
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-not-yet-cached", provider: "claude" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            const button = await screen.findByRole("button", { name: "Connect" });
+            button.click();
+
+            expect(claudeLoginPanel).toHaveBeenCalledWith(
+                expect.objectContaining({ existingAccountId: "acc-not-yet-cached" }),
+            );
+        });
+
         it("does NOT show a Connect/Re-login button on a non-claude row (github) — only Claude has an in-app session today", async () => {
             listAllAgentIdentities.mockResolvedValue([
                 mkLink({ agent_id: "agent-1", account_id: "acc-1", provider: "github" }),

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -167,6 +167,21 @@ describe("AgentIdentityLinksPanel", () => {
             expect(screen.queryByRole("button", { name: /re-login|connect/i })).not.toBeInTheDocument();
         });
 
+        it("shows Re-login for a legacy-aliased claude link row (\"claude-code\"), not just the canonical \"claude\" provider string (reagent P1 on PR #2414)", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-claude-1", provider: "claude-code" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            const button = await screen.findByRole("button", { name: "Re-login" });
+            button.click();
+
+            expect(claudeLoginPanel).toHaveBeenCalledWith(
+                expect.objectContaining({ existingAccountId: "acc-claude-1" }),
+            );
+        });
+
         it("empty state offers 'Connect Claude account' for an agent with NO links at all (the v0.54.9 stuck-instance case — no row exists to attach a per-row button to)", async () => {
             listAllAgentIdentities.mockResolvedValue([]);
 

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -10,7 +10,7 @@
  * degrade gracefully when it has no agent context at all.
  */
 
-import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import { cleanup, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const listAllAgentIdentities = vi.fn();
@@ -180,7 +180,7 @@ describe("AgentIdentityLinksPanel", () => {
             );
         });
 
-        it("does NOT show a Connect/Re-login button on a non-claude row (github) — only Claude has an in-app session today", async () => {
+        it("does NOT show a PER-ROW Connect/Re-login button on a non-claude row (github) — only Claude has an in-app session today", async () => {
             listAllAgentIdentities.mockResolvedValue([
                 mkLink({ agent_id: "agent-1", account_id: "acc-1", provider: "github" }),
             ]);
@@ -188,7 +188,44 @@ describe("AgentIdentityLinksPanel", () => {
             render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
 
             await waitFor(() => expect(screen.getByText("Work GitHub")).toBeInTheDocument());
-            expect(screen.queryByRole("button", { name: /re-login|connect/i })).not.toBeInTheDocument();
+            // The github row itself gets no button (only Claude rows do) —
+            // agent-1 is mocked as a claude-provider agent, though, so it
+            // DOES still get the standalone Connect affordance below the
+            // table (reagent P1 on PR #2414, round 6) since it has no
+            // claude/claude-code row of its own yet; that one action is
+            // legitimate and covered by the next test.
+            const table = screen.getByRole("table");
+            expect(within(table).queryByRole("button", { name: /re-login|connect/i })).not.toBeInTheDocument();
+        });
+
+        it("reagent P1 on PR #2414 (round 6): STILL offers 'Connect Claude account' when the agent has other-provider links but no claude/claude-code row of its own — the per-row button can't cover this since no claude row exists to attach it to", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-1", provider: "github" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            await waitFor(() => expect(screen.getByText("Work GitHub")).toBeInTheDocument());
+            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            button.click();
+
+            expect(claudeLoginPanel).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    existingAccountId: undefined,
+                    linkTarget: { agentDefinitionId: "agent-1" },
+                }),
+            );
+        });
+
+        it("reagent P1 on PR #2414 (round 6): does NOT offer 'Connect Claude account' anywhere for a non-claude agent that has other-provider links but no claude row — that would link an unrelated Claude account to an agent whose actual provider is something else entirely", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-3", account_id: "acc-1", provider: "github" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-3" />);
+
+            await waitFor(() => expect(screen.getByText("Work GitHub")).toBeInTheDocument());
+            expect(screen.queryByRole("button", { name: /connect|re-login/i })).not.toBeInTheDocument();
         });
 
         it("shows Re-login for a legacy-aliased claude link row (\"claude-code\"), not just the canonical \"claude\" provider string (reagent P1 on PR #2414)", async () => {

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -12,8 +12,16 @@
 // documented in docs/specs/SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md
 // §1.3.
 //
-// No create/edit/delete/bind/unbind here — new agent identities are
-// created from the agent-launch flow directly. See
+// Create/edit/delete/bind/unbind stayed out of scope here EXCEPT for one
+// exception carved out by docs/specs/SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md
+// §3.3 surface 3: a Connect/Re-login action for Claude specifically, since
+// this is otherwise the only place a broken/missing Claude binding is
+// visible per-agent — without it, an agent whose bound account was deleted
+// (or, per retro-agentu-0.54.9-stuck-error-2026-08-03.md, never had one) had
+// no in-app path to fix it short of the launch dialog's own "New Agent"
+// flow, which doesn't apply to an agent that already exists. New agent
+// identities for OTHER providers, and non-Claude relogin, remain out of
+// scope — created from the agent-launch flow directly, per
 // docs/specs/SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md.
 
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
@@ -25,6 +33,7 @@ import { waveEventSubscribe } from "@/app/store/wps";
 import { loadAccounts, subscribeAccountChanges, PROVIDER_LABELS, type Account } from "./identity-model";
 import { statusBadge } from "./identity-manager";
 import { joinAgentIdentityRows } from "./agent-identities-model";
+import { ClaudeLoginPanel } from "@/app/view/accounts/ClaudeLoginPanel";
 
 import "./identity-pane-view.scss";
 
@@ -41,6 +50,16 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
     const [allLinks, setAllLinks] = createSignal<AgentDefinitionIdentity[]>([]);
     const [accounts, setAccounts] = createSignal<Account[]>(loadAccounts());
     const [error, setError] = createSignal<string | null>(null);
+    // Set to the account id being refreshed (or "" for a fresh connect —
+    // distinguished from "closed" by claudePanelOpen()) when the Claude
+    // Connect/Re-login panel is open.
+    const [claudePanelOpen, setClaudePanelOpen] = createSignal(false);
+    const [claudeRefreshAccountId, setClaudeRefreshAccountId] = createSignal<string | undefined>(undefined);
+
+    const openClaudeLogin = (existingAccountId: string | undefined) => {
+        setClaudeRefreshAccountId(existingAccountId);
+        setClaudePanelOpen(true);
+    };
 
     const refreshLinks = async (): Promise<void> => {
         try {
@@ -113,10 +132,21 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                         <Show
                             when={rows().length > 0}
                             fallback={
-                                <p class="identity-pane-empty-hint">
-                                    This agent has no linked accounts yet. Link one from its launch
-                                    dialog.
-                                </p>
+                                <div class="identity-pane-empty-hint">
+                                    <p>This agent has no linked accounts yet. Link one from its launch dialog.</p>
+                                    {/* The retro-agentu-0.54.9-stuck-error-2026-08-03.md case: a
+                                        Claude agent with ZERO links has no row above to attach a
+                                        Re-login button to, and no way back into the launch dialog
+                                        once the agent already exists — this is the only in-app path
+                                        left for exactly that state. */}
+                                    <button
+                                        type="button"
+                                        class="identity-btn identity-btn-primary"
+                                        onClick={() => openClaudeLogin(undefined)}
+                                    >
+                                        Connect Claude account
+                                    </button>
+                                </div>
                             }
                         >
                             <table class="identity-pane-bindings">
@@ -125,6 +155,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                         <th>Provider</th>
                                         <th>Account</th>
                                         <th>Status</th>
+                                        <th />
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -155,6 +186,21 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                                             </span>
                                                         </span>
                                                     </td>
+                                                    <td>
+                                                        {/* Claude-only for now — the in-app session
+                                                            (InAppLoginPanel/ClaudeLoginPanel) only
+                                                            exists for Claude; other providers still
+                                                            route through the launch dialog. */}
+                                                        <Show when={row.provider === "claude"}>
+                                                            <button
+                                                                type="button"
+                                                                class="identity-btn identity-btn-secondary"
+                                                                onClick={() => openClaudeLogin(row.account?.id)}
+                                                            >
+                                                                {row.account ? "Re-login" : "Connect"}
+                                                            </button>
+                                                        </Show>
+                                                    </td>
                                                 </tr>
                                             );
                                         }}
@@ -165,6 +211,14 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                     </div>
                 </Show>
             </div>
+
+            <Show when={claudePanelOpen()}>
+                <ClaudeLoginPanel
+                    onClose={() => setClaudePanelOpen(false)}
+                    existingAccountId={claudeRefreshAccountId()}
+                    linkTarget={props.agentId ? { agentDefinitionId: props.agentId } : undefined}
+                />
+            </Show>
         </div>
     );
 };

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -232,7 +232,16 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                                             <button
                                                                 type="button"
                                                                 class="identity-btn identity-btn-secondary"
-                                                                onClick={() => openClaudeLogin(row.account?.id, row.provider)}
+                                                                // reagent P2 on PR #2414 (round 5): row.accountId
+                                                                // (from the link row itself, agent-identities-model.ts)
+                                                                // is always present when a link exists; row.account
+                                                                // (the JOINED Account object) is null whenever the
+                                                                // local accounts cache hasn't caught up yet — using
+                                                                // row.account?.id here passed undefined on a
+                                                                // stale-cache click, minting a brand-new Claude
+                                                                // account instead of refreshing the one the link
+                                                                // row already points at.
+                                                                onClick={() => openClaudeLogin(row.accountId, row.provider)}
                                                             >
                                                                 {row.account ? "Re-login" : "Connect"}
                                                             </button>

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -56,9 +56,18 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
     // Connect/Re-login panel is open.
     const [claudePanelOpen, setClaudePanelOpen] = createSignal(false);
     const [claudeRefreshAccountId, setClaudeRefreshAccountId] = createSignal<string | undefined>(undefined);
+    // reagent P0 on PR #2414: see ClaudeLoginPanel's staleAliasProvider doc
+    // comment — set when the row being acted on carries a legacy-alias
+    // provider string, so the panel can unlink it after a successful login
+    // instead of leaving an orphaned row that silently blocks every future
+    // spawn under the new canonical link.
+    const [claudeStaleAliasProvider, setClaudeStaleAliasProvider] = createSignal<string | undefined>(undefined);
 
-    const openClaudeLogin = (existingAccountId: string | undefined) => {
+    const openClaudeLogin = (existingAccountId: string | undefined, rawProvider?: string) => {
         setClaudeRefreshAccountId(existingAccountId);
+        setClaudeStaleAliasProvider(
+            rawProvider && rawProvider !== "claude" ? rawProvider : undefined,
+        );
         setClaudePanelOpen(true);
     };
 
@@ -200,7 +209,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                                             <button
                                                                 type="button"
                                                                 class="identity-btn identity-btn-secondary"
-                                                                onClick={() => openClaudeLogin(row.account?.id)}
+                                                                onClick={() => openClaudeLogin(row.account?.id, row.provider)}
                                                             >
                                                                 {row.account ? "Re-login" : "Connect"}
                                                             </button>
@@ -222,6 +231,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                     onClose={() => setClaudePanelOpen(false)}
                     existingAccountId={claudeRefreshAccountId()}
                     linkTarget={props.agentId ? { agentDefinitionId: props.agentId } : undefined}
+                    staleAliasProvider={claudeStaleAliasProvider()}
                 />
             </Show>
         </div>

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -62,6 +62,13 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
     // instead of leaving an orphaned row that silently blocks every future
     // spawn under the new canonical link.
     const [claudeStaleAliasProvider, setClaudeStaleAliasProvider] = createSignal<string | undefined>(undefined);
+    // reagent P2 on PR #2414 (round 3): the empty-state "Connect Claude
+    // account" button below must not appear before the initial load
+    // resolves (was previously indistinguishable from "genuinely zero
+    // links") or after it fails (the top error banner already covers that
+    // case — offering the button too just invites clicking it against
+    // still-broken/unknown state).
+    const [linksLoaded, setLinksLoaded] = createSignal(false);
 
     const openClaudeLogin = (existingAccountId: string | undefined, rawProvider?: string) => {
         setClaudeRefreshAccountId(existingAccountId);
@@ -78,6 +85,8 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
             setError(null);
         } catch (e: any) {
             setError(e?.message ?? "Failed to load agent identities");
+        } finally {
+            setLinksLoaded(true);
         }
     };
     void refreshLinks();
@@ -142,21 +151,35 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                         <Show
                             when={rows().length > 0}
                             fallback={
-                                <div class="identity-pane-empty-hint">
-                                    <p>This agent has no linked accounts yet. Link one from its launch dialog.</p>
-                                    {/* The retro-agentu-0.54.9-stuck-error-2026-08-03.md case: a
-                                        Claude agent with ZERO links has no row above to attach a
-                                        Re-login button to, and no way back into the launch dialog
-                                        once the agent already exists — this is the only in-app path
-                                        left for exactly that state. */}
-                                    <button
-                                        type="button"
-                                        class="identity-btn identity-btn-primary"
-                                        onClick={() => openClaudeLogin(undefined)}
-                                    >
-                                        Connect Claude account
-                                    </button>
-                                </div>
+                                // reagent P2 on PR #2414 (round 3): gated on
+                                // linksLoaded() && !error() — without this,
+                                // the empty state (and its "Connect Claude
+                                // account" button) rendered indistinguishably
+                                // for "still loading", "load failed" (the
+                                // banner above already covers that), and a
+                                // genuinely empty agent.
+                                <Show when={linksLoaded() && !error()}>
+                                    <div class="identity-pane-empty-hint">
+                                        <p>This agent has no linked accounts yet. Link one from its launch dialog.</p>
+                                        {/* The retro-agentu-0.54.9-stuck-error-2026-08-03.md case: a
+                                            Claude agent with ZERO links has no row above to attach a
+                                            Re-login button to, and no way back into the launch dialog
+                                            once the agent already exists — this is the only in-app path
+                                            left for exactly that state. Gated on the agent's own
+                                            provider (reagent P2 on PR #2414, round 3): otherwise this
+                                            button links an unrelated Claude account to an agent whose
+                                            actual provider is something else entirely. */}
+                                        <Show when={canonicalProviderId(agent()?.provider ?? "") === "claude"}>
+                                            <button
+                                                type="button"
+                                                class="identity-btn identity-btn-primary"
+                                                onClick={() => openClaudeLogin(undefined)}
+                                            >
+                                                Connect Claude account
+                                            </button>
+                                        </Show>
+                                    </div>
+                                </Show>
                             }
                         >
                             <table class="identity-pane-bindings">

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -34,6 +34,7 @@ import { loadAccounts, subscribeAccountChanges, PROVIDER_LABELS, type Account } 
 import { statusBadge } from "./identity-manager";
 import { joinAgentIdentityRows } from "./agent-identities-model";
 import { ClaudeLoginPanel } from "@/app/view/accounts/ClaudeLoginPanel";
+import { canonicalProviderId } from "@/app/view/agent/providers/provider-id-aliases";
 
 import "./identity-pane-view.scss";
 
@@ -190,8 +191,12 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                                         {/* Claude-only for now — the in-app session
                                                             (InAppLoginPanel/ClaudeLoginPanel) only
                                                             exists for Claude; other providers still
-                                                            route through the launch dialog. */}
-                                                        <Show when={row.provider === "claude"}>
+                                                            route through the launch dialog. Canonicalize
+                                                            — db_agent_identity_links can carry a
+                                                            legacy-alias row ("claude-code") for a
+                                                            migrated agent (reagent P1 on PR #2414;
+                                                            see provider-id-aliases.ts). */}
+                                                        <Show when={canonicalProviderId(row.provider) === "claude"}>
                                                             <button
                                                                 type="button"
                                                                 class="identity-btn identity-btn-secondary"

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -125,6 +125,18 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
         return joinAgentIdentityRows(id, allLinks(), accountsById());
     });
 
+    // reagent P1 on PR #2414 (round 6): the empty-state Connect button was
+    // gated on `rows().length === 0`, so a Claude-provider agent with ANY
+    // other-provider link (e.g. a github row, but no claude/claude-code
+    // row) fell into the table branch instead — where the per-row
+    // Connect/Re-login button only renders on rows whose OWN provider is
+    // claude, so there was no row to attach it to either. Net effect: no
+    // in-app affordance anywhere in the panel to connect Claude for that
+    // agent, despite this being exactly the broken/missing-Claude-binding
+    // case the panel exists to fix. Computed independently of rows().length
+    // so it applies whether the table renders or not.
+    const hasClaudeLink = createMemo(() => rows().some((r) => canonicalProviderId(r.provider) === "claude"));
+
     return (
         <div class="identity-pane">
             <div class="identity-pane-detail">
@@ -153,31 +165,13 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                             fallback={
                                 // reagent P2 on PR #2414 (round 3): gated on
                                 // linksLoaded() && !error() — without this,
-                                // the empty state (and its "Connect Claude
-                                // account" button) rendered indistinguishably
-                                // for "still loading", "load failed" (the
-                                // banner above already covers that), and a
+                                // this text rendered indistinguishably for
+                                // "still loading", "load failed" (the banner
+                                // above already covers that), and a
                                 // genuinely empty agent.
                                 <Show when={linksLoaded() && !error()}>
                                     <div class="identity-pane-empty-hint">
                                         <p>This agent has no linked accounts yet. Link one from its launch dialog.</p>
-                                        {/* The retro-agentu-0.54.9-stuck-error-2026-08-03.md case: a
-                                            Claude agent with ZERO links has no row above to attach a
-                                            Re-login button to, and no way back into the launch dialog
-                                            once the agent already exists — this is the only in-app path
-                                            left for exactly that state. Gated on the agent's own
-                                            provider (reagent P2 on PR #2414, round 3): otherwise this
-                                            button links an unrelated Claude account to an agent whose
-                                            actual provider is something else entirely. */}
-                                        <Show when={canonicalProviderId(agent()?.provider ?? "") === "claude"}>
-                                            <button
-                                                type="button"
-                                                class="identity-btn identity-btn-primary"
-                                                onClick={() => openClaudeLogin(undefined)}
-                                            >
-                                                Connect Claude account
-                                            </button>
-                                        </Show>
                                     </div>
                                 </Show>
                             }
@@ -253,6 +247,39 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                     </For>
                                 </tbody>
                             </table>
+                        </Show>
+
+                        {/* reagent P1 on PR #2414 (round 6): standalone, NOT
+                            nested inside the rows()===0 fallback above — a
+                            Claude-provider agent with other-provider links
+                            but no claude/claude-code row of its own needs
+                            this same affordance, and the per-row
+                            Connect/Re-login button (only rendered on rows
+                            whose OWN provider is claude) can't cover it since
+                            no such row exists to attach it to. The
+                            retro-agentu-0.54.9-stuck-error-2026-08-03.md case
+                            this button exists for. Gated on the agent's own
+                            provider (reagent P2 on PR #2414, round 3):
+                            otherwise this links an unrelated Claude account
+                            to an agent whose actual provider is something
+                            else entirely. */}
+                        <Show
+                            when={
+                                linksLoaded() &&
+                                !error() &&
+                                !hasClaudeLink() &&
+                                canonicalProviderId(agent()?.provider ?? "") === "claude"
+                            }
+                        >
+                            <div class="identity-pane-empty-hint">
+                                <button
+                                    type="button"
+                                    class="identity-btn identity-btn-primary"
+                                    onClick={() => openClaudeLogin(undefined)}
+                                >
+                                    Connect Claude account
+                                </button>
+                            </div>
                         </Show>
                     </div>
                 </Show>


### PR DESCRIPTION
## Summary
Closes the gap the v0.54.9 stuck-instance retro identified: a fresh AgentMux profile with zero linked Claude accounts had no in-app way to create one — Armory's Anthropic tile was key-only, and the Agent Stash's identity panel was read-only with no create/re-login path. This is surface 3 of `docs/specs/SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md`.

- **`run-provider-login.ts`**: `linkTarget.blockId` is now optional. The block `cmd:env` refresh only runs when a `blockId` is given — the account link itself doesn't need a live pane (Armory's bare Connect, or a Stash re-login for an agent with no open pane).
- **`accounts-catalog.ts`**: Anthropic's tile gets `authModes: ["oauth", "key"]`. The "oauth" pick does **not** use `oauth-catalog.ts`'s service-OAuth scaffold (Anthropic has no device/PKCE endpoint an app-driven client could hit — auth-broker Phase D's own conclusion) — `AccountsGallery` intercepts it the same way it already intercepts the AgentMux tile, opening a dedicated panel instead.
- **New `ClaudeLoginPanel`**: the in-app login session for contexts with no agent block — reuses `InAppLoginPanel` (extracted from `PreLaunchAuthPanel` in the first commit, pure relocation) and `runProviderLogin`'s awaited session exactly as the launch surface (#2410) does.
- **Agent Stash** (`agent-identity-links-panel.tsx`): a Connect/Re-login action per Claude row, plus a "Connect Claude account" button in the empty state for an agent with zero links — the exact shape of the v0.54.9 incident, where no row existed to attach a per-row button to.

## Stacked on #2410
Base branch is `nark/inapp-claude-oauth-login-spec` (PR #2410) — this PR is surface 3 of the 4-PR plan.

## Test plan
- `npx tsc --noEmit` — clean.
- `npx vitest run frontend/app/view` — 1098 passed (86 files; 6 new tests: `run-provider-login`'s optional-blockId guard, 3 new in `agent-identity-links-panel` covering Re-login/Connect button visibility and wiring).

<!-- agentmux:agent_id=nark -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)