### PR TITLE
feat(agent): wire in-app OAuth login into credential-loss relogin, retiring AuthUrlBox

### DIFF
--- a/.changesets/1785917501-feat-agent-wire-in-app-oauth-login-into-credential-loss-relo-1vy4.md
+++ b/.changesets/1785917501-feat-agent-wire-in-app-oauth-login-into-credential-loss-relo-1vy4.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+feat(agent): wire in-app OAuth login into credential-loss relogin, retiring AuthUrlBox
+
+Mid-session credential-loss relogin now renders the shared `InAppLoginPanel` (the same UI the Armory/Stash surfaces use) inside `AgentAuthPanel`'s bottom-docked slot — next to the composer, same as `AgentQuestionPanel`/`AgentDecisionPanel` — instead of the old hand-rolled `AuthUrlBox`, which is fully retired along with its dead CSS.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1632,6 +1632,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onCancelLogin={status.cancelLogin}
                 onUseTerminal={status.useTerminalInstead}
                 authProviderId={provider()?.id ?? providerKey()}
+                launchPhase={status.launchPhase}
             />
 
             <Show when={status.canRetry()}>

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -23,14 +23,17 @@
  * `log`/`handleShellTermReady`) — see `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { createSignal, onMount, Show, type Accessor, type JSX } from "solid-js";
-import { Button } from "@/element/button";
+import { Show, type Accessor, type JSX } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { LayoutView } from "@/app/store/agent-pane-layout-store";
 import { AgentDocumentVirtualList } from "../virtualization/AgentDocumentVirtualList";
 import { createAgentViewState } from "../virtualization/state";
+import { InAppLoginPanel } from "./InAppLoginPanel";
+import { PROVIDERS } from "../providers/catalog";
+import type { LaunchPhase } from "../flows/launch-phase";
+import { toInAppLoginPhase } from "./to-in-app-login-phase";
 
 interface AgentDocumentViewProps {
     documentAtom: SignalPair<DocumentNode[]>;
@@ -194,7 +197,7 @@ export interface AgentAuthPanelProps {
     authUrl?: Accessor<string | null>;
     /**
      * User-visible auth-recovery error (e.g. "Login Again" couldn't open a
-     * browser). Rendered as an error box below the auth-URL box, with a
+     * browser). Rendered as an error box below the login panel, with a
      * dismiss button. Never fail silently — see
      * retro-agent-auth-relogin-noop-2026-07-01 §5.1.
      */
@@ -203,11 +206,13 @@ export interface AgentAuthPanelProps {
     onDismissAuthNotice?: () => void;
     /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
     authProviderId?: string;
+    /** Drives the in-app login panel's phase line — see `toInAppLoginPhase`. */
+    launchPhase?: Accessor<LaunchPhase | null>;
     /** Cancel the in-flight login (kills the host CLI child) — shown as a
-     *  button on the auth-URL box so a stuck login has an exit besides
+     *  button on the login panel so a stuck login has an exit besides
      *  closing the pane. Wired to useAgentControllerStatus's cancelLogin. */
     onCancelLogin?: () => void;
-    /** Explicit "Use terminal instead" fallback on the auth-URL box — mirrors
+    /** Explicit "Use terminal instead" fallback on the login panel — mirrors
      *  PreLaunchAuthPanel's identical secondary action
      *  (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 2). Wired to
      *  useAgentControllerStatus's loginViaTerminal, which cancels this
@@ -220,19 +225,27 @@ export interface AgentAuthPanelProps {
  * Bottom-docked login UI. Rendered by agent-view.tsx as a flex sibling
  * after .agent-document-scroll-region, in the same slot band as
  * AgentDecisionPanel/AgentQuestionPanel — NOT inside AgentDocumentView's
- * scrollable header slot. It used to live there, which pinned it to the
- * top of the scroll area instead of near the composer (#2429 follow-up).
+ * scrollable header slot (that pinned it to the top of the scroll area,
+ * #2429 follow-up) and NOT a Modal (a floating dialog would dim/block the
+ * transcript, which the bottom-docked AgentQuestionPanel/AgentDecisionPanel
+ * pattern deliberately avoids — chosen over the modal for consistency).
+ *
+ * Renders the same InAppLoginPanel the Armory/Stash surfaces use (Fix 3a,
+ * PR #2423) instead of a hand-rolled copy — one fewer auth UI in the
+ * codebase — just without the Modal wrapper those surfaces use.
  */
 export function AgentAuthPanel(props: AgentAuthPanelProps): JSX.Element {
     return (
         <>
             <Show when={props.authUrl?.()}>
                 {(url) => (
-                    <AuthUrlBox
-                        url={url()}
-                        authProviderId={props.authProviderId}
-                        onCancel={props.onCancelLogin}
-                        onUseTerminal={props.onUseTerminal}
+                    <InAppLoginPanel
+                        providerId={props.authProviderId ?? ""}
+                        providerLabel={PROVIDERS[props.authProviderId ?? ""]?.displayName ?? props.authProviderId ?? "provider"}
+                        authUrl={url()}
+                        phase={toInAppLoginPhase(url(), props.launchPhase?.() ?? null)}
+                        onCancel={() => props.onCancelLogin?.()}
+                        onUseTerminal={() => props.onUseTerminal?.()}
                     />
                 )}
             </Show>
@@ -251,156 +264,5 @@ export function AgentAuthPanel(props: AgentAuthPanelProps): JSX.Element {
                 )}
             </Show>
         </>
-    );
-}
-
-interface AuthUrlBoxProps {
-    url: string;
-    authProviderId?: string;
-    onCancel?: () => void;
-    onUseTerminal?: () => void;
-}
-
-/**
- * OAuth code-paste box. Rendered by AgentAuthPanel while a login flow has
- * a pending auth URL.
- */
-function AuthUrlBox(props: AuthUrlBoxProps): JSX.Element {
-    const [pasteCode, setPasteCode] = createSignal("");
-    const [pasting, setPasting] = createSignal(false);
-    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
-    const [switchingToTerminal, setSwitchingToTerminal] = createSignal(false);
-    let inputRef: HTMLInputElement | undefined;
-
-    // Grab focus when the box appears so the user's pasted code lands HERE,
-    // not in the main agent message input (which otherwise holds focus and
-    // silently swallows the paste — the login then stalls waiting on stdin).
-    // Deferred past the current focus cycle (the pane's focus-reclaim runs
-    // synchronously on render) so this wins the race.
-    onMount(() => {
-        requestAnimationFrame(() => inputRef?.focus());
-    });
-
-    const submitCode = async (explicit?: string): Promise<void> => {
-        // Read from the live input element as a fallback. If focus desynced and
-        // the controlled signal missed the paste, the DOM value still holds it —
-        // otherwise a pasted-then-submitted code can be silently dropped.
-        const code = (explicit ?? inputRef?.value ?? pasteCode()).trim();
-        if (!code) return;
-        setPasting(true);
-        setPasteResult(null);
-        try {
-            const { getApi } = await import("@/app/store/global");
-            await getApi().setProviderAuth(props.authProviderId ?? "claude", code);
-            setPasteResult("Code accepted — signing you in…");
-            setPasteCode("");
-        } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            setPasteResult(`Error: ${msg}`);
-        } finally {
-            setPasting(false);
-        }
-    };
-
-    return (
-        <div class="agent-auth-url-box">
-            <div class="agent-auth-title">Sign in to Claude</div>
-
-            <div class="agent-auth-url-label">1 · Authorize in your browser</div>
-            <div class="agent-auth-hint">
-                Your browser should have opened. If it didn't, open this link:
-            </div>
-            <div class="agent-auth-url-row">
-                <span class="agent-auth-url-text">{props.url}</span>
-                <button
-                    class="agent-auth-url-copy"
-                    title="Open this URL in your browser"
-                    onClick={() => {
-                        void import("../flows/open-oauth-pane").then(m => m.openOAuthBrowserPane(props.url));
-                    }}
-                >
-                    Open
-                </button>
-                <button
-                    class="agent-auth-url-copy"
-                    onClick={() => { import("@/util/clipboard").then(c => c.writeText(props.url)); }}
-                    title="Copy URL"
-                >
-                    Copy
-                </button>
-            </div>
-
-            <div class="agent-auth-url-label agent-auth-step-2">2 · Paste the code from that page</div>
-            <div class="agent-auth-hint">
-                After you authorize, the page shows an <strong>authorization code</strong> — copy it and paste it here.
-            </div>
-            <div class="agent-auth-paste-row">
-                <input
-                    ref={inputRef}
-                    class="agent-auth-paste-input"
-                    type="text"
-                    placeholder="Paste the authorization code…"
-                    value={pasteCode()}
-                    onInput={(e) => setPasteCode((e.target as HTMLInputElement).value)}
-                    onKeyDown={(e) => { if (e.key === "Enter") void submitCode(); }}
-                    onPaste={(e) => {
-                        // Auto-submit on paste — pasting the code IS the intent to
-                        // submit, so the user doesn't have to also click a button.
-                        const text = (e.clipboardData?.getData("text") ?? "").trim();
-                        if (text) { setPasteCode(text); void submitCode(text); }
-                    }}
-                />
-                <button
-                    class="agent-auth-url-copy"
-                    title="Paste from clipboard and submit"
-                    onClick={() => {
-                        import("@/util/clipboard").then(c => c.readText()).then(text => {
-                            const trimmed = (text ?? "").trim();
-                            if (trimmed) { setPasteCode(trimmed); void submitCode(trimmed); }
-                        }).catch(() => {
-                            setPasteResult("Could not read clipboard — paste manually");
-                        });
-                    }}
-                >
-                    Paste &amp; submit
-                </button>
-                <button
-                    class="agent-auth-url-copy"
-                    onClick={() => { void submitCode(); }}
-                    disabled={pasting()}
-                >
-                    {pasting() ? "…" : "Submit"}
-                </button>
-            </div>
-            <Show when={pasteResult()}>
-                <div class="agent-auth-paste-result">{pasteResult()}</div>
-            </Show>
-            <div class="agent-auth-actions-row">
-                <Show when={props.onCancel}>
-                    <Button onClick={() => props.onCancel?.()}>Cancel login</Button>
-                </Show>
-                <Show when={props.onUseTerminal}>
-                    {/* Secondary fallback alongside Cancel — the URL/paste flow
-                        above is the default now (spec §3.2), but a browser that
-                        can't reach it (remote desktop, sandboxed host) still
-                        needs a way out besides giving up. Mirrors
-                        PreLaunchAuthPanel's identical secondary action. */}
-                    <Button
-                        className="grey"
-                        disabled={switchingToTerminal()}
-                        onClick={async () => {
-                            setSwitchingToTerminal(true);
-                            try {
-                                await props.onUseTerminal?.();
-                            } finally {
-                                setSwitchingToTerminal(false);
-                            }
-                        }}
-                    >
-                        {switchingToTerminal() ? "Switching…" : "Use terminal instead"}
-                    </Button>
-                </Show>
-            </div>
-        </div>
     );
 }

--- a/frontend/app/view/agent/components/to-in-app-login-phase.test.ts
+++ b/frontend/app/view/agent/components/to-in-app-login-phase.test.ts
@@ -1,0 +1,64 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for `toInAppLoginPhase` — the mapping that drives the credential-loss
+ * relogin surface's InAppLoginPanel phase line (Fix 3b of
+ * ANALYSIS_ARMORY_STASH_CREDENTIAL_VISIBILITY_GAP_2026_08_04.md). Derived
+ * from useAgentControllerStatus.ts's existing `authUrl`/`launchPhase`
+ * signals without changing that hook — this pins the derivation itself,
+ * particularly the one non-obvious case: `LaunchPhase`'s
+ * "waiting-for-login-completion" variant covers BOTH tier 1's post-URL wait
+ * and tier 3's terminal-completion poll (see launch-phase.ts's own doc
+ * comment on that variant), and `authUrl` presence is what disambiguates
+ * them here.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toInAppLoginPhase } from "./to-in-app-login-phase";
+import type { LaunchPhase } from "../flows/launch-phase";
+
+describe("toInAppLoginPhase", () => {
+    it("returns 'starting' when there is no launch phase yet", () => {
+        expect(toInAppLoginPhase(null, null)).toBe("starting");
+    });
+
+    it("returns 'starting' for phases before a URL/terminal decision is reached", () => {
+        const phases: LaunchPhase[] = [
+            { kind: "resolving-cli" },
+            { kind: "checking-auth" },
+            { kind: "waiting-for-login-link", deadlineMs: 0 },
+        ];
+        for (const phase of phases) {
+            expect(toInAppLoginPhase(null, phase)).toBe("starting");
+        }
+    });
+
+    it("returns 'fallback' once the terminal is being opened, regardless of a stale authUrl", () => {
+        const phase: LaunchPhase = { kind: "opening-login-terminal" };
+        expect(toInAppLoginPhase(null, phase)).toBe("fallback");
+        expect(toInAppLoginPhase("https://example.com/authorize", phase)).toBe("fallback");
+    });
+
+    it("returns 'waiting-authorize' during the completion wait WHEN a URL was shown (the in-app path)", () => {
+        const phase: LaunchPhase = { kind: "waiting-for-login-completion", deadlineMs: 0 };
+        expect(toInAppLoginPhase("https://example.com/authorize", phase)).toBe("waiting-authorize");
+    });
+
+    it("returns 'terminal-polling' during the completion wait when NO url was ever shown (the terminal path)", () => {
+        const phase: LaunchPhase = { kind: "waiting-for-login-completion", deadlineMs: 0 };
+        expect(toInAppLoginPhase(null, phase)).toBe("terminal-polling");
+    });
+
+    it("returns 'starting' for post-completion phases (verifying/ready/failed) — nothing left to show", () => {
+        const phases: LaunchPhase[] = [
+            { kind: "verifying" },
+            { kind: "fresh-ready" },
+            { kind: "resumed-ready" },
+            { kind: "failed", reason: "boom" },
+        ];
+        for (const phase of phases) {
+            expect(toInAppLoginPhase(null, phase)).toBe("starting");
+        }
+    });
+});

--- a/frontend/app/view/agent/components/to-in-app-login-phase.ts
+++ b/frontend/app/view/agent/components/to-in-app-login-phase.ts
@@ -1,0 +1,23 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { LaunchPhase } from "../flows/launch-phase";
+import type { InAppLoginPhase } from "./InAppLoginPanel";
+
+/**
+ * Derive InAppLoginPanel's narrower phase enum from
+ * useAgentControllerStatus.ts's existing `LaunchPhase` + `authUrl` signals
+ * — no changes to that hook's own (already extensively hardened) phase
+ * tracking. `waiting-for-login-completion` covers BOTH tier 1's post-URL
+ * wait and tier 3's terminal-completion poll (see that variant's own doc
+ * comment in launch-phase.ts); `authUrl` presence is what actually
+ * distinguishes them here — a URL was shown (in-app path) vs. none ever
+ * was (the terminal was opened instead).
+ */
+export function toInAppLoginPhase(authUrl: string | null, launchPhase: LaunchPhase | null): InAppLoginPhase {
+    if (launchPhase?.kind === "opening-login-terminal") return "fallback";
+    if (launchPhase?.kind === "waiting-for-login-completion") {
+        return authUrl ? "waiting-authorize" : "terminal-polling";
+    }
+    return "starting";
+}

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -1,25 +1,14 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Inline auth URL / auth paste UI. Wrapped in .agent-view so the cascade
-// chain matches the pre-split file (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
-// The activity-log panel that used to live in this file was removed —
-// activity-log lines now write directly into the shell terminal (see
-// agent-view.tsx's `log`/`handleShellTermReady`) instead of a separate
-// styled panel.
+// Wrapped in .agent-view so the cascade chain matches the pre-split file
+// (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24). The activity-log panel that used
+// to live in this file was removed — activity-log lines now write directly
+// into the shell terminal (see agent-view.tsx's `log`/`handleShellTermReady`)
+// instead of a separate styled panel.
 .agent-view {
-    .agent-auth-url-box {
-        margin-top: var(--space-2);
-        padding: 10px var(--space-3);
-        background: var(--panel-bg-color, rgba(74, 158, 255, 0.08));
-        border: 1px solid var(--accent-color);
-        border-radius: 0;
-        box-shadow: 0 0 12px rgba(74, 158, 255, 0.15);
-    }
-
-    // Auth-recovery error notice — same header slot as the auth-URL box, but
-    // error-accented: shown when a login action failed visibly (e.g. no OAuth
-    // URL could be captured, so no browser opened).
+    // Auth-recovery error notice: shown when a login action failed visibly
+    // (e.g. no OAuth URL could be captured, so no browser opened).
     .agent-auth-notice {
         display: flex;
         align-items: flex-start;
@@ -49,137 +38,5 @@
                 color: var(--main-text-color);
             }
         }
-    }
-
-    .agent-auth-title {
-        font-size: 12px;
-        font-weight: 700;
-        color: var(--main-text-color);
-        margin-bottom: var(--space-2);
-    }
-
-    .agent-auth-url-label {
-        font-size: 11px;
-        color: var(--accent-color);
-        margin-bottom: var(--space-1);
-        font-weight: 600;
-        letter-spacing: 0.3px;
-
-        // Second step gets breathing room from the URL row above it.
-        &.agent-auth-step-2 {
-            margin-top: var(--space-3);
-        }
-    }
-
-    .agent-auth-hint {
-        font-size: 10px;
-        color: var(--secondary-text-color, rgba(140, 200, 255, 0.55));
-        margin-bottom: var(--space-1-5);
-        line-height: 1.4;
-
-        strong {
-            color: var(--accent-color);
-            font-weight: 600;
-        }
-    }
-
-    .agent-auth-url-row {
-        position: relative;
-        display: flex;
-        align-items: center;
-        padding: var(--space-2) 10px;
-        background: rgba(0, 0, 0, 0.35);
-        border-radius: 0;
-        cursor: default;
-
-        &:hover .agent-auth-url-copy {
-            opacity: 1;
-            transform: translateY(-50%) scale(1);
-        }
-    }
-
-    .agent-auth-url-text {
-        flex: 1;
-        word-break: break-all;
-        color: var(--accent-color);
-        font-size: 11px;
-        font-family: var(--fixed-font, monospace);
-        user-select: text;
-        padding-right: 60px;
-    }
-
-    .agent-auth-url-copy {
-        position: absolute;
-        right: 8px;
-        top: 50%;
-        transform: translateY(-50%) scale(0.95);
-        padding: var(--space-1) var(--space-3);
-        font-size: 10px;
-        font-weight: 600;
-        background: var(--accent-color);
-        color: #fff; /* stylelint-disable-line color-no-hex */
-        border: none;
-        border-radius: 0;
-        cursor: default;
-        opacity: 0;
-        transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
-
-        &:hover {
-            background: color-mix(in srgb, var(--accent-color), white 15%);
-        }
-
-        &:active {
-            transform: translateY(-50%) scale(0.92);
-        }
-    }
-
-    .agent-auth-paste-row {
-        display: flex;
-        align-items: center;
-        gap: var(--space-1-5);
-        margin-top: var(--space-2);
-
-        .agent-auth-paste-input {
-            flex: 1;
-            padding: var(--space-1-5) 10px;
-            background: rgba(0, 0, 0, 0.35);
-            border: 1px solid rgba(74, 158, 255, 0.3);
-            border-radius: 0;
-            color: var(--main-text-color);
-            font-size: 11px;
-            font-family: var(--fixed-font, monospace);
-            outline: none;
-
-            &:focus {
-                border-color: var(--accent-color);
-            }
-
-            &::placeholder {
-                color: rgba(140, 200, 255, 0.4);
-            }
-        }
-
-        .agent-auth-url-copy {
-            position: static;
-            transform: none;
-            opacity: 1;
-            &:hover { background: color-mix(in srgb, var(--accent-color), white 15%); }
-            &:disabled { opacity: 0.4; cursor: default; }
-        }
-    }
-
-    .agent-auth-paste-result {
-        margin-top: 5px;
-        font-size: 10px;
-        color: var(--accent-color);
-        opacity: 0.8;
-    }
-
-    .agent-auth-actions-row {
-        display: flex;
-        align-items: center;
-        gap: var(--space-1-5);
-        margin-top: var(--space-2);
     }
 }


### PR DESCRIPTION
## Summary

Closes the last of the three surfaces `SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md` originally planned (§3.3 surface 2) — its own phasing explicitly listed this as a separate PR that was never built. Until now, a mid-session credential-loss relogin (an agent pane whose auth died) rendered the older, separate `AuthUrlBox` component inline in the transcript.

**Design update (2026-08-07):** originally built as a `Modal`-wrapped `InAppLoginPanel`, matching the Armory/Stash surfaces. Based on user feedback while live-testing #2429 ("the login UI needs to be pinned to the bottom, like question/answer"), switched to rendering `InAppLoginPanel` directly inside `AgentAuthPanel`'s bottom-docked slot (`agent-view.tsx`, introduced by #2436) instead — same flex-sibling band as `AgentDecisionPanel`/`AgentQuestionPanel`, no Modal/backdrop-dimming. Still reuses the shared `InAppLoginPanel` component (one fewer hand-rolled auth UI), just without the floating-dialog presentation. Rebased onto main after #2436 merged to pick up `AgentAuthPanel`.

`AuthUrlBox` and its dead CSS (`frontend/app/view/agent/styles/_activity-log.scss`) are fully retired — addresses the reagentx P2 finding from the original review.

Added `toInAppLoginPhase` (`frontend/app/view/agent/components/to-in-app-login-phase.ts`) to derive `InAppLoginPanel`'s phase enum from `useAgentControllerStatus.ts`'s existing `authUrl`/`launchPhase` signals, without touching that hook's own internal state tracking — purely additive.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` on `login.test.ts`, `useAgentControllerStatus.test.ts`, `to-in-app-login-phase.test.ts` — 30/30 passing
- [x] Confirmed zero remaining code references to `AuthUrlBox`/its CSS classes (only stale prose comments remain, same as originally scoped)

<!-- agentmux:agent_id=agenta -->
