### PR TITLE
Surface --resume outcome as an explicit pane transcript event

### DIFF
--- a/.changesets/1785955383-feat-agent-pane-surface-resume-outcome-as-an-explicit-transc-zb0y.md
+++ b/.changesets/1785955383-feat-agent-pane-surface-resume-outcome-as-an-explicit-transc-zb0y.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): surface --resume outcome as an explicit transcript event

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -45,6 +45,34 @@ pub const PERSISTENT_OUTPUT_SUBJECT: &str = "output";
 
 pub const BLOCK_CONTROLLER_PERSISTENT: &str = "persistent";
 
+/// Builds the NDJSON line for a `persistent_resume::ResumeEffect::
+/// EmitSessionOutcome` — a free function (not a method) so it's callable
+/// both from `PersistentSubprocessController::emit_session_outcome_line`
+/// and directly from the stdout-reader/process-waiter tasks below, which
+/// only hold `_read`-suffixed clones, not `&self`. See
+/// SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1.
+fn session_outcome_line(
+    outcome: persistent_resume::SessionOutcome,
+    attempted_sid: String,
+    actual_sid: Option<String>,
+) -> String {
+    let outcome_str = match outcome {
+        persistent_resume::SessionOutcome::Resumed => "resumed",
+        persistent_resume::SessionOutcome::Fresh => "fresh",
+    };
+    format!(
+        "{}\n",
+        serde_json::json!({
+            "type": "system",
+            "subtype": "agentmux_session_outcome",
+            "outcome": outcome_str,
+            "attempted_sid": attempted_sid,
+            "actual_sid": actual_sid,
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        })
+    )
+}
+
 /// Resolve the muxbus address (the agent's display name) from a spawn env map.
 /// `AGENTMUX_AGENT_ID` (= `agent.name`, set at block creation) is canonical;
 /// `WAVEMUX_AGENT_ID` is the legacy fallback. Returns `None` — i.e. not
@@ -2342,13 +2370,34 @@ impl PersistentSubprocessController {
                             // error line from an earlier turn on this
                             // same still-alive generation — execute it,
                             // same as every other `ResumeEffect` call
-                            // site in this module. `SessionCaptured`
-                            // never produces any other effect variant
-                            // (see `persistent_resume::update`'s own
-                            // handling), but this stays exhaustive rather
-                            // than assuming that never changes.
+                            // site in this module. `SessionCaptured` can
+                            // also now resolve tracking outright and
+                            // produce an `EmitSessionOutcome` (see
+                            // `persistent_resume::update`'s own handling,
+                            // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+                            // §2.1) — handled explicitly below; anything
+                            // else falls to the catch-all, kept exhaustive
+                            // rather than assuming the effect set never
+                            // grows again.
                             for effect in capture_effects {
                                 match effect {
+                                    persistent_resume::ResumeEffect::EmitSessionOutcome {
+                                        outcome,
+                                        attempted_sid,
+                                        actual_sid,
+                                    } => {
+                                        if let Some(ref broker) = broker_read {
+                                            let line = session_outcome_line(outcome, attempted_sid, actual_sid);
+                                            super::shell::handle_append_block_file(
+                                                broker,
+                                                &block_id_read,
+                                                PERSISTENT_OUTPUT_SUBJECT,
+                                                line.as_bytes(),
+                                                filestore_read.as_ref(),
+                                                global_output_zone.as_deref(),
+                                            );
+                                        }
+                                    }
                                     persistent_resume::ResumeEffect::FlushErrorLine(line) => {
                                         if let Some(ref broker) = broker_read {
                                             super::shell::handle_append_block_file(
@@ -2813,6 +2862,29 @@ impl PersistentSubprocessController {
                     // RETRO_STALE_RESUME_SESSION_ID_ACROSS_CHANNELS_2026_07_29.md).
                     for effect in effects {
                         match effect {
+                            // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+                            // §2.1: the `ConfirmedRetry` + `ProcessExited`
+                            // (not-stopped) arm now bundles this alongside
+                            // `FireRetry` — the resume's fate (Fresh) is
+                            // already known here, even though the retry
+                            // below hasn't launched yet.
+                            persistent_resume::ResumeEffect::EmitSessionOutcome {
+                                outcome,
+                                attempted_sid,
+                                actual_sid,
+                            } => {
+                                if let Some(ref broker) = broker_wait {
+                                    let line = session_outcome_line(outcome, attempted_sid, actual_sid);
+                                    super::shell::handle_append_block_file(
+                                        broker,
+                                        &block_id_wait,
+                                        PERSISTENT_OUTPUT_SUBJECT,
+                                        line.as_bytes(),
+                                        filestore_wait.as_ref(),
+                                        global_output_zone_wait.as_deref(),
+                                    );
+                                }
+                            }
                             persistent_resume::ResumeEffect::PersistImmediately(line)
                             | persistent_resume::ResumeEffect::FlushErrorLine(line) => {
                                 if let Some(ref broker) = broker_wait {
@@ -3071,6 +3143,19 @@ impl PersistentSubprocessController {
                             | persistent_resume::ResumeEffect::FlushErrorLine(line) => Some(line),
                             persistent_resume::ResumeEffect::FireRetry { held_error_line, .. } => held_error_line,
                             persistent_resume::ResumeEffect::PublishDone => None,
+                            // Not actually reachable here today — the "stop
+                            // wins" branch of `update()`'s ConfirmedRetry +
+                            // ProcessExited arm never produces this effect
+                            // (see SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+                            // §2.1) — but matched defensively, same as
+                            // `FireRetry` above, rather than assumed. Reuses
+                            // the same "append this line" path as every
+                            // other variant here.
+                            persistent_resume::ResumeEffect::EmitSessionOutcome {
+                                outcome,
+                                attempted_sid,
+                                actual_sid,
+                            } => Some(session_outcome_line(outcome, attempted_sid, actual_sid)),
                         };
                         if let Some(line) = line {
                         if let Some(ref broker) = broker_wait {
@@ -5065,7 +5150,14 @@ mod resume_poison_tests {
         let (_, effects) = inner.try_capture_session_id("dead-sid", 1, true);
         assert_eq!(
             effects,
-            vec![persistent_resume::ResumeEffect::FlushErrorLine("boom\n".to_string())],
+            vec![
+                persistent_resume::ResumeEffect::FlushErrorLine("boom\n".to_string()),
+                persistent_resume::ResumeEffect::EmitSessionOutcome {
+                    outcome: persistent_resume::SessionOutcome::Resumed,
+                    attempted_sid: "dead-sid".to_string(),
+                    actual_sid: None,
+                },
+            ],
             "a held-back error line from an earlier turn must be surfaced to the caller \
              when a later capture resolves tracking, not silently discarded"
         );

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -47,10 +47,9 @@ pub const BLOCK_CONTROLLER_PERSISTENT: &str = "persistent";
 
 /// Builds the NDJSON line for a `persistent_resume::ResumeEffect::
 /// EmitSessionOutcome` — a free function (not a method) so it's callable
-/// both from `PersistentSubprocessController::emit_session_outcome_line`
-/// and directly from the stdout-reader/process-waiter tasks below, which
-/// only hold `_read`-suffixed clones, not `&self`. See
-/// SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1.
+/// directly from the stdout-reader, process-waiter, and stop-path match
+/// arms below, which only hold `_read`/`_wait`-suffixed clones, not
+/// `&self`. See SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1.
 fn session_outcome_line(
     outcome: persistent_resume::SessionOutcome,
     attempted_sid: String,

--- a/agentmux-srv/src/backend/blockcontroller/persistent_resume.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent_resume.rs
@@ -177,6 +177,17 @@ pub(super) enum ResumeEvent {
     StopRequested { generation: u64 },
 }
 
+/// A resume attempt's outcome, once definitively known. See
+/// `ResumeEffect::EmitSessionOutcome`'s doc comment for how this is used.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum SessionOutcome {
+    /// The CLI continued the exact session `--resume` was given.
+    Resumed,
+    /// The CLI could not continue that session — a new one was (or is
+    /// about to be) started. The model has none of the prior turns.
+    Fresh,
+}
+
 /// What the caller must actually DO in response to an event — kept
 /// separate from `ResumeState` so `update()` stays a pure function with
 /// no I/O, fully exercisable in a unit test.
@@ -201,6 +212,16 @@ pub(super) enum ResumeEffect {
     FireRetry { retry: RetryPayload, held_error_line: Option<String> },
     /// Genuinely done, not retrying — publish the terminal status.
     PublishDone,
+    /// A `--resume <attempted_sid>` attempt's outcome just became
+    /// unambiguously known — surface it as a persisted transcript event
+    /// (not just a trace log line), so the pane's scrollback can never
+    /// silently disagree with what the model actually has in context.
+    /// `actual_sid` is `Some` when the CLI reported a different session id
+    /// in the same breath that resolved this generation (the
+    /// `SessionCaptured` divergence case); `None` for the `FireRetry` path,
+    /// where no fresh sid is known yet — the retry hasn't launched.
+    /// See SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1.
+    EmitSessionOutcome { outcome: SessionOutcome, attempted_sid: String, actual_sid: Option<String> },
 }
 
 /// Resolves a PRIOR generation's still-unresolved tracking
@@ -279,7 +300,18 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
                 // generation held one back, before this LATER capture
                 // resolves tracking) must be flushed, not silently
                 // discarded along with the state.
-                let effects = held_error_line.map(|line| vec![ResumeEffect::FlushErrorLine(line)]).unwrap_or_default();
+                let mut effects: Vec<ResumeEffect> =
+                    held_error_line.map(ResumeEffect::FlushErrorLine).into_iter().collect();
+                // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1: this
+                // is one of the two points where a resume attempt's fate
+                // becomes unambiguously known — surface it.
+                let outcome = if sid == attempted_sid && is_confirmed_success {
+                    SessionOutcome::Resumed
+                } else {
+                    SessionOutcome::Fresh
+                };
+                let actual_sid = if sid != attempted_sid { Some(sid) } else { None };
+                effects.push(ResumeEffect::EmitSessionOutcome { outcome, attempted_sid, actual_sid });
                 (ResumeState::NotTracking { current_generation: generation }, effects)
             } else {
                 (
@@ -311,7 +343,16 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
             ResumeEvent::SessionCaptured { generation: g, sid, is_confirmed_success },
         ) if generation == g => {
             if sid != attempted_sid || is_confirmed_success {
-                let effects = held_error_line.map(|line| vec![ResumeEffect::FlushErrorLine(line)]).unwrap_or_default();
+                let mut effects: Vec<ResumeEffect> =
+                    held_error_line.map(ResumeEffect::FlushErrorLine).into_iter().collect();
+                // Same rationale as the `AwaitingOutcome` arm above.
+                let outcome = if sid == attempted_sid && is_confirmed_success {
+                    SessionOutcome::Resumed
+                } else {
+                    SessionOutcome::Fresh
+                };
+                let actual_sid = if sid != attempted_sid { Some(sid) } else { None };
+                effects.push(ResumeEffect::EmitSessionOutcome { outcome, attempted_sid, actual_sid });
                 (ResumeState::NotTracking { current_generation: generation }, effects)
             } else {
                 (
@@ -456,7 +497,7 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
             (ResumeState::NotTracking { current_generation: generation }, effects)
         }
         (
-            ResumeState::ConfirmedRetry { generation, retry, held_error_line, stop_requested, .. },
+            ResumeState::ConfirmedRetry { generation, attempted_sid, retry, held_error_line, stop_requested },
             ResumeEvent::ProcessExited { generation: g },
         ) if generation == g => {
             let effects = if stop_requested {
@@ -477,7 +518,22 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
                 // (it's determined later, asynchronously, by the
                 // caller's own spawn attempt), so it's bundled into the
                 // effect rather than pre-decided here.
-                vec![ResumeEffect::FireRetry { retry, held_error_line }]
+                //
+                // The resume was CONFIRMED unreachable (`ResumeUnreachable`
+                // already fired to reach `ConfirmedRetry`) — the retry
+                // about to fire clears `session_id` before respawning
+                // (`retry_after_resume_failure`), so this is unambiguously
+                // a Fresh outcome, known now even though the retry itself
+                // hasn't launched yet. See
+                // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1.
+                vec![
+                    ResumeEffect::EmitSessionOutcome {
+                        outcome: SessionOutcome::Fresh,
+                        attempted_sid,
+                        actual_sid: None,
+                    },
+                    ResumeEffect::FireRetry { retry, held_error_line },
+                ]
             };
             (ResumeState::NotTracking { current_generation: generation }, effects)
         }
@@ -572,7 +628,14 @@ mod tests {
             },
         );
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
-        assert!(effects.is_empty());
+        assert_eq!(
+            effects,
+            vec![ResumeEffect::EmitSessionOutcome {
+                outcome: SessionOutcome::Resumed,
+                attempted_sid: "dead-sid".to_string(),
+                actual_sid: None,
+            }]
+        );
 
         // A later, unrelated exit on this now-resolved generation must
         // not retry or dredge up anything.
@@ -630,7 +693,14 @@ mod tests {
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
         assert_eq!(
             effects,
-            vec![ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: Some("boom".to_string()) }]
+            vec![
+                ResumeEffect::EmitSessionOutcome {
+                    outcome: SessionOutcome::Fresh,
+                    attempted_sid: "dead-sid".to_string(),
+                    actual_sid: None,
+                },
+                ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: Some("boom".to_string()) },
+            ]
         );
     }
 
@@ -685,7 +755,14 @@ mod tests {
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
         assert_eq!(
             effects,
-            vec![ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: Some("boom".to_string()) }]
+            vec![
+                ResumeEffect::EmitSessionOutcome {
+                    outcome: SessionOutcome::Fresh,
+                    attempted_sid: "dead-sid".to_string(),
+                    actual_sid: None,
+                },
+                ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: Some("boom".to_string()) },
+            ]
         );
     }
 
@@ -842,7 +919,14 @@ mod tests {
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
         assert_eq!(
             effects,
-            vec![ResumeEffect::FlushErrorLine("boom".to_string())],
+            vec![
+                ResumeEffect::FlushErrorLine("boom".to_string()),
+                ResumeEffect::EmitSessionOutcome {
+                    outcome: SessionOutcome::Resumed,
+                    attempted_sid: "dead-sid".to_string(),
+                    actual_sid: None,
+                },
+            ],
             "the held error must reach the user, not vanish along with the resolved tracking"
         );
     }
@@ -868,7 +952,17 @@ mod tests {
             ResumeEvent::SessionCaptured { generation: 1, sid: "dead-sid".to_string(), is_confirmed_success: true },
         );
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
-        assert_eq!(effects, vec![ResumeEffect::FlushErrorLine("boom".to_string())]);
+        assert_eq!(
+            effects,
+            vec![
+                ResumeEffect::FlushErrorLine("boom".to_string()),
+                ResumeEffect::EmitSessionOutcome {
+                    outcome: SessionOutcome::Resumed,
+                    attempted_sid: "dead-sid".to_string(),
+                    actual_sid: None,
+                },
+            ]
+        );
     }
 
     // reagentx P1 (round 9 on this PR, also flagged inline by codex): the
@@ -909,7 +1003,17 @@ mod tests {
         // The retry still fires normally once the process actually exits.
         let (state, effects) = update(state, ResumeEvent::ProcessExited { generation: 1 });
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
-        assert_eq!(effects, vec![ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: None }]);
+        assert_eq!(
+            effects,
+            vec![
+                ResumeEffect::EmitSessionOutcome {
+                    outcome: SessionOutcome::Fresh,
+                    attempted_sid: "dead-sid".to_string(),
+                    actual_sid: None,
+                },
+                ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: None },
+            ]
+        );
     }
 
     // reagentx P2 on PR #2373: an ErrorResultLine whose generation
@@ -1008,5 +1112,59 @@ mod tests {
         let (state, effects) = update(state, ResumeEvent::ProcessExited { generation: 1 });
         assert!(effects.is_empty(), "generation 1's stale exit must not fire its now-superseded retry");
         assert_eq!(state, ResumeState::NotTracking { current_generation: 2 });
+    }
+
+    // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1: the CLI itself
+    // can silently roll to a DIFFERENT session id (rather than failing
+    // outright) before `ResumeUnreachable` ever gets a chance to fire — the
+    // `sid != attempted_sid` branch of the unambiguity check. This must
+    // still be reported as Fresh, with `actual_sid` carrying the id the CLI
+    // actually landed on.
+    #[test]
+    fn session_captured_with_a_different_sid_emits_fresh_outcome_with_actual_sid() {
+        let state = spawned_with_resume(1);
+        let (state, effects) = update(
+            state,
+            ResumeEvent::SessionCaptured {
+                generation: 1,
+                sid: "brand-new-sid".to_string(),
+                is_confirmed_success: false,
+            },
+        );
+        assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
+        assert_eq!(
+            effects,
+            vec![ResumeEffect::EmitSessionOutcome {
+                outcome: SessionOutcome::Fresh,
+                attempted_sid: "dead-sid".to_string(),
+                actual_sid: Some("brand-new-sid".to_string()),
+            }]
+        );
+    }
+
+    // Regression guard for SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+    // §2.1's "deliberately not touched" call: a fresh spawn with no resume
+    // attempt at all (no session existed yet — nothing to lose), and a
+    // resume attempt that's never confirmed either way (auth failure etc.,
+    // §2.1's `unrelated_error_never_confirmed_flushes_instead_of_retrying`
+    // case), must NOT emit a session-outcome event — there's no positively-
+    // known outcome to report in either case.
+    #[test]
+    fn spawned_fresh_and_never_confirmed_paths_never_emit_a_session_outcome() {
+        let (state, effects) = update(ResumeState::default(), ResumeEvent::SpawnedFresh { generation: 1 });
+        assert!(!effects.iter().any(|e| matches!(e, ResumeEffect::EmitSessionOutcome { .. })));
+
+        let state2 = spawned_with_resume(2);
+        let (state2, _) =
+            update(state2, ResumeEvent::ErrorResultLine { generation: 2, line: "auth failed".to_string() });
+        let (_, effects) = update(state2, ResumeEvent::ProcessExited { generation: 2 });
+        assert!(
+            !effects.iter().any(|e| matches!(e, ResumeEffect::EmitSessionOutcome { .. })),
+            "a never-confirmed resume attempt has no positively-known outcome to report"
+        );
+
+        // Keep `state` (generation 1) used so the compiler doesn't flag it —
+        // its only purpose above is exercising the SpawnedFresh path.
+        assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
     }
 }

--- a/docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+++ b/docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
@@ -1,0 +1,357 @@
+# SPEC: Align pane scrollback with actual model context, and make cross-instance opens honest
+
+**Date:** 2026-08-05
+**Status:** Proposed — design for Part A below; implemented in this PR. Parts B/C
+scoped but deferred (see §6).
+**Severity:** Medium — no data loss, but a real correctness gap: the pane can
+imply the agent remembers a conversation it does not, with no visible signal
+that anything went wrong.
+**Trigger:** Follow-up to `audits/AUDIT_AGENT_PANE_HISTORY_2026_08_05.md` (an
+agent-pane-history audit written the same day), which found that "what the pane
+displays" and "what the model actually remembers" are two independently-loaded
+stores that can silently disagree.
+
+---
+
+## 0. Ask
+
+> "we want them to align as close as possible, is that possible? We also want
+> agents that open in a new version or new instance of agentmux retain whatever
+> is there, or at least loads empty if the memory is empty ... that is just in
+> the agent pane though, the actual data needs to be saved and organized"
+
+Three asks, in order of what this doc actually solves:
+
+1. **Align pane scrollback with model context "as close as possible."** Not
+   fully possible — the provider CLI's own context window/compaction is opaque
+   to AgentMux (see the audit, F2). What *is* possible, and what Part A of this
+   doc implements: never let the two *disagree silently*. Every time a
+   `--resume` attempt's outcome becomes known, record it as an explicit,
+   persisted transcript event, so the scrollback the human reads always
+   honestly reflects whether the model actually continued or started over.
+2. **Cross-instance/cross-version opens retain history if it exists, or load
+   genuinely empty if it doesn't** — never a stale/misleading in-between. This
+   is Part B (§6.2): rehydrate the provider's isolated session file from the
+   already-existing global transcript zone *before* attempting `--resume`, so
+   resume either genuinely works or is honestly skipped.
+3. **The actual data needs to be saved and organized.** Already substantially
+   true (see §1) — the global per-agent transcript zone
+   (`agent:<definitionId>:current`) built in
+   `docs/analysis/ANALYSIS_CROSS_CHANNEL_CONVERSATION_HISTORY_2026_06_14.md`
+   steps 1–4 is exactly this. What's missing is (a) the resume-outcome record
+   from Part A, and (b) the backfill/rehydrate step that doc's own §9 deferred
+   (Part B, C below).
+
+---
+
+## 1. What already exists (confirmed by reading the current code, not assumed)
+
+- **Global per-agent transcript store.** `agent:<definitionId>:current` is a
+  `FileStore` zone in a global (not per-channel) store, mirrored from every
+  channel's local blockfile on every append
+  (`agentmux-srv/src/backend/blockcontroller/shell.rs`, `resolve_global_output_zone`).
+  This is the "saved and organized" piece the ask calls for — it already exists
+  and is already the read-fallback for cross-channel opens
+  (`agentmux-srv/src/server/app_api/blockfile.rs`).
+- **The pane loads the tail, not everything, on mount** — 200 lines, paged
+  further back on scroll (`frontend/app/view/agent/hooks/useHistoryPagination.ts`).
+  This is a UI/virtualization bound, unrelated to model context, and out of
+  scope here — it's already correct for its purpose (instant open on very long
+  sessions).
+- **Model context is resumed via `--resume <session_id>`**, a value AgentMux
+  persists as opaque block meta (`agent:sessionid`) and hands to the provider
+  CLI on every spawn/respawn (`agentmux-srv/src/server/app_api/agent_io.rs`).
+  AgentMux does not read or reason about the CLI's actual transcript content.
+- **A dedicated state machine already tracks resume outcome internally.**
+  `agentmux-srv/src/backend/blockcontroller/persistent_resume.rs` — built after
+  issue #2368 and a live recurrence (agent "Marks", 2026-07-30) — is a pure
+  `(state, event) -> (state, effects)` machine that already knows, precisely and
+  per-generation, whether a `--resume` attempt (a) succeeded, (b) was confirmed
+  unreachable and is retrying fresh, or (c) never resolved. **This state is
+  computed today and then only logged** (`tracing::info!`) — never persisted to
+  the transcript, never shown to the user. Part A of this doc is almost entirely
+  "surface state that's already being computed."
+- **There is exact precedent for a synthetic, non-CLI-native transcript event
+  rendered as a distinct divider node**: `compact_boundary` /
+  `ContextCompactedNode`
+  (`docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md`,
+  `frontend/app/view/agent/compact-boundary.ts`). Both the live path
+  (`useAgentStream.ts`) and the history-replay path (`parseHistoryLines.ts`)
+  intercept a raw `{"type":"system","subtype":"compact_boundary",...}` frame
+  directly (bypassing the generic provider `Translator`, which has no shape for
+  it) and construct a node with a **content-derived stable id** so the same
+  event seen live and via a later history page merges into one node instead of
+  duplicating. Part A reuses this exact shape and this exact dual-interception
+  pattern for a new frame type.
+
+---
+
+## 2. Part A — explicit "session outcome" event (implemented in this PR)
+
+### 2.1 Backend: emit the event where the outcome is already decided
+
+`persistent_resume.rs`'s `update()` function has exactly two places where a
+resume attempt's fate becomes unambiguously known — both already produce
+`ResumeEffect`s today, just not this one:
+
+1. **`SessionCaptured` resolving a tracked generation** (the `AwaitingOutcome`
+   and `ConfirmedRetry` arms, both guarded by `sid != attempted_sid ||
+   is_confirmed_success`): `sid == attempted_sid && is_confirmed_success` means
+   the CLI genuinely continued the requested session — **Resumed**. `sid !=
+   attempted_sid` means the CLI itself silently rolled to a different session —
+   **Fresh**, even though no retry was ever fired.
+2. **`ConfirmedRetry` + `ProcessExited` (not `stop_requested`)** — the
+   `FireRetry` arm. `ResumeUnreachable` already confirmed the attempted session
+   is dead; the caller is about to relaunch with `session_id` cleared
+   (`retry_after_resume_failure` sets `config.session_id = String::new()`).
+   Unambiguously **Fresh**.
+
+Added, purely additively (no existing arm's condition or return value changes,
+only appends to the effects `Vec` already being built):
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum SessionOutcome {
+    /// The CLI continued the exact session `--resume` was given.
+    Resumed,
+    /// The CLI could not continue that session — a new one was (or is about
+    /// to be) started. The model has none of the prior turns.
+    Fresh,
+}
+```
+
+```rust
+/// A resume attempt's outcome became definitively known. Surfaced as a
+/// persisted transcript event (§2.1 of
+/// SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md), not just a trace log
+/// line, so the pane's scrollback can never silently disagree with what the
+/// model actually has in context.
+EmitSessionOutcome { outcome: SessionOutcome, attempted_sid: String, actual_sid: Option<String> },
+```
+
+`persistent.rs`'s three existing `ResumeEffect` match sites (the stdout
+`SessionCaptured` handler, the process-exit handler, and the stop-path handler)
+each get one new arm, mirroring `flush_error_line_now`'s existing
+`handle_append_block_file` call — appends to both the per-channel blockfile and
+the global mirror zone, so the event survives cross-channel/cross-instance
+exactly like every other transcript line already does:
+
+```rust
+fn emit_session_outcome_line(&self, outcome: SessionOutcome, attempted_sid: String, actual_sid: Option<String>) {
+    let Some(ref broker) = self.broker else { return };
+    let line = serde_json::json!({
+        "type": "system",
+        "subtype": "agentmux_session_outcome",
+        "outcome": match outcome { SessionOutcome::Resumed => "resumed", SessionOutcome::Fresh => "fresh" },
+        "attempted_sid": attempted_sid,
+        "actual_sid": actual_sid,
+        "timestamp": chrono_like_rfc3339_now(),
+    }).to_string() + "\n";
+    let global_output_zone = super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
+    super::shell::handle_append_block_file(
+        broker, &self.block_id, PERSISTENT_OUTPUT_SUBJECT, line.as_bytes(),
+        self.filestore.as_ref(), global_output_zone.as_deref(),
+    );
+}
+```
+
+`type: "system"` with a project-specific `subtype` mirrors `compact_boundary`
+exactly — a frame shape the provider CLI itself would never emit (no collision
+risk) that both consumers already know how to special-case.
+
+**Deliberately not touched:** the `SpawnedFresh` transition (spawn-time
+classification of "no resume attempted this generation"). As documented in
+`persistent.rs:1918-1932`, that classification also fires for a truly-first-ever
+turn (no session existed to lose) and for internal respawns with no immediate
+message — neither is a "the model lost its memory" event, and disambiguating
+them correctly from inside `spawn_process` would touch code with a long history
+of subtle races (issue #2368, PR #2373 rounds 4/5/7/9). Out of scope for this
+PR; not needed for the two outcome points above, which already cover every case
+where AgentMux *positively knows* what happened to a resume attempt.
+
+### 2.2 Frontend: render it as a distinct divider, not silently
+
+New file `frontend/app/view/agent/session-outcome.ts`, structurally identical to
+`compact-boundary.ts`:
+
+```ts
+export interface SessionOutcomeData {
+    outcome: "resumed" | "fresh";
+    attemptedSid: string;
+    actualSid: string | null;
+    frameTimestamp: string | null;
+}
+
+export function parseSessionOutcomeFrame(rawEvent: unknown): SessionOutcomeData | null { ... }
+
+export function sessionOutcomeNodeId(data: SessionOutcomeData): string {
+    // content-derived, same rationale as contextCompactedNodeId: a live-seen
+    // event and the same event re-seen via history-page overlap must land on
+    // one id, not two.
+    const suffix = data.frameTimestamp ?? `notime-${data.outcome}-${data.attemptedSid}`;
+    return `session-outcome-${suffix}`;
+}
+```
+
+`types.ts` gains:
+
+```ts
+export interface SessionOutcomeNode {
+    type: "session_outcome";
+    id: string;
+    outcome: "resumed" | "fresh";
+    attemptedSid: string;
+    actualSid: string | null;
+    timestamp: number;
+}
+```
+— added to the `DocumentNode` union.
+
+**Interception, not `dispatchPane`.** `compact_boundary` round-trips through
+`model.dispatchPane({ type: "CompactionBoundary", ... })` because the pane-state
+machine also drives the live token-meter reset on compaction. The session-outcome
+event has no such side effect — it is purely a transcript marker — so both
+`useAgentStream.ts` (live) and `parseHistoryLines.ts` (replay) construct and
+push the `SessionOutcomeNode` directly (`queue.pushNewNode(...)` /
+`nodes.push(...)` with the same `indexById`-based dedup `parseHistoryLines.ts`
+already uses for `context_compacted`), skipping the pane-dispatch layer
+entirely. This keeps the change confined to the same two files
+`compact_boundary` already touches for parsing, plus the render/size/expansion
+wiring below — no new pane-state action type.
+
+Render wiring (mirrors `context_compacted` at each site):
+- `DocumentRow.tsx` — a `<Show when={... === "session_outcome"}>` divider row:
+  *"Session continued"* (green/neutral) for `resumed`, *"New session started —
+  prior conversation is not available to this agent"* (amber) for `fresh`.
+- `renderers.ts` — non-expandable, fixed height (mirrors `context_compacted: 48`
+  in the three switch statements there).
+- `expansion-source.ts` — same `case "context_compacted":` treatment (not
+  expandable).
+
+### 2.3 Why this is the right (and only newly-needed) alignment mechanism
+
+This does not make the pane's scrollback and the model's context *identical* —
+that's impossible without AgentMux reimplementing the provider's own context
+management (audit F2, explicitly a non-goal). What it does is close the gap
+that actually matters: **the human can no longer be shown continuous-looking
+scrollback while the model silently has none of it.** Every resume boundary is
+now a first-class, persisted, honestly-labeled event in the same stream as
+everything else — exactly the "align as close as possible" the ask asked for,
+scoped to what's actually knowable from inside AgentMux.
+
+---
+
+## 3. Non-goals (this PR)
+
+- Reimplementing or introspecting the provider CLI's own context
+  window/compaction/token accounting. Out of reach from this codebase (audit
+  F2); `compact_boundary`/`ContextCompactedNode` already covers the one piece
+  of that the CLI *does* tell us about.
+- Changing the 200-line pane page size or the ring-buffer fallback cap — both
+  already correct for their purpose (audit §3).
+- The coordination/activity history log (`appendagenthistory` et al., audit
+  §4) — a separate feature, not a conversation store.
+
+---
+
+## 4. Scope and blast radius
+
+- **Backend:** `agentmux-srv/src/backend/blockcontroller/persistent_resume.rs`
+  (new enum + effect variant, additive changes to 3 match arms, new unit
+  tests), `agentmux-srv/src/backend/blockcontroller/persistent.rs` (new
+  `emit_session_outcome_line` helper + 3 new match arms at existing
+  `ResumeEffect` consumption sites).
+- **Frontend:** new `frontend/app/view/agent/session-outcome.ts`;
+  `types.ts`, `useAgentStream.ts`, `parseHistoryLines.ts`,
+  `virtualization/DocumentRow.tsx`, `virtualization/renderers.ts`,
+  `virtualization/expansion-source.ts` — each gets the same small, additive
+  case `context_compacted` already has, not a new subsystem.
+- Every change is additive: no existing `ResumeState`/`ResumeEffect` variant,
+  match arm condition, or return value is altered. Existing behavior (what
+  gets persisted, when a retry fires, when `PublishDone` happens) is byte-for-
+  byte unchanged; this PR only adds a new effect alongside effects that were
+  already being produced.
+- **Only the persistent-controller (Claude, and any future simple-flag-resume
+  provider) path is covered** — the interactive agent pane's primary path
+  (`providers.rs`: "Claude runs on the persistent controller"). The headless
+  one-shot drone `run_agent` path (`agents/runner.rs`) and the
+  `SubprocessController`/container-exec path do not share
+  `persistent_resume.rs`; extending this to them is a natural follow-up but is
+  not needed for the interactive-pane case this doc (and the originating
+  audit) is about.
+
+---
+
+## 5. Testing
+
+- `persistent_resume.rs`: new unit tests alongside the existing ~30, following
+  the same style (pure `update()` calls, no process/tokio needed) —
+  `session_captured_with_different_sid_emits_fresh_outcome`,
+  `session_captured_confirmed_success_emits_resumed_outcome`,
+  `fire_retry_emits_fresh_outcome`, plus a check that
+  `EmitSessionOutcome` never appears for the untouched `SpawnedFresh`/never-
+  confirmed paths (regression guard for §2.1's "deliberately not touched").
+- Frontend: `session-outcome.test.ts` (parse + id-stability, mirroring
+  `compact-boundary` tests already in the repo for the same shape), plus
+  extending `parseHistoryLines.test.ts` and `useAgentStream`'s existing test
+  coverage with one fixture each (live + replay produce the same node id for
+  the same frame).
+
+---
+
+## 6. Deferred — Parts B and C (cross-instance retention)
+
+Not implemented in this PR; scoped here so the remaining ask ("agents that open
+in a new version or instance retain whatever is there, or load empty if truly
+empty") has a concrete next step rather than staying an open question.
+
+### 6.1 Why this is still open
+
+`docs/analysis/ANALYSIS_CROSS_CHANNEL_CONVERSATION_HISTORY_2026_06_14.md` §9
+already shipped steps 1–4 (global transcript zone, hot-path mirror, read
+fallback, snapshot overlay) — the pane-display half of "retain whatever is
+there" is done. Its own §6 and §9 "step 5" flag what's still missing for the
+*model-continuation* half:
+
+- The 9 originally-migrated agents have `session_id = null` — `--resume` has no
+  id to attempt for them at all.
+- Even where a `session_id` is known, AgentMux runs the CLI with
+  `CLAUDE_CONFIG_DIR` pointed at an **isolated** per-agent home
+  (`~/.agentmux/shared/providers/claude`); `--resume` only searches inside
+  that isolated home. A session captured (or migrated) from a *different*
+  instance/version's isolated home — or from the global `~/.claude` — is
+  invisible to it, so `--resume` fails even though the transcript genuinely
+  exists in the global transcript zone (§1) or on disk elsewhere.
+
+### 6.2 Part B — rehydrate-before-resume
+
+Before `agent_io.rs`/`input.rs` attach `--resume <persisted_session_id>` to a
+spawn, check whether that session's `.jsonl` already exists inside the current
+instance's isolated `CLAUDE_CONFIG_DIR`. If not, look it up (by `session_id`,
+recoverable from the global transcript zone's own record of which sid produced
+it — the live mirror already captures this for new agents, per the analysis
+doc §6) and copy it into the isolated home before spawning — reusing the
+`rehydrate_claude_session` shape already prototyped for the import path
+(`import-agents.sh:107-120`, cited in the analysis doc). If no transcript can
+be found anywhere (genuinely nothing to rehydrate), spawn without `--resume` —
+this is the "load empty if the memory is empty" half of the ask, and with Part
+A already landed, that fresh-start is now an honest, visibly-labeled event
+instead of an unexplained blank pane.
+
+### 6.3 Part C — backfill the session_id-less migrated agents
+
+The analysis doc's deferred step 5: recover `session_id` for the 9 (or by then,
+however many) agents that migrated without one, from the transcript filename
+(`ClaudeHistoryAdapter` already does this lookup, per that doc's §5 evidence
+table), and run it once, the same shape as the existing `import-agents.sh`
+one-shot.
+
+### 6.4 Suggested order
+
+Part B alone is the correct next PR — it's the piece that turns "history is
+visible" (already shipped) into "history is *resumable*" for any agent that
+already has a captured `session_id`, and directly serves the ask's "retain
+whatever is there" for the common case (an agent moving between instances/
+versions, not the smaller backfill-only migrated set). Part C is a narrower
+one-shot cleanup for the already-identified 9 (or current count) legacy
+records and can follow independently.

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -12,7 +12,8 @@
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import { parseCompactBoundaryFrame, contextCompactedNodeId } from "./compact-boundary";
-import type { ContextCompactedNode, DocumentNode, SessionStats } from "./types";
+import { parseSessionOutcomeFrame, sessionOutcomeNodeId } from "./session-outcome";
+import type { ContextCompactedNode, DocumentNode, SessionOutcomeNode, SessionStats } from "./types";
 
 export interface ParsedHistory {
     nodes: DocumentNode[];
@@ -130,6 +131,36 @@ export function parseHistoryLines(
                     source: "real",
                     trigger: data.trigger,
                     durationMs: data.durationMs,
+                };
+                const existing = indexById.get(node.id);
+                if (existing != null) {
+                    nodes[existing] = node;
+                } else {
+                    indexById.set(node.id, nodes.length);
+                    nodes.push(node);
+                }
+            }
+            continue;
+        }
+
+        // AgentMux's own resume-outcome marker — same raw-frame interception
+        // as useAgentStream.ts's live path (shared parsing via
+        // session-outcome.ts). See
+        // docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.2.
+        if (rawEvent.type === "system" && rawEvent.subtype === "agentmux_session_outcome") {
+            parser.flushPending();
+            const data = parseSessionOutcomeFrame(rawEvent);
+            if (data) {
+                const parsedTs = typeof rawEvent.timestamp === "string" ? Date.parse(rawEvent.timestamp) : NaN;
+                const node: SessionOutcomeNode = {
+                    type: "session_outcome",
+                    // Shares useAgentStream.ts's exact id-construction
+                    // function — same rationale as context_compacted above.
+                    id: sessionOutcomeNodeId(data),
+                    outcome: data.outcome,
+                    attemptedSid: data.attemptedSid,
+                    actualSid: data.actualSid,
+                    timestamp: Number.isNaN(parsedTs) ? 0 : parsedTs,
                 };
                 const existing = indexById.get(node.id);
                 if (existing != null) {

--- a/frontend/app/view/agent/session-outcome.test.ts
+++ b/frontend/app/view/agent/session-outcome.test.ts
@@ -1,0 +1,121 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { parseSessionOutcomeFrame, sessionOutcomeNodeId, sessionOutcomeLiveTimestamp } from "./session-outcome";
+
+// Shared by useAgentStream.ts (live) and parseHistoryLines.ts (replay) —
+// mirrors compact-boundary.test.ts's shape for the same reason: SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.2.
+
+function frame(overrides: Record<string, unknown> = {}) {
+    return {
+        type: "system",
+        subtype: "agentmux_session_outcome",
+        outcome: "resumed",
+        attempted_sid: "abc-123",
+        actual_sid: null,
+        timestamp: "2026-08-05T08:00:00.000Z",
+        ...overrides,
+    };
+}
+
+describe("parseSessionOutcomeFrame", () => {
+    it("extracts a resumed outcome", () => {
+        expect(parseSessionOutcomeFrame(frame())).toEqual({
+            outcome: "resumed",
+            attemptedSid: "abc-123",
+            actualSid: null,
+            frameTimestamp: "2026-08-05T08:00:00.000Z",
+        });
+    });
+
+    it("extracts a fresh outcome with an actual_sid", () => {
+        const f = frame({ outcome: "fresh", actual_sid: "xyz-789" });
+        expect(parseSessionOutcomeFrame(f)).toEqual({
+            outcome: "fresh",
+            attemptedSid: "abc-123",
+            actualSid: "xyz-789",
+            frameTimestamp: "2026-08-05T08:00:00.000Z",
+        });
+    });
+
+    it("returns null for a non-system frame", () => {
+        expect(parseSessionOutcomeFrame({ type: "assistant" })).toBeNull();
+    });
+
+    it("returns null for a system frame with an unrelated subtype", () => {
+        expect(parseSessionOutcomeFrame({ type: "system", subtype: "compact_boundary" })).toBeNull();
+    });
+
+    it("returns null for an unrecognized outcome value", () => {
+        expect(parseSessionOutcomeFrame(frame({ outcome: "sometimes" }))).toBeNull();
+    });
+
+    it("returns null when attempted_sid is missing or not a string", () => {
+        expect(parseSessionOutcomeFrame(frame({ attempted_sid: undefined }))).toBeNull();
+        expect(parseSessionOutcomeFrame(frame({ attempted_sid: 42 }))).toBeNull();
+    });
+
+    it("treats a non-string actual_sid the same as absent (null)", () => {
+        expect(parseSessionOutcomeFrame(frame({ actual_sid: 42 }))?.actualSid).toBeNull();
+    });
+
+    it("returns frameTimestamp: null when timestamp is missing or not a string", () => {
+        const f = frame();
+        delete (f as Record<string, unknown>).timestamp;
+        expect(parseSessionOutcomeFrame(f)?.frameTimestamp).toBeNull();
+        expect(parseSessionOutcomeFrame(frame({ timestamp: 12345 }))?.frameTimestamp).toBeNull();
+    });
+
+    it("returns null for a non-object input", () => {
+        expect(parseSessionOutcomeFrame(null)).toBeNull();
+        expect(parseSessionOutcomeFrame(undefined)).toBeNull();
+        expect(parseSessionOutcomeFrame("not-an-object")).toBeNull();
+    });
+});
+
+describe("sessionOutcomeNodeId", () => {
+    it("keys on frameTimestamp when present", () => {
+        expect(
+            sessionOutcomeNodeId({
+                outcome: "resumed",
+                attemptedSid: "abc-123",
+                actualSid: null,
+                frameTimestamp: "2026-08-05T08:00:00.000Z",
+            }),
+        ).toBe("session-outcome-2026-08-05T08:00:00.000Z");
+    });
+
+    it("falls back to a content-derived key when frameTimestamp is absent, identically regardless of call site", () => {
+        // Same rationale as contextCompactedNodeId: the live path and the
+        // replay path must compute the SAME id for the SAME timestamp-less
+        // frame, or the document store's same-id dedup can't merge them.
+        const data = { outcome: "fresh" as const, attemptedSid: "abc-123", actualSid: "xyz-789", frameTimestamp: null };
+        expect(sessionOutcomeNodeId(data)).toBe(sessionOutcomeNodeId({ ...data }));
+        expect(sessionOutcomeNodeId(data)).toBe("session-outcome-notime-fresh-abc-123");
+    });
+});
+
+describe("sessionOutcomeLiveTimestamp", () => {
+    it("parses a valid frameTimestamp", () => {
+        expect(sessionOutcomeLiveTimestamp("2026-08-05T08:00:00.000Z")).toBe(
+            Date.parse("2026-08-05T08:00:00.000Z"),
+        );
+    });
+
+    it("falls back to Date.now() when frameTimestamp is null", () => {
+        const before = Date.now();
+        const result = sessionOutcomeLiveTimestamp(null);
+        const after = Date.now();
+        expect(result).toBeGreaterThanOrEqual(before);
+        expect(result).toBeLessThanOrEqual(after);
+    });
+
+    it("falls back to Date.now() when frameTimestamp is unparseable", () => {
+        const before = Date.now();
+        const result = sessionOutcomeLiveTimestamp("not-a-date");
+        const after = Date.now();
+        expect(result).toBeGreaterThanOrEqual(before);
+        expect(result).toBeLessThanOrEqual(after);
+    });
+});

--- a/frontend/app/view/agent/session-outcome.ts
+++ b/frontend/app/view/agent/session-outcome.ts
@@ -1,0 +1,74 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared parsing for AgentMux's own `system`/`agentmux_session_outcome` raw
+ * stream-json frame — emitted by the backend
+ * (`agentmux-srv/src/backend/blockcontroller/persistent.rs`,
+ * `session_outcome_line`) the moment a `--resume <sid>` attempt's fate
+ * becomes definitively known (see
+ * docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2). Mirrors
+ * `compact-boundary.ts`'s shape exactly: the provider CLI would never emit
+ * this frame itself, so both consumers — `useAgentStream.ts` (live) and
+ * `parseHistoryLines.ts` (persisted-history replay) — intercept it directly
+ * rather than routing through the generic provider `Translator`, which has
+ * no shape for it.
+ */
+
+export interface SessionOutcomeData {
+    outcome: "resumed" | "fresh";
+    attemptedSid: string;
+    actualSid: string | null;
+    /**
+     * The frame's own `timestamp` field, verbatim — used only to build a
+     * stable node id shared by both consumers (same rationale as
+     * `compact-boundary.ts`'s `frameTimestamp`: a live-seen event and the
+     * same event re-seen via a later history-page overlap must land on the
+     * same id, or the document store's dedup can't merge them).
+     */
+    frameTimestamp: string | null;
+}
+
+/**
+ * Validate + extract an `agentmux_session_outcome` frame, or `null` if this
+ * isn't one, or its fields don't match the expected shape. Malformed/missing
+ * fields degrade to `null` (skip rather than guess) — same philosophy as
+ * `compact-boundary.ts`'s `parseCompactBoundaryFrame`.
+ */
+export function parseSessionOutcomeFrame(rawEvent: unknown): SessionOutcomeData | null {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const e = rawEvent as Record<string, unknown>;
+    if (e.type !== "system" || e.subtype !== "agentmux_session_outcome") return null;
+
+    const outcome: "resumed" | "fresh" | null =
+        e.outcome === "resumed" ? "resumed" : e.outcome === "fresh" ? "fresh" : null;
+    const attemptedSid = typeof e.attempted_sid === "string" ? e.attempted_sid : null;
+    if (outcome == null || attemptedSid == null) return null;
+
+    const actualSid = typeof e.actual_sid === "string" ? e.actual_sid : null;
+    const frameTimestamp = typeof e.timestamp === "string" ? e.timestamp : null;
+    return { outcome, attemptedSid, actualSid, frameTimestamp };
+}
+
+/**
+ * Stable `session_outcome` node id, shared by both consumers — same
+ * content-derived fallback rationale as `compact-boundary.ts`'s
+ * `contextCompactedNodeId`.
+ */
+export function sessionOutcomeNodeId(data: SessionOutcomeData): string {
+    const suffix = data.frameTimestamp ?? `notime-${data.outcome}-${data.attemptedSid}`;
+    return `session-outcome-${suffix}`;
+}
+
+/**
+ * Epoch-ms time for a `session_outcome` node — parses `frameTimestamp` when
+ * present/valid. Callers on the live path fall back to `Date.now()`
+ * (mirrors `compact-boundary.ts`'s `contextCompactedLiveTimestamp`);
+ * `parseHistoryLines.ts` deliberately does NOT use this fallback — a
+ * timestamp-less replayed line should read as unknown (0), not claim to
+ * have happened "now".
+ */
+export function sessionOutcomeLiveTimestamp(frameTimestamp: string | null | undefined): number {
+    const parsed = typeof frameTimestamp === "string" ? Date.parse(frameTimestamp) : NaN;
+    return Number.isNaN(parsed) ? Date.now() : parsed;
+}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1738,6 +1738,65 @@
     }
 }
 
+// A `--resume` attempt's outcome, surfaced as an explicit transcript divider
+// so the pane's scrollback can never silently disagree with what the model
+// actually has in context — SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.2.
+// Same divider layout as .agent-context-compacted (neutral) for the
+// "resumed" case; the "fresh" (session lost) case gets the same
+// warning-color treatment as .agent-compaction-started so a discontinuity
+// the user should actually notice reads as visually distinct from routine
+// continuity, not just another neutral marker in the transcript.
+.agent-session-outcome {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    padding: 10px var(--space-2);
+    user-select: none;
+    position: relative;
+
+    &::before,
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        width: 25%;
+        height: 1px;
+        background: var(--border-color, rgba(255, 255, 255, 0.12));
+    }
+
+    &::before { left: 0; }
+    &::after  { right: 0; }
+
+    .agent-session-outcome-label {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.45));
+        padding: 2px 10px;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+        border-radius: 10px;
+    }
+
+    .agent-session-outcome-detail {
+        font-size: 11px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.3));
+    }
+
+    &.agent-session-outcome-fresh {
+        &::before,
+        &::after {
+            background: color-mix(in srgb, var(--warning-color, #d9a441) 40%, transparent);
+        }
+
+        .agent-session-outcome-label {
+            color: var(--warning-color, #d9a441);
+            border-color: color-mix(in srgb, var(--warning-color, #d9a441) 40%, transparent);
+        }
+    }
+}
+
 // Node hover-peek overlay (ToolBlock.tsx / MarkdownBlock.tsx via
 // PeekOverlay.tsx). Portal-rendered at document.body, NOT a plain in-DOM
 // absolute child of the row — see PeekOverlay.tsx's doc comment: each

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -53,7 +53,7 @@ export type InitState = {
 /**
  * Document node types that make up the agent's markdown document
  */
-export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | ShellNode | AgentErrorNode | ContextCompactedNode | CompactionStartedNode | JektMessageNode;
+export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | ShellNode | AgentErrorNode | ContextCompactedNode | CompactionStartedNode | JektMessageNode | SessionOutcomeNode;
 
 /**
  * Raw markdown text block
@@ -421,6 +421,24 @@ export interface CompactionStartedNode {
     id: string;
     trigger: "manual" | "auto";
     startedAt: number;
+}
+
+/**
+ * Transcript boundary marker for a `--resume` attempt's outcome — sourced
+ * from AgentMux's own `agentmux_session_outcome` frame (the backend's
+ * `persistent_resume` state machine, not the provider CLI). `"resumed"`
+ * means the CLI genuinely continued the prior session; `"fresh"` means it
+ * could not, and the model has none of the turns before this marker even
+ * though the pane's scrollback above it is still fully visible. See
+ * docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.2.
+ */
+export interface SessionOutcomeNode {
+    type: "session_outcome";
+    id: string;
+    outcome: "resumed" | "fresh";
+    attemptedSid: string;
+    actualSid: string | null;
+    timestamp: number;
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -41,8 +41,9 @@ import { onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import type { PendingMessage, SignalPair } from "./state";
 import { ClaudeCodeStreamParser } from "./stream-parser";
-import type { ContextCompactedNode, DocumentNode } from "./types";
+import type { ContextCompactedNode, DocumentNode, SessionOutcomeNode } from "./types";
 import { parseCompactBoundaryFrame, contextCompactedNodeId, contextCompactedLiveTimestamp } from "./compact-boundary";
+import { parseSessionOutcomeFrame, sessionOutcomeNodeId, sessionOutcomeLiveTimestamp } from "./session-outcome";
 import type { AgentPaneEvent, TurnPhase } from "@/app/store/agent-pane-state/types";
 import { getNodeIdSet } from "@/app/store/agent-document-store";
 import type { AgentPaneModel } from "@/app/store/agent-pane-model";
@@ -432,6 +433,36 @@ export function useAgentStream({
                             frameTimestamp: compactBoundary.frameTimestamp,
                         });
                         pushContextCompactedNodes(paneEvents, queue, hasNodeId, addNodeId);
+                    }
+                    continue;
+                }
+
+                // AgentMux's own resume-outcome marker (not a provider frame —
+                // see docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+                // §2). Intercepted the same way as `compact_boundary` just
+                // above: no `StreamEvent` shape in the translator, shared
+                // parsing with `parseHistoryLines.ts` via `session-outcome.ts`
+                // so the two can't drift. No `dispatchPane` round-trip needed —
+                // unlike compaction, this has no live token-meter side effect,
+                // it's purely a transcript marker — so the node is pushed
+                // directly.
+                if (rawEvent.type === "system" && rawEvent.subtype === "agentmux_session_outcome") {
+                    parser.flushPending();
+                    const sessionOutcome = parseSessionOutcomeFrame(rawEvent);
+                    if (sessionOutcome) {
+                        const node: SessionOutcomeNode = {
+                            type: "session_outcome",
+                            id: sessionOutcomeNodeId(sessionOutcome),
+                            outcome: sessionOutcome.outcome,
+                            attemptedSid: sessionOutcome.attemptedSid,
+                            actualSid: sessionOutcome.actualSid,
+                            timestamp: sessionOutcomeLiveTimestamp(sessionOutcome.frameTimestamp),
+                        };
+                        if (!hasNodeId(node.id)) {
+                            addNodeId(node.id);
+                            queue.pushNewNode(node);
+                            queue.scheduleFlush();
+                        }
                     }
                     continue;
                 }

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -300,6 +300,24 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     );
                 })()}
             </Show>
+            <Show when={props.node() && props.node().type === "session_outcome"}>
+                {(() => {
+                    const n = props.node() as Extract<DocumentNode, { type: "session_outcome" }>;
+                    const resumed = n.outcome === "resumed";
+                    return (
+                        <div class={resumed ? "agent-session-outcome" : "agent-session-outcome agent-session-outcome-fresh"}>
+                            <div class="agent-session-outcome-label">
+                                {resumed ? "Session continued" : "New session started"}
+                            </div>
+                            <Show when={!resumed}>
+                                <div class="agent-session-outcome-detail">
+                                    Prior conversation is not available to this agent
+                                </div>
+                            </Show>
+                        </div>
+                    );
+                })()}
+            </Show>
         </>
     );
 }

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -113,5 +113,9 @@ export function currentExpansion(
         case "compaction_started":
             // Fixed-height announcement — never collapsible.
             return OPEN_DEFAULT;
+
+        case "session_outcome":
+            // Fixed-height divider — never collapsible, same as context_compacted.
+            return OPEN_DEFAULT;
     }
 }

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -151,6 +151,8 @@ export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     compaction_started: false,
     // Arrives as a single complete user_message event, not chunk-by-chunk.
     jekt_message: false,
+    // One-shot marker, same as context_compacted — not chunked.
+    session_outcome: false,
 };
 
 /**
@@ -170,6 +172,7 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "agent_error":       return 64;
         case "context_compacted": return 48;
         case "compaction_started": return 32;
+        case "session_outcome":   return 48;
     }
 }
 
@@ -210,6 +213,7 @@ export function estimateNodeForState(
             case "agent_error":       return 64;
             case "context_compacted": return 48;
             case "compaction_started": return 32;
+            case "session_outcome":   return 48;
         }
     }
     // expanded
@@ -224,5 +228,6 @@ export function estimateNodeForState(
         case "agent_error":       return 64;
         case "context_compacted": return 48;
         case "compaction_started": return 32;
+        case "session_outcome":   return 48;
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to an audit of how agent-pane history is managed
(`audits/AUDIT_AGENT_PANE_HISTORY_2026_08_05.md`, written outside this repo)
which found two independently-loaded stores per agent pane:

1. **What the pane displays** — AgentMux's own NDJSON transcript, persisted
   unbounded, loaded 200 lines at a time.
2. **What the model actually remembers** — the provider CLI's own session,
   reached only if AgentMux's `--resume <session_id>` handshake succeeds.

These can silently disagree: if a `--resume` attempt is stale/unreachable,
`persistent_resume.rs`'s existing state machine already knows precisely
(per-generation) that the model started a fresh session with no memory of
the visible scrollback above it — but that fact was only ever logged
(`tracing::info!`), never shown to the user. The pane keeps rendering
continuous-looking scrollback either way.

This PR adds `docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md`
(Part A design + implementation) and implements it:

- **Backend** (`persistent_resume.rs`, `persistent.rs`): a new
  `ResumeEffect::EmitSessionOutcome` fires at the two points where a
  `--resume` attempt's fate becomes unambiguously known (a `SessionCaptured`
  resolution, or a confirmed-dead retry about to fire fresh), persisted as an
  `agentmux_session_outcome` transcript frame — same shape/interception
  pattern as the existing `compact_boundary` frame. Purely additive: no
  existing state/effect/condition changes, only new effects alongside ones
  already produced. All 1999 backend tests pass (24 in
  `persistent_resume` are new/updated for this).
- **Frontend** (`session-outcome.ts` + wiring through
  `useAgentStream.ts`/`parseHistoryLines.ts`/`DocumentRow.tsx`/
  `renderers.ts`/`expansion-source.ts`): renders the event as a distinct
  divider — "Session continued" vs "New session started — prior
  conversation is not available to this agent" — mirroring the existing
  `context_compacted` divider pattern exactly. `tsc --noEmit` and the full
  agent-view vitest suite pass (990/991; the one failure is a pre-existing
  flaky timeout in an unrelated tool-renderer test, confirmed passing in
  isolation).

Parts B/C (rehydrating a resumable session's transcript into a new
instance/version before attempting `--resume`, and backfilling
`session_id`-less migrated agents) are scoped in the design doc §6 but
deferred to a follow-up PR.

## Test plan

- [x] `cargo test -p agentmux-srv` — 1999 passed, 0 failed
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run frontend/app/view/agent/` — 990/991 passed (1
      pre-existing unrelated flake, passes in isolation)
- [ ] Manual verification in a running pane (not done — no browser/CEF host
      available in this environment; the div render is a straightforward
      mirror of the already-shipped `context_compacted` divider)

<!-- agentmux:agent_id=agenty -->