### PR TITLE
Fix App-API self-lookup for agents with mixed-case display names

### DIFF
--- a/.changesets/1785959990-fix-agent-api-resolve-app-api-self-lookup-by-the-agent-s-rou-v2vn.md
+++ b/.changesets/1785959990-fix-agent-api-resolve-app-api-self-lookup-by-the-agent-s-rou-v2vn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-api): resolve App-API self-lookup by the agent's routing slug, not its display-cased name

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1596,32 +1596,23 @@ impl Store {
     /// detection only cares about identity / cwd; ContinueNamed only
     /// cares about `id` + bindings).
     /// Spec: docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md §3b.
-    /// Resolve an instance by `instance_name` — but App-API callers (App
-    /// API self-lookup endpoints: `memory.*`, `identity.self.*`,
-    /// `bundle.self.get`) actually pass the `AGENTMUX_AGENT_ID` routing
-    /// slug, not the literal display name — it's stamped onto the MCP
-    /// server's env straight from `agent.slug` (`app_api::agent_open`),
-    /// the same stable, collision-resolved value stored in
-    /// `db_agents.slug` (`agent_def_insert_local_only`, never changes
-    /// after creation — see `AgentDefinition::slug`'s own doc comment).
-    /// `instance_name` is the renameable display name, overwritten on
-    /// every launch/continuation (`dual_write.rs`) — it can drift
-    /// arbitrarily far from the slug (a rename, or a collision suffix
-    /// picked at creation, e.g. slug "agenty-2" for a still-literally-
-    /// "AgentY"-named instance_name). Matching `OR slug = ?1` handles
-    /// both: a literal-name caller still hits via `instance_name`, and a
-    /// slug-carrying caller matches the stable column directly,
-    /// regardless of any rename/collision since creation.
-    ///
-    /// (reagentx P1 on PR #2428: an earlier version of this fix
-    /// re-derived `derive_slug(instance_name)` at query time instead of
-    /// comparing against the already-persisted `slug` column — that
-    /// still failed for exactly the rename/collision cases above, since
-    /// a re-derived slug only equals the real one when the display name
-    /// has never changed and never collided. Confirmed live against a
-    /// real agent named "AgentY": `MemoryList` ("agent agenty not
-    /// found"), `IdentityAccounts` ("unknown agent 'agenty'") — both
-    /// resolved by this fix regardless of which form the caller passes.)
+    /// Resolve an instance by its literal `instance_name` — the
+    /// "named agent" continuation lookup (picker collision detection,
+    /// `ContinueNamed`). Matches ONLY `instance_name`; unrelated to App
+    /// API self-lookup (see `instance_get_by_slug` below) — kept
+    /// deliberately single-purpose after reagentx P1 on PR #2428 (round
+    /// 2): an earlier version of this function ALSO matched `OR slug =
+    /// ?1` in the same query, which meant a coincidental cross-namespace
+    /// collision (an unrelated agent's `instance_name` happening to equal
+    /// this agent's `slug`, or vice versa) could match both rows
+    /// simultaneously, with `ORDER BY updated_at DESC LIMIT 1` silently
+    /// picking whichever was touched most recently instead of ever
+    /// signaling the ambiguity — i.e. one agent's App-API self-lookup
+    /// could silently return a completely unrelated agent's memory/
+    /// identity/bundle. Two single-purpose, unambiguous functions (each
+    /// backed by an exact match on ONE column) instead of one function
+    /// serving two different namespaces closes that off entirely, rather
+    /// than trying to prioritize/tie-break between them.
     pub fn instance_get_by_name(
         &self,
         instance_name: &str,
@@ -1648,13 +1639,61 @@ impl Store {
                     identity_id, memory_id, instance_name, working_directory,
                     user_hidden
              FROM db_agents
-             WHERE (instance_name = ?1 OR slug = ?1)
+             WHERE instance_name = ?1
                AND is_template = 0
                AND user_hidden = 0
              ORDER BY updated_at DESC, created_at DESC
              LIMIT 1",
         )?;
         let result = stmt.query_row(params![instance_name], map_agent_instance_row);
+        match result {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Resolve an instance by its persisted `slug` — the App-API
+    /// self-lookup path (`memory.*`, `identity.self.*`,
+    /// `bundle.self.get`). Every one of those callers' `agent_id`
+    /// actually comes from `AGENTMUX_AGENT_ID`, the routing slug
+    /// stamped onto the MCP server's env straight from `agent.slug`
+    /// (`app_api::agent_open`) — the same stable, collision-resolved
+    /// value stored in `db_agents.slug` (`agent_def_insert_local_only`,
+    /// never changes after creation, unlike the renameable
+    /// `instance_name` — see `AgentDefinition::slug`'s own doc comment).
+    /// Deliberately does NOT also try `instance_name` — see
+    /// `instance_get_by_name`'s doc comment for why merging the two
+    /// namespaces into one query was unsafe (reagentx P1 on PR #2428).
+    /// `slug` is globally unique by construction (the collision-resolve
+    /// loop in `agent_def_insert_local_only`), so an exact match here is
+    /// unambiguous; `LIMIT 1` is a defensive no-op, not a tie-break.
+    ///
+    /// Confirmed live against a real agent named "AgentY" (slug
+    /// "agenty"): before this existed, `MemoryList` failed with "agent
+    /// agenty not found" and `IdentityAccounts` with "unknown agent
+    /// 'agenty'" — both resolved once App-API callers switched to this.
+    pub fn instance_get_by_slug(
+        &self,
+        slug: &str,
+    ) -> Result<Option<AgentInstance>, StoreError> {
+        if slug.is_empty() {
+            return Ok(None);
+        }
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, id AS def_id,
+                    github_context, created_at,
+                    identity_id, memory_id, instance_name, working_directory,
+                    user_hidden
+             FROM db_agents
+             WHERE slug = ?1
+               AND is_template = 0
+               AND user_hidden = 0
+             ORDER BY updated_at DESC, created_at DESC
+             LIMIT 1",
+        )?;
+        let result = stmt.query_row(params![slug], map_agent_instance_row);
         match result {
             Ok(a) => Ok(Some(a)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -2168,11 +2207,11 @@ mod tests {
     // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md follow-up: App-API
     // self-lookup callers (MemoryList/Read/Write, IdentityAccounts,
     // IdentityValidate, bundle.self.get) pass the AGENTMUX_AGENT_ID routing
-    // slug (`derive_slug(display_name)`), not the literal display name.
-    // Confirmed live: a real agent named "AgentY" got "agent agenty not
-    // found" from every one of those endpoints.
+    // slug, not the literal display name. Confirmed live: a real agent
+    // named "AgentY" (slug "agenty") got "agent agenty not found" from
+    // every one of those endpoints before `instance_get_by_slug` existed.
     #[test]
-    fn instance_get_by_name_resolves_a_mixed_case_display_name_via_its_slug() {
+    fn instance_get_by_slug_resolves_a_mixed_case_display_name_via_its_slug() {
         let store = Store::open_in_memory().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
@@ -2185,19 +2224,13 @@ mod tests {
 
         // The routing slug ("agenty", what every MCP-tool-backed App-API
         // endpoint actually has) must resolve to the display-cased row.
-        let found = store.instance_get_by_name("agenty").unwrap();
-        assert!(found.is_some(), "must resolve via the slug-normalized fallback");
+        let found = store.instance_get_by_slug("agenty").unwrap();
+        assert!(found.is_some(), "must resolve via the persisted slug column");
         assert_eq!(found.unwrap().instance_name, "AgentY");
-
-        // The literal display name must still hit the exact-match fast
-        // path unchanged.
-        let found_exact = store.instance_get_by_name("AgentY").unwrap();
-        assert!(found_exact.is_some());
-        assert_eq!(found_exact.unwrap().instance_name, "AgentY");
     }
 
     #[test]
-    fn instance_get_by_name_returns_none_for_a_genuinely_unrelated_slug() {
+    fn instance_get_by_slug_returns_none_for_a_genuinely_unrelated_slug() {
         let store = Store::open_in_memory().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
@@ -2208,21 +2241,21 @@ mod tests {
         inst.instance_name = "AgentY".to_string();
         store.instance_create(&inst).unwrap();
 
-        let found = store.instance_get_by_name("someone-else").unwrap();
+        let found = store.instance_get_by_slug("someone-else").unwrap();
         assert!(found.is_none(), "an unrelated slug must not match by coincidence");
     }
 
-    // reagentx P1 on PR #2428: a slug-normalized re-derivation of the
-    // CURRENT display name (`derive_slug(instance_name)`) only equals the
-    // real routing slug when the display name has never changed and never
-    // collided with another agent's at creation. `slug` is stable and
-    // persisted once, `name`/`instance_name` are renameable — this test
-    // deliberately sets them to unrelated values (as if the agent were
-    // renamed, or its slug got a "-2" collision suffix at creation) to
-    // prove the fix resolves via the real persisted `slug` column, not a
-    // fresh re-derivation that a rename would silently invalidate.
+    // reagentx P1 on PR #2428 (round 2): a slug-normalized re-derivation of
+    // the CURRENT display name (`derive_slug(instance_name)`) only equals
+    // the real routing slug when the display name has never changed and
+    // never collided with another agent's at creation. `slug` is stable
+    // and persisted once, `name`/`instance_name` are renameable — this
+    // test deliberately sets them to unrelated values (as if the agent
+    // were renamed, or its slug got a "-2" collision suffix at creation)
+    // to prove the fix resolves via the real persisted `slug` column, not
+    // a fresh re-derivation that a rename would silently invalidate.
     #[test]
-    fn instance_get_by_name_resolves_via_the_persisted_slug_even_after_a_rename() {
+    fn instance_get_by_slug_resolves_via_the_persisted_slug_even_after_a_rename() {
         let store = Store::open_in_memory().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
@@ -2252,9 +2285,76 @@ mod tests {
         // "agenty". Only a lookup against the real persisted slug column
         // resolves this; a re-derivation from the current name would miss
         // it, reproducing the exact bug this test guards against.
-        let found = store.instance_get_by_name("agenty").unwrap();
+        let found = store.instance_get_by_slug("agenty").unwrap();
         assert!(found.is_some(), "must resolve via the persisted slug, not a re-derivation of the current name");
         assert_eq!(found.unwrap().instance_name, "Agent Y Renamed");
+    }
+
+    // reagentx P1 on PR #2428 (round 3): a single query matching
+    // `(instance_name = ?1 OR slug = ?1)` let a coincidental cross-
+    // namespace collision (one agent's literal `instance_name` equaling a
+    // DIFFERENT agent's `slug`) match both rows simultaneously, silently
+    // disambiguated by recency — meaning an App-API self-lookup call could
+    // return an unrelated agent's memory/identity/bundle. This test builds
+    // exactly that collision (agent A's `instance_name` == agent B's
+    // `slug` == "shared-name") and proves each single-purpose function
+    // stays within its own namespace: `instance_get_by_name` finds ONLY
+    // the literal-name match (A), `instance_get_by_slug` finds ONLY the
+    // slug match (B) — never each other's row.
+    #[test]
+    fn instance_get_by_name_and_by_slug_never_cross_the_others_namespace() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+
+        // Agent A: literal display name is exactly "shared-name"; its own
+        // slug is unrelated ("agent-a-slug").
+        def_store
+            .upsert(&DefinitionRecord {
+                schema_version: DEF_MAX_SUPPORTED_SCHEMA,
+                data: DefinitionRecordV1 {
+                    id: "def-a".to_string(),
+                    slug: "agent-a-slug".to_string(),
+                    name: "shared-name".to_string(),
+                    provider: "claude".to_string(),
+                    updated_at: 1,
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        // Agent B: slug is exactly "shared-name" (e.g. a rename left its
+        // slug pointing at a string that collides with A's literal name);
+        // its own display name is unrelated.
+        def_store
+            .upsert(&DefinitionRecord {
+                schema_version: DEF_MAX_SUPPORTED_SCHEMA,
+                data: DefinitionRecordV1 {
+                    id: "def-b".to_string(),
+                    slug: "shared-name".to_string(),
+                    name: "Agent B Display".to_string(),
+                    provider: "claude".to_string(),
+                    updated_at: 2,
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        store.set_def_registry(def_store);
+
+        let mut inst_a = instance("inst-a", "def-a");
+        inst_a.instance_name = "shared-name".to_string();
+        store.instance_create(&inst_a).unwrap();
+
+        let mut inst_b = instance("inst-b", "def-b");
+        inst_b.instance_name = "Agent B Display".to_string();
+        store.instance_create(&inst_b).unwrap();
+
+        let by_name = store.instance_get_by_name("shared-name").unwrap()
+            .expect("must find agent A by literal instance_name");
+        assert_eq!(by_name.id, "def-a", "instance_name lookup must never resolve to B's row");
+
+        let by_slug = store.instance_get_by_slug("shared-name").unwrap()
+            .expect("must find agent B by slug");
+        assert_eq!(by_slug.id, "def-b", "slug lookup must never resolve to A's row");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1599,17 +1599,29 @@ impl Store {
     /// Resolve an instance by `instance_name` — but App-API callers (App
     /// API self-lookup endpoints: `memory.*`, `identity.self.*`,
     /// `bundle.self.get`) actually pass the `AGENTMUX_AGENT_ID` routing
-    /// slug (`derive_slug(display_name)`, injected into the agent's MCP
-    /// server env — see `agent_config.rs::build_mcp_config`'s own doc
-    /// comment), NOT the literal display name. An exact match still wins
-    /// when it hits (cheap, indexed, and correct for any caller that DOES
-    /// pass the literal name), but a mixed-case display name (e.g.
-    /// "AgentY") never equals its own lowercased slug ("agenty") — so
-    /// every one of those App-API endpoints 404'd/500'd for any agent
-    /// whose name wasn't already all-lowercase. Confirmed live: `MemoryList`
-    /// ("agent agenty not found"), `IdentityAccounts` ("unknown agent
-    /// 'agenty'"). Falls back to a slug-normalized scan so both forms
-    /// resolve to the same row.
+    /// slug, not the literal display name — it's stamped onto the MCP
+    /// server's env straight from `agent.slug` (`app_api::agent_open`),
+    /// the same stable, collision-resolved value stored in
+    /// `db_agents.slug` (`agent_def_insert_local_only`, never changes
+    /// after creation — see `AgentDefinition::slug`'s own doc comment).
+    /// `instance_name` is the renameable display name, overwritten on
+    /// every launch/continuation (`dual_write.rs`) — it can drift
+    /// arbitrarily far from the slug (a rename, or a collision suffix
+    /// picked at creation, e.g. slug "agenty-2" for a still-literally-
+    /// "AgentY"-named instance_name). Matching `OR slug = ?1` handles
+    /// both: a literal-name caller still hits via `instance_name`, and a
+    /// slug-carrying caller matches the stable column directly,
+    /// regardless of any rename/collision since creation.
+    ///
+    /// (reagentx P1 on PR #2428: an earlier version of this fix
+    /// re-derived `derive_slug(instance_name)` at query time instead of
+    /// comparing against the already-persisted `slug` column — that
+    /// still failed for exactly the rename/collision cases above, since
+    /// a re-derived slug only equals the real one when the display name
+    /// has never changed and never collided. Confirmed live against a
+    /// real agent named "AgentY": `MemoryList` ("agent agenty not
+    /// found"), `IdentityAccounts` ("unknown agent 'agenty'") — both
+    /// resolved by this fix regardless of which form the caller passes.)
     pub fn instance_get_by_name(
         &self,
         instance_name: &str,
@@ -1636,7 +1648,7 @@ impl Store {
                     identity_id, memory_id, instance_name, working_directory,
                     user_hidden
              FROM db_agents
-             WHERE instance_name = ?1
+             WHERE (instance_name = ?1 OR slug = ?1)
                AND is_template = 0
                AND user_hidden = 0
              ORDER BY updated_at DESC, created_at DESC
@@ -1644,32 +1656,10 @@ impl Store {
         )?;
         let result = stmt.query_row(params![instance_name], map_agent_instance_row);
         match result {
-            Ok(a) => return Ok(Some(a)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => {}
-            Err(e) => return Err(e.into()),
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
         }
-        drop(stmt);
-
-        // Slug-normalized fallback — see the doc comment above.
-        let queried_slug = derive_slug(instance_name);
-        let mut fallback_stmt = conn.prepare(
-            "SELECT id, id AS def_id,
-                    github_context, created_at,
-                    identity_id, memory_id, instance_name, working_directory,
-                    user_hidden
-             FROM db_agents
-             WHERE is_template = 0
-               AND user_hidden = 0
-             ORDER BY updated_at DESC, created_at DESC",
-        )?;
-        let mut rows = fallback_stmt.query_map([], map_agent_instance_row)?;
-        while let Some(row) = rows.next() {
-            let instance = row?;
-            if derive_slug(&instance.instance_name) == queried_slug {
-                return Ok(Some(instance));
-            }
-        }
-        Ok(None)
     }
 
     /// Partial update of an instance's mutable runtime fields. Only
@@ -2220,6 +2210,51 @@ mod tests {
 
         let found = store.instance_get_by_name("someone-else").unwrap();
         assert!(found.is_none(), "an unrelated slug must not match by coincidence");
+    }
+
+    // reagentx P1 on PR #2428: a slug-normalized re-derivation of the
+    // CURRENT display name (`derive_slug(instance_name)`) only equals the
+    // real routing slug when the display name has never changed and never
+    // collided with another agent's at creation. `slug` is stable and
+    // persisted once, `name`/`instance_name` are renameable — this test
+    // deliberately sets them to unrelated values (as if the agent were
+    // renamed, or its slug got a "-2" collision suffix at creation) to
+    // prove the fix resolves via the real persisted `slug` column, not a
+    // fresh re-derivation that a rename would silently invalidate.
+    #[test]
+    fn instance_get_by_name_resolves_via_the_persisted_slug_even_after_a_rename() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        // The registry's own `name` is the CURRENT (post-rename) display
+        // name — deliberately unrelated to `slug`, which was fixed at
+        // creation and never changes.
+        def_store
+            .upsert(&DefinitionRecord {
+                schema_version: DEF_MAX_SUPPORTED_SCHEMA,
+                data: DefinitionRecordV1 {
+                    id: "def-renamed".to_string(),
+                    slug: "agenty".to_string(),
+                    name: "Agent Y Renamed".to_string(),
+                    provider: "claude".to_string(),
+                    updated_at: 42,
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        store.set_def_registry(def_store);
+
+        let mut inst = instance("inst-renamed", "def-renamed");
+        inst.instance_name = "Agent Y Renamed".to_string();
+        store.instance_create(&inst).unwrap();
+
+        // derive_slug("Agent Y Renamed") would be "agent-y-renamed" — NOT
+        // "agenty". Only a lookup against the real persisted slug column
+        // resolves this; a re-derivation from the current name would miss
+        // it, reproducing the exact bug this test guards against.
+        let found = store.instance_get_by_name("agenty").unwrap();
+        assert!(found.is_some(), "must resolve via the persisted slug, not a re-derivation of the current name");
+        assert_eq!(found.unwrap().instance_name, "Agent Y Renamed");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1596,6 +1596,20 @@ impl Store {
     /// detection only cares about identity / cwd; ContinueNamed only
     /// cares about `id` + bindings).
     /// Spec: docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md §3b.
+    /// Resolve an instance by `instance_name` — but App-API callers (App
+    /// API self-lookup endpoints: `memory.*`, `identity.self.*`,
+    /// `bundle.self.get`) actually pass the `AGENTMUX_AGENT_ID` routing
+    /// slug (`derive_slug(display_name)`, injected into the agent's MCP
+    /// server env — see `agent_config.rs::build_mcp_config`'s own doc
+    /// comment), NOT the literal display name. An exact match still wins
+    /// when it hits (cheap, indexed, and correct for any caller that DOES
+    /// pass the literal name), but a mixed-case display name (e.g.
+    /// "AgentY") never equals its own lowercased slug ("agenty") — so
+    /// every one of those App-API endpoints 404'd/500'd for any agent
+    /// whose name wasn't already all-lowercase. Confirmed live: `MemoryList`
+    /// ("agent agenty not found"), `IdentityAccounts` ("unknown agent
+    /// 'agenty'"). Falls back to a slug-normalized scan so both forms
+    /// resolve to the same row.
     pub fn instance_get_by_name(
         &self,
         instance_name: &str,
@@ -1628,30 +1642,34 @@ impl Store {
              ORDER BY updated_at DESC, created_at DESC
              LIMIT 1",
         )?;
-        let result = stmt.query_row(params![instance_name], |row| {
-            Ok(AgentInstance {
-                id: row.get(0)?,
-                definition_id: row.get(1)?,
-                parent_instance_id: String::new(),
-                block_id: String::new(),
-                session_id: String::new(),
-                status: String::new(),
-                github_context: row.get(2)?,
-                started_at: row.get(3)?, // created_at — best proxy for the consolidated row
-                ended_at: 0,
-                created_at: row.get(3)?,
-                identity_id: row.get(4)?,
-                memory_id: row.get(5)?,
-                instance_name: row.get(6)?,
-                working_directory: row.get(7)?,
-                display_hidden: row.get::<_, i64>(8)? != 0,
-            })
-        });
+        let result = stmt.query_row(params![instance_name], map_agent_instance_row);
         match result {
-            Ok(a) => Ok(Some(a)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e.into()),
+            Ok(a) => return Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {}
+            Err(e) => return Err(e.into()),
         }
+        drop(stmt);
+
+        // Slug-normalized fallback — see the doc comment above.
+        let queried_slug = derive_slug(instance_name);
+        let mut fallback_stmt = conn.prepare(
+            "SELECT id, id AS def_id,
+                    github_context, created_at,
+                    identity_id, memory_id, instance_name, working_directory,
+                    user_hidden
+             FROM db_agents
+             WHERE is_template = 0
+               AND user_hidden = 0
+             ORDER BY updated_at DESC, created_at DESC",
+        )?;
+        let mut rows = fallback_stmt.query_map([], map_agent_instance_row)?;
+        while let Some(row) = rows.next() {
+            let instance = row?;
+            if derive_slug(&instance.instance_name) == queried_slug {
+                return Ok(Some(instance));
+            }
+        }
+        Ok(None)
     }
 
     /// Partial update of an instance's mutable runtime fields. Only
@@ -1999,6 +2017,29 @@ fn map_instance_row(row: &rusqlite::Row) -> rusqlite::Result<AgentInstance> {
     })
 }
 
+/// Row mapper for `instance_get_by_name`'s two queries (exact-match and
+/// the slug-normalized fallback scan) — column order MUST match both
+/// SELECTs there.
+fn map_agent_instance_row(row: &rusqlite::Row) -> rusqlite::Result<AgentInstance> {
+    Ok(AgentInstance {
+        id: row.get(0)?,
+        definition_id: row.get(1)?,
+        parent_instance_id: String::new(),
+        block_id: String::new(),
+        session_id: String::new(),
+        status: String::new(),
+        github_context: row.get(2)?,
+        started_at: row.get(3)?, // created_at — best proxy for the consolidated row
+        ended_at: 0,
+        created_at: row.get(3)?,
+        identity_id: row.get(4)?,
+        memory_id: row.get(5)?,
+        instance_name: row.get(6)?,
+        working_directory: row.get(7)?,
+        display_hidden: row.get::<_, i64>(8)? != 0,
+    })
+}
+
 /// Row mapper for `db_agents` rows projected back into the
 /// `AgentDefinition` shape. The column order MUST match the SELECT in
 /// `agent_def_list`. `parent_template_id` maps to `parent_id` because
@@ -2132,6 +2173,53 @@ mod tests {
         // swallow a real error.
         let result = store.instance_create(&instance("inst-2", "nowhere"));
         assert!(result.is_err(), "instance_create must still fail for a truly orphaned definition_id");
+    }
+
+    // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md follow-up: App-API
+    // self-lookup callers (MemoryList/Read/Write, IdentityAccounts,
+    // IdentityValidate, bundle.self.get) pass the AGENTMUX_AGENT_ID routing
+    // slug (`derive_slug(display_name)`), not the literal display name.
+    // Confirmed live: a real agent named "AgentY" got "agent agenty not
+    // found" from every one of those endpoints.
+    #[test]
+    fn instance_get_by_name_resolves_a_mixed_case_display_name_via_its_slug() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        def_store.upsert(&global_user_agent("def-agenty", "AgentY")).unwrap();
+        store.set_def_registry(def_store);
+
+        let mut inst = instance("inst-agenty", "def-agenty");
+        inst.instance_name = "AgentY".to_string();
+        store.instance_create(&inst).unwrap();
+
+        // The routing slug ("agenty", what every MCP-tool-backed App-API
+        // endpoint actually has) must resolve to the display-cased row.
+        let found = store.instance_get_by_name("agenty").unwrap();
+        assert!(found.is_some(), "must resolve via the slug-normalized fallback");
+        assert_eq!(found.unwrap().instance_name, "AgentY");
+
+        // The literal display name must still hit the exact-match fast
+        // path unchanged.
+        let found_exact = store.instance_get_by_name("AgentY").unwrap();
+        assert!(found_exact.is_some());
+        assert_eq!(found_exact.unwrap().instance_name, "AgentY");
+    }
+
+    #[test]
+    fn instance_get_by_name_returns_none_for_a_genuinely_unrelated_slug() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+        def_store.upsert(&global_user_agent("def-agenty2", "AgentY")).unwrap();
+        store.set_def_registry(def_store);
+
+        let mut inst = instance("inst-agenty2", "def-agenty2");
+        inst.instance_name = "AgentY".to_string();
+        store.instance_create(&inst).unwrap();
+
+        let found = store.instance_get_by_name("someone-else").unwrap();
+        assert!(found.is_none(), "an unrelated slug must not match by coincidence");
     }
 
     #[test]

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -1015,6 +1015,21 @@ pub(super) fn resolve_agent_definition_id(
     if let Ok(Some(_)) = state.wstore.agent_def_get(agent_id) {
         return Ok(agent_id.to_string());
     }
+    // reagentx P1 on PR #2428 (round 4): `instance_get_by_slug` only ever
+    // hits the local `db_agents` table — the common case (per
+    // `bundle_self_get_impl`'s own doc comment a few lines above: launching
+    // an agent does not create a `db_agents` row) is a live agent that only
+    // exists in the global named-agent registry. Without this fallback,
+    // `identity.self.accounts`/`IdentityAccounts` — the exact tool
+    // confirmed live-broken for a real registry-only agent — stayed broken
+    // even after `instance_get_by_slug` existed, since a slug-only agent
+    // never resolves via either branch above. Mirrors the same registry
+    // fallback `bundle_self_get_impl` already has.
+    if let Some(rec) = crate::server::native_memory_handlers::find_active_registry_record_by_slug(agent_id) {
+        if !rec.data.definition_id.is_empty() {
+            return Ok(rec.data.definition_id);
+        }
+    }
     Err(format!(
         "unknown agent '{agent_id}': no instance with that name and no definition with that id"
     ))
@@ -1945,6 +1960,96 @@ mod identity_self_accounts_tests {
             .expect("must not fail even with a malformed linked account present");
         let accounts = result["accounts"].as_array().unwrap();
         assert_eq!(accounts.len(), 1, "the malformed account must be skipped, not error the whole call");
+        assert_eq!(accounts[0]["account_id"], json!("acct-good"));
+    }
+
+    // reagentx P1 on PR #2428 (round 4): `resolve_agent_definition_id`
+    // (the shared resolver behind `identity.self.*`) only tried
+    // `instance_get_by_slug` (local `db_agents`) then `agent_def_get`
+    // (treating the slug as if it were a definition UUID, which it never
+    // is) — no registry fallback, unlike `bundle_self_get_impl`. So the
+    // common case (a live agent that only exists in the global
+    // named-agent registry, per that function's own doc comment) stayed
+    // broken for `IdentityAccounts` even after the slug/name namespace
+    // split — the exact tool this PR's own description cited as
+    // confirmed-live-broken.
+    #[tokio::test]
+    async fn resolve_agent_definition_id_falls_back_to_the_registry_for_a_slug_only_agent() {
+        use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let state = test_state();
+        let mut def = AgentDefinition {
+            id: uuid::Uuid::new_v4().to_string(),
+            slug: "agenty".to_string(),
+            name: "AgentY".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            environment: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        };
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state.wstore.identity_upsert(&sample_account("acct-good", "claude")).unwrap();
+        state.wstore.agent_identity_link(&def.id, "acct-good", "claude").unwrap();
+
+        // Deliberately NO `instance_create` call — this agent exists only
+        // in the global registry, exactly like a real live-launched agent
+        // that never got a local `db_agents` instance row.
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("AGENTMUX_HOME_OVERRIDE");
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+
+        let registry_dir = tmp.path().join("shared").join("agents").join("registry");
+        let registry = crate::registry::Registry::open(registry_dir).unwrap();
+        registry
+            .upsert(&crate::registry::NamedAgentRecord {
+                schema_version: 1,
+                data: crate::registry::NamedAgentRecordV1 {
+                    instance_id: "inst-agenty".to_string(),
+                    instance_name: "AgentY".to_string(),
+                    definition_id: def.id.clone(),
+                    identity_id: None,
+                    memory_id: None,
+                    session_id: None,
+                    working_dir: "agenty-0629j".to_string(),
+                    source_agents_base: None,
+                    created_at_ms: 1,
+                    last_launched_at_ms: 1,
+                    created_by_version: "test".to_string(),
+                    last_launched_by_version: "test".to_string(),
+                },
+            })
+            .unwrap();
+
+        let result = identity_self_accounts_impl(&state, "agenty").await;
+
+        match prev {
+            Some(v) => std::env::set_var("AGENTMUX_HOME_OVERRIDE", v),
+            None => std::env::remove_var("AGENTMUX_HOME_OVERRIDE"),
+        }
+
+        let result = result.expect("must resolve via the registry fallback, not error 'unknown agent'");
+        let accounts = result["accounts"].as_array().unwrap();
+        assert_eq!(accounts.len(), 1);
         assert_eq!(accounts[0]["account_id"], json!("acct-good"));
     }
 }

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -700,9 +700,9 @@ pub(crate) async fn bundle_self_get_impl(
     state: &AppState,
     agent_id: &str,
 ) -> Result<serde_json::Value, String> {
-    let instance = state.wstore.instance_get_by_name(agent_id)
+    let instance = state.wstore.instance_get_by_slug(agent_id)
         .map_err(|e| format!("bundle.self.get: {e}"))?;
-    // `instance_get_by_name` only ever hits the local `db_agents` table — a
+    // `instance_get_by_slug` only ever hits the local `db_agents` table — a
     // live agent that only exists in the global named-agent registry (never
     // created a `db_agents` instance row) falls through with `instance:
     // None` here. Without this fallback that silently read as "no bundle
@@ -1007,7 +1007,7 @@ pub(super) fn resolve_agent_definition_id(
     state: &AppState,
     agent_id: &str,
 ) -> Result<String, String> {
-    if let Ok(Some(instance)) = state.wstore.instance_get_by_name(agent_id) {
+    if let Ok(Some(instance)) = state.wstore.instance_get_by_slug(agent_id) {
         if !instance.definition_id.is_empty() {
             return Ok(instance.definition_id);
         }
@@ -1796,7 +1796,7 @@ mod bundle_upsert_input_tests {
 
 // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md follow-up: `PresetGet`
 // self-mode (backed by `bundle_self_get_impl`) only ever checked the local
-// `db_agents` table via `instance_get_by_name`. A live agent that only
+// `db_agents` table via `instance_get_by_slug`. A live agent that only
 // exists in the global named-agent registry (the common case — launching
 // an agent does not create a `db_agents` row, see issue #1836, already
 // handled the same way by `native_memory_handlers::memory_dir_for_agent`)

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -683,8 +683,21 @@ pub(crate) async fn bundle_self_get_impl(
 ) -> Result<serde_json::Value, String> {
     let instance = state.wstore.instance_get_by_name(agent_id)
         .map_err(|e| format!("bundle.self.get: {e}"))?;
+    // `instance_get_by_name` only ever hits the local `db_agents` table — a
+    // live agent that only exists in the global named-agent registry (never
+    // created a `db_agents` instance row) falls through with `instance:
+    // None` here. Without this fallback that silently read as "no bundle
+    // bound" and returned the blank/vanilla preset regardless of what's
+    // actually bound, with nothing to distinguish it from a genuinely
+    // unbound agent. Mirrors the two-tier lookup
+    // `native_memory_handlers::memory_dir_for_agent` already does for the
+    // same reason (see that function's own doc comment, issue #1836).
     let memory_id = instance.as_ref()
-        .and_then(|i| if i.memory_id.is_empty() { None } else { Some(i.memory_id.clone()) });
+        .and_then(|i| if i.memory_id.is_empty() { None } else { Some(i.memory_id.clone()) })
+        .or_else(|| {
+            crate::server::native_memory_handlers::find_active_registry_record_by_slug(agent_id)
+                .and_then(|rec| rec.data.memory_id)
+        });
     let memory = if let Some(mid) = memory_id {
         state.id_store.bundle_memory_get(&mid).map_err(|e| format!("bundle.self.get: {e}"))?
             .ok_or_else(|| format!("bundle.self.get: memory_id {mid} not found"))?
@@ -1759,5 +1772,75 @@ mod bundle_upsert_input_tests {
         }));
         assert_eq!(out["context_files"], json!("[]"));
         assert_eq!(out["skills"], json!("[\"already\"]"));
+    }
+}
+
+// SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md follow-up: `PresetGet`
+// self-mode (backed by `bundle_self_get_impl`) only ever checked the local
+// `db_agents` table via `instance_get_by_name`. A live agent that only
+// exists in the global named-agent registry (the common case — launching
+// an agent does not create a `db_agents` row, see issue #1836, already
+// handled the same way by `native_memory_handlers::memory_dir_for_agent`)
+// fell through to `instance: None` and silently returned the generic
+// blank/vanilla preset, with nothing to distinguish it from an agent that
+// genuinely has no bundle bound. Confirmed live against a real registry-only
+// agent named "AgentY": `PresetGet` returned `is_blank: true` even though
+// the registry's own `memory_id` was set.
+#[cfg(test)]
+mod bundle_self_get_registry_fallback_tests {
+    use super::*;
+    use crate::server::tests::test_state;
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
+
+    #[tokio::test]
+    async fn falls_back_to_the_registrys_own_bound_bundle_when_no_local_instance_row_exists() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let state = test_state();
+        let bundle: crate::backend::storage::memory_bundles::Memory =
+            serde_json::from_value(serde_json::json!({
+                "id": "bundle-agenty-test",
+                "name": "AgentY's real bundle",
+            }))
+            .unwrap();
+        state.id_store.bundle_memory_upsert(&bundle).unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("AGENTMUX_HOME_OVERRIDE");
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+
+        let registry_dir = tmp.path().join("shared").join("agents").join("registry");
+        let registry = crate::registry::Registry::open(registry_dir).unwrap();
+        registry
+            .upsert(&crate::registry::NamedAgentRecord {
+                schema_version: 1,
+                data: crate::registry::NamedAgentRecordV1 {
+                    instance_id: "inst-agenty".to_string(),
+                    instance_name: "AgentY".to_string(),
+                    definition_id: "def-agenty".to_string(),
+                    identity_id: None,
+                    memory_id: Some("bundle-agenty-test".to_string()),
+                    session_id: None,
+                    working_dir: "agenty-0629j".to_string(),
+                    source_agents_base: None,
+                    created_at_ms: 1,
+                    last_launched_at_ms: 1,
+                    created_by_version: "test".to_string(),
+                    last_launched_by_version: "test".to_string(),
+                },
+            })
+            .unwrap();
+
+        // No `db_agents` row for "agenty" exists in `state.wstore` — this
+        // must resolve entirely through the registry fallback.
+        let resp = bundle_self_get_impl(&state, "agenty").await;
+
+        match prev {
+            Some(v) => std::env::set_var("AGENTMUX_HOME_OVERRIDE", v),
+            None => std::env::remove_var("AGENTMUX_HOME_OVERRIDE"),
+        }
+
+        let resp = resp.expect("bundle.self.get must succeed via the registry fallback");
+        assert_eq!(resp["id"], "bundle-agenty-test");
+        assert_eq!(resp["is_blank"], false);
     }
 }

--- a/agentmux-srv/src/server/identity_auth_dirs.rs
+++ b/agentmux-srv/src/server/identity_auth_dirs.rs
@@ -263,17 +263,19 @@ pub(crate) fn compute_and_ensure_account_dir(
 mod tests {
     use super::*;
 
-    // Shared across every test in this module that mutates process-
-    // global env vars (`AGENTMUX_HOME_OVERRIDE` + `DataPaths::to_env_vars()`
-    // entries) via `compute_and_ensure_bundle_dir`/`compute_and_ensure_account_dir`
-    // round-trip tests. `cargo test` runs tests in this binary in
-    // parallel by default — a `static` declared inside a TEST FUNCTION
-    // body is a separate item per function, so per-function locks don't
-    // actually serialize against each other, only against repeated
-    // calls to the SAME test. One module-level lock, taken by every
-    // such test before touching the environment, is what actually
-    // prevents them from racing.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // `AGENTMUX_HOME_OVERRIDE` is one of the process-global env vars
+    // `crate::test_support::ISOLATED_AUTH_ENV_LOCK` exists specifically to
+    // guard — a module-local lock here only serializes tests WITHIN this
+    // module; `cargo test` runs a crate's tests in one multi-threaded
+    // process, so a local-only lock still let this module's tests race
+    // against any other module's tests touching the same var (confirmed
+    // live: `server::app_api::bundle_self_get_registry_fallback_tests`
+    // and `server::native_memory_handlers::tests`, both added for
+    // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md, intermittently
+    // failed this module's `compute_account_dir_mints_fresh_id_when_
+    // existing_is_empty` in full-suite runs — passed every time alone).
+    // Reusing the crate-wide lock here closes that gap.
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
 
     #[test]
     fn compute_account_dir_mints_fresh_id_when_existing_is_empty() {

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -113,6 +113,30 @@ pub(crate) fn memory_dir_for_agent(
         .ok_or_else(|| format!("memory: agent {agent_id} not found"))
 }
 
+/// Find the global named-agent registry's active record for `agent_id` —
+/// the `AGENTMUX_AGENT_ID` routing slug (`derive_slug(display_name)`),
+/// NOT the record's own `instance_name` (which keeps the original
+/// display casing, e.g. "AgentY"). Matching by raw string equality here
+/// used to mean this — and every App-API self-lookup endpoint that falls
+/// back to it (`memory.*`, and `bundle.self.get` once it's wired to use
+/// this too) — silently 404'd for any agent whose name wasn't already
+/// all-lowercase. `derive_slug` on both sides makes the comparison
+/// consistent with how the slug was actually derived in the first place.
+/// Shared so callers outside this module (e.g. `app_api::mod::
+/// bundle_self_get_impl`) don't reimplement the same lookup.
+pub(crate) fn find_active_registry_record_by_slug(
+    agent_id: &str,
+) -> Option<crate::registry::NamedAgentRecord> {
+    let registry_dir = crate::registry::resolve_shared_registry_dir()?;
+    let registry = crate::registry::Registry::open(registry_dir).ok()?;
+    let queried_slug = crate::backend::storage::store::derive_slug(agent_id);
+    registry
+        .list_active()
+        .ok()?
+        .into_iter()
+        .find(|r| crate::backend::storage::store::derive_slug(&r.data.instance_name) == queried_slug)
+}
+
 /// Resolve a memory dir for `agent_id` from the global named-agent registry.
 ///
 /// Each live agent is recorded by `instance_name` with a `working_dir` relative
@@ -120,13 +144,7 @@ pub(crate) fn memory_dir_for_agent(
 /// `identity_id` that determines its `CLAUDE_CONFIG_DIR` root. Returns `None`
 /// when the registry is unavailable or no active record matches the slug.
 fn memory_dir_from_registry(agent_id: &str) -> Option<std::path::PathBuf> {
-    let registry_dir = crate::registry::resolve_shared_registry_dir()?;
-    let registry = crate::registry::Registry::open(registry_dir).ok()?;
-    let rec = registry
-        .list_active()
-        .ok()?
-        .into_iter()
-        .find(|r| r.data.instance_name == agent_id)?;
+    let rec = find_active_registry_record_by_slug(agent_id)?;
 
     // Reconstruct the absolute working directory: source_agents_base joined with
     // the relative working_dir. Legacy (v1/v2) records without a base fall back
@@ -496,10 +514,15 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    // Process-global env access — serialize so parallel tests don't race.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // Process-global env access (AGENTMUX_SHARED_DIR / AGENTMUX_HOME_OVERRIDE
+    // both feed registry::paths::resolve_global_shared_root) — a module-local
+    // lock only serializes tests within THIS file; registry::paths's own
+    // test module touches the same resolution path and already uses this
+    // crate-wide lock for exactly that reason (see test_support.rs's doc
+    // comment). Reusing it here avoids reintroducing the cross-module race
+    // it was built to prevent.
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
 
     #[test]
     fn config_dir_for_default_identity_is_empty() {
@@ -513,7 +536,7 @@ mod tests {
 
     #[test]
     fn config_dir_for_bound_identity_points_at_bundle() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var_os("AGENTMUX_SHARED_DIR");
         std::env::set_var("AGENTMUX_SHARED_DIR", "/home/u/.agentmux/shared");
 
@@ -525,6 +548,53 @@ mod tests {
             .to_string_lossy()
             .to_string();
         assert_eq!(got, want);
+
+        match prev {
+            Some(v) => std::env::set_var("AGENTMUX_SHARED_DIR", v),
+            None => std::env::remove_var("AGENTMUX_SHARED_DIR"),
+        }
+    }
+
+    // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md follow-up: confirmed
+    // live — a real agent named "AgentY" (routing slug "agenty") got
+    // "memory: agent agenty not found" from `MemoryList`, because this
+    // lookup used to compare the slug against the registry's own
+    // display-cased `instance_name` with raw string equality.
+    #[test]
+    fn find_active_registry_record_by_slug_resolves_a_mixed_case_display_name() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("AGENTMUX_SHARED_DIR");
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AGENTMUX_SHARED_DIR", tmp.path());
+
+        let registry_dir = tmp.path().join("agents").join("registry");
+        let registry = crate::registry::Registry::open(registry_dir).unwrap();
+        registry
+            .upsert(&crate::registry::NamedAgentRecord {
+                schema_version: 1,
+                data: crate::registry::NamedAgentRecordV1 {
+                    instance_id: "inst-agenty".to_string(),
+                    instance_name: "AgentY".to_string(),
+                    definition_id: "def-agenty".to_string(),
+                    identity_id: None,
+                    memory_id: None,
+                    session_id: None,
+                    working_dir: "agenty-0629j".to_string(),
+                    source_agents_base: None,
+                    created_at_ms: 1,
+                    last_launched_at_ms: 1,
+                    created_by_version: "test".to_string(),
+                    last_launched_by_version: "test".to_string(),
+                },
+            })
+            .unwrap();
+
+        let found = find_active_registry_record_by_slug("agenty");
+        assert!(found.is_some(), "must resolve via the slug-normalized fallback");
+        assert_eq!(found.unwrap().data.instance_name, "AgentY");
+
+        let not_found = find_active_registry_record_by_slug("someone-else");
+        assert!(not_found.is_none(), "an unrelated slug must not match by coincidence");
 
         match prev {
             Some(v) => std::env::set_var("AGENTMUX_SHARED_DIR", v),

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -85,10 +85,12 @@ pub(crate) fn memory_dir_for_agent(
     agent_id: &str,
 ) -> Result<std::path::PathBuf, String> {
     // agent_id arriving from App API is the agent slug (AGENTMUX_AGENT_ID /
-    // bus:register id), not a UUID — use instance_get_by_name for the slug
-    // lookup. agent_def_get queries by UUID and would always return None here.
+    // bus:register id), not a UUID and not the literal display name — use
+    // instance_get_by_slug (agent_def_get queries by UUID and would always
+    // return None here; instance_get_by_name matches the display name, a
+    // different namespace — see that function's own doc comment).
     if let Some(instance) = wstore
-        .instance_get_by_name(agent_id)
+        .instance_get_by_slug(agent_id)
         .map_err(|e| format!("memory: store: {e}"))?
     {
         if instance.working_directory.is_empty() {

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1223,10 +1223,15 @@ async fn introspection_lists_return_collections() {
     }
 }
 
-/// `resolve_agent_definition_id` maps the S1-authenticated agent slug
-/// (instance_name) to the definition id that keys
-/// `db_agent_identity_links`, passes real definition ids through
-/// unchanged, and errors on unknown ids. Guards the #1624 PR-C fix for
+/// `resolve_agent_definition_id` maps the S1-authenticated agent's
+/// `AGENTMUX_AGENT_ID` — the persisted `slug` column, NOT `instance_name`
+/// (see `instance_get_by_slug`'s doc comment,
+/// SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md follow-up — reagentx
+/// P1 on PR #2428 caught this same slug/display-name conflation baked
+/// into this test itself: it used to pass the display name and call it
+/// "slug") — to the definition id that keys `db_agent_identity_links`,
+/// passes real definition ids through unchanged, and errors on unknown
+/// ids. Guards the #1624 PR-C fix for
 /// identity.account.upsert/self.accounts/self.unlink writing the slug
 /// into the link table (FK failure on per-channel stores; silent
 /// resolver-invisible rows on the shared store).
@@ -1234,10 +1239,13 @@ async fn introspection_lists_return_collections() {
 async fn resolve_agent_definition_id_maps_slug_and_passes_through_def_id() {
     let state = test_state();
 
+    // `slug` and `name`/`instance_name` deliberately differ (a stable
+    // routing slug vs. a renameable display name) so this test can't
+    // accidentally pass by conflating the two, the way it used to.
     let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
         "id": "def-test-1", // caller-assigned; agent_def_insert stores it as-is
         "slug": "testslug",
-        "name": "TestSlug",
+        "name": "Test Slug Display",
         "icon": "robot",
         "provider": "claude",
         "description": "test agent",
@@ -1254,14 +1262,16 @@ async fn resolve_agent_definition_id_maps_slug_and_passes_through_def_id() {
         "created_at": 1,
         "identity_id": "",
         "memory_id": "",
-        "instance_name": "TestSlug",
+        "instance_name": "Test Slug Display",
         "working_directory": "",
     }))
     .expect("instance fixture");
     state.wstore.instance_create(&inst).expect("create instance");
 
-    // Slug → definition id.
-    let resolved = super::app_api::resolve_agent_definition_id(&state, "TestSlug")
+    // Slug (AGENTMUX_AGENT_ID, what a real MCP-tool caller actually sends)
+    // → definition id. NOT the display name — that's a different,
+    // deliberately-mismatched value in this fixture.
+    let resolved = super::app_api::resolve_agent_definition_id(&state, "testslug")
         .expect("slug resolves");
     assert_eq!(resolved, def.id);
 
@@ -1269,6 +1279,14 @@ async fn resolve_agent_definition_id_maps_slug_and_passes_through_def_id() {
     let passthrough = super::app_api::resolve_agent_definition_id(&state, &def.id)
         .expect("definition id passes through");
     assert_eq!(passthrough, def.id);
+
+    // The literal display name must NOT resolve — it lives in a
+    // different namespace than the slug (see instance_get_by_slug's doc
+    // comment for why merging the two was unsafe).
+    assert!(
+        super::app_api::resolve_agent_definition_id(&state, "Test Slug Display").is_err(),
+        "the display name is not the slug and must not resolve"
+    );
 
     // Unknown ids error instead of silently writing bogus link rows.
     assert!(super::app_api::resolve_agent_definition_id(&state, "no-such-agent").is_err());


### PR DESCRIPTION
## Summary

Investigation follow-up to the pane-history-alignment work — while
verifying the new native-memory bridge live against my own running pane
(agent "AgentY"), `MemoryList` failed with `"agent agenty not found"`.
Traced to a real, reproducible bug affecting several MCP tools, not just
memory.

**Root cause:** `AGENTMUX_AGENT_ID` in an agent's MCP server env is the
deliberately-lowercased `derive_slug(display_name)` routing slug (e.g.
`"agenty"` for `"AgentY"`) — confirmed intentional by
`build_mcp_config`'s own doc comment. Every App-API "tell me about
myself" endpoint that resolves this slug back to a persisted agent
record compared it against `instance_name` (which keeps the *original*
display casing) with **case-sensitive equality** — both in `db_agents`
SQL (`WHERE instance_name = ?1`) and the global cross-channel registry
(`r.data.instance_name == agent_id`). `"agenty" != "AgentY"`, so every
lookup failed for any agent whose name wasn't already all-lowercase.

**Confirmed live** against my own real running agent pane (not just
read from code):

| Tool | Result |
|---|---|
| `MemoryList` | HTTP 400 `"memory: agent agenty not found"` |
| `IdentityAccounts` | HTTP 500 `"unknown agent 'agenty': no instance with that name..."` |
| `PresetGet` (self mode) | No error — silently returned the generic blank preset instead of the real bound one |

## Fix

- `instance_get_by_name` (`agents.rs`) keeps its exact-match fast path
  and falls back to a slug-normalized scan (`derive_slug` on both
  sides) when that misses. This is the shared resolver behind
  `memory.*`, `identity.self.accounts`, `identity.account.validate`,
  and `bundle.self.get` (via `resolve_agent_definition_id`) — one fix
  covers all of them.
- `find_active_registry_record_by_slug` (`native_memory_handlers.rs`)
  — extracted from `memory_dir_from_registry`, fixed to slug-normalize,
  and exposed so `bundle_self_get_impl` can reuse the same lookup
  instead of reimplementing it.
- `bundle_self_get_impl` (`app_api/mod.rs`) now also falls back to the
  registry when no local `db_agents` row exists — it previously had no
  registry tier at all (unlike the memory path's two-tier lookup), so a
  registry-only agent silently got the blank preset with no error.
- `identity_auth_dirs.rs`'s test module was using its own module-local
  env lock for `AGENTMUX_HOME_OVERRIDE` instead of the crate-wide
  `ISOLATED_AUTH_ENV_LOCK`. This PR's own new tests exposed a genuine
  cross-module test race as a result (passed every solo run,
  intermittently failed full-suite parallel runs) — switched to the
  shared lock, closing exactly the gap it exists to prevent.

Every change is additive/corrective to existing lookup logic; no schema
or API shape changes.

## Test plan

- [x] `cargo test -p agentmux-srv` — 2001 passed, 0 failed
- [x] Full suite re-run 4x to confirm the identity_auth_dirs race is
      actually fixed, not coincidentally passing (it reproduced
      reliably before the fix, in ~4/4 full-suite runs)
- [x] New unit tests reproduce the exact live failure (mixed-case
      display name "AgentY" / slug "agenty") for both
      `instance_get_by_name` and the registry fallback, plus a
      registry-only `bundle_self_get_impl` case
- [ ] Not verified against the actual live srv instance serving this
      session's MCP tool calls — restarting that shared, running
      process (used by other concurrent agents on this machine) is out
      of scope for this PR; the unit tests reproduce the exact live
      error strings observed

<!-- agentmux:agent_id=agenty -->