### PR TITLE
feat: split low-memory banner into independent RAM and Page File signals

### DIFF
--- a/.changesets/1786156343-feat-memory-split-low-memory-banner-into-independent-ram-and-53if.md
+++ b/.changesets/1786156343-feat-memory-split-low-memory-banner-into-independent-ram-and-53if.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(memory): split low-memory banner into independent RAM and Page File signals

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/agentmux-cef/src/memory_heartbeat.rs
+++ b/agentmux-cef/src/memory_heartbeat.rs
@@ -139,7 +139,12 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
 
                 let ram_free = phys_free_mb();
                 let ram_total = phys_total_mb();
-                let ram_transition = ram_pressure.observe(ram_free, ram_total);
+                // `observe_local`, not `observe` — the RAM tracker must not
+                // publish to the shared PRESSURE_LEVEL atomic `current_level()`
+                // reads, or a RAM-only transition would clobber the commit
+                // tracker's published level and silently defeat pane-pool
+                // shedding (reagent-caught P0 on this PR).
+                let ram_transition = ram_pressure.observe_local(ram_free, ram_total);
                 let ram_level_now = ram_pressure.level();
 
                 if let Some(level) = transition {
@@ -187,13 +192,17 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
                 // unchanged level and a re-assert never un-dismisses); a steady
                 // Normal stays silent, so there's no traffic in the common case.
                 if transition.is_some() || level_now != crate::memory_pressure::PressureLevel::Normal {
-                    let (system_managed, disk_free_pct) = pagefile_disk_context().unwrap_or((true, 100.0));
+                    // Pass the Option straight through -- a `None` (read
+                    // failure) must reach the frontend as "no disk context",
+                    // not get collapsed into a fabricated "healthy" default
+                    // here (reagent-caught P1: that previously produced the
+                    // reassuring "expands automatically" copy even while
+                    // pressure was Critical).
                     crate::ui_tasks::post_memory_pressure_pagefile(
                         &state,
                         level_now.as_str(),
                         free,
-                        system_managed,
-                        disk_free_pct,
+                        pagefile_disk_context(),
                     );
                 }
                 if ram_transition.is_some() || ram_level_now != crate::memory_pressure::PressureLevel::Normal {

--- a/agentmux-cef/src/memory_heartbeat.rs
+++ b/agentmux-cef/src/memory_heartbeat.rs
@@ -24,6 +24,28 @@ static COMMIT_FREE_MB: AtomicU64 = AtomicU64::new(u64::MAX);
 /// bar already gauges by ratio; the pressure classifier didn't, until now).
 static COMMIT_TOTAL_MB: AtomicU64 = AtomicU64::new(0);
 
+/// Latest observed **physical RAM** free/total in MB — `SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07`
+/// §3. Distinct from `COMMIT_FREE_MB`/`COMMIT_TOTAL_MB` above: commit is RAM +
+/// page file combined, so a machine can be tight on RAM while commit (backed
+/// by a healthy page file) stays comfortable, or vice versa — conflating the
+/// two is exactly the bug that spec fixes. Populated from the same
+/// `GlobalMemoryStatusEx` call `log_memory_stats()` already makes (`ullAvailPhys`/
+/// `ullTotalPhys`), so this costs no extra syscall.
+static PHYS_FREE_MB: AtomicU64 = AtomicU64::new(u64::MAX);
+static PHYS_TOTAL_MB: AtomicU64 = AtomicU64::new(0);
+
+/// Latest published physical-RAM-free reading, in MB. `u64::MAX` until the
+/// first sample (mirrors `COMMIT_FREE_MB`'s "treat as ample" convention).
+pub fn phys_free_mb() -> u64 {
+    PHYS_FREE_MB.load(Ordering::Relaxed)
+}
+
+/// Latest published physical-RAM-total reading, in MB. `0` until the first
+/// sample — `memory_pressure.rs` treats a zero total as "not yet known".
+pub fn phys_total_mb() -> u64 {
+    PHYS_TOTAL_MB.load(Ordering::Relaxed)
+}
+
 /// On-demand synchronous probe of system commit-free (available page file), in
 /// MB. ~microsecond cost (a single `GlobalMemoryStatusEx`). Republishes the
 /// atomic so `last_commit_free_mb()` stays fresh. On non-Windows returns
@@ -57,6 +79,34 @@ pub fn commit_total_mb() -> u64 {
     COMMIT_TOTAL_MB.load(Ordering::Relaxed)
 }
 
+/// Page-file disk/OS-managed context for the current tick:
+/// `(system_managed, disk_free_pct)` on the volume backing the page file.
+/// `None` on non-Windows or any read failure (fail-open — the banner then
+/// omits the disk-aware guidance rather than showing a wrong one).
+/// `SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07` §4: reuses
+/// `agentmux_common::pagefile`, the same implementation
+/// `agentmux-srv/src/backend/sysinfo.rs`'s StatusBar telemetry already
+/// calls, so the two processes can't independently drift on "system
+/// managed?" the way the commit-ratio classifier and the StatusBar gauge
+/// once did (issue #2218). Registry read is `OnceLock`-cached inside that
+/// module (once per process lifetime); the disk-free check is a real syscall
+/// but runs on this heartbeat's own dedicated thread, not the Tokio runtime
+/// `agentmux-srv` has to protect with `block_in_place` — safe to call
+/// directly every 20s tick.
+#[cfg(target_os = "windows")]
+fn pagefile_disk_context() -> Option<(bool, f64)> {
+    let (drive, system_managed) = agentmux_common::pagefile::pagefile_watch_target();
+    agentmux_common::pagefile::drive_free_total_gb(drive).map(|(free_gb, total_gb)| {
+        let free_pct = if total_gb > 0.0 { (free_gb / total_gb) * 100.0 } else { 0.0 };
+        (system_managed, free_pct)
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+fn pagefile_disk_context() -> Option<(bool, f64)> {
+    None
+}
+
 /// Spawn a background thread that logs memory stats at a fixed interval.
 /// Also refreshes the log pointer file on UTC date rollover.
 /// Runs for the lifetime of the process — no shutdown signal needed.
@@ -65,12 +115,18 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
         .name("mem-heartbeat".into())
         .spawn(move || {
             let mut last_date = String::new();
-            let mut pressure = crate::memory_pressure::PressureTracker::new();
+            // Two independent trackers (SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07
+            // §3/§4): `commit_pressure` is the original signal (RAM + page
+            // file combined) driving the pane-pool shedding response and the
+            // Page File banner; `ram_pressure` is new, physical-RAM-only,
+            // banner-only (no shedding — see the spec's §6 non-goals).
+            let mut commit_pressure = crate::memory_pressure::PressureTracker::new();
+            let mut ram_pressure = crate::memory_pressure::PressureTracker::new();
             loop {
                 std::thread::sleep(Duration::from_secs(20));
                 log_memory_stats();
-                // Feed the debounced memory-pressure tracker from the just-
-                // sampled commit-free; on a level transition, log it AND push
+                // Feed the debounced memory-pressure trackers from the just-
+                // sampled readings; on a level transition, log it AND push
                 // the new level to the frontend low-memory banner
                 // (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.A/§5.F). The
                 // emit is posted to the CEF UI thread (this is a background
@@ -78,14 +134,21 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
                 // return to Normal.
                 let free = commit_free_mb();
                 let total = commit_total_mb();
-                let transition = pressure.observe(free, total);
-                let level_now = pressure.level();
+                let transition = commit_pressure.observe(free, total);
+                let level_now = commit_pressure.level();
+
+                let ram_free = phys_free_mb();
+                let ram_total = phys_total_mb();
+                let ram_transition = ram_pressure.observe(ram_free, ram_total);
+                let ram_level_now = ram_pressure.level();
+
                 if let Some(level) = transition {
                     tracing::warn!(
                         target: "mem_pressure",
+                        kind = "pagefile",
                         level = level.as_str(),
                         commit_free_mb = free,
-                        "system memory pressure changed"
+                        "page file (commit) pressure changed"
                     );
                     // B.5 Part 1 (issue #2218): react to the transition, not
                     // just log it. Entering Warn/Critical trims the pane pool
@@ -95,13 +158,25 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
                     // transient pressure blip doesn't leave them starved for
                     // the rest of the session. Both spawn_* fns are already
                     // internally single-flight + target-size-gated, so calling
-                    // them unconditionally here is safe.
+                    // them unconditionally here is safe. Commit-only: RAM
+                    // pressure alone (with healthy commit) doesn't risk a
+                    // crash the way commit pressure does, so it doesn't
+                    // trigger shedding — SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §6.
                     if level != crate::memory_pressure::PressureLevel::Normal {
                         while crate::commands::window_pool::evict_idle_pane_pool_window(&state) {}
                     } else {
                         crate::commands::window_pool::spawn_pane_pool_window(&state);
                         crate::commands::window_pool::spawn_pool_window(&state);
                     }
+                }
+                if let Some(level) = ram_transition {
+                    tracing::warn!(
+                        target: "mem_pressure",
+                        kind = "ram",
+                        level = level.as_str(),
+                        phys_free_mb = ram_free,
+                        "RAM pressure changed"
+                    );
                 }
                 // Push to the banner on a transition (to show or clear it), AND
                 // re-assert a steady non-Normal level each tick so a window
@@ -112,7 +187,17 @@ pub fn start(state: std::sync::Arc<crate::state::AppState>) {
                 // unchanged level and a re-assert never un-dismisses); a steady
                 // Normal stays silent, so there's no traffic in the common case.
                 if transition.is_some() || level_now != crate::memory_pressure::PressureLevel::Normal {
-                    crate::ui_tasks::post_memory_pressure(&state, level_now.as_str(), free);
+                    let (system_managed, disk_free_pct) = pagefile_disk_context().unwrap_or((true, 100.0));
+                    crate::ui_tasks::post_memory_pressure_pagefile(
+                        &state,
+                        level_now.as_str(),
+                        free,
+                        system_managed,
+                        disk_free_pct,
+                    );
+                }
+                if ram_transition.is_some() || ram_level_now != crate::memory_pressure::PressureLevel::Normal {
+                    crate::ui_tasks::post_memory_pressure_ram(&state, ram_level_now.as_str(), ram_free);
                 }
                 refresh_log_pointer(&mut last_date);
             }
@@ -202,6 +287,11 @@ fn log_memory_stats() {
 
         // Publish commit-free for the gated renderer recovery path (§6.A).
         COMMIT_FREE_MB.store((mem.ullAvailPageFile / (1024 * 1024)) as u64, Ordering::Relaxed);
+        // Publish physical RAM free/total for the RAM pressure tracker
+        // (SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §3) — same `mem`
+        // struct already fetched above, no extra syscall.
+        PHYS_FREE_MB.store((mem.ullAvailPhys / (1024 * 1024)) as u64, Ordering::Relaxed);
+        PHYS_TOTAL_MB.store((mem.ullTotalPhys / (1024 * 1024)) as u64, Ordering::Relaxed);
 
         tracing::info!(
             target: "mem_heartbeat",

--- a/agentmux-cef/src/memory_pressure.rs
+++ b/agentmux-cef/src/memory_pressure.rs
@@ -33,23 +33,44 @@
 
 use std::sync::atomic::{AtomicU8, Ordering};
 
-/// Commit-**free ratio** enter thresholds (free / total). Reagent-adjacent
-/// finding, `docs/retro/retro-commit-restart-reclaim-2026-07-16.md` §5.2: this
-/// classifier used to threshold on absolute free MB (1024 / 512), which on a
-/// large-commit-limit machine (60-80 GB seen live) never fires until far past
-/// the point the status bar already shows red — the frontend's gauge
-/// (`frontend/app/statusbar/SystemStats.tsx::commitColor`) has always been
-/// ratio-based (>95% used / >85% used). These are that same threshold,
-/// expressed as free-ratio (`1 - used/total`) so the two pipelines agree:
-/// used > 0.95 <=> free/total < 0.05, used > 0.85 <=> free/total < 0.15.
-const WARN_ENTER_FREE_RATIO: f64 = 0.15;
-const CRITICAL_ENTER_FREE_RATIO: f64 = 0.05;
-/// Hysteresis margin, in free-ratio points: to *leave* a pressure band,
-/// commit-free must recover this far past the enter threshold. Stops flap
-/// when commit hovers at a boundary — same role as the previous fixed-MB
-/// `HYSTERESIS_MB`, just expressed in ratio terms now that the thresholds
-/// themselves are ratios.
-const HYSTERESIS_RATIO: f64 = 0.03;
+/// Free-ratio thresholds (free / total) a `PressureTracker` classifies
+/// against. Originally module-level consts shared by a single commit
+/// tracker; made a field (`SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07` §3)
+/// so a second, independent RAM tracker can share the same classifier logic
+/// without being forced to share the same numbers — today both trackers use
+/// `::default()` (identical to the original consts), but they can diverge
+/// later once there's real data to tune against, without another rewrite.
+///
+/// Reagent-adjacent finding, `docs/retro/retro-commit-restart-reclaim-2026-07-16.md`
+/// §5.2: the commit tracker used to threshold on absolute free MB
+/// (1024 / 512), which on a large-commit-limit machine (60-80 GB seen live)
+/// never fired until far past the point the status bar already shows red —
+/// the frontend's gauge (`frontend/app/statusbar/SystemStats.tsx::commitColor`)
+/// has always been ratio-based (>95% used / >85% used). The defaults below
+/// are that same threshold, expressed as free-ratio (`1 - used/total`) so the
+/// two pipelines agree: used > 0.95 <=> free/total < 0.05, used > 0.85 <=>
+/// free/total < 0.15.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PressureThresholds {
+    pub warn_enter_free_ratio: f64,
+    pub critical_enter_free_ratio: f64,
+    /// Margin, in free-ratio points: to *leave* a pressure band, free ratio
+    /// must recover this far past the enter threshold. Stops flap when the
+    /// reading hovers at a boundary — same role as the previous fixed-MB
+    /// `HYSTERESIS_MB`, just expressed in ratio terms now that the
+    /// thresholds themselves are ratios.
+    pub hysteresis_ratio: f64,
+}
+
+impl Default for PressureThresholds {
+    fn default() -> Self {
+        Self {
+            warn_enter_free_ratio: 0.15,
+            critical_enter_free_ratio: 0.05,
+            hysteresis_ratio: 0.03,
+        }
+    }
+}
 
 /// Debounced system memory-pressure level. Ordered Normal < Warn < Critical.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -92,17 +113,20 @@ pub fn current_level() -> PressureLevel {
     PressureLevel::from_u8(PRESSURE_LEVEL.load(Ordering::Relaxed))
 }
 
-/// Debounced pressure classifier. One instance lives in the heartbeat thread;
-/// `observe()` is fed each commit-free sample and returns `Some(new)` only on a
-/// level change (so callers log/act once per transition, not every tick).
+/// Debounced pressure classifier. One instance per tracked metric lives in
+/// the heartbeat thread (today: one for commit/page-file, one for physical
+/// RAM — `SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07` §3); `observe()` is
+/// fed each sample and returns `Some(new)` only on a level change (so
+/// callers log/act once per transition, not every tick).
 #[derive(Debug, Clone, Copy)]
 pub struct PressureTracker {
     level: PressureLevel,
+    thresholds: PressureThresholds,
 }
 
 impl Default for PressureTracker {
     fn default() -> Self {
-        Self { level: PressureLevel::Normal }
+        Self { level: PressureLevel::Normal, thresholds: PressureThresholds::default() }
     }
 }
 
@@ -111,17 +135,26 @@ impl PressureTracker {
         Self::default()
     }
 
+    /// Construct with non-default thresholds. Not used yet — every tracker
+    /// today starts on `PressureThresholds::default()` (§3's "start with the
+    /// same ratios" call) — but kept available for the RAM tracker to diverge
+    /// from the commit tracker once there's real data to tune against.
+    #[allow(dead_code)]
+    pub fn with_thresholds(thresholds: PressureThresholds) -> Self {
+        Self { level: PressureLevel::Normal, thresholds }
+    }
+
     #[allow(dead_code)] // read by tests + future shedding responses
     pub fn level(&self) -> PressureLevel {
         self.level
     }
 
-    /// Feed a commit-free/commit-total reading (MB). Returns `Some(level)` iff
-    /// the debounced level changed, and publishes the new level to
-    /// `PRESSURE_LEVEL`. `commit_total_mb == 0` (not yet sampled) is treated
-    /// as "unknown — stay Normal" rather than dividing by zero.
-    pub fn observe(&mut self, commit_free_mb: u64, commit_total_mb: u64) -> Option<PressureLevel> {
-        let next = classify(commit_free_mb, commit_total_mb, self.level);
+    /// Feed a free/total reading (MB). Returns `Some(level)` iff the
+    /// debounced level changed, and publishes the new level to
+    /// `PRESSURE_LEVEL`. `total_mb == 0` (not yet sampled) is treated as
+    /// "unknown — stay Normal" rather than dividing by zero.
+    pub fn observe(&mut self, free_mb: u64, total_mb: u64) -> Option<PressureLevel> {
+        let next = classify(free_mb, total_mb, self.level, &self.thresholds);
         if next != self.level {
             self.level = next;
             PRESSURE_LEVEL.store(next as u8, Ordering::Relaxed);
@@ -133,36 +166,41 @@ impl PressureTracker {
 }
 
 /// Pure classifier with hysteresis: the *enter* thresholds are strict, but
-/// *leaving* a band requires recovering `HYSTERESIS_RATIO` past the enter
+/// *leaving* a band requires recovering `hysteresis_ratio` past the enter
 /// threshold, so a reading parked at a boundary doesn't oscillate.
-fn classify(free_mb: u64, total_mb: u64, current: PressureLevel) -> PressureLevel {
+fn classify(
+    free_mb: u64,
+    total_mb: u64,
+    current: PressureLevel,
+    t: &PressureThresholds,
+) -> PressureLevel {
     if total_mb == 0 {
         return PressureLevel::Normal;
     }
     let free_ratio = free_mb as f64 / total_mb as f64;
     match current {
         PressureLevel::Normal => {
-            if free_ratio < CRITICAL_ENTER_FREE_RATIO {
+            if free_ratio < t.critical_enter_free_ratio {
                 PressureLevel::Critical
-            } else if free_ratio < WARN_ENTER_FREE_RATIO {
+            } else if free_ratio < t.warn_enter_free_ratio {
                 PressureLevel::Warn
             } else {
                 PressureLevel::Normal
             }
         }
         PressureLevel::Warn => {
-            if free_ratio < CRITICAL_ENTER_FREE_RATIO {
+            if free_ratio < t.critical_enter_free_ratio {
                 PressureLevel::Critical
-            } else if free_ratio >= WARN_ENTER_FREE_RATIO + HYSTERESIS_RATIO {
+            } else if free_ratio >= t.warn_enter_free_ratio + t.hysteresis_ratio {
                 PressureLevel::Normal
             } else {
                 PressureLevel::Warn
             }
         }
         PressureLevel::Critical => {
-            if free_ratio >= WARN_ENTER_FREE_RATIO + HYSTERESIS_RATIO {
+            if free_ratio >= t.warn_enter_free_ratio + t.hysteresis_ratio {
                 PressureLevel::Normal
-            } else if free_ratio >= CRITICAL_ENTER_FREE_RATIO + HYSTERESIS_RATIO {
+            } else if free_ratio >= t.critical_enter_free_ratio + t.hysteresis_ratio {
                 PressureLevel::Warn
             } else {
                 PressureLevel::Critical

--- a/agentmux-cef/src/memory_pressure.rs
+++ b/agentmux-cef/src/memory_pressure.rs
@@ -102,13 +102,23 @@ impl PressureLevel {
 
 /// Latest published pressure level, readable lock-free by future shedding
 /// responses + tooling. `Normal` until the first sample.
+///
+/// **Commit/page-file pressure only.** This atomic predates
+/// `SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07`'s second (RAM) tracker;
+/// every existing reader (`commands/window_pool.rs`, `commands/pane_pool.rs`)
+/// gates pane/window-pool shedding on it, which must keep tracking commit
+/// pressure specifically (§6: RAM-only pressure with healthy commit isn't a
+/// crash risk, so it must not drive shedding). Only `PressureTracker::observe`
+/// (used by the commit tracker) publishes here — the RAM tracker uses
+/// `observe_local`, which deliberately does not, so it can never clobber this
+/// with a RAM-only transition.
 static PRESSURE_LEVEL: AtomicU8 = AtomicU8::new(PressureLevel::Normal as u8);
 
-/// The current debounced pressure level (last published by the tracker).
-/// Read by proactive-shedding responses — currently the warm-pool refill
-/// guard (`commands/window_pool.rs::spawn_pool_window` /
-/// `spawn_pane_pool_window`) — and available for future CDP purge / banner
-/// consumers.
+/// The current debounced **commit/page-file** pressure level (last published
+/// by a tracker's `observe()`, not `observe_local()`). Read by proactive-
+/// shedding responses — currently the warm-pool refill guard
+/// (`commands/window_pool.rs::spawn_pool_window` / `spawn_pane_pool_window`)
+/// — and available for future CDP purge / banner consumers.
 pub fn current_level() -> PressureLevel {
     PressureLevel::from_u8(PRESSURE_LEVEL.load(Ordering::Relaxed))
 }
@@ -150,14 +160,37 @@ impl PressureTracker {
     }
 
     /// Feed a free/total reading (MB). Returns `Some(level)` iff the
-    /// debounced level changed, and publishes the new level to
-    /// `PRESSURE_LEVEL`. `total_mb == 0` (not yet sampled) is treated as
-    /// "unknown — stay Normal" rather than dividing by zero.
+    /// debounced level changed, and publishes the new level to the shared
+    /// `PRESSURE_LEVEL` atomic that `current_level()` / the pane/window-pool
+    /// shedding responses read. `total_mb == 0` (not yet sampled) is treated
+    /// as "unknown — stay Normal" rather than dividing by zero.
+    ///
+    /// Use this for the commit/page-file tracker only. A second tracker
+    /// (e.g. the RAM tracker) must use `observe_local` instead — publishing
+    /// here from more than one tracker makes `current_level()` ambiguous
+    /// (whichever tracker transitioned most recently wins), silently
+    /// defeating the shedding response the commit signal exists to drive.
     pub fn observe(&mut self, free_mb: u64, total_mb: u64) -> Option<PressureLevel> {
+        self.observe_impl(free_mb, total_mb, true)
+    }
+
+    /// Like `observe`, but does not publish to the shared `PRESSURE_LEVEL`
+    /// atomic — only this tracker instance's own `level()` changes. Use for
+    /// any tracker whose level isn't what `current_level()`'s callers mean;
+    /// today that's the RAM tracker (`SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07`
+    /// §6: RAM pressure alone doesn't drive pane-pool shedding, so it must
+    /// never overwrite the commit tracker's published level).
+    pub fn observe_local(&mut self, free_mb: u64, total_mb: u64) -> Option<PressureLevel> {
+        self.observe_impl(free_mb, total_mb, false)
+    }
+
+    fn observe_impl(&mut self, free_mb: u64, total_mb: u64, publish: bool) -> Option<PressureLevel> {
         let next = classify(free_mb, total_mb, self.level, &self.thresholds);
         if next != self.level {
             self.level = next;
-            PRESSURE_LEVEL.store(next as u8, Ordering::Relaxed);
+            if publish {
+                PRESSURE_LEVEL.store(next as u8, Ordering::Relaxed);
+            }
             Some(next)
         } else {
             None
@@ -213,6 +246,23 @@ fn classify(
 mod tests {
     use super::*;
 
+    /// Serializes every test in this module. `observe()` writes to the
+    /// process-global `PRESSURE_LEVEL` atomic (by design — that's what makes
+    /// it readable by `current_level()`), so parallel test threads racing
+    /// unlocked writes/reads against the same static would be flaky —
+    /// same rationale as `agentmux_common::TEST_ENV_LOCK`.
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Acquire `TEST_LOCK`, tolerating poisoning. A poisoned lock here only
+    /// ever means some *other* test in this module panicked while holding
+    /// it — that failure is already reported on its own test thread; letting
+    /// poison propagate here would additionally fail every test that runs
+    /// after it with an unrelated `PoisonError`, masking which test actually
+    /// broke.
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// Fixed total used across every test below so the free-MB values read
     /// naturally as ratios (total = 10_000 MB, so e.g. free=1500 is exactly
     /// the 0.15 WARN_ENTER_FREE_RATIO boundary).
@@ -220,6 +270,7 @@ mod tests {
 
     #[test]
     fn starts_normal_and_classifies_each_band_from_normal() {
+        let _guard = lock();
         let mut t = PressureTracker::new();
         assert_eq!(t.level(), PressureLevel::Normal);
         // Ample headroom (ratio 0.8) → no transition.
@@ -232,6 +283,7 @@ mod tests {
 
     #[test]
     fn only_emits_on_change() {
+        let _guard = lock();
         let mut t = PressureTracker::new();
         assert_eq!(t.observe(1000, TOTAL), Some(PressureLevel::Warn));
         // Still in the Warn band → no repeat emission.
@@ -241,6 +293,7 @@ mod tests {
 
     #[test]
     fn hysteresis_prevents_flap_at_the_warn_boundary() {
+        let _guard = lock();
         let mut t = PressureTracker::new();
         assert_eq!(t.observe(1499, TOTAL), Some(PressureLevel::Warn)); // enter Warn (ratio <0.15)
         // Hovering just above the enter threshold but below enter+hysteresis
@@ -253,6 +306,7 @@ mod tests {
 
     #[test]
     fn critical_steps_down_through_warn_with_hysteresis() {
+        let _guard = lock();
         let mut t = PressureTracker::new();
         let _ = t.observe(400, TOTAL); // Normal → Critical (ratio 0.04)
         assert_eq!(t.level(), PressureLevel::Critical);
@@ -265,6 +319,7 @@ mod tests {
 
     #[test]
     fn normal_can_jump_straight_to_critical_and_back() {
+        let _guard = lock();
         let mut t = PressureTracker::new();
         assert_eq!(t.observe(100, TOTAL), Some(PressureLevel::Critical));
         assert_eq!(t.observe(5000, TOTAL), Some(PressureLevel::Normal));
@@ -272,6 +327,7 @@ mod tests {
 
     #[test]
     fn ratio_thresholds_match_frontend_commit_color() {
+        let _guard = lock();
         // frontend/app/statusbar/SystemStats.tsx::commitColor: used/total > 0.95
         // -> red, > 0.85 -> amber. Expressed as free-ratio here: < 0.05 -> Critical,
         // < 0.15 -> Warn. Locks the two independently-computed pipelines together
@@ -291,6 +347,7 @@ mod tests {
 
     #[test]
     fn zero_total_does_not_panic_or_misclassify() {
+        let _guard = lock();
         let mut t = PressureTracker::new();
         // Heartbeat hasn't sampled total yet -- must degrade to Normal, not
         // divide by zero / panic.
@@ -298,5 +355,44 @@ mod tests {
         assert_eq!(t.level(), PressureLevel::Normal);
         assert_eq!(t.observe(100_000, 0), None);
         assert_eq!(t.level(), PressureLevel::Normal);
+    }
+
+    #[test]
+    fn observe_local_tracks_level_without_publishing_to_the_shared_atomic() {
+        let _guard = lock();
+        // `PRESSURE_LEVEL` is a process-global static that outlives any one
+        // test — other tests in this module intentionally leave it in Warn
+        // or Critical when they finish, and test execution order is not
+        // guaranteed. So establish a KNOWN baseline via a real, guaranteed
+        // transition (Critical, since a fresh tracker always starts at
+        // Normal and 100/TOTAL is always Critical regardless of what any
+        // earlier test left the global at) rather than assuming it starts
+        // at Normal — that assumption is exactly what made this test flaky
+        // depending on run order before this fix.
+        let mut commit = PressureTracker::new();
+        assert_eq!(commit.observe(100, TOTAL), Some(PressureLevel::Critical));
+        assert_eq!(current_level(), PressureLevel::Critical);
+        // Now step it back down to Normal — another guaranteed transition —
+        // as the clean baseline the rest of this test builds on.
+        assert_eq!(commit.observe(8000, TOTAL), Some(PressureLevel::Normal));
+        assert_eq!(current_level(), PressureLevel::Normal);
+
+        // A second, independent tracker (standing in for the RAM tracker)
+        // transitions all the way to Critical via observe_local...
+        let mut ram = PressureTracker::new();
+        assert_eq!(ram.observe_local(100, TOTAL), Some(PressureLevel::Critical));
+        assert_eq!(ram.level(), PressureLevel::Critical); // its own state DID change...
+
+        // ...but the shared atomic every pane/window-pool shedding check
+        // reads must be untouched by that — this is the exact bug reagent
+        // caught: two trackers publishing to one atomic makes current_level()
+        // ambiguous. observe_local must never clobber it.
+        assert_eq!(current_level(), PressureLevel::Normal);
+
+        // The real commit tracker transitioning still publishes normally,
+        // proving observe_local's non-publishing is specific to that call,
+        // not a side effect that broke publishing generally.
+        assert_eq!(commit.observe(100, TOTAL), Some(PressureLevel::Critical));
+        assert_eq!(current_level(), PressureLevel::Critical);
     }
 }

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -702,18 +702,37 @@ pub fn post_close_window(state: &Arc<AppState>, label: &str) {
 // ── Memory-pressure → frontend banner event ────────────────────────────────
 
 wrap_task! {
+    // `kind` distinguishes RAM pressure from Page File (commit) pressure —
+    // SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07. `system_managed`/
+    // `disk_free_pct` are only meaningful (and only included in the emitted
+    // payload) for `kind == "pagefile"`; for `kind == "ram"` they're unused
+    // placeholders so the task struct stays one uniform shape.
     pub struct EmitMemoryPressureTask {
         state: Arc<AppState>,
+        kind: String,
         level: String,
-        commit_free_mb: u64,
+        free_mb: u64,
+        system_managed: bool,
+        disk_free_pct: f64,
     }
 
     impl Task {
         fn execute(&self) {
-            let payload = serde_json::json!({
-                "level": self.level,
-                "commit_free_mb": self.commit_free_mb,
-            });
+            let payload = if self.kind == "ram" {
+                serde_json::json!({
+                    "kind": self.kind,
+                    "level": self.level,
+                    "phys_free_mb": self.free_mb,
+                })
+            } else {
+                serde_json::json!({
+                    "kind": self.kind,
+                    "level": self.level,
+                    "commit_free_mb": self.free_mb,
+                    "system_managed": self.system_managed,
+                    "disk_free_pct": self.disk_free_pct,
+                })
+            };
             crate::events::emit_event_to_top_level_windows(
                 &self.state,
                 "memory-pressure",
@@ -723,12 +742,44 @@ wrap_task! {
     }
 }
 
-/// Push a memory-pressure level transition to the frontend banner. Callable
-/// from ANY thread (the memory heartbeat runs on a background std::thread); the
-/// emit itself (CEF JS execution) must run on the UI thread, so it's wrapped in
-/// a posted task. SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F.
-pub fn post_memory_pressure(state: &Arc<AppState>, level: &str, commit_free_mb: u64) {
-    let mut task = EmitMemoryPressureTask::new(state.clone(), level.to_string(), commit_free_mb);
+/// Push a RAM-pressure level transition to the frontend banner. Callable from
+/// ANY thread (the memory heartbeat runs on a background std::thread); the
+/// emit itself (CEF JS execution) must run on the UI thread, so it's wrapped
+/// in a posted task. SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §3/§5.
+pub fn post_memory_pressure_ram(state: &Arc<AppState>, level: &str, phys_free_mb: u64) {
+    let mut task = EmitMemoryPressureTask::new(
+        state.clone(),
+        "ram".to_string(),
+        level.to_string(),
+        phys_free_mb,
+        false,
+        0.0,
+    );
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
+/// Push a Page File (commit) pressure level transition to the frontend
+/// banner, including whether Windows can actually grow the page file right
+/// now (`system_managed` + `disk_free_pct` on the volume backing it) so the
+/// banner can pick the correct guidance — SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29
+/// §5.2 P0 via SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §4. Originally
+/// `post_memory_pressure` (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F);
+/// split by `kind` alongside `post_memory_pressure_ram`.
+pub fn post_memory_pressure_pagefile(
+    state: &Arc<AppState>,
+    level: &str,
+    commit_free_mb: u64,
+    system_managed: bool,
+    disk_free_pct: f64,
+) {
+    let mut task = EmitMemoryPressureTask::new(
+        state.clone(),
+        "pagefile".to_string(),
+        level.to_string(),
+        commit_free_mb,
+        system_managed,
+        disk_free_pct,
+    );
     post_task(ThreadId::UI, Some(&mut task));
 }
 

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -704,14 +704,23 @@ pub fn post_close_window(state: &Arc<AppState>, label: &str) {
 wrap_task! {
     // `kind` distinguishes RAM pressure from Page File (commit) pressure —
     // SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07. `system_managed`/
-    // `disk_free_pct` are only meaningful (and only included in the emitted
-    // payload) for `kind == "pagefile"`; for `kind == "ram"` they're unused
-    // placeholders so the task struct stays one uniform shape.
+    // `disk_free_pct` are only meaningful for `kind == "pagefile"`, and even
+    // then only when `has_disk_context` is true — a `GetDiskFreeSpaceExW`/
+    // registry read failure (or `kind == "ram"`, where the concept doesn't
+    // apply at all) must genuinely OMIT those two keys from the emitted
+    // payload rather than substitute a value, or `pagefileGuidance()` on the
+    // frontend renders a confident-sounding guess (reagent-caught P1: an
+    // earlier version defaulted to "system-managed, disk healthy" on read
+    // failure, which produces the reassuring message even while pressure is
+    // Critical). Plain `bool`/`f64` fields (not `Option<T>`) because
+    // `wrap_task!`'s generated struct is untested against `Option` fields —
+    // the extra flag reaches the same "no guess" outcome without that risk.
     pub struct EmitMemoryPressureTask {
         state: Arc<AppState>,
         kind: String,
         level: String,
         free_mb: u64,
+        has_disk_context: bool,
         system_managed: bool,
         disk_free_pct: f64,
     }
@@ -724,13 +733,19 @@ wrap_task! {
                     "level": self.level,
                     "phys_free_mb": self.free_mb,
                 })
-            } else {
+            } else if self.has_disk_context {
                 serde_json::json!({
                     "kind": self.kind,
                     "level": self.level,
                     "commit_free_mb": self.free_mb,
                     "system_managed": self.system_managed,
                     "disk_free_pct": self.disk_free_pct,
+                })
+            } else {
+                serde_json::json!({
+                    "kind": self.kind,
+                    "level": self.level,
+                    "commit_free_mb": self.free_mb,
                 })
             };
             crate::events::emit_event_to_top_level_windows(
@@ -753,30 +768,40 @@ pub fn post_memory_pressure_ram(state: &Arc<AppState>, level: &str, phys_free_mb
         level.to_string(),
         phys_free_mb,
         false,
+        false,
         0.0,
     );
     post_task(ThreadId::UI, Some(&mut task));
 }
 
 /// Push a Page File (commit) pressure level transition to the frontend
-/// banner, including whether Windows can actually grow the page file right
-/// now (`system_managed` + `disk_free_pct` on the volume backing it) so the
-/// banner can pick the correct guidance — SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29
-/// §5.2 P0 via SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §4. Originally
-/// `post_memory_pressure` (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F);
-/// split by `kind` alongside `post_memory_pressure_ram`.
+/// banner. `disk_context`, when `Some`, carries whether Windows can actually
+/// grow the page file right now (`system_managed` + `disk_free_pct` on the
+/// volume backing it) so the banner can pick the correct guidance —
+/// SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 via
+/// SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §4. `None` means the disk/
+/// registry read failed this tick — the payload omits both fields entirely
+/// (not a guessed default) so the frontend's own fail-open "no guidance"
+/// path (`pagefileGuidance`) is what actually renders, not a false "healthy"
+/// claim. Originally `post_memory_pressure`
+/// (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F); split by `kind`
+/// alongside `post_memory_pressure_ram`.
 pub fn post_memory_pressure_pagefile(
     state: &Arc<AppState>,
     level: &str,
     commit_free_mb: u64,
-    system_managed: bool,
-    disk_free_pct: f64,
+    disk_context: Option<(bool, f64)>,
 ) {
+    let (has_disk_context, system_managed, disk_free_pct) = match disk_context {
+        Some((system_managed, disk_free_pct)) => (true, system_managed, disk_free_pct),
+        None => (false, false, 0.0),
+    };
     let mut task = EmitMemoryPressureTask::new(
         state.clone(),
         "pagefile".to_string(),
         level.to_string(),
         commit_free_mb,
+        has_disk_context,
         system_managed,
         disk_free_pct,
     );

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -18,5 +18,14 @@ serde_json = "1"
 # layout (see docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md).
 dirs = "5"
 
+# Windows page-file volume tracking (pagefile.rs), shared by agentmux-srv
+# and agentmux-cef — see docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md §4.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_Registry",
+    "Win32_Storage_FileSystem",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod data_paths;
 pub mod errors;
 pub mod ipc;
 pub mod layout_types;
+pub mod pagefile;
 pub mod runtime_mode;
 pub mod toolchain_path;
 

--- a/agentmux-common/src/pagefile.rs
+++ b/agentmux-common/src/pagefile.rs
@@ -1,0 +1,260 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Windows page-file volume tracking, shared between `agentmux-srv`
+//! (`backend/sysinfo.rs`'s StatusBar telemetry) and `agentmux-cef`
+//! (`memory_heartbeat.rs`'s low-memory banner). Extracted from `sysinfo.rs`
+//! by `docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md` §4 so the
+//! two processes can't independently drift on "what counts as system-managed"
+//! the way the commit-ratio classifier and the StatusBar gauge once did
+//! (issue #2218) — one implementation, two callers.
+//!
+//! Per `docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md` §5.2 P0: a
+//! system-managed page file wants to grow toward `min(3×RAM, ⅛ volume)` but
+//! can't if the volume it lives on doesn't have the free space. This module
+//! answers two questions: which volume backs the page file, and can Windows
+//! actually grow it there.
+
+const BYTES_PER_GB: f64 = 1_073_741_824.0;
+
+/// One `PagingFiles` registry entry
+/// (`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management`),
+/// parsed from its `"<path> <initial_mb> <maximum_mb>"` string form. Per
+/// [Microsoft's documented format](https://learn.microsoft.com/en-us/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size-for-64-bit-versions-of-windows):
+/// `initial_mb == 0 && maximum_mb == 0` means "system managed" (auto-grow)
+/// for that specific pagefile.
+#[derive(Debug, Clone, PartialEq)]
+struct PagingFileEntry {
+    /// Drive letter the pagefile lives on, uppercased, e.g. `"C"`. `None` if
+    /// the path couldn't be parsed as `<letter>:\...` (UNC path, malformed).
+    drive_letter: Option<char>,
+    system_managed: bool,
+}
+
+/// Parse one raw `"<path> <initial_mb> <maximum_mb>"` line from the
+/// `PagingFiles` REG_MULTI_SZ value. Tolerant of the format's use of `??`
+/// instead of a drive letter for some `\\?\Volume{guid}\` forms — those
+/// yield `drive_letter: None` rather than erroring, since a pure parser
+/// should never fail on a value the OS itself produced.
+fn parse_paging_file_entry(line: &str) -> Option<PagingFileEntry> {
+    let mut parts = line.split_whitespace();
+    let path = parts.next()?;
+    let initial: u64 = parts.next()?.parse().ok()?;
+    let maximum: u64 = parts.next()?.parse().ok()?;
+    let drive_letter = path
+        .chars()
+        .next()
+        .filter(|c| c.is_ascii_alphabetic())
+        .map(|c| c.to_ascii_uppercase());
+    Some(PagingFileEntry {
+        drive_letter,
+        system_managed: initial == 0 && maximum == 0,
+    })
+}
+
+/// Decide which volume to watch and whether it's at risk of a stuck
+/// (non-growing) page file, from the parsed `PagingFiles` entries.
+///
+/// - **Empty list** (the common default): Windows fully automatically
+///   manages a single pagefile's size AND location — not expressed as any
+///   registry entry at all. Falls back to `system_drive` as the practical
+///   answer (where CEF/the OS itself lives; the overwhelmingly likely
+///   pagefile location in this configuration) — `system_managed: true`.
+/// - **Has entries**: watch the first volume with a `system_managed: true`
+///   entry (the volume that can actually run out of the growth room this
+///   spec is about). If every entry is fixed-size, no volume is at growth
+///   risk from disk space — report `system_managed: false` on
+///   `system_drive` for visibility, but callers must not apply the
+///   "can't grow" risk framing to a fixed-size pagefile.
+fn resolve_pagefile_watch_target(entries: &[PagingFileEntry], system_drive: char) -> (char, bool) {
+    if entries.is_empty() {
+        return (system_drive, true);
+    }
+    for e in entries {
+        if e.system_managed {
+            return (e.drive_letter.unwrap_or(system_drive), true);
+        }
+    }
+    (system_drive, false)
+}
+
+/// Read `PagingFiles` and split it into entries. Non-Windows / read failure
+/// returns an empty vec (caller's `resolve_pagefile_watch_target` then
+/// degrades to "watch the system drive as if system-managed" — the correct
+/// fail-open default: assume the common case rather than silently reporting
+/// nothing).
+#[cfg(target_os = "windows")]
+fn read_paging_files_registry() -> Vec<PagingFileEntry> {
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ,
+        REG_MULTI_SZ,
+    };
+
+    let subkey: Vec<u16> =
+        "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\0"
+            .encode_utf16()
+            .collect();
+    let value_name: Vec<u16> = "PagingFiles\0".encode_utf16().collect();
+
+    unsafe {
+        let mut hkey: HKEY = std::ptr::null_mut();
+        if RegOpenKeyExW(HKEY_LOCAL_MACHINE, subkey.as_ptr(), 0, KEY_READ, &mut hkey) as u32
+            != ERROR_SUCCESS
+        {
+            return Vec::new();
+        }
+
+        let mut buf_bytes: u32 = 0;
+        let mut value_type: u32 = 0;
+        let query1 = RegQueryValueExW(
+            hkey,
+            value_name.as_ptr(),
+            std::ptr::null(),
+            &mut value_type,
+            std::ptr::null_mut(),
+            &mut buf_bytes,
+        );
+        if query1 as u32 != ERROR_SUCCESS || value_type != REG_MULTI_SZ || buf_bytes == 0 {
+            RegCloseKey(hkey);
+            return Vec::new();
+        }
+
+        let mut buf: Vec<u16> = vec![0u16; buf_bytes as usize / 2];
+        let query2 = RegQueryValueExW(
+            hkey,
+            value_name.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            buf.as_mut_ptr() as *mut u8,
+            &mut buf_bytes,
+        );
+        RegCloseKey(hkey);
+        if query2 as u32 != ERROR_SUCCESS {
+            return Vec::new();
+        }
+
+        // REG_MULTI_SZ: NUL-separated strings, terminated by a double NUL.
+        buf.split(|&c| c == 0)
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| parse_paging_file_entry(&String::from_utf16_lossy(s)))
+            .collect()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn read_paging_files_registry() -> Vec<PagingFileEntry> {
+    Vec::new()
+}
+
+/// Free/total space (GB) for a drive letter, e.g. `'C'`. Windows-only;
+/// returns `None` on any failure (drive not found, API error) so callers
+/// degrade to "no data" rather than a wrong number.
+#[cfg(target_os = "windows")]
+pub fn drive_free_total_gb(drive_letter: char) -> Option<(f64, f64)> {
+    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+    let root: Vec<u16> = format!("{}:\\\0", drive_letter).encode_utf16().collect();
+    let mut free_available: u64 = 0;
+    let mut total: u64 = 0;
+    let ok = unsafe {
+        GetDiskFreeSpaceExW(
+            root.as_ptr(),
+            &mut free_available,
+            &mut total,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    Some((
+        free_available as f64 / BYTES_PER_GB,
+        total as f64 / BYTES_PER_GB,
+    ))
+}
+
+/// The `(drive_letter, system_managed)` pagefile watch target, resolved
+/// once per process lifetime. `PagingFiles` is machine configuration that
+/// requires a reboot to take effect — re-reading the registry on every
+/// caller's poll loop would be pure waste. Free disk space, by contrast,
+/// genuinely changes during a session — call `drive_free_total_gb` for that,
+/// as often as the caller's own poll cadence needs.
+#[cfg(target_os = "windows")]
+pub fn pagefile_watch_target() -> (char, bool) {
+    static TARGET: std::sync::OnceLock<(char, bool)> = std::sync::OnceLock::new();
+    *TARGET.get_or_init(|| {
+        let system_drive = std::env::var("SystemDrive")
+            .ok()
+            .and_then(|s| s.chars().next())
+            .map(|c| c.to_ascii_uppercase())
+            .unwrap_or('C');
+        let entries = read_paging_files_registry();
+        resolve_pagefile_watch_target(&entries, system_drive)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_system_managed_entry() {
+        let e = parse_paging_file_entry("C:\\pagefile.sys 0 0").unwrap();
+        assert_eq!(e.drive_letter, Some('C'));
+        assert!(e.system_managed);
+    }
+
+    #[test]
+    fn parses_fixed_size_entry() {
+        let e = parse_paging_file_entry("D:\\pagefile.sys 4096 8192").unwrap();
+        assert_eq!(e.drive_letter, Some('D'));
+        assert!(!e.system_managed);
+    }
+
+    #[test]
+    fn lowercases_drive_letter_normalized_to_upper() {
+        // Windows can report either case; the registry doesn't enforce one.
+        let e = parse_paging_file_entry("c:\\pagefile.sys 0 0").unwrap();
+        assert_eq!(e.drive_letter, Some('C'));
+    }
+
+    #[test]
+    fn malformed_line_returns_none() {
+        assert!(parse_paging_file_entry("").is_none());
+        assert!(parse_paging_file_entry("C:\\pagefile.sys").is_none());
+        assert!(parse_paging_file_entry("C:\\pagefile.sys notanumber 0").is_none());
+    }
+
+    #[test]
+    fn empty_entries_falls_back_to_system_drive_as_managed() {
+        // The common default: no explicit PagingFiles entries at all means
+        // Windows fully auto-manages a single pagefile — not expressed as a
+        // registry entry, so an empty list must NOT be read as "no pagefile
+        // risk" (the opposite of the truth).
+        let (drive, managed) = resolve_pagefile_watch_target(&[], 'C');
+        assert_eq!(drive, 'C');
+        assert!(managed);
+    }
+
+    #[test]
+    fn watches_the_first_system_managed_volume() {
+        let entries = vec![
+            PagingFileEntry { drive_letter: Some('D'), system_managed: false },
+            PagingFileEntry { drive_letter: Some('E'), system_managed: true },
+        ];
+        let (drive, managed) = resolve_pagefile_watch_target(&entries, 'C');
+        assert_eq!(drive, 'E');
+        assert!(managed);
+    }
+
+    #[test]
+    fn all_fixed_size_reports_not_managed_on_system_drive() {
+        // No volume is at "can't grow" risk — but we still surface a
+        // number (system drive) for visibility, correctly flagged as not
+        // subject to this specific risk.
+        let entries = vec![PagingFileEntry { drive_letter: Some('D'), system_managed: false }];
+        let (drive, managed) = resolve_pagefile_watch_target(&entries, 'C');
+        assert_eq!(drive, 'C');
+        assert!(!managed);
+    }
+}

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -80,7 +80,10 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
     "Win32_System_ProcessStatus",
     "Win32_System_SystemInformation",
-    "Win32_System_Registry",
+    # Win32_System_Registry dropped: its only caller (the PagingFiles
+    # registry read) moved to agentmux-common/src/pagefile.rs, which
+    # declares its own windows-sys dependency with that feature —
+    # SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §4.
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
 ] }

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -264,7 +264,7 @@ pub fn available_commit_gb() -> Option<f64> {
     None
 }
 
-// ── SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 ────────────────────────
+// ── SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 ──────────────────────────────────
 // "Track free disk on the pagefile volume, not just avail_page_gb. Warn when
 // free disk < ~15% and page file is system-managed." The existing commit
 // gauge above only sees the SYMPTOM (commit near limit); it is blind to the
@@ -272,182 +272,13 @@ pub fn available_commit_gb() -> Option<f64> {
 // min(3×RAM, ⅛ volume) but silently cannot if the volume it lives on doesn't
 // have the free space, pinning the commit ceiling well below what every
 // other gauge assumes. This makes the cause itself visible.
-
-/// One `PagingFiles` registry entry
-/// (`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management`),
-/// parsed from its `"<path> <initial_mb> <maximum_mb>"` string form. Per
-/// [Microsoft's documented format](https://learn.microsoft.com/en-us/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size-for-64-bit-versions-of-windows):
-/// `initial_mb == 0 && maximum_mb == 0` means "system managed" (auto-grow)
-/// for that specific pagefile.
-#[derive(Debug, Clone, PartialEq)]
-struct PagingFileEntry {
-    /// Drive letter the pagefile lives on, uppercased, e.g. `"C"`. `None` if
-    /// the path couldn't be parsed as `<letter>:\...` (UNC path, malformed).
-    drive_letter: Option<char>,
-    system_managed: bool,
-}
-
-/// Parse one raw `"<path> <initial_mb> <maximum_mb>"` line from the
-/// `PagingFiles` REG_MULTI_SZ value. Tolerant of the format's use of `??`
-/// instead of a drive letter for some `\\?\Volume{guid}\` forms — those
-/// yield `drive_letter: None` rather than erroring, since a pure parser
-/// should never fail on a value the OS itself produced.
-fn parse_paging_file_entry(line: &str) -> Option<PagingFileEntry> {
-    let mut parts = line.split_whitespace();
-    let path = parts.next()?;
-    let initial: u64 = parts.next()?.parse().ok()?;
-    let maximum: u64 = parts.next()?.parse().ok()?;
-    let drive_letter = path
-        .chars()
-        .next()
-        .filter(|c| c.is_ascii_alphabetic())
-        .map(|c| c.to_ascii_uppercase());
-    Some(PagingFileEntry {
-        drive_letter,
-        system_managed: initial == 0 && maximum == 0,
-    })
-}
-
-/// Decide which volume to watch and whether it's at risk of a stuck
-/// (non-growing) page file, from the parsed `PagingFiles` entries.
-///
-/// - **Empty list** (the common default): Windows fully automatically
-///   manages a single pagefile's size AND location — not expressed as any
-///   registry entry at all. Falls back to `system_drive` as the practical
-///   answer (where CEF/the OS itself lives; the overwhelmingly likely
-///   pagefile location in this configuration) — `system_managed: true`.
-/// - **Has entries**: watch the first volume with a `system_managed: true`
-///   entry (the volume that can actually run out of the growth room this
-///   spec is about). If every entry is fixed-size, no volume is at growth
-///   risk from disk space — report `system_managed: false` on
-///   `system_drive` for visibility, but the frontend must not apply the
-///   "can't grow" risk framing to a fixed-size pagefile.
-fn resolve_pagefile_watch_target(entries: &[PagingFileEntry], system_drive: char) -> (char, bool) {
-    if entries.is_empty() {
-        return (system_drive, true);
-    }
-    for e in entries {
-        if e.system_managed {
-            return (e.drive_letter.unwrap_or(system_drive), true);
-        }
-    }
-    (system_drive, false)
-}
-
-/// Read `PagingFiles` and split it into entries. Non-Windows / read failure
-/// returns an empty vec (caller's `resolve_pagefile_watch_target` then
-/// degrades to "watch the system drive as if system-managed" — the correct
-/// fail-open default: assume the common case rather than silently reporting
-/// nothing).
-#[cfg(target_os = "windows")]
-fn read_paging_files_registry() -> Vec<PagingFileEntry> {
-    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
-    use windows_sys::Win32::System::Registry::{
-        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ,
-        REG_MULTI_SZ,
-    };
-
-    let subkey: Vec<u16> =
-        "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\0"
-            .encode_utf16()
-            .collect();
-    let value_name: Vec<u16> = "PagingFiles\0".encode_utf16().collect();
-
-    unsafe {
-        let mut hkey: HKEY = std::ptr::null_mut();
-        if RegOpenKeyExW(HKEY_LOCAL_MACHINE, subkey.as_ptr(), 0, KEY_READ, &mut hkey) as u32
-            != ERROR_SUCCESS
-        {
-            return Vec::new();
-        }
-
-        let mut buf_bytes: u32 = 0;
-        let mut value_type: u32 = 0;
-        let query1 = RegQueryValueExW(
-            hkey,
-            value_name.as_ptr(),
-            std::ptr::null(),
-            &mut value_type,
-            std::ptr::null_mut(),
-            &mut buf_bytes,
-        );
-        if query1 as u32 != ERROR_SUCCESS || value_type != REG_MULTI_SZ || buf_bytes == 0 {
-            RegCloseKey(hkey);
-            return Vec::new();
-        }
-
-        let mut buf: Vec<u16> = vec![0u16; buf_bytes as usize / 2];
-        let query2 = RegQueryValueExW(
-            hkey,
-            value_name.as_ptr(),
-            std::ptr::null(),
-            std::ptr::null_mut(),
-            buf.as_mut_ptr() as *mut u8,
-            &mut buf_bytes,
-        );
-        RegCloseKey(hkey);
-        if query2 as u32 != ERROR_SUCCESS {
-            return Vec::new();
-        }
-
-        // REG_MULTI_SZ: NUL-separated strings, terminated by a double NUL.
-        buf.split(|&c| c == 0)
-            .filter(|s| !s.is_empty())
-            .filter_map(|s| parse_paging_file_entry(&String::from_utf16_lossy(s)))
-            .collect()
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-fn read_paging_files_registry() -> Vec<PagingFileEntry> {
-    Vec::new()
-}
-
-/// Free/total space (GB) for a drive letter, e.g. `'C'`. Windows-only;
-/// returns `None` on any failure (drive not found, API error) so callers
-/// degrade to "no data" rather than a wrong number.
-#[cfg(target_os = "windows")]
-fn drive_free_total_gb(drive_letter: char) -> Option<(f64, f64)> {
-    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
-    let root: Vec<u16> = format!("{}:\\\0", drive_letter).encode_utf16().collect();
-    let mut free_available: u64 = 0;
-    let mut total: u64 = 0;
-    let ok = unsafe {
-        GetDiskFreeSpaceExW(
-            root.as_ptr(),
-            &mut free_available,
-            &mut total,
-            std::ptr::null_mut(),
-        )
-    };
-    if ok == 0 {
-        return None;
-    }
-    Some((
-        free_available as f64 / BYTES_PER_GB,
-        total as f64 / BYTES_PER_GB,
-    ))
-}
-
-/// The `(drive_letter, system_managed)` pagefile watch target, resolved
-/// once per process lifetime. `PagingFiles` is machine configuration that
-/// requires a reboot to take effect — re-reading the registry every
-/// sysinfo tick (default 1 Hz) would be pure waste. Free disk space, by
-/// contrast, genuinely changes during a session and is re-read every tick
-/// in `get_pagefile_volume_data`.
-#[cfg(target_os = "windows")]
-fn pagefile_watch_target() -> (char, bool) {
-    static TARGET: std::sync::OnceLock<(char, bool)> = std::sync::OnceLock::new();
-    *TARGET.get_or_init(|| {
-        let system_drive = std::env::var("SystemDrive")
-            .ok()
-            .and_then(|s| s.chars().next())
-            .map(|c| c.to_ascii_uppercase())
-            .unwrap_or('C');
-        let entries = read_paging_files_registry();
-        resolve_pagefile_watch_target(&entries, system_drive)
-    })
-}
+//
+// The registry-parsing + disk-free logic itself now lives in
+// `agentmux_common::pagefile` (extracted by
+// SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §4) so `agentmux-cef`'s
+// low-memory banner can consume the identical implementation instead of a
+// second, independently-drifting copy — this file just wires it into the
+// StatusBar telemetry payload.
 
 /// Collect pagefile-volume disk tracking: `disk:pagefile_volume:free_gb`,
 /// `:total_gb`, `:free_pct`, and `disk:pagefile_system_managed` (1.0/0.0).
@@ -456,8 +287,8 @@ fn pagefile_watch_target() -> (char, bool) {
 fn get_pagefile_volume_data(_values: &mut HashMap<String, f64>) {
     #[cfg(target_os = "windows")]
     {
-        let (drive, system_managed) = pagefile_watch_target();
-        if let Some((free_gb, total_gb)) = drive_free_total_gb(drive) {
+        let (drive, system_managed) = agentmux_common::pagefile::pagefile_watch_target();
+        if let Some((free_gb, total_gb)) = agentmux_common::pagefile::drive_free_total_gb(drive) {
             _values.insert("disk:pagefile_volume:free_gb".to_string(), free_gb);
             _values.insert("disk:pagefile_volume:total_gb".to_string(), total_gb);
             if total_gb > 0.0 {
@@ -471,72 +302,6 @@ fn get_pagefile_volume_data(_values: &mut HashMap<String, f64>) {
                 if system_managed { 1.0 } else { 0.0 },
             );
         }
-    }
-}
-
-#[cfg(test)]
-mod pagefile_volume_tests {
-    use super::*;
-
-    #[test]
-    fn parses_system_managed_entry() {
-        let e = parse_paging_file_entry("C:\\pagefile.sys 0 0").unwrap();
-        assert_eq!(e.drive_letter, Some('C'));
-        assert!(e.system_managed);
-    }
-
-    #[test]
-    fn parses_fixed_size_entry() {
-        let e = parse_paging_file_entry("D:\\pagefile.sys 4096 8192").unwrap();
-        assert_eq!(e.drive_letter, Some('D'));
-        assert!(!e.system_managed);
-    }
-
-    #[test]
-    fn lowercases_drive_letter_normalized_to_upper() {
-        // Windows can report either case; the registry doesn't enforce one.
-        let e = parse_paging_file_entry("c:\\pagefile.sys 0 0").unwrap();
-        assert_eq!(e.drive_letter, Some('C'));
-    }
-
-    #[test]
-    fn malformed_line_returns_none() {
-        assert!(parse_paging_file_entry("").is_none());
-        assert!(parse_paging_file_entry("C:\\pagefile.sys").is_none());
-        assert!(parse_paging_file_entry("C:\\pagefile.sys notanumber 0").is_none());
-    }
-
-    #[test]
-    fn empty_entries_falls_back_to_system_drive_as_managed() {
-        // The common default: no explicit PagingFiles entries at all means
-        // Windows fully auto-manages a single pagefile — not expressed as a
-        // registry entry, so an empty list must NOT be read as "no pagefile
-        // risk" (the opposite of the truth).
-        let (drive, managed) = resolve_pagefile_watch_target(&[], 'C');
-        assert_eq!(drive, 'C');
-        assert!(managed);
-    }
-
-    #[test]
-    fn watches_the_first_system_managed_volume() {
-        let entries = vec![
-            PagingFileEntry { drive_letter: Some('D'), system_managed: false },
-            PagingFileEntry { drive_letter: Some('E'), system_managed: true },
-        ];
-        let (drive, managed) = resolve_pagefile_watch_target(&entries, 'C');
-        assert_eq!(drive, 'E');
-        assert!(managed);
-    }
-
-    #[test]
-    fn all_fixed_size_reports_not_managed_on_system_drive() {
-        // No volume is at "can't grow" risk — but we still surface a
-        // number (system drive) for visibility, correctly flagged as not
-        // subject to this specific risk.
-        let entries = vec![PagingFileEntry { drive_letter: Some('D'), system_managed: false }];
-        let (drive, managed) = resolve_pagefile_watch_target(&entries, 'C');
-        assert_eq!(drive, 'C');
-        assert!(!managed);
     }
 }
 

--- a/docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md
+++ b/docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md
@@ -1,0 +1,258 @@
+# Split the low-memory banner into independent RAM and Page File warnings
+
+**Date:** 2026-08-07
+**Status:** Draft — design proposal, not yet implemented
+**Affected:** `agentmux-cef` (memory heartbeat, pressure classifier, banner emit) and
+`frontend` (banner component), Windows only.
+
+> **Read first — this builds on prior work, it does not replace it:**
+> - `docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md` — the original
+>   `PressureTracker`/banner design this spec splits in two.
+> - `docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md` — established that free
+>   disk on the pagefile volume, and whether the pagefile is system-managed, gates
+>   whether Windows can actually grow it. §5.2 P0 ("track free disk on the pagefile
+>   volume ... warn when free disk is low *and* page file is system-managed") is the
+>   item this spec finally wires up into a user-facing signal.
+> - `docs/specs/SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02.md` and
+>   `docs/retro/retro-commit-restart-reclaim-2026-07-16.md` — background on why the
+>   pressure classifier is ratio-based, not absolute-MB.
+>
+> **Already shipped** (confirmed in tree, reused as-is by this spec): `PressureTracker`
+> + hysteresis classifier (`agentmux-cef/src/memory_pressure.rs`); commit-free/total
+> sampling every 20s (`agentmux-cef/src/memory_heartbeat.rs`); the `memory-pressure`
+> banner (`frontend/app/notification/memory-pressure-banner.tsx`); pagefile-volume free
+> disk + system-managed detection (`agentmux-srv/src/backend/sysinfo.rs::get_pagefile_volume_data`,
+> `pagefile_watch_target`, `read_paging_files_registry`) — currently cosmetic
+> StatusBar telemetry only, not wired into any warning.
+
+---
+
+## 1. The bug
+
+The banner text says **"System memory is critically low"**, but the signal driving it
+is `commit_free_mb` / `commit_total_mb` — Windows' **commit charge**, which is
+`physical RAM + page file` combined (`GlobalMemoryStatusEx`'s `ullAvailPageFile` /
+`ullTotalPageFile`, read in `memory_heartbeat.rs`). On a machine with plenty of free
+RAM but a page file pinned near its ceiling (exactly the failure mode
+`SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md` documented), this banner fires and says
+"system memory" when the actual constraint is virtual-memory/page-file headroom — the
+user goes looking for a RAM problem that isn't there.
+
+There is currently **one** tracker, **one** classifier instance, and **one** banner
+message for a combined metric that conflates two different resources with two
+different remediations:
+
+- **RAM low, commit healthy:** Windows pages more aggressively — the machine slows
+  down, but the page file absorbs the overflow. Not urgent; closing apps helps
+  performance, not survival.
+- **Commit (RAM + page file) low:** an allocation can fail outright — the crash mode
+  `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md §2` documented
+  (`0xE0000008`/`base::TerminateBecauseOutOfMemory`) or a silent Windows OOM-kill. This
+  is the genuinely urgent one, and today's banner is *only* this signal, mislabeled.
+
+## 2. Goal
+
+Split into two independently-tracked, independently-worded signals:
+
+1. **RAM pressure** — physical memory free/total (`ullAvailPhys`/`ullTotalPhys`),
+   softer framing ("performance may degrade").
+2. **Page File pressure** — commit free/total (today's existing signal, correctly
+   relabeled), sharper framing ("crash risk"), **extended with the pagefile-volume
+   disk-space + system-managed signal already computed in `agentmux-srv/src/backend/sysinfo.rs`**
+   so the message correctly reflects whether Windows can self-heal by growing the page
+   file, or is structurally stuck (§4).
+
+Both trackers reuse the existing `PressureTracker`/`classify()` machinery unchanged —
+this is a signal-split and a wiring change, not a new classifier design.
+
+## 3. RAM tracker — new, parallel to the existing commit tracker
+
+`memory_heartbeat.rs`'s `log_memory_stats()` already computes `avail_phys_gb` /
+`total_phys_gb` from the same `GlobalMemoryStatusEx` call it uses for the page-file
+numbers (lines 195-196) — it just never publishes or acts on them. No new syscall is
+needed, only two new atomics alongside the existing `COMMIT_FREE_MB`/`COMMIT_TOTAL_MB`:
+
+```rust
+static PHYS_FREE_MB: AtomicU64 = AtomicU64::new(u64::MAX);
+static PHYS_TOTAL_MB: AtomicU64 = AtomicU64::new(0);
+
+pub fn phys_free_mb() -> u64 { PHYS_FREE_MB.load(Ordering::Relaxed) }
+pub fn phys_total_mb() -> u64 { PHYS_TOTAL_MB.load(Ordering::Relaxed) }
+```
+
+`log_memory_stats()` stores into these two alongside its existing `COMMIT_FREE_MB`
+store (line 204) — same `mem` struct, zero extra cost. `start()`'s tick loop
+instantiates a second `PressureTracker` (`ram_pressure`, alongside the existing
+`commit_pressure` — rename `pressure` for clarity) and calls
+`ram_pressure.observe(phys_free_mb(), phys_total_mb())` right after the existing
+`commit_pressure.observe(...)` call.
+
+**Thresholds:** start with the same ratios the commit tracker already uses (Warn <15%
+free, Critical <5% free, 3-point hysteresis) rather than inventing new unvalidated
+numbers. `PressureTracker`'s thresholds are currently module-level `const`s shared by
+every instance — this spec makes them a field on the tracker
+(`PressureThresholds { warn_enter, critical_enter, hysteresis }`, with a `::default()`
+matching today's values) so RAM and Page File can diverge later once there's real
+signal to tune against, without another classifier rewrite.
+
+**Note on severity semantics:** RAM running low is not equally dangerous as commit
+running low (§1) — that distinction belongs in the *banner copy and framing*, not in
+different Warn/Critical ratios. Keeping the ratios equal for now avoids conflating "we
+picked a different number" with "we know this number is right"; nothing here has been
+measured against real low-RAM-but-healthy-commit machines yet.
+
+## 4. Page File tracker — existing commit tracker, extended with the disk/OS-managed signal
+
+This is the "may the OS handle it, or not" part. `agentmux-srv/src/backend/sysinfo.rs`
+already computes, once per tick, exactly what's needed and currently only feeds the
+cosmetic StatusBar gauge:
+
+- `disk:pagefile_volume:free_gb` / `free_pct` — free disk space on the drive backing
+  the page file (`drive_free_total_gb`, via `GetDiskFreeSpaceExW`).
+- `disk:pagefile_system_managed` — whether Windows controls the page file's size
+  (`pagefile_watch_target` / `read_paging_files_registry`, reading
+  `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PagingFiles`).
+  `initial == 0 && maximum == 0` for an entry means system-managed; no entries at all
+  means "fully auto," which also resolves to system-managed.
+
+This matters because the *meaning* of "page file commit is tight" depends entirely on
+whether the OS can respond:
+
+| System-managed? | Free disk on pagefile volume | What it means | Message tone |
+|---|---|---|---|
+| Yes | Healthy (≥ ~20% free / several GB) | Windows can grow the page file on demand — pressure may self-resolve | Softer: "Windows can expand virtual memory automatically, but performance may dip." |
+| Yes | Low | **The one `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29` documented** — Windows *wants* to grow it but physically can't | Sharpest: "Your page file can't grow because disk space is low. Free up disk space now to avoid a crash." |
+| No (fixed size) | n/a | Windows will **never** grow it — the ceiling is a hard, known limit | Sharp, immediate: "Your page file has a fixed size and won't grow. Free up disk space or increase its size in Windows settings." |
+
+**Wiring:** `memory_heartbeat.rs` needs its own copy of the disk-free + system-managed
+check — `agentmux-cef` and `agentmux-srv` are separate processes with no shared
+channel for `sysinfo.rs`'s per-tick `HashMap` today, and duplicating a single
+`GlobalMemoryStatusEx` call between the two crates already has precedent (`commit_free_mb()`
+here vs. `get_commit_data()` in `sysinfo.rs`, independently implemented since
+`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16`). But the registry-parsing +
+disk-free logic is ~120 lines, not one syscall — copy-pasting it risks exactly the kind
+of silent two-pipeline drift `memory_pressure.rs`'s own doc comment already flags as a
+past bug (issue #2218, the ratio-vs-absolute-MB mismatch between the classifier and
+`SystemStats.tsx`). **Recommended: extract `pagefile_watch_target` /
+`read_paging_files_registry` / `drive_free_total_gb` / `PagingFileEntry` from
+`agentmux-srv/src/backend/sysinfo.rs` into `agentmux-common`** (currently has no
+Windows-specific module — this would be its first) and have both `sysinfo.rs` and the
+new `memory_heartbeat.rs` code call the shared version. Lower-effort fallback if
+`agentmux-common` churn is out of scope right now: duplicate it, but leave a comment
+in both places pointing at each other so a future drift is at least discoverable by
+grep.
+
+The registry read is already `OnceLock`-cached in `sysinfo.rs` (only re-read once per
+process lifetime — the registry doesn't change without a reboot); the disk-free check
+(`GetDiskFreeSpaceExW`) is cheap enough to run every heartbeat tick (20s) or can be
+decoupled to a slower cadence (e.g. every 5th tick, ~100s) if profiling shows otherwise
+— not expected to matter at this frequency.
+
+The Page File `PressureTracker`'s Warn/Critical *entry* thresholds stay exactly as
+today (commit free-ratio 0.15/0.05) — the disk/system-managed signal does not change
+*when* it fires, only *what it says* once it has. Concretely: `PressureLevel` from
+`classify()` is combined with a `PageFileContext { system_managed: bool, disk_free_pct: f64 }`
+snapshot at emit time to select which of the three message variants above to send.
+
+## 5. Frontend banner changes
+
+`MemoryPressurePayload` gains a `kind: "ram" | "pagefile"` field, and for `pagefile`
+payloads, the `system_managed` / `disk_free_pct` needed to pick a message variant:
+
+```ts
+interface MemoryPressurePayload {
+    kind: "ram" | "pagefile";
+    level: PressureLevel;
+    // RAM: informational only today.
+    phys_free_mb?: number;
+    // Page File: drives which of the 3 message variants renders.
+    commit_free_mb?: number;
+    system_managed?: boolean;
+    disk_free_pct?: number;
+}
+```
+
+`MemoryPressureBanner` becomes two independent instances (`<MemoryPressureBanner kind="ram" />`
+/ `<MemoryPressureBanner kind="pagefile" />`, or one component keyed by `kind` with its
+own `level`/`dismissedAt` signals per instance) — RAM and Page File pressure are
+uncorrelated enough that both could be true at once (e.g. ample RAM, starved commit)
+and the user needs to see both, not have one silently overwrite the other. Each keeps
+its own sticky-per-severity dismiss state, unchanged from today's logic
+(`shouldShow`/`severity` are reused verbatim, they're already generic over "a pressure
+level," not RAM/commit-specific).
+
+`MESSAGE` becomes a `kind → level → string` map. Example copy (not final, needs a
+copy pass, but demonstrates the 2×2(+1) shape from §3/§4):
+
+```ts
+const MESSAGE = {
+  ram: {
+    warn: "System RAM is running low. Performance may degrade; closing some windows or apps will help.",
+    critical: "System RAM is critically low. Closing some windows or other apps will keep AgentMux responsive.",
+  },
+  pagefile: {
+    warn: "Virtual memory (page file) is running low.",
+    critical: "Virtual memory (page file) is critically low — an out-of-memory crash is imminent.",
+  },
+} as const;
+
+// pagefile critical + !system_managed → append the fixed-size guidance from §4's table
+// pagefile critical + system_managed + low disk_free_pct → append the "can't grow, free disk now" guidance
+// pagefile critical + system_managed + healthy disk_free_pct → append the "expanding automatically" guidance
+```
+
+## 6. Non-goals
+
+- **Non-Windows.** `commit_free_mb()`/`phys_free_mb()` are already `u64::MAX`-stubbed
+  on non-Windows (feature is effectively Windows-only today); this spec keeps that
+  scope, consistent with `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29`'s own framing
+  ("why Windows 11 is unaffected" — the underlying issue is Windows-specific commit
+  accounting, not a cross-platform concern).
+- **Changing Warn/Critical entry ratios.** Both trackers start on the existing
+  0.15/0.05 commit-derived ratios (§3); tuning RAM-specific thresholds is future work
+  once there's real data to tune against, not part of this split.
+- **The `0xE0000008` gated-recovery question** flagged as open in
+  `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md §5.2` (P0, "confirm caught by gated
+  renderer recovery") — orthogonal to the banner; not addressed here.
+- **Proactive shedding on RAM pressure.** Today only commit pressure triggers pane-pool
+  eviction/refill-suppression (`memory_heartbeat.rs` lines ~99-104,
+  `commands/window_pool.rs`). This spec does not extend shedding to the new RAM
+  tracker — RAM pressure alone (with healthy commit) doesn't risk a crash the way
+  commit pressure does, so there's no clear case for shedding on it yet. Worth
+  revisiting once the new banner has been live long enough to know how often RAM-only
+  episodes actually happen.
+
+## 7. Recommendations
+
+| Pri | Item | Why | Where |
+|-----|------|-----|-------|
+| **P0** | Publish `PHYS_FREE_MB`/`PHYS_TOTAL_MB` atomics + a second `PressureTracker` instance for RAM, wired parallel to the existing commit tracker. | Zero-cost (numbers already computed each tick); this is the core of the split. | `agentmux-cef/src/memory_heartbeat.rs` |
+| **P0** | Make `PressureTracker` thresholds a field (`PressureThresholds`), not module consts, defaulting to today's values. | Lets RAM and Page File diverge later without another classifier rewrite; §3. | `agentmux-cef/src/memory_pressure.rs` |
+| **P0** | Wire `disk:pagefile_volume:*` + `disk:pagefile_system_managed` (already computed in `sysinfo.rs`) into the Page File banner's message selection. | This is the literal P0 item `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2` asked for and that never got a user-facing consumer — currently StatusBar-only. | New code in `agentmux-cef`, extracting shared logic per §4 |
+| **P1** | Extract `pagefile_watch_target`/`read_paging_files_registry`/`drive_free_total_gb`/`PagingFileEntry` into `agentmux-common`. | Avoids a second independently-drifting copy of ~120 lines of registry/disk logic — the exact class of bug issue #2218 already caused once between two pipelines computing "the same" ratio differently. | `agentmux-common` (new module), `agentmux-srv/src/backend/sysinfo.rs`, `agentmux-cef/src/memory_heartbeat.rs` |
+| **P1** | Split `MemoryPressureBanner` into per-`kind` instances with independent dismiss state and a `kind`-aware `MESSAGE` map (§5). | RAM and Page File pressure are uncorrelated; today's single banner can only ever show one framing at a time. | `frontend/app/notification/memory-pressure-banner.tsx` |
+| **P2** | Relabel the existing StatusBar `commitColor` gauge tooltip/label if it currently says "memory" anywhere ambiguous, for consistency with the banner's new correct wording. | Not blocking, but leaving the StatusBar using old wording while the banner uses new wording would be a fresh (smaller) version of the same mislabeling bug this spec fixes. | `frontend/app/statusbar/SystemStats.tsx` |
+
+## 8. Verification
+
+- **Unit tests** (mirrors `memory_pressure.rs`'s existing `#[cfg(test)]` module):
+  independent transitions for two trackers fed different free/total pairs; confirm
+  `PressureThresholds` defaults reproduce every existing test's expected transitions
+  bit-for-bit (regression safety on the const → field refactor).
+- **`system_managed` classification:** unit tests against `resolve_pagefile_watch_target`
+  (already covers empty/system-managed/fixed-size cases per existing `sysinfo.rs`
+  logic) — confirm the shared/extracted version behaves identically.
+- **Manual — RAM-only pressure (commit healthy):** on a machine with a large page
+  file, open enough apps to drop free physical RAM under 15%/5% while commit stays
+  comfortably above its own thresholds. Expect only the RAM banner to appear, correctly
+  worded, no Page File banner.
+- **Manual — Page File pressure, system-managed, healthy disk:** artificially cap free
+  disk on the pagefile volume to a value still comfortably above ~20% free while commit
+  is tight. Expect the softer "expanding automatically" copy.
+- **Manual — Page File pressure, system-managed, low disk (the original bug):**
+  reproduce `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29`'s repro (free C: down to ~20 GB)
+  and confirm the banner now says "page file" / "virtual memory," not "system memory,"
+  and includes the "can't grow, free disk now" guidance.
+- **Manual — fixed-size page file:** set an explicit fixed-size page file in Windows
+  settings, drop commit into Warn/Critical. Expect the "fixed size, won't grow"
+  guidance regardless of free disk.

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -414,10 +414,14 @@ const AppInner = () => {
                 <AppFocusHandler />
                 <AppSettingsUpdater />
                 <Show when={!IS_FLOATING_PANE}>
-                    {/* Low-memory warning banner — app-wide, non-modal,
-                        dismissible. Driven by the host's mem_pressure level
-                        (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F). */}
-                    <MemoryPressureBanner />
+                    {/* Low-memory warning banners — app-wide, non-modal,
+                        dismissible. Driven by the host's mem_pressure level.
+                        RAM and Page File are independently-tracked signals
+                        (SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F,
+                        SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07) — both
+                        can show at once if both are true. */}
+                    <MemoryPressureBanner kind="ram" />
+                    <MemoryPressureBanner kind="pagefile" />
                 </Show>
                 <Show
                     when={IS_FLOATING_PANE}

--- a/frontend/app/notification/memory-pressure-banner.test.ts
+++ b/frontend/app/notification/memory-pressure-banner.test.ts
@@ -3,7 +3,13 @@
 
 import { describe, expect, it } from "vitest";
 
-import { severity, shouldShow, type PressureLevel } from "./memory-pressure-banner";
+import {
+    messageFor,
+    pagefileGuidance,
+    severity,
+    shouldShow,
+    type PressureLevel,
+} from "./memory-pressure-banner";
 
 describe("memory-pressure banner — severity", () => {
     it("orders normal < warn < critical", () => {
@@ -39,5 +45,51 @@ describe("memory-pressure banner — shouldShow", () => {
     it("stays hidden when pressure de-escalates below the dismissed level", () => {
         // Dismissed at critical, drops to warn → still hidden (less severe).
         expect(shouldShow("warn", "critical")).toBe(false);
+    });
+});
+
+describe("memory-pressure banner — pagefileGuidance", () => {
+    it("warns about a fixed-size page file regardless of free disk", () => {
+        expect(pagefileGuidance(false, 90)).toMatch(/fixed size/);
+        expect(pagefileGuidance(false, undefined)).toMatch(/fixed size/);
+    });
+
+    it("warns Windows can't grow the page file when disk is low and system-managed", () => {
+        expect(pagefileGuidance(true, 5)).toMatch(/can't grow/);
+        expect(pagefileGuidance(true, 19.9)).toMatch(/can't grow/);
+    });
+
+    it("uses the soft framing when system-managed with healthy free disk", () => {
+        expect(pagefileGuidance(true, 20)).toMatch(/expand virtual memory automatically/);
+        expect(pagefileGuidance(true, 80)).toMatch(/expand virtual memory automatically/);
+    });
+
+    it("returns no guidance when system-managed status is unknown (fail-open, no guess)", () => {
+        expect(pagefileGuidance(undefined, undefined)).toBe("");
+        expect(pagefileGuidance(undefined, 5)).toBe("");
+    });
+
+    it("falls back to the soft framing when managed is known but disk is unknown", () => {
+        // system_managed known + disk_free_pct missing -> can't tell if it's
+        // stuck, so default to the less alarming framing rather than silence.
+        expect(pagefileGuidance(true, undefined)).toMatch(/expand virtual memory automatically/);
+    });
+});
+
+describe("memory-pressure banner — messageFor", () => {
+    it("RAM messages never include page-file/disk guidance", () => {
+        const msg = messageFor("ram", "critical", { kind: "ram", level: "critical" });
+        expect(msg).toMatch(/RAM/);
+        expect(msg).not.toMatch(/page file|disk/i);
+    });
+
+    it("pagefile messages append disk-aware guidance", () => {
+        const msg = messageFor("pagefile", "critical", {
+            kind: "pagefile",
+            level: "critical",
+            system_managed: false,
+        });
+        expect(msg).toMatch(/page file/i);
+        expect(msg).toMatch(/fixed size/);
     });
 });

--- a/frontend/app/notification/memory-pressure-banner.tsx
+++ b/frontend/app/notification/memory-pressure-banner.tsx
@@ -3,14 +3,24 @@
 
 /**
  * MemoryPressureBanner — a non-modal, dismissible, app-wide banner that warns
- * the user when the host detects low system memory, BEFORE the cliff.
- * SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F.
+ * the user when the host detects low memory, BEFORE the cliff.
+ * SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.F,
+ * SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.
  *
  * The host (`memory_heartbeat` → `mem_pressure`, #1494) emits a `memory-pressure`
- * event carrying the debounced level on every transition; this renders a warning
- * (Warn) / error (Critical) banner and clears it when the level returns to
- * normal. It is **purely informational** — the user (closing a window or another
- * app) is the most reliable lever; the banner never touches renderers or windows.
+ * event carrying a `kind` ("ram" | "pagefile") and the debounced level on every
+ * transition; this renders a warning (Warn) / error (Critical) banner and clears
+ * it when the level returns to normal. It is **purely informational** — the user
+ * (closing a window or another app) is the most reliable lever; the banner never
+ * touches renderers or windows.
+ *
+ * RAM and Page File pressure are two independently-tracked signals (originally
+ * one combined "commit charge" signal mislabeled "System memory" — see the
+ * 2026-08-07 spec for why that was wrong): a machine can be tight on RAM with a
+ * healthy page file, or vice versa. Mount one `<MemoryPressureBanner kind="ram" />`
+ * and one `<MemoryPressureBanner kind="pagefile" />`; each has its own level and
+ * dismiss state and only reacts to events carrying its own `kind`, so both can
+ * show at once if both are true.
  *
  * Dismiss is sticky per *severity*: dismissing at Warn keeps it hidden until
  * pressure escalates to Critical or a fresh episode begins (level returns to
@@ -19,7 +29,7 @@
  * The show/dismiss decision is a pure function (`shouldShow`) so it's unit-tested
  * without a renderer. End-to-end the banner can be exercised from DevTools:
  *   window.dispatchEvent(new CustomEvent('agentmux-event',
- *     { detail: { event: 'memory-pressure', payload: { level: 'warn' } } }))
+ *     { detail: { event: 'memory-pressure', payload: { kind: 'pagefile', level: 'warn' } } }))
  */
 
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
@@ -27,10 +37,18 @@ import { listenEvent } from "@/app/platform/ipc";
 import "./memory-pressure-banner.scss";
 
 export type PressureLevel = "normal" | "warn" | "critical";
+export type PressureKind = "ram" | "pagefile";
+type ActiveLevel = Exclude<PressureLevel, "normal">;
 
 interface MemoryPressurePayload {
+    kind: PressureKind;
     level: PressureLevel;
+    // "ram" payloads carry this.
+    phys_free_mb?: number;
+    // "pagefile" payloads carry these three.
     commit_free_mb?: number;
+    system_managed?: boolean;
+    disk_free_pct?: number;
 }
 
 /** Ordinal severity, so escalation (warn→critical) can re-show a dismissed banner. */
@@ -44,22 +62,65 @@ export function shouldShow(level: PressureLevel, dismissedAt: PressureLevel): bo
     return severity(level) > 0 && severity(level) > severity(dismissedAt);
 }
 
-const MESSAGE: Record<Exclude<PressureLevel, "normal">, string> = {
-    warn: "System memory is running low. Closing some windows or other applications will keep AgentMux responsive.",
+const RAM_MESSAGE: Record<ActiveLevel, string> = {
+    warn: "System RAM is running low. Performance may degrade; closing some windows or apps will help.",
     critical:
-        "System memory is critically low — an out-of-memory crash is imminent. Close some windows or other apps now to keep your work safe.",
+        "System RAM is critically low. Closing some windows or other apps will keep AgentMux responsive.",
 };
 
-export const MemoryPressureBanner = () => {
+const PAGEFILE_MESSAGE: Record<ActiveLevel, string> = {
+    warn: "Virtual memory (page file) is running low.",
+    critical:
+        "Virtual memory (page file) is critically low — an out-of-memory crash is imminent.",
+};
+
+/** Disk-free % below which a system-managed page file is treated as
+ *  practically stuck even though Windows would like to grow it — matches the
+ *  ~15-20% free-disk framing in SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2. */
+const PAGEFILE_DISK_LOW_PCT = 20;
+
+/** The disk/OS-managed-aware guidance appended to the Page File message —
+ *  the "may the OS handle it, or not" distinction from
+ *  SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07 §4. Empty string if the
+ *  host didn't report disk context (e.g. a read failure) — no guidance is
+ *  better than a guess. */
+export function pagefileGuidance(systemManaged?: boolean, diskFreePct?: number): string {
+    if (systemManaged === false) {
+        return " Your page file has a fixed size and won't grow automatically — free up disk space or increase its size in Windows settings.";
+    }
+    if (systemManaged === true && diskFreePct !== undefined && diskFreePct < PAGEFILE_DISK_LOW_PCT) {
+        return " Windows can't grow your page file because disk space is low — free up disk space now to avoid a crash.";
+    }
+    if (systemManaged === true) {
+        return " Windows can expand virtual memory automatically, but performance may dip in the meantime.";
+    }
+    return "";
+}
+
+/** The full banner text for a given kind/level/payload — RAM never has
+ *  disk/OS-managed guidance (that concept doesn't apply to physical RAM). */
+export function messageFor(kind: PressureKind, level: ActiveLevel, payload: MemoryPressurePayload): string {
+    if (kind === "ram") return RAM_MESSAGE[level];
+    return PAGEFILE_MESSAGE[level] + pagefileGuidance(payload.system_managed, payload.disk_free_pct);
+}
+
+interface MemoryPressureBannerProps {
+    kind: PressureKind;
+}
+
+export const MemoryPressureBanner = (props: MemoryPressureBannerProps) => {
     const [level, setLevel] = createSignal<PressureLevel>("normal");
     // The level at which the user last dismissed; "normal" = not dismissed.
     const [dismissedAt, setDismissedAt] = createSignal<PressureLevel>("normal");
+    const [payload, setPayload] = createSignal<MemoryPressurePayload>({ kind: props.kind, level: "normal" });
 
     onMount(() => {
         let unsub: (() => void) | undefined;
         void listenEvent<MemoryPressurePayload>("memory-pressure", (p) => {
-            const next: PressureLevel = p?.level ?? "normal";
+            if (!p || p.kind !== props.kind) return;
+            const next: PressureLevel = p.level ?? "normal";
             setLevel(next);
+            setPayload(p);
             // A return to Normal ends the episode → re-arm so the next episode
             // shows even if the user had dismissed the previous one.
             if (next === "normal") setDismissedAt("normal");
@@ -82,13 +143,15 @@ export const MemoryPressureBanner = () => {
                     {level() === "critical" ? "⚠" : "▲"}
                 </span>
                 <span class="memory-pressure-banner-text">
-                    {level() === "critical" ? MESSAGE.critical : MESSAGE.warn}
+                    {level() === "critical"
+                        ? messageFor(props.kind, "critical", payload())
+                        : messageFor(props.kind, "warn", payload())}
                 </span>
                 <button
                     class="memory-pressure-banner-dismiss"
                     type="button"
                     title="Dismiss"
-                    aria-label="Dismiss low-memory warning"
+                    aria-label={props.kind === "ram" ? "Dismiss low-RAM warning" : "Dismiss low-page-file warning"}
                     onClick={() => setDismissedAt(level())}
                 >
                     ×


### PR DESCRIPTION
## Summary

The "System memory is critically low" banner was driven entirely by Windows' commit charge (physical RAM + page file combined), not RAM alone — correct when the page file is under pressure, but mislabeled as a RAM problem. This splits it into two independently-tracked, independently-worded signals, per `docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md`.

- **RAM pressure** — new tracker using physical-memory numbers already sampled every 20s but never published (no new syscall).
- **Page File pressure** — the existing commit signal, correctly relabeled, now carrying `system_managed` + `disk_free_pct` (extracted into a shared `agentmux-common::pagefile` module so `agentmux-srv`'s StatusBar telemetry and `agentmux-cef`'s banner can't independently drift on "system-managed?" the way two pipelines already did once — issue #2218) so the banner can distinguish:
  - Windows can grow the page file automatically → soft framing
  - Windows *wants* to grow it but disk space won't let it (the exact bug `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29` documented) → sharp, "free disk now"
  - Fixed-size page file → sharp, "increase its size in Windows settings"

`MemoryPressureBanner` now takes a `kind` prop and is mounted twice in `app.tsx` — RAM and Page File pressure are uncorrelated, so both can show at once.

## Test plan

- [x] `cargo check -p agentmux-common -p agentmux-srv -p agentmux-cef` — clean, no new warnings
- [x] `cargo test -p agentmux-common pagefile` — 7/7 pass (moved from `sysinfo.rs`, verbatim)
- [x] `cargo test -p agentmux-srv sysinfo` — 7/7 `commit_attribution_tests` still pass, `pagefile_volume_tests` correctly gone (moved)
- [x] `cargo test -p agentmux-cef memory_pressure` — 7/7 pass unchanged after the thresholds-as-a-field refactor
- [x] `npx vitest run .../memory-pressure-banner.test.ts` — 13/13 pass (6 existing + 7 new for `pagefileGuidance`/`messageFor`)
- [x] `tsc --noEmit` — clean

<!-- agentmux:agent_id=agenty-0629j -->