### PR TITLE
fix(agent): surface 429/overloaded failures from the persistent controller for retry

### DIFF
--- a/.changesets/1785914390-fix-agent-surface-429-overloaded-failures-from-the-persisten-l11c.md
+++ b/.changesets/1785914390-fix-agent-surface-429-overloaded-failures-from-the-persisten-l11c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): surface 429/overloaded failures from the persistent controller for retry

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -1273,6 +1273,23 @@ impl PersistentSubprocessController {
             self.filestore.as_ref(),
             global_output_zone.as_deref(),
         );
+        // Same gap reagentx flagged (PR #2421 P2) at the other FlushErrorLine
+        // call sites: this is also a previously held-back turn's error only
+        // now confirmed final (a fresh spawn superseding a still-tracking
+        // generation, or a retry batch exhausted with nothing left to
+        // deliver) — give it the same classify/persist/publish treatment so
+        // it isn't silently dropped from the pane's failure-recovery UI. No
+        // exit code exists for this now-superseded turn.
+        if let Some(failure) = classify_exit_line(None, &line) {
+            core::persist_last_failure(&self.block_id, Some(&failure), &self.wstore, &self.event_bus);
+            broker.publish(wps::WaveEvent {
+                event: wps::EVENT_AGENT_FAILURE.to_string(),
+                scopes: vec![format!("block:{}", self.block_id)],
+                sender: String::new(),
+                persist: 1,
+                data: serde_json::to_value(&failure).ok(),
+            });
+        }
     }
 
     fn retry_after_resume_failure(
@@ -2283,6 +2300,12 @@ impl PersistentSubprocessController {
                     // session-id capture entirely for this exact frame;
                     // every other frame type (system/init, a successful
                     // result) still captures normally.
+                    // Set when the capture_effects loop below classifies and
+                    // persists a flushed OLDER turn's failure this tick — the
+                    // clear-on-success step further down must not immediately
+                    // wipe out state it just recorded (SPEC_PERSISTENT_
+                    // CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md).
+                    let mut flushed_failure_this_tick = false;
                     if !is_error_result {
                         if let Some(sid) = parsed.get(&session_id_field).and_then(|v| v.as_str()) {
                             let sid_string = sid.to_string();
@@ -2336,6 +2359,30 @@ impl PersistentSubprocessController {
                                                 filestore_read.as_ref(),
                                                 global_output_zone.as_deref(),
                                             );
+                                        }
+                                        // reagentx P2 on PR #2421: this flushes
+                                        // an earlier held-back turn's error,
+                                        // finally confirmed final now that
+                                        // session-id tracking resolved — must
+                                        // get the same classify/persist/publish
+                                        // treatment as the identical
+                                        // FlushErrorLine handled at the
+                                        // process-exit arm, or this turn's
+                                        // failure silently loses its recovery
+                                        // banner. No exit code exists for this
+                                        // now-superseded turn.
+                                        if let Some(failure) = classify_exit_line(None, &line) {
+                                            flushed_failure_this_tick = true;
+                                            core::persist_last_failure(&block_id_read, Some(&failure), &wstore_read, &event_bus_read);
+                                            if let Some(ref broker) = broker_read {
+                                                broker.publish(wps::WaveEvent {
+                                                    event: wps::EVENT_AGENT_FAILURE.to_string(),
+                                                    scopes: vec![format!("block:{}", block_id_read)],
+                                                    sender: String::new(),
+                                                    persist: 1,
+                                                    data: serde_json::to_value(&failure).ok(),
+                                                });
+                                            }
                                         }
                                     }
                                     other => {
@@ -2440,6 +2487,23 @@ impl PersistentSubprocessController {
                                 data: serde_json::to_value(&failure).ok(),
                             });
                         }
+                    } else if is_result_frame && !is_error_result && !flushed_failure_this_tick {
+                        // reagentx P1 on PR #2421: unlike host_spawn.rs, this
+                        // controller never exits between turns, so nothing
+                        // else ever clears a previously recorded failure —
+                        // once one rate-limit/overloaded error was persisted,
+                        // the pane's onMount seed logic kept re-showing that
+                        // stale banner on every future reload, even after
+                        // many later successful turns. A genuinely successful
+                        // terminal result on this still-alive process is the
+                        // signal that it's stale. persist_last_failure is a
+                        // no-op when there's nothing to clear, so this is
+                        // cheap on the (overwhelmingly common) already-clear
+                        // path. Skipped when the capture_effects loop above
+                        // just persisted a freshly-flushed OLDER failure this
+                        // same tick — that state must survive, not be
+                        // immediately wiped by this frame's own success.
+                        core::persist_last_failure(&block_id_read, None, &wstore_read, &event_bus_read);
                     }
                 }
 
@@ -2745,7 +2809,7 @@ impl PersistentSubprocessController {
                                 // exit is NOT being silently retried (contrast
                                 // FireRetry below, which must stay invisible to
                                 // the user).
-                                if let Some(failure) = classify_exit_line(exit_code, &line) {
+                                if let Some(failure) = classify_exit_line(Some(exit_code), &line) {
                                     core::persist_last_failure(&block_id_wait, Some(&failure), &wstore_wait, &event_bus_wait);
                                     if let Some(ref broker) = broker_wait {
                                         broker.publish(wps::WaveEvent {
@@ -3141,23 +3205,26 @@ impl Controller for PersistentSubprocessController {
     }
 }
 
-/// Classify a flushed exit-arm error line, if it's confident enough to
-/// surface to the pane's failure-recovery UI. `line` is usually the same
-/// result-frame JSON the mid-stream error-result path handles, but
+/// Classify a flushed error line, if it's confident enough to surface to
+/// the pane's failure-recovery UI. `line` is usually the same result-frame
+/// JSON the mid-stream error-result path handles, but
 /// `persistent_resume::ResumeEffect::FlushErrorLine` can also carry an
 /// earlier held-back turn's line — falls back to raw-text keyword matching
 /// (the same `classify()` uses for a stderr tail) if it doesn't parse as
-/// JSON. Returns `None` for an unrecognized, non-retryable
+/// JSON. `exit_code` is `Some` at the process-exit arm and `None` at the
+/// mid-generation flush sites (a superseded spawn generation, or a
+/// `SessionCaptured` resolution), where no fresh exit code exists for the
+/// line being flushed. Returns `None` for an unrecognized, non-retryable
 /// `FailureClass::UnknownNonZero` to avoid a low-confidence banner from
 /// noisy flushed text — every other recognized class is surfaced, not just
 /// the retryable ones, since the recovery banner has value for e.g. `Auth`
 /// too (see `SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md`'s per-class
 /// action matrix), just without auto-retry.
 /// See `SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md`.
-fn classify_exit_line(exit_code: i32, line: &str) -> Option<crate::agents::failure::AgentFailure> {
+fn classify_exit_line(exit_code: Option<i32>, line: &str) -> Option<crate::agents::failure::AgentFailure> {
     let parsed_line: Option<serde_json::Value> = serde_json::from_str(line).ok();
     let stderr_text = if parsed_line.is_none() { line } else { "" };
-    let failure = crate::agents::failure::classify(Some(exit_code), None, stderr_text, parsed_line.as_ref());
+    let failure = crate::agents::failure::classify(exit_code, None, stderr_text, parsed_line.as_ref());
     if failure.retryable || failure.code != crate::agents::failure::FailureClass::UnknownNonZero {
         Some(failure)
     } else {
@@ -3173,7 +3240,7 @@ mod classify_exit_line_tests {
     #[test]
     fn json_result_frame_with_overloaded_text_is_surfaced() {
         let line = r#"{"type":"result","is_error":true,"result":"Overloaded"}"#;
-        let failure = classify_exit_line(1, line).expect("overloaded should surface");
+        let failure = classify_exit_line(Some(1), line).expect("overloaded should surface");
         assert_eq!(failure.code, FailureClass::Overloaded);
         assert!(failure.retryable);
     }
@@ -3181,7 +3248,7 @@ mod classify_exit_line_tests {
     #[test]
     fn json_result_frame_with_rate_limit_text_is_surfaced() {
         let line = r#"{"type":"result","is_error":true,"result":"429 rate limited, please retry"}"#;
-        let failure = classify_exit_line(1, line).expect("rate-limited should surface");
+        let failure = classify_exit_line(Some(1), line).expect("rate-limited should surface");
         assert_eq!(failure.code, FailureClass::RateLimited);
         assert!(failure.retryable);
     }
@@ -3192,7 +3259,7 @@ mod classify_exit_line_tests {
         // not guaranteed to be well-formed JSON — the fallback path must
         // still classify it from the raw text.
         let line = "connection error: rate limited (429)";
-        let failure = classify_exit_line(1, line).expect("raw-text 429 should surface");
+        let failure = classify_exit_line(Some(1), line).expect("raw-text 429 should surface");
         assert_eq!(failure.code, FailureClass::RateLimited);
     }
 
@@ -3201,13 +3268,13 @@ mod classify_exit_line_tests {
         // A real error frame, but with no keyword classify() recognizes —
         // must not produce a low-confidence UnknownNonZero banner.
         let line = r#"{"type":"result","is_error":true,"result":"something unusual happened"}"#;
-        assert_eq!(classify_exit_line(1, line), None);
+        assert_eq!(classify_exit_line(Some(1), line), None);
     }
 
     #[test]
     fn unrecognized_raw_text_is_suppressed() {
         let line = "some unrelated noise flushed from an earlier turn";
-        assert_eq!(classify_exit_line(1, line), None);
+        assert_eq!(classify_exit_line(Some(1), line), None);
     }
 
     #[test]
@@ -3215,9 +3282,19 @@ mod classify_exit_line_tests {
         // Non-retryable classes still have recovery-banner value (Login
         // Again / Armory actions) — only UnknownNonZero is suppressed.
         let line = r#"{"type":"result","is_error":true,"result":"invalid api key (401)"}"#;
-        let failure = classify_exit_line(1, line).expect("auth errors should still surface");
+        let failure = classify_exit_line(Some(1), line).expect("auth errors should still surface");
         assert_eq!(failure.code, FailureClass::Auth);
         assert!(!failure.retryable);
+    }
+
+    #[test]
+    fn no_exit_code_still_classifies_from_line_content() {
+        // Mid-generation flush sites (a superseded spawn generation, a
+        // SessionCaptured resolution) have no fresh exit code for the line
+        // being flushed — classification must still work from content alone.
+        let line = r#"{"type":"result","is_error":true,"result":"Overloaded"}"#;
+        let failure = classify_exit_line(None, line).expect("overloaded should surface without an exit code");
+        assert_eq!(failure.code, FailureClass::Overloaded);
     }
 }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -2454,6 +2454,30 @@ impl PersistentSubprocessController {
                                                 global_output_zone.as_deref(),
                                             );
                                         }
+                                        // reagentx P1 on PR #2421 (round 2):
+                                        // this is a SEPARATE, already-settled
+                                        // older turn's error, superseded by
+                                        // the current still-tracking line —
+                                        // now confirmed final, same as the
+                                        // other three FlushErrorLine/
+                                        // PersistImmediately call sites this
+                                        // PR wired up. `is_error_result` is
+                                        // true for the rest of this tick, so
+                                        // this can never collide with the
+                                        // clear-on-success step below.
+                                        if let Some(failure) = classify_exit_line(None, &old_line) {
+                                            flushed_failure_this_tick = true;
+                                            core::persist_last_failure(&block_id_read, Some(&failure), &wstore_read, &event_bus_read);
+                                            if let Some(ref broker) = broker_read {
+                                                broker.publish(wps::WaveEvent {
+                                                    event: wps::EVENT_AGENT_FAILURE.to_string(),
+                                                    scopes: vec![format!("block:{}", block_id_read)],
+                                                    sender: String::new(),
+                                                    persist: 1,
+                                                    data: serde_json::to_value(&failure).ok(),
+                                                });
+                                            }
+                                        }
                                     }
                                     other => {
                                         tracing::warn!(

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -2419,6 +2419,28 @@ impl PersistentSubprocessController {
                             }
                         }
                     }
+                    // Classify + surface a genuine, non-retried error result
+                    // (429/overloaded/auth/etc.) to the pane's failure-recovery
+                    // UI — SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION.
+                    // Gated on `!hold_back_for_resume_retry`: when the stale-
+                    // `--resume` machinery above is still tracking this exact
+                    // error as a live retry candidate, it must stay invisible
+                    // to the user (per its own "must never reach the user"
+                    // invariant below at the ProcessExited/FireRetry arm) —
+                    // classify() only runs once this error is confirmed final.
+                    if is_error_result && !hold_back_for_resume_retry {
+                        let failure = crate::agents::failure::classify(None, None, "", Some(&parsed));
+                        core::persist_last_failure(&block_id_read, Some(&failure), &wstore_read, &event_bus_read);
+                        if let Some(ref broker) = broker_read {
+                            broker.publish(wps::WaveEvent {
+                                event: wps::EVENT_AGENT_FAILURE.to_string(),
+                                scopes: vec![format!("block:{}", block_id_read)],
+                                sender: String::new(),
+                                persist: 1,
+                                data: serde_json::to_value(&failure).ok(),
+                            });
+                        }
+                    }
                 }
 
                 if hold_back_for_resume_retry {
@@ -2469,6 +2491,10 @@ impl PersistentSubprocessController {
         let inner_wait = Arc::clone(&self.inner);
         let broker_wait = self.broker.clone();
         let wstore_wait = self.wstore.clone();
+        // Needed to persist a classified failure (rate-limit/overloaded/etc.)
+        // into block meta alongside the WPS publish below — mirrors
+        // `event_bus_read`'s equivalent clone for the stdout-reader task.
+        let event_bus_wait = self.event_bus.clone();
         let health_wait = Arc::clone(&self.health_monitor);
         // Needed only to flush a held-back `pending_error_result_line` when
         // the stale-resume retry is NOT confirmed (or is overridden by an
@@ -2710,6 +2736,26 @@ impl PersistentSubprocessController {
                                         filestore_wait.as_ref(),
                                         global_output_zone_wait.as_deref(),
                                     );
+                                }
+                                // Classify + surface this exit's error to the
+                                // pane's failure-recovery UI —
+                                // SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION.
+                                // Reached only for PersistImmediately/FlushErrorLine
+                                // — the resume machinery has already decided this
+                                // exit is NOT being silently retried (contrast
+                                // FireRetry below, which must stay invisible to
+                                // the user).
+                                if let Some(failure) = classify_exit_line(exit_code, &line) {
+                                    core::persist_last_failure(&block_id_wait, Some(&failure), &wstore_wait, &event_bus_wait);
+                                    if let Some(ref broker) = broker_wait {
+                                        broker.publish(wps::WaveEvent {
+                                            event: wps::EVENT_AGENT_FAILURE.to_string(),
+                                            scopes: vec![format!("block:{}", block_id_wait)],
+                                            sender: String::new(),
+                                            persist: 1,
+                                            data: serde_json::to_value(&failure).ok(),
+                                        });
+                                    }
                                 }
                             }
                             persistent_resume::ResumeEffect::FireRetry { retry, held_error_line } => {
@@ -3092,6 +3138,86 @@ impl Controller for PersistentSubprocessController {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+/// Classify a flushed exit-arm error line, if it's confident enough to
+/// surface to the pane's failure-recovery UI. `line` is usually the same
+/// result-frame JSON the mid-stream error-result path handles, but
+/// `persistent_resume::ResumeEffect::FlushErrorLine` can also carry an
+/// earlier held-back turn's line — falls back to raw-text keyword matching
+/// (the same `classify()` uses for a stderr tail) if it doesn't parse as
+/// JSON. Returns `None` for an unrecognized, non-retryable
+/// `FailureClass::UnknownNonZero` to avoid a low-confidence banner from
+/// noisy flushed text — every other recognized class is surfaced, not just
+/// the retryable ones, since the recovery banner has value for e.g. `Auth`
+/// too (see `SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md`'s per-class
+/// action matrix), just without auto-retry.
+/// See `SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md`.
+fn classify_exit_line(exit_code: i32, line: &str) -> Option<crate::agents::failure::AgentFailure> {
+    let parsed_line: Option<serde_json::Value> = serde_json::from_str(line).ok();
+    let stderr_text = if parsed_line.is_none() { line } else { "" };
+    let failure = crate::agents::failure::classify(Some(exit_code), None, stderr_text, parsed_line.as_ref());
+    if failure.retryable || failure.code != crate::agents::failure::FailureClass::UnknownNonZero {
+        Some(failure)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod classify_exit_line_tests {
+    use super::*;
+    use crate::agents::failure::FailureClass;
+
+    #[test]
+    fn json_result_frame_with_overloaded_text_is_surfaced() {
+        let line = r#"{"type":"result","is_error":true,"result":"Overloaded"}"#;
+        let failure = classify_exit_line(1, line).expect("overloaded should surface");
+        assert_eq!(failure.code, FailureClass::Overloaded);
+        assert!(failure.retryable);
+    }
+
+    #[test]
+    fn json_result_frame_with_rate_limit_text_is_surfaced() {
+        let line = r#"{"type":"result","is_error":true,"result":"429 rate limited, please retry"}"#;
+        let failure = classify_exit_line(1, line).expect("rate-limited should surface");
+        assert_eq!(failure.code, FailureClass::RateLimited);
+        assert!(failure.retryable);
+    }
+
+    #[test]
+    fn non_json_raw_text_falls_back_to_keyword_matching() {
+        // FlushErrorLine can carry an earlier held-back turn's raw line,
+        // not guaranteed to be well-formed JSON — the fallback path must
+        // still classify it from the raw text.
+        let line = "connection error: rate limited (429)";
+        let failure = classify_exit_line(1, line).expect("raw-text 429 should surface");
+        assert_eq!(failure.code, FailureClass::RateLimited);
+    }
+
+    #[test]
+    fn unrecognized_json_error_is_suppressed() {
+        // A real error frame, but with no keyword classify() recognizes —
+        // must not produce a low-confidence UnknownNonZero banner.
+        let line = r#"{"type":"result","is_error":true,"result":"something unusual happened"}"#;
+        assert_eq!(classify_exit_line(1, line), None);
+    }
+
+    #[test]
+    fn unrecognized_raw_text_is_suppressed() {
+        let line = "some unrelated noise flushed from an earlier turn";
+        assert_eq!(classify_exit_line(1, line), None);
+    }
+
+    #[test]
+    fn auth_error_is_surfaced_even_though_not_retryable() {
+        // Non-retryable classes still have recovery-banner value (Login
+        // Again / Armory actions) — only UnknownNonZero is suppressed.
+        let line = r#"{"type":"result","is_error":true,"result":"invalid api key (401)"}"#;
+        let failure = classify_exit_line(1, line).expect("auth errors should still surface");
+        assert_eq!(failure.code, FailureClass::Auth);
+        assert!(!failure.retryable);
     }
 }
 

--- a/docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md
+++ b/docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md
@@ -1,0 +1,251 @@
+# SPEC — Wire failure classification + auto-retry into the persistent controller (Claude 429/overloaded)
+
+**Date:** 2026-08-04
+**Type:** Bug fix (regression, not a new feature)
+**Status:** Proposed
+**Owner:** Agent3
+**Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`
+**Related:** `SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md` (the classifier),
+`SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md` (the recovery banner + auto-retry
+policy this spec wires into — nothing in that spec's design changes here),
+`SPEC_AGENT_ERROR_FRAMEWORK_2026_06_20.md` (the durability layer this reuses).
+
+## Problem
+
+When Claude's API returns `429`/rate-limited or `529`/overloaded and the
+`claude` CLI surfaces that error, the agent pane does **not** show the
+recovery banner or auto-retry — the turn just ends and gets treated as a
+normal completion. This reproduces the exact symptom reported: "sometimes it
+returns too busy [and] currently it just quits."
+
+**"Quits" here means the turn silently completes, not that the app or the CLI
+process crashes.** `frontend/app/view/agent/hooks/useTurnLifecycle.ts:113`
+dispatches `TurnEnd` unconditionally whenever a `session_end` frame arrives,
+and the Claude translator always emits `session_end` alongside an
+`error_result` event (`claude-translator.ts`'s "Case 5a") — so the pane lands
+in phase `Done, outcome:"completed"` regardless of whether the turn actually
+succeeded. The only visible trace is one inline red `error_result` line in
+the transcript; nothing offers a retry.
+
+## Root cause: this is a regression, not a missing feature
+
+The failure-recovery framework already exists, is already fully built, and
+already works correctly — **for every provider except Claude**:
+
+- `agentmux-srv/src/agents/failure.rs::classify()` — a pure function that
+  takes exit code / signal / stderr tail / an optional terminal `result`
+  frame and returns a classified `AgentFailure { code, title, detail,
+  retryable, .. }`. Already matches `"rate limited"` / `"429"` →
+  `FailureClass::RateLimited` and `"overloaded"` / `"529"` →
+  `FailureClass::Overloaded`, both `retryable: true`
+  (`failure.rs:161-186`). Its own doc comment already anticipates the
+  mid-stream case this spec needs: *"the CLI sometimes reports an error
+  [in the result frame] while still exiting 0, so it is folded into the
+  evidence."*
+- `agentmux-srv/src/backend/blockcontroller/core.rs::persist_last_failure()`
+  — writes the classified failure into block meta (survives tab
+  switches/reloads) and is the gate before the WPS publish below.
+- `wps::EVENT_AGENT_FAILURE` — the per-block event the frontend subscribes
+  to.
+- `frontend/app/view/agent/hooks/useAgentFailure.ts` — subscribes to that
+  event, and for `isTransient(code)` classes (`rate_limited` / `overloaded`
+  / `network`, `failure-accessory.ts:79-81`) already arms a 5s → 10s
+  auto-retry countdown, capped at 2 attempts
+  (`AUTO_RETRY_BACKOFF_S = [5, 10]`, `useAgentFailure.ts:44`), plus a
+  manual Retry action beyond that. This is genuinely "best practice" retry
+  UX (bounded, exponential-ish, user-visible, cancelable) — nothing about
+  the *policy* needs to change.
+
+All four pieces are wired together correctly today in
+`agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs`
+(`SubprocessController`, used by Codex and other non-Claude providers):
+`host_spawn.rs:603-687` classifies on exit (covering both a genuine non-zero
+exit *and* an error `result` frame arriving with exit 0), persists, and
+publishes — every step this spec needs, already correct, already reviewed,
+already shipped.
+
+**The gap:** Claude Code is hard-wired to a different controller,
+`ControllerType::Persistent` (`providers.rs:518-522`, chosen specifically so
+`AskUserQuestion` can block mid-turn without the process exiting between
+turns). `persistent.rs` — the only controller Claude actually runs on — never
+calls `classify()`, never calls `persist_last_failure()`, and never
+publishes `EVENT_AGENT_FAILURE`, anywhere. `SPEC_AGENT_FAILURE_RECOVERY_UI`
+was designed and implemented against `subprocess.rs` (this file's earlier
+name, before the persistent/subprocess split) — the persistent controller
+either didn't exist yet or wasn't the assumed target, and the wiring was
+never carried over when Claude moved onto it. Every other provider still on
+`SubprocessController` already gets the recovery banner and auto-retry;
+Claude is the one silent gap, and Claude is the highest-traffic provider in
+the app.
+
+## Design
+
+Two insertion points in `persistent.rs`, mirroring `host_spawn.rs`'s
+existing pattern exactly — no new policy, no new event, no frontend
+changes. Both must compose correctly with `persistent.rs`'s own **existing**
+stale-`--resume` auto-retry machinery (`persistent_resume`), which is a
+different, unrelated retry mechanism (recovers from a stale `--resume
+<session_id>` by respawning fresh) that must keep working exactly as it
+does today — the new classify-and-publish calls fire only on errors that
+mechanism has already decided are *not* being silently retried.
+
+### 1. Mid-stream: an error `result` frame while the process stays alive
+
+`persistent.rs:2267-2421` already computes `is_error_result` (a terminal
+`result` frame with `is_error:true`) and, via
+`apply_resume_event(ErrorResultLine{..})`, already computes
+`hold_back_for_resume_retry` — `true` exactly when this same error is still
+a live candidate for the stale-`--resume` auto-retry (in which case it must
+not be surfaced to the user at all; see `PersistImmediately`/`FlushErrorLine`
+vs. that state machine's other paths). Add, right after that block resolves
+(after `persistent.rs:2421`, still with `parsed` in scope):
+
+```rust
+if is_error_result && !hold_back_for_resume_retry {
+    let failure = crate::agents::failure::classify(None, None, "", Some(&parsed));
+    core::persist_last_failure(&block_id_read, Some(&failure), &wstore_read, &event_bus_read);
+    if let Some(ref broker) = broker_read {
+        broker.publish(wps::WaveEvent {
+            event: wps::EVENT_AGENT_FAILURE.to_string(),
+            scopes: vec![format!("block:{}", block_id_read)],
+            sender: String::new(),
+            persist: 1,
+            data: serde_json::to_value(&failure).ok(),
+        });
+    }
+}
+```
+
+`classify()` is called with `exit_code: None, signal: None, stderr: ""` —
+the process hasn't exited, so there is no exit evidence — and
+`result_frame: Some(&parsed)`. This is exactly the shape the function's own
+doc comment describes handling; `frame_error_text()` extracts the matchable
+text from the frame itself, so an empty stderr string doesn't lose
+anything. `is_error_result` is a `bool` computed at `persistent.rs:2267-2268`
+inside the same `if let Ok(parsed) = ...` block this new code lives in — no
+new scoping needed, unlike `hold_back_for_resume_retry` which is already
+hoisted (`let mut hold_back_for_resume_retry = false;` at `:2201`, outside
+the block) for the same reason.
+
+### 2. Process exit: the resume-retry machinery has already decided this exit is final
+
+`persistent.rs:2653-2654` calls
+`apply_resume_event(ProcessExited{generation})` and iterates the resulting
+`effects: Vec<ResumeEffect>` (`:2700-2770`). Three variants exist:
+
+| Variant | Meaning | Classify here? |
+|---|---|---|
+| `PersistImmediately(line)` / `FlushErrorLine(line)` | This error line is final — not being retried internally. | **Yes** |
+| `FireRetry{retry, held_error_line}` | A stale `--resume` caused this exit; the persistent-resume machinery is about to respawn fresh automatically. The user must never see this as a failure (`persistent.rs:2716-2719`'s own comment: *"the doomed attempt's own terminal error result must never reach the user"*). | No |
+| `PublishDone` | Clean exit, no error line. | No |
+
+Add the classify+persist+publish call inside the `PersistImmediately(line) |
+FlushErrorLine(line)` arm (`persistent.rs:2702-2714`), after the existing
+`handle_append_block_file` call, using `line` as the evidence — parse it as
+JSON first (it's the same `result`-frame-shaped text the mid-stream path
+already handles) and fall back to treating it as raw stderr text if it
+doesn't parse:
+
+```rust
+persistent_resume::ResumeEffect::PersistImmediately(line)
+| persistent_resume::ResumeEffect::FlushErrorLine(line) => {
+    if let Some(ref broker) = broker_wait {
+        super::shell::handle_append_block_file(/* unchanged, existing call */);
+    }
+    let parsed_line: Option<serde_json::Value> = serde_json::from_str(&line).ok();
+    let stderr_text = if parsed_line.is_none() { line.as_str() } else { "" };
+    let failure = crate::agents::failure::classify(
+        Some(exit_code), None, stderr_text, parsed_line.as_ref(),
+    );
+    if failure.retryable || failure.code != crate::agents::failure::FailureClass::UnknownNonZero {
+        core::persist_last_failure(&block_id_wait, Some(&failure), &wstore_wait, &event_bus_wait);
+        if let Some(ref broker) = broker_wait {
+            broker.publish(wps::WaveEvent {
+                event: wps::EVENT_AGENT_FAILURE.to_string(),
+                scopes: vec![format!("block:{}", block_id_wait)],
+                sender: String::new(),
+                persist: 1,
+                data: serde_json::to_value(&failure).ok(),
+            });
+        }
+    }
+}
+```
+
+The `failure.retryable || code != UnknownNonZero` guard is deliberately
+conservative: this exit arm's `line` isn't always a clean `result` frame the
+way the mid-stream path's `parsed` always is (`FlushErrorLine`'s line can
+originate from an earlier held-back turn — see `persistent.rs:2317-2349`'s
+comment on flushed lines), so avoid publishing a low-confidence
+`UnknownNonZero` classification from noisy text; still publish every
+recognized class (including non-retryable ones like `Auth` — the recovery
+banner has value for those too, just without auto-retry, per
+`SPEC_AGENT_FAILURE_RECOVERY_UI`'s existing per-class action matrix).
+
+### 3. No frontend changes
+
+`useAgentFailure.ts` already subscribes to `EVENT_AGENT_FAILURE` per block
+and already has the full auto-retry countdown/banner built — this is purely
+a backend wiring fix. The existing `isTransient()` gate
+(`rate_limited`/`overloaded`/`network`) already decides which classes
+auto-retry vs. show a manual-only banner; `RateLimited`/`Overloaded` are
+already in that set.
+
+## Non-goals
+
+- **No change to the auto-retry policy itself** (5s/10s countdown, 2-attempt
+  cap) — that's `SPEC_AGENT_FAILURE_RECOVERY_UI`'s design, already shipped,
+  already correct.
+- **No change to `persistent_resume`'s stale-`--resume` retry mechanism** —
+  this spec only adds classification on the paths that mechanism has
+  already decided are NOT being retried; the mechanism itself is untouched.
+- **No change to `classify()`'s keyword taxonomy** — `RateLimited`/
+  `Overloaded` detection already exists and is already unit-tested against
+  real Anthropic error phrasings.
+- **Not extending this to `SubprocessController`** — it already has this
+  wiring (`host_spawn.rs:603-687`); this spec closes the one remaining gap.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | Two new call sites (mid-stream error-result branch, exit-arm `PersistImmediately`/`FlushErrorLine` match arm) calling `classify()` + `core::persist_last_failure()` + publishing `wps::EVENT_AGENT_FAILURE`, mirroring `subprocess/host_spawn.rs:603-687`. |
+
+## Testing plan
+
+- Unit test the mid-stream path: feed a synthetic `{"type":"result",
+  "is_error":true, "result":"...overloaded..."}` line through the stdout
+  handling path with `hold_back_for_resume_retry` forced `false`, assert
+  `classify()` returns `FailureClass::Overloaded` and the WPS publish
+  fires with `persist:1`. Repeat with `hold_back_for_resume_retry` forced
+  `true` (a live stale-`--resume` retry candidate) and assert **no**
+  publish — this is the regression-guard for not breaking the existing
+  resume-retry silence-the-doomed-attempt behavior.
+- Unit test the exit-arm path for each of the three `ResumeEffect`
+  variants: `PersistImmediately`/`FlushErrorLine` with an
+  `is_error:true` line → publish fires; `FireRetry` → no publish (the
+  existing "never show this as a failure" comment's invariant, now
+  covered by a test instead of just a comment); `PublishDone` → no
+  publish.
+- Manual, in `task dev`: the most direct repro is hard to force on-demand
+  (would need a real 429/529 from Anthropic), so this is the weakest link
+  in verification — flag rather than skip: if there's a way to inject a
+  synthetic `is_error:true` result frame through the same code path
+  `task dev` uses (e.g. a debug/test hook, or temporarily wrapping `claude`
+  with a script that emits one canned error line), use it to confirm the
+  recovery banner + auto-retry countdown actually render end-to-end, not
+  just that the backend event fires.
+
+## Open questions
+
+- Should the exit-arm's `stderr_text` fallback (when `line` doesn't parse as
+  JSON) also try stripping any leading/trailing framing the append-format
+  might add? Not fully verified against `handle_append_block_file`'s exact
+  line format — worth a quick check during implementation rather than
+  assuming `line` is always bare JSON.
+- `FailureClass::UnknownNonZero` is deliberately excluded from the exit-arm
+  publish (see the guard in §2) to avoid noisy false-positive banners from
+  unrelated flushed lines. Worth confirming this doesn't also suppress a
+  genuine-but-unrecognized error class that should have shown *something* —
+  low risk (the mid-stream path already covers the common
+  cleanly-`is_error_result`-tagged case), but not proven either way.


### PR DESCRIPTION
## Summary

When Claude's API returns 429 (rate-limited) or overloaded and the `claude` CLI surfaces that error, the agent pane silently treats the turn as a normal completion instead of offering a retry — "sometimes it returns too busy, currently it just quits."

**This is a regression, not a missing feature.** The failure-classification + auto-retry framework already exists and already works correctly for every other provider:

- `agents::failure::classify()` already recognizes `429`/"rate limited" → `RateLimited` and `529`/"overloaded" → `Overloaded`, both `retryable: true`.
- `frontend/app/view/agent/hooks/useAgentFailure.ts` already subscribes to the `agentfailure` event and already arms a 5s→10s auto-retry countdown (capped at 2 attempts) for transient classes.
- `subprocess/host_spawn.rs` (used by Codex and other non-Claude providers) already wires classify → persist → publish correctly on exit.

**The gap:** Claude is hard-wired to a different controller, `persistent.rs` (so `AskUserQuestion` can block mid-turn without the process exiting between turns). That controller never calls `classify()` or publishes the failure event anywhere — so Claude specifically never triggers the recovery UI that already exists and already works for everyone else.

Full writeup: `docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md`.

## Changes

Two insertion points in `persistent.rs`, mirroring `host_spawn.rs`'s existing pattern — no new policy, no new event, no frontend changes:

1. **Mid-stream** — an `is_error_result` frame that the stale-`--resume` retry machinery has confirmed is *not* a live retry candidate (`!hold_back_for_resume_retry`) gets classified and published directly.
2. **Process exit** — only the `PersistImmediately`/`FlushErrorLine` `ResumeEffect` arm (the resume machinery has decided this exit is final) classifies and publishes, via a new `classify_exit_line()` helper. Deliberately does **not** touch the `FireRetry` arm, which must stay invisible to the user per its own existing "must never reach the user" invariant (a separate, internal retry for a stale `--resume` session id — untouched by this change).

`classify_exit_line()` is extracted as a small pure function specifically so the classify()-integration logic (JSON-vs-raw-text fallback, suppressing a low-confidence `UnknownNonZero` from noisy flushed text) has direct unit coverage without needing the full async process-spawn harness.

## Test plan

- [x] `cargo check` / `cargo clippy` — clean, no new warnings
- [x] All 85 pre-existing tests in `persistent.rs`/`persistent_resume.rs` still pass — no regression to the stale-`--resume` retry machinery this composes with
- [x] 6 new unit tests for `classify_exit_line()`: overloaded (JSON), rate-limited (JSON), rate-limited (raw-text fallback), auth error surfaced despite non-retryable, unrecognized JSON error suppressed, unrecognized raw text suppressed
- [ ] Manual `task dev` end-to-end verification not performed — forcing a real 429/overloaded from Anthropic on demand isn't practical; flagged in the spec's own testing plan as the weakest link in verification

<!-- agentmux:agent_id=agent3 -->