### PR TITLE
feat(backend): add shared FsWatchPool filesystem-watcher framework

### DIFF
--- a/.changesets/1786157012-feat-backend-add-shared-fswatchpool-filesystem-watcher-frame-lgn0.md
+++ b/.changesets/1786157012-feat-backend-add-shared-fswatchpool-filesystem-watcher-frame-lgn0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(backend): add shared FsWatchPool filesystem-watcher framework

--- a/agentmux-srv/src/backend/fs_watch/mod.rs
+++ b/agentmux-srv/src/backend/fs_watch/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared filesystem-watcher framework.
+//!
+//! Before this module, three independent `notify`-based watchers
+//! (`config_watcher_fs.rs`, `editor_file_watcher.rs`, `media_file_watcher.rs`)
+//! each hand-rolled the same ~80 lines of plumbing — `notify` construction,
+//! sync-callback-to-async bridging, refcounted watch/unwatch, and the
+//! correctness-critical "watch the parent directory, not the file itself, so
+//! an atomic rename-over-target save is still detected" rule. None of the
+//! three (nor `subagent_watcher/`, the fourth) had any recovery if a watch
+//! failed to start or silently died later — see
+//! `docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md` for the full
+//! audit and design rationale this module implements.
+//!
+//! `FsWatchPool` owns exactly the shared plumbing plus the new recovery
+//! layer (retry-with-backoff, a `PollWatcher` fallback, and a periodic
+//! self-healing sweep). It does NOT own domain-specific debounce or event
+//! payload/publish logic — callers subscribe, get a broadcast stream of raw
+//! change events, and apply their own filtering/debounce on top, the same
+//! way `editor_file_watcher.rs`/`media_file_watcher.rs` already do internally
+//! today (that part is genuinely domain-specific: editor wants per-path
+//! debounce, media wants per-directory+extension filtering).
+//!
+//! This is a pure addition in its first PR — no existing watcher has been
+//! migrated onto it yet. See the spec's §5 migration path.
+
+mod pool;
+mod recovery;
+
+pub use pool::{FsWatchEvent, FsWatchEventKind, FsWatchPool, Subscription};
+pub use recovery::{FsWatchHealth, WatchBackend};

--- a/agentmux-srv/src/backend/fs_watch/pool.rs
+++ b/agentmux-srv/src/backend/fs_watch/pool.rs
@@ -1,0 +1,416 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::{EventKind, RecursiveMode, Watcher};
+use tokio::sync::{broadcast, mpsc};
+
+use super::recovery::{HealthState, WatchBackend, FsWatchHealth, RETRY_BACKOFF, HEALTH_SWEEP_INTERVAL};
+
+/// Broadcast channel capacity. Generous relative to real fs-event volume
+/// (file-save bursts, not high-frequency streams) — a slow consumer would
+/// need to fall behind by this many raw events before `RecvError::Lagged`,
+/// at which point it should resync from scratch rather than assume it saw
+/// everything (same "wake signal, not a guaranteed delivery log" contract
+/// the existing three watchers already have via their own debounce logic).
+const EVENT_CHANNEL_CAPACITY: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsWatchEventKind {
+    Created,
+    Modified,
+    Removed,
+    Other,
+}
+
+impl From<EventKind> for FsWatchEventKind {
+    fn from(kind: EventKind) -> Self {
+        match kind {
+            EventKind::Create(_) => FsWatchEventKind::Created,
+            EventKind::Modify(_) => FsWatchEventKind::Modified,
+            EventKind::Remove(_) => FsWatchEventKind::Removed,
+            _ => FsWatchEventKind::Other,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FsWatchEvent {
+    pub path: PathBuf,
+    pub kind: FsWatchEventKind,
+}
+
+/// Handle returned by `subscribe_file`/`subscribe_dir`. Holding this alive
+/// is not required (unlike the raw `notify::Watcher`, which must be kept
+/// alive by its owner) — the pool itself owns the underlying watcher.
+/// `unsubscribe` takes this by value so a caller can't accidentally
+/// unsubscribe the same handle twice.
+#[derive(Debug, Clone)]
+pub struct Subscription {
+    id: u64,
+    /// What the caller actually asked to watch (a file or a directory).
+    pub path: PathBuf,
+    /// What's actually registered with the OS watcher — the parent
+    /// directory for a file subscription (see module doc: this is the
+    /// baked-in atomic-rename-safety rule), or `path` itself for a
+    /// directory subscription.
+    watch_target: PathBuf,
+    mode: RecursiveMode,
+}
+
+struct WatchEntry {
+    refcount: usize,
+    mode: RecursiveMode,
+}
+
+struct Inner {
+    watcher: Option<Box<dyn Watcher + Send>>,
+    targets: HashMap<PathBuf, WatchEntry>,
+}
+
+pub struct FsWatchPool {
+    inner: Mutex<Inner>,
+    health: HealthState,
+    backend: WatchBackend,
+    next_id: AtomicU64,
+    tx: broadcast::Sender<FsWatchEvent>,
+}
+
+impl FsWatchPool {
+    /// Construct the pool and start its background event-bridging and
+    /// health-sweep tasks. Always succeeds — if even the `PollWatcher`
+    /// fallback fails to construct (practically never happens; it's pure
+    /// userspace polling), the pool still comes up with `watcher: None` and
+    /// every subscribe call fails cleanly into `degraded_paths` rather than
+    /// panicking or requiring every caller to handle an `Option<Arc<Self>>`
+    /// at the top level. Live-update is additive everywhere it's used.
+    pub fn new() -> Arc<Self> {
+        let (raw_tx, mut raw_rx) = mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+        let (watcher, backend) = construct_watcher(raw_tx);
+
+        let (broadcast_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+
+        let this = Arc::new(Self {
+            inner: Mutex::new(Inner { watcher, targets: HashMap::new() }),
+            health: HealthState::default(),
+            backend,
+            next_id: AtomicU64::new(1),
+            tx: broadcast_tx,
+        });
+
+        // Bridge notify's sync callback (already funneled into raw_rx by
+        // construct_watcher's closure) into the broadcast stream. Mirrors
+        // the sync-callback -> mpsc -> async-task shape all three existing
+        // watchers already use, just shared once here instead of three
+        // times.
+        let bridge = this.clone();
+        tokio::spawn(async move {
+            while let Some(res) = raw_rx.recv().await {
+                match res {
+                    Ok(event) => {
+                        let kind = FsWatchEventKind::from(event.kind);
+                        if matches!(kind, FsWatchEventKind::Other) {
+                            continue;
+                        }
+                        for path in event.paths {
+                            let _ = bridge.tx.send(FsWatchEvent { path, kind });
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "fs_watch: backend reported an error");
+                    }
+                }
+            }
+        });
+
+        // Periodic self-healing sweep — see recovery.rs's HEALTH_SWEEP_INTERVAL
+        // doc comment for why re-issuing watch() on an already-watched path
+        // is a safe, cheap way to detect and recover from a silent death
+        // without needing a true OS-level "is this watch still alive" signal.
+        let sweeper = this.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(HEALTH_SWEEP_INTERVAL);
+            loop {
+                tick.tick().await;
+                sweeper.sweep();
+            }
+        });
+
+        this
+    }
+
+    /// Watch the file at `path` (specifically: its parent directory,
+    /// non-recursively — see module doc). Returns a fresh `Subscription`
+    /// even when the underlying OS watch is currently failing (tracked in
+    /// `degraded_paths` instead) — a degraded subscription still becomes
+    /// live automatically once retry/sweep succeeds, with no action needed
+    /// from the caller.
+    pub fn subscribe_file(self: &Arc<Self>, path: &Path) -> Subscription {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let target = canonical.parent().map(Path::to_path_buf).unwrap_or(canonical.clone());
+        self.subscribe_target(canonical, target, RecursiveMode::NonRecursive)
+    }
+
+    /// Watch the directory at `path` directly (non-recursive — matching
+    /// `media_file_watcher.rs`'s existing behavior; extension/content
+    /// filtering is the caller's concern, not the pool's).
+    pub fn subscribe_dir(self: &Arc<Self>, path: &Path) -> Subscription {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        self.subscribe_target(canonical.clone(), canonical, RecursiveMode::NonRecursive)
+    }
+
+    fn subscribe_target(self: &Arc<Self>, requested_path: PathBuf, target: PathBuf, mode: RecursiveMode) -> Subscription {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let is_new = {
+            let mut inner = self.inner.lock().unwrap();
+            let entry = inner.targets.entry(target.clone()).or_insert_with(|| WatchEntry { refcount: 0, mode });
+            entry.refcount += 1;
+            entry.refcount == 1
+        };
+
+        if is_new {
+            self.start_watch(target.clone(), mode);
+        }
+
+        Subscription { id, path: requested_path, watch_target: target, mode }
+    }
+
+    /// Stop watching on behalf of `sub`. Idempotent-safe: unsubscribing the
+    /// same handle twice would underflow the refcount, so this takes `self`
+    /// by shared ref but `sub` by value specifically to discourage reuse —
+    /// callers that need multiple independent subscriptions to the same
+    /// path should call `subscribe_file`/`subscribe_dir` once per logical
+    /// subscriber, matching how `editor_file_watcher.rs` already tracks one
+    /// entry per `block_id` today.
+    pub fn unsubscribe(&self, sub: Subscription) {
+        let should_unwatch = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.targets.get_mut(&sub.watch_target) else {
+                return;
+            };
+            entry.refcount = entry.refcount.saturating_sub(1);
+            let empty = entry.refcount == 0;
+            if empty {
+                inner.targets.remove(&sub.watch_target);
+            }
+            empty
+        };
+
+        if should_unwatch {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(w) = inner.watcher.as_mut() {
+                let _ = w.unwatch(&sub.watch_target);
+            }
+            drop(inner);
+            self.health.clear_degraded(&sub.watch_target);
+        }
+    }
+
+    /// Raw change events for every currently-watched target, pool-wide.
+    /// Each call returns an independent receiver — subscribe to this once
+    /// per domain module (not once per file), and filter down to the paths
+    /// that module actually cares about, same as today's per-watcher
+    /// `Inner.watched_paths` filtering.
+    pub fn events(&self) -> broadcast::Receiver<FsWatchEvent> {
+        self.tx.subscribe()
+    }
+
+    pub fn health(&self) -> FsWatchHealth {
+        let active_watches = self.inner.lock().unwrap().targets.len();
+        FsWatchHealth {
+            backend: self.backend,
+            active_watches,
+            degraded_paths: self.health.snapshot(),
+        }
+    }
+
+    /// First attempt at a new target, plus a bounded retry-with-backoff if
+    /// it fails — see `RETRY_BACKOFF`'s doc comment. Runs the retries on a
+    /// spawned task so `subscribe_file`/`subscribe_dir` never blocks on it.
+    fn start_watch(self: &Arc<Self>, target: PathBuf, mode: RecursiveMode) {
+        let first_attempt = self.try_watch(&target, mode);
+        if first_attempt.is_ok() {
+            return;
+        }
+        let err = first_attempt.unwrap_err();
+        tracing::warn!(path = %target.display(), error = %err, "fs_watch: initial watch failed, retrying with backoff");
+        self.health.mark_degraded(target.clone(), err);
+
+        let this = self.clone();
+        tokio::spawn(async move {
+            for delay in RETRY_BACKOFF {
+                tokio::time::sleep(delay).await;
+                // The subscription may have been torn down (refcount back to
+                // zero) while we were waiting — don't resurrect a watch
+                // nobody wants anymore.
+                if !this.inner.lock().unwrap().targets.contains_key(&target) {
+                    return;
+                }
+                match this.try_watch(&target, mode) {
+                    Ok(()) => {
+                        this.health.clear_degraded(&target);
+                        tracing::info!(path = %target.display(), "fs_watch: watch recovered after retry");
+                        return;
+                    }
+                    Err(e) => {
+                        this.health.mark_degraded(target.clone(), e);
+                    }
+                }
+            }
+            tracing::warn!(
+                path = %target.display(),
+                "fs_watch: still degraded after all retries — will keep retrying via the periodic health sweep"
+            );
+        });
+    }
+
+    fn try_watch(&self, target: &Path, mode: RecursiveMode) -> Result<(), String> {
+        let mut inner = self.inner.lock().unwrap();
+        let Some(watcher) = inner.watcher.as_mut() else {
+            return Err("no fs watcher backend available".to_string());
+        };
+        watcher.watch(target, mode).map_err(|e| e.to_string())
+    }
+
+    /// Re-issue `watch()` for every currently-subscribed target, regardless
+    /// of its current health — cheap (a no-op for an already-live watch per
+    /// `notify`'s own docs) and is the only way this pool detects a *silent*
+    /// death, since neither `notify` nor the OS reliably tells us a watch
+    /// died without us asking.
+    fn sweep(&self) {
+        let targets: Vec<(PathBuf, RecursiveMode)> = {
+            let inner = self.inner.lock().unwrap();
+            inner.targets.iter().map(|(p, e)| (p.clone(), e.mode)).collect()
+        };
+        for (target, mode) in targets {
+            match self.try_watch(&target, mode) {
+                Ok(()) => self.health.clear_degraded(&target),
+                Err(e) => self.health.mark_degraded(target, e),
+            }
+        }
+    }
+}
+
+/// Build the watcher backend: prefer the native OS backend
+/// (inotify/FSEvents/ReadDirectoryChangesW); fall back to `notify`'s
+/// stat-based `PollWatcher` if the native backend can't even construct
+/// (practically never on the platforms AgentMux ships for, but real on some
+/// restricted/containerized environments). Returns `(None, Native)` only if
+/// both fail to construct — recorded as `WatchBackend::Native` since that
+/// was the attempted backend; every `subscribe_*` call will immediately
+/// fail into `degraded_paths` until the process restarts, matching the
+/// existing three watchers' "live-update becomes unavailable, nothing else
+/// breaks" posture, just now with a health signal instead of silence.
+fn construct_watcher(
+    tx: mpsc::UnboundedSender<notify::Result<notify::Event>>,
+) -> (Option<Box<dyn Watcher + Send>>, WatchBackend) {
+    let tx_native = tx.clone();
+    match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        let _ = tx_native.send(res);
+    }) {
+        Ok(w) => return (Some(Box::new(w)), WatchBackend::Native),
+        Err(e) => {
+            tracing::warn!(error = %e, "fs_watch: native backend unavailable, falling back to polling");
+        }
+    }
+
+    let poll_config = notify::Config::default().with_poll_interval(Duration::from_secs(2));
+    match notify::PollWatcher::new(move |res: notify::Result<notify::Event>| { let _ = tx.send(res); }, poll_config) {
+        Ok(w) => (Some(Box::new(w)), WatchBackend::Polling),
+        Err(e) => {
+            tracing::error!(error = %e, "fs_watch: polling fallback also failed to construct — live-update unavailable this session");
+            (None, WatchBackend::Native)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration as StdDuration;
+
+    #[tokio::test]
+    async fn subscribe_unsubscribe_refcounting_does_not_panic() {
+        let pool = FsWatchPool::new();
+        let tmp = std::env::temp_dir().join("agentmux_fs_watch_pool_test");
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let sub1 = pool.subscribe_dir(&tmp);
+        let sub2 = pool.subscribe_dir(&tmp);
+        assert_eq!(pool.health().active_watches, 1, "two subscriptions to the same dir share one OS watch");
+
+        pool.unsubscribe(sub1);
+        assert_eq!(pool.health().active_watches, 1, "still watched — sub2 is still active");
+
+        pool.unsubscribe(sub2);
+        assert_eq!(pool.health().active_watches, 0, "last subscriber gone -> watch torn down");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn subscribe_file_watches_the_parent_directory() {
+        let pool = FsWatchPool::new();
+        let dir = std::env::temp_dir().join("agentmux_fs_watch_pool_file_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("thing.md");
+        std::fs::write(&file, "hello").unwrap();
+
+        let sub = pool.subscribe_file(&file);
+        assert_eq!(sub.watch_target, dir.canonicalize().unwrap());
+
+        pool.unsubscribe(sub);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_change_event_is_observable_on_the_broadcast_stream() {
+        let pool = FsWatchPool::new();
+        let dir = std::env::temp_dir().join("agentmux_fs_watch_pool_event_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("watched.md");
+        std::fs::write(&file, "v1").unwrap();
+
+        let mut events = pool.events();
+        let sub = pool.subscribe_file(&file);
+        // Give the native backend a moment to actually register before we
+        // write — otherwise this is a flaky "wrote before the watch was live"
+        // race, not a real assertion about the pool's behavior.
+        tokio::time::sleep(StdDuration::from_millis(200)).await;
+        std::fs::write(&file, "v2").unwrap();
+
+        let seen = tokio::time::timeout(StdDuration::from_secs(5), async {
+            loop {
+                match events.recv().await {
+                    Ok(ev) if ev.path.file_name() == file.file_name() => return true,
+                    Ok(_) => continue,
+                    Err(_) => return false,
+                }
+            }
+        })
+        .await
+        .unwrap_or(false);
+
+        assert!(seen, "expected to observe a change event for the watched file");
+
+        pool.unsubscribe(sub);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn health_reports_the_constructed_backend() {
+        let pool = FsWatchPool::new();
+        // On every platform this actually runs on in CI, the native backend
+        // constructs successfully — this just pins that expectation rather
+        // than the (currently untestable-without-platform-mocking) fallback
+        // path, which recovery.rs's own unit tests cover at the bookkeeping
+        // level instead.
+        assert_eq!(pool.health().backend, WatchBackend::Native);
+    }
+}

--- a/agentmux-srv/src/backend/fs_watch/recovery.rs
+++ b/agentmux-srv/src/backend/fs_watch/recovery.rs
@@ -1,0 +1,110 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Health tracking + retry policy for `FsWatchPool`. Split out of `pool.rs`
+//! so the recovery bookkeeping (what's degraded, which backend is active)
+//! is testable independent of the notify/tokio wiring.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Which `notify` backend is actually driving watches right now. `Polling`
+/// only happens if the native backend failed to construct at all (rare —
+/// e.g. inotify unavailable) — see `SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md`
+/// §4 point 2. Once picked at pool construction, this doesn't change for the
+/// pool's lifetime; per-path failures are tracked in `degraded_paths`
+/// instead, independent of which backend is in use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchBackend {
+    Native,
+    Polling,
+}
+
+/// Snapshot of the pool's current health, for diagnostics (`muxlog`,
+/// eventually a UI surface — not built here, see spec §6 non-goals).
+#[derive(Debug, Clone)]
+pub struct FsWatchHealth {
+    pub backend: WatchBackend,
+    pub active_watches: usize,
+    /// Paths that failed to (re-)establish a watch on their last attempt,
+    /// paired with the error. Retried in the background per
+    /// `RETRY_BACKOFF`/the periodic sweep; a path leaves this list the
+    /// moment any attempt succeeds.
+    pub degraded_paths: Vec<(PathBuf, String)>,
+}
+
+/// Backoff schedule for retrying a failed `watch()` call, per spec §4 point
+/// 1 — bounded at 3 attempts over ~4.2s total, not indefinite: a path that's
+/// still failing after this moves into `degraded_paths` and is picked up by
+/// the periodic health sweep (`pool.rs`'s `HEALTH_SWEEP_INTERVAL`) instead of
+/// spinning a dedicated retry loop forever.
+pub const RETRY_BACKOFF: [Duration; 3] = [
+    Duration::from_millis(200),
+    Duration::from_millis(800),
+    Duration::from_millis(3200),
+];
+
+/// How often the background sweep re-verifies every currently-subscribed
+/// path still has a live watch, self-healing a silent death (inotify
+/// instance-limit churn, a watched directory deleted and recreated at a new
+/// inode, a flaky network mount) without needing a true "is this watch still
+/// alive" signal from the OS — re-issuing `watch()` on an already-watched
+/// path is a documented-safe no-op in `notify`, so this is cheap even when
+/// nothing is actually wrong.
+pub const HEALTH_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Default)]
+pub(super) struct HealthState {
+    degraded: Mutex<HashMap<PathBuf, String>>,
+}
+
+impl HealthState {
+    pub(super) fn mark_degraded(&self, path: PathBuf, err: String) {
+        self.degraded.lock().unwrap().insert(path, err);
+    }
+
+    pub(super) fn clear_degraded(&self, path: &std::path::Path) {
+        self.degraded.lock().unwrap().remove(path);
+    }
+
+    pub(super) fn snapshot(&self) -> Vec<(PathBuf, String)> {
+        self.degraded
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(p, e)| (p.clone(), e.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mark_then_clear_round_trips() {
+        let state = HealthState::default();
+        let path = PathBuf::from("/tmp/watched-thing");
+        state.mark_degraded(path.clone(), "permission denied".to_string());
+        assert_eq!(state.snapshot(), vec![(path.clone(), "permission denied".to_string())]);
+
+        state.clear_degraded(&path);
+        assert!(state.snapshot().is_empty());
+    }
+
+    #[test]
+    fn clearing_an_unknown_path_is_a_no_op() {
+        let state = HealthState::default();
+        state.clear_degraded(std::path::Path::new("/never/watched"));
+        assert!(state.snapshot().is_empty());
+    }
+
+    #[test]
+    fn retry_backoff_is_bounded_and_increasing() {
+        assert_eq!(RETRY_BACKOFF.len(), 3);
+        assert!(RETRY_BACKOFF[0] < RETRY_BACKOFF[1]);
+        assert!(RETRY_BACKOFF[1] < RETRY_BACKOFF[2]);
+    }
+}

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -16,6 +16,7 @@ pub mod providers;
 pub mod model_catalog;
 pub mod config_watcher_fs;
 pub mod editor_file_watcher;
+pub mod fs_watch;
 pub mod media_file_watcher;
 pub mod ijson;
 pub mod docsite;

--- a/docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md
+++ b/docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md
@@ -1,0 +1,234 @@
+# SPEC: Shared filesystem-watcher framework — audit + design
+
+**Date:** 2026-08-07
+**Status:** Proposed
+**Trigger:** Follow-up to `docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md`,
+which deferred live capture of Claude's autonomous memory writes as a
+non-goal specifically because it would need a filesystem watcher. User
+asked: do we already have watchers, and should there be one shared,
+robust framework (with error handling + recovery) everything lives under?
+
+---
+
+## 0. Answers
+
+**Do we already have watchers?** Yes — four independent, hand-rolled
+implementations, all on the `notify` crate (already a dependency,
+`agentmux-srv/Cargo.toml:37`, v7). See §1.
+
+**Should there be a shared framework?** Yes, for two independent reasons:
+
+1. **Three of the four already duplicate the same ~80 lines of
+   plumbing**, and say so in their own doc comments (§2) — this isn't a
+   hypothetical future benefit, it's dedup of code that exists today.
+2. **None of the four have any error recovery** — every one logs a warning
+   and silently gives up if the initial watch fails, and none re-check or
+   re-subscribe if the OS-level watch dies later. This is a real gap, not
+   just style — it's the specific thing blocking the native-memory spec's
+   deferred follow-up, and it's invisible today because every existing
+   consumer treats live-update as "nice to have," so a silently-dead watcher
+   just looks like "nothing changed" instead of an error. §3.
+
+---
+
+## 1. Existing watchers, audited
+
+| File | Watches | Scope | Debounce | Error on create | Recovery if watch later dies |
+|---|---|---|---|---|---|
+| `agentmux-srv/src/backend/config_watcher_fs.rs` | `settings.json`'s directory | One fixed path, global | 300ms, drain-loop | log + `None`, feature silently off | none |
+| `agentmux-srv/src/backend/editor_file_watcher.rs` | Arbitrary open-editor-tab files | Dynamic set, per-block refcounted | 300ms, per-path generation counter | log + `None`, feature silently off | none |
+| `agentmux-srv/src/backend/media_file_watcher.rs` | Arbitrary Media-pane directories | Dynamic set, per-block refcounted, extension-filtered | 300ms, per-path generation counter | log + `None`, feature silently off | none |
+| `agentmux-srv/src/backend/subagent_watcher/` | Claude Code session/subagent dirs | Dynamic set, per-block, full module (parse/scan/jsonl/query submodules) | domain-specific (JSONL line-buffering, 500ms activity-flush) | log + presumably `None`/panic-avoided (not re-checked here) | partial — has its own **reconciliation** (`scan.rs`'s `reconcile_stale_subagents`, event-triggered on confirmed-idle) for stale *application state*, but that's a different problem from "the OS watch itself died" |
+
+All four constructed independently in `agentmux-srv/src/bootstrap.rs`
+(lines ~852, 860, 887, 1117) — no shared registry, no shared lifecycle, no
+shared health surface.
+
+## 2. Duplication, quantified
+
+`editor_file_watcher.rs`'s own doc comment: *"Generalizes
+`config_watcher_fs.rs`'s single-file `notify`-watcher pattern to an
+arbitrary, dynamically-changing set of paths."* `media_file_watcher.rs`'s own
+doc comment: *"Directory-mode sibling of `editor_file_watcher.rs`'s
+single-file watcher."* This is explicit, self-documented copy-adapt
+evolution — not speculation. Concretely duplicated across editor+media (near
+byte-identical in places):
+
+- `notify::recommended_watcher` construction + the sync-callback → `mpsc`
+  channel → async `tokio::spawn` consumer bridge (`new()`, ~35 lines each).
+- Per-path debounce via an `AtomicU64` generation counter per watched path,
+  pruned on unwatch (`handle_fs_event`, ~25 lines each).
+- Refcounted watch/unwatch bookkeeping so a directory is only actually
+  under OS watch while ≥1 subscriber cares about it.
+- **The correctness-critical decision to watch the parent directory, not the
+  file itself**, `RecursiveMode::NonRecursive` — necessary so an
+  atomic-write-via-tmp-then-rename save (exactly what
+  `native_memory_handlers.rs`'s own `write_file` handler does, and what most
+  editors/tools do) is still detected; watching a file's own inode directly
+  can silently stop firing after a rename-over-target. Every implementer had
+  to independently know this. A shared framework should bake it in once.
+- Publishing a WPS event scoped to the subscribing block IDs, never a global
+  broadcast (`publish_editor_file_changed`/`publish_media_file_changed` are
+  structurally identical).
+
+`config_watcher_fs.rs` predates the refcounted-subscriber pattern (it only
+ever watches one fixed path) but duplicates the construction + debounce
+shape inline in its own `spawn_settings_watcher`.
+
+## 3. The actual gap: zero error recovery, anywhere
+
+Every one of the four handles watcher-creation failure the same way: log a
+`tracing::warn!` and return `None`/skip setup. That's a reasonable *initial*
+posture (live-update is additive, not required for the feature to work at
+all) — but none of them handle **degradation after a successful start**:
+
+- If the OS-level watch dies mid-session (inotify instance-limit exhaustion,
+  a network-drive/WSL mount where inotify is flaky, the watched directory
+  itself getting deleted and recreated at a new inode), there is no
+  detection, no retry, no re-subscribe, and no signal anywhere (`muxlog
+  errors` included) that live-update quietly stopped working. The feature
+  just looks like "nothing has changed" — indistinguishable from "the file
+  genuinely hasn't changed" from the user's side.
+- `notify` itself ships a `PollWatcher` fallback (stat-based, works
+  everywhere the native backend doesn't) — none of the four ever reach for
+  it.
+
+This is precisely the gap the native-memory durability spec's §2.3 flagged
+as a "known residual risk... not proposed here": closing it requires exactly
+this missing recovery layer, and building it once, shared, is a better
+trade than adding a bespoke retry loop to a fifth watcher.
+
+## 4. Design
+
+New module `agentmux-srv/src/backend/fs_watch/` (mirrors `subagent_watcher/`
+being its own directory once it outgrew one file):
+
+```rust
+/// One shared notify backend + subscription registry. Domain modules
+/// (editor, media, config, subagent, and the new native-memory one) each
+/// hold an `Arc<FsWatchPool>` and call subscribe/unsubscribe; they own
+/// their own debounce policy and event payload/publish shape, since those
+/// are genuinely domain-specific (editor wants per-path, media wants
+/// per-directory+extension-filter, subagent wants JSONL-aware buffering).
+pub struct FsWatchPool { /* ... */ }
+
+pub struct Subscription {
+    pub id: SubscriptionId,
+    pub path: PathBuf,
+    pub recursive: bool,
+}
+
+impl FsWatchPool {
+    pub fn new() -> Arc<Self>;
+
+    /// Start watching `path` on behalf of `owner` (refcounted — matches the
+    /// existing editor/media pattern, generalized). Always watches the
+    /// parent directory non-recursively when `path` is a file, per §2's
+    /// baked-in atomic-rename-safety rule; recursive directory watches are
+    /// opt-in via `recursive: true`.
+    pub fn subscribe(&self, path: &Path, owner: SubscriberId, recursive: bool) -> Subscription;
+    pub fn unsubscribe(&self, sub: &Subscription);
+
+    /// Raw change stream — domain modules apply their own debounce/filter on
+    /// top rather than the pool imposing one policy for everyone (editor's
+    /// 300ms-per-path and subagent's 500ms-activity-flush are both
+    /// legitimate, different needs).
+    pub fn events(&self) -> broadcast::Receiver<FsWatchEvent>;
+
+    /// Current health snapshot — the new capability none of the four have
+    /// today. Exposed for `muxlog`/diagnostics, not just internal use.
+    pub fn health(&self) -> FsWatchHealth;
+}
+
+pub struct FsWatchHealth {
+    pub backend: WatchBackend,        // Native | Polling (which one is actually active)
+    pub active_watches: usize,
+    pub degraded_paths: Vec<(PathBuf, String)>, // path -> last error, still being retried
+}
+```
+
+**Recovery policy (the part that's actually new, not just dedup):**
+
+1. **On initial `watch()` failure**: retry with exponential backoff
+   (bounded — e.g. 3 attempts over ~5s) before giving up and logging at
+   `warn`, rather than failing on the first attempt. Transient failures
+   (directory not yet created, brief permission hiccup during another
+   process's own atomic write) shouldn't need a full restart to recover
+   from.
+2. **Degraded-native fallback**: if the native backend
+   (`RecommendedWatcher`) fails to construct at all, fall back to `notify`'s
+   own `PollWatcher` (interval configurable, default a few seconds) instead
+   of disabling live-update outright — worse latency, still correct.
+3. **Silent-death detection**: no perfect way to know an inotify watch died
+   without OS support notify doesn't expose — so this is necessarily
+   heuristic. Pragmatic version: a low-frequency (e.g. every 30s) background
+   sweep that re-verifies every currently-"active" watched path still
+   resolves (`Path::exists()` / re-stat) and, for paths that do, confirms
+   the underlying watch descriptor is still registered with the OS backend
+   (`notify` exposes this on some platforms; where it doesn't, re-issuing
+   `watch()` on an already-watched path is a safe, cheap no-op per the
+   crate's own docs) — self-healing without needing a true "is this dead"
+   signal.
+4. **Observable, not just logged**: `FsWatchHealth` surfaces `degraded_paths`
+   so a future diagnostics surface (or just `muxlog errors`, which already
+   greps host+sidecar logs) can show "this has been failing for N minutes,"
+   not just a single warn line that scrolls out of view.
+
+## 5. Migration path
+
+Not a big-bang rewrite. Lowest-risk order:
+
+1. **Build `fs_watch::FsWatchPool`** with the recovery policy above, no
+   consumers yet — pure addition, zero behavior change to anything live.
+2. **Migrate `config_watcher_fs.rs`** first — smallest, single fixed path,
+   easiest to verify byte-for-byte behavior parity.
+3. **Migrate `editor_file_watcher.rs` and `media_file_watcher.rs`** —
+   they already share the same shape, so this is mostly deleting their
+   duplicated plumbing and keeping their genuinely-distinct debounce/publish
+   logic as thin wrappers over `FsWatchPool`.
+4. **`subagent_watcher`** last, and possibly not fully — it's the most
+   mature and most domain-coupled (JSONL parsing, dispatch state); only
+   worth moving its raw notify-subscription layer onto the shared pool, not
+   its scan/reconciliation logic, which is legitimately its own thing.
+5. **New consumer: native memory.** Once `FsWatchPool` exists, the
+   native-memory durability spec's deferred §2.3 gap (capturing Claude's
+   autonomous writes between Stash tab opens) becomes a straightforward
+   addition: subscribe to each agent's resolved memory directory while its
+   Stash Memory tab is open (or, if wanted later, for the lifetime of a live
+   agent process), and on a change event, run the same upsert-into-mirror
+   logic §2.2 of that spec already added to the read path — just triggered
+   by a push instead of only a pull. This closes that spec's one accepted
+   gap essentially for free once the shared framework exists, rather than
+   needing its own bespoke watcher.
+
+## 6. Non-goals
+
+- Frontend/TypeScript file watching (Vite's own dev-server watcher is
+  separate infrastructure, out of scope — nothing in the app's own runtime
+  code watches files from the frontend process).
+- Forcing `subagent_watcher`'s domain logic (JSONL parsing, dispatch state
+  machine, reconciliation) onto the shared pool — only its raw
+  subscribe/unsubscribe plumbing is a migration candidate.
+- A UI-visible "watcher health" panel — `FsWatchHealth` is designed to be
+  cheap to add one later, not proposing one now.
+
+## 7. Test plan
+
+- Unit: retry-with-backoff on a forced `watch()` failure (inject via a
+  path that doesn't exist yet, then create it mid-retry) succeeds within the
+  bounded attempt window.
+- Unit: `PollWatcher` fallback actually detects a change when the native
+  backend is unavailable (test harness forces the fallback path rather than
+  relying on CI's sandbox lacking inotify, which is a real but unreliable
+  way this already gets partially exercised today per `editor_file_watcher.rs`'s
+  own test comment: "CI sandboxes may not support inotify").
+- Unit: refcounted subscribe/unsubscribe parity with the existing
+  editor/media tests (port those tests onto the new pool directly — they're
+  already written against exactly this behavior).
+- Integration: simulate an atomic rename-over-target save and confirm a
+  directory-level subscription still fires (regression guard for §2's
+  baked-in rule).
+- Manual: exhaust something to force a degraded state (e.g. temporarily
+  chmod a watched directory unreadable), confirm `FsWatchHealth.degraded_paths`
+  reflects it and self-heals once permissions are restored, without a
+  process restart.


### PR DESCRIPTION
## Summary

Three of the four `notify`-based watchers in this codebase (`config_watcher_fs.rs`, `editor_file_watcher.rs`, `media_file_watcher.rs`) independently duplicate the same ~80 lines of plumbing — their own doc comments say so explicitly ("generalizes `config_watcher_fs.rs`'s pattern", "directory-mode sibling of `editor_file_watcher.rs`"). None of the four have any recovery if a watch fails to start or silently dies later — every one just logs a warning and gives up, with zero signal anywhere that live-update quietly stopped working.

Full audit + design rationale: `docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md`.

`FsWatchPool` (new, `agentmux-srv/src/backend/fs_watch/`) owns the shared plumbing plus a genuinely new recovery layer:
- **Retry-with-backoff** on initial watch failure (3 attempts, ~4.2s bounded).
- **Automatic `PollWatcher` fallback** if the native backend won't construct at all.
- **Periodic self-healing sweep** (every 30s) that re-verifies every watched path is still live — a documented-safe no-op when nothing's wrong, so this recovers from a silent death without needing a true "is this watch dead" signal from the OS.
- **Queryable health** (`FsWatchHealth`: active backend, active watch count, degraded paths + last error) for future diagnostics.
- Bakes in the correctness-critical "watch the parent directory, not the file, so an atomic rename-based save is still detected" rule every existing implementer had to independently discover.

**Pure addition — no existing watcher migrated onto it yet.** Zero behavior change to anything live. Migration (config → editor+media → native-memory-as-a-new-consumer) is scoped as separate follow-up PRs per the spec's §5.

## Test plan
- [x] 7 new unit tests (refcounted subscribe/unsubscribe, file-subscription watches the parent dir, a real fs event is observable on the broadcast stream, health reports the active backend, recovery bookkeeping)
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test --workspace -- --test-threads=1` (matches CI exactly) — 2045+ passed, 0 failed, no regressions

<!-- agentmux:agent_id=agent2 -->