### PR TITLE
fix(login): widen login PTY so the OAuth URL never wraps, restyle the login card

### DIFF
--- a/.changesets/1786089201-fix-login-widen-the-login-pty-so-the-oauth-url-never-h-x7q2.md
+++ b/.changesets/1786089201-fix-login-widen-the-login-pty-so-the-oauth-url-never-h-x7q2.md
@@ -1,0 +1,11 @@
+---
+type: patch
+---
+
+fix(login): widen the login PTY so the OAuth URL never hard-wraps, and restyle the in-app login card
+
+Two follow-ups to #2429/#2436:
+
+1. **The `client_id` truncation bug wasn't actually fixed by the earlier OSC-8 priority change.** A live capture showed the Claude CLI doesn't emit an OSC-8 hyperlink for this URL at all (only an OSC-0 window-title sequence) — so `extract_url()`'s OSC-8 preference had nothing to prefer and kept falling through to the plain-text line, which the CLI's own renderer hard-wraps at the PTY's 80-column width, truncating the URL mid-query-string before `client_id` ever appears. The real fix: widen the login PTY to 4096 columns (both the Windows `PtySize` and Unix `winsize` spawn paths) so the CLI's line-wrapping never kicks in. Confirmed live: the captured URL is no longer split across `[login-pty]` log lines, and login completes successfully end-to-end. The OSC-8 preference is left in place as defense-in-depth for CLIs that do emit one.
+
+2. **Restyled the login card in the agent pane** to match `AgentQuestionPanel`'s look: bordered/shadowed card chrome (it previously rendered as bare, unbordered text — every other caller of `InAppLoginPanel` gets its box from a wrapping `Modal`, which this bottom-docked context doesn't have), each step ("Authorize in your browser" / "Paste the authorization code") boxed as a distinct section, and the backup URL now renders as a fully-visible wrapped block instead of a single-line ellipsis-truncated one.

--- a/agentmux-cef/src/commands/cli_login.rs
+++ b/agentmux-cef/src/commands/cli_login.rs
@@ -445,7 +445,12 @@ fn spawn_login_pty_unix(
     let mut slave_fd: libc::c_int = -1;
     let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
     ws.ws_row = 24;
-    ws.ws_col = 80;
+    // Wide enough that the CLI's own line-wrapping never wraps the OAuth
+    // URL — see the matching Windows PtySize comment above for why (no
+    // OSC-8 hyperlink in the wild; the plain-text URL line hard-wraps at
+    // the reported column width and extract_url() only sees a truncated
+    // fragment).
+    ws.ws_col = 4096;
     let rc = unsafe {
         libc::openpty(
             &mut master_fd,
@@ -686,7 +691,15 @@ async fn run_cli_login_pty(
         let pair = pty_system
             .openpty(PtySize {
                 rows: 24,
-                cols: 80,
+                // Wide enough that the CLI's own line-wrapping never wraps
+                // the OAuth URL. At 80 cols it did — Claude Code prints
+                // "If the browser didn't open, visit: <url>" as plain text
+                // (no OSC-8 hyperlink in the wild, despite an earlier
+                // synthetic probe suggesting otherwise) and hard-wraps it
+                // mid-query-string, so extract_url() only ever saw a
+                // truncated fragment missing client_id and everything after
+                // it. 4096 comfortably covers any realistic query string.
+                cols: 4096,
                 pixel_width: 0,
                 pixel_height: 0,
             })
@@ -1041,12 +1054,17 @@ fn redact_url_query(url: &str) -> String {
 fn extract_url(line: &str) -> Option<String> {
     // Strip ANSI escapes. Two families matter here:
     //   * CSI  — `ESC [ … <final 0x40..=0x7e>` (colors, cursor moves)
-    //   * OSC  — `ESC ] … (BEL | ST)` — notably OSC-8 hyperlinks, which the
-    //     Claude CLI emits. OSC-8 embeds the URL in the sequence params AND
-    //     repeats it as visible link text, so a naive pass that only knew CSI
-    //     left the raw `]8;;https://…<BEL>` in place and captured the URL
-    //     twice (doubled), producing a broken link. We discard the OSC
-    //     sequence but stash any URI it carried as a fallback.
+    //   * OSC  — `ESC ] … (BEL | ST)` — the Claude CLI can, in principle,
+    //     emit an OSC-8 hyperlink here (embeds the URL in the sequence
+    //     params AND repeats it as visible link text), though a live
+    //     capture under the fixed PTY (see cols comment in run_cli_login)
+    //     only ever showed an OSC-0 window-title sequence, no OSC-8 — so
+    //     this is defense-in-depth, not the thing that actually fixed
+    //     #2429's client_id truncation (the PTY width did). A naive pass
+    //     that only knew CSI left the raw `]8;;https://…<BEL>` in place and
+    //     captured the URL twice (doubled) whenever OSC-8 IS present, so we
+    //     still discard the OSC sequence but stash any URI it carried as a
+    //     fallback.
     let mut clean = String::with_capacity(line.len());
     let mut osc_uris: Vec<String> = Vec::new();
     let bytes = line.as_bytes();

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -239,14 +239,23 @@ export function AgentAuthPanel(props: AgentAuthPanelProps): JSX.Element {
         <>
             <Show when={props.authUrl?.()}>
                 {(url) => (
-                    <InAppLoginPanel
-                        providerId={props.authProviderId ?? ""}
-                        providerLabel={PROVIDERS[props.authProviderId ?? ""]?.displayName ?? props.authProviderId ?? "provider"}
-                        authUrl={url()}
-                        phase={toInAppLoginPhase(url(), props.launchPhase?.() ?? null)}
-                        onCancel={() => props.onCancelLogin?.()}
-                        onUseTerminal={() => props.onUseTerminal?.()}
-                    />
+                    // AgentQuestionPanel-style card chrome (border/bg/shadow) —
+                    // InAppLoginPanel itself ships with none, since its other
+                    // two callers (PreLaunchAuthPanel, the Armory/Stash Modal)
+                    // already provide their own box. This is the one context
+                    // that renders it bare in normal document flow, so it
+                    // needs its own card here to read as a distinct prompt
+                    // instead of loose, unbordered text.
+                    <div class="agent-auth-panel-card">
+                        <InAppLoginPanel
+                            providerId={props.authProviderId ?? ""}
+                            providerLabel={PROVIDERS[props.authProviderId ?? ""]?.displayName ?? props.authProviderId ?? "provider"}
+                            authUrl={url()}
+                            phase={toInAppLoginPhase(url(), props.launchPhase?.() ?? null)}
+                            onCancel={() => props.onCancelLogin?.()}
+                            onUseTerminal={() => props.onUseTerminal?.()}
+                        />
+                    </div>
                 )}
             </Show>
             <Show when={props.authNotice?.()}>

--- a/frontend/app/view/agent/components/InAppLoginPanel.tsx
+++ b/frontend/app/view/agent/components/InAppLoginPanel.tsx
@@ -113,92 +113,104 @@ export const InAppLoginPanel = (p: InAppLoginPanelProps): JSX.Element => {
             >
                 {(url) => (
                     <>
-                        <div class="pre-launch-auth-panel-url-label">
-                            1 · Authorize in your browser (it should have opened — if not, use this link):
+                        <div class="pre-launch-auth-panel-step">
+                            <div class="pre-launch-auth-panel-url-label">
+                                1 · Authorize in your browser
+                            </div>
+                            <div class="pre-launch-auth-panel-hint">
+                                Your browser should have opened automatically. If it didn't, copy this backup link and open it manually:
+                            </div>
+                            <div class="pre-launch-auth-panel-url-row">
+                                <code class="pre-launch-auth-panel-url-text" title={url()}>
+                                    {url()}
+                                </code>
+                            </div>
+                            <div class="pre-launch-auth-panel-url-actions">
+                                <Button
+                                    className="grey solid"
+                                    onClick={() => {
+                                        try {
+                                            getApi().openExternal(url());
+                                        } catch (e) {
+                                            console.warn(`[auth-diag] openExternal failed: ${(e as Error)?.message ?? String(e)}`);
+                                        }
+                                    }}
+                                >
+                                    Open link
+                                </Button>
+                                <Button
+                                    className="grey solid"
+                                    onClick={() => {
+                                        // CEF clipboard wrapper, not navigator.clipboard —
+                                        // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
+                                        void clipboardWriteText(url()).catch((err) =>
+                                            console.log("clipboard write failed", err),
+                                        );
+                                    }}
+                                >
+                                    Copy link
+                                </Button>
+                            </div>
                         </div>
-                        <div class="pre-launch-auth-panel-url-row">
-                            <code class="pre-launch-auth-panel-url-text" title={url()}>
-                                {url()}
-                            </code>
-                            <Button
-                                className="grey solid"
-                                onClick={() => {
-                                    try {
-                                        getApi().openExternal(url());
-                                    } catch (e) {
-                                        console.warn(`[auth-diag] openExternal failed: ${(e as Error)?.message ?? String(e)}`);
-                                    }
-                                }}
-                            >
-                                Open
-                            </Button>
-                            <Button
-                                className="grey solid"
-                                onClick={() => {
-                                    // CEF clipboard wrapper, not navigator.clipboard —
-                                    // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
-                                    void clipboardWriteText(url()).catch((err) =>
-                                        console.log("clipboard write failed", err),
-                                    );
-                                }}
-                            >
-                                Copy
-                            </Button>
+                        <div class="pre-launch-auth-panel-step">
+                            <div class="pre-launch-auth-panel-url-label">
+                                2 · Paste the authorization code
+                            </div>
+                            <div class="pre-launch-auth-panel-hint">
+                                After you authorize, the page shows a code — paste it here:
+                            </div>
+                            <div class="pre-launch-auth-panel-callback-row">
+                                <input
+                                    ref={inputRef}
+                                    class="pre-launch-auth-panel-url-input"
+                                    type="text"
+                                    placeholder="Paste the authorization code…"
+                                    value={pasteCode()}
+                                    onInput={(e) => setPasteCode(e.currentTarget.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter") void submitCode();
+                                    }}
+                                    onPaste={(e) => {
+                                        // Auto-submit on paste — pasting the code IS the
+                                        // intent to submit (same UX as AuthUrlBox).
+                                        const text = (e.clipboardData?.getData("text") ?? "").trim();
+                                        if (text) {
+                                            setPasteCode(text);
+                                            void submitCode(text);
+                                        }
+                                    }}
+                                />
+                                <Button
+                                    className="grey solid"
+                                    title="Paste from clipboard and submit"
+                                    onClick={() => {
+                                        clipboardReadText()
+                                            .then((text) => {
+                                                const trimmed = (text ?? "").trim();
+                                                if (trimmed) {
+                                                    setPasteCode(trimmed);
+                                                    void submitCode(trimmed);
+                                                }
+                                            })
+                                            .catch(() => {
+                                                setPasteResult("Could not read clipboard — paste manually");
+                                            });
+                                    }}
+                                >
+                                    Paste &amp; submit
+                                </Button>
+                                <Button
+                                    className="grey solid"
+                                    onClick={() => void submitCode()}
+                                    disabled={pasting()}
+                                >
+                                    {pasting() ? "…" : "Submit"}
+                                </Button>
+                            </div>
+                            <Show when={pasteResult()}>
+                                <div class="pre-launch-auth-panel-hint">{pasteResult()}</div>
+                            </Show>
                         </div>
-                        <div class="pre-launch-auth-panel-url-label">
-                            2 · If the page shows an authorization code, paste it here:
-                        </div>
-                        <div class="pre-launch-auth-panel-callback-row">
-                            <input
-                                ref={inputRef}
-                                class="pre-launch-auth-panel-url-input"
-                                type="text"
-                                placeholder="Paste the authorization code…"
-                                value={pasteCode()}
-                                onInput={(e) => setPasteCode(e.currentTarget.value)}
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") void submitCode();
-                                }}
-                                onPaste={(e) => {
-                                    // Auto-submit on paste — pasting the code IS the
-                                    // intent to submit (same UX as AuthUrlBox).
-                                    const text = (e.clipboardData?.getData("text") ?? "").trim();
-                                    if (text) {
-                                        setPasteCode(text);
-                                        void submitCode(text);
-                                    }
-                                }}
-                            />
-                            <Button
-                                className="grey solid"
-                                title="Paste from clipboard and submit"
-                                onClick={() => {
-                                    clipboardReadText()
-                                        .then((text) => {
-                                            const trimmed = (text ?? "").trim();
-                                            if (trimmed) {
-                                                setPasteCode(trimmed);
-                                                void submitCode(trimmed);
-                                            }
-                                        })
-                                        .catch(() => {
-                                            setPasteResult("Could not read clipboard — paste manually");
-                                        });
-                                }}
-                            >
-                                Paste &amp; submit
-                            </Button>
-                            <Button
-                                className="grey solid"
-                                onClick={() => void submitCode()}
-                                disabled={pasting()}
-                            >
-                                {pasting() ? "…" : "Submit"}
-                            </Button>
-                        </div>
-                        <Show when={pasteResult()}>
-                            <div class="pre-launch-auth-panel-hint">{pasteResult()}</div>
-                        </Show>
                     </>
                 )}
             </Show>

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.scss
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.scss
@@ -84,12 +84,34 @@
     }
 }
 
+// Bordered sub-section for each numbered step (URL / paste-code) — mirrors
+// AgentQuestionPanel's per-question fieldset treatment so the login panel
+// reads as organized steps instead of one flat block of text.
+.pre-launch-auth-panel-step {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+    padding: var(--space-2) var(--space-2-5, var(--space-2));
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm, 0);
+
+    & + & {
+        margin-top: var(--space-1);
+    }
+}
+
 .pre-launch-auth-panel-url-row {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--space-2);
     min-width: 0;
+}
+
+.pre-launch-auth-panel-url-actions {
+    display: flex;
+    flex-direction: row;
+    gap: var(--space-2);
 }
 
 .pre-launch-auth-panel-callback-row {
@@ -113,13 +135,13 @@
     color: var(--secondary-text-color);
 }
 
-// The captured OAuth URL. One line, ellipsis-truncate so a 500-char
-// state= query string doesn't blow the panel layout. The full URL is
-// in the `title` attr for hover-reveal; clicking Copy grabs the
-// full value from the underlying signal.
+// The captured OAuth URL — this IS the backup link a user copies when the
+// browser didn't open, so it must be fully readable, not hidden behind a
+// hover tooltip. Wraps across lines (a 500-char state= query string can run
+// long) instead of the old single-line ellipsis-truncation.
 .pre-launch-auth-panel-url-text {
-    flex: 1 1 auto;
-    min-width: 0;
+    display: block;
+    width: 100%;
     padding: var(--space-2) var(--space-3);
     background-color: var(--input-bg, rgba(255, 255, 255, 0.04));
     border: 1px solid var(--border-color);
@@ -127,10 +149,9 @@
     color: var(--main-text-color);
     font-family: var(--mono-font-family);
     font-size: 12px;
-    line-height: 1.3;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    line-height: 1.4;
+    white-space: normal;
+    word-break: break-all;
     user-select: text;
 }
 

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -7,6 +7,21 @@
 // into the shell terminal (see agent-view.tsx's `log`/`handleShellTermReady`)
 // instead of a separate styled panel.
 .agent-view {
+    // Card chrome for AgentAuthPanel's InAppLoginPanel — mirrors
+    // .agent-question-panel's floating-card treatment (accent border,
+    // modal-bg background, shadow) so the bottom-docked login prompt reads
+    // as a distinct card next to AgentQuestionPanel/AgentDecisionPanel,
+    // instead of bare unbordered text (see #2429 follow-up).
+    .agent-auth-panel-card {
+        margin: var(--space-2) 0;
+        padding: var(--space-3);
+        background: var(--modal-bg-color, #232323);
+        border: 1px solid var(--accent-color);
+        border-radius: var(--radius-md, 0);
+        box-shadow: var(--shadow-lg, 0 12px 24px rgba(0, 0, 0, 0.35));
+        color: var(--main-text-color);
+    }
+
     // Auth-recovery error notice: shown when a login action failed visibly
     // (e.g. no OAuth URL could be captured, so no browser opened).
     .agent-auth-notice {


### PR DESCRIPTION
## Summary

Follow-up to #2436. User live-tested the merged fix and reported the captured URL was still truncated (`https://claude.com/cai/oauth/authorize?code=t`) — identical to the pre-#2436 symptom.

**Root cause of the persisting bug:** my earlier fix in #2436 made `extract_url()` prefer an OSC-8 hyperlink URI over the wrapped plain-text line, on the assumption the Claude CLI emits one. A live capture from this session shows it does **not** — the actual output only contains an OSC-0 window-title sequence, never OSC-8. So that fix had nothing to prefer and kept falling through to the plain-text `"If the browser didn't open, visit: ..."` line, which the CLI's own renderer hard-wraps at the PTY's 80-column width, truncating the URL before `client_id` (and everything after it).

**The real fix:** widen the login PTY from 80 to 4096 columns, on both the Windows (`PtySize`) and Unix (`winsize`) spawn paths in `agentmux-cef/src/commands/cli_login.rs`. With no width to wrap against, the CLI prints the URL on one line and `extract_url()` captures it whole. The OSC-8 preference from #2436 is left in place as defense-in-depth (harmless, and would help if a CLI version ever does emit one), with its doc comment corrected to not assert something not actually observed.

**Also restyled the in-app login card** in the agent pane (user feedback: it looked unorganized compared to `AgentQuestionPanel`). Root cause: every other caller of `InAppLoginPanel` gets box chrome for free — wrapped in `.pre-launch-auth-panel` in the launch modal, or inside a `Modal` dialog for Armory/Stash — but the new bottom-docked `AgentAuthPanel` context (from #2436) rendered it completely bare. Added a card wrapper matching `AgentQuestionPanel`'s bordered/shadowed treatment, boxed each step ("Authorize in your browser" / "Paste the authorization code") as a distinct section, and changed the backup URL from single-line ellipsis-truncated text to a fully visible wrapped block — that URL is the whole point of the backup-link affordance, so it needs to actually be readable/copyable.

## Test plan

- [x] `cargo check -p agentmux-cef` — clean
- [x] `cargo test -p agentmux-cef cli_login` — 25/25 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` on the login/auth-status test files — 30/30 passing
- [x] **Live-verified in a rebuilt dev instance**: captured URL log shows zero wrapped continuation fragments (previously always 3-4 follow-up `[login-pty]` lines), and login completes end-to-end (`Login successful` → credentials written)
- [x] User confirmed the login flow and restyled card look correct

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->