### PR TITLE
fix(accounts): unify ClaudeLoginPanel onto the canonical Modal, fix Stash nesting

### DIFF
--- a/.changesets/1785916655-fix-accounts-unify-claudeloginpanel-onto-the-canonical-modal-42wj.md
+++ b/.changesets/1785916655-fix-accounts-unify-claudeloginpanel-onto-the-canonical-modal-42wj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(accounts): unify ClaudeLoginPanel onto the canonical Modal, fix Stash nesting

--- a/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
@@ -10,9 +10,15 @@
  * old alias — otherwise the orphaned alias row lingers and the resolver's
  * inject.rs aborts every future spawn on it, even though a healthy
  * canonical "claude" link now exists right alongside it.
+ *
+ * Uses `screen.findByText` (document-wide), not `render()`'s own bound
+ * `findByText` — ClaudeLoginPanel now renders through the canonical `Modal`
+ * (ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md's Fix 3),
+ * which `<Portal>`s outside the test's render container; container-scoped
+ * queries can't see it.
  */
 
-import { cleanup, render, waitFor } from "@solidjs/testing-library";
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hub = vi.hoisted(() => ({
@@ -53,6 +59,8 @@ vi.mock("@/app/view/identity/identity-model", () => ({
 }));
 
 import { ClaudeLoginPanel } from "./ClaudeLoginPanel";
+import { Modal } from "@/element/modal";
+import { createSignal } from "solid-js";
 
 beforeEach(() => {
     hub.runProviderLogin.mockReset();
@@ -145,11 +153,11 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
         });
         hub.listAgentIdentities.mockResolvedValue([]); // no link for this agent
 
-        const { findByText } = render(() => (
+        render(() => (
             <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
         ));
 
-        await findByText(/couldn't confirm the account was linked/i);
+        await screen.findByText(/couldn't confirm the account was linked/i);
         expect(hub.refreshAccountCache).not.toHaveBeenCalled();
         expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
     });
@@ -165,10 +173,10 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
         });
         hub.listAgentIdentities.mockResolvedValueOnce([]); // link never landed
 
-        const { findByText } = render(() => (
+        render(() => (
             <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
         ));
-        const retryButton = await findByText("Retry");
+        const retryButton = await screen.findByText("Retry");
 
         // Second attempt (Retry): this time the link verification succeeds.
         hub.runProviderLogin.mockImplementationOnce(async (opts: any) => {
@@ -180,7 +188,7 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
         ]);
         retryButton.click();
 
-        await findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to claude/i);
         // The whole point: Retry must refresh the SAME account
         // ("acct-new") the first attempt already minted and persisted, not
         // mint a brand-new one under the still-undefined original prop —
@@ -197,11 +205,11 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
             return "inapp-success";
         });
 
-        const { findByText } = render(() => (
+        render(() => (
             <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
         ));
 
-        await findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to claude/i);
         expect(hub.refreshAccountCache).toHaveBeenCalled();
     });
 
@@ -220,7 +228,7 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
             { agent_id: "agent-1", account_id: "acct-existing", provider: "claude-code" },
         ]);
 
-        const { findByText } = render(() => (
+        render(() => (
             <ClaudeLoginPanel
                 onClose={() => {}}
                 existingAccountId="acct-existing"
@@ -229,7 +237,7 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
             />
         ));
 
-        await findByText(/couldn't confirm the account was linked/i);
+        await screen.findByText(/couldn't confirm the account was linked/i);
         // Must NOT proceed to the stale-alias cleanup unlink — that would
         // delete the one link that actually works, leaving zero links.
         expect(hub.unlinkAgentIdentity).not.toHaveBeenCalled();
@@ -242,9 +250,9 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
             return "inapp-success";
         });
 
-        const { findByText } = render(() => <ClaudeLoginPanel onClose={() => {}} />);
+        render(() => <ClaudeLoginPanel onClose={() => {}} />);
 
-        await findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to claude/i);
         expect(hub.listAgentIdentities).not.toHaveBeenCalled();
     });
 });
@@ -256,10 +264,10 @@ describe("ClaudeLoginPanel — unmount cleanup (codex P2 on PR #2414)", () => {
             return "inapp-success";
         });
 
-        const { findByText, unmount } = render(() => (
+        const { unmount } = render(() => (
             <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
         ));
-        await findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to claude/i);
         hub.cancelCliLogin.mockClear(); // clear whatever the login flow itself called
 
         unmount();
@@ -286,9 +294,50 @@ describe("ClaudeLoginPanel — login-runner rejection (codex P2 on PR #2414)", (
     it("surfaces a retryable error instead of leaving the panel stuck when runProviderLogin rejects outright", async () => {
         hub.runProviderLogin.mockRejectedValue(new Error("PTY spawn failed"));
 
-        const { findByText } = render(() => <ClaudeLoginPanel onClose={() => {}} />);
+        render(() => <ClaudeLoginPanel onClose={() => {}} />);
 
-        await findByText(/PTY spawn failed/i);
+        await screen.findByText(/PTY spawn failed/i);
         expect(hub.cancelCliLogin).toHaveBeenCalled();
+    });
+});
+
+describe("ClaudeLoginPanel — nested modal stacking (Fix 3 of ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md)", () => {
+    // ClaudeLoginPanel's own `Modal` is opened from INSIDE the Agent Stash's
+    // Accounts tab, which is itself already inside a canonical `Modal`
+    // (AgentStashModal, dispatched via modal-dispatch.tsx/ModalLayer.tsx).
+    // The real risk this guards against: if ClaudeLoginPanel were wired
+    // through `useModalLayer().open(...)` instead of a plain `<Modal>`
+    // (a mistake that's easy to make — that's the established pattern for
+    // most of this app's other dialogs), it would hit ModalLayer's
+    // single-`current`-signal "replace" semantics and CLOSE the Stash
+    // modal it's nested in, instead of stacking on top of it. Standing up
+    // the full `AgentStashModal` (many unrelated tabs/RPC deps) isn't
+    // needed to exercise this — the behavior lives entirely in the shared
+    // `Modal`/`modal-stack.ts` primitive, so a minimal outer `<Modal>`
+    // standing in for AgentStashModal is a faithful, much cheaper test of
+    // the same mechanism.
+    it("opening ClaudeLoginPanel from inside another open Modal does not close that outer Modal", async () => {
+        const [outerOpen, setOuterOpen] = createSignal(true);
+        const [innerOpen, setInnerOpen] = createSignal(false);
+
+        render(() => (
+            <Modal open={outerOpen()} onClose={() => setOuterOpen(false)} ariaLabel="Agent Stash">
+                <div>Stash content marker</div>
+                <button onClick={() => setInnerOpen(true)}>Connect</button>
+                {innerOpen() && <ClaudeLoginPanel onClose={() => setInnerOpen(false)} />}
+            </Modal>
+        ));
+
+        expect(screen.getByRole("dialog", { name: "Agent Stash" })).toBeInTheDocument();
+
+        screen.getByText("Connect").click();
+
+        // Both dialogs must be simultaneously present — the outer one must
+        // NOT have been closed/replaced by the inner one opening.
+        await waitFor(() => {
+            expect(screen.getByRole("dialog", { name: "Connect Anthropic" })).toBeInTheDocument();
+        });
+        expect(screen.getByRole("dialog", { name: "Agent Stash" })).toBeInTheDocument();
+        expect(screen.getByText("Stash content marker")).toBeInTheDocument();
     });
 });

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -26,6 +26,7 @@ import { PROVIDERS } from "@/app/view/agent/providers/catalog";
 import { runProviderLogin, type ProviderLoginOutcome } from "@/app/view/agent/flows/run-provider-login";
 import { InAppLoginPanel, type InAppLoginPhase } from "@/app/view/agent/components/InAppLoginPanel";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
+import { Modal, type ModalScope } from "@/element/modal";
 
 const CLAUDE_PROVIDER = PROVIDERS["claude"];
 
@@ -53,14 +54,23 @@ export function ClaudeLoginPanel(props: {
      *  success, this panel unlinks `staleAliasProvider` for the same
      *  agent so only the canonical row remains. */
     staleAliasProvider?: string;
+    /** Which region the dialog locks — see `Modal`'s `scope` prop. Armory
+     *  (no ModalLayer ancestor) passes "tab"; the Agent Stash (already
+     *  inside agent-view.tsx's `ModalLayer scope="pane"`) passes "pane" so
+     *  this stacks correctly over the Stash modal instead of both
+     *  competing for the same window-level backdrop. */
+    scope?: ModalScope;
 }): JSX.Element {
     const [phase, setPhase] = createSignal<InAppLoginPhase>("starting");
     const [authUrl, setAuthUrl] = createSignal<string | undefined>(undefined);
     const [error, setError] = createSignal<string | null>(null);
     const [done, setDone] = createSignal(false);
+    // Signal (not a plain `let`) so `Modal`'s `closeOnBackdropClick` can
+    // reactively track it — preserves the original hand-rolled overlay's
+    // "don't dismiss on backdrop click mid-login" behavior.
+    const [inFlight, setInFlight] = createSignal(false);
     let cancelled = false;
     let terminalRequested = false;
-    let inFlight = false;
     // Set by onAccountRegistered — run-provider-login.ts fires it ONLY once
     // the account row is actually persisted (reagent P0 on #2263). A
     // credential can be validly seeded/pasted on disk while that persist
@@ -88,7 +98,7 @@ export function ClaudeLoginPanel(props: {
     // one.
     onCleanup(() => {
         cancelled = true;
-        if (inFlight) {
+        if (inFlight()) {
             getApi().cancelCliLogin().catch(() => {});
         }
     });
@@ -132,8 +142,8 @@ export function ClaudeLoginPanel(props: {
         });
 
     const start = async () => {
-        if (inFlight) return;
-        inFlight = true;
+        if (inFlight()) return;
+        setInFlight(true);
         setError(null);
         setPhase("starting");
         try {
@@ -285,7 +295,7 @@ export function ClaudeLoginPanel(props: {
             const t = translateError(e);
             setError(`${t.title}: ${t.message}${t.retry ? ` — ${t.retry}` : ""}`);
         } finally {
-            inFlight = false;
+            setInFlight(false);
         }
     };
 
@@ -298,55 +308,58 @@ export function ClaudeLoginPanel(props: {
     void start();
 
     return (
-        <div
-            class="accounts-chooser-overlay"
-            onClick={(e) => e.target === e.currentTarget && !inFlight && props.onClose()}
+        <Modal
+            open={true}
+            onClose={() => !inFlight() && props.onClose()}
+            scope={props.scope ?? "window"}
+            closeOnBackdropClick={!inFlight()}
+            size="md"
+            ariaLabel="Connect Anthropic"
+            panelClass="accounts-chooser"
         >
-            <div class="accounts-chooser" role="dialog" aria-label="Connect Anthropic">
+            <Show
+                when={!done()}
+                fallback={
+                    <div class="accounts-chooser-modes">
+                        <div class="oauth-byo-note">✓ Signed in to Claude.</div>
+                        <div class="identity-key-actions">
+                            <button class="identity-btn identity-btn-primary" onClick={() => props.onClose()}>
+                                Done
+                            </button>
+                        </div>
+                    </div>
+                }
+            >
                 <Show
-                    when={!done()}
+                    when={!error()}
                     fallback={
                         <div class="accounts-chooser-modes">
-                            <div class="oauth-byo-note">✓ Signed in to Claude.</div>
+                            <div class="oauth-byo-note">{error()}</div>
                             <div class="identity-key-actions">
-                                <button class="identity-btn identity-btn-primary" onClick={() => props.onClose()}>
-                                    Done
+                                <button class="identity-btn identity-btn-primary" onClick={() => void start()}>
+                                    Retry
+                                </button>
+                                <button class="identity-btn identity-btn-secondary" onClick={() => props.onClose()}>
+                                    Close
                                 </button>
                             </div>
                         </div>
                     }
                 >
-                    <Show
-                        when={!error()}
-                        fallback={
-                            <div class="accounts-chooser-modes">
-                                <div class="oauth-byo-note">{error()}</div>
-                                <div class="identity-key-actions">
-                                    <button class="identity-btn identity-btn-primary" onClick={() => void start()}>
-                                        Retry
-                                    </button>
-                                    <button class="identity-btn identity-btn-secondary" onClick={() => props.onClose()}>
-                                        Close
-                                    </button>
-                                </div>
-                            </div>
-                        }
-                    >
-                        <InAppLoginPanel
-                            providerId={CLAUDE_PROVIDER.id}
-                            providerLabel={CLAUDE_PROVIDER.displayName}
-                            authUrl={authUrl()}
-                            phase={phase()}
-                            onCancel={onCancel}
-                            onUseTerminal={() => {
-                                terminalRequested = true;
-                                setPhase("fallback");
-                            }}
-                        />
-                    </Show>
+                    <InAppLoginPanel
+                        providerId={CLAUDE_PROVIDER.id}
+                        providerLabel={CLAUDE_PROVIDER.displayName}
+                        authUrl={authUrl()}
+                        phase={phase()}
+                        onCancel={onCancel}
+                        onUseTerminal={() => {
+                            terminalRequested = true;
+                            setPhase("fallback");
+                        }}
+                    />
                 </Show>
-            </div>
-        </div>
+            </Show>
+        </Modal>
     );
 }
 

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -108,17 +108,13 @@
 }
 
 // ── Tile-click chooser (OAuth / Key) ──────────────────────────────────────────
-.accounts-chooser-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--zindex-modal-wrapper);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0, 0, 0, 0.45);
-}
-
-.accounts-chooser {
+// Outer chrome (backdrop, z-index, scroll lock, inert) is provided by the
+// canonical <Modal>; this file only styles the panel sizing + inner content.
+// `.modal-panel.accounts-chooser` (not a bare `.accounts-chooser`) matches
+// command-palette.scss's pattern — a bare class loses the width override to
+// `.modal-panel[data-size="md"]`'s equal-or-higher specificity, rendering
+// the dialog at the default ~520px instead of this intended 320px.
+.modal-panel.accounts-chooser {
     width: 320px;
     max-width: calc(100vw - 32px);
     background: var(--modal-bg-color);

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -108,13 +108,37 @@
 }
 
 // ── Tile-click chooser (OAuth / Key) ──────────────────────────────────────────
-// Outer chrome (backdrop, z-index, scroll lock, inert) is provided by the
-// canonical <Modal>; this file only styles the panel sizing + inner content.
-// `.modal-panel.accounts-chooser` (not a bare `.accounts-chooser`) matches
-// command-palette.scss's pattern — a bare class loses the width override to
-// `.modal-panel[data-size="md"]`'s equal-or-higher specificity, rendering
-// the dialog at the default ~520px instead of this intended 320px.
-.modal-panel.accounts-chooser {
+// These class names are shared by TWO different dialogs:
+//  1. AccountsGallery.tsx's own OAuth-vs-Key mode picker — a small, still
+//     hand-rolled overlay+dialog (`.accounts-chooser-overlay` provides its
+//     backdrop; `.accounts-chooser` its box chrome). Unrelated to Modal.
+//  2. ClaudeLoginPanel.tsx's dialog — now wrapped in the canonical <Modal>
+//     via `panelClass="accounts-chooser"`, which just adds this class
+//     alongside `modal-panel` on the same element. Outer chrome (backdrop,
+//     z-index, scroll lock, inert) comes from Modal there; the bare
+//     `.accounts-chooser` width rule below still applies to it (harmless —
+//     background/border/shadow duplicate what `.modal-panel` already
+//     provides) but LOSES the width cascade to `.modal-panel[data-size="md"]`
+//     (equal 0,2,0 specificity, later source order) — hence the second,
+//     Modal-specific override rule further down, matching
+//     command-palette.scss's `.modal-panel.command-palette-panel` pattern.
+//
+// Live-verified 2026-08-05: an earlier version of this fix replaced the bare
+// `.accounts-chooser`/`.accounts-chooser-overlay` rules outright (assuming
+// only ClaudeLoginPanel used them), which broke AccountsGallery's own picker
+// — it rendered unstyled (position: static, transparent backdrop) since it's
+// a plain div, never wrapped by Modal.
+.accounts-chooser-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: var(--zindex-modal-wrapper);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.accounts-chooser {
     width: 320px;
     max-width: calc(100vw - 32px);
     background: var(--modal-bg-color);
@@ -188,4 +212,13 @@
         font-size: 11px;
         color: var(--secondary-text-color);
     }
+}
+
+// ClaudeLoginPanel's Modal-wrapped case only: beat
+// `.modal-panel[data-size="md"]`'s equal-specificity width rule. Only `width`/
+// `max-width` are needed here — `.modal-panel` already supplies background,
+// border, border-radius, box-shadow, and overflow for this element.
+.modal-panel.accounts-chooser {
+    width: 320px;
+    max-width: calc(100vw - 32px);
 }

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -134,7 +134,9 @@ export function AccountsManager(): JSX.Element {
             </Show>
 
             <Show when={claudePanelOpen()}>
-                <ClaudeLoginPanel onClose={() => setClaudePanelOpen(false)} />
+                {/* Armory has no ModalLayer/PaneModalScope ancestor — "tab"
+                    resolves via tabcontent.tsx's outer ModalLayer scope="tab". */}
+                <ClaudeLoginPanel onClose={() => setClaudePanelOpen(false)} scope="tab" />
             </Show>
         </div>
     );

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -286,11 +286,16 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
             </div>
 
             <Show when={claudePanelOpen()}>
+                {/* AgentStashModal (this panel's host) is itself inside
+                    agent-view.tsx's ModalLayer scope="pane" — "pane" here
+                    stacks this dialog correctly over the Stash modal instead
+                    of both competing for the same window-level backdrop. */}
                 <ClaudeLoginPanel
                     onClose={() => setClaudePanelOpen(false)}
                     existingAccountId={claudeRefreshAccountId()}
                     linkTarget={props.agentId ? { agentDefinitionId: props.agentId } : undefined}
                     staleAliasProvider={claudeStaleAliasProvider()}
+                    scope="pane"
                 />
             </Show>
         </div>


### PR DESCRIPTION
## Summary

`ClaudeLoginPanel` hand-rolled its own overlay (`accounts-chooser-overlay`/`accounts-chooser` divs, manual backdrop-click-to-close, manual `role="dialog"`) instead of using the app's canonical `Modal` ("the one modal system for the whole app"). Not just an inconsistency — when opened from the Agent Stash's Accounts tab, it stacked a hand-rolled dialog *on top of* `AgentStashModal` (itself a real canonical `Modal`) with none of the shared system's coordinated focus-trap/ESC/backdrop stacking logic.

## Changes

- Replaced the overlay with `<Modal>`, added a `scope` prop so each caller supplies the right region:
  - Armory's Accounts tile (no `ModalLayer` ancestor) → `scope="tab"`
  - Agent Stash's Accounts tab (already inside `agent-view.tsx`'s `ModalLayer scope="pane"`) → `scope="pane"`
- Converted `inFlight` from a plain variable to a signal so `Modal`'s `closeOnBackdropClick` can reactively preserve the original "don't dismiss mid-login" guard.
- **Confirmed empirically, not just by inspection**: added a test that opens `ClaudeLoginPanel`'s `Modal` from inside another open `Modal` and asserts the outer one is *not* closed — `Modal` instances stack independently via `modal-stack.ts`'s containment-based reachability, as long as the inner one is used directly (not routed through `useModalLayer().open()`, which would replace rather than stack — a mistake that's easy to make since that's the established pattern for most of this app's other dialogs).

Part of the Fix 3 DRY-the-login-UI work from `docs/analysis/ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md`. A follow-up PR wires the same primitive into the previously-unbuilt credential-loss relogin surface (agent pane).

## Test plan

- [x] All 11 pre-existing `ClaudeLoginPanel.test.tsx` assertions pass unchanged — switched from `render()`'s container-scoped `findByText` to `screen.findByText` (document-wide), since `Modal` portals outside the test's render container. Query-scoping fix, not a behavior change.
- [x] New nested-modal-stacking regression test passes.
- [x] `agent-identity-links-panel.test.tsx` (13 tests, mocks `ClaudeLoginPanel` at the module level) unaffected — confirms the new `scope` prop doesn't break existing prop-passing assertions.
- [x] `tsc --noEmit` clean project-wide.
- [ ] Live re-verification on `task dev`: Armory → Accounts → Connect (shared `Modal` chrome); Agent Stash → Accounts tab → Connect/Re-login (dialog stacks correctly, Stash stays open behind it). Batching with the other open PRs' (#2419, #2422) live verification in one rebuild.

<!-- agentmux:agent_id=agenta -->