### PR TITLE
chore: release v0.54.11

### DIFF
--- a/.changesets/1785801693-fix-migrations-stop-trusting-marker-existence-as-proof-of-ef-i3ak.md
+++ b/.changesets/1785801693-fix-migrations-stop-trusting-marker-existence-as-proof-of-ef-i3ak.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(migrations): stop trusting marker existence as proof of effect

--- a/.changesets/1785805646-fix-agent-pane-composer-strip-centers-at-wide-widths-pairs-h-mmmd.md
+++ b/.changesets/1785805646-fix-agent-pane-composer-strip-centers-at-wide-widths-pairs-h-mmmd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): composer strip centers at wide widths, pairs HOST/SANDBOX with Shell

--- a/.changesets/1785806209-feat-launcher-detect-srv-hang-while-alive-and-force-a-recycl-s606.md
+++ b/.changesets/1785806209-feat-launcher-detect-srv-hang-while-alive-and-force-a-recycl-s606.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(launcher): detect srv hang-while-alive and force a recycle (#942)

--- a/.changesets/1785807323-fix-agent-pane-remove-the-model-selector-s-misleading-traili-ucxu.md
+++ b/.changesets/1785807323-fix-agent-pane-remove-the-model-selector-s-misleading-traili-ucxu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): remove the model selector's misleading trailing caret

--- a/.changesets/1785808171-feat-auth-in-app-claude-oauth-login-core-session-catalog-rev-8sgd.md
+++ b/.changesets/1785808171-feat-auth-in-app-claude-oauth-login-core-session-catalog-rev-8sgd.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(auth): in-app Claude OAuth login — core session, catalog revival, and launch surface

--- a/.changesets/1785810626-feat-auth-revive-in-app-relogin-on-credential-loss-fix-spawn-76wn.md
+++ b/.changesets/1785810626-feat-auth-revive-in-app-relogin-on-credential-loss-fix-spawn-76wn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(auth): revive in-app relogin on credential loss + fix spawn-gate stuck-pane classification

--- a/.changesets/1785811191-feat-armory-connect-re-login-claude-oauth-accounts-from-armo-dit6.md
+++ b/.changesets/1785811191-feat-armory-connect-re-login-claude-oauth-accounts-from-armo-dit6.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): connect/re-login Claude OAuth accounts from Armory and Agent Stash

--- a/.changesets/1785812402-docs-auth-sweep-stale-dead-end-claims-after-reviving-in-app--xiyz.md
+++ b/.changesets/1785812402-docs-auth-sweep-stale-dead-end-claims-after-reviving-in-app--xiyz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(auth): sweep stale 'dead end' claims after reviving in-app Claude OAuth login

--- a/.changesets/1785875969-fix-ambient-ghost-text-suggestions-read-as-direct-instructio-z6gs.md
+++ b/.changesets/1785875969-fix-ambient-ghost-text-suggestions-read-as-direct-instructio-z6gs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ambient): ghost-text suggestions read as direct instructions, not chat filler

--- a/.changesets/1785877152-fix-dev-default-dev-agent-cmd-window-title-to-agent-identity-tu4r.md
+++ b/.changesets/1785877152-fix-dev-default-dev-agent-cmd-window-title-to-agent-identity-tu4r.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dev): default dev-agent.cmd window title to agent identity

--- a/.changesets/1785877245-feat-cron-agentmux-native-scheduling-tool-disambiguation-exp-fsjt.md
+++ b/.changesets/1785877245-feat-cron-agentmux-native-scheduling-tool-disambiguation-exp-fsjt.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(cron): AgentMux/native scheduling tool disambiguation + expiry bound

--- a/.changesets/1785892369-fix-identity-tolerate-a-malformed-secret-ref-row-instead-of--5nfj.md
+++ b/.changesets/1785892369-fix-identity-tolerate-a-malformed-secret-ref-row-instead-of--5nfj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): tolerate a malformed secret_ref row instead of hiding every account

--- a/.changesets/1785914097-fix-agent-pane-remove-the-picked-up-more-work-synthetic-syst-phhq.md
+++ b/.changesets/1785914097-fix-agent-pane-remove-the-picked-up-more-work-synthetic-syst-phhq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): remove the 'Picked up more work' synthetic system notification

--- a/.changesets/1785914390-fix-agent-surface-429-overloaded-failures-from-the-persisten-l11c.md
+++ b/.changesets/1785914390-fix-agent-surface-429-overloaded-failures-from-the-persisten-l11c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): surface 429/overloaded failures from the persistent controller for retry

--- a/.changesets/1785915259-fix-agent-pane-decouple-working-state-from-window-focus-xbdj.md
+++ b/.changesets/1785915259-fix-agent-pane-decouple-working-state-from-window-focus-xbdj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): decouple Working state from window focus

--- a/.changesets/1785915999-fix-login-resolve-npm-cmd-shims-before-spawning-under-a-pty--mh56.md
+++ b/.changesets/1785915999-fix-login-resolve-npm-cmd-shims-before-spawning-under-a-pty--mh56.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(login): resolve npm .cmd shims before spawning under a PTY on Windows

--- a/.changesets/1785916655-fix-accounts-unify-claudeloginpanel-onto-the-canonical-modal-42wj.md
+++ b/.changesets/1785916655-fix-accounts-unify-claudeloginpanel-onto-the-canonical-modal-42wj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(accounts): unify ClaudeLoginPanel onto the canonical Modal, fix Stash nesting

--- a/.changesets/1785917467-fix-build-exclude-target-from-the-vite-dev-server-watcher-uqtv.md
+++ b/.changesets/1785917467-fix-build-exclude-target-from-the-vite-dev-server-watcher-uqtv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(build): exclude target/ from the Vite dev-server watcher

--- a/.changesets/1785955383-feat-agent-pane-surface-resume-outcome-as-an-explicit-transc-zb0y.md
+++ b/.changesets/1785955383-feat-agent-pane-surface-resume-outcome-as-an-explicit-transc-zb0y.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): surface --resume outcome as an explicit transcript event

--- a/.changesets/1785959990-fix-agent-api-resolve-app-api-self-lookup-by-the-agent-s-rou-v2vn.md
+++ b/.changesets/1785959990-fix-agent-api-resolve-app-api-self-lookup-by-the-agent-s-rou-v2vn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-api): resolve App-API self-lookup by the agent's routing slug, not its display-cased name

--- a/.changesets/1785961013-fix-editor-markdown-preview-blank-on-first-mcp-tree-open-zako.md
+++ b/.changesets/1785961013-fix-editor-markdown-preview-blank-on-first-mcp-tree-open-zako.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): markdown preview blank on first MCP/tree open

--- a/.changesets/1786003083-feat-identity-non-stable-channels-task-dev-task-package-now--u8g0.md
+++ b/.changesets/1786003083-feat-identity-non-stable-channels-task-dev-task-package-now--u8g0.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-feat(identity): non-stable channels (task dev, task package) now default to isolated Armory accounts
-
-Every `task dev` branch and local `task package` build now starts with a genuinely empty Armory account list instead of sharing the real global account list — you'll need to reconnect Armory-bound providers per branch/build. This does not affect default (non-identity-bound) agent spawns, which keep resolving auth from the same global provider credential dir as before. The `stable` release channel is unaffected either way. Set `AGENTMUX_ISOLATED_AUTH=0` before `task dev`/`task package` to opt back into the old global-sharing behavior for that session. See `docs/specs/SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`.

--- a/.changesets/1786011021-feat-muxspect-diagnose-and-clear-stuck-activity-dock-entries-9lpm.md
+++ b/.changesets/1786011021-feat-muxspect-diagnose-and-clear-stuck-activity-dock-entries-9lpm.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-feat(muxspect): diagnose and clear stuck Activity Dock entries (dock, dock clear)
-
-`muxspect dock <block_id>` reads a live snapshot of an Agent pane's ToolNode statuses and flags entries that look stuck (e.g. a tool call rejected by the outer CLI harness before it ever ran, which never receives a terminating event and stays "running" indefinitely). `muxspect dock clear <block_id> <node_id>` force-clears one, live, in whatever renderer has that block open — no pane reload needed. muxspect's first mutating command; every other command remains read-only. See docs/specs/SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.10"
+version = "0.54.11"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.10"
+version = "0.54.11"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.10"
+version = "0.54.11"
 dependencies = [
  "dirs",
  "serde",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.10"
+version = "0.54.11"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.10"
+version = "0.54.11"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.10"
+version = "0.54.11"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.10"
+version = "0.54.11"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,32 @@
 # AgentMux Version History
 
+## 0.54.11 — 2026-08-06
+
+- fix(migrations): stop trusting marker existence as proof of effect
+- fix(agent-pane): composer strip centers at wide widths, pairs HOST/SANDBOX with Shell
+- feat(launcher): detect srv hang-while-alive and force a recycle (#942)
+- fix(agent-pane): remove the model selector's misleading trailing caret
+- feat(auth): in-app Claude OAuth login — core session, catalog revival, and launch surface
+- feat(auth): revive in-app relogin on credential loss + fix spawn-gate stuck-pane classification
+- feat(armory): connect/re-login Claude OAuth accounts from Armory and Agent Stash
+- docs(auth): sweep stale 'dead end' claims after reviving in-app Claude OAuth login
+- fix(ambient): ghost-text suggestions read as direct instructions, not chat filler
+- fix(dev): default dev-agent.cmd window title to agent identity
+- feat(cron): AgentMux/native scheduling tool disambiguation + expiry bound
+- fix(identity): tolerate a malformed secret_ref row instead of hiding every account
+- fix(agent-pane): remove the 'Picked up more work' synthetic system notification
+- fix(agent): surface 429/overloaded failures from the persistent controller for retry
+- fix(agent-pane): decouple Working state from window focus
+- fix(login): resolve npm .cmd shims before spawning under a PTY on Windows
+- fix(accounts): unify ClaudeLoginPanel onto the canonical Modal, fix Stash nesting
+- fix(build): exclude target/ from the Vite dev-server watcher
+- feat(agent-pane): surface --resume outcome as an explicit transcript event
+- fix(agent-api): resolve App-API self-lookup by the agent's routing slug, not its display-cased name
+- fix(editor): markdown preview blank on first MCP/tree open
+- feat(identity): non-stable channels (task dev, task package) now default to isolated Armory accounts
+- feat(muxspect): diagnose and clear stuck Activity Dock entries (dock, dock clear)
+
+
 ## 0.54.10 — 2026-08-03
 
 - feat(muxspect): surface last persisted spawn/execution error in list/describe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.10",
+  "version": "0.54.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.10",
+      "version": "0.54.11",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.10",
+  "version": "0.54.11",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release consuming 23 pending changesets (forced patch bump via `task release -- --as patch` despite several `minor`-level changes queued — some minor-level changes ship under this patch version, per the user's explicit request for this release).

0.54.10 → 0.54.11. All 5 release-consistency locations verified in agreement (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`).

## Test plan

- [x] `scripts/release.sh` itself re-reads and verifies all 5 version locations agree after the bump (fails loudly on mismatch) — passed.
- [x] Manually cross-checked `VERSION_HISTORY.md` top section, `package.json`, `Cargo.toml`, `package-lock.json` all read `0.54.11`.

<!-- agentmux:agent_id=agenta -->