### PR TITLE
feat(cron): disambiguate AgentMux vs native scheduling tools, add expiry bound

### DIFF
--- a/.changesets/1785877245-feat-cron-agentmux-native-scheduling-tool-disambiguation-exp-fsjt.md
+++ b/.changesets/1785877245-feat-cron-agentmux-native-scheduling-tool-disambiguation-exp-fsjt.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(cron): AgentMux/native scheduling tool disambiguation + expiry bound

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -1519,7 +1519,7 @@ async fn call_tool(
                 let next = j["next_fire"].as_str().unwrap_or("—");
                 let fires = j["fire_count"].as_i64().unwrap_or(0);
                 let max = j["max_fires"].as_i64().map(|n| format!("/{n}")).unwrap_or_default();
-                let age_bound = j["max_age_secs"].as_i64().map(|n| format!("  expires_in={}s_of_age", n)).unwrap_or_default();
+                let age_bound = j["expires_in_secs"].as_i64().map(|n| format!("  expires_in={n}s")).unwrap_or_default();
                 lines.push(format!(
                     "  {}  {}  [{}]  fires={fires}{max}  next={}  expr='{}'{age_bound}",
                     j["id"].as_str().unwrap_or("?"),

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -238,7 +238,7 @@ const OPEN_MEDIA_TOOL: &str = r#"{
 
 const LOOP_TOOL: &str = r#"{
   "name": "Loop",
-  "description": "Run a prompt or slash command on a recurring interval by re-injecting it into a conversation. AgentMux's analogue of Claude's /loop. Returns immediately with a loop_id; the prompt is injected on a fixed schedule until you call LoopStop(loop_id) or it exhausts max_iterations. Use for polling/babysitting tasks ('check the deploy every 5m', 'keep running /babysit-prs'). Loops stop automatically when the agent pane closes. Do NOT use for one-off tasks — use ScheduleWakeup for that.",
+  "description": "Cross-agent recurring inject: run a prompt or slash command on a recurring interval by injecting it into ANOTHER agent's conversation (or your own, if you explicitly need muxbus-delivered self-messaging). Returns immediately with a loop_id; the prompt is injected on a fixed schedule until you call LoopStop(loop_id) or it exhausts max_iterations. If you're scheduling your OWN future turn (a same-session self-check, no other agent involved) — prefer the native ScheduleWakeup (one-off or adaptive-delay recurring, via re-arming) or native CronCreate (durable, cron-expression) tools instead: they have zero delivery overhead (no cross-agent messaging envelope) and built-in cache-window-aware backoff guidance this tool doesn't have. Use THIS tool only when the target is a different agent, or you specifically need AgentMux-persisted delivery across a restart. Loops stop automatically when the agent pane closes.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -275,7 +275,7 @@ const LOOP_LIST_TOOL: &str = r#"{
 
 const CRON_CREATE_TOOL: &str = r#"{
   "name": "CronCreate",
-  "description": "Create a persistent scheduled cron job that survives agent pane restarts. Fires the prompt on a UTC cron schedule by injecting it into the target agent. Unlike Loop, cron jobs persist as long as agentmux-srv is running. Returns a job id and the next scheduled fire time.",
+  "description": "AgentMux's own cross-agent cron — NOT the same tool as the native (non-mcp__agentmux__-prefixed) CronCreate your harness may also expose, which schedules only your own session's future turn. Use this one specifically to target a DIFFERENT agent (or when you need AgentMux-persisted delivery independent of any single session). Creates a persistent scheduled cron job that survives agent pane restarts. Fires the prompt on a UTC cron schedule by injecting it into the target agent. Unlike Loop, cron jobs persist as long as agentmux-srv is running. Returns a job id and the next scheduled fire time. If you're scheduling your OWN future turn instead, prefer the native CronCreate/ScheduleWakeup tools — no cross-agent envelope overhead.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -283,7 +283,8 @@ const CRON_CREATE_TOOL: &str = r#"{
       "expression": { "type": "string",  "description": "5-field UTC cron expression: 'min hour dom month dow' (e.g. '0 9 * * 1-5' = 9am weekdays). Standard cron syntax; ranges, lists, and step values are supported." },
       "prompt":     { "type": "string",  "description": "The prompt or slash command to inject at each scheduled fire" },
       "to":         { "type": "string",  "description": "Target agent id to inject into. Required." },
-      "max_fires":  { "type": "integer", "description": "Auto-disable after this many fires (the job row stays in DB for audit; use CronDelete to remove it). Omit for unlimited." }
+      "max_fires":  { "type": "integer", "description": "Auto-disable after this many fires (the job row stays in DB for audit; use CronDelete to remove it). Omit for unlimited." },
+      "max_age_secs": { "type": "integer", "description": "Auto-disable this many seconds after creation, regardless of fire count (a hard staleness/stuck-loop bound, matching the spirit of native CronCreate's 7-day auto-expiry). Omit for no expiry — appropriate for genuinely long-running cross-agent automations; set this when babysitting something that should have a natural end (e.g. 'stop checking this PR after 6 hours even if it's still open')." }
     },
     "required": ["name", "expression", "prompt", "to"]
   }
@@ -291,7 +292,7 @@ const CRON_CREATE_TOOL: &str = r#"{
 
 const CRON_DELETE_TOOL: &str = r#"{
   "name": "CronDelete",
-  "description": "Delete a persistent cron job by id. Stops all future fires immediately.",
+  "description": "Delete a persistent AgentMux cross-agent cron job (created via this same mcp__agentmux__ tool family's CronCreate, not the native per-session one) by id. Stops all future fires immediately.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -303,7 +304,7 @@ const CRON_DELETE_TOOL: &str = r#"{
 
 const CRON_LIST_TOOL: &str = r#"{
   "name": "CronList",
-  "description": "List all persistent cron jobs (enabled and disabled). Returns each job's id, name, expression, next fire time, fire count, and enabled state.",
+  "description": "List all persistent AgentMux cross-agent cron jobs (created via this same mcp__agentmux__ tool family, not the native per-session ones). Returns each job's id, name, expression, next fire time, fire count, and enabled state.",
   "inputSchema": {
     "type": "object",
     "properties": {}
@@ -312,7 +313,7 @@ const CRON_LIST_TOOL: &str = r#"{
 
 const CRON_PAUSE_TOOL: &str = r#"{
   "name": "CronPause",
-  "description": "Pause a persistent cron job. The job definition is kept in the DB but no fires occur until CronResume is called.",
+  "description": "Pause a persistent AgentMux cross-agent cron job (this mcp__agentmux__ tool family, not the native per-session one — native cron has no pause/resume, only delete). The job definition is kept in the DB but no fires occur until CronResume is called.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -324,7 +325,7 @@ const CRON_PAUSE_TOOL: &str = r#"{
 
 const CRON_RESUME_TOOL: &str = r#"{
   "name": "CronResume",
-  "description": "Resume a paused cron job. The job will fire at its next scheduled UTC time.",
+  "description": "Resume a paused AgentMux cross-agent cron job (this mcp__agentmux__ tool family). The job will fire at its next scheduled UTC time.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -1453,12 +1454,14 @@ async fn call_tool(
             let target = arguments.get("to").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: to (target agent id)"))?;
             let max_fires = arguments.get("max_fires").and_then(|v| v.as_i64()).filter(|&n| n > 0);
+            let max_age_secs = arguments.get("max_age_secs").and_then(|v| v.as_i64()).filter(|&n| n > 0);
             let self_id = std::env::var("AGENTMUX_AGENT_ID").ok().filter(|s| !s.is_empty()).unwrap_or_default();
 
             let url = format!("{}/agentmux/cron", local_url.trim_end_matches('/'));
             let body = serde_json::json!({
                 "name": name, "expression": expression, "prompt": prompt,
                 "target": target, "created_by": self_id, "max_fires": max_fires,
+                "max_age_secs": max_age_secs,
             });
             let resp = client.post(&url).header("X-AuthKey", auth_key).json(&body).send().await
                 .map_err(|e| anyhow::anyhow!("cron create request failed: {e}"))?;
@@ -1516,8 +1519,9 @@ async fn call_tool(
                 let next = j["next_fire"].as_str().unwrap_or("—");
                 let fires = j["fire_count"].as_i64().unwrap_or(0);
                 let max = j["max_fires"].as_i64().map(|n| format!("/{n}")).unwrap_or_default();
+                let age_bound = j["max_age_secs"].as_i64().map(|n| format!("  expires_in={}s_of_age", n)).unwrap_or_default();
                 lines.push(format!(
-                    "  {}  {}  [{}]  fires={fires}{max}  next={}  expr='{}'",
+                    "  {}  {}  [{}]  fires={fires}{max}  next={}  expr='{}'{age_bound}",
                     j["id"].as_str().unwrap_or("?"),
                     j["name"].as_str().unwrap_or("?"),
                     status_str,

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -132,6 +132,8 @@ impl CronScheduler {
         let job_prompt = job.prompt.clone();
         let job_target = job.target.clone();
         let job_max_fires = job.max_fires;
+        let job_created_at = job.created_at;
+        let job_max_age_secs = job.max_age_secs;
 
         let handle = tokio::spawn(async move {
             // `initial_fires` is seeded from the persisted fire_count (plus 1
@@ -142,7 +144,10 @@ impl CronScheduler {
                 // Guard at top of loop: if fires was seeded at or above max_fires
                 // (e.g. a catch-up fire brought the persisted count to the cap),
                 // don't fire again before sleeping — this prevents one extra fire
-                // on restart when the catch-up itself hits the limit.
+                // on restart when the catch-up itself hits the limit. Age is
+                // checked the same way (Phase 0, SPEC_AGENT_POLLING_AND_WAKEUP_
+                // HARDENING_2026_08_04.md) — a job created before max_age_secs
+                // existed has max_age_secs = None and is never expired by this.
                 if let Some(max) = job_max_fires {
                     if fires >= max {
                         tracing::info!(id = %job_id, fires, "cron: max_fires reached — disabling job");
@@ -153,6 +158,15 @@ impl CronScheduler {
                         sched.publish_changed();
                         break;
                     }
+                }
+                if is_expired_by_age(job_created_at, job_max_age_secs, Utc::now().timestamp()) {
+                    tracing::info!(id = %job_id, "cron: max_age_secs reached — disabling job");
+                    if let Some(store) = &sched.shared_store {
+                        let _ = store.cron_set_enabled(&job_id, false);
+                    }
+                    sched.handles.lock().unwrap().remove(&job_id);
+                    sched.publish_changed();
+                    break;
                 }
                 let next = match schedule.upcoming(Utc).next() {
                     Some(t) => t,
@@ -249,5 +263,43 @@ fn should_catchup(job: &CronJob, now_dt: DateTime<Utc>) -> bool {
     match schedule.after(&last_dt).next() {
         Some(next_after_last) => next_after_last < now_dt,
         None => false,
+    }
+}
+
+/// True when a job's hard age-expiry bound (`max_age_secs`, seconds since
+/// `created_at`) has been reached. `None` = no bound, never expires by age
+/// (the default for every job created before this field existed, and for
+/// any job that explicitly opts out). See
+/// docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md Phase 0.
+fn is_expired_by_age(created_at: i64, max_age_secs: Option<i64>, now: i64) -> bool {
+    match max_age_secs {
+        Some(max_age) => now - created_at >= max_age,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_expired_by_age_none_never_expires() {
+        assert!(!is_expired_by_age(1_000, None, 1_000_000_000));
+    }
+
+    #[test]
+    fn is_expired_by_age_before_bound_is_not_expired() {
+        assert!(!is_expired_by_age(1_000, Some(3_600), 1_000 + 3_599));
+    }
+
+    #[test]
+    fn is_expired_by_age_at_bound_is_expired() {
+        // >= at the boundary, matching the max_fires check's own >= semantics.
+        assert!(is_expired_by_age(1_000, Some(3_600), 1_000 + 3_600));
+    }
+
+    #[test]
+    fn is_expired_by_age_past_bound_is_expired() {
+        assert!(is_expired_by_age(1_000, Some(3_600), 1_000 + 10_000));
     }
 }

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -150,28 +150,31 @@ impl CronScheduler {
                 // existed has max_age_secs = None and is never expired by this.
                 if let Some(max) = job_max_fires {
                     if fires >= max {
-                        tracing::info!(id = %job_id, fires, "cron: max_fires reached — disabling job");
-                        if let Some(store) = &sched.shared_store {
-                            let _ = store.cron_set_enabled(&job_id, false);
-                        }
-                        sched.handles.lock().unwrap().remove(&job_id);
-                        sched.publish_changed();
+                        sched.disable_job(&job_id, "max_fires reached");
                         break;
                     }
                 }
                 if is_expired_by_age(job_created_at, job_max_age_secs, Utc::now().timestamp()) {
-                    tracing::info!(id = %job_id, "cron: max_age_secs reached — disabling job");
-                    if let Some(store) = &sched.shared_store {
-                        let _ = store.cron_set_enabled(&job_id, false);
-                    }
-                    sched.handles.lock().unwrap().remove(&job_id);
-                    sched.publish_changed();
+                    sched.disable_job(&job_id, "max_age_secs reached");
                     break;
                 }
                 let next = match schedule.upcoming(Utc).next() {
                     Some(t) => t,
                     None => break,
                 };
+                // Reviewer-caught gap (P1, PR #2418): checking age only in "now"
+                // terms at the top of the loop lets one extra fire slip through
+                // when the cron interval is longer than the remaining time to
+                // expiry — the loop would sleep straight past the expiry bound
+                // and fire anyway, only catching it on the *next* iteration.
+                // Check whether the fire we're about to sleep for would itself
+                // land at/after expiry, and skip it (disable now, don't sleep)
+                // if so — the "hard expiry bound, regardless of fire count"
+                // guarantee has to hold at fire time, not just at loop-top time.
+                if is_expired_by_age(job_created_at, job_max_age_secs, next.timestamp()) {
+                    sched.disable_job(&job_id, "max_age_secs would be reached before the next scheduled fire");
+                    break;
+                }
                 let delay = (next - Utc::now()).to_std().unwrap_or_default();
                 tokio::time::sleep(delay).await;
                 sched.fire(&job_id, &job_prompt, &job_target).await;
@@ -181,12 +184,7 @@ impl CronScheduler {
                 // normal live-run case.
                 if let Some(max) = job_max_fires {
                     if fires >= max {
-                        tracing::info!(id = %job_id, fires, "cron: max_fires reached — disabling job");
-                        if let Some(store) = &sched.shared_store {
-                            let _ = store.cron_set_enabled(&job_id, false);
-                        }
-                        sched.handles.lock().unwrap().remove(&job_id);
-                        sched.publish_changed();
+                        sched.disable_job(&job_id, "max_fires reached");
                         break;
                     }
                 }
@@ -201,6 +199,20 @@ impl CronScheduler {
         if let Some(handle) = self.handles.lock().unwrap().remove(id) {
             handle.abort();
         }
+    }
+
+    /// Disable a job in the DB (audit trail preserved, unlike delete), drop
+    /// its live task handle, and notify listeners. Shared by every
+    /// self-disabling reason a scheduled job's own loop hits (max_fires,
+    /// max_age_secs) — extracted so those call sites don't each repeat the
+    /// same three-step disable sequence.
+    fn disable_job(&self, job_id: &str, reason: &str) {
+        tracing::info!(id = job_id, reason, "cron: disabling job");
+        if let Some(store) = &self.shared_store {
+            let _ = store.cron_set_enabled(job_id, false);
+        }
+        self.handles.lock().unwrap().remove(job_id);
+        self.publish_changed();
     }
 
     /// Fire a cron job: POST to reactive inject and record the fire in DB.
@@ -301,5 +313,22 @@ mod tests {
     #[test]
     fn is_expired_by_age_past_bound_is_expired() {
         assert!(is_expired_by_age(1_000, Some(3_600), 1_000 + 10_000));
+    }
+
+    /// Regression test for PR #2418's P1 review finding: the scheduler now
+    /// calls this same function with the *next scheduled fire's* timestamp,
+    /// not just "now", to decide whether to skip a fire that would land past
+    /// expiry rather than sleeping through the bound and firing anyway. A
+    /// job created 1000s ago with a 3600s bound, checked against a `next`
+    /// fire time far past that bound (e.g. a daily cron job's next fire is
+    /// hours away), must report expired — this is exactly the "would this
+    /// fire itself violate the hard expiry bound" check the loop performs
+    /// before deciding whether to sleep at all.
+    #[test]
+    fn is_expired_by_age_catches_a_next_fire_time_past_the_bound() {
+        let created_at = 1_000;
+        let max_age_secs = Some(3_600);
+        let next_fire_far_in_the_future = created_at + 86_400; // 24h away
+        assert!(is_expired_by_age(created_at, max_age_secs, next_fire_far_in_the_future));
     }
 }

--- a/agentmux-srv/src/backend/storage/cron.rs
+++ b/agentmux-srv/src/backend/storage/cron.rs
@@ -26,6 +26,11 @@ pub struct CronJob {
     /// `None` = unlimited.
     pub max_fires: Option<i64>,
     pub created_at: i64,
+    /// Hard expiry bound in seconds since `created_at`. `None` = no expiry
+    /// (the default — existing jobs created before this field are
+    /// unaffected). See
+    /// docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md Phase 0.
+    pub max_age_secs: Option<i64>,
 }
 
 impl Store {
@@ -34,8 +39,8 @@ impl Store {
         conn.execute(
             "INSERT INTO db_cron_jobs
                 (id, name, expression, prompt, target, created_by, enabled,
-                 last_fired, fire_count, max_fires, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                 last_fired, fire_count, max_fires, created_at, max_age_secs)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 job.id,
                 job.name,
@@ -48,6 +53,7 @@ impl Store {
                 job.fire_count,
                 job.max_fires,
                 job.created_at,
+                job.max_age_secs,
             ],
         )?;
         Ok(())
@@ -57,7 +63,7 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, expression, prompt, target, created_by, enabled,
-                    last_fired, fire_count, max_fires, created_at
+                    last_fired, fire_count, max_fires, created_at, max_age_secs
              FROM db_cron_jobs ORDER BY created_at ASC",
         )?;
         let iter = stmt.query_map([], map_row)?;
@@ -68,7 +74,7 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, expression, prompt, target, created_by, enabled,
-                    last_fired, fire_count, max_fires, created_at
+                    last_fired, fire_count, max_fires, created_at, max_age_secs
              FROM db_cron_jobs WHERE enabled = 1 ORDER BY created_at ASC",
         )?;
         let iter = stmt.query_map([], map_row)?;
@@ -79,7 +85,7 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, expression, prompt, target, created_by, enabled,
-                    last_fired, fire_count, max_fires, created_at
+                    last_fired, fire_count, max_fires, created_at, max_age_secs
              FROM db_cron_jobs WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], map_row)?;
@@ -123,16 +129,17 @@ impl Store {
 
 fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     Ok(CronJob {
-        id:          row.get(0)?,
-        name:        row.get(1)?,
-        expression:  row.get(2)?,
-        prompt:      row.get(3)?,
-        target:      row.get(4)?,
-        created_by:  row.get(5)?,
-        enabled:     row.get::<_, i64>(6)? != 0,
-        last_fired:  row.get(7)?,
-        fire_count:  row.get(8)?,
-        max_fires:   row.get(9)?,
-        created_at:  row.get(10)?,
+        id:            row.get(0)?,
+        name:          row.get(1)?,
+        expression:    row.get(2)?,
+        prompt:        row.get(3)?,
+        target:        row.get(4)?,
+        created_by:    row.get(5)?,
+        enabled:       row.get::<_, i64>(6)? != 0,
+        last_fired:    row.get(7)?,
+        fire_count:    row.get(8)?,
+        max_fires:     row.get(9)?,
+        created_at:    row.get(10)?,
+        max_age_secs:  row.get(11)?,
     })
 }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -35,7 +35,11 @@ use super::error::StoreError;
 ///        (see agentmux-cloud's PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md)
 ///        instead of the single shared per-account MUXBUS_TOKEN for every
 ///        /reactive/* call.
-pub const SHARED_STORE_SCHEMA_VERSION: i64 = 4;
+///   v5 — db_cron_jobs.max_age_secs: optional hard expiry bound (seconds since
+///        created_at) alongside the existing max_fires bound. NULL = no expiry
+///        (existing rows unaffected). See
+///        docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md Phase 0.
+pub const SHARED_STORE_SCHEMA_VERSION: i64 = 5;
 
 /// `user_version` value stamped into `objects.db` after `run_object_schema`.
 /// The flat schema reset the counter to 1 (the pre-flatten chain never set
@@ -746,17 +750,18 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
         );
 
         CREATE TABLE IF NOT EXISTS db_cron_jobs (
-            id          TEXT PRIMARY KEY,
-            name        TEXT NOT NULL,
-            expression  TEXT NOT NULL,
-            prompt      TEXT NOT NULL,
-            target      TEXT NOT NULL,
-            created_by  TEXT NOT NULL DEFAULT '',
-            enabled     INTEGER NOT NULL DEFAULT 1,
-            last_fired  INTEGER,
-            fire_count  INTEGER NOT NULL DEFAULT 0,
-            max_fires   INTEGER,
-            created_at  INTEGER NOT NULL DEFAULT 0
+            id            TEXT PRIMARY KEY,
+            name          TEXT NOT NULL,
+            expression    TEXT NOT NULL,
+            prompt        TEXT NOT NULL,
+            target        TEXT NOT NULL,
+            created_by    TEXT NOT NULL DEFAULT '',
+            enabled       INTEGER NOT NULL DEFAULT 1,
+            last_fired    INTEGER,
+            fire_count    INTEGER NOT NULL DEFAULT 0,
+            max_fires     INTEGER,
+            created_at    INTEGER NOT NULL DEFAULT 0,
+            max_age_secs  INTEGER
         );
         CREATE INDEX IF NOT EXISTS idx_ss_cron_jobs_enabled
             ON db_cron_jobs(enabled);
@@ -784,6 +789,27 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
             (id, name, description, is_blank, created_at, updated_at)
          VALUES ('blank', '__blank__', 'Vanilla CLI — no instructions, no context', 1, 0, 0);",
     )?;
+
+    // ---- Additive column migrations (schema v5+) ----
+    // Same idempotent pattern as run_object_schema's ALTER-TABLE loop below:
+    // the flat CREATE batch above covers fresh DBs; these carry an existing
+    // shared store forward. "duplicate column" is swallowed so this is safe
+    // to run on every startup regardless of whether the column already exists.
+    //
+    // v5: db_cron_jobs.max_age_secs — optional hard expiry bound (seconds
+    //     since created_at), alongside the existing max_fires bound. NULL
+    //     for all existing rows = no behavior change for jobs created before
+    //     this column existed.
+    for stmt in &[
+        "ALTER TABLE db_cron_jobs ADD COLUMN max_age_secs INTEGER",
+    ] {
+        if let Err(e) = conn.execute_batch(stmt) {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column") {
+                return Err(e.into());
+            }
+        }
+    }
 
     Ok(())
 }

--- a/agentmux-srv/src/server/cron.rs
+++ b/agentmux-srv/src/server/cron.rs
@@ -62,6 +62,13 @@ pub struct CronJobView {
     pub max_fires: Option<i64>,
     pub created_at: i64,
     pub max_age_secs: Option<i64>,
+    /// Seconds remaining before `max_age_secs` expiry, computed server-side
+    /// (clamped to 0, never negative) so callers don't need their own clock/
+    /// date-math to display something meaningful — `None` when there's no
+    /// `max_age_secs` bound. Fixes a review finding on the first cut of this
+    /// field: the MCP CLI was printing the raw `max_age_secs` bound under an
+    /// "expires_in" label, which is only correct at the instant of creation.
+    pub expires_in_secs: Option<i64>,
     /// ISO-8601 string of the next scheduled fire (UTC), or null if disabled.
     pub next_fire: Option<String>,
 }
@@ -72,6 +79,10 @@ fn to_view(job: &CronJob) -> CronJobView {
     } else {
         None
     };
+    let expires_in_secs = job.max_age_secs.map(|max_age| {
+        let elapsed = Utc::now().timestamp() - job.created_at;
+        (max_age - elapsed).max(0)
+    });
     CronJobView {
         id: job.id.clone(),
         name: job.name.clone(),
@@ -83,6 +94,7 @@ fn to_view(job: &CronJob) -> CronJobView {
         fire_count: job.fire_count,
         max_fires: job.max_fires,
         created_at: job.created_at,
+        expires_in_secs,
         max_age_secs: job.max_age_secs,
         next_fire,
     }

--- a/agentmux-srv/src/server/cron.rs
+++ b/agentmux-srv/src/server/cron.rs
@@ -35,6 +35,12 @@ pub struct CronCreateRequest {
     #[serde(default)]
     pub created_by: String,
     pub max_fires: Option<i64>,
+    /// Hard expiry bound in seconds since creation. Optional — omit for no
+    /// expiry (matching native CronCreate's 7-day default is a caller
+    /// choice, not enforced here; AgentMux's cross-agent jobs are often
+    /// meant to run indefinitely, e.g. a recurring standup check).
+    #[serde(default)]
+    pub max_age_secs: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,6 +61,7 @@ pub struct CronJobView {
     pub fire_count: i64,
     pub max_fires: Option<i64>,
     pub created_at: i64,
+    pub max_age_secs: Option<i64>,
     /// ISO-8601 string of the next scheduled fire (UTC), or null if disabled.
     pub next_fire: Option<String>,
 }
@@ -76,6 +83,7 @@ fn to_view(job: &CronJob) -> CronJobView {
         fire_count: job.fire_count,
         max_fires: job.max_fires,
         created_at: job.created_at,
+        max_age_secs: job.max_age_secs,
         next_fire,
     }
 }
@@ -170,6 +178,7 @@ pub(super) async fn handle_cron_create(
         fire_count: 0,
         max_fires: req.max_fires,
         created_at: Utc::now().timestamp(),
+        max_age_secs: req.max_age_secs,
     };
 
     if let Err(e) = store.cron_create(&job) {
@@ -273,6 +282,7 @@ mod tests {
             fire_count,
             max_fires,
             created_at: 1_699_000_000,
+            max_age_secs: None,
         }
     }
 

--- a/docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md
+++ b/docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md
@@ -1,0 +1,150 @@
+# Agent Recurring-Task / Polling Primitives — Design Hardening
+**Date:** 2026-08-04
+**Status:** Phase 0 implemented (same-day follow-up PR) — Phases 1-2 still proposed, not started.
+**Scope:** `agentmux-mcp` (`Loop` tool), `agentmux-srv` (`Cron`, `/agentmux/reactive/inject`, `wrap_jekt_message`)
+**Trigger:** Live use of `mcp__agentmux__Loop` this session to babysit a GitHub PR's review status (poll every 1m, react when approved+mergeable). Concretely: ~20+ fires, most reporting "no change," each one arriving as a full agent-to-agent JEKT message with the complete envelope overhead; no way to express "wake me only when the review state changes" declaratively; no automatic detection of the ~26-consecutive-unchanged-checks stretch that made the loop unproductive; the human directly observed and flagged this as "poorly designed" in the moment.
+
+**Correction, and the actual point of this doc (2026-08-04, same day):** the first draft of this doc concluded `ScheduleWakeup` doesn't exist and proposed AgentMux build a `PollCondition`/backoff/circuit-breaker system from scratch to fix the pain points above. **Both are wrong in the same way** — the research only looked inside the `agentmux` repo. `ScheduleWakeup` is real: it's a **harness-native, top-level Claude Code tool** (not `mcp__agentmux__`-prefixed), and so are native `CronCreate`/`CronList`/`CronDelete`. Pulled their actual schemas directly: **native `ScheduleWakeup` already has essentially everything Part 3 of the first draft proposed building** — cache-window-aware backoff guidance, zero delivery overhead (it's the harness re-invoking its own session, not a message to anyone), explicit guidance against polling harness-tracked work, and a `reason` field for transparency. Native `CronCreate` already has jitter guidance, a `durable` flag (session vs. persisted — the exact Loop-vs-Cron split, unified into one tool), and 7-day auto-expiry (a form of stuck-loop bound). **The right fix isn't reimplementing this in AgentMux — it's using what already exists and stopping AgentMux's own `Loop`/`Cron` from shadowing it under near-identical names.** This is also, in retrospect, the direct answer to why this session's `Loop`-based PR-babysitting was the wrong tool choice: it was a same-session, self-scheduling, externally-tracked-state-polling task — exactly `ScheduleWakeup`'s stated use case — routed instead through AgentMux's cross-agent messaging pipeline. The rest of this doc is rewritten around that correction. See §1.9 for the concrete comparison and Part 2 for the resulting direction: **align with, and delegate to, native harness primitives (1:1) rather than build parallel ones.**
+
+---
+
+## TL;DR
+
+- `Loop`, `Cron`, and `SendMessage` are not three delivery mechanisms — they're three schedulers sitting on **one shared delivery primitive** (`POST /agentmux/reactive/inject` → `wrap_jekt_message`), and every single fire of any of them pays the same fixed ~600-650 byte / ~150 token JEKT envelope cost, **even for a self-loop with nothing to report.**
+- **Claude Code already ships native `ScheduleWakeup` and `CronCreate`/`CronList`/`CronDelete` tools that solve the self-scheduling case AgentMux's `Loop`/`Cron` also try to solve — with better-designed backoff, jitter, durability, and expiry semantics than AgentMux built.** AgentMux's versions exist under the *same names* (`CronCreate` vs. `mcp__agentmux__CronCreate`), which is exactly the confusion a prior draft spec already flagged and never resolved.
+- There is **no server-side condition evaluation** in AgentMux's own `Loop`/`Cron` — every "check and react" cycle costs a full LLM turn. Native `ScheduleWakeup` sidesteps this differently (and arguably better): it doesn't poll at all when the harness can already track completion, and hands the model explicit guidance for picking a sane delay when it must poll externally-tracked state.
+- **No backoff, no stuck-loop detection in AgentMux's own primitives.** Both were explicitly proposed in a prior draft spec (`SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md`, Phase P2/P3) and never implemented — a documented plan stalling after partial adoption, same pattern found twice elsewhere this session (migration markers, docs staleness). Native `ScheduleWakeup`/`CronCreate` already have both, unprompted.
+- `wait_for_idle`, the one field in AgentMux's own delivery path that could have carried "wait for a quiet moment" semantics, is dead — three separate prior specs already independently confirm srv never reads it.
+
+---
+
+## Part 1 — Current state (verified against source, not the tool descriptions)
+
+### 1.1 One delivery primitive, three schedulers
+
+- `Loop` lives entirely client-side in `agentmux-mcp/src/main.rs` — a per-`Loop()` call `tokio::spawn` task in an in-process `HashMap<loop_id, LoopEntry>` that dies with the agent pane (`main.rs:42-55, 1348-1372`). Deliberately srv-free by design (`docs/specs/SPEC_MCP_LOOP_TOOL_2026_06_16.md`: *"a loop has no state beyond 'fire the inject on a timer'... would mean new endpoints + an AppState registry + scheduler tasks for a feature that is purely a timer"*).
+- `Cron` lives server-side (`agentmux-srv/src/backend/cron/mod.rs`, `backend/storage/cron.rs`) — persisted SQLite rows, one `tokio` task per enabled job, computed via the `cron` crate, survives srv restarts (unlike `Loop`, which dies with the pane).
+- Both — and `SendMessage` — construct the identical `InjectRequest` and `POST` it to the identical `/agentmux/reactive/inject` endpoint (`agentmux-mcp/src/main.rs:1338` for Loop, `backend/cron/mod.rs:193-216` for Cron, `main.rs:985-993` for SendMessage — the request shape is byte-for-byte the same). Server-side this becomes one call: `Handler::inject_message` (`agentmux-srv/src/backend/reactive/handler.rs:192`).
+- **There is no branch anywhere for `source_agent == target_agent`.** A self-loop is, to the delivery code, indistinguishable from one agent messaging a different agent.
+
+### 1.2 Every fire pays the full JEKT envelope, unconditionally
+
+`wrap_jekt_message` (`agentmux-srv/src/backend/reactive/sanitize.rs:197-230`) is called exactly once, unconditionally, on every inject (`handler.rs:276` — the only call site in the codebase):
+
+```rust
+let structured_tag = format!(
+    "[JEKT:FROM={from} TO={target_agent} TIER={effective_tier} DELIVERY={delivery_tier} \
+     TRUST={trust} MSGID={msg_id} PRIORITY={priority} TS={ts_secs}]"
+);
+format!(
+    "{structured_tag}\n{sep}\nFrom: {from} | To: {target_agent} | ts={ts_secs}{warn}\n{msg}\n{sep}\n{hint}\n[/JEKT]"
+)
+```
+
+Measured directly: the two box-drawing separator lines are 180 bytes each in UTF-8 (multi-byte `─`, not ASCII), the structured tag runs ~150-160 bytes — **~600-650 bytes / ~150 tokens of fixed overhead per fire**, before the actual prompt content. For a 1-minute babysitting loop, that's ~150 tokens spent on envelope alone every 60 seconds, whether or not anything changed.
+
+The human-facing UI *does* mitigate this — `JektBubble.tsx` collapses jekt messages to a one-line summary by default. **But this is a frontend rendering trick applied after the fact**; it doesn't reduce what the agent's own context actually receives. The expensive resource (LLM context) pays the full cost every time; only the cheap resource (a human's scrollback) is protected.
+
+### 1.3 No declarative "poll until X" — condition logic lives in re-derived prose
+
+Every fire re-injects the *same static prompt text*, and the condition-check + branching logic ("if approved and mergeable, merge and stop; if changed, investigate; if unchanged, one-line status") has to be written into that prompt as instructions and re-parsed by the model from scratch on every single fire. There is no way to say, declaratively, "poll this until condition X holds" — the tool has no concept of a condition at all, only "re-inject this text on a timer."
+
+### 1.4 No backoff
+
+Both `Loop` (fixed `interval: String` parsed once) and `Cron` (fixed cron expression) fire on a strictly regular schedule for their entire lifetime. No linear/exponential backoff, no jitter, no adaptive slow-down when nothing has changed for a while.
+
+### 1.5 `wait_for_idle` is dead scaffolding
+
+`InjectRequest.wait_for_idle: bool` (`reactive/types.rs:47`) is hardcoded `false` at every call site across the codebase and never read by `Handler::inject_message`. Confirmed dead independently by three prior specs' own words (`SPEC_MCP_LOOP_TOOL_2026_06_16.md`, `SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md`, `SPEC_INJECT_AT_TOOL_BOUNDARY_2026_06_16.md`) — the one field that could plausibly have carried "don't wake the agent mid-turn" or "wait for a quiet window" semantics has been inert since it was added.
+
+### 1.6 Stuck-loop detection: proposed, never built
+
+`SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md` §3.1.4 (Phase P3) proposed hashing the last N injected prompts and circuit-breaking on repeats. No hash tracking, no circuit breaker, exists anywhere in `agentmux-mcp` or `agentmux-srv` today. This session hit exactly the gap that proposal was meant to close: ~26 consecutive unchanged checks with no automatic signal, requiring a human to notice and ask whether to pause, and then me stopping the loop manually.
+
+### 1.7 `ScheduleWakeup` is real — it's a harness-native tool, not an AgentMux one (correction from first draft)
+
+`Loop`'s own shipped description says *"Do NOT use for one-off tasks — use ScheduleWakeup for that"* — and this is **correct advice, not a dangling reference.** `ScheduleWakeup` is a top-level Claude Code tool (not routed through `mcp__agentmux__` MCP calls at all), confirmed live by fetching its actual schema. It genuinely does not exist inside the `agentmux` *repo* — grepping the repo for it finds nothing, and the AgentMux MCP tool-list test (`agentmux-mcp/src/main.rs:1841`, 27 tools enumerated) correctly doesn't include it, **because it isn't AgentMux's to implement.** The first draft of this doc searched only the repo and concluded it was missing; that was the wrong scope for the question. `Loop`'s description was already pointing agents at the right tool for the one-off case — it just doesn't say so clearly enough to stop an agent (this one, this session) from reaching for AgentMux's `Loop` for a same-session recurring self-check instead, where native `ScheduleWakeup`'s re-arm-by-resubmitting-the-prompt pattern (see §1.9) covers that case too.
+
+### 1.8 This has partial prior art, and it already stalled once
+
+`SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md` is a real, already-written analysis of Loop/Cron gaps — some of its recommendations shipped (`LoopList`, `max_iterations`), several explicitly didn't (idle-aware firing "deferred to follow-up," stuck-loop detection never built). This is the same pattern independently found twice already this session in unrelated subsystems (migration markers, docs staleness): **a documented plan, partially executed, with no mechanism forcing the rest to land.** Any fix proposed here should account for that pattern rather than just add a fourth spec to the pile.
+
+**That same doc already named the exact problem this rewrite is about, in one sentence, and it was never acted on:** *"The confusion: Claude Code CLI exposes its own `CronCreate`/`CronList`/`CronDelete` tools... but these are ephemeral... and are not persisted by AgentMux's server."* That's the name collision in §1.9 below, flagged in this repo's own docs over a month before this session re-discovered it the hard way.
+
+### 1.9 Native harness primitives already solve most of what §1.1-1.6 are missing
+
+Direct schema comparison, native (top-level, Claude Code) vs. AgentMux (`mcp__agentmux__`-prefixed):
+
+| Capability | AgentMux `Loop`/`Cron` | Native `ScheduleWakeup`/`CronCreate` |
+|---|---|---|
+| Backoff / adaptive delay | None (§1.4) | Explicit cache-window-aware guidance baked into the tool description itself (60-270s stays in the 5-min prompt-cache TTL; 300s+ commits to a longer wait; "don't pick 300s, it's worst-of-both") |
+| Delivery cost for a self-wakeup | Full JEKT envelope via muxbus, every fire (§1.2) — ~150 tokens fixed overhead | **Zero** — it's the harness re-invoking its own session; there is no message, no envelope, nothing to parse |
+| Guidance against wasteful polling | None — a `Loop` will happily poll something the platform already tracks | Explicit: *"Do NOT schedule a short-interval wakeup to poll for background work you started — when harness-tracked work finishes, you are re-invoked automatically"* |
+| Durable vs. session-only | Two separate tool families (`Loop` = session-only, `Cron` = persisted) | One tool, one `durable: bool` flag |
+| One-shot vs. recurring | `Loop` = recurring only, `CronCreate` (AgentMux) = both via `max_fires` | One tool, one `recurring: bool` flag |
+| Stuck-loop bound | None (§1.6) | 7-day auto-expiry on recurring native cron jobs; `ScheduleWakeup`-chained loops end whenever the agent stops re-arming them (no infinite-fire failure mode by construction) |
+| Stampede avoidance | None | Explicit jitter guidance ("avoid :00 and :30 minute marks... every user who asks for 9am gets `0 9`... which means requests from across the planet land on the API at the same instant") + scheduler-level deterministic jitter |
+| Transparency to the human | Collapsed JEKT bubble, opaque reasoning | `reason` field, shown directly to the user: *"watching CI run" beats "waiting"* |
+
+**This is not a close call.** Native `ScheduleWakeup`/`CronCreate` are more thoughtfully designed than what AgentMux built, for the specific case of an agent scheduling its own future turn. AgentMux's `Loop`/`Cron` add exactly one thing native tools can't do: **target a different agent, or persist/deliver across whatever CLI/provider that other agent runs** (native `CronCreate` schedules *this* Claude Code session's own future prompt; it has no concept of "some other agent, possibly running Codex or Gemini, elsewhere"). That cross-agent/cross-provider case is real and AgentMux is right to have a mechanism for it — but it's a narrower case than "any recurring check," and it's not what this session's self-loop needed.
+
+---
+
+## Part 2 — Goals / non-goals
+
+**Primary goal (per explicit direction, 2026-08-04): keep AgentMux's scheduling primitives 1:1 with what Claude Code has already built in, rather than re-deriving parallel design decisions AgentMux is worse-positioned to get right.** Concretely, that means:
+
+- **For same-agent, same-session self-scheduling (the case this session actually needed): stop routing it through `mcp__agentmux__Loop`/`Cron` at all.** Use native `ScheduleWakeup` (one-off or self-re-arming recurring) or native `CronCreate` (durable, cron-expression-based) directly — they already have the backoff, jitter, durability, and expiry semantics AgentMux would otherwise have to reinvent to match (§1.9).
+- **Resolve the name collision.** `mcp__agentmux__CronCreate` and native `CronCreate` coexisting under the same bare name (disambiguated only by MCP prefix, which is easy to miss — this session almost certainly would have grabbed the wrong one without careful checking) was flagged in `SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md` over a month ago and never fixed. Either rename AgentMux's tools to be unambiguous at a glance (e.g. `AgentMuxCron*`/`CrossAgentLoop`) or make each tool's description explicitly cross-reference the other so an agent picks correctly without needing to already know both exist.
+- **Scope AgentMux's own `Loop`/`Cron` down to what native tools genuinely can't do**: targeting a *different* agent, and working across whatever CLI/provider that agent runs (native scheduling is inherently single-session/single-provider). Stop treating them as a general-purpose "recurring task" primitive for every case, including the self-loop case they were never the best fit for.
+- Where AgentMux's own primitives remain the right tool (the cross-agent case), still borrow the *design*, not just the delivery mechanism: backoff guidance, jitter, a durability flag instead of two separate tool families, and a stuck/expiry bound — because these are good ideas regardless of which tool implements them, and native `ScheduleWakeup`/`CronCreate` already prove them out.
+- Fix `Loop`'s description to state the self-loop-vs-cross-agent distinction explicitly, rather than relying on an agent to infer it (this session didn't).
+
+**Non-goals:**
+- Not building a bespoke `PollCondition`/server-side-condition-evaluation system in AgentMux (this was the first draft's Part 3 — retired by this rewrite). If a genuinely AgentMux-specific cross-agent polling need turns out to require it later, revisit then; don't build it speculatively to match a native capability that already exists for the case actually observed this session.
+- Not building a general workflow/DAG engine — `agentmux-srv/src/drone/executor/blocks/condition.rs` already exists for that in the separate Drone subsystem, orthogonal to this doc.
+- Not redesigning JEKT envelope semantics for genuine cross-agent messaging — that delivery path is correct for what it's actually for (a different agent, possibly a different provider); the issue was only ever using it for same-agent wakeups.
+
+---
+
+## Part 3 — Proposed direction
+
+### Self-loop case: delegate, don't build
+
+For an agent scheduling its *own* future turn (recurring self-checks, one-off reminders, babysitting external state like a CI run or a PR) — the exact shape of this session's actual need — the answer is: **use native `ScheduleWakeup`/`CronCreate` directly.** No AgentMux engineering work is required for this case; it already works today, better than what a from-scratch AgentMux implementation would likely produce on a first pass. The work here is *documentation and habit*, not code:
+- Update `mcp__agentmux__Loop`'s own description to say explicitly: *"For a same-session self-check (no other agent involved), prefer native `ScheduleWakeup` (one-off/adaptive) or `CronCreate` (durable/cron-expression) — they have no delivery overhead and built-in backoff guidance. Use this tool only when the target is a different agent."*
+- Same clarifying cross-reference the other direction isn't needed (native tools don't know AgentMux exists, appropriately — they're host-level primitives).
+
+### Cross-agent case: keep AgentMux's own primitives, but align their design with native ones
+
+`mcp__agentmux__Loop`/`Cron` remain necessary for their actual differentiator — targeting another agent, potentially on a different CLI/provider, via the muxbus delivery path (`wrap_jekt_message` → PTY/structured-stdin). That's legitimate and native tools can't do it. But their *design* should borrow from §1.9 rather than staying as-is:
+- **Durability as one flag, not two tool families.** Fold `Loop` and `Cron` into one primitive with a `durable: bool` (matching native `CronCreate`'s shape exactly), rather than maintaining two separately-evolving implementations that have already started drifting (`LoopList`/`max_iterations` exist for `Loop`; `Cron` has no equivalent).
+- **Backoff and jitter guidance**, adapted for the cross-agent case (the cache-window math is Claude-session-specific and won't directly translate, but "don't let every stampede land on the same instant" and "slow down once nothing's changing" both do).
+- **An expiry/stuck bound**, matching native `CronCreate`'s 7-day auto-expiry — AgentMux's own primitives currently have no equivalent (§1.6).
+- Rename to resolve the collision from §1.9/§1.8 — an agent should not need to already know two tools of the same name exist and pick the MCP-prefixed one correctly by instinct, which is what this session actually had to do.
+
+### What's explicitly *not* being built
+
+The first draft's `PollCondition` (server-side declarative condition evaluation with zero-LLM-cost polling) is retired as a goal for now. It would meaningfully improve the cross-agent case too, but building it isn't justified by anything observed this session — the actual pain (self-loop overhead, no backoff, no stuck detection) is fully addressed by delegating to native tools for the case that needs it. Revisit only if a genuine cross-agent polling need surfaces that native tools structurally can't cover and the muxbus-delivery overhead is shown to matter at that point.
+
+---
+
+## Part 4 — Phased plan
+
+### Phase 0 — cheap, immediate (S)
+- Update `Loop`'s tool description to explicitly recommend native `ScheduleWakeup`/`CronCreate` for same-session self-checks, and state the cross-agent-only scope clearly (see Part 3). This directly prevents the mistake made this session — no code change, just fixing what the tool tells the agent to do.
+- Resolve the `CronCreate`/`CronList`/`CronDelete` name collision with the native tools of the same name — at minimum, add an explicit disambiguating line to each AgentMux tool's description ("this is AgentMux's cross-agent cron, distinct from the native per-session `CronCreate`"); a rename is the more durable fix but needs a compat/migration decision (see below).
+- Add an expiry/stuck bound to AgentMux's own `Cron` (e.g. auto-disable a job after N consecutive fires with no observable state change, or a hard max-age default) — closes §1.6 without needing full condition evaluation.
+
+### Phase 1 — Loop/Cron consolidation onto a `durable` flag (M)
+- Merge `Loop` and `Cron` into one tool family differentiated by `durable: bool`, matching native `CronCreate`'s shape. Requires a compat decision for existing `loop_id`/cron-job-id callers and any in-flight jobs at rollout time — scope this properly rather than assuming it's a clean swap.
+- Add backoff/jitter as an opt-in policy on the unified primitive.
+
+### Phase 2 — Rename to fully resolve the collision (S, depends on Phase 1's shape being settled)
+- Once the unified primitive's shape is stable, rename away from the bare `Cron*`/`Loop` names so the distinction from native tools is visible without reading descriptions (e.g. an `AgentMux`-prefixed or `CrossAgent`-prefixed family).
+
+---
+
+## Priority order
+
+`Phase 0` (this week — the description fix is the single highest-value, lowest-risk change in this doc: it would have prevented this session's actual mistake, and costs nothing but editing a string) → `Phase 1` (real but bounded engineering, needs its own compat scoping) → `Phase 2` (depends on 1, cosmetic/naming once the shape is settled).


### PR DESCRIPTION
## Summary
Design doc + Phase 0 implementation: `docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md`.

Triggered by live use of `mcp__agentmux__Loop` this session to babysit a GitHub PR's review status — the wrong tool for a same-session self-check. The harness already ships native `ScheduleWakeup`/`CronCreate`/`CronList`/`CronDelete` tools with better-designed backoff, jitter, durability, and expiry semantics than AgentMux's own `Loop`/`Cron`, but AgentMux's tools shadow them under near-identical names (`CronCreate` vs `mcp__agentmux__CronCreate`) with no indication in either description that the other exists — a collision already flagged in `SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md` over a month ago and never resolved.

- Rewrote `Loop`'s and all five `Cron*` tools' MCP descriptions to state explicitly they're for targeting a *different* agent, and to recommend native `ScheduleWakeup`/`CronCreate` for same-session self-checks (zero delivery overhead vs. this family's cross-agent muxbus envelope). No schema/functional change to `Loop`/`LoopStop`/`LoopList`.
- Added an optional `max_age_secs` hard expiry bound to AgentMux's own `CronCreate` (matching the spirit of native `CronCreate`'s 7-day auto-expiry) alongside the existing `max_fires` bound. Opt-in, defaults to no expiry — AgentMux's cross-agent jobs are often meant to run indefinitely (e.g. a recurring standup check), so an unconditional default would be a surprising behavior change for existing automations.
- New `db_cron_jobs.max_age_secs` column (`SHARED_STORE_SCHEMA_VERSION` v4→v5, additive/idempotent `ALTER TABLE`, `NULL` for all pre-existing rows = no behavior change for jobs created before this shipped).
- Extracted the age-expiry check into a standalone `is_expired_by_age()` function (matching the existing `should_catchup()` pattern) with unit tests, rather than leaving it inline and untested like the sibling `max_fires` check already was.

Explicitly not done here (see the design doc's Phase 1/2): consolidating `Loop`/`Cron` onto one primitive, or renaming AgentMux's tools outright — both need their own compat/rollout scoping.

## Test plan
- [x] `cargo check -p agentmux-srv -p agentmux-mcp` — clean
- [x] `cargo test -p agentmux-srv` — 1976 passed, 0 failed (5 new)
- [x] `cargo test -p agentmux-mcp` — 4 passed, 0 failed (27-tool-count assertion still holds — no tools added/removed, only description/schema changes)
- [ ] reagent review

<!-- agentmux:agent_id=agentx -->