### PR TITLE
fix(context-meter): seed Claude Sonnet 5 context window at 1M

### DIFF
--- a/.changesets/1786044997-fix-context-meter-seed-claude-sonnet-5-context-window-at-1m--l4np.md
+++ b/.changesets/1786044997-fix-context-meter-seed-claude-sonnet-5-context-window-at-1m--l4np.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(context-meter): seed Claude Sonnet 5 context window at 1M (no beta gate)

--- a/frontend/app/store/agent-pane-state/context-window.test.ts
+++ b/frontend/app/store/agent-pane-state/context-window.test.ts
@@ -17,8 +17,16 @@ describe("contextWindowForModel", () => {
     test("Haiku resolves to 200K", () => {
         expect(contextWindowForModel("claude-haiku-4-5")).toBe(200_000);
     });
-    test("Sonnet seeds conservatively at 200K (learns up to 1M)", () => {
+    test("Sonnet 4.x seeds conservatively at 200K (learns up to 1M)", () => {
         expect(contextWindowForModel("claude-sonnet-4-6")).toBe(200_000);
+        expect(contextWindowForModel("claude-sonnet-4-5")).toBe(200_000);
+    });
+    test("Sonnet 5+ has no beta gate — seeds at 1M directly", () => {
+        expect(contextWindowForModel("claude-sonnet-5")).toBe(1_000_000);
+        expect(contextWindowForModel("CLAUDE-SONNET-5")).toBe(1_000_000);
+    });
+    test("bare 'sonnet' family alias (unresolved) stays conservative", () => {
+        expect(contextWindowForModel("sonnet")).toBe(200_000);
     });
     test("unknown / non-Claude models are undefined (caller falls back)", () => {
         expect(contextWindowForModel("gpt-5-codex")).toBeUndefined();
@@ -33,11 +41,17 @@ describe("learnContextWindow", () => {
         expect(learnContextWindow(null, 1_000, "claude-opus-4-8")).toBe(1_000_000);
         expect(learnContextWindow(null, 1_000, "claude-haiku-4-5")).toBe(200_000);
     });
-    test("Sonnet-1M: promotes 200K → 1M once context exceeds 200K", () => {
+    test("Sonnet-4.x-1M-beta: promotes 200K → 1M once context exceeds 200K", () => {
         const seed = learnContextWindow(null, 50_000, "claude-sonnet-4-6");
         expect(seed).toBe(200_000);
         // a later turn whose prompt exceeds the 200K seed proves it's the 1M variant
         expect(learnContextWindow(seed, 250_000, "claude-sonnet-4-6")).toBe(1_000_000);
+    });
+    test("Sonnet 5 seeds at 1M on first observation — no learning needed", () => {
+        expect(learnContextWindow(null, 50_000, "claude-sonnet-5")).toBe(1_000_000);
+    });
+    test("model switch mid-session Sonnet-4.6(learned 1M) → Sonnet 5 stays at 1M", () => {
+        expect(learnContextWindow(1_000_000, 50_000, "claude-sonnet-5", "claude-sonnet-4-6")).toBe(1_000_000);
     });
     test("learn-up-only: never shrinks within a session", () => {
         expect(learnContextWindow(1_000_000, 50_000, "claude-sonnet-4-6")).toBe(1_000_000);

--- a/frontend/app/store/agent-pane-state/context-window.ts
+++ b/frontend/app/store/agent-pane-state/context-window.ts
@@ -4,14 +4,16 @@
 /**
  * Per-model context-window resolution for the agent-pane context meter.
  *
- * The window is NOT a per-provider constant: the Claude provider spans
- * Opus/Sonnet (1M) and Haiku (200K), and Sonnet itself is 200K by default but
- * 1M with the `context-1m-2025-08-07` beta. The CLI never reports the effective
- * window (verified — `system/init` and `result` carry `model` but no window
- * field), so we (a) SEED from the resolved model id the stream reports and
- * (b) LEARN upward from observed usage: a prompt can never exceed the real
- * window, so if it ever does, promote to the next known tier (this is what
- * catches Sonnet-1M).
+ * The window is NOT a per-provider constant, and it isn't even uniform within
+ * the Sonnet family: Opus/Fable/Mythos are 1M, Haiku is 200K, and Sonnet 4.x
+ * is 200K by default but 1M with the `context-1m-2025-08-07` beta — while
+ * Sonnet 5 ships with a 1M window by default, no beta gate. The CLI never
+ * reports the effective window (verified — `system/init` and `result` carry
+ * `model` but no window field), so for the beta-gated 4.x models we (a) SEED
+ * conservatively from the resolved model id and (b) LEARN upward from
+ * observed usage: a prompt can never exceed the real window, so if it ever
+ * does, promote to the next known tier. Sonnet 5+ skips the seed-low dance
+ * entirely since there's nothing to learn — it's always 1M.
  *
  * Spec: docs/specs/SPEC_CONTEXT_VISIBILITY_2026_06_17.md §5 P1.
  * Follow-ups (not here): seed the catalog from the Anthropic Models API on CLI
@@ -28,16 +30,29 @@ const COMPACTION_BUFFER = 33_000;
 /**
  * Seed window from a resolved model id/alias. Returns `undefined` for models we
  * don't recognise (non-Claude, or future ids) — the caller falls back to the
- * provider's static window. Sonnet seeds CONSERVATIVELY at 200K; the high-water
- * upgrade promotes it to 1M the moment context exceeds 200K (its beta-gated ceiling).
+ * provider's static window. Sonnet 4.x and earlier seed CONSERVATIVELY at 200K;
+ * the high-water upgrade promotes to 1M the moment context exceeds 200K (its
+ * beta-gated ceiling). Sonnet 5+ has no beta gate — it seeds at 1M directly.
  */
 export function contextWindowForModel(model: string | null | undefined): number | undefined {
     if (!model) return undefined;
     const m = model.toLowerCase();
     if (m.includes("haiku")) return 200_000;
     if (m.includes("opus") || m.includes("fable") || m.includes("mythos")) return 1_000_000;
-    if (m.includes("sonnet")) return 200_000; // conservative seed; learns up to 1M
+    if (m.includes("sonnet")) return sonnetMajorVersion(m) >= 5 ? 1_000_000 : 200_000;
     return undefined;
+}
+
+/**
+ * Major version number following "sonnet" in a model id or alias, e.g.
+ * "claude-sonnet-5" → 5, "claude-sonnet-4-6" → 4. The bare family alias
+ * ("sonnet") carries no version digits and returns 0 — treated as pre-5
+ * (conservative) since the CLI resolves it to whatever the current pin is,
+ * and we can't tell which from the string alone.
+ */
+function sonnetMajorVersion(m: string): number {
+    const match = m.match(/sonnet-(\d+)/);
+    return match ? parseInt(match[1], 10) : 0;
 }
 
 /** Smallest known tier strictly greater than `n`; `n` itself if above all tiers. */


### PR DESCRIPTION
## Summary
- `contextWindowForModel()` treated every model id matching `sonnet` as the beta-gated Sonnet 4.x default: seed at 200K, only promote to 1M once observed usage actually exceeds it (`context-1m-2025-08-07` beta behavior).
- Sonnet 5 has no such beta gate — it ships with a 1M window by default — so a freshly opened agent pane that hadn't yet pushed past 200K of context stayed stuck showing "200K" in the dock, while another pane running the identical model that had already exceeded 200K showed "1M". Same model, two different displayed context sizes.
- Fix: seed directly at 1M for Sonnet 5+ (detected via the version number following `sonnet-` in the resolved model id reported by the CLI stream). Sonnet 4.x and earlier keep the existing conservative seed-then-learn-up behavior, since those really do need the beta header for 1M.

## Test plan
- [x] Added unit tests for `contextWindowForModel("claude-sonnet-5")` → 1M, case-insensitivity, and the bare `"sonnet"` family-alias fallback staying conservative
- [x] Added unit tests for `learnContextWindow` seeding Sonnet 5 at 1M on first observation (no learning needed) and a mid-session model-switch case (Sonnet 4.6 learned-1M → Sonnet 5 stays 1M)
- [x] `npx vitest run frontend/app/store/agent-pane-state/context-window.test.ts` — 18/18 passed
- [x] `npx tsc --noEmit` — no new errors

<!-- agentmux:agent_id=agent2 -->