### PR TITLE
fix(editor): markdown preview blank on first MCP/tree open

### DIFF
--- a/.changesets/1785961013-fix-editor-markdown-preview-blank-on-first-mcp-tree-open-zako.md
+++ b/.changesets/1785961013-fix-editor-markdown-preview-blank-on-first-mcp-tree-open-zako.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): markdown preview blank on first MCP/tree open

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -104,8 +104,6 @@ const Markdown = (props: MarkdownProps) => {
         rehype = true,
         onClickExecute,
     } = props;
-    const textAtomValue = useAtomValueSafe<string>(textAtom as any);
-    const showToc = useAtomValueSafe(showTocAtom) ?? false;
     const [focusedHeading, setFocusedHeading] = createSignal<string | null>(null);
 
     let contentsEl!: HTMLDivElement;
@@ -115,7 +113,19 @@ const Markdown = (props: MarkdownProps) => {
 
     const [idPrefix] = createSignal<string>(crypto.randomUUID());
 
-    const resolvedText = createMemo(() => textAtomValue ?? props.text ?? "");
+    // `useAtomValueSafe(textAtom)` must be called INSIDE the memo, not hoisted
+    // to a plain outer `const`. `textAtom` (e.g. the editor's `() => liveDoc()`)
+    // is a live reactive getter — calling it once at component-setup time
+    // (before setup, before any effect has had a chance to seed the real
+    // value) froze the memo's only input, so it never recomputed again for
+    // the lifetime of this component instance. On a freshly-mounted markdown
+    // preview this snapshot was almost always "" (the seed value hasn't
+    // landed yet), producing a permanently blank preview — "fixed" only by
+    // remounting the component (e.g. toggling Source → Preview), which
+    // re-captures a fresh (by-then-correct) snapshot. Reading the accessor
+    // here makes the memo properly track its underlying signal.
+    const resolvedText = createMemo(() => useAtomValueSafe<string>(textAtom as any) ?? props.text ?? "");
+    const showToc = createMemo(() => useAtomValueSafe(showTocAtom) ?? false);
 
     const transformedOutput = createMemo(() => transformBlocks(resolvedText()));
     const transformedText = createMemo(() => transformedOutput().content);
@@ -315,10 +325,24 @@ const Markdown = (props: MarkdownProps) => {
                 }
             >
                 <div class={cn("content", contentClassName)} ref={contentsEl}>
-                    {renderedMarkdown().element}
+                    {/* OverlayScrollbars (below, onMount) restructures contentsEl's
+                        DOM once, moving whatever children exist AT INIT TIME into
+                        its generated .os-viewport. On first open, liveDoc/textAtom
+                        is often still "" when this initial move happens (the real
+                        content lands a beat later via a reactive update), which
+                        orphaned Solid's insertion anchor for {renderedMarkdown().element}
+                        outside the new viewport — a permanently blank preview until
+                        something (e.g. a Source/Preview toggle) fully remounted this
+                        component. A single, never-replaced wrapper div is the node
+                        OverlayScrollbars moves; Solid's reactive updates always target
+                        children of THIS stable node, so they keep landing correctly
+                        regardless of OverlayScrollbars' init timing. */}
+                    <div class="markdown-content-inner">
+                        {renderedMarkdown().element}
+                    </div>
                 </div>
             </Show>
-            <Show when={showToc && tocItems().length > 0}>
+            <Show when={showToc() && tocItems().length > 0}>
                 <div class="toc mt-1" ref={tocEl}>
                     <div class="toc-inner">
                         <h4 class="font-bold">Table of Contents</h4>
@@ -334,7 +358,7 @@ const Markdown = (props: MarkdownProps) => {
                     </div>
                 </div>
             </Show>
-            <Show when={showToc && tocItems().length === 0}>
+            <Show when={showToc() && tocItems().length === 0}>
                 <div class="toc mt-1">
                     <div class="toc-inner">
                         <h4 class="font-bold">Table of Contents</h4>


### PR DESCRIPTION
## Summary

Root-caused and fixed the "blank markdown preview on first open" bug referenced by `docs/specs/SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md` Part 1 — that spec's static analysis was inconclusive and called for a live, instrumented repro before any fix; this PR is that repro (via CDP against a running instance) plus the resulting fix.

- `Markdown`'s `resolvedText` memo read `textAtom` (e.g. the editor's `() => liveDoc()`) through a plain outer `const textAtomValue = useAtomValueSafe(textAtom)`, evaluated once at component setup — **outside** any reactive tracking scope. This froze the memo's only input to whatever the accessor returned at that instant, almost always `""` for a freshly-mounted pane, since the seed effect that populates `liveDoc` runs *after* mount. The preview stayed blank forever until something (e.g. toggling Source → Preview) fully remounted the component and re-captured a by-then-correct snapshot.
- Confirmed live: attached to a running portable instance over the Chrome DevTools Protocol, opened a fresh `.md` file via the `OpenEditor` MCP tool, and inspected the DOM directly — CodeMirror (`.cm-content`) had the real file content while the preview's rendered output (`.editor-preview-content .content`) was completely empty (0 children). After the fix, the same fresh-mount scenario renders correctly with no manual toggle.
- Same one-shot-capture pattern existed for `showTocAtom`; fixed identically.
- Also wrapped the preview's rendered output in a stable, never-replaced div so `OverlayScrollbars`' one-time DOM restructuring (in `onMount`) can't orphan Solid's insertion point for later reactive updates, regardless of how much content exists when it first runs — defense in depth, independent of the primary fix above.

This file already had one instance of this exact bug class fixed before (see the PR #786 comment on `props.text`, lines 86-93) — `textAtom`/`showTocAtom` were simply missed in that pass.

## Test plan
- [x] `npx tsc --noEmit` passes on the changed file
- [x] Live-verified via CDP against a running packaged instance: reproduced the blank preview on a fresh `OpenEditor`-opened pane (both a docked pane and a `floating: true` pane), then reproduced the fix after rebuilding with the change — preview renders real content on first open, no toggle needed
- [ ] Manual sanity pass in a `task dev` session recommended before merge (this verification used a rebuilt bundle hot-swapped into a running portable instance, not `task dev`)

<!-- agentmux:agent_id=agent3 -->