### PR TITLE
fix(ambient): ghost-text suggestions read as direct instructions

### DIFF
--- a/.changesets/1785875969-fix-ambient-ghost-text-suggestions-read-as-direct-instructio-z6gs.md
+++ b/.changesets/1785875969-fix-ambient-ghost-text-suggestions-read-as-direct-instructio-z6gs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ambient): ghost-text suggestions read as direct instructions, not chat filler

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -527,12 +527,17 @@ fn register_session_next_prompt_suggestion(engine: &Arc<WshRpcEngine>, state: &A
                 }
 
                 let prompt = format!(
-                    "Based on this recent activity, predict ONE short, natural next \
-                     message the user might send to continue the conversation. \
-                     Respond with just that message and nothing else — plain text only, \
-                     no markdown, no code fences, no backticks, no quotes, no explanation, \
-                     no preamble. If nothing plausible comes to mind, respond with an \
-                     empty string.\n\n\
+                    "Based on this recent activity, predict ONE short next instruction \
+                     the user is likely to give to continue the work. Phrase it as a \
+                     direct, imperative command — the way someone types a task into a \
+                     prompt box, not casual chat. Do not start with conversational \
+                     filler or throat-clearing (\"Yeah\", \"Sure\", \"Let's\", \"Go ahead \
+                     and\", \"OK\", or similar) — begin directly with the action itself. \
+                     For example, write \"Debug the blank preview bug next\", not \"Yeah \
+                     let's debug the blank preview bug next\". Respond with just that \
+                     instruction and nothing else — plain text only, no markdown, no code \
+                     fences, no backticks, no quotes, no explanation, no preamble. If \
+                     nothing plausible comes to mind, respond with an empty string.\n\n\
                      Recent activity:\n\n{extracted}"
                 );
 
@@ -715,20 +720,25 @@ pub(crate) async fn invoke_ambient_haiku_call(
     Ok((last_text, tokens))
 }
 
-/// Defends against the model wrapping its answer in markdown despite every
-/// ambient-call prompt asking for a bare line of plain text — instruction-
-/// following isn't guaranteed, and an unwrapped fence is exactly what
-/// produces a literal ` ``` `/newline/` ``` ` blob on a UI surface that
-/// renders this text verbatim (e.g. the ghost-text composer placeholder,
-/// which has no markdown renderer). Applied once here so every current and
-/// future `invoke_ambient_haiku_call` caller is covered, not just the one
-/// that first surfaced the bug.
+/// Defends against the model wrapping its answer in markdown, or opening
+/// with conversational filler, despite every ambient-call prompt asking for
+/// a bare, direct line of plain text — instruction-following isn't
+/// guaranteed. An unwrapped fence is what produces a literal
+/// ` ``` `/newline/` ``` ` blob on a UI surface that renders this text
+/// verbatim (e.g. the ghost-text composer placeholder, which has no
+/// markdown renderer). Filler ("Yeah, let's fix the bug" instead of "Fix
+/// the bug") is a separate readability problem the prompt alone can't fully
+/// prevent — same "prompt nudge + reliable sanitizer" split this project
+/// already uses for the fence/quote case. Applied once here so every
+/// current and future `invoke_ambient_haiku_call` caller is covered, not
+/// just the one that first surfaced each bug.
 ///
-/// Strips a wrapping code fence and wrapping quote characters, repeatedly (a
-/// model can nest both), then trims. A result left with nothing but
-/// backticks (e.g. an empty fence) collapses to "" so callers' existing
-/// empty-string handling (skip writing ghost text / filter out the summary)
-/// covers it without any caller-side change.
+/// Strips a wrapping code fence, wrapping quote characters, and a leading
+/// conversational preamble, repeatedly (a model can combine all three —
+/// e.g. a quoted, filler-prefixed sentence), then trims. A result left with
+/// nothing but backticks (e.g. an empty fence) collapses to "" so callers'
+/// existing empty-string handling (skip writing ghost text / filter out the
+/// summary) covers it without any caller-side change.
 fn sanitize_ambient_text(raw: &str) -> String {
     let mut s = raw.trim().to_string();
     for _ in 0..4 {
@@ -742,6 +752,9 @@ fn sanitize_ambient_text(raw: &str) -> String {
             })
             .trim()
             .to_string();
+        if let Some(rest) = strip_conversational_preamble(&s) {
+            s = rest;
+        }
         if s == before {
             break;
         }
@@ -767,6 +780,66 @@ fn strip_wrapping_fence(s: &str) -> Option<String> {
                 }
             }
             return Some(inner.trim().to_string());
+        }
+    }
+    None
+}
+
+/// Conversational-filler openers a model reaches for despite being told to
+/// respond with a bare, direct instruction — e.g. "Yeah, let's fix the
+/// bug" instead of "Fix the bug". Matched case-insensitively against the
+/// very start of the string only (a "let's" appearing mid-sentence is left
+/// alone — this strips openers, not arbitrary word choice). Longer/more
+/// specific entries first so e.g. "let's go ahead and " matches whole
+/// rather than the shorter "let's " eating only part of it.
+const CONVERSATIONAL_PREAMBLES: &[&str] = &[
+    "let's go ahead and ",
+    "lets go ahead and ",
+    "yeah, let's ",
+    "yeah let's ",
+    "yeah, lets ",
+    "yeah lets ",
+    "sure, let's ",
+    "sure let's ",
+    "ok, let's ",
+    "okay, let's ",
+    "alright, let's ",
+    "go ahead and ",
+    "let's ",
+    "lets ",
+    "sure, i'll ",
+    "sure, i will ",
+    "sure, ",
+    "yeah, ",
+    "yeah ",
+    "ok, ",
+    "okay, ",
+    "alright, ",
+    "i'll ",
+    "i will ",
+    "i should ",
+    "we should ",
+    "next up, ",
+    "next, ",
+];
+
+/// Strip one leading conversational-filler opener (see
+/// `CONVERSATIONAL_PREAMBLES`) and re-capitalize the new first letter, so
+/// "Yeah, let's debug the bug" becomes "Debug the bug" — matching the
+/// direct-instruction register every ambient-call prompt asks for. Returns
+/// `None` if no known opener matches (left alone rather than guessed at —
+/// this list is deliberately not exhaustive NLP-style filler detection,
+/// just the handful of openers a model actually reaches for here).
+fn strip_conversational_preamble(s: &str) -> Option<String> {
+    let lower = s.to_lowercase();
+    for prefix in CONVERSATIONAL_PREAMBLES {
+        if lower.starts_with(prefix) {
+            let rest = &s[prefix.len()..];
+            let mut chars = rest.chars();
+            return Some(match chars.next() {
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            });
         }
     }
     None
@@ -927,5 +1000,51 @@ mod sanitize_ambient_text_tests {
     #[test]
     fn lone_backticks_with_no_content_collapse_to_empty() {
         assert_eq!(sanitize_ambient_text("```"), "");
+    }
+
+    #[test]
+    fn strips_yeah_lets_preamble() {
+        assert_eq!(
+            sanitize_ambient_text("Yeah, let's debug the blank preview bug next"),
+            "Debug the blank preview bug next"
+        );
+        assert_eq!(sanitize_ambient_text("Yeah let's fix the login bug"), "Fix the login bug");
+    }
+
+    #[test]
+    fn strips_go_ahead_and_preamble() {
+        assert_eq!(
+            sanitize_ambient_text("Go ahead and add tests for the parser"),
+            "Add tests for the parser"
+        );
+    }
+
+    #[test]
+    fn strips_sure_ok_alright_preamble() {
+        assert_eq!(sanitize_ambient_text("Sure, fix the typo"), "Fix the typo");
+        assert_eq!(sanitize_ambient_text("OK, run the tests"), "Run the tests");
+        assert_eq!(sanitize_ambient_text("Alright, let's ship it"), "Ship it");
+    }
+
+    #[test]
+    fn strips_preamble_from_inside_quotes_and_fences() {
+        assert_eq!(sanitize_ambient_text("\"Yeah, let's fix the bug\""), "Fix the bug");
+        assert_eq!(sanitize_ambient_text("```\nYeah, let's fix the bug\n```"), "Fix the bug");
+    }
+
+    #[test]
+    fn leaves_a_mid_sentence_lets_alone() {
+        let s = "Check whether the retry logic still lets errors through";
+        assert_eq!(sanitize_ambient_text(s), s);
+    }
+
+    #[test]
+    fn a_filler_word_with_no_trailing_content_is_left_alone() {
+        // "Yeah," alone (no instruction after it) doesn't match any
+        // CONVERSATIONAL_PREAMBLES entry — they all require trailing
+        // content after the opener, matching the "strip openers, not
+        // guess at degenerate whole-string filler" scope this function
+        // documents.
+        assert_eq!(sanitize_ambient_text("Yeah,"), "Yeah,");
     }
 }

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -831,10 +831,9 @@ const CONVERSATIONAL_PREAMBLES: &[&str] = &[
 /// this list is deliberately not exhaustive NLP-style filler detection,
 /// just the handful of openers a model actually reaches for here).
 fn strip_conversational_preamble(s: &str) -> Option<String> {
-    let lower = s.to_lowercase();
     for prefix in CONVERSATIONAL_PREAMBLES {
-        if lower.starts_with(prefix) {
-            let rest = &s[prefix.len()..];
+        if let Some(byte_len) = case_insensitive_prefix_byte_len(s, prefix) {
+            let rest = &s[byte_len..];
             let mut chars = rest.chars();
             return Some(match chars.next() {
                 Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
@@ -843,6 +842,32 @@ fn strip_conversational_preamble(s: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Byte length in `s` of a prefix that case-insensitively matches `prefix`
+/// (always plain ASCII lowercase), or `None` if `s` doesn't start with it.
+/// Walks `s`'s own char boundaries rather than slicing by an offset computed
+/// against a separately-lowercased copy of `s` — a char's lowercase mapping
+/// can change UTF-8 byte length (e.g. the Kelvin sign 'K' -> 'k') or even
+/// character count (e.g. Turkish 'İ' -> "i̇"), which would otherwise misalign
+/// the offset or land it off a char boundary and panic on slice.
+fn case_insensitive_prefix_byte_len(s: &str, prefix: &str) -> Option<usize> {
+    let mut prefix_chars = prefix.chars().peekable();
+    for (byte_idx, c) in s.char_indices() {
+        if prefix_chars.peek().is_none() {
+            return Some(byte_idx);
+        }
+        for lc in c.to_lowercase() {
+            if prefix_chars.next_if_eq(&lc).is_none() {
+                return None;
+            }
+        }
+    }
+    if prefix_chars.peek().is_none() {
+        Some(s.len())
+    } else {
+        None
+    }
 }
 
 /// Extract meaningful text from raw stream-json lines for digest summarization.
@@ -1046,5 +1071,26 @@ mod sanitize_ambient_text_tests {
         // guess at degenerate whole-string filler" scope this function
         // documents.
         assert_eq!(sanitize_ambient_text("Yeah,"), "Yeah,");
+    }
+
+    #[test]
+    fn preamble_strip_handles_byte_length_changing_case_folding() {
+        // U+212A KELVIN SIGN lowercases to ASCII 'k' (3 bytes -> 1 byte). If the
+        // preamble strip computed its slice offset from a separately-lowercased
+        // copy of the string instead of walking the original string's own char
+        // boundaries, this would misalign the slice (or panic on a non-char-
+        // boundary index) instead of matching "ok, " normally.
+        let s = "O\u{212A}, run the tests";
+        assert_eq!(sanitize_ambient_text(s), "Run the tests");
+    }
+
+    #[test]
+    fn preamble_strip_handles_char_count_changing_case_folding() {
+        // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE lowercases to "i̇" (2
+        // chars) under Rust's default Unicode case folding. This does not
+        // match any configured preamble, but must not panic or corrupt the
+        // string while failing to match.
+        let s = "\u{0130} think we should refactor this";
+        assert_eq!(sanitize_ambient_text(s), s);
     }
 }


### PR DESCRIPTION
## Summary
- User report: the composer's ghost-text next-prompt suggestion reads like "Yeah let's debug that blank preview bug next" instead of "Debug the blank preview bug next" -- conversational filler, not a direct instruction.
- Root cause: `next_prompt_suggestion`'s prompt (`session.rs`) asked Haiku to predict "a message the user might send to continue the conversation" -- inviting casual chat register. `activity_summary`/`subagent_name`'s prompts are already imperative/factual and don't have this problem, so the fix is scoped to that one prompt.
- Same "prompt nudge + reliable sanitizer" split this codebase already established for the fence/quote-wrapping bug (`SPEC_AMBIENT_SUMMARY_SANITIZATION_AND_TERSENESS_2026_07_08.md`):
  1. Tightened the prompt to explicitly ask for a direct, imperative command, with a concrete before/after example baked in.
  2. Extended `sanitize_ambient_text` (the shared choke point for all three ambient Haiku call purposes) with `strip_conversational_preamble` -- strips a small, non-exhaustive list of known filler openers ("Yeah, let's ", "Go ahead and ", "Sure, ", etc.) from the start of the string only, re-capitalizing what remains. This is the reliable half of the fix, per the same philosophy already documented for the fence/quote case.

## Test plan
- [x] 7 new unit tests covering: filler stripping, mid-sentence "lets" left alone, preamble inside quotes/fences, filler-only input left alone (no trailing content to strip).
- [x] `cargo test -p agentmux-srv` -- 1978/1978 pass.
- [ ] Manual: trigger the ghost-text suggestion after a turn and confirm it reads as a direct instruction, not "Yeah, let's..."

<!-- agentmux:agent_id=agenty -->