### PR TITLE
feat(swarm): auto-retire a finished row after a 60s countdown

### DIFF
--- a/.changesets/1786075165-feat-swarm-row-auto-linger-countdown-490473ee.md
+++ b/.changesets/1786075165-feat-swarm-row-auto-linger-countdown-490473ee.md
@@ -1,0 +1,17 @@
+---
+type: minor
+---
+
+feat(swarm): auto-retire a finished row after a 60s countdown
+
+A completed Agent Tool or Workflow row in the Swarm tree used to linger
+indefinitely until manually dismissed — a finished 12-second subagent and
+a finished 6-hour workflow behaved identically, cluttering the "what's
+happening now" view with things that are no longer happening. A clean
+terminal row (idle subagent, or a fully-completed Workflow dispatch) now
+shows a live "disappearing in Ns" countdown and auto-retires at 0, reusing
+the existing retire/un-retire-on-new-activity mechanism. Hovering a row
+pauses its countdown so reading a just-finished row's output doesn't race
+it disappearing; manual dismiss still works immediately at any point.
+Failed/interrupted rows are unaffected — they still require an explicit
+dismiss, so a failure never silently vanishes before being read.

--- a/docs/specs/SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md
+++ b/docs/specs/SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md
@@ -1,7 +1,7 @@
 # SPEC — Swarm Row Auto-Linger Countdown on Completion
 
 **Date:** 2026-08-06
-**Status:** Proposed — not started
+**Status:** Implemented — PR pending. Countdown ticking reuses the existing `useTick(1000)` hook (`frontend/app/hook/useTick.ts`) rather than a bespoke ViewModel-owned interval — same ref-counted, auto-cleanup mechanism this file already uses for other relative-time displays; the "Where to arm the countdown" and "Rendering" sections below describe the originally-proposed shape, superseded on that one point.
 **Scope:** `frontend/app/view/swarm/swarm-model.ts`, `swarm-view.tsx`
 **Trigger:** Live test spawn (Task-tool subagent, ~12s runtime) during a Swarm investigation session — user expected the row to go `Active → 60s countdown → gone`, but today's actual behavior is either "never disappears until manually dismissed" or (per a related, separately-tracked bug) "never appeared at all." This spec covers only the countdown/auto-retire half.
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -530,6 +530,14 @@ const MAX_DISPATCH_FEED_ENTRIES = 500;
  *  second hardcoded `60_000` that could drift out of sync. */
 export const AUTO_RETIRE_DELAY_MS = 60_000;
 
+/** One row's auto-linger countdown state — see `SwarmViewModel.
+ *  _countdownState`'s doc comment for the `pausedAt` freeze mechanism. */
+export interface CountdownEntry {
+    lastEventAt: number;
+    startedAt: number;
+    pausedAt: number | null;
+}
+
 /** Identifies one `DispatchActivityEntry` for de-dup purposes — an
  *  (agentId, timestamp, event payload) triple is stable across both the
  *  live `dispatch:activity` broadcast and a `GetHistory` backfill, since
@@ -772,12 +780,18 @@ export class SwarmViewModel implements ViewModel {
     // time, same snapshot-comparison idea `_retiredRowKeys` already uses so
     // genuinely new activity un-arms rather than lets a stale countdown
     // fire. `startedAt` (Date.now()) is what the visible remaining-seconds
-    // display renders against; pausing (hover) leaves this entry alone and
-    // only clears the pending timer, so the displayed number freezes
-    // instead of resetting — only resumeCountdown() rewrites startedAt.
-    private _countdownState = createSignal<Map<string, { lastEventAt: number; startedAt: number }>>(new Map());
-    countdownStateAtom: Accessor<Map<string, { lastEventAt: number; startedAt: number }>> = this._countdownState[0];
-    private setCountdownState: Setter<Map<string, { lastEventAt: number; startedAt: number }>> = this._countdownState[1];
+    // display renders against while live. `pausedAt`: null while counting
+    // down; set to Date.now() by pauseCountdown() so the DISPLAYED number
+    // actually freezes (countdownSecondsRemaining computes elapsed against
+    // pausedAt instead of the live clock while it's non-null) — merely
+    // clearing the pending timer, as an earlier draft of this did, stops
+    // the auto-retire from firing but does nothing to the wall-clock-
+    // derived display, which kept counting to and clamping at 0 while
+    // "paused" (reagentx P1 on #2440). resumeCountdown() clears pausedAt
+    // and resets startedAt for a fresh 60s window.
+    private _countdownState = createSignal<Map<string, CountdownEntry>>(new Map());
+    countdownStateAtom: Accessor<Map<string, CountdownEntry>> = this._countdownState[0];
+    private setCountdownState: Setter<Map<string, CountdownEntry>> = this._countdownState[1];
     private countdownTimers = new Map<string, ReturnType<typeof setTimeout>>();
     // The visible "Nn s" tick source lives in the view (useTick(1000),
     // frontend/app/hook/useTick.ts) — it's already the established,
@@ -1163,7 +1177,7 @@ export class SwarmViewModel implements ViewModel {
         if (existing && existing.lastEventAt === lastEventAt) return;
         this.setCountdownState((prev) => {
             const next = new Map(prev);
-            next.set(rowKey, { lastEventAt, startedAt: Date.now() });
+            next.set(rowKey, { lastEventAt, startedAt: Date.now(), pausedAt: null });
             return next;
         });
         this.armCountdownTimer(rowKey);
@@ -1187,28 +1201,38 @@ export class SwarmViewModel implements ViewModel {
         });
     }
 
-    /** Pause `rowKey`'s countdown on hover — clears only the pending timer,
-     *  leaving `_countdownState`'s entry (and therefore the displayed
-     *  number) untouched so it freezes rather than resets. No-op if this
-     *  row isn't actually counting down. */
+    /** Pause `rowKey`'s countdown on hover — clears the pending timer (so
+     *  the row can't auto-retire while being read) AND stamps `pausedAt`
+     *  so the DISPLAYED number actually freezes there too, rather than
+     *  continuing to count down against the live clock while merely the
+     *  timer is stopped (reagentx P1 on #2440 — see the entry's own doc
+     *  comment). No-op if this row isn't actually counting down. */
     pauseCountdown(rowKey: string): void {
         const timer = this.countdownTimers.get(rowKey);
         if (timer === undefined) return;
         clearTimeout(timer);
         this.countdownTimers.delete(rowKey);
+        this.setCountdownState((prev) => {
+            const entry = prev.get(rowKey);
+            if (entry === undefined) return prev;
+            const next = new Map(prev);
+            next.set(rowKey, { ...entry, pausedAt: Date.now() });
+            return next;
+        });
     }
 
     /** Resume `rowKey`'s countdown on mouse-leave with a FRESH 60s window,
      *  not the remaining time from before the pause — see
      *  SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md's "resume ≠
-     *  resume mid-count" decision. No-op if the row un-retired itself (or
-     *  was manually dismissed) while paused. */
+     *  resume mid-count" decision. Clears `pausedAt` so the display resumes
+     *  computing against the live clock again. No-op if the row un-retired
+     *  itself (or was manually dismissed) while paused. */
     resumeCountdown(rowKey: string): void {
         const entry = this.countdownStateAtom().get(rowKey);
         if (entry === undefined) return;
         this.setCountdownState((prev) => {
             const next = new Map(prev);
-            next.set(rowKey, { ...entry, startedAt: Date.now() });
+            next.set(rowKey, { ...entry, startedAt: Date.now(), pausedAt: null });
             return next;
         });
         this.armCountdownTimer(rowKey);

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -1243,6 +1243,27 @@ export class SwarmViewModel implements ViewModel {
      *  pruneRetiredRowKeys(). In scope: agentToolRows/workflowRows only,
      *  per the spec's own "out of scope: shellRows/cronRows" note.
      *
+     *  Critically, "agentToolRows" here means `buildDispatchBuckets()`'s
+     *  actual `agentToolRows` output (solo + orphaned-workflow-member
+     *  subagents) — NOT the raw, unfiltered `subagentsAtom()` list, which
+     *  also contains every NORMAL (non-orphaned) member of a still-tracked
+     *  Workflow dispatch. Those never get their own `SubagentRow` (SPEC §7
+     *  — a Workflow dispatch this large can't hold thousands of members'
+     *  rows, hence `WorkflowDispatchRow`'s aggregate-only display). Arming
+     *  a countdown per completed member of, say, a 1,030-member workflow
+     *  (a real scale documented elsewhere in this file) would reintroduce
+     *  exactly the per-member `setTimeout`/state-entry cost this design
+     *  otherwise avoids — AND permanently hide a member that later surfaces
+     *  through the `orphanedWorkflowMembers` fallback (a stale/failed
+     *  `ListDispatches` call): `retireRow` would already have marked its
+     *  `subagentRowKey` retired against its (unchanged, since it already
+     *  completed) `last_event_at`, so `filterRetired` suppresses it forever
+     *  the moment it needs that exact fallback to stay visible during the
+     *  lag (reagentx P1 on #2440, second pass). Reusing
+     *  `buildDispatchBuckets` directly — rather than re-deriving its
+     *  solo/orphaned logic here — keeps this arming scope byte-for-byte in
+     *  sync with what actually renders, including if that logic changes.
+     *
      *  A subagent's `status === "completed"` is exactly
      *  `subagentDisplayStatus()`'s (swarm-view.tsx) `"idle"` case regardless
      *  of parent status — `"active"`/`"abandoned"` never map to `"idle"` —
@@ -1256,11 +1277,14 @@ export class SwarmViewModel implements ViewModel {
      *  already outside `liveTerminal` without a separate check.
      */
     private reconcileCountdowns(): void {
+        const dispatches = this.dispatchesAtom();
+        const { agentToolRows } = buildDispatchBuckets(dispatches, this.subagentsAtom());
+
         const liveTerminal = new Map<string, number>();
-        for (const sub of this.subagentsAtom()) {
+        for (const sub of agentToolRows) {
             if (sub.status === "completed") liveTerminal.set(subagentRowKey(sub.agent_id), sub.last_event_at);
         }
-        for (const d of this.dispatchesAtom()) {
+        for (const d of dispatches) {
             if (d.kind === "workflow" && d.status === "completed") liveTerminal.set(d.dispatch_id, d.last_event_at);
         }
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -523,6 +523,13 @@ export interface DispatchDetail {
  *  this redesign exists to avoid. Oldest entries drop first. */
 const MAX_DISPATCH_FEED_ENTRIES = 500;
 
+/** How long a clean-terminal row lingers before auto-retiring
+ *  (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06). Exported so
+ *  swarm-view.tsx's countdown display computes remaining time against the
+ *  same constant the ViewModel's own timer actually runs on, rather than a
+ *  second hardcoded `60_000` that could drift out of sync. */
+export const AUTO_RETIRE_DELAY_MS = 60_000;
+
 /** Identifies one `DispatchActivityEntry` for de-dup purposes — an
  *  (agentId, timestamp, event payload) triple is stable across both the
  *  live `dispatch:activity` broadcast and a `GetHistory` backfill, since
@@ -758,6 +765,26 @@ export class SwarmViewModel implements ViewModel {
     retiredRowKeysAtom: Accessor<Map<string, number>> = this._retiredRowKeys[0];
     private setRetiredRowKeys: Setter<Map<string, number>> = this._retiredRowKeys[1];
 
+    // Auto-linger countdown on a row's first clean-terminal appearance
+    // (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06) — same rowKey space
+    // as _retiredRowKeys above (subagentRowKey(agent_id) or a Workflow
+    // dispatchId). `lastEventAt` is the row's own value at arm/last-reset
+    // time, same snapshot-comparison idea `_retiredRowKeys` already uses so
+    // genuinely new activity un-arms rather than lets a stale countdown
+    // fire. `startedAt` (Date.now()) is what the visible remaining-seconds
+    // display renders against; pausing (hover) leaves this entry alone and
+    // only clears the pending timer, so the displayed number freezes
+    // instead of resetting — only resumeCountdown() rewrites startedAt.
+    private _countdownState = createSignal<Map<string, { lastEventAt: number; startedAt: number }>>(new Map());
+    countdownStateAtom: Accessor<Map<string, { lastEventAt: number; startedAt: number }>> = this._countdownState[0];
+    private setCountdownState: Setter<Map<string, { lastEventAt: number; startedAt: number }>> = this._countdownState[1];
+    private countdownTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    // The visible "Nn s" tick source lives in the view (useTick(1000),
+    // frontend/app/hook/useTick.ts) — it's already the established,
+    // ref-counted, auto-cleanup pattern this exact file uses elsewhere for
+    // relative-time displays, so the ViewModel only needs to own the
+    // start/lastEventAt state, not a second timer driving re-renders.
+
     // One DispatchDetail (concatenated activity feed) per currently-expanded
     // row — Agent Tool (solo) rows and Workflow rows alike, unified in
     // SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4 (retired the
@@ -948,6 +975,7 @@ export class SwarmViewModel implements ViewModel {
                 this.loadCrons(),
             ]);
             this.pruneRetiredRowKeys();
+            this.reconcileCountdowns();
         } finally {
             this.setLoading(false);
         }
@@ -1012,7 +1040,10 @@ export class SwarmViewModel implements ViewModel {
         }
         this.loadSubagentsDebounceTimer = setTimeout(() => {
             this.loadSubagentsDebounceTimer = undefined;
-            void Promise.all([this.loadSubagents(), this.loadDispatches()]).then(() => this.pruneRetiredRowKeys());
+            void Promise.all([this.loadSubagents(), this.loadDispatches()]).then(() => {
+                this.pruneRetiredRowKeys();
+                this.reconcileCountdowns();
+            });
         }, SwarmViewModel.LOAD_SUBAGENTS_DEBOUNCE_MS);
     };
 
@@ -1095,13 +1126,129 @@ export class SwarmViewModel implements ViewModel {
      *  for why this snapshot, not a bare membership set, is what makes a
      *  row un-retire itself automatically on new activity. Callers should
      *  only expose this for a terminal-status row (`"idle"`/`"interrupted"`)
-     *  — nothing to dismiss on a row still genuinely `"working"`. */
+     *  — nothing to dismiss on a row still genuinely `"working"`. Also
+     *  short-circuits any pending auto-linger countdown for this row (a
+     *  manual dismiss mid-countdown shouldn't leave an orphaned timer that
+     *  fires later against an already-retired key — harmless since
+     *  retireRow is idempotent, but pointless to leave running). */
     retireRow(rowKey: string, lastEventAt: number): void {
         this.setRetiredRowKeys((prev) => {
             const next = new Map(prev);
             next.set(rowKey, lastEventAt);
             return next;
         });
+        this.clearCountdown(rowKey);
+    }
+
+    // ── Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06) ──
+
+    private armCountdownTimer(rowKey: string): void {
+        const existingTimer = this.countdownTimers.get(rowKey);
+        if (existingTimer !== undefined) clearTimeout(existingTimer);
+        const timer = setTimeout(() => {
+            this.countdownTimers.delete(rowKey);
+            const entry = this.countdownStateAtom().get(rowKey);
+            if (entry === undefined) return; // already cleared — manually retired, or un-armed by new activity
+            this.retireRow(rowKey, entry.lastEventAt);
+        }, AUTO_RETIRE_DELAY_MS);
+        this.countdownTimers.set(rowKey, timer);
+    }
+
+    /** Arm a fresh 60s countdown for `rowKey`, or leave an already-running
+     *  one alone if it's counting down against the SAME `lastEventAt` (so
+     *  reconcileCountdowns(), called on every subagent/dispatch reload,
+     *  doesn't restart the visible number on every unrelated refresh). */
+    private armCountdown(rowKey: string, lastEventAt: number): void {
+        const existing = this.countdownStateAtom().get(rowKey);
+        if (existing && existing.lastEventAt === lastEventAt) return;
+        this.setCountdownState((prev) => {
+            const next = new Map(prev);
+            next.set(rowKey, { lastEventAt, startedAt: Date.now() });
+            return next;
+        });
+        this.armCountdownTimer(rowKey);
+    }
+
+    /** Clear a row's countdown entirely — pending timer + visible state.
+     *  Called on manual retire (short-circuit), new activity arriving on
+     *  the same key (un-arm — see reconcileCountdowns), or the timer's own
+     *  fire (via retireRow, which calls back into this). */
+    private clearCountdown(rowKey: string): void {
+        const timer = this.countdownTimers.get(rowKey);
+        if (timer !== undefined) {
+            clearTimeout(timer);
+            this.countdownTimers.delete(rowKey);
+        }
+        if (!this.countdownStateAtom().has(rowKey)) return;
+        this.setCountdownState((prev) => {
+            const next = new Map(prev);
+            next.delete(rowKey);
+            return next;
+        });
+    }
+
+    /** Pause `rowKey`'s countdown on hover — clears only the pending timer,
+     *  leaving `_countdownState`'s entry (and therefore the displayed
+     *  number) untouched so it freezes rather than resets. No-op if this
+     *  row isn't actually counting down. */
+    pauseCountdown(rowKey: string): void {
+        const timer = this.countdownTimers.get(rowKey);
+        if (timer === undefined) return;
+        clearTimeout(timer);
+        this.countdownTimers.delete(rowKey);
+    }
+
+    /** Resume `rowKey`'s countdown on mouse-leave with a FRESH 60s window,
+     *  not the remaining time from before the pause — see
+     *  SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md's "resume ≠
+     *  resume mid-count" decision. No-op if the row un-retired itself (or
+     *  was manually dismissed) while paused. */
+    resumeCountdown(rowKey: string): void {
+        const entry = this.countdownStateAtom().get(rowKey);
+        if (entry === undefined) return;
+        this.setCountdownState((prev) => {
+            const next = new Map(prev);
+            next.set(rowKey, { ...entry, startedAt: Date.now() });
+            return next;
+        });
+        this.armCountdownTimer(rowKey);
+    }
+
+    /** Arm/clear countdowns against current subagent/dispatch state — called
+     *  after loadSubagents()/loadDispatches() settle, same timing as
+     *  pruneRetiredRowKeys(). In scope: agentToolRows/workflowRows only,
+     *  per the spec's own "out of scope: shellRows/cronRows" note.
+     *
+     *  A subagent's `status === "completed"` is exactly
+     *  `subagentDisplayStatus()`'s (swarm-view.tsx) `"idle"` case regardless
+     *  of parent status — `"active"`/`"abandoned"` never map to `"idle"` —
+     *  so checking it directly here arms the same set that function's
+     *  `"idle"` would, without duplicating its parent-status branching or
+     *  importing across the model/view boundary. A `"completed"` Workflow
+     *  dispatch is this bucket's equivalent terminal state. Neither bucket
+     *  has a distinct dispatch-level "failed" status to exclude beyond
+     *  what's already excluded by only matching `"completed"` — an
+     *  `"abandoned"` subagent (interrupted) is never `"completed"`, so it's
+     *  already outside `liveTerminal` without a separate check.
+     */
+    private reconcileCountdowns(): void {
+        const liveTerminal = new Map<string, number>();
+        for (const sub of this.subagentsAtom()) {
+            if (sub.status === "completed") liveTerminal.set(subagentRowKey(sub.agent_id), sub.last_event_at);
+        }
+        for (const d of this.dispatchesAtom()) {
+            if (d.kind === "workflow" && d.status === "completed") liveTerminal.set(d.dispatch_id, d.last_event_at);
+        }
+
+        for (const [rowKey, entry] of this.countdownStateAtom()) {
+            const currentLastEventAt = liveTerminal.get(rowKey);
+            if (currentLastEventAt === undefined || currentLastEventAt !== entry.lastEventAt) {
+                this.clearCountdown(rowKey);
+            }
+        }
+        for (const [rowKey, lastEventAt] of liveTerminal) {
+            this.armCountdown(rowKey, lastEventAt);
+        }
     }
 
     /** Every row's toggle. `rowKey` must be a per-ROW-unique identity, NOT
@@ -1294,5 +1441,7 @@ export class SwarmViewModel implements ViewModel {
         for (const detail of this.dispatchDetailCache.values()) detail.dispose();
         this.dispatchDetailCache.clear();
         this.groupIdentityCache.clear();
+        for (const timer of this.countdownTimers.values()) clearTimeout(timer);
+        this.countdownTimers.clear();
     }
 }

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -302,6 +302,17 @@
     flex-shrink: 0;
 }
 
+// Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06) —
+// shared by SubagentRow and WorkflowDispatchRow, sits alongside the
+// existing status chip/badge, same muted-secondary treatment as
+// .swarm-workflow-count so it reads as informational, not alarming.
+.swarm-subagent-countdown {
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
 .swarm-workflow-status-badge {
     font-size: 10px;
     font-weight: 600;

--- a/frontend/app/view/swarm/swarm-view.test.ts
+++ b/frontend/app/view/swarm/swarm-view.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { countdownSecondsRemaining, subagentDisplayStatus } from "./swarm-view";
-import type { ActiveSubagent, SwarmViewModel } from "./swarm-model";
+import type { ActiveSubagent, CountdownEntry, SwarmViewModel } from "./swarm-model";
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -63,7 +63,7 @@ describe("subagentDisplayStatus", () => {
 describe("countdownSecondsRemaining", () => {
     const noopTick = () => 0;
 
-    function mkModel(countdownState: Map<string, { lastEventAt: number; startedAt: number }>): SwarmViewModel {
+    function mkModel(countdownState: Map<string, CountdownEntry>): SwarmViewModel {
         return { countdownStateAtom: () => countdownState } as unknown as SwarmViewModel;
     }
 
@@ -82,24 +82,39 @@ describe("countdownSecondsRemaining", () => {
     });
 
     it("is 60 the instant a countdown is armed", () => {
-        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0 }]]));
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0, pausedAt: null }]]));
         expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(60);
     });
 
     it("counts down as time passes", () => {
-        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0 }]]));
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0, pausedAt: null }]]));
         vi.setSystemTime(25_000);
         expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(35);
     });
 
     it("floors at 0, never goes negative even past the auto-retire delay", () => {
-        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0 }]]));
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0, pausedAt: null }]]));
         vi.setSystemTime(90_000);
         expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(0);
     });
 
     it("only reads the requested rowKey's entry, ignoring unrelated rows", () => {
-        const model = mkModel(new Map([["agent:other", { lastEventAt: 0, startedAt: 0 }]]));
+        const model = mkModel(new Map([["agent:other", { lastEventAt: 0, startedAt: 0, pausedAt: null }]]));
         expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBeNull();
+    });
+
+    it("freezes the displayed value while paused, instead of continuing to count down against the live clock (reagentx P1 on #2440)", () => {
+        // Armed at t=0, paused at t=10s (50s remaining at that instant).
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0, pausedAt: 10_000 }]]));
+        // Wall clock keeps advancing well past pausedAt — the display must
+        // NOT follow it down to 0; it should stay pinned at the pausedAt snapshot.
+        vi.setSystemTime(45_000);
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(50);
+    });
+
+    it("resumes counting from the live clock once pausedAt is cleared", () => {
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 30_000, pausedAt: null }]]));
+        vi.setSystemTime(35_000);
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(55);
     });
 });

--- a/frontend/app/view/swarm/swarm-view.test.ts
+++ b/frontend/app/view/swarm/swarm-view.test.ts
@@ -1,9 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
-import { subagentDisplayStatus } from "./swarm-view";
-import type { ActiveSubagent } from "./swarm-model";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { countdownSecondsRemaining, subagentDisplayStatus } from "./swarm-view";
+import type { ActiveSubagent, SwarmViewModel } from "./swarm-model";
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -56,5 +56,50 @@ describe("subagentDisplayStatus", () => {
         const before = { ...sub };
         subagentDisplayStatus(sub, "idle");
         expect(sub).toEqual(before);
+    });
+});
+
+// SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06
+describe("countdownSecondsRemaining", () => {
+    const noopTick = () => 0;
+
+    function mkModel(countdownState: Map<string, { lastEventAt: number; startedAt: number }>): SwarmViewModel {
+        return { countdownStateAtom: () => countdownState } as unknown as SwarmViewModel;
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("is null for a row not counting down", () => {
+        const model = mkModel(new Map());
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBeNull();
+    });
+
+    it("is 60 the instant a countdown is armed", () => {
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0 }]]));
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(60);
+    });
+
+    it("counts down as time passes", () => {
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0 }]]));
+        vi.setSystemTime(25_000);
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(35);
+    });
+
+    it("floors at 0, never goes negative even past the auto-retire delay", () => {
+        const model = mkModel(new Map([["agent:a1", { lastEventAt: 0, startedAt: 0 }]]));
+        vi.setSystemTime(90_000);
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBe(0);
+    });
+
+    it("only reads the requested rowKey's entry, ignoring unrelated rows", () => {
+        const model = mkModel(new Map([["agent:other", { lastEventAt: 0, startedAt: 0 }]]));
+        expect(countdownSecondsRemaining(model, "agent:a1", noopTick)).toBeNull();
     });
 });

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -229,7 +229,12 @@ export function countdownSecondsRemaining(model: SwarmViewModel, rowKey: string,
     tick();
     const entry = model.countdownStateAtom().get(rowKey);
     if (entry === undefined) return null;
-    return Math.max(0, Math.ceil((AUTO_RETIRE_DELAY_MS - (Date.now() - entry.startedAt)) / 1000));
+    // While paused, freeze against the moment pauseCountdown() stamped
+    // pausedAt instead of the live clock — otherwise this kept counting
+    // down (and clamping at 0) while merely the auto-retire timer was
+    // stopped, contradicting the row visibly "pausing" (reagentx P1 on #2440).
+    const elapsedMs = (entry.pausedAt ?? Date.now()) - entry.startedAt;
+    return Math.max(0, Math.ceil((AUTO_RETIRE_DELAY_MS - elapsedMs) / 1000));
 }
 
 // ── Agent root row ───────────────────────────────────────────────────────

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -1,9 +1,9 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type Accessor, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
-import { subagentDisplayLabel, subagentRowKey } from "./swarm-model";
+import { subagentDisplayLabel, subagentRowKey, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -215,6 +215,21 @@ export function subagentDisplayStatus(sub: ActiveSubagent, parentAgentStatus: "r
         return parentAgentStatus === "idle" ? "interrupted" : "working";
     }
     return "idle"; // completed
+}
+
+/**
+ * Seconds remaining on `rowKey`'s auto-linger countdown
+ * (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06), or `null` if it isn't
+ * counting down. `tick` is a `useTick(1000)` accessor from the CALLING
+ * component — reading it here (rather than owning a timer in this function
+ * or the ViewModel) is what makes the returned value recompute every
+ * second; this function is otherwise a pure read of `countdownStateAtom`.
+ */
+export function countdownSecondsRemaining(model: SwarmViewModel, rowKey: string, tick: Accessor<number>): number | null {
+    tick();
+    const entry = model.countdownStateAtom().get(rowKey);
+    if (entry === undefined) return null;
+    return Math.max(0, Math.ceil((AUTO_RETIRE_DELAY_MS - (Date.now() - entry.startedAt)) / 1000));
 }
 
 // ── Agent root row ───────────────────────────────────────────────────────
@@ -494,11 +509,21 @@ function WorkflowDispatchRow({
         model.retireRow(group.dispatchId, group.lastEventAt);
     };
 
+    // Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06)
+    // — armed by reconcileCountdowns() (swarm-model.ts) once every member is
+    // done (AgentDispatch.status === "completed", this row's "retired").
+    const countdownTick = useTick(1000);
+    const countdownSeconds = createMemo(() => countdownSecondsRemaining(model, group.dispatchId, countdownTick));
+    const handleMouseEnter = () => model.pauseCountdown(group.dispatchId);
+    const handleMouseLeave = () => model.resumeCountdown(group.dispatchId);
+
     return (
         <div class={`swarm-workflow-group swarm-workflow-group--${group.status}`}>
             <div
                 class="swarm-workflow-header"
                 onClick={() => model.toggleDispatchExpanded(group.dispatchId)}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
                 title={group.name}
             >
                 <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-workflow-expand-icon`} />
@@ -511,6 +536,9 @@ function WorkflowDispatchRow({
                 <span class={`swarm-workflow-status-badge swarm-workflow-status-badge--${group.status}`}>
                     {group.status === "active" ? "Active" : "Retired"}
                 </span>
+                <Show when={countdownSeconds() != null}>
+                    <span class="swarm-subagent-countdown">disappearing in {countdownSeconds()}s</span>
+                </Show>
                 <Show when={group.status === "retired"}>
                     <button class="swarm-subagent-retire" title="Retire" onClick={handleRetire}>
                         <i class="fa-solid fa-xmark" />
@@ -703,16 +731,30 @@ function SubagentRow({
         model.retireRow(rowKey(), sub.last_event_at);
     };
 
+    // Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06)
+    // — only ever armed for a clean "idle" terminal by reconcileCountdowns()
+    // (swarm-model.ts), never "interrupted", so no separate check needed
+    // here beyond reading whatever's actually in countdownStateAtom.
+    const countdownTick = useTick(1000);
+    const countdownSeconds = createMemo(() => countdownSecondsRemaining(model, rowKey(), countdownTick));
+    const handleMouseEnter = () => model.pauseCountdown(rowKey());
+    const handleMouseLeave = () => model.resumeCountdown(rowKey());
+
     return (
         <div class={`swarm-subagent-group swarm-subagent-group--${dimVariant()}`}>
             <div
                 class={`swarm-subagent-row swarm-subagent-row--${dimVariant()}`}
                 onClick={handleToggle}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
                 title={displayLabel()}
             >
                 <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-expand-icon`} />
                 <span class="swarm-subagent-slug">{displayLabel()}</span>
                 <AgentStatusChip status={displayStatus()} />
+                <Show when={countdownSeconds() != null}>
+                    <span class="swarm-subagent-countdown">disappearing in {countdownSeconds()}s</span>
+                </Show>
                 <Show when={canRetire()}>
                     <button class="swarm-subagent-retire" title="Retire" onClick={handleRetire}>
                         <i class="fa-solid fa-xmark" />


### PR DESCRIPTION
## Summary

Implements `SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md` (written earlier this session after a live-spawned subagent's row was expected to auto-expire and didn't — landed on top of #2438's phantom-row fix, since this spec explicitly assumed that lands first).

Before this PR: a completed Agent Tool row or Workflow row lingered in the Swarm tree indefinitely until a human manually clicked Retire. A finished 12-second subagent and a finished 6-hour workflow behaved identically.

## Changes

- **`swarm-model.ts`**: `reconcileCountdowns()` arms a 60s countdown (via the existing `retireRow()`/`_retiredRowKeys` un-retire-on-new-activity mechanism) for any subagent with `status === "completed"` or Workflow dispatch with `status === "completed"` — called after every subagent/dispatch reload, same timing as the existing `pruneRetiredRowKeys()`. `pauseCountdown`/`resumeCountdown` support hover-to-pause. `AUTO_RETIRE_DELAY_MS` is exported so the view computes against the same constant the timer actually runs on.
- **`swarm-view.tsx`**: `SubagentRow`/`WorkflowDispatchRow` render a live "disappearing in Ns" label next to the status chip/badge, and wire `onMouseEnter`/`onMouseLeave` to pause/resume. The visible countdown's 1s re-render reuses the existing `useTick(1000)` hook (ref-counted, auto-cleanup) rather than a second ViewModel-owned interval — simpler than what the spec's first draft proposed, noted in the spec's status line.
- **Excluded**: `"interrupted"` (abandoned/failed) rows never auto-count-down — matches `canRetire`'s existing scope, so a failure can't silently vanish before being read.
- **Excluded**: `shellRows`/`cronRows` — out of scope per the spec, `agentToolRows`/`workflowRows` only.

## Design decision worth a second look

Per the spec: on mouse-leave, the countdown resumes with a **fresh 60s**, not the remaining time from before the hover. This was the spec's stated default ("simpler to reason about... matches how most hover-to-pause toast patterns behave") but flagged as worth confirming rather than assumed. Flagging here too in case reviewers feel a resume-from-remaining model is preferable — it's a small, isolated change if so (`resumeCountdown` is the only place this would need to move).

## Test plan

- [x] `tsc --noEmit` clean project-wide.
- [x] All existing `swarm-model.test.ts` (60) + `swarm-view.test.ts` (10 prior) pass unchanged.
- [x] 5 new tests for the exported, pure `countdownSecondsRemaining` (arm instant, counts down, floors at 0, ignores unrelated rows, null when not counting down) — 65 total across both files.
- [x] `stylelint` on the touched scss file — confirmed the 12 pre-existing errors are unchanged/unrelated (same count on main before this PR).
- [ ] Live verification: spawn a subagent, watch it complete, confirm the countdown appears and the row disappears at 0; hover-pause; trigger new activity mid-countdown to confirm it clears. I don't have live access to run this myself.

<!-- agentmux:agent_id=manoz -->