### PR TITLE
fix(identity): tolerate a malformed secret_ref row instead of hiding every account

### DIFF
--- a/.changesets/1785892369-fix-identity-tolerate-a-malformed-secret-ref-row-instead-of--5nfj.md
+++ b/.changesets/1785892369-fix-identity-tolerate-a-malformed-secret-ref-row-instead-of--5nfj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): tolerate a malformed secret_ref row instead of hiding every account

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -141,44 +141,31 @@ fn default_identity_status() -> String {
     "unknown".to_string()
 }
 
-/// Escape every backslash in `raw` that isn't already the start of a valid
-/// JSON escape sequence (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`,
-/// `\uXXXX`). Targets exactly the one corruption shape seen in production —
-/// a raw Windows path (`C:\Users\...`) pasted into a JSON string without
-/// escaping — without touching JSON that's already correctly escaped, so
-/// it's safe to run against every row unconditionally (`identity_repair_
-/// malformed_secret_refs` only calls this on values that already failed to
-/// parse as-is). Not a general JSON repair tool — only handles this one bug
-/// class.
+/// Escape every backslash in `raw` unconditionally. Targets exactly the one
+/// corruption shape seen in production — a raw Windows path (`C:\Users\...`)
+/// pasted into a JSON string with NO escaping at all — so every backslash in
+/// a still-unparseable row is a literal path separator, never an intentional
+/// JSON escape (a document containing even one real `\n`/`\t`/`\\` escape
+/// alongside bare backslashes would imply two different corruption
+/// mechanisms touched the same row, which has no evidence and isn't
+/// something this targeted repair needs to handle).
+///
+/// This is deliberately NOT a no-op on already-valid JSON — doubling a
+/// genuine `\\` pair would over-escape it. That's fine because the only
+/// caller (`identity_repair_malformed_secret_refs`) already checks
+/// `serde_json::from_str` first and skips rows that parse cleanly; this
+/// function must never be called on a value that isn't already confirmed
+/// invalid.
+///
+/// A prior version tried to distinguish "bare" backslashes from "already
+/// valid escape sequences" by peeking at the next character (`\b`, `\t`,
+/// `\n`, ... look like valid escapes). That's unsound for real Windows
+/// paths: a segment like `\bob\test` starts with `\b` and `\t`, which are
+/// themselves valid JSON escape shapes, so the heuristic left them
+/// un-doubled and silently produced a backspace/tab character instead of
+/// the literal path (caught by reagent review on PR #2419).
 fn repair_bare_backslashes(raw: &str) -> String {
-    let mut out = String::with_capacity(raw.len());
-    let mut chars = raw.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '\\' {
-            out.push(c);
-            continue;
-        }
-        match chars.peek() {
-            Some('"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' | 'u') => {
-                // Already a valid escape sequence — copy BOTH characters
-                // through unchanged, consuming the second one now. Leaving
-                // it for the next loop iteration (a prior version of this
-                // function did) means a valid `\\` pair's second backslash
-                // gets reprocessed as if it were a fresh, standalone
-                // backslash — and since whatever follows it is very
-                // unlikely to itself be a valid escape starter, it gets
-                // doubled again, corrupting already-valid JSON.
-                out.push('\\');
-                out.push(chars.next().unwrap());
-            }
-            _ => {
-                // A bare backslash (or one at end-of-string) — double it.
-                out.push('\\');
-                out.push('\\');
-            }
-        }
-    }
-    out
+    raw.replace('\\', "\\\\")
 }
 
 /// Junction row: which identity an agent uses for a given provider.
@@ -926,13 +913,37 @@ mod tests {
         }
     }
 
-    /// Already-valid JSON (the normal case — every real row written via
-    /// `identity_upsert`) must pass through byte-for-byte unchanged; the
-    /// repair must never double-escape a correctly-escaped value.
+    /// Regression for the P0 caught on PR #2419 review: a path segment that
+    /// starts with a letter matching a valid JSON escape (`\bob`, `\test`,
+    /// `\node_modules`, ...) must still get its backslash doubled, not
+    /// mistaken for an already-valid `\b`/`\t`/`\n` escape.
     #[test]
-    fn repair_bare_backslashes_is_a_noop_on_valid_json() {
+    fn repair_bare_backslashes_fixes_paths_with_escape_letter_prefixed_segments() {
+        let broken = r#"{"backend":"oauth_config_dir","dir":"C:\Users\bob\test\node_modules\uploads\format"}"#;
+        let repaired = repair_bare_backslashes(broken);
+        let parsed: SecretRef =
+            serde_json::from_str(&repaired).expect("repair must produce valid JSON");
+        match parsed {
+            SecretRef::OAuthConfigDir { dir } => {
+                assert_eq!(dir, r"C:\Users\bob\test\node_modules\uploads\format");
+            }
+            other => panic!("expected OAuthConfigDir, got {other:?}"),
+        }
+    }
+
+    /// `repair_bare_backslashes` is only ever called on rows that already
+    /// failed to parse as JSON (`identity_repair_malformed_secret_refs`
+    /// checks `serde_json::from_str` first and skips valid rows) — it must
+    /// never run against already-valid JSON, since unconditionally doubling
+    /// every backslash would over-escape a genuine `\\` pair.
+    #[test]
+    fn repair_bare_backslashes_over_escapes_already_valid_json_by_design() {
         let valid = r#"{"backend":"oauth_config_dir","dir":"C:\\Users\\area54\\claude"}"#;
-        assert_eq!(repair_bare_backslashes(valid), valid);
+        assert_ne!(
+            repair_bare_backslashes(valid),
+            valid,
+            "documents that callers must never invoke this on already-valid JSON"
+        );
     }
 
     /// `identity_list` must return the good rows and skip the malformed

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -141,6 +141,46 @@ fn default_identity_status() -> String {
     "unknown".to_string()
 }
 
+/// Escape every backslash in `raw` that isn't already the start of a valid
+/// JSON escape sequence (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`,
+/// `\uXXXX`). Targets exactly the one corruption shape seen in production —
+/// a raw Windows path (`C:\Users\...`) pasted into a JSON string without
+/// escaping — without touching JSON that's already correctly escaped, so
+/// it's safe to run against every row unconditionally (`identity_repair_
+/// malformed_secret_refs` only calls this on values that already failed to
+/// parse as-is). Not a general JSON repair tool — only handles this one bug
+/// class.
+fn repair_bare_backslashes(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            Some('"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' | 'u') => {
+                // Already a valid escape sequence — copy BOTH characters
+                // through unchanged, consuming the second one now. Leaving
+                // it for the next loop iteration (a prior version of this
+                // function did) means a valid `\\` pair's second backslash
+                // gets reprocessed as if it were a fresh, standalone
+                // backslash — and since whatever follows it is very
+                // unlikely to itself be a valid escape starter, it gets
+                // doubled again, corrupting already-valid JSON.
+                out.push('\\');
+                out.push(chars.next().unwrap());
+            }
+            _ => {
+                // A bare backslash (or one at end-of-string) — double it.
+                out.push('\\');
+                out.push('\\');
+            }
+        }
+    }
+    out
+}
+
 /// Junction row: which identity an agent uses for a given provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentIdentityLink {
@@ -176,6 +216,15 @@ impl Store {
     /// List identity accounts. If `provider` is `Some`, filter to that
     /// provider; otherwise return every account, ordered by most recent
     /// update first (so the identity panel shows live accounts on top).
+    ///
+    /// A row whose `secret_ref`/`context` JSON fails to parse is skipped
+    /// (logged with its account id) rather than aborting the whole query —
+    /// one corrupted row must never hide every other account. This is the
+    /// isolation the `oauth_config_dir` tag-alias comment above already
+    /// flagged as missing ("`identity_list()` aborts entirely on the first
+    /// unparseable row") after that incident; this closes it at the source
+    /// instead of only patching the one wire-format mismatch that triggered
+    /// it. See `docs/analysis/ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md`.
     pub fn identity_list(
         &self,
         provider: Option<&str>,
@@ -183,21 +232,32 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let mut rows_vec = Vec::new();
         let map_row = |row: &rusqlite::Row| -> rusqlite::Result<IdentityAccount> {
+            let id: String = row.get(0)?;
             let secret_ref_json: String = row.get(5)?;
             let context_json: String = row.get(6)?;
+            let secret_ref = match serde_json::from_str(&secret_ref_json) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "identity",
+                        account_id = %id,
+                        error = %e,
+                        "identity_list: skipping account with malformed secret_ref JSON",
+                    );
+                    return Err(rusqlite::Error::FromSqlConversionFailure(
+                        5,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    ));
+                }
+            };
             Ok(IdentityAccount {
-                id: row.get(0)?,
+                id,
                 name: row.get(1)?,
                 provider: row.get(2)?,
                 kind: row.get(3)?,
                 display_name: row.get(4)?,
-                secret_ref: serde_json::from_str(&secret_ref_json).map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        5,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
-                })?,
+                secret_ref,
                 context: serde_json::from_str(&context_json)
                     .unwrap_or_else(|_| serde_json::json!({})),
                 status: row.get(7)?,
@@ -216,7 +276,9 @@ impl Store {
                 )?;
                 let iter = stmt.query_map(params![p], map_row)?;
                 for r in iter {
-                    rows_vec.push(r?);
+                    if let Ok(account) = r {
+                        rows_vec.push(account);
+                    }
                 }
             }
             None => {
@@ -228,7 +290,9 @@ impl Store {
                 )?;
                 let iter = stmt.query_map([], map_row)?;
                 for r in iter {
-                    rows_vec.push(r?);
+                    if let Ok(account) = r {
+                        rows_vec.push(account);
+                    }
                 }
             }
         }
@@ -307,6 +371,67 @@ impl Store {
             ],
         )?;
         Ok(())
+    }
+
+    /// Migration-only repair pass (`m0019_repair_malformed_secret_ref`):
+    /// scan every `db_accounts.secret_ref` for JSON that fails to parse and
+    /// attempt to fix the one known corruption shape — a Windows path
+    /// pasted into the JSON string with its backslashes never escaped
+    /// (found live: `{"backend":"oauth_config_dir","dir":"C:\Users\..."}`,
+    /// not reproducible from any write path in this codebase — every real
+    /// caller goes through `identity_upsert` above, which always
+    /// `serde_json::to_string`s correctly; this shape only arises from an
+    /// out-of-band edit of the database file). Rows that still don't parse
+    /// after the repair attempt are left untouched and logged — never
+    /// deleted, since a broken row may still be linked via
+    /// `db_agent_identity_links` and `identity_list`'s per-row skip (above)
+    /// already makes leaving it alone safe. Returns the number of rows
+    /// repaired.
+    pub fn identity_repair_malformed_secret_refs(&self) -> Result<usize, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let candidates: Vec<(String, String)> = {
+            let mut stmt = conn.prepare("SELECT id, secret_ref FROM db_accounts")?;
+            let iter = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            let mut out = Vec::new();
+            for r in iter {
+                out.push(r?);
+            }
+            out
+        };
+
+        let mut repaired = 0usize;
+        for (id, raw) in candidates {
+            if serde_json::from_str::<SecretRef>(&raw).is_ok() {
+                continue; // already valid — the common case
+            }
+            let candidate = repair_bare_backslashes(&raw);
+            match serde_json::from_str::<SecretRef>(&candidate) {
+                Ok(fixed) => {
+                    let canonical = serde_json::to_string(&fixed)?;
+                    conn.execute(
+                        "UPDATE db_accounts SET secret_ref = ?1 WHERE id = ?2",
+                        params![canonical, id],
+                    )?;
+                    repaired += 1;
+                    tracing::warn!(
+                        target: "identity",
+                        account_id = %id,
+                        "identity.repair: fixed malformed secret_ref JSON (unescaped backslashes)",
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "identity",
+                        account_id = %id,
+                        error = %e,
+                        "identity.repair: secret_ref still unparseable after repair attempt — left as-is",
+                    );
+                }
+            }
+        }
+        Ok(repaired)
     }
 
     /// Delete an identity account AND every `db_agent_identity_links`
@@ -773,5 +898,154 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 0, "retired bundle-binding tables must not exist");
+    }
+
+    // ---- Malformed secret_ref tolerance (ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04) ----
+
+    /// Directly pins the production corruption: a raw Windows path pasted
+    /// into JSON with unescaped backslashes must round-trip through the
+    /// repair to a valid, semantically-equivalent `SecretRef`.
+    #[test]
+    fn repair_bare_backslashes_fixes_unescaped_windows_path() {
+        let broken = r#"{"backend":"oauth_config_dir","dir":"C:\Users\area54\.agentmux\shared\identities\34db876e-ccef-4bb4-a41f-5962d6212df5\claude"}"#;
+        assert!(
+            serde_json::from_str::<SecretRef>(broken).is_err(),
+            "fixture must reproduce the real parse failure"
+        );
+        let repaired = repair_bare_backslashes(broken);
+        let parsed: SecretRef =
+            serde_json::from_str(&repaired).expect("repair must produce valid JSON");
+        match parsed {
+            SecretRef::OAuthConfigDir { dir } => {
+                assert_eq!(
+                    dir,
+                    r"C:\Users\area54\.agentmux\shared\identities\34db876e-ccef-4bb4-a41f-5962d6212df5\claude"
+                );
+            }
+            other => panic!("expected OAuthConfigDir, got {other:?}"),
+        }
+    }
+
+    /// Already-valid JSON (the normal case — every real row written via
+    /// `identity_upsert`) must pass through byte-for-byte unchanged; the
+    /// repair must never double-escape a correctly-escaped value.
+    #[test]
+    fn repair_bare_backslashes_is_a_noop_on_valid_json() {
+        let valid = r#"{"backend":"oauth_config_dir","dir":"C:\\Users\\area54\\claude"}"#;
+        assert_eq!(repair_bare_backslashes(valid), valid);
+    }
+
+    /// `identity_list` must return the good rows and skip the malformed
+    /// one — not abort the whole query. This is the actual bug: one
+    /// corrupted account made 9 real accounts invisible everywhere
+    /// `identity_list` is called (Armory's account list, boot-time
+    /// identity sweep, post-login cache refresh).
+    #[test]
+    fn identity_list_skips_a_malformed_row_instead_of_failing_the_whole_query() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .identity_upsert(&sample_account("acct-good-1", "claude"))
+            .unwrap();
+        store
+            .identity_upsert(&sample_account("acct-good-2", "claude"))
+            .unwrap();
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_accounts
+                    (id, name, provider, kind, display_name, secret_ref, context,
+                     status, created_at, updated_at)
+                 VALUES ('acct-bad', 'broken', 'claude', 'oauth', '',
+                         '{\"backend\":\"oauth_config_dir\",\"dir\":\"C:\\bad\\path\"}',
+                         '{}', 'unknown', 0, 0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let accounts = store
+            .identity_list(None)
+            .expect("must not fail even with a malformed row present");
+        let ids: Vec<&str> = accounts.iter().map(|a| a.id.as_str()).collect();
+        assert!(ids.contains(&"acct-good-1"));
+        assert!(ids.contains(&"acct-good-2"));
+        assert!(!ids.contains(&"acct-bad"), "malformed row must be excluded, not error the whole call");
+        assert_eq!(accounts.len(), 2);
+    }
+
+    /// End-to-end: the migration-facing repair method fixes the known
+    /// corruption shape in place, and a subsequent `identity_list` picks up
+    /// the repaired row.
+    #[test]
+    fn identity_repair_malformed_secret_refs_fixes_row_and_identity_list_recovers_it() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .identity_upsert(&sample_account("acct-good", "claude"))
+            .unwrap();
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_accounts
+                    (id, name, provider, kind, display_name, secret_ref, context,
+                     status, created_at, updated_at)
+                 VALUES ('acct-broken', 'broken', 'claude', 'oauth', '',
+                         '{\"backend\":\"oauth_config_dir\",\"dir\":\"C:\\Users\\a\\claude\"}',
+                         '{}', 'unknown', 0, 0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Before repair: identity_list tolerates it (previous test) but the
+        // account itself is invisible.
+        assert_eq!(store.identity_list(None).unwrap().len(), 1);
+
+        let repaired = store.identity_repair_malformed_secret_refs().unwrap();
+        assert_eq!(repaired, 1);
+
+        let accounts = store.identity_list(None).unwrap();
+        assert_eq!(accounts.len(), 2, "repaired row must now be visible");
+        let fixed = accounts.iter().find(|a| a.id == "acct-broken").unwrap();
+        match &fixed.secret_ref {
+            SecretRef::OAuthConfigDir { dir } => assert_eq!(dir, r"C:\Users\a\claude"),
+            other => panic!("expected OAuthConfigDir, got {other:?}"),
+        }
+
+        // Idempotent: running it again on an already-repaired store is a no-op.
+        assert_eq!(store.identity_repair_malformed_secret_refs().unwrap(), 0);
+    }
+
+    /// A row whose corruption ISN'T the known "bare backslash" shape (e.g. a
+    /// genuinely unrecognizable backend tag) must be left untouched rather
+    /// than mangled or deleted — the repair only handles the one known bug
+    /// class, per its own doc comment.
+    #[test]
+    fn identity_repair_leaves_unrecognized_corruption_untouched() {
+        let store = Store::open_in_memory().unwrap();
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_accounts
+                    (id, name, provider, kind, display_name, secret_ref, context,
+                     status, created_at, updated_at)
+                 VALUES ('acct-weird', 'weird', 'claude', 'oauth', '',
+                         '{\"backend\":\"totally_unknown_backend\"}',
+                         '{}', 'unknown', 0, 0)",
+                [],
+            )
+            .unwrap();
+        }
+        let repaired = store.identity_repair_malformed_secret_refs().unwrap();
+        assert_eq!(repaired, 0, "unrecognized corruption must not be reported as repaired");
+        assert_eq!(
+            store.identity_list(None).unwrap().len(),
+            0,
+            "still-broken row stays invisible to identity_list (safe default) but is not deleted"
+        );
+        let conn = store.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM db_accounts WHERE id = 'acct-weird'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "row must survive an unsuccessful repair attempt");
     }
 }

--- a/agentmux-srv/src/migrations/m0019_repair_malformed_secret_ref.rs
+++ b/agentmux-srv/src/migrations/m0019_repair_malformed_secret_ref.rs
@@ -1,0 +1,119 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Repair `db_accounts.secret_ref` rows whose JSON was corrupted by an
+//! out-of-band edit of the shared store — found live: a raw Windows path
+//! pasted into the JSON string with its backslashes never escaped
+//! (`{"backend":"oauth_config_dir","dir":"C:\Users\..."}`, valid JSON needs
+//! `\\` per separator). Not reproducible from any write path in this
+//! codebase (`Store::identity_upsert` always `serde_json::to_string`s
+//! correctly) — see
+//! `docs/analysis/ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md`
+//! §7 for the full incident.
+//!
+//! Global-scoped (touches the shared store directly, like
+//! `m0012_dedup_identity_accounts` and `m0018_ambient_login_registry`). Safe
+//! to re-run: `identity_repair_malformed_secret_refs` is a no-op once every
+//! row parses.
+//!
+//! This migration is a data repair, not a substitute for
+//! `identity_list`/`identity_get`'s own per-row tolerance (see the same
+//! analysis doc's §6 option 1, implemented alongside this migration in
+//! `backend/storage/identities.rs`) — the two are independent defenses:
+//! this fixes the one known-bad row; that keeps any future corruption from
+//! ever again hiding every other account.
+
+use crate::backend::storage::store::Store;
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0019RepairMalformedSecretRef;
+
+impl Migration for M0019RepairMalformedSecretRef {
+    fn id(&self) -> &'static str { "0019_repair_malformed_secret_ref" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Global }
+    fn description(&self) -> &'static str {
+        "Repair db_accounts.secret_ref rows with unescaped-backslash JSON corruption"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.shared_store_path.exists() {
+            return Ok(());
+        }
+        let shared = Store::open_shared(&ctx.shared_store_path)
+            .map_err(|e| MigrationError(format!("repair_malformed_secret_ref: open shared store: {}", e)))?;
+        let repaired = shared
+            .identity_repair_malformed_secret_refs()
+            .map_err(|e| MigrationError(format!("repair_malformed_secret_ref: {}", e)))?;
+        tracing::info!(
+            target: "identity",
+            repaired,
+            "identity.repair: secret_ref repair pass — {} row(s) fixed",
+            repaired,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::store::{IdentityAccount, SecretRef};
+
+    fn ctx_for(shared: &std::path::Path) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path: shared.to_path_buf(),
+            channel_store_path: std::env::temp_dir().join("agentmux-test-unused-channel.db"),
+        }
+    }
+
+    #[test]
+    fn repairs_a_malformed_row_in_the_shared_store() {
+        let shared = tempfile::NamedTempFile::new().unwrap();
+        let store = Store::open_shared(shared.path()).unwrap();
+        store
+            .identity_upsert(&IdentityAccount {
+                id: "acct-good".to_string(),
+                name: "claude-good".to_string(),
+                provider: "claude".to_string(),
+                kind: "oauth".to_string(),
+                display_name: String::new(),
+                secret_ref: SecretRef::OAuthConfigDir { dir: "/tmp/good".to_string() },
+                context: serde_json::json!({}),
+                status: "ok".to_string(),
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+        {
+            let conn = store.conn().lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_accounts
+                    (id, name, provider, kind, display_name, secret_ref, context,
+                     status, created_at, updated_at)
+                 VALUES ('acct-broken', 'broken', 'claude', 'oauth', '',
+                         '{\"backend\":\"oauth_config_dir\",\"dir\":\"C:\\Users\\a\\claude\"}',
+                         '{}', 'unknown', 0, 0)",
+                [],
+            )
+            .unwrap();
+        }
+        drop(store);
+
+        M0019RepairMalformedSecretRef.up(&ctx_for(shared.path())).unwrap();
+
+        let store = Store::open_shared(shared.path()).unwrap();
+        let accounts = store.identity_list(None).unwrap();
+        assert_eq!(accounts.len(), 2, "both the already-good and the repaired row must be visible");
+        assert!(accounts.iter().any(|a| a.id == "acct-broken"));
+    }
+
+    #[test]
+    fn missing_shared_store_is_a_noop() {
+        let missing = std::env::temp_dir().join("agentmux-test-shared-definitely-missing-r7z.db");
+        let _ = std::fs::remove_file(&missing);
+        M0019RepairMalformedSecretRef.up(&ctx_for(&missing)).unwrap();
+        assert!(!missing.exists(), "up() must not create the store");
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -34,6 +34,7 @@ mod m0015_seed_starter_skills;
 mod m0016_seed_starter_mcp_servers;
 mod m0017_ambient_login_grandfather;
 mod m0018_ambient_login_registry;
+mod m0019_repair_malformed_secret_ref;
 mod runner;
 
 pub use runner::count_pending_migrations;
@@ -128,4 +129,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0016_seed_starter_mcp_servers::M0016SeedStarterMcpServers,
     &m0017_ambient_login_grandfather::M0017AmbientLoginGrandfather,
     &m0018_ambient_login_registry::M0018AmbientLoginRegistry,
+    &m0019_repair_malformed_secret_ref::M0019RepairMalformedSecretRef,
 ];

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -705,12 +705,22 @@ mod tests {
     /// still contains every agent — only the identity-name enrichment
     /// degrades, not the whole list.
     #[tokio::test]
-    async fn a_malformed_identity_account_row_degrades_that_source_without_zeroing_the_whole_list() {
+    async fn a_malformed_identity_account_row_is_tolerated_without_degrading_the_accounts_source() {
         let (state, engine, mut output_rx, _reg_dir, _def_dir) =
             setup_with_n_cross_channel_agents(2);
 
         // Same malformed shape as the real PR #2296 incident: a
         // `secret_ref.backend` tag no `SecretRef` variant matches.
+        //
+        // Updated for ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04:
+        // `identity_list` itself now skips a malformed row (with a warning)
+        // instead of erroring the whole call (backend/storage/identities.rs),
+        // so this scenario no longer reaches the `unwrap_or_else` degrade
+        // path below at all — the "accounts" source is no longer degraded
+        // by a single bad row, it's just quietly correct. The `degraded`
+        // push at that call site still exists and is still meaningful for a
+        // genuine `identity_list` error (e.g. a real DB failure); it's
+        // simply no longer reachable via this specific fixture.
         {
             let conn = state.wstore.conn().lock().unwrap();
             conn.execute(
@@ -742,17 +752,21 @@ mod tests {
             result.rows.len(),
             2,
             "a single malformed db_accounts row must not zero out the whole \
-             My Agents list — it must only degrade identity-name display for \
-             affected rows"
+             My Agents list"
         );
-        // reagent P1 on PR #2327: the degradation must reach the CALLER, not
-        // just a server-side log line — otherwise the frontend has no way to
-        // ever distinguish "a source failed" from "genuinely zero agents"
-        // when a failure DOES happen to zero out the row count (e.g. both
-        // instance sources failing at once, unlike this identity-only case).
+        // The improved behavior: identity_list's own per-row tolerance means
+        // this is no longer a "source failure" at all — nothing degraded,
+        // the malformed row was just silently excluded. Contrast with the
+        // OLD assertion this test used to make (`degraded` contains
+        // "accounts") — that was evidence of a real, if survivable, failure;
+        // this is evidence there wasn't one. The `degraded.push("accounts")`
+        // call site (above, in the handler) is still meaningful for a
+        // genuine `identity_list` error — just no longer reachable via this
+        // fixture.
         assert!(
-            result.degraded.contains(&"accounts".to_string()),
-            "the accounts source's failure must be reported in the response, got: {:?}",
+            !result.degraded.contains(&"accounts".to_string()),
+            "a single malformed row must not degrade the accounts source at all \
+             (identity_list now tolerates it internally), got: {:?}",
             result.degraded
         );
     }

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -598,15 +598,34 @@ pub(crate) async fn identity_self_accounts_impl(
         .map_err(|e| format!("identity.self.accounts: {e}"))?;
     let mut accounts = Vec::new();
     for link in &links {
-        if let Some(acct) = state.id_store.identity_get(&link.account_id)
-            .map_err(|e| format!("identity.self.accounts: {e}"))? {
-            let masked_tail = acct.context.get("masked_tail")
-                .and_then(|v| v.as_str()).unwrap_or("").to_string();
-            accounts.push(json!({
-                "account_id": acct.id, "provider": acct.provider, "name": acct.name,
-                "kind": acct.kind, "status": acct.status, "masked_tail": masked_tail,
-                "updated_at": acct.updated_at,
-            }));
+        // A malformed `secret_ref` on ONE linked account must not hide this
+        // agent's other, perfectly readable accounts — the same "one bad row
+        // hides everything" bug class `identity_list` was fixed for
+        // (ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md),
+        // just reachable through this separate per-agent lookup too (reagent
+        // P1 on PR #2419 review). Skip and log rather than `?`-propagate.
+        match state.id_store.identity_get(&link.account_id) {
+            Ok(Some(acct)) => {
+                let masked_tail = acct.context.get("masked_tail")
+                    .and_then(|v| v.as_str()).unwrap_or("").to_string();
+                accounts.push(json!({
+                    "account_id": acct.id, "provider": acct.provider, "name": acct.name,
+                    "kind": acct.kind, "status": acct.status, "masked_tail": masked_tail,
+                    "updated_at": acct.updated_at,
+                }));
+            }
+            Ok(None) => {
+                // Link points at a since-deleted account — skip silently.
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "identity",
+                    account_id = %link.account_id,
+                    agent_id = %def_id,
+                    error = %e,
+                    "identity.self.accounts: skipping unreadable linked account",
+                );
+            }
         }
     }
     Ok(json!({ "accounts": accounts }))
@@ -1759,5 +1778,90 @@ mod bundle_upsert_input_tests {
         }));
         assert_eq!(out["context_files"], json!("[]"));
         assert_eq!(out["skills"], json!("[\"already\"]"));
+    }
+}
+
+#[cfg(test)]
+mod identity_self_accounts_tests {
+    use super::*;
+    use crate::backend::storage::identities::SecretRef;
+    use crate::server::tests::test_state;
+
+    fn sample_account(id: &str, provider: &str) -> IdentityAccount {
+        IdentityAccount {
+            id: id.to_string(),
+            name: format!("{provider}-oauth"),
+            provider: provider.to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir { dir: format!("/tmp/{id}") },
+            context: json!({}),
+            status: "ok".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    /// Regression for reagent P1 on PR #2419 review: one malformed linked
+    /// account must not hide this agent's other, perfectly readable
+    /// accounts — the same bug class `identity_list` was fixed for, just
+    /// reachable through this separate per-agent lookup too.
+    #[tokio::test]
+    async fn skips_a_malformed_linked_account_instead_of_failing_the_whole_call() {
+        let state = test_state();
+
+        let mut def = AgentDefinition {
+            id: uuid::Uuid::new_v4().to_string(),
+            slug: String::new(),
+            name: "test agent".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            environment: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        };
+        state.wstore.agent_def_insert(&mut def).unwrap();
+
+        state.wstore.identity_upsert(&sample_account("acct-good", "claude")).unwrap();
+        {
+            let conn = state.wstore.conn().lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_accounts
+                    (id, name, provider, kind, display_name, secret_ref, context,
+                     status, created_at, updated_at)
+                 VALUES ('acct-bad', 'broken', 'github', 'oauth', '',
+                         '{\"backend\":\"oauth_config_dir\",\"dir\":\"C:\\bad\\path\"}',
+                         '{}', 'unknown', 0, 0)",
+                [],
+            )
+            .unwrap();
+        }
+        state.wstore.agent_identity_link(&def.id, "acct-good", "claude").unwrap();
+        state.wstore.agent_identity_link(&def.id, "acct-bad", "github").unwrap();
+
+        let result = identity_self_accounts_impl(&state, &def.id)
+            .await
+            .expect("must not fail even with a malformed linked account present");
+        let accounts = result["accounts"].as_array().unwrap();
+        assert_eq!(accounts.len(), 1, "the malformed account must be skipped, not error the whole call");
+        assert_eq!(accounts[0]["account_id"], json!("acct-good"));
     }
 }


### PR DESCRIPTION
## Summary

Live-testing the in-app Claude OAuth login (`SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md`, #2410/#2414/#2415) surfaced a real data-integrity bug: one `db_accounts` row's `secret_ref` JSON has unescaped Windows-path backslashes — invalid JSON, confirmed as an out-of-band DB edit (not reproducible from any write path in this repo; `identity_upsert` always serializes correctly via `serde_json::to_string`).

`identity_list()` had **zero per-row error isolation**, so this one corrupted row made the *entire* 9-account list fail for every caller: Armory's account list UI, the boot-time identity sweep, and the post-login cache refresh all hit the identical `Conversion error from type Text at index: 5, invalid escape` error.

This is the same failure class a prior incident already flagged in a code comment (the `oauth_config_dir`/`o_auth_config_dir` tag-rename fix) without ever fixing the root no-isolation issue: *"`identity_list()` aborts entirely on the first unparseable row."*

## Changes

- `identity_list` now skips a malformed row (logged with its account id) instead of erroring the whole query. `identity_get` is unchanged (single-row fetch, no "skip to" fallback — its one problematic caller, the identity sweep, already tolerates a fetch failure per-candidate).
- New migration `m0019_repair_malformed_secret_ref`: scans `db_accounts.secret_ref`, repairs the one known corruption shape (escapes bare backslashes that aren't already a valid JSON escape, re-validates, only rewrites if the repair round-trips), and leaves unrepairable rows untouched — never deletes, since a broken row may still be linked via `db_agent_identity_links`.
- Updated one existing test (`session.rs`) whose fixture assumed the old whole-list-degrades-on-one-bad-row behavior — the accounts source is no longer reported as degraded for a single malformed row, since it's now genuinely tolerated at the source rather than caught downstream.

Full incident writeup: `docs/analysis/ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md` (not included in this PR — separate doc-only artifact from the investigation, happy to land it here too if useful).

## Test plan

- [x] `cargo test -p agentmux-srv` — 1990 tests pass (1979 + 4 + 7 across the three binaries), including 6 new tests (repair-function correctness, `identity_list` row-skip behavior, migration repair + idempotency + safe-no-op-on-unrecognized-corruption) and the one updated existing test.
- [x] `cargo check -p agentmux-srv` clean.
- [ ] Live verification on `task dev` against the real corrupted row on this machine's shared store — will confirm after review, before merge.

<!-- agentmux:agent_id=agenta -->