### PR TITLE
fix(login): resolve npm .cmd shims before spawning under a PTY on Windows

### DIFF
--- a/.changesets/1785915999-fix-login-resolve-npm-cmd-shims-before-spawning-under-a-pty--mh56.md
+++ b/.changesets/1785915999-fix-login-resolve-npm-cmd-shims-before-spawning-under-a-pty--mh56.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(login): resolve npm .cmd shims before spawning under a PTY on Windows

--- a/agentmux-cef/src/commands/cli_login.rs
+++ b/agentmux-cef/src/commands/cli_login.rs
@@ -602,7 +602,17 @@ async fn run_cli_login_pty(
             })
             .map_err(|e| format!("openpty for {cli_path}: {e}"))?;
 
-        let mut cmd = CommandBuilder::new(&cli_path);
+        // Resolve past the `.cmd`/`.bat` npm shim before spawning under the
+        // PTY — CommandBuilder on the raw shim path forces Windows through
+        // `cmd.exe /c`, which hangs indefinitely under a real ConPTY (no
+        // output, target config dir never created, confirmed live). Every
+        // other spawn site in this codebase already resolves through this;
+        // this was the one PTY-specific gap.
+        let (spawn_program, spawn_prefix_args) = agentmux_common::resolve_cli_spawn_target(&cli_path);
+        let mut cmd = CommandBuilder::new(&spawn_program);
+        for a in &spawn_prefix_args {
+            cmd.arg(a);
+        }
         for a in &login_args {
             cmd.arg(a);
         }

--- a/agentmux-cef/src/commands/cli_login.rs
+++ b/agentmux-cef/src/commands/cli_login.rs
@@ -608,7 +608,15 @@ async fn run_cli_login_pty(
         // output, target config dir never created, confirmed live). Every
         // other spawn site in this codebase already resolves through this;
         // this was the one PTY-specific gap.
-        let (spawn_program, spawn_prefix_args) = agentmux_common::resolve_cli_spawn_target(&cli_path);
+        //
+        // `None` means the shim didn't match either known npm shape — fail
+        // fast instead of falling back to `cmd.exe /C`, which hangs just as
+        // indefinitely under this real ConPTY as the raw shim path did
+        // (that's the exact bug this resolves; silently reintroducing it
+        // for an unrecognized shim shape would just move the 15s timeout
+        // somewhere less visible).
+        let (spawn_program, spawn_prefix_args) = agentmux_common::resolve_cli_spawn_target(&cli_path)
+            .ok_or_else(|| format!("could not resolve .cmd/.bat shim for spawn: {cli_path}"))?;
         let mut cmd = CommandBuilder::new(&spawn_program);
         for a in &spawn_prefix_args {
             cmd.arg(a);

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -43,28 +43,40 @@ pub fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
 /// Resolve `cli_path` to a runnable `Command` (the `.cmd`/`.bat` shim parsing
 /// on Windows). `make_cli_cmd` wraps this to apply `CREATE_NO_WINDOW`.
 fn build_cli_cmd(cli_path: &str) -> tokio::process::Command {
+    let (program, args) = resolve_cli_spawn_target(cli_path);
+    let mut cmd = tokio::process::Command::new(&program);
+    cmd.args(&args);
+    cmd
+}
+
+/// Resolve `cli_path` to the actual `(program, args)` spawn target — the
+/// `.cmd`/`.bat` shim parsing on Windows, factored out of `build_cli_cmd` so
+/// non-`tokio::process::Command` spawners (e.g. `portable_pty::CommandBuilder`,
+/// which `run_cli_login_pty` uses) can reuse the same resolution instead of
+/// spawning the raw shim path directly. Spawning a `.cmd` file straight
+/// through `CommandBuilder` forces Windows through `cmd.exe /c`, and that
+/// layer hangs indefinitely under a real ConPTY (confirmed live: 0% CPU, zero
+/// output, target dir never created) — this is the fix for that class of bug,
+/// not just a refactor for its own sake.
+pub fn resolve_cli_spawn_target(cli_path: &str) -> (String, Vec<String>) {
     #[cfg(windows)]
     if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
         match parse_cmd_wrapper(cli_path) {
             Some(ResolvedShim::NodeScript(entry_script)) => {
                 tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-                let mut c = tokio::process::Command::new("node");
-                c.arg(&entry_script);
-                return c;
+                return ("node".to_string(), vec![entry_script]);
             }
             Some(ResolvedShim::Executable(exe_path)) => {
                 tracing::debug!(cmd = %cli_path, exe = %exe_path, "resolved .cmd → native .exe");
-                return tokio::process::Command::new(&exe_path);
+                return (exe_path, Vec::new());
             }
             None => {
                 tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-                let mut c = tokio::process::Command::new("cmd.exe");
-                c.args(["/C", cli_path]);
-                return c;
+                return ("cmd.exe".to_string(), vec!["/C".to_string(), cli_path.to_string()]);
             }
         }
     }
-    tokio::process::Command::new(cli_path)
+    (cli_path.to_string(), Vec::new())
 }
 
 /// Parse an npm-generated `.cmd` wrapper to extract the real entry point.
@@ -119,4 +131,97 @@ fn parse_cmd_wrapper(cmd_path: &str) -> Option<ResolvedShim> {
         }
     }
     None
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    /// Real Claude Code v2+ `.cmd` content (`agentmux-instances/.../claude/
+    /// node_modules/.bin/claude.cmd`, verified live) — ships a prebuilt
+    /// native `claude.exe`, no Node entry point. This exact shape is what
+    /// made `run_cli_login_pty` hang under ConPTY when spawned raw.
+    const CLAUDE_EXE_SHIM: &str = concat!(
+        "@ECHO off\r\n",
+        "GOTO start\r\n",
+        ":find_dp0\r\n",
+        "SET dp0=%~dp0\r\n",
+        "EXIT /b\r\n",
+        ":start\r\n",
+        "SETLOCAL\r\n",
+        "CALL :find_dp0\r\n",
+        "\"%dp0%\\..\\@anthropic-ai\\claude-code\\bin\\claude.exe\"   %*\r\n",
+    );
+
+    /// Representative JS-entry-point npm shim shape (e.g. OpenClaw), the
+    /// other real shape `resolve_cli_spawn_target` must handle.
+    const NODE_SCRIPT_SHIM: &str = concat!(
+        "@ECHO off\r\n",
+        "GOTO start\r\n",
+        ":find_dp0\r\n",
+        "SET dp0=%~dp0\r\n",
+        "EXIT /b\r\n",
+        ":start\r\n",
+        "SETLOCAL\r\n",
+        "\"%_prog%\"  \"%dp0%\\..\\openclaw\\cli.js\" %*\r\n",
+    );
+
+    /// Lay out a `<root>/node_modules/.bin/<name>.cmd` shim pointing at
+    /// `<root>/node_modules/<pkg_rel>` — the real npm install shape
+    /// `parse_cmd_wrapper` expects. Target files are NOT created; canonicalize
+    /// falls back to the non-canonical path (see `parse_cmd_wrapper`'s `Err`
+    /// arm), so a bare `.cmd` fixture is enough — no need to fake the CLI
+    /// binary/script itself.
+    fn write_shim(dir: &std::path::Path, name: &str, content: &str) -> String {
+        let bin_dir = dir.join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let cmd_path = bin_dir.join(format!("{name}.cmd"));
+        std::fs::write(&cmd_path, content).unwrap();
+        cmd_path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn resolves_native_exe_shim_directly_bypassing_cmd_exe() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd_path = write_shim(dir.path(), "claude", CLAUDE_EXE_SHIM);
+
+        let (program, args) = resolve_cli_spawn_target(&cmd_path);
+
+        assert!(
+            program.ends_with("claude.exe") || program.ends_with("claude-code\\bin\\claude.exe"),
+            "expected the resolved native exe, got: {program}"
+        );
+        assert!(args.is_empty(), "exe shim must not prefix extra args, got: {args:?}");
+        assert_ne!(program, "cmd.exe", "must not fall back to spawning cmd.exe /C for a parseable shim");
+    }
+
+    #[test]
+    fn resolves_node_script_shim_to_node_plus_script_arg() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd_path = write_shim(dir.path(), "openclaw", NODE_SCRIPT_SHIM);
+
+        let (program, args) = resolve_cli_spawn_target(&cmd_path);
+
+        assert_eq!(program, "node");
+        assert_eq!(args.len(), 1, "expected exactly the script path as the sole arg: {args:?}");
+        assert!(args[0].ends_with("cli.js"), "expected the resolved script path, got: {args:?}");
+    }
+
+    #[test]
+    fn non_cmd_path_passes_through_unchanged() {
+        let (program, args) = resolve_cli_spawn_target(r"C:\some\native\tool.exe");
+        assert_eq!(program, r"C:\some\native\tool.exe");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn unparseable_cmd_falls_back_to_cmd_exe_c() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd_path = write_shim(dir.path(), "weird", "@ECHO off\r\necho nothing useful here\r\n");
+
+        let (program, args) = resolve_cli_spawn_target(&cmd_path);
+
+        assert_eq!(program, "cmd.exe");
+        assert_eq!(args, vec!["/C".to_string(), cmd_path]);
+    }
 }

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -43,7 +43,17 @@ pub fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
 /// Resolve `cli_path` to a runnable `Command` (the `.cmd`/`.bat` shim parsing
 /// on Windows). `make_cli_cmd` wraps this to apply `CREATE_NO_WINDOW`.
 fn build_cli_cmd(cli_path: &str) -> tokio::process::Command {
-    let (program, args) = resolve_cli_spawn_target(cli_path);
+    // `None` means the `.cmd` shim didn't match either known npm shape — fall
+    // back to spawning the raw path directly. For a `tokio::process::Command`
+    // (piped stdio, no PTY) this has the pre-existing, already-documented
+    // failure mode of npm `.cmd` wrappers (args/output can get lost through
+    // `cmd.exe`'s implicit association) rather than the ConPTY indefinite
+    // hang — see `resolve_cli_spawn_target`'s doc for why that hang is
+    // PTY-specific and why this fallback must NOT be `cmd.exe /C` (that's
+    // exactly as broken here as the raw path, so there's nothing to gain by
+    // routing through it explicitly).
+    let (program, args) = resolve_cli_spawn_target(cli_path)
+        .unwrap_or_else(|| (cli_path.to_string(), Vec::new()));
     let mut cmd = tokio::process::Command::new(&program);
     cmd.args(&args);
     cmd
@@ -58,25 +68,36 @@ fn build_cli_cmd(cli_path: &str) -> tokio::process::Command {
 /// layer hangs indefinitely under a real ConPTY (confirmed live: 0% CPU, zero
 /// output, target dir never created) — this is the fix for that class of bug,
 /// not just a refactor for its own sake.
-pub fn resolve_cli_spawn_target(cli_path: &str) -> (String, Vec<String>) {
+///
+/// Returns `None` when `cli_path` is a `.cmd`/`.bat` shim that doesn't match
+/// either known npm shape (Node-script or native-exe). A previous version
+/// fell back to `("cmd.exe", ["/C", cli_path])` here, but that's the exact
+/// invocation this function exists to avoid — under a ConPTY it hangs just
+/// as indefinitely as the raw shim path did, silently reintroducing the bug
+/// for any unrecognized shim shape (reagent P2 on PR review). Callers must
+/// decide how to handle an unresolvable shim themselves: `build_cli_cmd`
+/// (piped stdio, no ConPTY) falls back to the raw path, which loses some
+/// stdio fidelity but doesn't hang; `run_cli_login_pty` (real ConPTY) must
+/// fail fast instead of attempting a doomed spawn.
+pub fn resolve_cli_spawn_target(cli_path: &str) -> Option<(String, Vec<String>)> {
     #[cfg(windows)]
     if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
-        match parse_cmd_wrapper(cli_path) {
+        return match parse_cmd_wrapper(cli_path) {
             Some(ResolvedShim::NodeScript(entry_script)) => {
                 tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-                return ("node".to_string(), vec![entry_script]);
+                Some(("node".to_string(), vec![entry_script]))
             }
             Some(ResolvedShim::Executable(exe_path)) => {
                 tracing::debug!(cmd = %cli_path, exe = %exe_path, "resolved .cmd → native .exe");
-                return (exe_path, Vec::new());
+                Some((exe_path, Vec::new()))
             }
             None => {
-                tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-                return ("cmd.exe".to_string(), vec!["/C".to_string(), cli_path.to_string()]);
+                tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper — no safe spawn target");
+                None
             }
-        }
+        };
     }
-    (cli_path.to_string(), Vec::new())
+    Some((cli_path.to_string(), Vec::new()))
 }
 
 /// Parse an npm-generated `.cmd` wrapper to extract the real entry point.
@@ -185,7 +206,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cmd_path = write_shim(dir.path(), "claude", CLAUDE_EXE_SHIM);
 
-        let (program, args) = resolve_cli_spawn_target(&cmd_path);
+        let (program, args) = resolve_cli_spawn_target(&cmd_path).expect("parseable shim must resolve");
 
         assert!(
             program.ends_with("claude.exe") || program.ends_with("claude-code\\bin\\claude.exe"),
@@ -200,7 +221,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cmd_path = write_shim(dir.path(), "openclaw", NODE_SCRIPT_SHIM);
 
-        let (program, args) = resolve_cli_spawn_target(&cmd_path);
+        let (program, args) = resolve_cli_spawn_target(&cmd_path).expect("parseable shim must resolve");
 
         assert_eq!(program, "node");
         assert_eq!(args.len(), 1, "expected exactly the script path as the sole arg: {args:?}");
@@ -209,19 +230,27 @@ mod tests {
 
     #[test]
     fn non_cmd_path_passes_through_unchanged() {
-        let (program, args) = resolve_cli_spawn_target(r"C:\some\native\tool.exe");
+        let (program, args) =
+            resolve_cli_spawn_target(r"C:\some\native\tool.exe").expect("non-.cmd path always resolves");
         assert_eq!(program, r"C:\some\native\tool.exe");
         assert!(args.is_empty());
     }
 
+    /// An unparseable `.cmd` shim must resolve to `None`, not a `cmd.exe /C`
+    /// fallback — that fallback is exactly the invocation this resolver
+    /// exists to avoid, and hangs just as indefinitely under a real ConPTY
+    /// as the raw shim path did (reagent P2 on PR #2422 review). Callers
+    /// decide their own fallback: `build_cli_cmd` uses the raw path (piped
+    /// stdio, no hang risk); `run_cli_login_pty` fails fast instead.
     #[test]
-    fn unparseable_cmd_falls_back_to_cmd_exe_c() {
+    fn unparseable_cmd_resolves_to_none_not_cmd_exe_c() {
         let dir = tempfile::tempdir().unwrap();
         let cmd_path = write_shim(dir.path(), "weird", "@ECHO off\r\necho nothing useful here\r\n");
 
-        let (program, args) = resolve_cli_spawn_target(&cmd_path);
-
-        assert_eq!(program, "cmd.exe");
-        assert_eq!(args, vec!["/C".to_string(), cmd_path]);
+        assert_eq!(
+            resolve_cli_spawn_target(&cmd_path),
+            None,
+            "must not silently fall back to the broken cmd.exe /C invocation"
+        );
     }
 }

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod layout_types;
 pub mod runtime_mode;
 pub mod toolchain_path;
 
-pub use cli::make_cli_cmd;
+pub use cli::{make_cli_cmd, resolve_cli_spawn_target};
 pub use data_paths::{isolated_auth_enabled, DataPaths};
 pub use errors::{AgentMuxError, AmxCode};
 pub use layout_types::{


### PR DESCRIPTION
## Summary

Root cause of the "tier-1 in-app OAuth URL capture" bug from `SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md`: `run_cli_login_pty` (`agentmux-cef/src/commands/cli_login.rs`) spawned `cli_path` — a raw npm `node_modules\.bin\*.cmd` shim path — directly via `portable_pty::CommandBuilder`. On Windows this forces the OS through `cmd.exe /c "<path>.cmd" ...`, and **that layer hangs indefinitely under a real ConPTY**.

Live-confirmed via the actual production IPC path (`POST /ipc` `run_cli_login` with `requires_tty: true`, fresh `CLAUDE_CONFIG_DIR`): the spawned `cmd.exe` child sat alive at 0% CPU, produced zero PTY output, and never even created the target config directory — for the full 15s timeout and beyond (had to `taskkill` it manually). This matches the original bug exactly: `run_cli_login_pty: no auth URL captured within 15s`, silently falling through to the tier-2 fallback, masking the failure.

Ruled out along the way: the URL-matching regex (unit-tested, correct), CLI version drift (confirmed pinned 2.1.198), stray inherited env vars (confirmed absent in the actual failing run's own log), and the original "fresh config dir hits an onboarding wizard" hypothesis (directly refuted — a fresh dir works instantly without a PTY).

## Fix

`agentmux_common::make_cli_cmd`/`build_cli_cmd` already parses `.cmd` shims and resolves them to the real spawn target (a native `.exe` directly — Claude v2+'s actual shape — or `node <script>` for JS-based CLIs like OpenClaw) — and is already used by every other spawn site in the codebase (plain-pipe login, CLI version checks, persistent/subprocess block-controller spawns). `run_cli_login_pty` was the *only* one that bypassed it.

Factored the existing resolution logic into `pub fn resolve_cli_spawn_target(cli_path: &str) -> (String, Vec<String>)`, shared by `build_cli_cmd` (unchanged behavior, now delegates) and the new call site in `run_cli_login_pty`'s Windows branch. Provider-agnostic — fixes both Claude and OpenClaw (the other `requires_tty` PTY-spawn provider) with one change.

## Test plan

- [x] `cargo test -p agentmux-common` — 96 tests pass, including 4 new tests for `resolve_cli_spawn_target` (native `.exe` shim — using the real Claude `.cmd` content as a fixture; `node <script>` shim; non-`.cmd` passthrough; unparseable-shim fallback).
- [x] `cargo check -p agentmux-common` clean.
- [ ] Live re-verification on a rebuilt `task dev`: confirm the host log shows a captured URL within 15s instead of the timeout, and no orphaned `cmd.exe`/`claude.exe` process survives. Batching this with a related PR's live verification (Armory account-list fix, PR #2419) in one rebuild rather than rebuilding twice — will confirm before merge.

<!-- agentmux:agent_id=agenta -->