### PR TITLE
fix(dev): default dev-agent.cmd window title to agent identity

### DIFF
--- a/.changesets/1785877152-fix-dev-default-dev-agent-cmd-window-title-to-agent-identity-tu4r.md
+++ b/.changesets/1785877152-fix-dev-default-dev-agent-cmd-window-title-to-agent-identity-tu4r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dev): default dev-agent.cmd window title to agent identity

--- a/scripts/dev-agent.cmd
+++ b/scripts/dev-agent.cmd
@@ -63,8 +63,20 @@ set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
 :: quoting the caller's own arguments already carry; wrapping it in an
 :: extra `"..."` pair (`set "ARGS=%*"`) breaks quote-parity and reopens
 :: the same injection when a caller-quoted value contains its own quotes.
+::
+:: reagentx P0 (round 2): cmd.exe's `SetEnvironmentVariable` has no
+:: defined-but-empty state — `set ARGS=%*` with no args passed, or an
+:: earlier version's `set "TITLE_ARG="` with no auto-title needed, both
+:: DELETE the variable entirely instead of setting it to "". An undefined
+:: `%VAR%` is then left as the literal text `%VAR%` when spliced into a
+:: command line (unlike delayed `!VAR!` expansion, which the detection
+:: logic below already relies on and which correctly reads an undefined
+:: variable as empty). That broke the bare no-args call, this script's
+:: PRIMARY documented usage. Fixed below by never expanding a possibly-
+:: undefined %ARGS%/title token directly into the final command line —
+:: each branch only ever expands a variable it has just confirmed
+:: (`if defined`) is actually set.
 set ARGS=%*
-set "TITLE_ARG="
 setlocal enabledelayedexpansion
 set "U=!ARGS!"
 set "U=!U:"=!"
@@ -75,9 +87,12 @@ set "U=!U:e=E!"
 set "HAS_TITLE="
 if "!U:~0,6!"=="TITLE=" set "HAS_TITLE=1"
 if not "!U!"=="!U: TITLE==!" set "HAS_TITLE=1"
-set "NEWTITLE="
-if not defined HAS_TITLE if not "%AGENTMUX_AGENT_ID%"=="" set "NEWTITLE=TITLE=%AGENTMUX_AGENT_ID%"
-endlocal & set "TITLE_ARG=%NEWTITLE%"
+:: Always assigned a real (non-empty) value on both branches — unlike
+:: TITLE_ARG above, "0"/"1" can safely round-trip through `endlocal & set`
+:: without hitting the same empty-value-undefines-it trap.
+set "NEED_AUTO_TITLE_INNER=0"
+if not defined HAS_TITLE if not "%AGENTMUX_AGENT_ID%"=="" set "NEED_AUTO_TITLE_INNER=1"
+endlocal & set "NEED_AUTO_TITLE=%NEED_AUTO_TITLE_INNER%"
 
 :: Call bare `task` (no extension) — this .cmd wrapper itself runs under cmd.exe
 :: (Gap A only applies to bash resolving .cmd files, not to us), so PATHEXT
@@ -86,4 +101,26 @@ endlocal & set "TITLE_ARG=%NEWTITLE%"
 :: depends on how `task` was installed on the machine.
 :: Merge stderr into stdout so shell viewers don't color build progress red
 :: (cargo writes all output to stderr, not stdout).
-task dev %ARGS% %TITLE_ARG% 2>&1
+::
+:: Four explicit branches (rather than building one command-line string in
+:: a variable) so every %ARGS%/%AGENTMUX_AGENT_ID% expansion happens
+:: directly at a real `task dev` invocation, never round-tripped through
+:: an intermediate `set "X=...token with embedded quotes..."` — cmd.exe's
+:: quote-nesting inside `set "VAR=...""..."""` is fragile enough to be its
+:: own bug source. The auto-generated title is quoted as ONE token
+:: (`"TITLE=%AGENTMUX_AGENT_ID%"`, matching the caller-supplied usage
+:: convention documented above) — reagentx P2 (round 2): unquoted, a
+:: multi-word AGENTMUX_AGENT_ID would split into separate positional args.
+if "%NEED_AUTO_TITLE%"=="1" (
+    if defined ARGS (
+        task dev %ARGS% "TITLE=%AGENTMUX_AGENT_ID%" 2>&1
+    ) else (
+        task dev "TITLE=%AGENTMUX_AGENT_ID%" 2>&1
+    )
+) else (
+    if defined ARGS (
+        task dev %ARGS% 2>&1
+    ) else (
+        task dev 2>&1
+    )
+)

--- a/scripts/dev-agent.cmd
+++ b/scripts/dev-agent.cmd
@@ -45,12 +45,39 @@ set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
 :: any other parallel dev session — this is the common case: an agent runs its
 :: own `task dev` to let the human test a fix, and the human needs to tell
 :: whose window is whose. An explicit TITLE= from the caller always wins.
-set "ARGS=%*"
+::
+:: Detection avoids two traps found by testing against a deliberately
+:: malicious TITLE value (e.g. containing `&`/`>`):
+::   - `echo %ARGS% | findstr` (an earlier version of this fix) put
+::     caller-controlled text unquoted on an external command's line,
+::     letting cmd.exe metacharacters in it execute as separate commands.
+::     Detection below never spawns a command with ARGS-derived text on
+::     its line — only quoted `if` string comparisons, which cmd.exe does
+::     not split on `&`/`|`/etc.
+::   - `for %%A in (%*)` / `%1`..%9` both split tokens on a bare `=`
+::     (not just whitespace — a documented cmd.exe quirk), so a single
+::     `TITLE=value` argument arrives as two separate tokens and a
+::     per-token prefix check silently never matches. Detection instead
+::     runs directly against the whole ARGS string.
+:: `set ARGS=%*` (deliberately no surrounding quotes) preserves whatever
+:: quoting the caller's own arguments already carry; wrapping it in an
+:: extra `"..."` pair (`set "ARGS=%*"`) breaks quote-parity and reopens
+:: the same injection when a caller-quoted value contains its own quotes.
+set ARGS=%*
 set "TITLE_ARG="
-echo %ARGS% | findstr /C:"TITLE=" >nul
-if errorlevel 1 (
-    if not "%AGENTMUX_AGENT_ID%"=="" set "TITLE_ARG=TITLE=%AGENTMUX_AGENT_ID%"
-)
+setlocal enabledelayedexpansion
+set "U=!ARGS!"
+set "U=!U:"=!"
+set "U=!U:t=T!"
+set "U=!U:i=I!"
+set "U=!U:l=L!"
+set "U=!U:e=E!"
+set "HAS_TITLE="
+if "!U:~0,6!"=="TITLE=" set "HAS_TITLE=1"
+if not "!U!"=="!U: TITLE==!" set "HAS_TITLE=1"
+set "NEWTITLE="
+if not defined HAS_TITLE if not "%AGENTMUX_AGENT_ID%"=="" set "NEWTITLE=TITLE=%AGENTMUX_AGENT_ID%"
+endlocal & set "TITLE_ARG=%NEWTITLE%"
 
 :: Call bare `task` (no extension) — this .cmd wrapper itself runs under cmd.exe
 :: (Gap A only applies to bash resolving .cmd files, not to us), so PATHEXT

--- a/scripts/dev-agent.cmd
+++ b/scripts/dev-agent.cmd
@@ -21,6 +21,10 @@
 ::   cmd:  C:\<repo>\scripts\dev-agent.cmd
 ::   or:   C:\<repo>\scripts\dev-agent.cmd TITLE="zoom-fix: PR #1234"
 ::
+:: If TITLE= isn't passed, it defaults to $AGENTMUX_AGENT_ID (the calling
+:: agent's own identity, injected at spawn) so the OS taskbar shows whose
+:: dev window is whose — see specs/SPEC_DEV_WINDOW_TITLE_ARG_2026_06_25.md.
+::
 :: On macOS / Linux `task dev` works directly — this script is Windows-only.
 
 :: Change to the repo root (parent of scripts\) so go-task can find Taskfile.yml.
@@ -34,6 +38,20 @@ set "GIT_BIN=C:\Program Files\Git\bin"
 set "GIT_USR=C:\Program Files\Git\usr\bin"
 set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
 
+:: Default the OS window title to this agent's own identity (AGENTMUX_AGENT_ID,
+:: injected into every agent's shell at spawn — see CLAUDE.md) when the caller
+:: didn't pass an explicit TITLE= override. Without this, every agent-launched
+:: dev window shows as plain "AgentMux" in the taskbar, indistinguishable from
+:: any other parallel dev session — this is the common case: an agent runs its
+:: own `task dev` to let the human test a fix, and the human needs to tell
+:: whose window is whose. An explicit TITLE= from the caller always wins.
+set "ARGS=%*"
+set "TITLE_ARG="
+echo %ARGS% | findstr /C:"TITLE=" >nul
+if errorlevel 1 (
+    if not "%AGENTMUX_AGENT_ID%"=="" set "TITLE_ARG=TITLE=%AGENTMUX_AGENT_ID%"
+)
+
 :: Call bare `task` (no extension) — this .cmd wrapper itself runs under cmd.exe
 :: (Gap A only applies to bash resolving .cmd files, not to us), so PATHEXT
 :: resolution finds task.exe (go install / WinGet) OR task.cmd (npm global
@@ -41,4 +59,4 @@ set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
 :: depends on how `task` was installed on the machine.
 :: Merge stderr into stdout so shell viewers don't color build progress red
 :: (cargo writes all output to stderr, not stdout).
-task dev %* 2>&1
+task dev %ARGS% %TITLE_ARG% 2>&1

--- a/specs/SPEC_DEV_WINDOW_TITLE_ARG_2026_06_25.md
+++ b/specs/SPEC_DEV_WINDOW_TITLE_ARG_2026_06_25.md
@@ -1,7 +1,11 @@
 # Spec: `task dev TITLE="..."` — per-session window title for dev builds
 
 **Date:** 2026-06-25  
-**Status:** Draft  
+**Status:** Implemented (this doc's own design shipped — confirmed by reading
+current `main`: `Taskfile.yml`'s `dev`/`dev:serve` tasks carry `TITLE` →
+`VITE_DEV_TITLE` exactly as designed, and `frontend/app-init.ts` applies it via
+`UpdateObjectMeta` — status was never updated after landing, corrected here).
+See "Addendum" below for a 2026-08-04 follow-up (agent auto-title).  
 **Branch:** `agentx/dev-window-title`  
 **Scope:** `Taskfile.yml` (dev task env), `frontend/app-init.ts`
 
@@ -159,3 +163,28 @@ window keeps whatever name it had before — either the prior dev-title or "Wind
 |---|---|
 | `Taskfile.yml` | Add `TITLE: ''` var + `VITE_DEV_TITLE: '{{.TITLE}}'` env to `dev` / `dev:serve` |
 | `frontend/app-init.ts` | After each `initWaveWrap` call site: read `VITE_DEV_TITLE`, call `UpdateObjectMeta` |
+
+---
+
+## Addendum (2026-08-04): agent auto-title in `dev-agent.cmd`
+
+**Problem:** the design above requires the caller to pass `TITLE="..."` explicitly.
+Agents invoking `task dev` via `scripts/dev-agent.cmd` (the CLAUDE.md-documented
+Windows entry point — see "Launching `task dev` from an agent / MCP Shell" in the
+repo's root `CLAUDE.md`) almost never did, so every agent-launched dev window
+still showed as plain "AgentMux" in the taskbar — indistinguishable from any other
+agent's parallel dev session.
+
+**Fix:** `scripts/dev-agent.cmd` now defaults `TITLE` to the caller's own
+`$AGENTMUX_AGENT_ID` (injected into every agent's shell at spawn) when the caller
+didn't already pass an explicit `TITLE=` argument. An explicit `TITLE=` from the
+caller always wins — this only fills the gap when the argument is absent entirely.
+
+No changes to `Taskfile.yml` or `frontend/app-init.ts` — the existing `TITLE=`
+data flow (see "Design" above) is reused unmodified; only the *caller* of `task dev`
+changed. This keeps the fix scoped to the one place (`dev-agent.cmd`) that agents
+are actually documented to invoke, rather than adding a second default mechanism
+inside the Taskfile itself.
+
+See `scripts/dev-agent.cmd` (top-of-file usage comment and the `TITLE_ARG`
+computation ahead of the final `task dev` invocation) for the implementation.


### PR DESCRIPTION
## Summary
- `scripts/dev-agent.cmd` (the CLAUDE.md-documented Windows entry point agents use to invoke `task dev`) now defaults `TITLE` to the caller's own `$AGENTMUX_AGENT_ID` when no explicit `TITLE=` argument is passed, so the OS taskbar shows whose dev window is whose instead of a generic "AgentMux" for every agent-launched session.
- An explicit `TITLE=` from the caller still always wins — this only fills the gap when it's absent.
- No changes to `Taskfile.yml` or `frontend/app-init.ts` — reuses the existing `TITLE=` → `VITE_DEV_TITLE` → `UpdateObjectMeta` flow from `specs/SPEC_DEV_WINDOW_TITLE_ARG_2026_06_25.md` unmodified; only the caller changed.
- Corrected that spec's stale `Status: Draft` header (the design was already shipped) and added an addendum documenting this follow-up.

## Test plan
- [x] Empirically exercised the batch logic via throwaway `.cmd` files under `cmd.exe`: no explicit TITLE + agent-id set → defaults correctly; explicit TITLE passed → caller's value wins; genuinely-unset agent-id (`env -u AGENTMUX_AGENT_ID`) → no TITLE arg added, `task dev` runs with no override.
- [x] Pure batch script change — no compile step required.

<!-- agentmux:agent_id=agenty -->