### PR TITLE
feat(context-menu): Swarm copy menu, agent-pane paste menu, and app-wide fix for the same gap

### DIFF
--- a/.changesets/1786158722-feat-context-menu-swarm-copy-menu-agent-pane-composer-paste--7b7y.md
+++ b/.changesets/1786158722-feat-context-menu-swarm-copy-menu-agent-pane-composer-paste--7b7y.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(context-menu): Swarm copy menu, agent-pane composer paste menu, and shared Cut/Copy/Paste fix for every in-pane text input missing it

--- a/docs/specs/REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md
+++ b/docs/specs/REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md
@@ -1,0 +1,105 @@
+# REPORT — context-menu gap audit: Swarm copy, agent-pane paste, and beyond
+
+**Date:** 2026-08-07
+**Trigger:** Direct ask — add a Copy menu on Swarm right-click and a Paste
+menu on the agent-pane composer's right-click, then scour the app for the
+same class of gap.
+**Scope:** Diagnosis + fix for the two requested spots, plus every other
+free-text `<input>`/`<textarea>` found to have the identical bug. List/table
+Copy-menu polish beyond Swarm (drone/warden/list managers) and low-value
+single-line inputs (settings, file-tree rename, editor "Save As", toolchain,
+identity account form) are catalogued but intentionally left for later.
+
+---
+
+## 1. Root cause (one bug, ~20 symptoms)
+
+Two independent right-click handlers exist, and whichever is closer to the
+clicked element in the DOM wins (event bubbles from the target outward):
+
+1. **`block/blockframe.tsx`'s `onBodyContextMenu`** — attached to every
+   pane's body `<div>`. Calls `preventDefault`/`stopPropagation` and shows
+   `buildPaneContextMenu()` (`block/pane-actions.ts`): Copy only if there's
+   an active `window.getSelection()`, Paste **only** when
+   `blockData.meta?.view === "term"`, plus Split/Replace/Close.
+2. **`app.tsx`'s root-level `handleContextMenu`** — a document-root
+   fallback that shows real Cut/Copy/Paste based on
+   `document.activeElement`'s tag. Portalled `Modal`/`ModalLayer` content
+   renders outside the pane-body DOM subtree, so its context-menu events
+   never pass through (1) and reach this fallback untouched — modal inputs
+   already worked correctly before this fix.
+
+Since (1) sits between any in-pane element and (2), and non-`term` panes
+never offer Paste, **every `<input>`/`<textarea>` living directly in a
+non-terminal pane's body — not inside a portalled modal — had no way to
+paste via right-click**: the click gets hijacked into a useless
+disabled-Copy menu instead. `agent-view.tsx`'s existing `handleContextMenu`
+(a Copy-on-selection handler covering the transcript) made this worse for
+the composer specifically: it doesn't call `preventDefault`/`stopPropagation`
+when there's no selection, so an empty/partially-typed composer's
+right-click falls through to (1) anyway.
+
+Confirmed via full-file greps: `frontend/app/view/swarm/` has zero
+context-menu wiring anywhere, and its rows are `user-select: none`
+(`swarm-view.scss`), so right-click there did literally nothing — not even
+degraded to the generic Copy-on-selection fallback.
+
+## 2. The fix
+
+**Shared helper, single source of truth.** `app.tsx`'s root fallback logic
+(`canEnableCut/Copy/Paste`, clipboard-URL detection, the Cut/Copy/Paste role
+menu) moved into `frontend/app/store/contextmenu.ts` as an exported
+`showTextInputContextMenu(e: MouseEvent)`, colocated with `ContextMenuModel`
+it already depends on. `app.tsx` now imports and uses it instead of a local
+duplicate — no behavior change for the root-fallback path itself.
+
+**Per-element opt-in.** Every affected `<input>`/`<textarea>` gets
+`onContextMenu={showTextInputContextMenu}` directly. Because the handler
+calls `stopPropagation`, attaching it on the element always wins over
+`blockframe.tsx`'s pane-body handler for that element specifically — the
+same mechanism that already made modal inputs work, just applied explicitly
+instead of relying on a portal to route around the problem.
+
+**Swarm Copy menu.** The primary agent row (`AgentRow`'s `.swarm-agent-card`
+in `swarm-view.tsx`) gets a native `ContextMenuModel` menu ("Copy agent
+name", "Copy block ID") — the `AgentPicker.tsx` per-row pattern
+(`handleTemplateContextMenu`) was the template. Scoped to the primary row
+only; shell/cron/subagent/workflow sub-rows are cataloged in §4 as
+follow-up, not fixed here.
+
+## 3. Files changed
+
+| File | Fix |
+|---|---|
+| `app/store/contextmenu.ts` | New exported `showTextInputContextMenu`; moved `canEnableCut/Copy/Paste`, `getClipboardURL` here from `app.tsx` |
+| `app/app.tsx` | Uses the shared helper instead of a local duplicate |
+| `app/view/agent/components/AgentFooter.tsx` | Composer textarea (the original ask) |
+| `app/view/swarm/swarm-view.tsx` | Copy menu on the primary agent row (the original ask) |
+| `app/view/agent/components/AgentDecisionPanel.tsx` | Deny-feedback textarea |
+| `app/view/agent/components/AgentQuestionPanel.tsx` | "Other" free-text answer input |
+| `app/view/browser/browser-nav-bar.tsx` | Address bar |
+| `app/view/skill/skill-manager.tsx` | Name/trigger/description/content fields |
+| `app/view/mcp/mcp-manager.tsx` | Name/transport/config fields |
+| `app/view/memory/memory-manager.tsx` | Name/description/instructions fields |
+| `app/view/brain/global-brain-manager.tsx` | Name/content fields |
+| `app/view/drone/drone-view.tsx` | Drone name + all node-editor fields (task/URL/body/condition/template/variables/instance) |
+
+## 4. Catalogued, not yet fixed
+
+Found during the sweep, deliberately out of scope for this pass:
+
+- **List/table Copy-id polish** — `warden.tsx` (host/agent table + audit
+  feed), and the skill/MCP/memory/brain-manager list rows: generic
+  selection-Copy technically works (not `user-select: none`), but there's
+  no contextual "Copy id" the way the new Swarm menu has. `drone-view.tsx`
+  node/workflow labels ARE `user-select: none` (same total-gap pattern as
+  Swarm) and would need the same treatment Swarm just got.
+- **Low-value single-line inputs**, same underlying bug but short/rarely-pasted
+  values: `view/toolchain/toolchain-view.tsx`, `view/editor/editor-tab-strip.tsx`
+  ("Save As" path), `view/editor/file-tree.tsx` (rename/new-file),
+  `view/settings/**`, `view/identity/identity-account-form.tsx` (needs a
+  quick check whether it's ever rendered inline vs. only inside a modal
+  before fixing — not yet confirmed either way).
+- `AgentSearchBar.tsx`'s in-transcript search input and
+  `MyAgentsList.tsx`'s fork "Session name" input — same bug, lower value
+  since both are typically typed fresh rather than pasted into.

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -8,14 +8,14 @@ import "./diag/replace-child-diagnostic";
 
 import { Workspace } from "@/app/workspace/workspace";
 import { FloatingPaneWorkspace } from "@/app/workspace/floating-pane-workspace";
-import { ContextMenuModel } from "@/store/contextmenu";
+import { showTextInputContextMenu } from "@/store/contextmenu";
 import { LIGHT_THEME_IDS } from "@/app/menu/base-menus";
-import { atoms, getApi, getSettingsPrefixAtom, isDev, openLink, removeFlashError, flashErrors } from "@/store/global";
+import { atoms, getApi, getSettingsPrefixAtom, isDev, removeFlashError, flashErrors } from "@/store/global";
 import { appHandleKeyDown, keyboardMouseDownHandler } from "@/store/keymodel";
 import { chromeZoomIn, chromeZoomOut, zoomBlockIn, zoomBlockOut, WHEEL_STEP } from "@/store/zoom.platform";
 import { getElemAsStr } from "@/util/focusutil";
 import * as keyutil from "@/util/keyutil";
-import { readText as clipboardReadText, writeText as clipboardWriteText } from "@/util/clipboard";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { PLATFORM } from "@/util/platformutil";
 import * as util from "@/util/util";
 import clsx from "clsx";
@@ -48,80 +48,6 @@ const focusLog = debug("wave:focus");
 const App = () => {
     return <AppInner />;
 };
-
-function isContentEditableBeingEdited(): boolean {
-    const activeElement = document.activeElement;
-    return (
-        activeElement &&
-        activeElement.getAttribute("contenteditable") !== null &&
-        activeElement.getAttribute("contenteditable") !== "false"
-    );
-}
-
-function canEnablePaste(): boolean {
-    const activeElement = document.activeElement;
-    return activeElement.tagName === "INPUT" || activeElement.tagName === "TEXTAREA" || isContentEditableBeingEdited();
-}
-
-function canEnableCopy(): boolean {
-    const sel = window.getSelection();
-    return !util.isBlank(sel?.toString());
-}
-
-function canEnableCut(): boolean {
-    const sel = window.getSelection();
-    if (document.activeElement?.classList.contains("xterm-helper-textarea")) {
-        return false;
-    }
-    return !util.isBlank(sel?.toString()) && canEnablePaste();
-}
-
-async function getClipboardURL(): Promise<URL> {
-    try {
-        const clipboardText = await clipboardReadText();
-        if (clipboardText == null) {
-            return null;
-        }
-        const url = new URL(clipboardText);
-        if (!url.protocol.startsWith("http")) {
-            return null;
-        }
-        return url;
-    } catch (e) {
-        return null;
-    }
-}
-
-async function handleContextMenu(e: MouseEvent) {
-    e.preventDefault();
-    const canPaste = canEnablePaste();
-    const canCopy = canEnableCopy();
-    const canCut = canEnableCut();
-    const clipboardURL = await getClipboardURL();
-    if (!canPaste && !canCopy && !canCut && !clipboardURL) {
-        return;
-    }
-    let menu: ContextMenuItem[] = [];
-    if (canCut) {
-        menu.push({ label: "Cut", role: "cut" });
-    }
-    if (canCopy) {
-        menu.push({ label: "Copy", role: "copy" });
-    }
-    if (canPaste) {
-        menu.push({ label: "Paste", role: "paste" });
-    }
-    if (clipboardURL) {
-        menu.push({ type: "separator" });
-        menu.push({
-            label: "Open Clipboard URL (" + clipboardURL.hostname + ")",
-            click: () => {
-                openLink(clipboardURL.toString());
-            },
-        });
-    }
-    ContextMenuModel.showContextMenu(menu, e);
-}
 
 function AppSettingsUpdater() {
     const windowSettingsAtom = getSettingsPrefixAtom("window");
@@ -406,7 +332,7 @@ const AppInner = () => {
                     "prefers-reduced-motion": prefersReducedMotion(),
                     "floating-pane-mode": IS_FLOATING_PANE,
                 })}
-                onContextMenu={handleContextMenu}
+                onContextMenu={showTextInputContextMenu}
             >
                 <AppBackground />
                 <AppKeyHandlers />

--- a/frontend/app/store/contextmenu.ts
+++ b/frontend/app/store/contextmenu.ts
@@ -1,7 +1,9 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, getApi } from "./global";
+import { atoms, getApi, openLink } from "./global";
+import { readText as clipboardReadText } from "@/util/clipboard";
+import * as util from "@/util/util";
 
 class ContextMenuModelType {
     handlers: Map<string, () => void> = new Map(); // id -> handler
@@ -61,4 +63,91 @@ class ContextMenuModelType {
 
 const ContextMenuModel = new ContextMenuModelType();
 
-export { ContextMenuModel };
+// ── Shared Cut/Copy/Paste text-input menu ────────────────────────────────
+//
+// Any pane body (block/blockframe.tsx's onBodyContextMenu) intercepts
+// right-click before it can reach the app-root fallback in app.tsx, and
+// replaces it with a generic Copy-on-selection-only menu that never offers
+// Paste (except for `view: "term"` panes). That leaves every <input>/
+// <textarea> living directly in a pane body (not inside a portalled Modal,
+// which escapes the pane body entirely) with no way to paste via right-click.
+// This is the fix: attach `onContextMenu={showTextInputContextMenu}` directly
+// on the element. `stopPropagation` keeps the event from ever reaching
+// blockframe's handler, so this always wins for the element it's attached
+// to, matching what already works correctly for modal inputs.
+function isContentEditableBeingEdited(): boolean {
+    const activeElement = document.activeElement;
+    return (
+        activeElement != null &&
+        activeElement.getAttribute("contenteditable") !== null &&
+        activeElement.getAttribute("contenteditable") !== "false"
+    );
+}
+
+function canEnablePaste(): boolean {
+    const activeElement = document.activeElement;
+    return activeElement?.tagName === "INPUT" || activeElement?.tagName === "TEXTAREA" || isContentEditableBeingEdited();
+}
+
+function canEnableCopy(): boolean {
+    const sel = window.getSelection();
+    return !util.isBlank(sel?.toString());
+}
+
+function canEnableCut(): boolean {
+    const sel = window.getSelection();
+    if (document.activeElement?.classList.contains("xterm-helper-textarea")) {
+        return false;
+    }
+    return !util.isBlank(sel?.toString()) && canEnablePaste();
+}
+
+async function getClipboardURL(): Promise<URL | null> {
+    try {
+        const clipboardText = await clipboardReadText();
+        if (clipboardText == null) {
+            return null;
+        }
+        const url = new URL(clipboardText);
+        if (!url.protocol.startsWith("http")) {
+            return null;
+        }
+        return url;
+    } catch (e) {
+        return null;
+    }
+}
+
+async function showTextInputContextMenu(e: MouseEvent): Promise<void> {
+    e.preventDefault();
+    e.stopPropagation();
+    const canPaste = canEnablePaste();
+    const canCopy = canEnableCopy();
+    const canCut = canEnableCut();
+    const clipboardURL = await getClipboardURL();
+    if (!canPaste && !canCopy && !canCut && !clipboardURL) {
+        return;
+    }
+    let menu: ContextMenuItem[] = [];
+    if (canCut) {
+        menu.push({ label: "Cut", role: "cut" });
+    }
+    if (canCopy) {
+        menu.push({ label: "Copy", role: "copy" });
+    }
+    if (canPaste) {
+        menu.push({ label: "Paste", role: "paste" });
+    }
+    if (clipboardURL) {
+        menu.push({ type: "separator" });
+        menu.push({
+            label: "Open Clipboard URL (" + clipboardURL.hostname + ")",
+            click: () => {
+                openLink(clipboardURL.toString());
+            },
+        });
+    }
+    ContextMenuModel.showContextMenu(menu, e);
+}
+
+export { ContextMenuModel, showTextInputContextMenu };

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -19,6 +19,7 @@
 
 import { createEffect, createMemo, createSignal, createUniqueId, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import type { PermissionRequestEvent, ToolNode } from "../types";
 
 export interface DecisionOutcome {
@@ -390,6 +391,7 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                                 setFeedback(e.currentTarget.value);
                                 if (denyError()) setDenyError(null);
                             }}
+                            onContextMenu={showTextInputContextMenu}
                             rows={3}
                             autofocus
                             aria-invalid={denyError() != null}

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -11,6 +11,7 @@ import { getVoiceSession, type PaneVoiceHandle } from "@/app/hook/useVoiceInput"
 import { markEnd, markStart } from "@/perf";
 import { makeORef } from "@/app/store/wos";
 import { atoms } from "@/app/store/global";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { ObjectService } from "@/app/store/services";
 import { fireAndForget } from "@/util/util";
 import { formatCompactNumber } from "@/util/format-count";
@@ -854,6 +855,13 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                         // dropdown reflects the committed text.
                         updateAutocomplete();
                     }}
+                    // The pane body's own onContextMenu (blockframe.tsx) only
+                    // ever offers Copy-on-selection and never Paste (agent
+                    // panes aren't `view: "term"`) — without this, right-click
+                    // here silently shows a useless disabled-Copy menu instead
+                    // of letting the user paste. See
+                    // docs/specs/REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md.
+                    onContextMenu={showTextInputContextMenu}
                     rows={1}
                 />
                 {/* Pinned to the composer's right edge instead of the pane's

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -20,6 +20,7 @@
 
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import type { AskUserQuestionAnswer, AskUserQuestionOption, AskUserQuestionRequest, ToolNode } from "../types";
 import "./AgentQuestionPanel.scss";
 
@@ -428,6 +429,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                                                 placeholder="Type a custom answer…"
                                                 value={state()[qi()]?.other ?? ""}
                                                 onInput={(e) => setOther(qi(), e.currentTarget.value, q.multiSelect)}
+                                                onContextMenu={showTextInputContextMenu}
                                             />
                                         </label>
                                     </div>

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -12,6 +12,7 @@
 // bundle_* RPCs. Spec: specs/archive/SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md.
 
 import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { GlobalBrainViewModel, NEW_SECTION_ID } from "./global-brain-model";
 import "./global-brain.scss";
 
@@ -27,6 +28,7 @@ function SectionEditor(props: { model: GlobalBrainViewModel; isNew: boolean }): 
                     type="text"
                     value={model.draftNameAtom()}
                     onInput={(e) => model.setDraftName(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
                     placeholder="e.g. Coding Standards"
                 />
             </label>
@@ -37,6 +39,7 @@ function SectionEditor(props: { model: GlobalBrainViewModel; isNew: boolean }): 
                     rows={8}
                     value={model.draftInstructionsAtom()}
                     onInput={(e) => model.setDraftInstructions(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
                     placeholder="Markdown injected into every agent's CLAUDE.md under a # [Workspace] heading."
                     spellcheck={false}
                 />

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -3,6 +3,7 @@
 
 import { createEffect, createSignal, Show, type JSX } from "solid-js";
 import { invokeCommand } from "@/app/platform/ipc";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import type { BrowserViewModel } from "./browser-model";
 
 // Compact tag for an Element — used by diag log lines to identify the
@@ -112,6 +113,7 @@ export function BrowserNavBar(props: {
                     value={addressBar()}
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
+                    onContextMenu={showTextInputContextMenu}
                     onMouseDown={() => {
                         // Fire main_window_focus on mousedown — BEFORE focus
                         // moves — so OS keyboard focus reclaims from the pane

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -5,6 +5,7 @@ import { createResource, createSignal, For, onCleanup, onMount, Show, type JSX }
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { abbreviateText } from "@/util/format-text";
 import { BLOCK_KINDS, blockMeta } from "./block-registry";
 import type { DroneViewModel } from "./drone-model";
@@ -47,6 +48,7 @@ const NodeTypeBar = (p: { model: DroneViewModel }): JSX.Element => {
                 class="drone-bar-name"
                 value={m.draftAtom().name}
                 onInput={(e) => m.setName(e.currentTarget.value)}
+                onContextMenu={showTextInputContextMenu}
                 placeholder="Untitled Drone"
                 aria-label="Drone name"
             />
@@ -647,6 +649,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                             autoGrow(e.currentTarget);
                         }}
                         onFocus={(e) => autoGrow(e.currentTarget)}
+                        onContextMenu={showTextInputContextMenu}
                     />
                 </NodeField>
                 <AgentResultPanel model={p.model} blockId={p.node.id} />
@@ -670,6 +673,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                         class="drone-input nodrag"
                         value={(p.node.data["url"] as string) ?? ""}
                         onInput={(e) => update({ url: e.currentTarget.value })}
+                        onContextMenu={showTextInputContextMenu}
                         placeholder="https://…/{{var.path}}"
                     />
                 </NodeField>
@@ -684,6 +688,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                             autoGrow(e.currentTarget);
                         }}
                         onFocus={(e) => autoGrow(e.currentTarget)}
+                        onContextMenu={showTextInputContextMenu}
                     />
                 </NodeField>
             </Show>
@@ -693,6 +698,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                         class="drone-input nodrag"
                         value={(p.node.data["expr"] as string) ?? ""}
                         onInput={(e) => update({ expr: e.currentTarget.value })}
+                        onContextMenu={showTextInputContextMenu}
                         placeholder="{{var.count}} > 0"
                     />
                 </NodeField>
@@ -709,6 +715,7 @@ const NodeFields = (p: { model: DroneViewModel; node: FlowNode }): JSX.Element =
                             autoGrow(e.currentTarget);
                         }}
                         onFocus={(e) => autoGrow(e.currentTarget)}
+                        onContextMenu={showTextInputContextMenu}
                     />
                 </NodeField>
             </Show>
@@ -755,12 +762,14 @@ const VariablesEditor = (p: {
                             class="drone-input nodrag"
                             value={entry.name}
                             onInput={(e) => update(i(), { name: e.currentTarget.value })}
+                            onContextMenu={showTextInputContextMenu}
                             placeholder="name"
                         />
                         <input
                             class="drone-input nodrag"
                             value={entry.value}
                             onInput={(e) => update(i(), { value: e.currentTarget.value })}
+                            onContextMenu={showTextInputContextMenu}
                             placeholder="value"
                         />
                         <button
@@ -852,6 +861,7 @@ const AgentRefEditor = (p: {
                     class="drone-input nodrag"
                     value={ref().instanceName}
                     onInput={(e) => setRef({ instanceName: e.currentTarget.value })}
+                    onContextMenu={showTextInputContextMenu}
                     placeholder="blank = one-shot"
                 />
             </NodeField>

--- a/frontend/app/view/mcp/mcp-manager.tsx
+++ b/frontend/app/view/mcp/mcp-manager.tsx
@@ -11,6 +11,7 @@
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { McpCatalogModel } from "./mcp-model";
 import { McpCatalogPicker } from "./McpCatalogPicker";
 import { findPreloadEntryByName } from "./mcp-preload-catalog";
@@ -185,6 +186,7 @@ export const McpManager = (): JSX.Element => {
                                     type="text"
                                     value={draft().name}
                                     onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
+                                    onContextMenu={showTextInputContextMenu}
                                     placeholder="e.g. filesystem"
                                     required
                                 />
@@ -194,6 +196,7 @@ export const McpManager = (): JSX.Element => {
                                     type="text"
                                     value={draft().transport}
                                     onInput={(e) => model.setDraft({ ...draft(), transport: e.currentTarget.value })}
+                                    onContextMenu={showTextInputContextMenu}
                                     placeholder="stdio"
                                 />
                                 <span class="agent-primitive-modal-field-label">Config (JSON)</span>
@@ -202,6 +205,7 @@ export const McpManager = (): JSX.Element => {
                                     rows={6}
                                     value={draft().config}
                                     onInput={(e) => model.setDraft({ ...draft(), config: e.currentTarget.value })}
+                                    onContextMenu={showTextInputContextMenu}
                                     spellcheck={false}
                                 />
                                 <div class="agent-primitive-modal-actions">

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -21,6 +21,7 @@ import { For, onCleanup, Show, type JSX } from "solid-js";
 
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { useModalLayer } from "@/app/element/modal-layer";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { type MemoryDraft, MemoryViewModel } from "./memory-model";
 
 import "./memory-view.scss";
@@ -245,6 +246,7 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                                     type="text"
                                     value={draft().name}
                                     onInput={(e) => updateDraft("name", e.currentTarget.value)}
+                                    onContextMenu={showTextInputContextMenu}
                                     placeholder="e.g. Claude-coder"
                                     required
                                 />
@@ -259,6 +261,7 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                                     onInput={(e) =>
                                         updateDraft("description", e.currentTarget.value)
                                     }
+                                    onContextMenu={showTextInputContextMenu}
                                     placeholder="Short label shown in the launch picker"
                                 />
                             </label>
@@ -276,6 +279,7 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                                     onInput={(e) =>
                                         updateDraft("instructions", e.currentTarget.value)
                                     }
+                                    onContextMenu={showTextInputContextMenu}
                                     placeholder="System prompt. The agent's soul."
                                 />
                             </label>

--- a/frontend/app/view/skill/skill-manager.tsx
+++ b/frontend/app/view/skill/skill-manager.tsx
@@ -12,6 +12,7 @@
 import { onCleanup, For, Show, type JSX } from "solid-js";
 import { Markdown } from "@/app/element/markdown";
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { SkillCatalogModel } from "./skill-model";
 import "../agent/components/AgentPrimitiveModal.scss";
 
@@ -146,6 +147,7 @@ export const SkillManager = (): JSX.Element => {
                                     type="text"
                                     value={draft().name}
                                     onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
+                                    onContextMenu={showTextInputContextMenu}
                                     placeholder="e.g. pdf-extraction"
                                     required
                                 />
@@ -165,6 +167,7 @@ export const SkillManager = (): JSX.Element => {
                                         type="text"
                                         value={draft().trigger}
                                         onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
+                                        onContextMenu={showTextInputContextMenu}
                                         placeholder="When should this skill be invoked?"
                                     />
                                 </Show>
@@ -174,6 +177,7 @@ export const SkillManager = (): JSX.Element => {
                                     type="text"
                                     value={draft().description}
                                     onInput={(e) => model.setDraft({ ...draft(), description: e.currentTarget.value })}
+                                    onContextMenu={showTextInputContextMenu}
                                 />
                                 <span class="agent-primitive-modal-field-label">Content</span>
                                 <textarea
@@ -181,6 +185,7 @@ export const SkillManager = (): JSX.Element => {
                                     rows={8}
                                     value={draft().content}
                                     onInput={(e) => model.setDraft({ ...draft(), content: e.currentTarget.value })}
+                                    onContextMenu={showTextInputContextMenu}
                                     spellcheck={false}
                                 />
                                 <div class="agent-primitive-modal-actions">

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -10,6 +10,8 @@ import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { WOS, workspace, setActiveTab, atoms, getApi } from "@/app/store/global";
+import { ContextMenuModel } from "@/app/store/contextmenu";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
 import { getBlockTurnPhase } from "@/app/store/agentActivity";
 import { WorkspaceService } from "@/app/store/services";
@@ -274,6 +276,24 @@ function AgentRow({
     });
     onCleanup(() => clearTimeout(flashTimer));
 
+    // Rows are `user-select: none` (swarm-view.scss) for the drag/click UX,
+    // so unlike a normal text pane there's no way to select-and-Copy — the
+    // pane body's generic Copy-on-selection context menu (block/pane-
+    // actions.ts) can never fire anything here. This is the only way to
+    // copy an agent's name or block id out of Swarm. See
+    // docs/specs/REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md.
+    const handleAgentRowContextMenu = (e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const menu: ContextMenuItem[] = [
+            { label: "Copy agent name", click: () => clipboardWriteText(node.agentName) },
+        ];
+        if (node.blockId) {
+            menu.push({ label: "Copy block ID", click: () => clipboardWriteText(node.blockId!) });
+        }
+        ContextMenuModel.showContextMenu(menu, e);
+    };
+
     return (
         <div class="swarm-agent-group">
             <div
@@ -283,6 +303,7 @@ function AgentRow({
                     "swarm-agent-card--active": focusedBlockId() === node.blockId,
                 }}
                 onClick={() => node.blockId && model.toggleAgentCollapsed(node.blockId)}
+                onContextMenu={handleAgentRowContextMenu}
                 title={node.agentName}
             >
                 <div class="swarm-agent-row">


### PR DESCRIPTION
## Summary

Two requested fixes, plus a scour of the app for the same class of gap:

- **Swarm right-click Copy menu** (previously nothing at all — rows are `user-select: none`, so there was no way to copy an agent's name or block ID out of Swarm).
- **Agent-pane composer right-click Paste menu** (previously hijacked by the pane body's generic Copy-on-selection-only handler, which no-ops with nothing selected — the common case when right-clicking to paste).

## Root cause (one bug, ~20 fixed spots)

`block/pane-actions.ts`'s pane-body context menu only offers Copy-on-selection and Paste for `view: "term"` panes. Any `<input>`/`<textarea>` living directly in a non-terminal pane's body (not inside a portalled `Modal`, which already worked correctly) had no way to paste via right-click.

## Fix

- Extracted `app.tsx`'s root Cut/Copy/Paste fallback logic into a shared, exported `showTextInputContextMenu()` in `store/contextmenu.ts` — single source of truth, `app.tsx` now uses it too instead of a local duplicate.
- Attached it directly to every affected input/textarea found in a full sweep: agent decision-panel deny-feedback, agent question-panel "Other" answer, browser address bar, skill/MCP/memory/brain manager forms, drone node-editor fields (task/URL/body/condition/template/variables/instance).
- Swarm's primary agent row gets a native `ContextMenuModel` Copy menu ("Copy agent name" / "Copy block ID"), following the existing `AgentPicker.tsx` per-row pattern.

Full gap inventory — including what's intentionally left for a follow-up pass (list/table copy-id polish on drone/warden/list-managers, and lower-value single-line inputs in settings/toolchain/editor/identity) — is in `docs/specs/REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2370 passed, 0 failed, 3 skipped (no regressions)
- [ ] Manual click-through recommended: right-click the Swarm agent row, the agent-pane composer, and a couple of the manager forms to confirm the menus render correctly

<!-- agentmux:agent_id=agent3 -->