### PR TITLE
fix(backend): migrate editor and media file watchers onto the shared FsWatchPool

### DIFF
--- a/.changesets/1786159108-fix-backend-migrate-editor-and-media-file-watchers-onto-the--zhu6.md
+++ b/.changesets/1786159108-fix-backend-migrate-editor-and-media-file-watchers-onto-the--zhu6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(backend): migrate editor and media file watchers onto the shared FsWatchPool

--- a/agentmux-srv/src/backend/editor_file_watcher.rs
+++ b/agentmux-srv/src/backend/editor_file_watcher.rs
@@ -6,10 +6,15 @@
 //! second AgentMux window) and pushes a per-block "this file changed on
 //! disk" wake signal so panes can refresh instead of silently going stale.
 //!
-//! Generalizes `config_watcher_fs.rs`'s single-file `notify`-watcher pattern
-//! to an arbitrary, dynamically-changing set of paths anywhere under the
-//! user's home directory — one per open editor tab, refcounted by block id
-//! so a path is watched only while at least one tab has it open.
+//! Migrated onto the shared `fs_watch::FsWatchPool`
+//! (SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md) — this module keeps only
+//! its own domain-specific bookkeeping (which block ids have which paths
+//! open, per-path debounce, and the `EVENT_EDITOR_FILE_CHANGED` publish
+//! shape). The actual `notify` construction, OS-level watch/unwatch, and
+//! recovery-on-failure now live in the pool, shared with every other
+//! watcher that migrates onto it (`config_watcher_fs.rs` already has;
+//! `media_file_watcher.rs`, below in the same PR, is the directory-mode
+//! sibling migrating alongside this one).
 //!
 //! Spec: docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md
 
@@ -19,10 +24,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::json;
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 
+use super::fs_watch::{FsWatchPool, Subscription};
 use super::wps::{Broker, WaveEvent};
 
 /// WPS event fired when a file open in at least one editor tab changes on
@@ -38,11 +43,12 @@ const DEBOUNCE: Duration = Duration::from_millis(300);
 struct Inner {
     /// Canonicalized file path -> block ids with a tab open on it.
     watched_paths: HashMap<PathBuf, std::collections::HashSet<String>>,
-    /// Parent directory -> number of distinct watched paths under it.
-    /// `notify` watches directories (non-recursive) rather than individual
-    /// files, matching `config_watcher_fs.rs`'s approach; this refcount
-    /// decides when a directory watch is added/removed.
-    watched_dirs: HashMap<PathBuf, usize>,
+    /// One pool subscription per watched path — held so it can be handed
+    /// back to `pool.unsubscribe` once the last block id for that path
+    /// unsubscribes. The pool does its own OS-level refcounting internally;
+    /// this is a *different* refcount (by block id, which the pool has no
+    /// concept of), so both layers of bookkeeping are genuinely needed.
+    pool_subs: HashMap<PathBuf, Subscription>,
 }
 
 /// Per-path debounce generation counters. A new fs event for a path bumps
@@ -52,60 +58,41 @@ struct Inner {
 type DebounceGens = Mutex<HashMap<PathBuf, Arc<AtomicU64>>>;
 
 pub struct EditorFileWatcher {
-    // Held only to keep the watcher alive — never read directly outside `new`.
-    _watcher: Mutex<RecommendedWatcher>,
+    pool: Arc<FsWatchPool>,
     inner: Mutex<Inner>,
     debounce_gens: DebounceGens,
     broker: Arc<Broker>,
 }
 
 impl EditorFileWatcher {
-    /// Construct and start the watcher. Returns `None` if the underlying
-    /// `notify` watcher can't be created (matches
-    /// `config_watcher_fs::spawn_settings_watcher`'s fallible-but-non-fatal
-    /// convention — live-reload is a nice-to-have, not a boot requirement).
-    pub fn new(broker: Arc<Broker>) -> Option<Arc<Self>> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<PathBuf>();
-
-        let watcher = match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-            match res {
-                Ok(event) => {
-                    if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
-                        for path in event.paths {
-                            let _ = tx.send(path);
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "editor file watcher error");
-                }
-            }
-        }) {
-            Ok(w) => w,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to create editor file watcher");
-                return None;
-            }
-        };
-
+    /// Construct and start the watcher, subscribing to `pool`'s shared
+    /// broadcast stream. Unlike the pre-migration version, this always
+    /// succeeds — `FsWatchPool` itself absorbs the "can the OS backend even
+    /// construct" failure mode (see its own `health()`), so there's no
+    /// `Option` for callers to check anymore.
+    pub fn new(pool: Arc<FsWatchPool>, broker: Arc<Broker>) -> Arc<Self> {
         let this = Arc::new(Self {
-            _watcher: Mutex::new(watcher),
-            inner: Mutex::new(Inner {
-                watched_paths: HashMap::new(),
-                watched_dirs: HashMap::new(),
-            }),
+            pool: pool.clone(),
+            inner: Mutex::new(Inner { watched_paths: HashMap::new(), pool_subs: HashMap::new() }),
             debounce_gens: Mutex::new(HashMap::new()),
             broker,
         });
 
+        let mut events = pool.events();
         let worker = this.clone();
         tokio::spawn(async move {
-            while let Some(changed_path) = rx.recv().await {
-                worker.handle_fs_event(changed_path);
+            loop {
+                match events.recv().await {
+                    Ok(ev) => worker.handle_fs_event(ev.path),
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!(skipped, "editor file watcher lagged behind the fs_watch broadcast stream");
+                    }
+                }
             }
         });
 
-        Some(this)
+        this
     }
 
     /// Start watching `path` on behalf of `block_id`. Idempotent — calling
@@ -124,17 +111,8 @@ impl EditorFileWatcher {
             return;
         }
 
-        let Some(dir) = canonical.parent().map(Path::to_path_buf) else {
-            return;
-        };
-        let refcount = inner.watched_dirs.entry(dir.clone()).or_insert(0);
-        *refcount += 1;
-        if *refcount == 1 {
-            let mut w = self._watcher.lock().unwrap();
-            if let Err(e) = w.watch(&dir, RecursiveMode::NonRecursive) {
-                tracing::warn!(dir = %dir.display(), error = %e, "failed to watch editor file directory");
-            }
-        }
+        let sub = self.pool.subscribe_file(&canonical);
+        inner.pool_subs.insert(canonical.clone(), sub);
         tracing::debug!(path = %canonical.display(), block_id, "editor file watch: started");
     }
 
@@ -151,16 +129,8 @@ impl EditorFileWatcher {
             return;
         }
         inner.watched_paths.remove(&canonical);
-
-        if let Some(dir) = canonical.parent().map(Path::to_path_buf) {
-            if let Some(refcount) = inner.watched_dirs.get_mut(&dir) {
-                *refcount -= 1;
-                if *refcount == 0 {
-                    inner.watched_dirs.remove(&dir);
-                    let mut w = self._watcher.lock().unwrap();
-                    let _ = w.unwatch(&dir);
-                }
-            }
+        if let Some(sub) = inner.pool_subs.remove(&canonical) {
+            self.pool.unsubscribe(sub);
         }
         drop(inner);
 
@@ -253,10 +223,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_watch_unwatch_refcounting_does_not_panic() {
-        // Exercises the refcount bookkeeping without touching the real
-        // filesystem watcher backend (CI sandboxes may not support inotify).
         let broker = Arc::new(Broker::new());
-        let watcher = EditorFileWatcher::new(broker).expect("watcher should construct");
+        let pool = FsWatchPool::new();
+        let watcher = EditorFileWatcher::new(pool, broker);
 
         let tmp = std::env::temp_dir().join("agentmux_editor_watch_test.txt");
         std::fs::write(&tmp, "hello").unwrap();
@@ -293,7 +262,8 @@ mod tests {
         // the last watcher for that path unsubscribed, so the map grew
         // unbounded over a long-running process's lifetime.
         let broker = Arc::new(Broker::new());
-        let watcher = EditorFileWatcher::new(broker).expect("watcher should construct");
+        let pool = FsWatchPool::new();
+        let watcher = EditorFileWatcher::new(pool, broker);
 
         let tmp = std::env::temp_dir().join("agentmux_editor_watch_debounce_test.txt");
         std::fs::write(&tmp, "hello").unwrap();
@@ -335,5 +305,51 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].0, "route-1");
         assert_eq!(events[0].1.event, EVENT_EDITOR_FILE_CHANGED);
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end_real_fs_write_triggers_publish() {
+        // Regression for the migration itself: a real notify event flowing
+        // through the shared pool must still reach this watcher's own
+        // debounce + publish path, not just the bookkeeping unit tests above.
+        let broker = Arc::new(Broker::new());
+        let client = Arc::new(TestClient { events: StdMutex::new(Vec::new()) });
+        broker.set_client(Box::new(client.clone()));
+        broker.subscribe(
+            "route-e2e",
+            super::super::wps::SubscriptionRequest {
+                event: EVENT_EDITOR_FILE_CHANGED.to_string(),
+                scopes: vec!["block:e2e".to_string()],
+                allscopes: false,
+            },
+        );
+
+        let pool = FsWatchPool::new();
+        let watcher = EditorFileWatcher::new(pool, broker);
+
+        let dir = std::env::temp_dir().join("agentmux_editor_watch_e2e_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("watched.md");
+        std::fs::write(&file, "v1").unwrap();
+
+        watcher.watch_path(&file, "e2e");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        std::fs::write(&file, "v2").unwrap();
+
+        let saw_it = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if !client.events.lock().unwrap().is_empty() {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .unwrap_or(false);
+
+        assert!(saw_it, "expected a real on-disk change to reach the publish path via the shared pool");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/agentmux-srv/src/backend/media_file_watcher.rs
+++ b/agentmux-srv/src/backend/media_file_watcher.rs
@@ -7,11 +7,13 @@
 //! matching file changed" wake signal so panes update without a manual
 //! reload.
 //!
-//! Directory-mode sibling of `editor_file_watcher.rs`'s single-file watcher:
-//! that one watches individually-opened files (one entry per open tab);
-//! this one watches whole directories directly, filtered by a per-subscriber
-//! extension set, since a Media pane's job is "show me the latest render in
-//! this folder," not "watch this one exact file."
+//! Migrated onto the shared `fs_watch::FsWatchPool`
+//! (SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md), alongside
+//! `editor_file_watcher.rs` in the same PR. Directory-mode sibling of that
+//! file: that one watches individually-opened files (one entry per open
+//! tab); this one watches whole directories directly, filtered by a
+//! per-subscriber extension set, since a Media pane's job is "show me the
+//! latest render in this folder," not "watch this one exact file."
 //!
 //! Spec: docs/specs/SPEC_MEDIA_PANE_2026_07_26.md
 
@@ -21,10 +23,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::json;
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 
+use super::fs_watch::{FsWatchPool, Subscription};
 use super::wps::{Broker, WaveEvent};
 
 /// WPS event fired when a file matching a Media pane's extension filter is
@@ -39,9 +41,13 @@ const DEBOUNCE: Duration = Duration::from_millis(300);
 
 struct Inner {
     /// Canonicalized directory -> (block id -> lowercase extensions that
-    /// block cares about, no leading dot). A directory is under active OS
-    /// watch exactly while this map has at least one entry for it.
+    /// block cares about, no leading dot). A directory has a live pool
+    /// subscription exactly while this map has at least one entry for it.
     watched_dirs: HashMap<PathBuf, HashMap<String, HashSet<String>>>,
+    /// One pool subscription per watched directory — see
+    /// `editor_file_watcher.rs::Inner::pool_subs`'s doc comment for why this
+    /// bookkeeping is separate from the pool's own OS-level refcounting.
+    pool_subs: HashMap<PathBuf, Subscription>,
 }
 
 /// Per-file debounce generation counters, same collapsing-burst-writes
@@ -51,55 +57,39 @@ struct Inner {
 type DebounceGens = Mutex<HashMap<PathBuf, Arc<AtomicU64>>>;
 
 pub struct MediaFileWatcher {
-    _watcher: Mutex<RecommendedWatcher>,
+    pool: Arc<FsWatchPool>,
     inner: Mutex<Inner>,
     debounce_gens: DebounceGens,
     broker: Arc<Broker>,
 }
 
 impl MediaFileWatcher {
-    /// Construct and start the watcher. Returns `None` if the underlying
-    /// `notify` watcher can't be created — live-update is a nice-to-have,
-    /// not a boot requirement (matches `EditorFileWatcher::new`).
-    pub fn new(broker: Arc<Broker>) -> Option<Arc<Self>> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<PathBuf>();
-
-        let watcher = match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-            match res {
-                Ok(event) => {
-                    if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
-                        for path in event.paths {
-                            let _ = tx.send(path);
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "media file watcher error");
-                }
-            }
-        }) {
-            Ok(w) => w,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to create media file watcher");
-                return None;
-            }
-        };
-
+    /// Construct and start the watcher, subscribing to `pool`'s shared
+    /// broadcast stream. Always succeeds — see `EditorFileWatcher::new`'s
+    /// doc comment for why there's no `Option` to check anymore.
+    pub fn new(pool: Arc<FsWatchPool>, broker: Arc<Broker>) -> Arc<Self> {
         let this = Arc::new(Self {
-            _watcher: Mutex::new(watcher),
-            inner: Mutex::new(Inner { watched_dirs: HashMap::new() }),
+            pool: pool.clone(),
+            inner: Mutex::new(Inner { watched_dirs: HashMap::new(), pool_subs: HashMap::new() }),
             debounce_gens: Mutex::new(HashMap::new()),
             broker,
         });
 
+        let mut events = pool.events();
         let worker = this.clone();
         tokio::spawn(async move {
-            while let Some(changed_path) = rx.recv().await {
-                worker.handle_fs_event(changed_path);
+            loop {
+                match events.recv().await {
+                    Ok(ev) => worker.handle_fs_event(ev.path),
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!(skipped, "media file watcher lagged behind the fs_watch broadcast stream");
+                    }
+                }
             }
         });
 
-        Some(this)
+        this
     }
 
     /// Start watching `dir` on behalf of `block_id`, notifying only for
@@ -117,10 +107,8 @@ impl MediaFileWatcher {
         subscribers.insert(block_id.to_string(), ext_set);
 
         if is_new_dir {
-            let mut w = self._watcher.lock().unwrap();
-            if let Err(e) = w.watch(&canonical, RecursiveMode::NonRecursive) {
-                tracing::warn!(dir = %canonical.display(), error = %e, "failed to watch media directory");
-            }
+            let sub = self.pool.subscribe_dir(&canonical);
+            inner.pool_subs.insert(canonical.clone(), sub);
         }
         tracing::debug!(dir = %canonical.display(), block_id, "media dir watch: started/updated");
     }
@@ -138,11 +126,10 @@ impl MediaFileWatcher {
             return;
         }
         inner.watched_dirs.remove(&canonical);
+        if let Some(sub) = inner.pool_subs.remove(&canonical) {
+            self.pool.unsubscribe(sub);
+        }
         drop(inner);
-
-        let mut w = self._watcher.lock().unwrap();
-        let _ = w.unwatch(&canonical);
-        drop(w);
 
         // Prune debounce entries for files under this now-unwatched dir —
         // same rationale as EditorFileWatcher::unwatch_path: don't let
@@ -239,7 +226,8 @@ mod tests {
     #[tokio::test]
     async fn test_watch_unwatch_refcounting_does_not_panic() {
         let broker = Arc::new(Broker::new());
-        let watcher = MediaFileWatcher::new(broker).expect("watcher should construct");
+        let pool = FsWatchPool::new();
+        let watcher = MediaFileWatcher::new(pool, broker);
 
         let tmp_dir = std::env::temp_dir().join("agentmux_media_watch_test");
         std::fs::create_dir_all(&tmp_dir).unwrap();
@@ -316,5 +304,49 @@ mod tests {
 
         let events = client.events.lock().unwrap();
         assert_eq!(events.len(), 0, "png-only block must not receive a .webm change event");
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end_real_fs_write_triggers_publish_for_matching_extension() {
+        // Regression for the migration itself: a real notify event flowing
+        // through the shared pool must still reach this watcher's own
+        // extension-filter + debounce + publish path.
+        let broker = Arc::new(Broker::new());
+        let client = Arc::new(TestClient { events: StdMutex::new(Vec::new()) });
+        broker.set_client(Box::new(client.clone()));
+        broker.subscribe(
+            "route-e2e",
+            super::super::wps::SubscriptionRequest {
+                event: EVENT_MEDIA_FILE_CHANGED.to_string(),
+                scopes: vec!["block:e2e".to_string()],
+                allscopes: false,
+            },
+        );
+
+        let pool = FsWatchPool::new();
+        let watcher = MediaFileWatcher::new(pool, broker);
+
+        let dir = std::env::temp_dir().join("agentmux_media_watch_e2e_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        watcher.watch_directory(&dir, "e2e", &["webm".to_string()]);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        std::fs::write(dir.join("render.webm"), b"fake video bytes").unwrap();
+
+        let saw_it = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if !client.events.lock().unwrap().is_empty() {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .unwrap_or(false);
+
+        assert!(saw_it, "expected a real .webm write to reach the publish path via the shared pool");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -818,8 +818,8 @@ pub fn open_stores_and_migrate(config: &config::Config, version: &str, build_tim
 pub struct BackgroundSubsystems {
     pub event_bus: Arc<EventBus>,
     pub broker: Arc<Broker>,
-    pub editor_file_watcher: Option<Arc<backend::editor_file_watcher::EditorFileWatcher>>,
-    pub media_file_watcher: Option<Arc<backend::media_file_watcher::MediaFileWatcher>>,
+    pub editor_file_watcher: Arc<backend::editor_file_watcher::EditorFileWatcher>,
+    pub media_file_watcher: Arc<backend::media_file_watcher::MediaFileWatcher>,
     pub fs_watch_pool: Arc<backend::fs_watch::FsWatchPool>,
     pub config_watcher: Arc<wconfig::ConfigWatcher>,
     pub reactive_handler: &'static reactive::ReactiveHandler,
@@ -849,25 +849,20 @@ pub fn spawn_background_subsystems(
     broker.set_client(Box::new(bridge));
 
     // Shared filesystem-watcher framework — constructed once, before any
-    // consumer. `config_watcher_fs` below is its first consumer;
-    // `editor_file_watcher`/`media_file_watcher` haven't migrated onto it
-    // yet (see SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md §5).
+    // consumer, all three of which now build on it (see
+    // SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md §5's migration order:
+    // config_watcher_fs first, editor+media here, native memory as a future
+    // consumer).
     let fs_watch_pool = backend::fs_watch::FsWatchPool::new();
 
     // Watches files open in editor/preview panes, publishing a per-block
     // wake signal on external changes. See SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md.
-    let editor_file_watcher = backend::editor_file_watcher::EditorFileWatcher::new(broker.clone());
-    if editor_file_watcher.is_none() {
-        tracing::warn!("editor file watcher not started; editor panes will not live-reload on external changes");
-    }
+    let editor_file_watcher = backend::editor_file_watcher::EditorFileWatcher::new(fs_watch_pool.clone(), broker.clone());
 
     // Watches directories a Media pane is pointed at, publishing a per-block
     // wake signal when a matching-extension file changes. See
     // SPEC_MEDIA_PANE_2026_07_26.md.
-    let media_file_watcher = backend::media_file_watcher::MediaFileWatcher::new(broker.clone());
-    if media_file_watcher.is_none() {
-        tracing::warn!("media file watcher not started; media panes will not live-update on new/changed files");
-    }
+    let media_file_watcher = backend::media_file_watcher::MediaFileWatcher::new(fs_watch_pool.clone(), broker.clone());
 
     // Deploy shell integration scripts (muxlog.mjs/muxspect.mjs + rcfiles)
     // unconditionally at startup, not opportunistically from a specific

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -315,6 +315,7 @@ mod recent_sessions_tests {
             crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
         );
         let process_broker = Arc::new(crate::broker::ProcessBroker::new(Some(broker.clone())));
+        let fs_watch_pool = crate::backend::fs_watch::FsWatchPool::new();
         let state = AppState {
             auth_key: "test".to_string(),
             boot_id: std::sync::Arc::from("test-boot"),
@@ -360,11 +361,17 @@ mod recent_sessions_tests {
                 reqwest::Client::new(),
                 String::new(),
                 "test".to_string(),
-                broker,
+                broker.clone(),
             ),
-            editor_file_watcher: None,
-            media_file_watcher: None,
-            fs_watch_pool: crate::backend::fs_watch::FsWatchPool::new(),
+            editor_file_watcher: crate::backend::editor_file_watcher::EditorFileWatcher::new(
+                fs_watch_pool.clone(),
+                broker.clone(),
+            ),
+            media_file_watcher: crate::backend::media_file_watcher::MediaFileWatcher::new(
+                fs_watch_pool.clone(),
+                broker.clone(),
+            ),
+            fs_watch_pool: fs_watch_pool.clone(),
         };
 
         // Seed: 1 SEEDED definition (template), 1 account + direct
@@ -635,6 +642,7 @@ mod recent_sessions_tests {
             crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
         );
         let process_broker = Arc::new(crate::broker::ProcessBroker::new(Some(broker.clone())));
+        let fs_watch_pool = crate::backend::fs_watch::FsWatchPool::new();
         let state = AppState {
             auth_key: "test".to_string(),
             boot_id: std::sync::Arc::from("test-boot"),
@@ -680,11 +688,17 @@ mod recent_sessions_tests {
                 reqwest::Client::new(),
                 String::new(),
                 "test".to_string(),
-                broker,
+                broker.clone(),
             ),
-            editor_file_watcher: None,
-            media_file_watcher: None,
-            fs_watch_pool: crate::backend::fs_watch::FsWatchPool::new(),
+            editor_file_watcher: crate::backend::editor_file_watcher::EditorFileWatcher::new(
+                fs_watch_pool.clone(),
+                broker.clone(),
+            ),
+            media_file_watcher: crate::backend::media_file_watcher::MediaFileWatcher::new(
+                fs_watch_pool.clone(),
+                broker.clone(),
+            ),
+            fs_watch_pool: fs_watch_pool.clone(),
         };
 
         // One seeded template + one already-user-owned definition.

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -111,8 +111,11 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
     // watcheditorfile → start live-reload watching for a (path, block_id)
     // pair. Called by the frontend once a tab's content finishes loading.
-    // No-op (not an error) if the watcher failed to start at boot — editor
-    // panes still work, they just don't live-reload.
+    // Since the migration onto the shared FsWatchPool
+    // (SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md), the watcher itself
+    // always exists — a construction-time failure now degrades into
+    // FsWatchPool::health()'s degraded_paths instead of a missing watcher,
+    // so there's nothing to check here.
     // Spec: docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md
     {
         let watcher = editor_file_watcher.clone();
@@ -125,10 +128,8 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     struct Cmd { path: String, block_id: String }
                     let cmd: Cmd = serde_json::from_value(data)
                         .map_err(|e| format!("watcheditorfile: {e}"))?;
-                    if let Some(w) = watcher {
-                        let expanded = expand_home_dir_safe(&cmd.path);
-                        w.watch_path(expanded.as_path(), &cmd.block_id);
-                    }
+                    let expanded = expand_home_dir_safe(&cmd.path);
+                    watcher.watch_path(expanded.as_path(), &cmd.block_id);
                     Ok(None)
                 })
             }),
@@ -148,10 +149,8 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     struct Cmd { path: String, block_id: String }
                     let cmd: Cmd = serde_json::from_value(data)
                         .map_err(|e| format!("unwatcheditorfile: {e}"))?;
-                    if let Some(w) = watcher {
-                        let expanded = expand_home_dir_safe(&cmd.path);
-                        w.unwatch_path(expanded.as_path(), &cmd.block_id);
-                    }
+                    let expanded = expand_home_dir_safe(&cmd.path);
+                    watcher.unwatch_path(expanded.as_path(), &cmd.block_id);
                     Ok(None)
                 })
             }),
@@ -174,10 +173,8 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     struct Cmd { path: String, block_id: String, extensions: Vec<String> }
                     let cmd: Cmd = serde_json::from_value(data)
                         .map_err(|e| format!("watchmediadir: {e}"))?;
-                    if let Some(w) = watcher {
-                        let expanded = expand_home_dir_safe(&cmd.path);
-                        w.watch_directory(expanded.as_path(), &cmd.block_id, &cmd.extensions);
-                    }
+                    let expanded = expand_home_dir_safe(&cmd.path);
+                    watcher.watch_directory(expanded.as_path(), &cmd.block_id, &cmd.extensions);
                     Ok(None)
                 })
             }),
@@ -197,10 +194,8 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     struct Cmd { path: String, block_id: String }
                     let cmd: Cmd = serde_json::from_value(data)
                         .map_err(|e| format!("unwatchmediadir: {e}"))?;
-                    if let Some(w) = watcher {
-                        let expanded = expand_home_dir_safe(&cmd.path);
-                        w.unwatch_directory(expanded.as_path(), &cmd.block_id);
-                    }
+                    let expanded = expand_home_dir_safe(&cmd.path);
+                    watcher.unwatch_directory(expanded.as_path(), &cmd.block_id);
                     Ok(None)
                 })
             }),

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -192,24 +192,23 @@ pub struct AppState {
     /// Filesystem watcher for files open in editor/preview panes — publishes
     /// `EVENT_EDITOR_FILE_CHANGED` (scoped per-block) when a watched path
     /// changes on disk, so panes can refresh instead of silently going
-    /// stale. `None` when the underlying `notify` watcher couldn't be
-    /// created (live-reload is a nice-to-have, not a boot requirement).
+    /// stale. Migrated onto the shared `fs_watch_pool` below
+    /// (SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md) — always constructs
+    /// successfully now (a construction-time failure degrades into
+    /// `fs_watch_pool.health()`'s `degraded_paths` instead of `None`), so
+    /// unlike before this field is no longer optional.
     /// See docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md.
-    pub editor_file_watcher: Option<std::sync::Arc<crate::backend::editor_file_watcher::EditorFileWatcher>>,
+    pub editor_file_watcher: std::sync::Arc<crate::backend::editor_file_watcher::EditorFileWatcher>,
     /// Filesystem watcher for directories a Media pane is pointed at —
     /// publishes `EVENT_MEDIA_FILE_CHANGED` (scoped per-block) when a
-    /// matching-extension file is created/modified. `None` when the
-    /// underlying `notify` watcher couldn't be created.
+    /// matching-extension file is created/modified. Same migration and
+    /// no-longer-optional note as `editor_file_watcher` above.
     /// See docs/specs/SPEC_MEDIA_PANE_2026_07_26.md.
-    pub media_file_watcher: Option<std::sync::Arc<crate::backend::media_file_watcher::MediaFileWatcher>>,
+    pub media_file_watcher: std::sync::Arc<crate::backend::media_file_watcher::MediaFileWatcher>,
     /// Shared filesystem-watcher framework (retry/fallback/self-healing on
-    /// top of `notify`). `editor_file_watcher`/`media_file_watcher` above
-    /// predate this and haven't migrated onto it yet — see
-    /// docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md §5 for the
-    /// migration path. Unlike those two, this always constructs
-    /// successfully (a construction-time failure degrades into
-    /// `FsWatchPool::health()`'s `degraded_paths` instead of `None`), so
-    /// there's no `Option` wrapper to check.
+    /// top of `notify`) that `editor_file_watcher`/`media_file_watcher`
+    /// above are built on. See
+    /// docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md.
     pub fs_watch_pool: std::sync::Arc<crate::backend::fs_watch::FsWatchPool>,
 }
 

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -34,6 +34,7 @@ pub(crate) fn test_state() -> AppState {
         crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
     );
     let process_broker = Arc::new(crate::broker::ProcessBroker::new(Some(broker.clone())));
+    let fs_watch_pool = crate::backend::fs_watch::FsWatchPool::new();
 
     AppState {
         auth_key: "test-secret-key".to_string(),
@@ -84,11 +85,17 @@ pub(crate) fn test_state() -> AppState {
             reqwest::Client::new(),
             String::new(),
             "test-secret-key".to_string(),
-            broker,
+            broker.clone(),
         ),
-        editor_file_watcher: None,
-        media_file_watcher: None,
-        fs_watch_pool: crate::backend::fs_watch::FsWatchPool::new(),
+        editor_file_watcher: crate::backend::editor_file_watcher::EditorFileWatcher::new(
+            fs_watch_pool.clone(),
+            broker.clone(),
+        ),
+        media_file_watcher: crate::backend::media_file_watcher::MediaFileWatcher::new(
+            fs_watch_pool.clone(),
+            broker.clone(),
+        ),
+        fs_watch_pool: fs_watch_pool.clone(),
     }
 }
 


### PR DESCRIPTION
## Summary
- PR3 in the FsWatchPool migration series (SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md): moves `EditorFileWatcher` and `MediaFileWatcher` onto the shared pool.
- Both constructors now take `Arc<FsWatchPool>` and always return `Arc<Self>` (construction failure is absorbed into the pool's own health tracking rather than propagated as `None`) — `AppState.editor_file_watcher`/`media_file_watcher` are no longer `Option<Arc<...>>`.
- Per-path/per-dir subscribe/unsubscribe now delegates to `pool.subscribe_file`/`subscribe_dir`/`unsubscribe`; each watcher consumes its own `broadcast::Receiver` from `pool.events()`.
- Stacked on #2456 (PR2, `config_watcher_fs` migration) since this branch was cut from it — please merge #2456 first, or this will be rebased onto `main` automatically once that lands.

## Test plan
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test --workspace -- --test-threads=1` — 2050 passed, 0 failed
- [x] Kept all pre-migration unit tests for both watchers; added a real end-to-end fs-write test per watcher asserting a `WaveEvent` is published via the shared pool

<!-- agentmux:agent_id=agent2 -->