### PR TITLE
feat(agent-pane): AskUserQuestion auto-selects the recommended option after 30s

### DIFF
--- a/.changesets/1786077015-feat-agent-pane-askuserquestion-auto-selects-the-recommended-ier2.md
+++ b/.changesets/1786077015-feat-agent-pane-askuserquestion-auto-selects-the-recommended-ier2.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): AskUserQuestion auto-selects the recommended option after 30s

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -45,6 +45,7 @@ See also:
 | [SPEC_AGENT_GLOBAL_PORTABILITY_2026-06-16](SPEC_AGENT_GLOBAL_PORTABILITY_2026-06-16.md) | Agent definitions shared across workspaces |
 | [SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13](SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md) | Cross-channel conversation continuity |
 | [SPEC_ASK_USER_QUESTION_2026_06_15](SPEC_ASK_USER_QUESTION_2026_06_15.md) | `ask_user_question` tool |
+| [SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06](SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md) | 30s auto-timeout + countdown, auto-selects the recommended option |
 | [SPEC_CONTEXT_VISIBILITY_2026_06_17](SPEC_CONTEXT_VISIBILITY_2026_06_17.md) | Context-meter / token-budget visibility |
 
 ## Shell / Terminal Pane

--- a/docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
@@ -1,0 +1,378 @@
+# SPEC: Auto-timeout for AskUserQuestion — 30s countdown, auto-select the recommended option
+
+**Date:** 2026-08-06
+**Status:** Proposed — all open questions resolved (§5); ready for implementation.
+**Severity:** Low-Medium — no data-loss risk, but an unanswered question
+blocks the agent's turn indefinitely today, which defeats unattended/overnight
+runs and any workflow where the human isn't watching the pane.
+**Trigger:** User request (below) — give `AskUserQuestion` a 30s auto-timeout
+with a visible countdown so a pending question can never stall work forever.
+
+---
+
+## 0. Ask
+
+> get the latest agentmuxai/agentmux .. for the AskQuestion tool, we want to
+> add a 30 second timer (also add a UI countdown) if the user does not respond
+> by zero, the recommended is auto selected. this is so work does not stop.
+> write a spec to file
+
+---
+
+## 1. Current behavior (confirmed by reading the code)
+
+- `AskUserQuestion` tool-use is delivered to AgentMux via the Agent SDK
+  **control protocol** (`--permission-prompt-tool stdio`), not the stream —
+  Claude Code auto-rejects the tool in plain headless mode. See
+  `docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md`. The CLI sends a
+  `control_request` (subtype `can_use_tool`), and AgentMux's backend parks it
+  in `pending_questions: HashMap<String,(String, serde_json::Value)>`
+  (`agentmux-srv/src/backend/blockcontroller/persistent.rs:250-255`) until a
+  `control_response` is sent back via `answer_question()` (`persistent.rs:1695`).
+- The frontend surfaces this as a `ToolNode` with `status: "awaiting_answer"`
+  and a populated `question` field
+  (`frontend/app/view/agent/types.ts:591-618` for the wire shapes). It is
+  rendered by `AgentQuestionPanel.tsx`, collected via
+  `pendingQuestions()`/`handleAnswer()` in
+  `frontend/app/view/agent/hooks/useAgentQuestions.ts`, mounted from
+  `agent-view.tsx:1667-1676`.
+- **There is no timeout anywhere in this path today.** The panel sits open —
+  full or minimized — until a human answers or the pane is closed. This is the
+  gap this spec closes.
+- `AskUserQuestionOption` (`types.ts:591-594`) is `{ label, description? }` —
+  **no explicit "recommended" flag exists in the wire schema.** The only
+  signal available is Claude Code's own convention for the `AskUserQuestion`
+  tool: *"If you recommend a specific option, make that the first option in
+  the list and add '(Recommended)' at the end of the label."* So detection has
+  to be heuristic: look for a `(Recommended)` suffix on `option.label`, and
+  fall back to the first option in the list when nothing is marked.
+- Answer delivery already has two independent paths from the same
+  `AnswerOutcome` object (built by `AgentQuestionPanel.submit()`):
+  1. **Control-protocol path** — `RpcApi.AgentAnswerCommand` →
+     `answer_question()` in `persistent.rs`, which resumes the CLI's parked
+     turn with a `control_response`.
+  2. **Follow-up-message fallback** — when the control-protocol path fails
+     with one of a known-safe set of errors (`useAgentQuestions.ts:60-66`,
+     `SAFE_TO_RETRY_VIA_FOLLOWUP`), the answer is instead sent as a normal
+     chat turn (`opts.sendMessage(outcome.answer_text)`).
+
+  An auto-timeout only needs to trigger the *same* `submit()` call a human
+  click already triggers — no new wire format, no backend change.
+- **Existing countdown precedent to reuse**, not invent from scratch:
+  `frontend/app/modals/userinputmodal.tsx` — `countdown` signal seeded from a
+  timeout, `setInterval` ticking every 1000ms, firing an action at 0
+  (lines 17, 80-95), rendered in the modal title as `` `${title} (${countdown()}s)` ``
+  (line 157), cleaned up via `onCleanup` clearing both the interval and a
+  pending timeout (lines 92-95). This spec's timer follows the identical
+  shape, just living inside `AgentQuestionPanel.tsx` instead of a modal.
+- Severity color tokens already exist in the app's SCSS and should be reused
+  rather than introduced fresh: `--warning-color` (`app/block/block.scss:215,405`)
+  and `--error-color` (`app/errors/ErrorBanner.scss`, `app/block/block.scss:592`).
+
+---
+
+## 2. Design
+
+### 2.1 Scope
+
+- Applies only to `AgentQuestionPanel` (the `AskUserQuestion` tool). The
+  sibling `AgentDecisionPanel` (tool-permission "always ask" prompts) is
+  **explicitly out of scope** — different tool, different risk profile
+  (approving a destructive action unattended is not the same as picking a
+  clarifying-question default); a separate spec should cover that if wanted.
+- **One timer per panel instance** — i.e., per `tool_use_id` of the head
+  question-set, not per individual question. A request can carry multiple
+  `questions[]` (see `AskUserQuestionRequest`, `types.ts:605-610`); all of
+  them share one 30s countdown and are auto-filled + submitted together at 0.
+- **One question-set visible at a time.** The queue (`queueDepth()` in
+  `AgentQuestionPanel.tsx:59`) already only renders the head; when the head
+  auto-submits, the next queued question-set becomes head with a fresh
+  `tool_use_id`, and gets its own fresh 30s window for free (see §2.3).
+
+### 2.2 Recommended-option detection
+
+New pure helper, colocated with `AgentQuestionPanel.tsx`:
+
+```ts
+const RECOMMENDED_RE = /\(recommended\)\s*$/i;
+
+function recommendedOptions(options: AskUserQuestionOption[]): AskUserQuestionOption[] {
+    const flagged = options.filter((o) => RECOMMENDED_RE.test(o.label));
+    if (flagged.length > 0) return flagged;
+    // Per the AskUserQuestion tool's own instructions to the model: when a
+    // recommendation isn't explicitly marked, it's conventionally the first
+    // option in the list. Falling back to it is always safe — worst case
+    // it's just "the first option," the same outcome as a human clicking
+    // through without reading closely.
+    return options.length > 0 ? [options[0]] : [];
+}
+```
+
+- **Single-select** (`multiSelect: false`): auto-select
+  `recommendedOptions(q.options)[0]`.
+- **Multi-select** (`multiSelect: true`): auto-select **all** flagged
+  options; if none are flagged, select just `options[0]` — never leave a
+  multi-select question with zero selections, since `allAnswered()`
+  (`AgentQuestionPanel.tsx:105-109`) requires at least one selected option or
+  free text per question.
+- Detection is **display-neutral**: the rendered label text is unchanged
+  (the `"(Recommended)"` suffix, if present, stays visible — it's meaningful
+  context for a human deciding whether to intervene). Additionally apply an
+  `agent-question-panel-option--recommended` class (computed from the same
+  `recommendedOptions()` call) to visually highlight which option(s) the
+  countdown will pick, so a watching user can predict the outcome before it
+  happens.
+
+### 2.3 Timer lifecycle
+
+**Resolved (§5.1): there is no disarm mechanism.** The timer always fires at
+30s regardless of interaction; at zero it *merges* rather than blindly
+overwrites — see the merge rule below. This replaces an earlier draft of this
+section that disarmed the whole panel on first interaction (rejected: it
+directly contradicted the "work does not stop" goal — a human who answers
+question 1 of 2 and then gets pulled away would otherwise cancel the safety
+net entirely, leaving question 2 blocked forever, the exact failure mode this
+spec exists to fix).
+
+- `const AUTO_TIMEOUT_MS = 30_000;` — module-level constant in
+  `AgentQuestionPanel.tsx`.
+- `const [remainingMs, setRemainingMs] = createSignal(AUTO_TIMEOUT_MS);`
+- Extend the existing `createEffect` that resets `state()` whenever the head
+  question changes (`AgentQuestionPanel.tsx:68-73`, keyed on `tool_use_id`) to
+  also (re)arm the timer in the same effect body:
+  - Clear any previous interval.
+  - Reset `remainingMs` to `AUTO_TIMEOUT_MS`.
+  - Start a new `setInterval(1000ms)` that decrements `remainingMs`; on
+    reaching 0, for each question `i` where `!questionAnswered(i)`
+    (`AgentQuestionPanel.tsx:100-103` — no selection and no non-empty "Other"
+    text), apply the recommended default from §2.2 into `state()[i]`.
+    Questions the user already answered — fully or partially — are left
+    exactly as-is. Then call `submit()`; the resulting `outcome.autoFilledCount`
+    reflects how many questions were auto-filled (see §2.5).
+  - `onCleanup` clears the interval — mirrors `userinputmodal.tsx:92-95` —
+    so unmount or a `tool_use_id` change (new head question) never leaves a
+    stale interval running against the wrong question.
+- **Keeps running while minimized.** The whole point is "work does not
+  stop" even if the human dismissed the panel without answering, so the
+  interval must **not** be gated on `!minimized()`. Only the *rendering* of
+  the countdown differs between the full panel and the minimized chip
+  (§2.4) — the timer itself is identical either way.
+- **No interaction listeners needed.** Because there's no disarm, `toggleOption`/
+  `setOther` (`AgentQuestionPanel.tsx:79-98`) need no changes at all — the
+  merge-at-timeout logic reads whatever is in `state()` at the moment the
+  interval fires, which is already kept live by those existing setters.
+- **Manual submit still wins whenever it happens first.** Clicking "Submit
+  answer" transitions the node before the interval next ticks; the effect's
+  `onCleanup` (triggered by the resulting `tool_use_id` change) tears down the
+  interval, so there is no race with the timer.
+- **Queue advance is automatic.** When the head auto-submits, it transitions
+  out of `awaiting_answer` (same as a manual submit), the queue's `head()`
+  memo recomputes to the next pending question-set (a different
+  `tool_use_id`), and the reset effect above re-arms a fresh 30s timer for
+  it. No queue-specific auto-timeout code is needed.
+
+### 2.4 UI countdown
+
+**Resolved (§5.3): concrete token values below** (superseding "left to
+implementation-time judgment").
+
+- **Full panel** (`.agent-question-panel-header`,
+  `AgentQuestionPanel.tsx:230-236`): add a countdown chip, e.g.
+  `Auto-selects recommended in {Math.ceil(remainingMs() / 1000)}s`.
+  `transition: color 120ms ease;` (matches the panel's existing
+  `80ms ease`-family transitions closely enough to feel consistent without
+  being a literal copy of the option-hover timing). Color escalates by
+  remaining time:
+  - `> 10s`: `var(--secondary-text-color)` — same muted tone already used for
+    the queue-depth chip (`.agent-question-panel-queue`) and option
+    descriptions, so it doesn't compete with the question text.
+  - `≤ 10s, > 5s`: `var(--warning-color)`, `font-weight: 600`.
+  - `≤ 5s`: `var(--error-color)`, `font-weight: 600`, plus a subtle pulse —
+    `animation: amux-question-countdown-pulse 1s ease-in-out infinite;` with
+    `@keyframes amux-question-countdown-pulse { 50% { opacity: 0.6; } }`.
+    Kept to an opacity pulse only (no color/size change in the keyframe) so
+    it reads as "urgent" without being distracting.
+- **Minimized chip** (`.agent-question-panel-minimized`,
+  `AgentQuestionPanel.tsx:208-218`): append the same countdown, same color
+  thresholds, next to "Question waiting" so a user who minimized the panel
+  still sees the time pressure without having to reopen it.
+- The countdown is always visible from panel-open to submit (manual or
+  automatic) — there is no "disarmed" state to hide it early, per §2.3.
+
+### 2.5 Delivered answer / audit trail
+
+- The value delivered to the agent — both `answers_map` (control-protocol
+  path) and `answer_text` (follow-up-message fallback) — is **identical in
+  shape** to a normal human answer: the recommended option's exact label(s).
+  **No wire-format change** on `AnswerOutcome`, `CommandAgentAnswerData`
+  (`agentmux-srv/src/backend/rpc_types/block.rs:160-170`), or the
+  `control_response` payload. This keeps the entire backend untouched.
+- For human-facing traceability only, extend `AnswerOutcome`
+  (`AgentQuestionPanel.tsx:19-30`) with `autoFilledCount: number` — how many
+  of the request's questions were filled by the timeout merge (§2.3), `0` for
+  a fully manual submit. When building the optimistic transcript summary in
+  `useAgentQuestions.ts:123` (currently
+  `` `❓ Answered — ${outcome.answer_text...}` ``), prefix based on the count
+  relative to `outcome.answers.length`:
+  - `0` → unchanged, `` `❓ Answered — ...` ``.
+  - `< answers.length` (partial) →
+    `` `⏱️ Partly auto-answered (${autoFilledCount}/${answers.length} — no response in 30s) — ...` ``.
+  - `=== answers.length` (fully timed out, nothing was touched) →
+    `` `⏱️ Auto-answered (no response in 30s) — ...` ``.
+
+  A boolean would have collapsed the "user answered Q1, timeout filled Q2"
+  case into the same label as "user never touched anything" — the count
+  distinguishes them, which matters for anyone auditing the transcript later.
+  This is the only change outside `AgentQuestionPanel.tsx`/its styles/tests.
+
+---
+
+## 3. Files touched
+
+- `frontend/app/view/agent/components/AgentQuestionPanel.tsx` — timer state
+  and lifecycle, `recommendedOptions()` helper, merge-at-timeout logic,
+  countdown rendering (full + minimized), `autoFilledCount` on `AnswerOutcome`.
+- `frontend/app/view/agent/components/AgentQuestionPanel.scss` — countdown
+  chip styling (default/`--warning-color`/`--error-color` states + pulse
+  keyframe), `--recommended` option highlight class.
+- `frontend/app/view/agent/hooks/useAgentQuestions.ts` — consume
+  `outcome.autoFilledCount` when building the transcript summary text
+  (~line 123).
+- `frontend/app/view/agent/components/AgentQuestionPanel.test.tsx` — new
+  test cases per §7 (file already exists — see current Enter/Escape
+  keyboard-handling tests for the mount/mock conventions to follow).
+- **No `agentmux-srv` (Rust) changes.** No `agentmux-common` changes. No new
+  RPC command, no new field on any wire struct that crosses the process
+  boundary.
+
+---
+
+## 4. Edge cases & decisions
+
+| Case | Behavior |
+|---|---|
+| No option anywhere marked `(Recommended)` | Falls back to `options[0]` per question (documented model convention) |
+| Multi-select, no flagged options | Auto-select `options[0]` only — never zero |
+| Multi-select, several flagged options | Auto-select all of them |
+| User answers question 1 of a 2-question set, never touches question 2, timer hits 0 | Question 1 keeps the user's answer untouched; question 2 gets the recommended default; both submit together as one outcome with `autoFilledCount: 1` (see §5.1) |
+| Panel minimized, never touched | Timer keeps running in the background; auto-submits at 0; panel disappears (queue advances, or closes if empty) |
+| Queue has 3 pending question-sets | Only the head is shown/timed; each becomes head in turn and gets its own fresh 30s window |
+| User submits manually with 1s left on the clock | Manual `submit()` simply runs first — the resulting `tool_use_id` change tears down the interval via `onCleanup`, so there's no race |
+| Pane closed while a question is pending | Existing `onCleanup` (unrelated to this change) already handles teardown; the timer's own `onCleanup` clears alongside it |
+| Timer fires while user is mid-keystroke in an "Other" field | Whatever text is currently in the reactive `state()` signal at that instant counts as "answered" (per `questionAnswered()`) and is kept as-is — no special-casing needed, since `setOther` already updates `state()` on every keystroke |
+
+---
+
+## 5. Resolved design decisions
+
+Originally left open for review; resolved on 2026-08-06 before implementation.
+
+1. **Per-panel disarm vs. per-question merge — resolved: merge, no disarm.**
+   The first draft of this spec disarmed the *entire* panel's timer on the
+   first interaction with *any* question in a multi-question set. Rejected:
+   it directly contradicts the spec's own stated goal. If a human answers
+   question 1 of 2 and then gets pulled away — the exact "human isn't
+   watching anymore" scenario this feature exists to handle — a full disarm
+   would cancel the safety net entirely and question 2 could block forever,
+   reproducing the original bug for anyone who partially engages before
+   leaving.
+
+   **Resolution:** the timer is never disarmed. It always fires at 30s. At
+   zero, questions the user already answered (fully or even partially — any
+   selection or non-empty "Other" text) are left exactly as they are;
+   only genuinely untouched questions get the recommended default; the
+   merged result is what submits. This is also the simpler implementation —
+   it removes the need for a `disarmed` signal and any interaction
+   listeners, since the merge logic only ever reads `state()` at the moment
+   the interval fires, and that signal is already kept live by the existing
+   `toggleOption`/`setOther` setters. See §2.3, §4.
+
+   One accepted tradeoff: a human who is actively deciding between options
+   (clicking around, still undecided) with less than 30s left gets cut off
+   at exactly 30s same as someone who never showed up. This is a narrow edge
+   case and is the literal reading of the ask ("if the user does not respond
+   by zero, the recommended is auto selected") — the countdown UI (§2.4)
+   exists specifically to make that deadline visible in advance rather than
+   a surprise.
+
+2. **Timeout duration configurability — resolved: non-goal, hardcoded.**
+   `AUTO_TIMEOUT_MS = 30_000` as a plain constant, no settings toggle, per
+   the ask. Confirmed as out of scope for this pass (§6); a per-user or
+   per-agent override is a reasonable follow-up if requested later, but
+   nothing here blocks adding one afterward — it's a single constant with
+   one obvious injection point (a settings-store read where it's currently a
+   literal).
+
+3. **SCSS token values for the urgency escalation — resolved: specified.**
+   No longer "left to implementation-time judgment." §2.4 now specifies
+   exact thresholds and tokens: `--secondary-text-color` above 10s,
+   `--warning-color` at ≤10s, `--error-color` with a 1s opacity-pulse
+   keyframe at ≤5s, `transition: color 120ms ease`. Chosen to reuse existing
+   app-wide severity tokens (confirmed present via `--warning-color` in
+   `app/block/block.scss` and `--error-color` in `app/errors/ErrorBanner.scss`)
+   rather than introduce new ones, and to keep the pulse subtle (opacity
+   only, no color or size change in the keyframe) so it signals urgency
+   without being distracting.
+
+---
+
+## 6. Non-goals
+
+- `AgentDecisionPanel` (tool-permission "always ask" prompts) — no
+  auto-timeout added here; separate risk profile, separate spec if wanted.
+- Any backend/Rust change. The answer is delivered through the exact same
+  control-protocol / follow-up-message paths that already exist today.
+- A user-configurable timeout duration or a settings toggle to disable the
+  feature entirely.
+- Signaling "this was auto-selected" to the model itself over the wire — only
+  the AgentMux-local transcript is annotated (§2.5); the CLI/model sees a
+  normal answer, indistinguishable from a human one.
+
+---
+
+## 7. Test plan
+
+**Unit** (`AgentQuestionPanel.test.tsx`, extending the existing
+`@solidjs/testing-library` + `vitest` setup):
+
+- `recommendedOptions()`: returns the flagged option(s) when one or more
+  labels end in `(Recommended)` (case-insensitive); falls back to
+  `[options[0]]` when none are flagged; returns `[]` for an empty options
+  array.
+- Using `vi.useFakeTimers()`: a fully-idle panel auto-fires `onAnswer` at
+  exactly 30s with the expected `answers_map` (single-select → the
+  recommended label; multi-select with flags → all flagged labels;
+  multi-select with no flags → `[options[0]]`); `autoFilledCount` equals the
+  full question count.
+- **Merge case:** a 2-question set where the user answers question 1 only
+  (via `toggleOption`), then fake-advance past 30s — question 1's chosen
+  label survives unchanged in the submitted outcome, question 2 gets the
+  recommended default, `autoFilledCount === 1`.
+- **Manual-submit-wins case:** answer every question and call `submit()`
+  manually before 30s — advancing fake time past 30s afterward fires no
+  second submit (the interval was torn down by the `tool_use_id` change).
+- The countdown value decrements once per simulated 1000ms tick and reaches
+  exactly 0 at the 30s mark (no off-by-one).
+- `useAgentQuestions.ts`'s summary-building picks the right prefix for each
+  of the three `autoFilledCount` bands (`0`, partial, full) — small addition
+  to that hook's own existing tests, if any (confirm exact file at
+  implementation time).
+
+**Manual / integration:**
+
+- `task dev`, trigger a live `AskUserQuestion` call, leave the panel fully
+  untouched. Confirm: (a) the countdown renders and ticks down correctly in
+  both the full panel and the minimized chip; (b) color escalates at the
+  10s/5s thresholds; (c) at 0 the recommended option(s) submit automatically
+  and the agent's turn resumes without further input; (d) the transcript
+  line shows the `⏱️ Auto-answered` marker, distinguishable from a normal
+  answer.
+- Repeat with a multi-question panel: manually answer one question shortly
+  after it opens, leave the other(s) untouched. Confirm the countdown keeps
+  running (it is never dismissed by the interaction), and at 0 the manually
+  answered question keeps its answer while the rest fill in with the
+  recommended default, submitted together as one outcome — transcript line
+  shows the partial marker (§2.5), not the full-auto one.
+- Repeat once more, answering *every* question manually before 0 — confirm
+  submission happens immediately on click with no further wait, and the
+  transcript line shows the normal (non-auto) marker.

--- a/docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
@@ -260,6 +260,7 @@ implementation-time judgment").
 | User submits manually with 1s left on the clock | Manual `submit()` simply runs first — the resulting `tool_use_id` change tears down the interval via `onCleanup`, so there's no race |
 | Pane closed while a question is pending | Existing `onCleanup` (unrelated to this change) already handles teardown; the timer's own `onCleanup` clears alongside it |
 | Timer fires while user is mid-keystroke in an "Other" field | Whatever text is currently in the reactive `state()` signal at that instant counts as "answered" (per `questionAnswered()`) and is kept as-is — no special-casing needed, since `setOther` already updates `state()` on every keystroke |
+| Question has a zero-length `options` array (malformed `AskUserQuestion` call) | `recommendedOptions([])` returns `[]`, so there's nothing to select. **Caught in review (reagent P1, PR #2441):** the original implementation left the question unanswered in this case, so `submit()`'s `allAnswered()` gate silently no-op'd — and since the timer's interval is cleared unconditionally *before* that check, the panel got stuck forever with no further timeout retry. Fixed: `applyRecommendedDefaults()` falls back to a free-text placeholder (`"No option was available to auto-select"`) for a question with no options, which is always sufficient to satisfy `questionAnswered()` and let the merged outcome submit. |
 
 ---
 

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -3,7 +3,18 @@
 //
 // AgentQuestionPanel — interactive AskUserQuestion prompt floated over the
 // agent conversation. Colors bind to the global theme tokens.
-// Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+// Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md,
+// docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md.
+
+// Subtle urgency pulse for the countdown chip's final 5 seconds — opacity
+// only (no color/size change here; color escalation is handled by the
+// --warning/--critical modifier classes below) so it reads as "urgent"
+// without being distracting.
+@keyframes amux-question-countdown-pulse {
+    50% {
+        opacity: 0.6;
+    }
+}
 
 .agent-question-panel {
     display: flex;
@@ -38,6 +49,32 @@
     margin-left: auto;
     font-size: var(--text-xs, 11px);
     color: var(--secondary-text-color);
+}
+
+// 30s auto-timeout countdown (SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
+// §2.4). In the header it's pushed to the far right like `.agent-question-panel-queue`
+// (both can be present at once — flex auto-margins group them together with no gap
+// beyond the header's own `gap`); in the minimized chip it just flows inline.
+.agent-question-panel-header .agent-question-panel-countdown {
+    margin-left: auto;
+}
+
+.agent-question-panel-countdown {
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+    transition: color 120ms ease;
+    white-space: nowrap;
+
+    &--warning {
+        color: var(--warning-color);
+        font-weight: var(--font-weight-medium, 500);
+    }
+
+    &--critical {
+        color: var(--error-color);
+        font-weight: var(--font-weight-medium, 500);
+        animation: amux-question-countdown-pulse 1s ease-in-out infinite;
+    }
 }
 
 .agent-question-panel-q {
@@ -98,6 +135,16 @@
     &--checked {
         border-color: var(--accent-color);
         background: rgba(var(--accent-color-rgb, 65, 159, 224), 0.1);
+    }
+
+    // Marks which option(s) the 30s auto-timeout would pick if left
+    // untouched — a lighter-weight treatment than `--checked` (dashed
+    // border, no fill) so a genuinely checked option is still visually
+    // primary. Applies independently of `--checked`: an option can be both
+    // recommended AND already chosen by the user.
+    &--recommended {
+        border-style: dashed;
+        border-color: var(--accent-color);
     }
 }
 

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -12,14 +12,18 @@
  * panel (e.g. the Ctrl+F search bar, AgentSearchBar.tsx) as something Enter
  * shouldn't be stolen from, so pressing Enter there silently submitted a
  * fully-answered pending question.
+ *
+ * Also covers the 30s auto-timeout (recommended-option auto-select +
+ * countdown) added by
+ * docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md.
  */
 
 import { cleanup, render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AgentQuestionPanel } from "./AgentQuestionPanel";
+import { AgentQuestionPanel, recommendedOptions } from "./AgentQuestionPanel";
 import type { ToolNode } from "../types";
 
 afterEach(() => {
@@ -43,6 +47,34 @@ const singleSelectQuestion = (toolUseId = "q1"): ToolNode => ({
                 header: "Test",
                 multiSelect: false,
                 options: [{ label: "Red" }, { label: "Blue" }],
+            },
+        ],
+    },
+});
+
+const twoQuestionSet = (toolUseId = "q2"): ToolNode => ({
+    type: "tool",
+    id: toolUseId,
+    tool: "Other",
+    params: {},
+    status: "awaiting_answer",
+    collapsed: false,
+    summary: "❓ Waiting for your answer",
+    question: {
+        type: "ask_user_question",
+        tool_use_id: toolUseId,
+        questions: [
+            {
+                question: "Pick a color",
+                header: "Color",
+                multiSelect: false,
+                options: [{ label: "Red" }, { label: "Blue" }],
+            },
+            {
+                question: "Pick a size",
+                header: "Size",
+                multiSelect: false,
+                options: [{ label: "Small" }, { label: "Large" }],
             },
         ],
     },
@@ -126,5 +158,113 @@ describe("AgentQuestionPanel keyboard handling", () => {
         escapeOn(document.body);
         expect(onDefer).toHaveBeenCalledTimes(1);
         expect(onAnswer).not.toHaveBeenCalled();
+    });
+});
+
+describe("recommendedOptions", () => {
+    it("returns the flagged option(s) when one label ends in '(Recommended)'", () => {
+        const opts = [{ label: "OAuth (Recommended)" }, { label: "API Key" }];
+        expect(recommendedOptions(opts)).toEqual([opts[0]]);
+    });
+
+    it("is case-insensitive and tolerates trailing whitespace", () => {
+        const opts = [{ label: "Foo (recommended)  " }, { label: "Bar" }];
+        expect(recommendedOptions(opts)).toEqual([opts[0]]);
+    });
+
+    it("returns every flagged option for a multi-select set", () => {
+        const opts = [{ label: "A (Recommended)" }, { label: "B (Recommended)" }, { label: "C" }];
+        expect(recommendedOptions(opts)).toEqual([opts[0], opts[1]]);
+    });
+
+    it("falls back to the first option when none are flagged", () => {
+        const opts = [{ label: "Red" }, { label: "Blue" }];
+        expect(recommendedOptions(opts)).toEqual([opts[0]]);
+    });
+
+    it("returns an empty array for an empty options list", () => {
+        expect(recommendedOptions([])).toEqual([]);
+    });
+});
+
+describe("AgentQuestionPanel 30s auto-timeout", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("auto-submits the recommended (fallback: first) option after 30s of no interaction", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        vi.advanceTimersByTime(30_000);
+
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        const outcome = onAnswer.mock.calls[0][0];
+        expect(outcome.answers_map["Pick a color"]).toBe("Red");
+        expect(outcome.autoFilledCount).toBe(1);
+    });
+
+    it("merges: keeps a manually-answered question and only auto-fills the untouched one", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([twoQuestionSet()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        await user.click(screen.getByRole("radio", { name: /Blue/ }));
+        vi.advanceTimersByTime(30_000);
+
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        const outcome = onAnswer.mock.calls[0][0];
+        // Kept exactly as the user left it — NOT overwritten to "Red" (the
+        // fallback recommended default for this question).
+        expect(outcome.answers_map["Pick a color"]).toBe("Blue");
+        // Untouched question auto-filled with its own fallback default.
+        expect(outcome.answers_map["Pick a size"]).toBe("Small");
+        expect(outcome.autoFilledCount).toBe(1);
+    });
+
+    it("a fully manual submit before 30s prevents any later auto-submit", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onAnswer = vi.fn();
+        // Mirrors the real caller contract (useAgentQuestions.ts): answering
+        // removes the item from the pending queue, which is what tears down
+        // the panel's timer effect.
+        const [pending, setPending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        const handleAnswer = vi.fn((outcome: unknown) => {
+            onAnswer(outcome);
+            setPending([]);
+        });
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={handleAnswer} />);
+
+        await user.click(screen.getByRole("radio", { name: /Red/ }));
+        await user.click(screen.getByRole("button", { name: /Submit answer/ }));
+
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        expect(onAnswer.mock.calls[0][0].autoFilledCount).toBe(0);
+
+        vi.advanceTimersByTime(30_000);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    it("countdown decrements once per second and reaches exactly 0 at 30s", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(1_000);
+        expect(screen.getByText(/Auto-selects recommended in 29s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(28_000);
+        expect(screen.getByText(/Auto-selects recommended in 1s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(1_000);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -228,6 +228,40 @@ describe("AgentQuestionPanel 30s auto-timeout", () => {
         expect(outcome.autoFilledCount).toBe(1);
     });
 
+    // reagent P1, PR #2441: a malformed AskUserQuestion with a zero-length
+    // `options` array left `recommendedOptions` with nothing to select, so
+    // the question never became "answered" and `submit()`'s `allAnswered()`
+    // gate silently no-op'd — but the interval had already been cleared
+    // unconditionally, so the panel got stuck forever with no further
+    // timeout retry. Pin the fix: every question must be answerable after
+    // the timeout fires, regardless of how degenerate its `options` list is.
+    it("still auto-submits when a question has zero options — falls back to a free-text placeholder", () => {
+        const onAnswer = vi.fn();
+        const noOptionsQuestion: ToolNode = {
+            type: "tool",
+            id: "q3",
+            tool: "Other",
+            params: {},
+            status: "awaiting_answer",
+            collapsed: false,
+            summary: "❓ Waiting for your answer",
+            question: {
+                type: "ask_user_question",
+                tool_use_id: "q3",
+                questions: [{ question: "Pick one", header: "Test", multiSelect: false, options: [] }],
+            },
+        };
+        const [pending] = createSignal<ToolNode[]>([noOptionsQuestion]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        vi.advanceTimersByTime(30_000);
+
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        const outcome = onAnswer.mock.calls[0][0];
+        expect(outcome.answers_map["Pick one"]).toBe("No option was available to auto-select");
+        expect(outcome.autoFilledCount).toBe(1);
+    });
+
     it("a fully manual submit before 30s prevents any later auto-submit", async () => {
         const user = userEvent.setup({ delay: null });
         const onAnswer = vi.fn();

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -8,13 +8,45 @@
  * single- or multi-select options plus a free-text "Other", and submits the
  * answer so the caller can deliver it back to the agent as a tool_result.
  *
- * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
+ * Also runs a 30s auto-timeout so an unanswered question can never block the
+ * agent's turn forever: any question the user hasn't touched by zero is
+ * filled in with its recommended option and the (possibly-merged) answer is
+ * submitted automatically. See §2.3 for why this merges rather than
+ * disarming on first interaction.
+ *
+ * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md,
+ * docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md.
  */
 
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
-import type { AskUserQuestionAnswer, AskUserQuestionRequest, ToolNode } from "../types";
+import type { AskUserQuestionAnswer, AskUserQuestionOption, AskUserQuestionRequest, ToolNode } from "../types";
 import "./AgentQuestionPanel.scss";
+
+/** How long an AskUserQuestion panel waits for a human before auto-selecting
+ *  the recommended option(s) and submitting. Hardcoded per
+ *  SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §5.2 — not user-
+ *  configurable in v1. */
+const AUTO_TIMEOUT_MS = 30_000;
+
+/** Matches a Claude Code AskUserQuestion "(Recommended)" label suffix,
+ *  case-insensitively, with optional trailing whitespace. */
+const RECOMMENDED_RE = /\(recommended\)\s*$/i;
+
+/**
+ * The option(s) to auto-select for a question at timeout. There is no
+ * explicit "recommended" field in the wire schema — only Claude Code's own
+ * convention for this tool: mark the recommended option's label with a
+ * trailing "(Recommended)", and make it the first option in the list. When
+ * no label is flagged, falling back to the first option is always safe —
+ * worst case it's just "the first option," the same outcome as a human
+ * clicking through without reading closely.
+ */
+export function recommendedOptions(options: AskUserQuestionOption[]): AskUserQuestionOption[] {
+    const flagged = options.filter((o) => RECOMMENDED_RE.test(o.label));
+    if (flagged.length > 0) return flagged;
+    return options.length > 0 ? [options[0]] : [];
+}
 
 export interface AnswerOutcome {
     tool_use_id: string;
@@ -27,6 +59,13 @@ export interface AnswerOutcome {
     /** Flat-text rendering kept for the optimistic node summary + the one-shot/
      *  container follow-up fallback (which has no control channel). */
     answer_text: string;
+    /** How many of `answers` were filled in by the 30s auto-timeout rather
+     *  than the user, per SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
+     *  §2.5 — `0` for a fully manual submit, up to `answers.length` for a
+     *  fully timed-out one. A plain boolean would conflate "user answered
+     *  some, timeout filled the rest" with "user never touched anything,"
+     *  which matters for anyone auditing the transcript later. */
+    autoFilledCount: number;
 }
 
 interface AgentQuestionPanelProps {
@@ -61,6 +100,9 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
 
     const [minimized, setMinimized] = createSignal(false);
     const [state, setState] = createSignal<QState[]>([]);
+    /** Milliseconds left before the auto-timeout fires. See the timer effect
+     *  below (defined after `submit`, once all its dependencies exist). */
+    const [remainingMs, setRemainingMs] = createSignal(AUTO_TIMEOUT_MS);
 
     // Reset working state whenever the head question changes (new tool_use_id,
     // queue advance). Keyed on tool_use_id so we never inherit a prior
@@ -70,6 +112,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         void r?.tool_use_id; // touch so the effect re-runs on change
         setMinimized(false);
         setState((r?.questions ?? []).map(() => ({ selected: [], other: "" })));
+        setRemainingMs(AUTO_TIMEOUT_MS);
     });
 
     const setQ = (i: number, next: Partial<QState>) => {
@@ -108,7 +151,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         return r.questions.every((_, i) => questionAnswered(i));
     });
 
-    const buildOutcome = (): AnswerOutcome | null => {
+    const buildOutcome = (autoFilledCount: number): AnswerOutcome | null => {
         const r = request();
         if (!r) return null;
         const answers: AskUserQuestionAnswer[] = r.questions.map((q, i) => {
@@ -133,14 +176,66 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
             else if (q.multiSelect) answers_map[q.question] = s.selected;
             else answers_map[q.question] = s.selected[0] ?? "";
         });
-        return { tool_use_id: r.tool_use_id, answers, answers_map, answer_text };
+        return { tool_use_id: r.tool_use_id, answers, answers_map, answer_text, autoFilledCount };
     };
 
-    const submit = () => {
+    // `autoFilledCount` defaults to 0 — every manual call site (the Submit
+    // button, Enter-to-submit) leaves it unset. Only the timeout path below
+    // passes a non-zero count.
+    const submit = (autoFilledCount = 0) => {
         if (!allAnswered()) return;
-        const outcome = buildOutcome();
+        const outcome = buildOutcome(autoFilledCount);
         if (outcome) void props.onAnswer(outcome);
     };
+
+    // Fill in the recommended default for every question the user hasn't
+    // touched yet (per `questionAnswered`); questions already answered —
+    // fully or partially — are left exactly as-is. Returns how many
+    // questions were filled, for the transcript's audit trail (§2.5 of the
+    // spec). Called only from the timeout below, never on manual submit.
+    const applyRecommendedDefaults = (): number => {
+        const r = request();
+        if (!r) return 0;
+        let count = 0;
+        r.questions.forEach((q, i) => {
+            if (questionAnswered(i)) return;
+            count++;
+            setQ(i, { selected: recommendedOptions(q.options).map((o) => o.label), other: "" });
+        });
+        return count;
+    };
+
+    // 30s auto-timeout: fires unconditionally at zero, regardless of any
+    // interaction so far. Deliberately NOT disarmed on the first click/
+    // keystroke — an earlier design did that, and it was rejected because it
+    // directly undercuts the feature's own goal ("work does not stop"): a
+    // user who answers one question in a multi-question set and then steps
+    // away would otherwise cancel the safety net entirely, leaving the rest
+    // blocked forever. Instead, `applyRecommendedDefaults` merges — anything
+    // the user already answered survives untouched. See
+    // docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §5.1.
+    //
+    // A separate effect (rather than folding into the reset effect above)
+    // because it depends on `submit`/`applyRecommendedDefaults`, which in
+    // turn depend on `setQ`/`questionAnswered`/`allAnswered` — keeping the
+    // reset effect's own dependencies minimal and unchanged.
+    createEffect(() => {
+        const r = request();
+        void r?.tool_use_id; // touch so the effect re-runs on change, same as the reset effect
+        if (!r) return;
+
+        const intervalId = setInterval(() => {
+            setRemainingMs((prev) => {
+                if (prev <= 1000) {
+                    clearInterval(intervalId);
+                    submit(applyRecommendedDefaults());
+                    return 0;
+                }
+                return prev - 1000;
+            });
+        }, 1000);
+        onCleanup(() => clearInterval(intervalId));
+    });
 
     const defer = () => {
         setMinimized(true);
@@ -200,6 +295,16 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         onCleanup(() => window.removeEventListener("keydown", onWindowKey, true));
     });
 
+    const countdownSeconds = () => Math.ceil(remainingMs() / 1000);
+    /** Color-escalation band for the countdown chip. Thresholds/tokens per
+     *  SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §2.4/§5.3. */
+    const countdownSeverity = (): "default" | "warning" | "critical" => {
+        const s = countdownSeconds();
+        if (s <= 5) return "critical";
+        if (s <= 10) return "warning";
+        return "default";
+    };
+
     return (
         <Show when={request()} keyed>
             {(r) => (
@@ -214,6 +319,15 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                         >
                             <span class="agent-question-panel-icon" aria-hidden="true">❓</span>
                             <span>Question waiting</span>
+                            <span
+                                class="agent-question-panel-countdown"
+                                classList={{
+                                    "agent-question-panel-countdown--warning": countdownSeverity() === "warning",
+                                    "agent-question-panel-countdown--critical": countdownSeverity() === "critical",
+                                }}
+                            >
+                                auto-selects in {countdownSeconds()}s
+                            </span>
                             <span class="agent-question-panel-minimized-cta">click to answer</span>
                         </button>
                     }
@@ -233,6 +347,15 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                             <Show when={queueDepth() > 1}>
                                 <span class="agent-question-panel-queue">+{queueDepth() - 1} more</span>
                             </Show>
+                            <span
+                                class="agent-question-panel-countdown"
+                                classList={{
+                                    "agent-question-panel-countdown--warning": countdownSeverity() === "warning",
+                                    "agent-question-panel-countdown--critical": countdownSeverity() === "critical",
+                                }}
+                            >
+                                Auto-selects recommended in {countdownSeconds()}s
+                            </span>
                         </div>
 
                         <For each={r.questions}>
@@ -247,10 +370,19 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                                             {(opt) => {
                                                 const checked = () =>
                                                     state()[qi()]?.selected.includes(opt.label) ?? false;
+                                                // Highlight which option(s) the 30s auto-timeout would pick,
+                                                // so a watching user can predict the outcome before it
+                                                // happens. Display-neutral: the label text itself (including
+                                                // any "(Recommended)" suffix) is unchanged.
+                                                const recommended = () =>
+                                                    recommendedOptions(q.options).some((o) => o.label === opt.label);
                                                 return (
                                                     <label
                                                         class="agent-question-panel-option"
-                                                        classList={{ "agent-question-panel-option--checked": checked() }}
+                                                        classList={{
+                                                            "agent-question-panel-option--checked": checked(),
+                                                            "agent-question-panel-option--recommended": recommended(),
+                                                        }}
                                                     >
                                                         <input
                                                             type={q.multiSelect ? "checkbox" : "radio"}
@@ -295,7 +427,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                                 type="button"
                                 class="agent-question-panel-btn agent-question-panel-btn--submit"
                                 disabled={!allAnswered()}
-                                onClick={submit}
+                                onClick={() => submit()}
                             >
                                 Submit answer
                             </button>

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -193,6 +193,18 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     // fully or partially — are left exactly as-is. Returns how many
     // questions were filled, for the transcript's audit trail (§2.5 of the
     // spec). Called only from the timeout below, never on manual submit.
+    //
+    // GUARANTEES every question is answered by the time this returns — even
+    // a malformed AskUserQuestion with a zero-length `options` array (so
+    // `recommendedOptions` has nothing to select) falls back to a free-text
+    // placeholder. This matters because the timer effect below clears its
+    // interval unconditionally before calling `submit()`: if a question
+    // came back from this function still unanswered, `submit()`'s
+    // `allAnswered()` gate would silently no-op and — with the interval
+    // already gone — the panel would be stuck forever with no further
+    // timeout retry, defeating the whole "work never stalls" guarantee for
+    // exactly the unattended-run case this feature exists to protect
+    // (reagent P1, PR #2441).
     const applyRecommendedDefaults = (): number => {
         const r = request();
         if (!r) return 0;
@@ -200,7 +212,15 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         r.questions.forEach((q, i) => {
             if (questionAnswered(i)) return;
             count++;
-            setQ(i, { selected: recommendedOptions(q.options).map((o) => o.label), other: "" });
+            const recommended = recommendedOptions(q.options);
+            if (recommended.length > 0) {
+                setQ(i, { selected: recommended.map((o) => o.label), other: "" });
+            } else {
+                // No options at all to recommend — leave a free-text note
+                // rather than an unanswerable blank, so `allAnswered()`
+                // passes and the merged outcome can still submit.
+                setQ(i, { selected: [], other: "No option was available to auto-select" });
+            }
         });
         return count;
     };

--- a/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
@@ -97,6 +97,7 @@ describe("useAgentQuestions — handleAnswer fallback", () => {
             answers: [],
             answers_map: { "Pick one": "a" },
             answer_text: "Pick one: a",
+            autoFilledCount: 0,
         });
         await Promise.resolve();
         await Promise.resolve();
@@ -122,6 +123,7 @@ describe("useAgentQuestions — handleAnswer fallback", () => {
             answers: [],
             answers_map: { "Pick one": "a" },
             answer_text: "Pick one: a",
+            autoFilledCount: 0,
         });
         await Promise.resolve();
         await Promise.resolve();
@@ -160,6 +162,7 @@ describe("useAgentQuestions — handleAnswer fallback", () => {
             answers: [],
             answers_map: { "Pick one": "a" },
             answer_text: "Pick one: a",
+            autoFilledCount: 0,
         });
         await Promise.resolve();
         await Promise.resolve();
@@ -185,6 +188,7 @@ describe("useAgentQuestions — handleAnswer fallback", () => {
             answers: [],
             answers_map: { "Pick one": "a" },
             answer_text: "Pick one: a",
+            autoFilledCount: 0,
         });
         await Promise.resolve();
         await Promise.resolve();

--- a/frontend/app/view/agent/hooks/useAgentQuestions.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.ts
@@ -110,6 +110,20 @@ export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuest
         // Optimistic transition: flip the node out of awaiting_answer so the
         // panel dismisses immediately. We snapshot the original node(s) so a
         // failed delivery can roll the transition back.
+        //
+        // The transcript summary prefix distinguishes three bands by how
+        // much of this outcome came from the 30s auto-timeout rather than
+        // the user (SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §2.5):
+        // a plain boolean would have conflated "user answered some
+        // questions, the timeout filled the rest" with "user never touched
+        // anything," which matters for anyone auditing the transcript later.
+        const flatText = outcome.answer_text.replace(/\n/g, "; ");
+        const summary =
+            outcome.autoFilledCount === 0
+                ? `❓ Answered — ${flatText}`
+                : outcome.autoFilledCount === outcome.answers.length
+                  ? `⏱️ Auto-answered (no response in 30s) — ${flatText}`
+                  : `⏱️ Partly auto-answered (${outcome.autoFilledCount}/${outcome.answers.length} — no response in 30s) — ${flatText}`;
         const originals: ToolNode[] = [];
         const updated: ToolNode[] = [];
         for (const n of opts.getDocument()) {
@@ -120,7 +134,7 @@ export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuest
                 ...n,
                 status: "success",
                 question: undefined,
-                summary: `❓ Answered — ${outcome.answer_text.replace(/\n/g, "; ")}`,
+                summary,
             });
         }
         const applyDoc = (nodes: ToolNode[]) => {

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -588,7 +588,7 @@ type PermissionPreview =
  *
  * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
  */
-interface AskUserQuestionOption {
+export interface AskUserQuestionOption {
     label: string;
     description?: string;
 }


### PR DESCRIPTION
## Summary

An unanswered `AskUserQuestion` tool call blocks the agent's turn indefinitely today — there's no timeout anywhere in that path. This adds a 30s auto-timeout with a visible countdown so a pending question can never stall work forever.

- **Recommended-option detection.** No such flag exists in the wire schema, so it's heuristic: a `"(Recommended)"` suffix on the option label (Claude Code's own documented convention for this tool), falling back to the first listed option when nothing is flagged.
- **Merge at timeout, not disarm-on-interaction.** An earlier design disarmed the whole timer the moment the user touched anything — rejected during spec review because it directly undercuts the goal: a user who answers question 1 of a 2-question set and steps away would otherwise cancel the safety net entirely, leaving question 2 blocked forever. Instead, the timer always fires at 30s; at zero it only fills in whichever questions are still genuinely untouched, leaving anything the user already answered (even partially) exactly as-is.
- **Countdown UI** in both the full panel header and the minimized chip, with color escalation (`--warning-color` at ≤10s, `--error-color` + a subtle pulse at ≤5s) using the app's existing severity tokens. Recommended option(s) get a dashed highlight so a watching user can predict the outcome.
- **Audit trail, no wire-format change.** The answer delivered to the agent is identical in shape to a manual one — same `answers_map`/`answer_text`, no backend change. A new `autoFilledCount` on `AnswerOutcome` only feeds the local transcript summary, distinguishing fully-manual / partly-auto / fully-auto so anyone reviewing later can tell how much of an answer was actually a human choice.

Spec (design decisions + rationale, including why the disarm-on-interaction design was rejected): `docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md`

## Test plan
- [x] New unit tests: `recommendedOptions()` (flagged/case-insensitive/multi-flag/fallback/empty), full-idle auto-submit, merge case (one question answered, one auto-filled), manual-submit-before-30s prevents any later auto-submit, countdown decrements exactly once per second to 0
- [x] `npx vitest run` — full suite: 2343 passed / 3 skipped, no regressions
- [x] `npx tsc --noEmit` — clean
- [x] Manually caught and fixed a real bug during testing: the Submit button's `onClick={submit}` was passing the click `PointerEvent` as `submit`'s new `autoFilledCount` parameter — fixed to `onClick={() => submit()}`

<!-- agentmux:agent_id=agent2 -->