### PR TITLE
fix(swarm): drop redundant agent-id tag on solo feeds, colorize ANSI in activity feed

### DIFF
--- a/.changesets/1786127987-fix-swarm-drop-redundant-agent-id-tag-on-solo-feeds-colorize-7dlw.md
+++ b/.changesets/1786127987-fix-swarm-drop-redundant-agent-id-tag-on-solo-feeds-colorize-7dlw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): drop redundant agent-id tag on solo feeds, colorize ANSI in activity feed

--- a/frontend/app/view/swarm/swarm-view.render.test.tsx
+++ b/frontend/app/view/swarm/swarm-view.render.test.tsx
@@ -1,0 +1,124 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Component-level coverage for DispatchActivityFeedEntry — the Swarm view's
+ * per-dispatch activity feed row. Two fixes covered here:
+ *
+ *   1. The `showAgentTag` gate: a solo Agent Tool dispatch's feed only ever
+ *      contains its own agent's events, so tagging every line with the same
+ *      unchanging 7-char hex id is pure noise. Only a genuine multi-member
+ *      Workflow feed needs the tag. (Reported 2026-08-07 as "hex codes on
+ *      nearly every line".)
+ *   2. ANSI-aware rendering: captured shell output can carry SGR escape
+ *      sequences with zero backend sanitization — these should render
+ *      colorized (matching the Agent pane's own tool-result view), not as
+ *      literal escape text.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import { DispatchActivityFeedEntry } from "./swarm-view";
+import type { DispatchActivityEntry } from "./swarm-model";
+
+afterEach(() => cleanup());
+
+function textEntry(agentId: string, content: string): DispatchActivityEntry {
+    return {
+        agentId,
+        event: { agent_id: agentId, timestamp: 0, event_type: { type: "text", content } },
+    };
+}
+
+function toolResultEntry(agentId: string, preview: string, isError = false): DispatchActivityEntry {
+    return {
+        agentId,
+        event: { agent_id: agentId, timestamp: 0, event_type: { type: "tool_result", is_error: isError, preview } },
+    };
+}
+
+function progressEntry(agentId: string, output: string): DispatchActivityEntry {
+    return {
+        agentId,
+        event: { agent_id: agentId, timestamp: 0, event_type: { type: "progress", output } },
+    };
+}
+
+describe("DispatchActivityFeedEntry — agent tag visibility", () => {
+    it("renders the agent tag when showAgentTag is true (multi-member workflow feed)", () => {
+        const { container } = render(() => (
+            <DispatchActivityFeedEntry entry={textEntry("abcdef1234567", "hello")} showAgentTag={true} />
+        ));
+        const tag = container.querySelector(".swarm-dispatch-feed-tag");
+        expect(tag).not.toBeNull();
+        expect(tag!.textContent).toBe("abcdef1");
+    });
+
+    it("omits the agent tag when showAgentTag is false (solo Agent Tool feed)", () => {
+        const { container } = render(() => (
+            <DispatchActivityFeedEntry entry={textEntry("abcdef1234567", "hello")} showAgentTag={false} />
+        ));
+        expect(container.querySelector(".swarm-dispatch-feed-tag")).toBeNull();
+    });
+
+    it("gates the tag consistently across every entry kind (text, tool_result, progress)", () => {
+        for (const entry of [
+            textEntry("a1", "hi"),
+            toolResultEntry("a1", "ok"),
+            progressEntry("a1", "working"),
+        ]) {
+            const { container, unmount } = render(() => (
+                <DispatchActivityFeedEntry entry={entry} showAgentTag={false} />
+            ));
+            expect(container.querySelector(".swarm-dispatch-feed-tag")).toBeNull();
+            unmount();
+        }
+    });
+});
+
+describe("DispatchActivityFeedEntry — ANSI-aware rendering", () => {
+    it("colorizes ANSI SGR sequences in a text entry via text-ansi-* classes, instead of literal escape text", () => {
+        const { container } = render(() => (
+            <DispatchActivityFeedEntry
+                entry={textEntry("a1", "\x1b[31mred\x1b[0m plain")}
+                showAgentTag={false}
+            />
+        ));
+        const colored = container.querySelector(".text-ansi-red");
+        expect(colored).not.toBeNull();
+        expect(colored!.textContent).toBe("red");
+        expect(container.textContent).toContain("plain");
+    });
+
+    it("colorizes ANSI in an expanded tool_result preview", async () => {
+        const { container, findByText } = render(() => (
+            <DispatchActivityFeedEntry
+                entry={toolResultEntry("a1", "\x1b[32mok\x1b[0m", false)}
+                showAgentTag={false}
+            />
+        ));
+        // tool_result body only renders once expanded.
+        const header = await findByText("Result");
+        header.click();
+        expect(container.querySelector(".text-ansi-green")).not.toBeNull();
+    });
+
+    it("splits a multi-line body into one row per line", () => {
+        const { container } = render(() => (
+            <DispatchActivityFeedEntry entry={textEntry("a1", "line1\nline2\nline3")} showAgentTag={false} />
+        ));
+        const body = container.querySelector(".swarm-subagent-detail-text")!;
+        expect(body.children.length).toBe(3);
+        expect(body.textContent).toBe("line1line2line3");
+    });
+
+    it("does not route progress output through AnsiText (inline layout, not a captured command body)", () => {
+        const { container } = render(() => (
+            <DispatchActivityFeedEntry entry={progressEntry("a1", "\x1b[31mworking\x1b[0m")} showAgentTag={false} />
+        ));
+        // Still renders literally (unchanged behavior) — asserts the
+        // deliberate scoping decision, not a bug.
+        expect(container.querySelector(".swarm-subagent-detail-progress span")!.textContent).toContain("working");
+        expect(container.querySelector(".text-ansi-red")).toBeNull();
+    });
+});

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -5,6 +5,7 @@ import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, 
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
 import { subagentDisplayLabel, subagentRowKey, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
+import AnsiLine from "@/element/ansiline";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -597,20 +598,50 @@ function DispatchActivityFeed({
 }): JSX.Element {
     const detail = model.getDispatchDetail(rowKey, dispatchId, backfillAgentId);
     const entries = detail.entriesAtom;
+    // A solo Agent Tool row's feed only ever contains that one agent's own
+    // events — tagging every line with the same, unchanging 7-char id is
+    // pure noise (2026-08-07: reported as "hex codes on nearly every
+    // line"). Only a genuine multi-member Workflow feed (no
+    // backfillAgentId — see the doc comment above) actually needs the tag
+    // to say which member a line belongs to.
+    const showAgentTag = backfillAgentId === undefined;
     return (
         <div class="swarm-dispatch-feed">
             <Show when={entries().length === 0}>
                 <div class="swarm-dispatch-feed-empty">No activity yet.</div>
             </Show>
-            <For each={entries()}>{(entry) => <DispatchActivityFeedEntry entry={entry} />}</For>
+            <For each={entries()}>{(entry) => <DispatchActivityFeedEntry entry={entry} showAgentTag={showAgentTag} />}</For>
         </div>
     );
 }
 
-function DispatchActivityFeedEntry({ entry }: { entry: DispatchActivityEntry }): JSX.Element {
+/** One line of a multi-line body, ANSI-colored via `AnsiLine` instead of
+ *  dumped as literal escape-sequence text — a subagent's tool call can
+ *  capture colorized shell output (e.g. `git diff --color`, a test
+ *  reporter) with zero sanitization on the backend
+ *  (`subagent_watcher/parse.rs`), unlike the Agent pane's own tool-result
+ *  view. Styled inline with the existing `.swarm-subagent-detail-text`
+ *  class rather than reusing `TerminalOutput` — that component's bordered
+ *  panel chrome doesn't match this feed's compact, unboxed line list. */
+function AnsiText(props: { text: string; class?: string }): JSX.Element {
+    const lines = createMemo(() => props.text.split("\n"));
+    return (
+        <div class={props.class}>
+            <For each={lines()}>{(line) => <AnsiLine line={line} />}</For>
+        </div>
+    );
+}
+
+export function DispatchActivityFeedEntry({
+    entry,
+    showAgentTag,
+}: {
+    entry: DispatchActivityEntry;
+    showAgentTag: boolean;
+}): JSX.Element {
     const et = entry.event.event_type;
     const [expanded, setExpanded] = createSignal(false);
-    const tag = <span class="swarm-dispatch-feed-tag">{entry.agentId.substring(0, 7)}</span>;
+    const tag = showAgentTag ? <span class="swarm-dispatch-feed-tag">{entry.agentId.substring(0, 7)}</span> : null;
 
     switch (et.type) {
         case "text":
@@ -618,7 +649,7 @@ function DispatchActivityFeedEntry({ entry }: { entry: DispatchActivityEntry }):
             return (
                 <div class="swarm-dispatch-feed-entry">
                     {tag}
-                    <pre class="swarm-subagent-detail-text">{et.content}</pre>
+                    <AnsiText class="swarm-subagent-detail-text" text={et.content} />
                 </div>
             );
         case "tool_use":
@@ -631,7 +662,7 @@ function DispatchActivityFeedEntry({ entry }: { entry: DispatchActivityEntry }):
                             <span class="swarm-subagent-detail-tool-name">{et.name}</span>
                         </div>
                         <Show when={expanded()}>
-                            <pre class="swarm-subagent-detail-text">{et.input_summary}</pre>
+                            <AnsiText class="swarm-subagent-detail-text" text={et.input_summary} />
                         </Show>
                     </div>
                 </div>
@@ -649,14 +680,20 @@ function DispatchActivityFeedEntry({ entry }: { entry: DispatchActivityEntry }):
                             <span>{et.is_error ? "Error" : "Result"}</span>
                         </div>
                         <Show when={expanded()}>
-                            <pre class={`swarm-subagent-detail-text ${et.is_error ? "swarm-subagent-detail-text--error" : ""}`}>
-                                {et.preview}
-                            </pre>
+                            <AnsiText
+                                class={`swarm-subagent-detail-text ${et.is_error ? "swarm-subagent-detail-text--error" : ""}`}
+                                text={et.preview}
+                            />
                         </Show>
                     </div>
                 </div>
             );
         case "progress":
+            // Not routed through AnsiText: progress output is a short,
+            // inline status label next to the spinner icon (never a
+            // captured command's stdout/stderr the way text/tool_use/
+            // tool_result can be), and AnsiText's per-line <div> would
+            // break this row's inline flex layout for no real benefit.
             return (
                 <div class="swarm-dispatch-feed-entry">
                     {tag}


### PR DESCRIPTION
## Summary

Investigated a report of "hex codes on nearly every line" in the Swarm view's expanded per-dispatch activity feed. Two issues found and fixed:

1. **Redundant agent-id tag.** `DispatchActivityFeedEntry` unconditionally prepends `entry.agentId.substring(0, 7)` to every entry. For the common case — a solo Agent Tool dispatch (one subagent per row) — every single line in the feed carries the exact same 7-char hex fragment, styled as unmarked 10px secondary-color text with no badge/tooltip. It reads as pure noise. The tag genuinely earns its keep in a multi-member Workflow dispatch's concatenated feed (it's the only thing saying which member a line belongs to), so the fix gates it on `showAgentTag = backfillAgentId === undefined` — the same discriminator `DispatchActivityFeed` already uses to distinguish solo vs. multi-member feeds — rather than removing it outright.
2. **No ANSI handling.** The feed's `text`/`tool_use`/`tool_result` bodies rendered raw `<pre>{text}</pre>` with zero ANSI-escape processing, unlike the Agent pane's own tool-result view (`CompactResult` → `TerminalOutput` → `AnsiLine`). A subagent's captured shell output (colorized `git diff`, a test reporter, etc.) has no ANSI stripping on the backend either (`subagent_watcher/parse.rs`), so it would render as literal escape-sequence text. Added a small `AnsiText` helper — `AnsiLine` per line, styled inline with the feed's existing `.swarm-subagent-detail-text` class rather than pulling in `TerminalOutput`'s bordered-panel chrome (which doesn't match this feed's compact list). `progress.output` deliberately left untouched — it's a short inline status label next to a spinner, not a captured command body, and `AnsiLine`'s per-line `<div>` would break that row's inline flex layout for no real benefit.

## Test plan

- [x] New `swarm-view.render.test.tsx` — 7 tests covering tag visibility (shown for multi-member, hidden for solo, consistent across all four entry kinds) and ANSI colorization (text entries, expanded tool_result preview, multi-line splitting, and confirming progress intentionally stays unrouted)
- [x] Verified with a throwaway mutation (swapped `AnsiLine` for a plain `<span>`) that the ANSI tests actually fail when the fix is broken, then reverted
- [x] `npx vitest run frontend/app/view/swarm/` — 74/74 passing
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=agentx -->