### PR TITLE
fix(login): make tier-1 PTY capture actually work end-to-end

### DIFF
--- a/.changesets/1786054204-fix-login-answer-the-cli-s-cursor-position-query-so-tier-1-p-g7wn.md
+++ b/.changesets/1786054204-fix-login-answer-the-cli-s-cursor-position-query-so-tier-1-p-g7wn.md
@@ -1,0 +1,13 @@
+---
+type: patch
+---
+
+fix(login): make tier-1 PTY capture actually work end-to-end
+
+Fixes #2429, in three parts:
+
+1. **Root cause — the CLI never printed anything.** Claude Code, on detecting a real TTY, immediately sends a cursor-position query (`ESC[6n`) and blocks waiting for a reply before printing anything — nothing was ever answering it. `run_cli_login_pty` now transparently answers this query the moment it appears in the stream, unblocking the CLI. Confirmed live: URL capture now takes ~450ms instead of timing out at 15s with zero bytes seen.
+
+2. **Follow-up — the captured URL was missing `client_id`.** Once capture started working, `extract_url()` preferred the CLI's plain-text fallback line, which gets word-wrapped by the PTY's 80-column width mid-query-string. The OSC-8 hyperlink payload (immune to that wrapping, since it's inside an escape sequence, not printed text) carries the complete URL the whole time — `extract_url()` now prefers it.
+
+3. **Follow-up — the login UI rendered pinned to the top of the pane.** It was rendered inside `AgentDocumentView`'s scrollable header slot. Extracted into `AgentAuthPanel`, now rendered by `agent-view.tsx` as a flex sibling after the scroll region — same bottom-docked slot band as `AgentDecisionPanel`/`AgentQuestionPanel`.

--- a/agentmux-cef/src/commands/cli_login.rs
+++ b/agentmux-cef/src/commands/cli_login.rs
@@ -575,6 +575,96 @@ fn spawn_login_pty_unix(
 ///   - Unix: `spawn_login_pty_unix` — portable_pty's spawn is UNUSABLE in
 ///     this host because its pre-exec fd cleanup trips libcef's interposed
 ///     close() and crashes the child before exec (see that fn's doc).
+
+/// Device Status Report cursor-position query — some CLIs (confirmed:
+/// Claude Code, on detecting a real TTY) send this immediately and BLOCK
+/// waiting for the terminal to reply with `ESC[<row>;<col>R` before
+/// printing anything else at all. A bare `portable_pty` handle has no
+/// attached terminal emulator to answer this automatically — nothing
+/// does, on any platform, without code specifically watching for it — so
+/// the child hangs forever and the whole capture loop below times out
+/// having seen zero bytes. This is the confirmed root cause of issue
+/// #2429 ("no PTY output captured... despite correct binary resolution"):
+/// isolated repro (a standalone portable_pty harness spawning the exact
+/// same binary/args) showed the child's first and ONLY output was these
+/// 4 bytes, then silence: answering this one query unblocked it
+/// immediately, and it printed its OAuth URL within half a second.
+const DSR_CURSOR_POSITION_QUERY: &[u8] = b"\x1b[6n";
+/// Synthetic "row 1, col 1" reply. The actual reported position doesn't
+/// matter to these CLIs — confirmed by the repro above — they only need
+/// *something* to answer so their TTY-capability probe stops blocking.
+const DSR_CURSOR_POSITION_REPLY: &[u8] = b"\x1b[1;1R";
+
+/// Wraps the raw PTY reader and transparently answers a cursor-position
+/// query (see [`DSR_CURSOR_POSITION_QUERY`]) the moment it appears
+/// anywhere in the stream — not just at startup, since a TUI could
+/// plausibly re-probe after a resize — passing every byte through
+/// unchanged to the caller (the query's own bytes included; they're
+/// harmless noise to the line-scanning loop below, not worth the extra
+/// complexity of stripping them from the pass-through).
+///
+/// Generic over `on_query` (rather than baking in `Arc<AppState>`
+/// directly) so the byte-scanning logic — the actually bug-prone part —
+/// is unit-testable without constructing a real `AppState`. The
+/// production call site's closure writes through `state.cli_login_stdin`
+/// — the SAME handle `set_provider_auth` uses to deliver a pasted OAuth
+/// code — rather than a second independent writer, since `portable_pty`'s
+/// writer is a single-owner handle already moved into that slot by the
+/// time this reader is constructed.
+struct DsrRespondingReader<R, F> {
+    inner: R,
+    on_query: F,
+    /// Carry-over from the previous `read()` call — bounded to
+    /// `DSR_CURSOR_POSITION_QUERY.len() - 1` bytes — so a query split
+    /// across two `read()` calls (e.g. a slow/busy child) is still
+    /// detected instead of silently missed at the chunk boundary.
+    tail: Vec<u8>,
+}
+
+impl<R, F: FnMut()> DsrRespondingReader<R, F> {
+    fn new(inner: R, on_query: F) -> Self {
+        Self { inner, on_query, tail: Vec::new() }
+    }
+}
+
+impl<R: std::io::Read, F: FnMut()> std::io::Read for DsrRespondingReader<R, F> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if n == 0 {
+            return Ok(0);
+        }
+        self.tail.extend_from_slice(&buf[..n]);
+        if self
+            .tail
+            .windows(DSR_CURSOR_POSITION_QUERY.len())
+            .any(|w| w == DSR_CURSOR_POSITION_QUERY)
+        {
+            (self.on_query)();
+        }
+        let keep = DSR_CURSOR_POSITION_QUERY.len().saturating_sub(1);
+        if self.tail.len() > keep {
+            let drop = self.tail.len() - keep;
+            self.tail.drain(0..drop);
+        }
+        Ok(n)
+    }
+}
+
+/// Production `on_query` callback: writes [`DSR_CURSOR_POSITION_REPLY`]
+/// through `state.cli_login_stdin`. Separated from `DsrRespondingReader`
+/// itself (see its doc comment) purely so the reader's byte-scanning
+/// logic stays unit-testable without a real `AppState`.
+fn reply_to_dsr_via_cli_login_stdin(state: &Arc<AppState>) {
+    tracing::debug!(
+        target: "login_pty",
+        "[login-pty] answering cursor-position query (ESC[6n) — see issue #2429"
+    );
+    if let Some(CliLoginStdin::Pty(w)) = state.cli_login_stdin.lock().as_mut() {
+        let _ = w.write_all(DSR_CURSOR_POSITION_REPLY);
+        let _ = w.flush();
+    }
+}
+
 async fn run_cli_login_pty(
     state: Arc<AppState>,
     cli_path: String,
@@ -698,8 +788,15 @@ async fn run_cli_login_pty(
     // the frontend and let the wait task below reap the child whenever
     // it finishes naturally.
     let (url_tx, url_rx) = tokio::sync::oneshot::channel::<Option<String>>();
+    let state_for_dsr = state.clone();
     tokio::task::spawn_blocking(move || {
         use std::io::BufRead;
+        // See DsrRespondingReader's doc comment / issue #2429: without
+        // this, a child that probes cursor position on startup (Claude
+        // Code does) hangs forever before printing anything, and
+        // read_line below would never even see the query bytes (they
+        // carry no trailing newline) to know to respond.
+        let reader = DsrRespondingReader::new(reader, || reply_to_dsr_via_cli_login_stdin(&state_for_dsr));
         let mut reader = std::io::BufReader::new(reader);
         // Wrap the oneshot in an Option so we send the URL exactly once and then
         // keep reading. We LOG every line from the first byte AND scan for an
@@ -1015,8 +1112,16 @@ fn extract_url(line: &str) -> Option<String> {
         }
     };
 
-    // Prefer the visible (de-escaped) text; fall back to any OSC-8 URI.
-    pick(&clean).or_else(|| osc_uris.iter().find_map(|u| pick(u)))
+    // Prefer any OSC-8 URI: it's carried inside an escape-sequence payload,
+    // so it can never be truncated by the terminal's column-width wrapping.
+    // The visible text is only a fallback for CLIs that don't emit OSC-8 —
+    // it CAN be wrapped mid-URL by the PTY (see issue #2429 follow-up: the
+    // plain "If the browser didn't open, visit: ..." line got hard-wrapped
+    // at col 80, silently dropping `client_id` from the captured URL).
+    osc_uris
+        .iter()
+        .find_map(|u| pick(u))
+        .or_else(|| pick(&clean))
 }
 
 /// Kill the in-progress CLI login process. Covers both transports:
@@ -1462,6 +1567,102 @@ mod redact_url_queries_in_line_tests {
 }
 
 #[cfg(test)]
+mod dsr_responding_reader_tests {
+    use super::{DsrRespondingReader, DSR_CURSOR_POSITION_QUERY};
+    use std::cell::Cell;
+    use std::io::Read;
+
+    /// Yields each element of `chunks` on successive `read()` calls,
+    /// copying as much as fits in the caller's buffer — lets a test force
+    /// a specific byte-boundary split, which a plain `std::io::Cursor`
+    /// (single-buffer, fills as much as requested in one call) can't do.
+    struct ChunkedReader {
+        chunks: std::collections::VecDeque<Vec<u8>>,
+    }
+
+    impl ChunkedReader {
+        fn new(chunks: Vec<&[u8]>) -> Self {
+            Self { chunks: chunks.into_iter().map(|c| c.to_vec()).collect() }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let Some(chunk) = self.chunks.front_mut() else { return Ok(0) };
+            let n = chunk.len().min(buf.len());
+            buf[..n].copy_from_slice(&chunk[..n]);
+            chunk.drain(..n);
+            if chunk.is_empty() {
+                self.chunks.pop_front();
+            }
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn invokes_callback_when_query_arrives_in_one_read() {
+        let inner = ChunkedReader::new(vec![DSR_CURSOR_POSITION_QUERY]);
+        let calls = Cell::new(0);
+        let mut r = DsrRespondingReader::new(inner, || calls.set(calls.get() + 1));
+        let mut buf = [0u8; 64];
+        let n = r.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], DSR_CURSOR_POSITION_QUERY);
+        assert_eq!(calls.get(), 1, "callback must fire exactly once for the query");
+    }
+
+    #[test]
+    fn does_not_invoke_callback_for_unrelated_bytes() {
+        let inner = ChunkedReader::new(vec![b"Opening browser to sign in...\r\n"]);
+        let calls = Cell::new(0);
+        let mut r = DsrRespondingReader::new(inner, || calls.set(calls.get() + 1));
+        let mut buf = [0u8; 64];
+        let n = r.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"Opening browser to sign in...\r\n");
+        assert_eq!(calls.get(), 0);
+    }
+
+    #[test]
+    fn detects_query_split_across_two_read_calls() {
+        // The exact failure mode a naive single-read scan would miss:
+        // "\x1b[6" in one chunk, "n" arriving in the next.
+        let inner = ChunkedReader::new(vec![b"\x1b[6", b"n"]);
+        let calls = Cell::new(0);
+        let mut r = DsrRespondingReader::new(inner, || calls.set(calls.get() + 1));
+        let mut buf = [0u8; 64];
+        let n1 = r.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n1], b"\x1b[6");
+        assert_eq!(calls.get(), 0, "must not fire on the incomplete first half");
+        let n2 = r.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n2], b"n");
+        assert_eq!(calls.get(), 1, "must fire once the second half completes the pattern");
+    }
+
+    #[test]
+    fn passes_every_byte_through_unchanged_query_included() {
+        // The query's own bytes are harmless noise to the line-scanning
+        // loop downstream — verify they're never stripped, only observed.
+        let payload = [DSR_CURSOR_POSITION_QUERY, b"Paste code here if prompted > "].concat();
+        let inner = ChunkedReader::new(vec![&payload]);
+        let mut r = DsrRespondingReader::new(inner, || {});
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        assert_eq!(out, payload);
+    }
+
+    #[test]
+    fn does_not_refire_on_subsequent_unrelated_reads_after_the_query() {
+        let inner = ChunkedReader::new(vec![DSR_CURSOR_POSITION_QUERY, b"more output\r\n"]);
+        let calls = Cell::new(0);
+        let mut r = DsrRespondingReader::new(inner, || calls.set(calls.get() + 1));
+        let mut buf = [0u8; 64];
+        r.read(&mut buf).unwrap();
+        assert_eq!(calls.get(), 1);
+        r.read(&mut buf).unwrap();
+        assert_eq!(calls.get(), 1, "later unrelated bytes must not re-trigger the callback");
+    }
+}
+
+#[cfg(test)]
 mod capture_cred_baseline_tests {
     use super::capture_cred_baseline;
     use std::collections::HashMap;
@@ -1563,6 +1764,20 @@ mod extract_url_claude_authorize_tests {
     #[test]
     fn ignores_non_auth_urls() {
         assert_eq!(extract_url("see https://claude.com/docs for details"), None);
+    }
+
+    #[test]
+    fn prefers_osc8_uri_when_the_visible_fallback_line_was_wrapped_by_the_pty() {
+        // Regression for the #2429 follow-up: at an 80-column PTY width, the
+        // CLI's own line-wrapping of the plain "visit: ..." text can split
+        // the URL mid-query-string before a `\r\n` is ever reached, so the
+        // OSC-8 payload (never subject to that wrapping) is the only place
+        // the full URL — with client_id intact — actually appears.
+        let truncated_visible = "https://claude.com/cai/oauth/authorize?code=t";
+        let line = format!(
+            "\u{1b}]8;;{AUTHORIZE_URL}\u{7}link text\u{1b}]8;;\u{7}If the browser didn't open, visit: {truncated_visible}"
+        );
+        assert_eq!(extract_url(&line), Some(AUTHORIZE_URL.to_string()));
     }
 }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -68,7 +68,7 @@ import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
 import { AgentQuestionPanel } from "./components/AgentQuestionPanel";
 import { AgentDisconnectedBanner } from "./components/AgentDisconnectedBanner";
 import { AgentCredentialsRevokedChip } from "./components/AgentCredentialsRevokedChip";
-import { AgentDocumentView } from "./components/AgentDocumentView";
+import { AgentDocumentView, AgentAuthPanel } from "./components/AgentDocumentView";
 import { AgentFooter, AgentWorkingRow } from "./components/AgentFooter";
 import { AgentComposerStrip } from "./components/AgentComposerStrip";
 import { AgentShellSubblock } from "./components/AgentShellSubblock";
@@ -1555,12 +1555,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 <AgentDocumentView
                     documentAtom={agentAtoms().documentAtom}
                     documentStateAtom={agentAtoms().documentStateAtom}
-                    authUrl={status.authUrl}
-                    authNotice={status.authNotice}
-                    onDismissAuthNotice={() => status.setAuthNotice(null)}
-                    onCancelLogin={status.cancelLogin}
-                    onUseTerminal={status.useTerminalInstead}
-                    authProviderId={provider()?.id ?? providerKey()}
                     onAgentErrorLogin={() => {
                         // Must match onLoginAgain above: the button is labeled "Login
                         // Again", so it has to force a fresh OAuth regardless of
@@ -1625,6 +1619,20 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     </Show>
                 </div>
             </div>
+
+            {/* Login UI — bottom-docked like AgentDecisionPanel/
+                AgentQuestionPanel below, not inside the scrollable document.
+                See #2429 follow-up: it used to render inside
+                AgentDocumentView's header slot, which pinned it to the top
+                of the scroll area. */}
+            <AgentAuthPanel
+                authUrl={status.authUrl}
+                authNotice={status.authNotice}
+                onDismissAuthNotice={() => status.setAuthNotice(null)}
+                onCancelLogin={status.cancelLogin}
+                onUseTerminal={status.useTerminalInstead}
+                authProviderId={provider()?.id ?? providerKey()}
+            />
 
             <Show when={status.canRetry()}>
                 <div class="agent-retry-bar">

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -3,10 +3,14 @@
 
 /**
  * AgentDocumentView — owns the agent pane's data state interface
- * (collapsed/pinned toggles, auto-collapse policy, auth-url and
- * loading-older banner), then delegates list rendering to
- * AgentDocumentVirtualList (Phase 2 of the virtualization redesign,
- * see docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md).
+ * (collapsed/pinned toggles, auto-collapse policy, loading-older banner),
+ * then delegates list rendering to AgentDocumentVirtualList (Phase 2 of
+ * the virtualization redesign, see
+ * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md).
+ *
+ * Also exports AgentAuthPanel (the login UI), a component agent-view.tsx
+ * renders separately as a bottom-docked sibling — not part of this
+ * component's own scrollable output.
  *
  * All scroll behavior — stick-to-bottom, anchor capture, jump-to-node,
  * pagination restore — lives in the VirtualList. This component is
@@ -31,29 +35,6 @@ import { createAgentViewState } from "../virtualization/state";
 interface AgentDocumentViewProps {
     documentAtom: SignalPair<DocumentNode[]>;
     documentStateAtom: SignalPair<DocumentState>;
-    authUrl?: Accessor<string | null>;
-    /**
-     * User-visible auth-recovery error (e.g. "Login Again" couldn't open a
-     * browser). Rendered as an error box in the same header slot as the
-     * auth-URL box, with a dismiss button. Never fail silently — see
-     * retro-agent-auth-relogin-noop-2026-07-01 §5.1.
-     */
-    authNotice?: Accessor<string | null>;
-    /** Dismiss handler for the auth notice (clears the signal). */
-    onDismissAuthNotice?: () => void;
-    /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
-    authProviderId?: string;
-    /** Cancel the in-flight login (kills the host CLI child) — shown as a
-     *  button on the auth-URL box so a stuck login has an exit besides
-     *  closing the pane. Wired to useAgentControllerStatus's cancelLogin. */
-    onCancelLogin?: () => void;
-    /** Explicit "Use terminal instead" fallback on the auth-URL box — mirrors
-     *  PreLaunchAuthPanel's identical secondary action
-     *  (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 2). Wired to
-     *  useAgentControllerStatus's loginViaTerminal, which cancels this
-     *  session's own login child itself (tier 1 starting a second one would
-     *  race against the one still open in this box). */
-    onUseTerminal?: () => void;
     /** Re-run the provider login flow — forwarded to the list so an inline
      *  auth-error node can offer a "Login Again" CTA (SPEC_REAUTH_FROM_AUTH_ERROR §7). */
     onAgentErrorLogin?: () => void;
@@ -167,40 +148,19 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
         });
     };
 
-    // Header slot: loading-older banner + optional auth-url box,
-    // rendered above the virtualizer inside the scroll container.
-    // VirtualList's scrollMargin (=virtualContainerRef.offsetTop)
-    // handles the offset automatically.
+    // Header slot: loading-older banner, rendered above the virtualizer
+    // inside the scroll container. VirtualList's scrollMargin
+    // (=virtualContainerRef.offsetTop) handles the offset automatically.
+    //
+    // The auth-URL box and auth-notice USED to render here too, but that
+    // pinned the login UI to the top of the scroll area instead of near the
+    // composer like AgentQuestionPanel/AgentDecisionPanel — see the #2429
+    // follow-up. They're now AgentAuthPanel, rendered by agent-view.tsx as a
+    // flex sibling after .agent-document-scroll-region.
     const headerSlot = (): JSX.Element => (
-        <>
-            <Show when={props.loadingOlder?.()}>
-                <div class="agent-history-loading">Loading older messages...</div>
-            </Show>
-            <Show when={props.authUrl?.()}>
-                {(url) => (
-                    <AuthUrlBox
-                        url={url()}
-                        authProviderId={props.authProviderId}
-                        onCancel={props.onCancelLogin}
-                        onUseTerminal={props.onUseTerminal}
-                    />
-                )}
-            </Show>
-            <Show when={props.authNotice?.()}>
-                {(notice) => (
-                    <div class="agent-auth-notice" role="alert">
-                        <span class="agent-auth-notice-text">{notice()}</span>
-                        <button
-                            class="agent-auth-notice-dismiss"
-                            title="Dismiss"
-                            onClick={() => props.onDismissAuthNotice?.()}
-                        >
-                            ✕
-                        </button>
-                    </div>
-                )}
-            </Show>
-        </>
+        <Show when={props.loadingOlder?.()}>
+            <div class="agent-history-loading">Loading older messages...</div>
+        </Show>
     );
 
     return (
@@ -228,7 +188,71 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
 
 AgentDocumentView.displayName = "AgentDocumentView";
 
-// ── Auth URL box ────────────────────────────────────────────────────────────
+// ── Auth panel (bottom-docked, sibling of AgentQuestionPanel) ──────────────
+
+export interface AgentAuthPanelProps {
+    authUrl?: Accessor<string | null>;
+    /**
+     * User-visible auth-recovery error (e.g. "Login Again" couldn't open a
+     * browser). Rendered as an error box below the auth-URL box, with a
+     * dismiss button. Never fail silently — see
+     * retro-agent-auth-relogin-noop-2026-07-01 §5.1.
+     */
+    authNotice?: Accessor<string | null>;
+    /** Dismiss handler for the auth notice (clears the signal). */
+    onDismissAuthNotice?: () => void;
+    /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
+    authProviderId?: string;
+    /** Cancel the in-flight login (kills the host CLI child) — shown as a
+     *  button on the auth-URL box so a stuck login has an exit besides
+     *  closing the pane. Wired to useAgentControllerStatus's cancelLogin. */
+    onCancelLogin?: () => void;
+    /** Explicit "Use terminal instead" fallback on the auth-URL box — mirrors
+     *  PreLaunchAuthPanel's identical secondary action
+     *  (SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md §3.3 surface 2). Wired to
+     *  useAgentControllerStatus's loginViaTerminal, which cancels this
+     *  session's own login child itself (tier 1 starting a second one would
+     *  race against the one still open in this box). */
+    onUseTerminal?: () => void;
+}
+
+/**
+ * Bottom-docked login UI. Rendered by agent-view.tsx as a flex sibling
+ * after .agent-document-scroll-region, in the same slot band as
+ * AgentDecisionPanel/AgentQuestionPanel — NOT inside AgentDocumentView's
+ * scrollable header slot. It used to live there, which pinned it to the
+ * top of the scroll area instead of near the composer (#2429 follow-up).
+ */
+export function AgentAuthPanel(props: AgentAuthPanelProps): JSX.Element {
+    return (
+        <>
+            <Show when={props.authUrl?.()}>
+                {(url) => (
+                    <AuthUrlBox
+                        url={url()}
+                        authProviderId={props.authProviderId}
+                        onCancel={props.onCancelLogin}
+                        onUseTerminal={props.onUseTerminal}
+                    />
+                )}
+            </Show>
+            <Show when={props.authNotice?.()}>
+                {(notice) => (
+                    <div class="agent-auth-notice" role="alert">
+                        <span class="agent-auth-notice-text">{notice()}</span>
+                        <button
+                            class="agent-auth-notice-dismiss"
+                            title="Dismiss"
+                            onClick={() => props.onDismissAuthNotice?.()}
+                        >
+                            ✕
+                        </button>
+                    </div>
+                )}
+            </Show>
+        </>
+    );
+}
 
 interface AuthUrlBoxProps {
     url: string;
@@ -238,9 +262,8 @@ interface AuthUrlBoxProps {
 }
 
 /**
- * OAuth code-paste box. Rendered at the top of the scroll container
- * while a login flow has a pending auth URL. Previously inline in
- * AgentDocumentView; extracted as a sibling for the Phase 2 shell.
+ * OAuth code-paste box. Rendered by AgentAuthPanel while a login flow has
+ * a pending auth URL.
  */
 function AuthUrlBox(props: AuthUrlBoxProps): JSX.Element {
     const [pasteCode, setPasteCode] = createSignal("");


### PR DESCRIPTION
## Summary

Fixes #2429. Tier-1 in-app PTY capture for Claude CLI login was completely non-functional; this closes it out end-to-end, plus two follow-on bugs discovered while live-verifying the fix.

1. **Root cause — nothing was ever captured.** Claude Code, on detecting a real TTY, immediately sends a cursor-position query (`ESC[6n`) and blocks waiting for a reply before printing anything. Nothing was answering it, so tier 1 always timed out at 15s with zero bytes seen and silently fell back to the terminal tiers. `run_cli_login_pty` now transparently answers this query the moment it appears in the byte stream via a `DsrRespondingReader` wrapper. Confirmed live: URL capture now takes ~450ms instead of timing out.

2. **Follow-up — captured URL was missing `client_id`.** Once capture started working, live testing surfaced "Invalid OAuth Request — Missing client_id parameter" in the browser. Root cause: `extract_url()` preferred the CLI's plain-text fallback line ("If the browser didn't open, visit: ..."), which the CLI's terminal-width-aware wrapping splits mid-query-string at the PTY's 80-column width — truncating the URL before `client_id` ever appears. The OSC-8 hyperlink payload carries the complete, unwrapped URL the whole time (it's inside an escape sequence, not printed/wrapped text); `extract_url()` now prefers it, falling back to the plain text only for CLIs that don't emit OSC-8.

3. **Follow-up — login UI pinned to the top of the pane.** Also surfaced by the same live test. The auth-URL box rendered inside `AgentDocumentView`'s scrollable header slot, which pinned it to the top of the scroll area instead of near the composer. Extracted into a new `AgentAuthPanel` component, now rendered by `agent-view.tsx` as a flex sibling directly after the scroll region — the same slot band as `AgentDecisionPanel`/`AgentQuestionPanel`, so it's bottom-docked the same way.

## Test plan

- [x] `cargo test -p agentmux-cef cli_login` — 25/25 passing, including a new regression test for the DSR reader and one reproducing the exact wrapped-line URL truncation
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` on the affected login/auth-status test files — 24/24 passing, no regressions
- [x] Live-verified DSR fix in a dev instance: URL capture completes in ~450ms instead of timing out
- [ ] Live re-verification of the client_id + UI-positioning follow-ups pending a fresh manual click-through (structural fix confirmed via tests + exact pattern parity with AgentQuestionPanel's proven-working bottom-docked layout)

Note for reviewers: PR #2425 (`agenta/relogin-inapp-modal`) also touches this exact render site (retiring `AuthUrlBox` for a Modal-wrapped `InAppLoginPanel`). Once this merges, #2425 will be rebased to render `InAppLoginPanel` inside this PR's `AgentAuthPanel` bottom-docked slot instead of a Modal, per user direction — chosen over the Modal so the login UI stays consistent with `AgentQuestionPanel`'s inline, non-blocking bottom-docked pattern.

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->