### PR TITLE
fix(agent-pane): flush AskQuestion/disconnected-banner margins and remove scrollbar padding gap

### DIFF
--- a/.changesets/1786093177-fix-agent-pane-flush-askquestion-disconnected-banner-margins-293h.md
+++ b/.changesets/1786093177-fix-agent-pane-flush-askquestion-disconnected-banner-margins-293h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): flush AskQuestion/disconnected-banner margins and remove scrollbar padding gap

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1480,6 +1480,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         <div
             ref={rootRef}
             class="agent-view agent-view--presentation"
+            classList={{ "agent-view--working-row-visible": workingRowVisible() }}
             style={{ zoom: zoomFactor(), "--agent-pane-zoom": String(zoomFactor()) }}
             onContextMenu={handleContextMenu}
             tabIndex={-1}

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -37,23 +37,42 @@
 
     // When AgentWorkingRow is visible, its color reaches this box's true
     // bottom edge (.agent-working-row-backdrop above). Whichever
-    // interposing row renders immediately after this box in the DOM —
-    // AgentQuestionPanel or the disconnected banner, the only two of the
+    // interposing row ends up adjacent to it — AgentAuthPanel,
+    // AgentQuestionPanel, or the disconnected banner, the three
     // normal-flow rows between here and the composer that carry their own
     // top margin for standalone breathing room — should sit flush against
     // that color instead of leaving their usual gap, matching how the row
     // already sits flush above the composer. Scoped to
     // .agent-view--working-row-visible (agent-view.tsx, driven by the same
     // workingRowVisible() memo that gates the row itself) so this only
-    // applies in that specific combined state — AgentQuestionPanel (etc.)
-    // appearing on its own, with no active working row above it, keeps its
-    // normal margin unchanged. AgentDecisionPanel/the retry bar/the
-    // pending-message queue are unaffected: they only ever add a border,
-    // not a margin, in this direction, so they already sit flush.
+    // applies in that specific combined state — these panels appearing on
+    // their own, with no active working row above them, keep their normal
+    // margin unchanged. AgentDecisionPanel/the retry bar/the
+    // pending-message queue/PaneRow-based rows (AgentCredentialsRevokedChip,
+    // the failure-recovery pin)/ActivityDock are unaffected: they only
+    // ever add a border, not a margin, in this direction, so they already
+    // sit flush against whatever ends up next to them.
+    //
+    // ~ (general sibling), not + (adjacent) — reagent P2 on the re-review:
+    // AgentAuthPanel, the retry bar, PendingMessagesPanel,
+    // AgentCredentialsRevokedChip, or the failure-recovery PaneRow can all
+    // legitimately render between .agent-document-scroll-region and the
+    // target panel (e.g. a disconnected stream with a queued message, or
+    // an auth retry with a pending question), and + only matches when the
+    // target is the LITERAL next element — any border-only row (all of
+    // the above except AgentAuthPanel) rendering in between would
+    // otherwise silently reintroduce the gap, same class of bug as the
+    // bottom-margin fix below. AgentAuthPanel itself is included in this
+    // rule (not just an "in-between" row) because it's a genuinely
+    // plausible working-row co-occurrence — AgentWorkingRow's own loading
+    // condition already covers launch/auth activity (showingLaunchActivity()) —
+    // and, unlike the border-only rows, it carries a real top margin
+    // (PreLaunchAuthPanel.scss) that needed the same fix.
     &.agent-view--working-row-visible {
-        .agent-document-scroll-region + .agent-question-panel,
-        .agent-document-scroll-region + .agent-question-panel-minimized,
-        .agent-document-scroll-region + .agent-disconnected-banner {
+        .agent-document-scroll-region ~ .pre-launch-auth-panel,
+        .agent-document-scroll-region ~ .agent-question-panel,
+        .agent-document-scroll-region ~ .agent-question-panel-minimized,
+        .agent-document-scroll-region ~ .agent-disconnected-banner {
             margin-top: 0;
         }
     }
@@ -83,9 +102,14 @@
     // banner's bottom margin never fights another row's own spacing;
     // AgentDecisionPanel needs no rule here either, since it never carries
     // a bottom margin to begin with (see the top-edge comment above).
+    // AgentAuthPanel included too — same real (non-border) margin as the
+    // other two, and it can be the only thing between the scroll region
+    // and the composer during a pure auth/login flow with nothing else
+    // pending.
     .agent-question-panel:has(~ .agent-composer-strip),
     .agent-question-panel-minimized:has(~ .agent-composer-strip),
-    .agent-disconnected-banner:has(~ .agent-composer-strip) {
+    .agent-disconnected-banner:has(~ .agent-composer-strip),
+    .pre-launch-auth-panel:has(~ .agent-composer-strip) {
         margin-bottom: 0;
     }
 

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -60,19 +60,32 @@
 
     // Same shape at the OTHER end: AgentQuestionPanel/the disconnected
     // banner's own bottom margin (the same `margin: <space> 0` shorthand
-    // that caused the top-edge gap above) leaves a gap before
-    // AgentComposerStrip when it's the very next thing below — unrelated
-    // to the working row, so unconditional (unlike the top-edge fix
-    // above): the composer strip is always there, not something that
-    // only sometimes follows. Uses :has() to target the panel's own
-    // margin from a "what's my next sibling" condition, since CSS has no
+    // that caused the top-edge gap above) leaves a gap before whatever
+    // comes next — unrelated to the working row, so unconditional (unlike
+    // the top-edge fix above). Uses :has() to target the panel's own
+    // margin from a "what comes after me" condition, since CSS has no
     // parent/previous-sibling selector otherwise — already an accepted
     // pattern in this codebase (_pending-footer.scss, tabbar.scss, etc.).
-    // AgentDecisionPanel/the pending-message queue don't need this: they
-    // carry no bottom margin to begin with (see the comment above).
-    .agent-question-panel:has(+ .agent-composer-strip),
-    .agent-question-panel-minimized:has(+ .agent-composer-strip),
-    .agent-disconnected-banner:has(+ .agent-composer-strip) {
+    //
+    // ~ (general sibling), not + (adjacent) — reagent P2 caught the
+    // original + version: PendingMessagesPanel, AgentCredentialsRevokedChip
+    // (a PaneRow), the failure-recovery PaneRow, or ActivityDock can all
+    // legitimately render between AgentQuestionPanel and AgentComposerStrip
+    // (a pending question and a long-running shell are an entirely
+    // plausible combination), and + only matches when AgentComposerStrip
+    // is the LITERAL next element — any of those rendering in between
+    // silently defeated the fix. ~ matches regardless of what's between
+    // them. Safe unconditionally: every one of those possible in-between
+    // rows (.agent-pending-zone, .pane-row, .agent-activity-dock) carries
+    // its own border instead of a margin for spacing — same "pinned via
+    // border, not margin" convention .agent-pending-zone's own comment
+    // describes — so removing AgentQuestionPanel's/the disconnected
+    // banner's bottom margin never fights another row's own spacing;
+    // AgentDecisionPanel needs no rule here either, since it never carries
+    // a bottom margin to begin with (see the top-edge comment above).
+    .agent-question-panel:has(~ .agent-composer-strip),
+    .agent-question-panel-minimized:has(~ .agent-composer-strip),
+    .agent-disconnected-banner:has(~ .agent-composer-strip) {
         margin-bottom: 0;
     }
 

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -37,7 +37,7 @@
 
     // When AgentWorkingRow is visible, its color reaches this box's true
     // bottom edge (.agent-working-row-backdrop above). Whichever
-    // interposing row ends up adjacent to it — AgentAuthPanel,
+    // interposing row ends up adjacent to it — the auth-recovery notice,
     // AgentQuestionPanel, or the disconnected banner, the three
     // normal-flow rows between here and the composer that carry their own
     // top margin for standalone breathing room — should sit flush against
@@ -49,27 +49,37 @@
     // their own, with no active working row above them, keep their normal
     // margin unchanged. AgentDecisionPanel/the retry bar/the
     // pending-message queue/PaneRow-based rows (AgentCredentialsRevokedChip,
-    // the failure-recovery pin)/ActivityDock are unaffected: they only
-    // ever add a border, not a margin, in this direction, so they already
-    // sit flush against whatever ends up next to them.
+    // the failure-recovery pin)/ActivityDock/InAppLoginPanel
+    // (.pre-launch-auth-panel-waiting) are unaffected: they only ever add
+    // a border (or, for InAppLoginPanel, no spacing at all) rather than a
+    // margin in this direction, so they already sit flush against
+    // whatever ends up next to them.
     //
-    // ~ (general sibling), not + (adjacent) — reagent P2 on the re-review:
-    // AgentAuthPanel, the retry bar, PendingMessagesPanel,
+    // ~ (general sibling), not + (adjacent) — reagent P2 on round 1 of
+    // review: the retry bar, PendingMessagesPanel,
     // AgentCredentialsRevokedChip, or the failure-recovery PaneRow can all
     // legitimately render between .agent-document-scroll-region and the
     // target panel (e.g. a disconnected stream with a queued message, or
     // an auth retry with a pending question), and + only matches when the
-    // target is the LITERAL next element — any border-only row (all of
-    // the above except AgentAuthPanel) rendering in between would
-    // otherwise silently reintroduce the gap, same class of bug as the
-    // bottom-margin fix below. AgentAuthPanel itself is included in this
-    // rule (not just an "in-between" row) because it's a genuinely
-    // plausible working-row co-occurrence — AgentWorkingRow's own loading
-    // condition already covers launch/auth activity (showingLaunchActivity()) —
-    // and, unlike the border-only rows, it carries a real top margin
-    // (PreLaunchAuthPanel.scss) that needed the same fix.
+    // target is the LITERAL next element — any of those border-only rows
+    // rendering in between would otherwise silently reintroduce the gap,
+    // same class of bug as the bottom-margin fix below.
+    //
+    // .agent-auth-notice, not .pre-launch-auth-panel — reagent P1 on
+    // round 2: an earlier version of this rule targeted
+    // .pre-launch-auth-panel, which is dead CSS here. That class belongs
+    // to the separate PreLaunchAuthPanel component (AgentLaunchModal.tsx
+    // only, never a sibling of .agent-document-scroll-region) — an
+    // unrelated component with a confusingly similar name to the
+    // AgentAuthPanel actually rendered at agent-view.tsx:1654 (exported
+    // from AgentDocumentView.tsx). AgentAuthPanel renders either
+    // InAppLoginPanel (.pre-launch-auth-panel-waiting — no margin, needs
+    // no fix) or .agent-auth-notice (margin-top: var(--space-2) per
+    // _activity-log.scss — the actual element left with the unfixed gap,
+    // shown on a failed login where AgentWorkingRow's loading condition
+    // can still be true via showingLaunchActivity()).
     &.agent-view--working-row-visible {
-        .agent-document-scroll-region ~ .pre-launch-auth-panel,
+        .agent-document-scroll-region ~ .agent-auth-notice,
         .agent-document-scroll-region ~ .agent-question-panel,
         .agent-document-scroll-region ~ .agent-question-panel-minimized,
         .agent-document-scroll-region ~ .agent-disconnected-banner {
@@ -102,14 +112,12 @@
     // banner's bottom margin never fights another row's own spacing;
     // AgentDecisionPanel needs no rule here either, since it never carries
     // a bottom margin to begin with (see the top-edge comment above).
-    // AgentAuthPanel included too — same real (non-border) margin as the
-    // other two, and it can be the only thing between the scroll region
-    // and the composer during a pure auth/login flow with nothing else
-    // pending.
+    // .agent-auth-notice is not included here (unlike the top-edge fix
+    // above) — it only carries margin-top, no margin-bottom
+    // (_activity-log.scss), so there's no gap on this end to close.
     .agent-question-panel:has(~ .agent-composer-strip),
     .agent-question-panel-minimized:has(~ .agent-composer-strip),
-    .agent-disconnected-banner:has(~ .agent-composer-strip),
-    .pre-launch-auth-panel:has(~ .agent-composer-strip) {
+    .agent-disconnected-banner:has(~ .agent-composer-strip) {
         margin-bottom: 0;
     }
 

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -36,49 +36,36 @@
     }
 
     // When AgentWorkingRow is visible, its color reaches this box's true
-    // bottom edge (.agent-working-row-backdrop above). Whichever
-    // interposing row ends up adjacent to it — the auth-recovery notice,
-    // AgentQuestionPanel, or the disconnected banner, the three
-    // normal-flow rows between here and the composer that carry their own
-    // top margin for standalone breathing room — should sit flush against
-    // that color instead of leaving their usual gap, matching how the row
+    // bottom edge (.agent-working-row-backdrop above). The normal-flow
+    // rows between here and the composer that carry their own margin for
+    // standalone breathing room — AgentAuthPanel's two states
+    // (.agent-auth-panel-card during an active OAuth login,
+    // .agent-auth-notice after a failed one; both can co-occur with the
+    // working row, since AgentWorkingRow's own loading condition already
+    // covers launch/auth activity via showingLaunchActivity()),
+    // AgentQuestionPanel, and the disconnected banner — should sit flush
+    // against that color instead of leaving a gap, matching how the row
     // already sits flush above the composer. Scoped to
     // .agent-view--working-row-visible (agent-view.tsx, driven by the same
-    // workingRowVisible() memo that gates the row itself) so this only
-    // applies in that specific combined state — these panels appearing on
-    // their own, with no active working row above them, keep their normal
-    // margin unchanged. AgentDecisionPanel/the retry bar/the
-    // pending-message queue/PaneRow-based rows (AgentCredentialsRevokedChip,
-    // the failure-recovery pin)/ActivityDock/InAppLoginPanel
-    // (.pre-launch-auth-panel-waiting) are unaffected: they only ever add
-    // a border (or, for InAppLoginPanel, no spacing at all) rather than a
-    // margin in this direction, so they already sit flush against
-    // whatever ends up next to them.
+    // workingRowVisible() memo that gates the row itself) so a panel
+    // appearing on its own, with no active working row above it, keeps
+    // its normal margin. Every OTHER row that can appear in this stack —
+    // AgentDecisionPanel, the retry bar, PendingMessagesPanel,
+    // PaneRow-based rows (AgentCredentialsRevokedChip, the
+    // failure-recovery pin), ActivityDock, InAppLoginPanel's own root
+    // (.pre-launch-auth-panel-waiting) — needs no rule here: confirmed via
+    // their own CSS that they carry a border (or nothing) instead of a
+    // margin in this direction, so they're already flush against whatever
+    // ends up next to them.
     //
-    // ~ (general sibling), not + (adjacent) — reagent P2 on round 1 of
-    // review: the retry bar, PendingMessagesPanel,
-    // AgentCredentialsRevokedChip, or the failure-recovery PaneRow can all
-    // legitimately render between .agent-document-scroll-region and the
-    // target panel (e.g. a disconnected stream with a queued message, or
-    // an auth retry with a pending question), and + only matches when the
-    // target is the LITERAL next element — any of those border-only rows
-    // rendering in between would otherwise silently reintroduce the gap,
-    // same class of bug as the bottom-margin fix below.
-    //
-    // .agent-auth-notice, not .pre-launch-auth-panel — reagent P1 on
-    // round 2: an earlier version of this rule targeted
-    // .pre-launch-auth-panel, which is dead CSS here. That class belongs
-    // to the separate PreLaunchAuthPanel component (AgentLaunchModal.tsx
-    // only, never a sibling of .agent-document-scroll-region) — an
-    // unrelated component with a confusingly similar name to the
-    // AgentAuthPanel actually rendered at agent-view.tsx:1654 (exported
-    // from AgentDocumentView.tsx). AgentAuthPanel renders either
-    // InAppLoginPanel (.pre-launch-auth-panel-waiting — no margin, needs
-    // no fix) or .agent-auth-notice (margin-top: var(--space-2) per
-    // _activity-log.scss — the actual element left with the unfixed gap,
-    // shown on a failed login where AgentWorkingRow's loading condition
-    // can still be true via showingLaunchActivity()).
+    // ~ (general sibling), not + (adjacent): any of those border-only rows
+    // can legitimately render between .agent-document-scroll-region and
+    // the target panel (e.g. a disconnected stream with a queued message),
+    // and + only matches when the target is the LITERAL next element —
+    // reagent caught this fragility on round 1 for the bottom-margin rule
+    // below and on round 2 for this one.
     &.agent-view--working-row-visible {
+        .agent-document-scroll-region ~ .agent-auth-panel-card,
         .agent-document-scroll-region ~ .agent-auth-notice,
         .agent-document-scroll-region ~ .agent-question-panel,
         .agent-document-scroll-region ~ .agent-question-panel-minimized,
@@ -87,34 +74,22 @@
         }
     }
 
-    // Same shape at the OTHER end: AgentQuestionPanel/the disconnected
-    // banner's own bottom margin (the same `margin: <space> 0` shorthand
-    // that caused the top-edge gap above) leaves a gap before whatever
-    // comes next — unrelated to the working row, so unconditional (unlike
-    // the top-edge fix above). Uses :has() to target the panel's own
-    // margin from a "what comes after me" condition, since CSS has no
-    // parent/previous-sibling selector otherwise — already an accepted
-    // pattern in this codebase (_pending-footer.scss, tabbar.scss, etc.).
-    //
-    // ~ (general sibling), not + (adjacent) — reagent P2 caught the
-    // original + version: PendingMessagesPanel, AgentCredentialsRevokedChip
-    // (a PaneRow), the failure-recovery PaneRow, or ActivityDock can all
-    // legitimately render between AgentQuestionPanel and AgentComposerStrip
-    // (a pending question and a long-running shell are an entirely
-    // plausible combination), and + only matches when AgentComposerStrip
-    // is the LITERAL next element — any of those rendering in between
-    // silently defeated the fix. ~ matches regardless of what's between
-    // them. Safe unconditionally: every one of those possible in-between
-    // rows (.agent-pending-zone, .pane-row, .agent-activity-dock) carries
-    // its own border instead of a margin for spacing — same "pinned via
-    // border, not margin" convention .agent-pending-zone's own comment
-    // describes — so removing AgentQuestionPanel's/the disconnected
-    // banner's bottom margin never fights another row's own spacing;
-    // AgentDecisionPanel needs no rule here either, since it never carries
-    // a bottom margin to begin with (see the top-edge comment above).
-    // .agent-auth-notice is not included here (unlike the top-edge fix
-    // above) — it only carries margin-top, no margin-bottom
-    // (_activity-log.scss), so there's no gap on this end to close.
+    // Same shape at the OTHER end: these panels' own bottom margin (the
+    // same shorthand that caused the top-edge gap above) leaves a gap
+    // before whatever comes next — unrelated to the working row, so
+    // unconditional (unlike the top-edge fix above): the composer strip is
+    // always there eventually, not something that only sometimes follows.
+    // Uses :has() to target the panel's own margin from a "what comes
+    // after me" condition, since CSS has no parent/previous-sibling
+    // selector otherwise — already an accepted pattern in this codebase
+    // (_pending-footer.scss, tabbar.scss, etc.). ~ (general), not +
+    // (adjacent), for the same reason as the top-edge fix above — reagent
+    // P2 on the original + version. .agent-auth-notice is excluded here:
+    // it only carries margin-top, no margin-bottom (_activity-log.scss),
+    // so there's no gap on this end. AgentDecisionPanel needs no rule
+    // either, since it never carries a bottom margin to begin with (see
+    // the top-edge comment above).
+    .agent-auth-panel-card:has(~ .agent-composer-strip),
     .agent-question-panel:has(~ .agent-composer-strip),
     .agent-question-panel-minimized:has(~ .agent-composer-strip),
     .agent-disconnected-banner:has(~ .agent-composer-strip) {

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -35,6 +35,47 @@
         overflow: hidden; // .agent-document inside owns the real scrolling
     }
 
+    // When AgentWorkingRow is visible, its color reaches this box's true
+    // bottom edge (.agent-working-row-backdrop above). Whichever
+    // interposing row renders immediately after this box in the DOM —
+    // AgentQuestionPanel or the disconnected banner, the only two of the
+    // normal-flow rows between here and the composer that carry their own
+    // top margin for standalone breathing room — should sit flush against
+    // that color instead of leaving their usual gap, matching how the row
+    // already sits flush above the composer. Scoped to
+    // .agent-view--working-row-visible (agent-view.tsx, driven by the same
+    // workingRowVisible() memo that gates the row itself) so this only
+    // applies in that specific combined state — AgentQuestionPanel (etc.)
+    // appearing on its own, with no active working row above it, keeps its
+    // normal margin unchanged. AgentDecisionPanel/the retry bar/the
+    // pending-message queue are unaffected: they only ever add a border,
+    // not a margin, in this direction, so they already sit flush.
+    &.agent-view--working-row-visible {
+        .agent-document-scroll-region + .agent-question-panel,
+        .agent-document-scroll-region + .agent-question-panel-minimized,
+        .agent-document-scroll-region + .agent-disconnected-banner {
+            margin-top: 0;
+        }
+    }
+
+    // Same shape at the OTHER end: AgentQuestionPanel/the disconnected
+    // banner's own bottom margin (the same `margin: <space> 0` shorthand
+    // that caused the top-edge gap above) leaves a gap before
+    // AgentComposerStrip when it's the very next thing below — unrelated
+    // to the working row, so unconditional (unlike the top-edge fix
+    // above): the composer strip is always there, not something that
+    // only sometimes follows. Uses :has() to target the panel's own
+    // margin from a "what's my next sibling" condition, since CSS has no
+    // parent/previous-sibling selector otherwise — already an accepted
+    // pattern in this codebase (_pending-footer.scss, tabbar.scss, etc.).
+    // AgentDecisionPanel/the pending-message queue don't need this: they
+    // carry no bottom margin to begin with (see the comment above).
+    .agent-question-panel:has(+ .agent-composer-strip),
+    .agent-question-panel-minimized:has(+ .agent-composer-strip),
+    .agent-disconnected-banner:has(+ .agent-composer-strip) {
+        margin-bottom: 0;
+    }
+
     // === Document Container ===
     .agent-document {
         position: absolute;
@@ -44,7 +85,12 @@
         // top/bottom (e.g. OS-level swipe-navigation gestures). Nested tool
         // previews get their own `contain` too — see SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.
         overscroll-behavior: contain;
-        padding: var(--space-0-5) var(--space-1);
+        // Right padding removed: content used to wrap var(--space-1) (4px)
+        // short of the scrollbar track, reading as a small but visible gap
+        // between the conversation and the scrollbar. Left padding kept for
+        // the pane's own left-edge breathing room, which nobody reported
+        // an issue with.
+        padding: var(--space-0-5) 0 var(--space-0-5) var(--space-1);
         // Reserves exactly AgentWorkingRow's current rendered height (0 when
         // hidden) so scrolling to true bottom leaves the last message above
         // the floating row, not hidden underneath it. Set on


### PR DESCRIPTION
## Summary

Three related visual-continuity fixes in the agent pane, found while verifying #2439 (the Working row scrollbar-gap fix):

1. **AgentQuestionPanel/AgentDisconnectedBanner top margin vs. the Working row.** Both panels carry `margin: <space> 0` for standalone breathing room. When `AgentWorkingRow` is visible directly above them, that top margin left a gap between the row's now-continuous color (#2439) and the panel's top border. Zeroed via `.agent-document-scroll-region + <panel>`, scoped to a new `.agent-view--working-row-visible` class (driven by the same `workingRowVisible`/`workingRowLoading` memos the row itself uses — hoisted once, reused for both) so a panel appearing on its own, without an active working row above it, keeps its normal margin.
2. **Same panels' bottom margin vs. the composer strip.** Left a gap before `AgentComposerStrip` when it's the very next thing below — unconditional this time, since the composer strip is always there. Uses `:has()` to target the panel's own margin from a "what's my next sibling" condition (an existing pattern in this codebase — `_pending-footer.scss`, `tabbar.scss`, etc.).
3. **`.agent-document`'s right padding vs. its own scrollbar.** 4px (`var(--space-1)`) of right padding left conversation content wrapping short of the scrollbar track, reading as a small gap between content and scrollbar. Removed (left padding kept for the pane's own left-edge breathing room).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All three verified live via `task dev` + Vite HMR, confirmed by the user before commit: AskQuestion panel flush against the Working row's blue above and the composer strip's stats bar below; conversation text now reaches the scrollbar with no gap

<!-- agentmux:agent_id=agent3 -->