### PR TITLE
feat(backend): durable, cross-channel native memory mirror

### DIFF
--- a/.changesets/1786160984-feat-backend-durable-cross-channel-native-memory-mirror-09og.md
+++ b/.changesets/1786160984-feat-backend-durable-cross-channel-native-memory-mirror-09og.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(backend): durable, cross-channel native memory mirror

--- a/agentmux-srv/src/backend/storage/agent_native_memory.rs
+++ b/agentmux-srv/src/backend/storage/agent_native_memory.rs
@@ -25,6 +25,16 @@ pub struct NativeMemoryMirrorRow {
     pub size_bytes: i64,
     pub updated_at: i64,
     pub last_seen_path: String,
+    /// The live file's own on-disk mtime (ms epoch) as of the last upsert —
+    /// NOT `updated_at` (this row's own write time). Callers use this
+    /// together with `size_bytes` to detect whether a live file has
+    /// actually changed since it was last mirrored, without re-reading its
+    /// full content: size alone under-detects a same-byte-length edit
+    /// (reagent P1 on PR #2459 — a same-size edit made only on channel A,
+    /// never re-read there via `read_file`, would otherwise serve stale
+    /// content to channel B forever, since B has no live copy of its own to
+    /// self-correct with).
+    pub last_seen_mtime_ms: i64,
 }
 
 fn now_ms() -> i64 {
@@ -44,7 +54,7 @@ impl Store {
     ) -> Result<Vec<NativeMemoryMirrorRow>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT filename, '', metadata_type, size_bytes, updated_at, last_seen_path
+            "SELECT filename, '', metadata_type, size_bytes, updated_at, last_seen_path, last_seen_mtime_ms
              FROM db_agent_native_memory WHERE agent_id = ?1",
         )?;
         let rows = stmt
@@ -57,6 +67,7 @@ impl Store {
                     size_bytes: row.get(3)?,
                     updated_at: row.get(4)?,
                     last_seen_path: row.get(5)?,
+                    last_seen_mtime_ms: row.get(6)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -86,6 +97,13 @@ impl Store {
     /// every `agent:memory:list`/`read_file`/`write_file` RPC on every file
     /// it touches — cheap (one local SQLite write already on the request),
     /// and is what makes native memory durable across a channel switch.
+    ///
+    /// `mtime_ms` is the live file's own on-disk modified time (0 if
+    /// unavailable, e.g. a `write_file` call that hasn't re-stat'd the file
+    /// it just wrote) — stored as `last_seen_mtime_ms` so callers like
+    /// `agent:memory:list` can detect a real content change via
+    /// `(size_bytes, last_seen_mtime_ms)` without re-reading full content on
+    /// every call.
     pub fn agent_native_memory_upsert(
         &self,
         agent_id: &str,
@@ -93,18 +111,20 @@ impl Store {
         content: &str,
         metadata_type: Option<&str>,
         last_seen_path: &str,
+        mtime_ms: i64,
     ) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO db_agent_native_memory
-                 (agent_id, filename, content, metadata_type, size_bytes, updated_at, last_seen_path)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 (agent_id, filename, content, metadata_type, size_bytes, updated_at, last_seen_path, last_seen_mtime_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(agent_id, filename) DO UPDATE SET
                  content = excluded.content,
                  metadata_type = excluded.metadata_type,
                  size_bytes = excluded.size_bytes,
                  updated_at = excluded.updated_at,
-                 last_seen_path = excluded.last_seen_path",
+                 last_seen_path = excluded.last_seen_path,
+                 last_seen_mtime_ms = excluded.last_seen_mtime_ms",
             params![
                 agent_id,
                 filename,
@@ -113,6 +133,7 @@ impl Store {
                 content.len() as i64,
                 now_ms(),
                 last_seen_path,
+                mtime_ms,
             ],
         )?;
         Ok(())
@@ -132,7 +153,7 @@ mod tests {
     fn upsert_then_read_round_trips() {
         let store = shared_store();
         store
-            .agent_native_memory_upsert("agent-1", "MEMORY.md", "# hello", Some("user"), "/tmp/memory/MEMORY.md")
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "# hello", Some("user"), "/tmp/memory/MEMORY.md", 1000)
             .unwrap();
 
         let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
@@ -149,10 +170,10 @@ mod tests {
     fn upsert_is_idempotent_and_updates_in_place() {
         let store = shared_store();
         store
-            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v1", None, "/a")
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v1", None, "/a", 1000)
             .unwrap();
         store
-            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v2", Some("user"), "/b")
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v2", Some("user"), "/b", 2000)
             .unwrap();
 
         let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
@@ -163,13 +184,14 @@ mod tests {
         assert_eq!(meta[0].metadata_type, Some("user".to_string()));
         assert_eq!(meta[0].last_seen_path, "/b");
         assert_eq!(meta[0].size_bytes, 2);
+        assert_eq!(meta[0].last_seen_mtime_ms, 2000);
     }
 
     #[test]
     fn list_meta_scopes_to_the_requested_agent_only() {
         let store = shared_store();
-        store.agent_native_memory_upsert("agent-1", "a.md", "x", None, "/a").unwrap();
-        store.agent_native_memory_upsert("agent-2", "b.md", "y", None, "/b").unwrap();
+        store.agent_native_memory_upsert("agent-1", "a.md", "x", None, "/a", 1000).unwrap();
+        store.agent_native_memory_upsert("agent-2", "b.md", "y", None, "/b", 1000).unwrap();
 
         let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
         assert_eq!(meta.len(), 1);
@@ -182,7 +204,7 @@ mod tests {
         // bodies (that's what agent_native_memory_read is for), so a large
         // mirrored file doesn't get loaded into memory just to render a list.
         let store = shared_store();
-        store.agent_native_memory_upsert("agent-1", "a.md", "big content", None, "/a").unwrap();
+        store.agent_native_memory_upsert("agent-1", "a.md", "big content", None, "/a", 1000).unwrap();
         let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
         assert_eq!(meta[0].content, "");
     }
@@ -193,7 +215,7 @@ mod tests {
         // mirror is the only remaining copy once the live FS file is gone —
         // list/read must still return it from here.
         let store = shared_store();
-        store.agent_native_memory_upsert("agent-1", "MEMORY.md", "content", None, "/gone").unwrap();
+        store.agent_native_memory_upsert("agent-1", "MEMORY.md", "content", None, "/gone", 1000).unwrap();
 
         let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
         assert_eq!(meta.len(), 1);

--- a/agentmux-srv/src/backend/storage/agent_native_memory.rs
+++ b/agentmux-srv/src/backend/storage/agent_native_memory.rs
@@ -98,12 +98,20 @@ impl Store {
     /// it touches — cheap (one local SQLite write already on the request),
     /// and is what makes native memory durable across a channel switch.
     ///
+    /// `size_bytes` is the file's REAL on-disk size, not necessarily
+    /// `content.len()` — `content` may be truncated at the RPC layer's
+    /// `MAX_MEMORY_FILE_BYTES` cap for a file Claude Code wrote directly
+    /// (bypassing `write_file`'s own size guard). Storing the real size (not
+    /// the capped one) is what lets `agent:memory:list`'s change-detection
+    /// via `(size_bytes, last_seen_mtime_ms)` still work correctly for an
+    /// oversized file — comparing against a capped mirror size would never
+    /// match the live (larger) size, forcing a full re-read + rewrite on
+    /// every single list() call forever (reagent P1 on PR #2459, fourth pass).
+    ///
     /// `mtime_ms` is the live file's own on-disk modified time (0 if
     /// unavailable, e.g. a `write_file` call that hasn't re-stat'd the file
-    /// it just wrote) — stored as `last_seen_mtime_ms` so callers like
-    /// `agent:memory:list` can detect a real content change via
-    /// `(size_bytes, last_seen_mtime_ms)` without re-reading full content on
-    /// every call.
+    /// it just wrote) — stored as `last_seen_mtime_ms` for the same
+    /// change-detection purpose.
     pub fn agent_native_memory_upsert(
         &self,
         agent_id: &str,
@@ -111,6 +119,7 @@ impl Store {
         content: &str,
         metadata_type: Option<&str>,
         last_seen_path: &str,
+        size_bytes: i64,
         mtime_ms: i64,
     ) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
@@ -130,7 +139,7 @@ impl Store {
                 filename,
                 content,
                 metadata_type.unwrap_or(""),
-                content.len() as i64,
+                size_bytes,
                 now_ms(),
                 last_seen_path,
                 mtime_ms,
@@ -153,7 +162,7 @@ mod tests {
     fn upsert_then_read_round_trips() {
         let store = shared_store();
         store
-            .agent_native_memory_upsert("agent-1", "MEMORY.md", "# hello", Some("user"), "/tmp/memory/MEMORY.md", 1000)
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "# hello", Some("user"), "/tmp/memory/MEMORY.md", 7, 1000)
             .unwrap();
 
         let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
@@ -170,10 +179,10 @@ mod tests {
     fn upsert_is_idempotent_and_updates_in_place() {
         let store = shared_store();
         store
-            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v1", None, "/a", 1000)
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v1", None, "/a", 2, 1000)
             .unwrap();
         store
-            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v2", Some("user"), "/b", 2000)
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v2", Some("user"), "/b", 2, 2000)
             .unwrap();
 
         let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
@@ -188,10 +197,28 @@ mod tests {
     }
 
     #[test]
+    fn upsert_stores_the_caller_supplied_size_not_the_content_length() {
+        // reagent P1 on PR #2459 (fourth pass): for a file exceeding the RPC
+        // layer's MAX_MEMORY_FILE_BYTES cap, `content` is truncated but the
+        // real on-disk size is larger — callers pass that real size
+        // explicitly so a later comparison against the live file's actual
+        // size still matches. Deriving size_bytes from content.len() instead
+        // would make an oversized file's mirror row NEVER match the live
+        // size, forcing a full re-read on every single list() call forever.
+        let store = shared_store();
+        store
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "truncated...", None, "/a", 50_000_000, 1000)
+            .unwrap();
+
+        let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
+        assert_eq!(meta[0].size_bytes, 50_000_000, "size_bytes must be the caller-supplied real size, not content.len()");
+    }
+
+    #[test]
     fn list_meta_scopes_to_the_requested_agent_only() {
         let store = shared_store();
-        store.agent_native_memory_upsert("agent-1", "a.md", "x", None, "/a", 1000).unwrap();
-        store.agent_native_memory_upsert("agent-2", "b.md", "y", None, "/b", 1000).unwrap();
+        store.agent_native_memory_upsert("agent-1", "a.md", "x", None, "/a", 1, 1000).unwrap();
+        store.agent_native_memory_upsert("agent-2", "b.md", "y", None, "/b", 1, 1000).unwrap();
 
         let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
         assert_eq!(meta.len(), 1);
@@ -204,7 +231,7 @@ mod tests {
         // bodies (that's what agent_native_memory_read is for), so a large
         // mirrored file doesn't get loaded into memory just to render a list.
         let store = shared_store();
-        store.agent_native_memory_upsert("agent-1", "a.md", "big content", None, "/a", 1000).unwrap();
+        store.agent_native_memory_upsert("agent-1", "a.md", "big content", None, "/a", 11, 1000).unwrap();
         let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
         assert_eq!(meta[0].content, "");
     }
@@ -215,7 +242,7 @@ mod tests {
         // mirror is the only remaining copy once the live FS file is gone —
         // list/read must still return it from here.
         let store = shared_store();
-        store.agent_native_memory_upsert("agent-1", "MEMORY.md", "content", None, "/gone", 1000).unwrap();
+        store.agent_native_memory_upsert("agent-1", "MEMORY.md", "content", None, "/gone", 7, 1000).unwrap();
 
         let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
         assert_eq!(meta.len(), 1);

--- a/agentmux-srv/src/backend/storage/agent_native_memory.rs
+++ b/agentmux-srv/src/backend/storage/agent_native_memory.rs
@@ -1,0 +1,203 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Durable, location-consistent mirror of each agent's native (Claude Code)
+//! memory files. See db_agent_native_memory in migrations.rs
+//! (SHARED_STORE_SCHEMA_VERSION v6 / OBJECT_SCHEMA_VERSION v14) and
+//! docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md for the full
+//! design.
+//!
+//! Keyed by (agent_id, filename), where agent_id is the stable
+//! `AgentDefinition.id` — NOT any live filesystem path, which is
+//! channel-relative by design and therefore not the same across
+//! channels/instances for the same logical agent.
+
+use rusqlite::params;
+
+use super::error::StoreError;
+use super::store::Store;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct NativeMemoryMirrorRow {
+    pub filename: String,
+    pub content: String,
+    pub metadata_type: Option<String>,
+    pub size_bytes: i64,
+    pub updated_at: i64,
+    pub last_seen_path: String,
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+impl Store {
+    /// List every mirrored file for `agent_id` (no content — callers that
+    /// only need list-view metadata should prefer this over
+    /// `agent_native_memory_list` to avoid loading full file bodies).
+    pub fn agent_native_memory_list_meta(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<NativeMemoryMirrorRow>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT filename, '', metadata_type, size_bytes, updated_at, last_seen_path
+             FROM db_agent_native_memory WHERE agent_id = ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |row| {
+                let metadata_type: String = row.get(2)?;
+                Ok(NativeMemoryMirrorRow {
+                    filename: row.get(0)?,
+                    content: row.get(1)?,
+                    metadata_type: if metadata_type.is_empty() { None } else { Some(metadata_type) },
+                    size_bytes: row.get(3)?,
+                    updated_at: row.get(4)?,
+                    last_seen_path: row.get(5)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Read one mirrored file's content by `(agent_id, filename)`. Used as
+    /// the read-path fallback when the file is missing from the live FS
+    /// (e.g. a different channel wrote it, or the live folder was wiped).
+    pub fn agent_native_memory_read(
+        &self,
+        agent_id: &str,
+        filename: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT content FROM db_agent_native_memory WHERE agent_id = ?1 AND filename = ?2",
+        )?;
+        match stmt.query_row(params![agent_id, filename], |row| row.get::<_, String>(0)) {
+            Ok(content) => Ok(Some(content)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Upsert a file's current live-FS content into the mirror. Called from
+    /// every `agent:memory:list`/`read_file`/`write_file` RPC on every file
+    /// it touches — cheap (one local SQLite write already on the request),
+    /// and is what makes native memory durable across a channel switch.
+    pub fn agent_native_memory_upsert(
+        &self,
+        agent_id: &str,
+        filename: &str,
+        content: &str,
+        metadata_type: Option<&str>,
+        last_seen_path: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_agent_native_memory
+                 (agent_id, filename, content, metadata_type, size_bytes, updated_at, last_seen_path)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(agent_id, filename) DO UPDATE SET
+                 content = excluded.content,
+                 metadata_type = excluded.metadata_type,
+                 size_bytes = excluded.size_bytes,
+                 updated_at = excluded.updated_at,
+                 last_seen_path = excluded.last_seen_path",
+            params![
+                agent_id,
+                filename,
+                content,
+                metadata_type.unwrap_or(""),
+                content.len() as i64,
+                now_ms(),
+                last_seen_path,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shared_store() -> Store {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Store::open_shared(tmp.path()).unwrap()
+    }
+
+    #[test]
+    fn upsert_then_read_round_trips() {
+        let store = shared_store();
+        store
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "# hello", Some("user"), "/tmp/memory/MEMORY.md")
+            .unwrap();
+
+        let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
+        assert_eq!(content, Some("# hello".to_string()));
+    }
+
+    #[test]
+    fn read_returns_none_for_an_unmirrored_file() {
+        let store = shared_store();
+        assert_eq!(store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap(), None);
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_updates_in_place() {
+        let store = shared_store();
+        store
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v1", None, "/a")
+            .unwrap();
+        store
+            .agent_native_memory_upsert("agent-1", "MEMORY.md", "v2", Some("user"), "/b")
+            .unwrap();
+
+        let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
+        assert_eq!(content, Some("v2".to_string()));
+
+        let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
+        assert_eq!(meta.len(), 1);
+        assert_eq!(meta[0].metadata_type, Some("user".to_string()));
+        assert_eq!(meta[0].last_seen_path, "/b");
+        assert_eq!(meta[0].size_bytes, 2);
+    }
+
+    #[test]
+    fn list_meta_scopes_to_the_requested_agent_only() {
+        let store = shared_store();
+        store.agent_native_memory_upsert("agent-1", "a.md", "x", None, "/a").unwrap();
+        store.agent_native_memory_upsert("agent-2", "b.md", "y", None, "/b").unwrap();
+
+        let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
+        assert_eq!(meta.len(), 1);
+        assert_eq!(meta[0].filename, "a.md");
+    }
+
+    #[test]
+    fn list_meta_omits_content_by_design() {
+        // list_meta is the list-view path — it must not carry full file
+        // bodies (that's what agent_native_memory_read is for), so a large
+        // mirrored file doesn't get loaded into memory just to render a list.
+        let store = shared_store();
+        store.agent_native_memory_upsert("agent-1", "a.md", "big content", None, "/a").unwrap();
+        let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
+        assert_eq!(meta[0].content, "");
+    }
+
+    #[test]
+    fn a_file_deleted_from_the_live_fs_after_being_mirrored_once_stays_visible() {
+        // Simulates SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md §5(c): the
+        // mirror is the only remaining copy once the live FS file is gone —
+        // list/read must still return it from here.
+        let store = shared_store();
+        store.agent_native_memory_upsert("agent-1", "MEMORY.md", "content", None, "/gone").unwrap();
+
+        let meta = store.agent_native_memory_list_meta("agent-1").unwrap();
+        assert_eq!(meta.len(), 1);
+        let content = store.agent_native_memory_read("agent-1", "MEMORY.md").unwrap();
+        assert_eq!(content, Some("content".to_string()));
+    }
+}

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -519,13 +519,14 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         -- that would read this table first 404s on agent_def_get, so a
         -- dangling mirror row is never reached, let alone surfaced.
         CREATE TABLE IF NOT EXISTS db_agent_native_memory (
-            agent_id       TEXT NOT NULL,
-            filename       TEXT NOT NULL,
-            content        TEXT NOT NULL,
-            metadata_type  TEXT NOT NULL DEFAULT '',
-            size_bytes     INTEGER NOT NULL DEFAULT 0,
-            updated_at     INTEGER NOT NULL DEFAULT 0,
-            last_seen_path TEXT NOT NULL DEFAULT '',
+            agent_id           TEXT NOT NULL,
+            filename           TEXT NOT NULL,
+            content            TEXT NOT NULL,
+            metadata_type      TEXT NOT NULL DEFAULT '',
+            size_bytes         INTEGER NOT NULL DEFAULT 0,
+            updated_at         INTEGER NOT NULL DEFAULT 0,
+            last_seen_path     TEXT NOT NULL DEFAULT '',
+            last_seen_mtime_ms INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (agent_id, filename)
         );",
     )?;
@@ -823,13 +824,14 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
         -- db_agent_credentials above) for id_store's per-channel fallback
         -- before 0011_shared_store_backfill has run.
         CREATE TABLE IF NOT EXISTS db_agent_native_memory (
-            agent_id       TEXT NOT NULL,
-            filename       TEXT NOT NULL,
-            content        TEXT NOT NULL,
-            metadata_type  TEXT NOT NULL DEFAULT '',
-            size_bytes     INTEGER NOT NULL DEFAULT 0,
-            updated_at     INTEGER NOT NULL DEFAULT 0,
-            last_seen_path TEXT NOT NULL DEFAULT '',
+            agent_id           TEXT NOT NULL,
+            filename           TEXT NOT NULL,
+            content            TEXT NOT NULL,
+            metadata_type      TEXT NOT NULL DEFAULT '',
+            size_bytes         INTEGER NOT NULL DEFAULT 0,
+            updated_at         INTEGER NOT NULL DEFAULT 0,
+            last_seen_path     TEXT NOT NULL DEFAULT '',
+            last_seen_mtime_ms INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (agent_id, filename)
         );",
     )?;

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -39,7 +39,10 @@ use super::error::StoreError;
 ///        created_at) alongside the existing max_fires bound. NULL = no expiry
 ///        (existing rows unaffected). See
 ///        docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md Phase 0.
-pub const SHARED_STORE_SCHEMA_VERSION: i64 = 5;
+///   v6 — db_agent_native_memory: durable, location-consistent mirror of
+///        each agent's native memory files, keyed by (agent_id, filename).
+///        See docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md.
+pub const SHARED_STORE_SCHEMA_VERSION: i64 = 6;
 
 /// `user_version` value stamped into `objects.db` after `run_object_schema`.
 /// The flat schema reset the counter to 1 (the pre-flatten chain never set
@@ -81,7 +84,12 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 5;
 ///        back to this (per-channel) schema on installs that haven't yet
 ///        applied 0011_shared_store_backfill, so cloud_subscriber's calls
 ///        must not assume the shared-schema copy (v4 there) is the one in use.
-pub const OBJECT_SCHEMA_VERSION: i64 = 13;
+///   v14 — db_agent_native_memory: durable mirror of each agent's native
+///        memory files, keyed by (agent_id, filename). Same both-schemas
+///        duplication as db_agent_credentials, for the same id_store
+///        fallback reason. See
+///        docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md.
+pub const OBJECT_SCHEMA_VERSION: i64 = 14;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -498,6 +506,27 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             access_token   TEXT NOT NULL DEFAULT '',
             expires_at     INTEGER NOT NULL DEFAULT 0,
             created_at     INTEGER NOT NULL DEFAULT 0
+        );
+
+        -- v14: per-agent native-memory durable mirror — see
+        -- db_agent_native_memory in run_shared_store_schema's doc comment for
+        -- the full rationale (SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md).
+        -- No FK to db_agent_definitions: this table is duplicated into the
+        -- shared store below (same pattern as db_agent_credentials, for
+        -- id_store's per-channel fallback before 0011_shared_store_backfill),
+        -- and SQLite can't enforce a FK across separate database files.
+        -- Orphan rows after an agent's deleted are inert: every RPC handler
+        -- that would read this table first 404s on agent_def_get, so a
+        -- dangling mirror row is never reached, let alone surfaced.
+        CREATE TABLE IF NOT EXISTS db_agent_native_memory (
+            agent_id       TEXT NOT NULL,
+            filename       TEXT NOT NULL,
+            content        TEXT NOT NULL,
+            metadata_type  TEXT NOT NULL DEFAULT '',
+            size_bytes     INTEGER NOT NULL DEFAULT 0,
+            updated_at     INTEGER NOT NULL DEFAULT 0,
+            last_seen_path TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (agent_id, filename)
         );",
     )?;
 
@@ -779,6 +808,29 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
             access_token   TEXT NOT NULL DEFAULT '',
             expires_at     INTEGER NOT NULL DEFAULT 0,
             created_at     INTEGER NOT NULL DEFAULT 0
+        );
+
+        -- v6: durable mirror of each agent's native (Claude Code) memory
+        -- files, keyed by the stable AgentDefinition.id rather than any live
+        -- filesystem path — the live path is channel-relative by design
+        -- (per-build-channel filesystem isolation), so the same agent opened
+        -- from two channels resolves two different on-disk memory dirs. This
+        -- table is what makes native memory durable and location-consistent
+        -- across channels: agent:memory:list/read_file upsert into it on
+        -- every read, and merge the live-FS view with it in the response —
+        -- see docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md.
+        -- Duplicated into run_object_schema (same both-schemas pattern as
+        -- db_agent_credentials above) for id_store's per-channel fallback
+        -- before 0011_shared_store_backfill has run.
+        CREATE TABLE IF NOT EXISTS db_agent_native_memory (
+            agent_id       TEXT NOT NULL,
+            filename       TEXT NOT NULL,
+            content        TEXT NOT NULL,
+            metadata_type  TEXT NOT NULL DEFAULT '',
+            size_bytes     INTEGER NOT NULL DEFAULT 0,
+            updated_at     INTEGER NOT NULL DEFAULT 0,
+            last_seen_path TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (agent_id, filename)
         );",
     )?;
 

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -5,6 +5,7 @@
 //! Port of Go's pkg/wstore and pkg/filestore.
 
 pub mod agent_credentials;
+pub mod agent_native_memory;
 pub mod agents;
 pub mod agents_consolidate;
 pub mod content;
@@ -25,6 +26,7 @@ pub mod snapshot;
 pub mod store;
 
 pub use agent_credentials::AgentCredential;
+pub use agent_native_memory::NativeMemoryMirrorRow;
 pub use agents::{AgentDefinition, AgentInstance, InstanceStatus, InstanceUpdate};
 pub use content::AgentContent;
 pub use cron::CronJob;

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -337,20 +337,27 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
 
                 // Existing mirror metadata (no content) for this agent, keyed by
                 // filename — lets the loop below skip the expensive full-content
-                // read+upsert for a file whose size hasn't changed since it was
-                // last mirrored, instead of doing it unconditionally on every
-                // list call (reagent P1 on PR #2459: `list` fires on every Stash
+                // read+upsert for a file that hasn't changed since it was last
+                // mirrored, instead of doing it unconditionally on every list
+                // call (reagent P1 on PR #2459: `list` fires on every Stash
                 // Memory tab open/refresh, so an unconditional full read + SQLite
                 // write per file would mean synchronous, potentially many-MB
                 // disk I/O on a call meant to be a lightweight metadata listing).
-                // A same-size-but-changed-content file is a known, accepted gap
-                // here — read_file always re-reads the live file fresh regardless,
-                // so this can only make the mirror (not the read path) briefly stale.
-                let mirrored_meta: std::collections::HashMap<String, i64> = id_store
+                //
+                // Compares BOTH size and mtime, not size alone: a same-byte-length
+                // edit is common (e.g. correcting a typo) and size-only comparison
+                // would silently leave the mirror stale for it. This matters for
+                // exactly the case this table exists for — a channel with no live
+                // copy of a file relies entirely on the mirror (reagent P1 on
+                // PR #2459's first pass: read_file only "always re-reads fresh"
+                // on the channel that still HAS a live copy; a channel that never
+                // did has nothing to self-correct with, so a stale mirror row
+                // there is permanent, not "briefly stale").
+                let mirrored_meta: std::collections::HashMap<String, (i64, i64)> = id_store
                     .agent_native_memory_list_meta(&agent.id)
                     .unwrap_or_default()
                     .into_iter()
-                    .map(|row| (row.filename, row.size_bytes))
+                    .map(|row| (row.filename, (row.size_bytes, row.last_seen_mtime_ms)))
                     .collect();
 
                 let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
@@ -414,7 +421,8 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                         let metadata_type = parse_frontmatter_type(&preview_content);
                         let is_index = name == "MEMORY.md";
 
-                        let unchanged_since_last_mirror = mirrored_meta.get(&name) == Some(&(size_bytes as i64));
+                        let unchanged_since_last_mirror =
+                            mirrored_meta.get(&name) == Some(&(size_bytes as i64, modified_at));
                         if !unchanged_since_last_mirror {
                             let full_content = {
                                 use std::io::Read;
@@ -433,6 +441,7 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                                 &full_content,
                                 full_metadata_type.as_deref(),
                                 &entry.path().to_string_lossy(),
+                                modified_at,
                             ) {
                                 tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
                             }
@@ -520,11 +529,11 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 // read for another reason (permissions, non-regular file)
                 // still surfaces as an error rather than silently masking it
                 // with stale mirrored content.
-                let live = std::fs::symlink_metadata(&path).ok().and_then(|m| {
-                    if m.file_type().is_file() { Some(()) } else { None }
-                });
+                let live_meta = std::fs::symlink_metadata(&path)
+                    .ok()
+                    .filter(|m| m.file_type().is_file());
 
-                let content = if live.is_some() {
+                let content = if let Some(live_meta) = live_meta {
                     let mut buf = Vec::new();
                     std::fs::File::open(&path)
                         .and_then(|f| {
@@ -535,12 +544,19 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     let content = String::from_utf8_lossy(&buf).into_owned();
 
                     let metadata_type = parse_frontmatter_type(&content);
+                    let mtime_ms = live_meta
+                        .modified()
+                        .ok()
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_millis() as i64)
+                        .unwrap_or(0);
                     if let Err(e) = id_store.agent_native_memory_upsert(
                         &agent.id,
                         &cmd.filename,
                         &content,
                         metadata_type.as_deref(),
                         &path.to_string_lossy(),
+                        mtime_ms,
                     ) {
                         tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:read_file: mirror upsert failed (non-fatal)");
                     }
@@ -620,12 +636,24 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 }
 
                 let metadata_type = parse_frontmatter_type(&cmd.content);
+                // Re-stat the just-written file for its real on-disk mtime rather
+                // than stamping now_ms() here — keeps this in exact agreement with
+                // what a subsequent list() will compute, so the size+mtime change
+                // check there doesn't spuriously treat this write as "changed
+                // again" due to clock/precision drift between the two.
+                let mtime_ms = std::fs::metadata(&dest)
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
                 if let Err(e) = id_store.agent_native_memory_upsert(
                     &agent.id,
                     &cmd.filename,
                     &cmd.content,
                     metadata_type.as_deref(),
                     &dest.to_string_lossy(),
+                    mtime_ms,
                 ) {
                     tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:write_file: mirror upsert failed (non-fatal)");
                 }
@@ -928,7 +956,7 @@ mod tests {
         // Directly stamp a stale mirror row behind the live FS's back — the
         // read path must still prefer the live file, not this stale row.
         shared_id_store
-            .agent_native_memory_upsert("agent-shared-2", "MEMORY.md", "stale mirror content", None, "/nowhere")
+            .agent_native_memory_upsert("agent-shared-2", "MEMORY.md", "stale mirror content", None, "/nowhere", 0)
             .unwrap();
 
         let read: NativeMemoryReadFileResult = call_rpc(
@@ -1029,6 +1057,53 @@ mod tests {
         assert_eq!(
             first_updated_at, second_updated_at,
             "an unchanged file must not be re-upserted into the mirror on a second list() call"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_detects_a_same_size_content_change_via_mtime() {
+        // reagent P1 on PR #2459: comparing size alone would miss a same-byte-
+        // length edit (e.g. correcting a typo), leaving the mirror serving
+        // stale content forever to a channel that never had a live copy of
+        // its own to self-correct with. Confirm the mtime check catches it.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        let (engine, mut rx) = build_channel_state("agent-samesize", "/work/channel-a", config.path(), shared_id_store.clone());
+
+        let memory_dir = config.path().join("projects").join("-work-channel-a").join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+        let file = memory_dir.join("MEMORY.md");
+        std::fs::write(&file, "content A!").unwrap();
+
+        let _: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-samesize" }),
+        )
+        .await;
+        assert_eq!(
+            shared_id_store.agent_native_memory_read("agent-samesize", "MEMORY.md").unwrap(),
+            Some("content A!".to_string())
+        );
+
+        // Same byte length, different content, comfortably past mtime resolution.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        std::fs::write(&file, "content B!").unwrap();
+        assert_eq!(file.metadata().unwrap().len(), "content A!".len() as u64);
+
+        let _: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-samesize" }),
+        )
+        .await;
+        assert_eq!(
+            shared_id_store.agent_native_memory_read("agent-samesize", "MEMORY.md").unwrap(),
+            Some("content B!".to_string()),
+            "a same-size content change must still be picked up by list() via mtime"
         );
     }
 

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -424,26 +424,40 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                         let unchanged_since_last_mirror =
                             mirrored_meta.get(&name) == Some(&(size_bytes as i64, modified_at));
                         if !unchanged_since_last_mirror {
-                            let full_content = {
+                            // A read failure here (permission change, TOCTOU
+                            // delete, AV/NFS lock, concurrent editor) must NOT
+                            // upsert an empty string — that would overwrite any
+                            // previously-durable mirrored content, destroying the
+                            // exact cross-channel durability guarantee this table
+                            // exists for on the very first transient read hiccup
+                            // (reagent P0 on PR #2459). Skip the upsert entirely
+                            // this round instead; it retries on the next list().
+                            let full_content_read = {
                                 use std::io::Read;
-                                std::fs::File::open(entry.path())
-                                    .map(|f| {
-                                        let mut buf = Vec::new();
-                                        f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf).ok();
-                                        String::from_utf8_lossy(&buf).into_owned()
-                                    })
-                                    .unwrap_or_default()
+                                std::fs::File::open(entry.path()).and_then(|f| {
+                                    let mut buf = Vec::new();
+                                    f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf)?;
+                                    Ok(buf)
+                                })
                             };
-                            let full_metadata_type = parse_frontmatter_type(&full_content);
-                            if let Err(e) = id_store.agent_native_memory_upsert(
-                                &agent.id,
-                                &name,
-                                &full_content,
-                                full_metadata_type.as_deref(),
-                                &entry.path().to_string_lossy(),
-                                modified_at,
-                            ) {
-                                tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
+                            match full_content_read {
+                                Ok(buf) => {
+                                    let full_content = String::from_utf8_lossy(&buf).into_owned();
+                                    let full_metadata_type = parse_frontmatter_type(&full_content);
+                                    if let Err(e) = id_store.agent_native_memory_upsert(
+                                        &agent.id,
+                                        &name,
+                                        &full_content,
+                                        full_metadata_type.as_deref(),
+                                        &entry.path().to_string_lossy(),
+                                        modified_at,
+                                    ) {
+                                        tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: full-content read failed, skipping mirror upsert this round (non-fatal)");
+                                }
                             }
                         }
                         live_filenames.insert(name.clone());
@@ -529,40 +543,53 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 // read for another reason (permissions, non-regular file)
                 // still surfaces as an error rather than silently masking it
                 // with stale mirrored content.
-                let live_meta = std::fs::symlink_metadata(&path)
-                    .ok()
-                    .filter(|m| m.file_type().is_file());
+                // Distinguish "genuinely absent" (fall back to the mirror) from
+                // every other symlink_metadata outcome, matching the
+                // pre-durable-sync behavior exactly: a real access error
+                // (permissions, I/O) must surface as an error, not silently
+                // fall back to possibly-stale mirrored content, and an existing
+                // non-regular-file path must be explicitly rejected, not treated
+                // as "absent" either (reagent P1 on PR #2459, second pass —
+                // collapsing every outcome into "absent" the first time around
+                // could serve stale content or a misleading "not found" for a
+                // path that actually exists but errored or is the wrong type).
+                let content = match std::fs::symlink_metadata(&path) {
+                    Ok(live_meta) if live_meta.file_type().is_file() => {
+                        let mut buf = Vec::new();
+                        std::fs::File::open(&path)
+                            .and_then(|f| {
+                                use std::io::Read;
+                                f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf)
+                            })
+                            .map_err(|e| format!("agent:memory:read_file: {}: {e}", cmd.filename))?;
+                        let content = String::from_utf8_lossy(&buf).into_owned();
 
-                let content = if let Some(live_meta) = live_meta {
-                    let mut buf = Vec::new();
-                    std::fs::File::open(&path)
-                        .and_then(|f| {
-                            use std::io::Read;
-                            f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf)
-                        })
-                        .map_err(|e| format!("agent:memory:read_file: {}: {e}", cmd.filename))?;
-                    let content = String::from_utf8_lossy(&buf).into_owned();
-
-                    let metadata_type = parse_frontmatter_type(&content);
-                    let mtime_ms = live_meta
-                        .modified()
-                        .ok()
-                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                        .map(|d| d.as_millis() as i64)
-                        .unwrap_or(0);
-                    if let Err(e) = id_store.agent_native_memory_upsert(
-                        &agent.id,
-                        &cmd.filename,
-                        &content,
-                        metadata_type.as_deref(),
-                        &path.to_string_lossy(),
-                        mtime_ms,
-                    ) {
-                        tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:read_file: mirror upsert failed (non-fatal)");
+                        let metadata_type = parse_frontmatter_type(&content);
+                        let mtime_ms = live_meta
+                            .modified()
+                            .ok()
+                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|d| d.as_millis() as i64)
+                            .unwrap_or(0);
+                        if let Err(e) = id_store.agent_native_memory_upsert(
+                            &agent.id,
+                            &cmd.filename,
+                            &content,
+                            metadata_type.as_deref(),
+                            &path.to_string_lossy(),
+                            mtime_ms,
+                        ) {
+                            tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:read_file: mirror upsert failed (non-fatal)");
+                        }
+                        content
                     }
-                    content
-                } else {
-                    match id_store.agent_native_memory_read(&agent.id, &cmd.filename) {
+                    Ok(_) => {
+                        return Err(format!("agent:memory:read_file: {} is not a regular file", cmd.filename));
+                    }
+                    Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+                        return Err(format!("agent:memory:read_file: {}: {e}", cmd.filename));
+                    }
+                    Err(_) => match id_store.agent_native_memory_read(&agent.id, &cmd.filename) {
                         Ok(Some(mirrored)) => mirrored,
                         Ok(None) => {
                             return Err(format!("agent:memory:read_file: {}: not found", cmd.filename));
@@ -984,6 +1011,36 @@ mod tests {
         )
         .await;
         assert!(err.contains("not found"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn read_file_rejects_a_non_regular_file_instead_of_falling_back_to_the_mirror() {
+        // reagent P1 on PR #2459 (second pass): a path that exists but isn't a
+        // regular file (e.g. a directory landed at the expected filename) must
+        // be rejected explicitly — collapsing it into "absent, fall back to
+        // mirror" could serve stale mirrored content for a path that actually
+        // exists but is the wrong type.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        // Pre-mirror some content, so a bug that treats this as "absent" would
+        // wrongly succeed by serving it instead of erroring.
+        shared_id_store
+            .agent_native_memory_upsert("agent-wrongtype", "MEMORY.md", "mirrored content", None, "/elsewhere", 0)
+            .unwrap();
+        let (engine, mut rx) = build_channel_state("agent-wrongtype", "/work/channel-a", config.path(), shared_id_store);
+
+        let memory_dir = config.path().join("projects").join("-work-channel-a").join("memory");
+        std::fs::create_dir_all(memory_dir.join("MEMORY.md")).unwrap(); // a directory, not a file
+
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_READ_FILE,
+            serde_json::json!({ "agent_id": "agent-wrongtype", "filename": "MEMORY.md" }),
+        )
+        .await;
+        assert!(err.contains("not a regular file"), "unexpected error: {err}");
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -450,6 +450,7 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                                         &full_content,
                                         full_metadata_type.as_deref(),
                                         &entry.path().to_string_lossy(),
+                                        size_bytes as i64,
                                         modified_at,
                                     ) {
                                         tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
@@ -577,6 +578,7 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                             &content,
                             metadata_type.as_deref(),
                             &path.to_string_lossy(),
+                            live_meta.len() as i64,
                             mtime_ms,
                         ) {
                             tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:read_file: mirror upsert failed (non-fatal)");
@@ -663,13 +665,14 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 }
 
                 let metadata_type = parse_frontmatter_type(&cmd.content);
-                // Re-stat the just-written file for its real on-disk mtime rather
-                // than stamping now_ms() here — keeps this in exact agreement with
-                // what a subsequent list() will compute, so the size+mtime change
-                // check there doesn't spuriously treat this write as "changed
-                // again" due to clock/precision drift between the two.
-                let mtime_ms = std::fs::metadata(&dest)
-                    .ok()
+                // Re-stat the just-written file for its real on-disk size/mtime
+                // rather than deriving them from cmd.content here — keeps this
+                // in exact agreement with what a subsequent list() will compute,
+                // so the size+mtime change check there doesn't spuriously treat
+                // this write as "changed again" due to clock/precision drift.
+                let dest_meta = std::fs::metadata(&dest).ok();
+                let size_bytes = dest_meta.as_ref().map(|m| m.len() as i64).unwrap_or(cmd.content.len() as i64);
+                let mtime_ms = dest_meta
                     .and_then(|m| m.modified().ok())
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_millis() as i64)
@@ -680,6 +683,7 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     &cmd.content,
                     metadata_type.as_deref(),
                     &dest.to_string_lossy(),
+                    size_bytes,
                     mtime_ms,
                 ) {
                     tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:write_file: mirror upsert failed (non-fatal)");
@@ -983,7 +987,7 @@ mod tests {
         // Directly stamp a stale mirror row behind the live FS's back — the
         // read path must still prefer the live file, not this stale row.
         shared_id_store
-            .agent_native_memory_upsert("agent-shared-2", "MEMORY.md", "stale mirror content", None, "/nowhere", 0)
+            .agent_native_memory_upsert("agent-shared-2", "MEMORY.md", "stale mirror content", None, "/nowhere", "stale mirror content".len() as i64, 0)
             .unwrap();
 
         let read: NativeMemoryReadFileResult = call_rpc(
@@ -1026,7 +1030,7 @@ mod tests {
         // Pre-mirror some content, so a bug that treats this as "absent" would
         // wrongly succeed by serving it instead of erroring.
         shared_id_store
-            .agent_native_memory_upsert("agent-wrongtype", "MEMORY.md", "mirrored content", None, "/elsewhere", 0)
+            .agent_native_memory_upsert("agent-wrongtype", "MEMORY.md", "mirrored content", None, "/elsewhere", "mirrored content".len() as i64, 0)
             .unwrap();
         let (engine, mut rx) = build_channel_state("agent-wrongtype", "/work/channel-a", config.path(), shared_id_store);
 

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -10,6 +10,14 @@
 //!   agent:memory:write_file — write/create one file atomically (tmp→rename)
 //!
 //! Spec: docs/specs/SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md §7
+//!
+//! All three also write through into `db_agent_native_memory` (via
+//! `state.id_store`) — a durable mirror keyed by the stable
+//! `AgentDefinition.id`, since the live filesystem path above is
+//! channel-relative by design and not the same across channels/instances for
+//! the same logical agent. `list`/`read_file` merge the live-FS view with
+//! the mirror so a file written from one channel stays visible from another.
+//! See docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md.
 
 use std::sync::Arc;
 use std::path::PathBuf;
@@ -293,12 +301,18 @@ fn parse_frontmatter_type(content: &str) -> Option<String> {
     None
 }
 
+/// Cap for both live-FS reads and mirror upserts — one shared limit so a
+/// file that's readable stays within the size the mirror can also store.
+const MAX_MEMORY_FILE_BYTES: u64 = 10 * 1024 * 1024;
+
 pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore_list = state.wstore.clone();
+    let id_store_list = state.id_store.clone();
     engine.register_handler(
         COMMAND_NATIVE_MEMORY_LIST,
         Box::new(move |data, _ctx| {
             let wstore = wstore_list.clone();
+            let id_store = id_store_list.clone();
             Box::pin(async move {
                 let cmd: CommandNativeMemoryListData = serde_json::from_value(data)
                     .map_err(|e| format!("agent:memory:list: {e}"))?;
@@ -322,67 +336,100 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 let memory_dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
 
                 let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
+                let mut live_filenames: std::collections::HashSet<String> = std::collections::HashSet::new();
                 // Treat both "dir doesn't exist" and the TOCTOU case where the dir
-                // is deleted between exists() and read_dir() as an empty result.
-                let entries = match std::fs::read_dir(&memory_dir) {
-                    Ok(e) => e,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        return Ok(Some(serde_json::to_value(NativeMemoryListResult { files: vec![] }).map_err(|e| e.to_string())?));
-                    }
-                    Err(e) => return Err(format!("agent:memory:list: read_dir: {e}")),
-                };
+                // is deleted between exists() and read_dir() as an empty result —
+                // the mirror merge below still runs, so a wiped live folder
+                // doesn't lose durability for files it mirrored previously.
+                let entries = std::fs::read_dir(&memory_dir).ok();
 
-                for entry in entries {
-                    let entry = entry.map_err(|e| format!("agent:memory:list: read_dir entry: {e}"))?;
-                    let name = entry.file_name().to_string_lossy().into_owned();
-                    if !name.ends_with(".md") {
-                        continue;
-                    }
-                    // Reject symlinks — entry.file_type() does NOT follow symlinks.
-                    let file_type = entry
-                        .file_type()
-                        .map_err(|e| format!("agent:memory:list: file_type {name}: {e}"))?;
-                    if !file_type.is_file() {
-                        continue;
-                    }
-                    // The file may be deleted after read_dir but before metadata —
-                    // skip the entry on NotFound rather than aborting the whole listing.
-                    let meta = match entry.metadata() {
-                        Ok(m) => m,
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-                        Err(e) => return Err(format!("agent:memory:list: metadata {name}: {e}")),
-                    };
-                    let size_bytes = meta.len();
-                    let modified_at = meta
-                        .modified()
-                        .ok()
-                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                        .map(|d| d.as_millis() as i64)
-                        .unwrap_or(0);
+                if let Some(entries) = entries {
+                    for entry in entries {
+                        let entry = entry.map_err(|e| format!("agent:memory:list: read_dir entry: {e}"))?;
+                        let name = entry.file_name().to_string_lossy().into_owned();
+                        if !name.ends_with(".md") {
+                            continue;
+                        }
+                        // Reject symlinks — entry.file_type() does NOT follow symlinks.
+                        let file_type = entry
+                            .file_type()
+                            .map_err(|e| format!("agent:memory:list: file_type {name}: {e}"))?;
+                        if !file_type.is_file() {
+                            continue;
+                        }
+                        // The file may be deleted after read_dir but before metadata —
+                        // skip the entry on NotFound rather than aborting the whole listing.
+                        let meta = match entry.metadata() {
+                            Ok(m) => m,
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                            Err(e) => return Err(format!("agent:memory:list: metadata {name}: {e}")),
+                        };
+                        let size_bytes = meta.len();
+                        let modified_at = meta
+                            .modified()
+                            .ok()
+                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|d| d.as_millis() as i64)
+                            .unwrap_or(0);
 
-                    // Read up to 512 bytes for frontmatter type parsing.
-                    // Take + read_to_end loops internally to fill the buffer —
-                    // a single read() call may return fewer bytes on the first try.
-                    let preview_content = {
-                        use std::io::Read;
-                        std::fs::File::open(entry.path())
-                            .map(|f| {
-                                let mut buf = Vec::with_capacity(512);
-                                f.take(512).read_to_end(&mut buf).ok();
-                                String::from_utf8_lossy(&buf).into_owned()
-                            })
-                            .unwrap_or_default()
-                    };
-                    let metadata_type = parse_frontmatter_type(&preview_content);
-                    let is_index = name == "MEMORY.md";
+                        // Read the full file (same cap as read_file) — both for
+                        // frontmatter parsing and to write through into the
+                        // durable mirror below.
+                        let content = {
+                            use std::io::Read;
+                            std::fs::File::open(entry.path())
+                                .map(|f| {
+                                    let mut buf = Vec::new();
+                                    f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf).ok();
+                                    String::from_utf8_lossy(&buf).into_owned()
+                                })
+                                .unwrap_or_default()
+                        };
+                        let metadata_type = parse_frontmatter_type(&content);
+                        let is_index = name == "MEMORY.md";
 
-                    files.push(NativeMemoryFileMeta {
-                        filename: name,
-                        is_index,
-                        metadata_type,
-                        size_bytes,
-                        modified_at,
-                    });
+                        if let Err(e) = id_store.agent_native_memory_upsert(
+                            &agent.id,
+                            &name,
+                            &content,
+                            metadata_type.as_deref(),
+                            &entry.path().to_string_lossy(),
+                        ) {
+                            tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
+                        }
+                        live_filenames.insert(name.clone());
+
+                        files.push(NativeMemoryFileMeta {
+                            filename: name,
+                            is_index,
+                            metadata_type,
+                            size_bytes,
+                            modified_at,
+                        });
+                    }
+                }
+
+                // Merge in mirror-only files — present in a different channel's
+                // write (or the live folder was wiped) but not on this channel's
+                // live FS. Served transparently, with no distinguishing treatment.
+                match id_store.agent_native_memory_list_meta(&agent.id) {
+                    Ok(mirrored) => {
+                        for row in mirrored {
+                            if live_filenames.contains(&row.filename) {
+                                continue;
+                            }
+                            files.push(NativeMemoryFileMeta {
+                                is_index: row.filename == "MEMORY.md",
+                                metadata_type: row.metadata_type,
+                                size_bytes: row.size_bytes as u64,
+                                modified_at: row.updated_at,
+                                filename: row.filename,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(agent_id = %agent.id, error = %e, "agent:memory:list: mirror list failed (non-fatal)");
+                    }
                 }
 
                 // MEMORY.md first, then alphabetical
@@ -396,10 +443,12 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
     );
 
     let wstore_read = state.wstore.clone();
+    let id_store_read = state.id_store.clone();
     engine.register_handler(
         COMMAND_NATIVE_MEMORY_READ_FILE,
         Box::new(move |data, _ctx| {
             let wstore = wstore_read.clone();
+            let id_store = id_store_read.clone();
             Box::pin(async move {
                 let cmd: CommandNativeMemoryReadFileData = serde_json::from_value(data)
                     .map_err(|e| format!("agent:memory:read_file: {e}"))?;
@@ -422,24 +471,51 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     .map(|c| parse_claude_config_dir(&c.content))
                     .unwrap_or_default();
                 let path = memory_dir_for_cwd(&config_dir, &agent.working_directory).join(&cmd.filename);
-                // Reject symlinks — consistent with list handler's file_type check.
-                let file_type = std::fs::symlink_metadata(&path)
-                    .map_err(|e| format!("agent:memory:read_file: {}: {e}", cmd.filename))?
-                    .file_type();
-                if !file_type.is_file() {
-                    return Err(format!("agent:memory:read_file: {} is not a regular file", cmd.filename));
-                }
-                // Cap at 10 MiB; use read_to_end + from_utf8_lossy so a boundary
-                // mid-UTF-8 sequence doesn't surface as InvalidData.
-                const MAX_READ_BYTES: u64 = 10 * 1024 * 1024;
-                let mut buf = Vec::new();
-                std::fs::File::open(&path)
-                    .and_then(|f| {
-                        use std::io::Read;
-                        f.take(MAX_READ_BYTES).read_to_end(&mut buf)
-                    })
-                    .map_err(|e| format!("agent:memory:read_file: {}: {e}", cmd.filename))?;
-                let content = String::from_utf8_lossy(&buf).into_owned();
+
+                // Live FS is the freshest copy when present — Claude may have
+                // written moments ago, before this call's mirror upsert even
+                // runs. Fall back to the mirror only when the live file is
+                // genuinely absent (a different channel's write, or the live
+                // folder was wiped) — a live path that exists but fails to
+                // read for another reason (permissions, non-regular file)
+                // still surfaces as an error rather than silently masking it
+                // with stale mirrored content.
+                let live = std::fs::symlink_metadata(&path).ok().and_then(|m| {
+                    if m.file_type().is_file() { Some(()) } else { None }
+                });
+
+                let content = if live.is_some() {
+                    let mut buf = Vec::new();
+                    std::fs::File::open(&path)
+                        .and_then(|f| {
+                            use std::io::Read;
+                            f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf)
+                        })
+                        .map_err(|e| format!("agent:memory:read_file: {}: {e}", cmd.filename))?;
+                    let content = String::from_utf8_lossy(&buf).into_owned();
+
+                    let metadata_type = parse_frontmatter_type(&content);
+                    if let Err(e) = id_store.agent_native_memory_upsert(
+                        &agent.id,
+                        &cmd.filename,
+                        &content,
+                        metadata_type.as_deref(),
+                        &path.to_string_lossy(),
+                    ) {
+                        tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:read_file: mirror upsert failed (non-fatal)");
+                    }
+                    content
+                } else {
+                    match id_store.agent_native_memory_read(&agent.id, &cmd.filename) {
+                        Ok(Some(mirrored)) => mirrored,
+                        Ok(None) => {
+                            return Err(format!("agent:memory:read_file: {}: not found", cmd.filename));
+                        }
+                        Err(e) => {
+                            return Err(format!("agent:memory:read_file: {}: not found on this channel and mirror lookup failed: {e}", cmd.filename));
+                        }
+                    }
+                };
 
                 Ok(Some(serde_json::to_value(NativeMemoryReadFileResult { content }).map_err(|e| e.to_string())?))
             })
@@ -447,10 +523,12 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
     );
 
     let wstore_write = state.wstore.clone();
+    let id_store_write = state.id_store.clone();
     engine.register_handler(
         COMMAND_NATIVE_MEMORY_WRITE_FILE,
         Box::new(move |data, _ctx| {
             let wstore = wstore_write.clone();
+            let id_store = id_store_write.clone();
             Box::pin(async move {
                 let cmd: CommandNativeMemoryWriteFileData = serde_json::from_value(data)
                     .map_err(|e| format!("agent:memory:write_file: {e}"))?;
@@ -499,6 +577,17 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 if let Err(e) = std::fs::rename(&tmp, &dest) {
                     let _ = std::fs::remove_file(&tmp);
                     return Err(format!("agent:memory:write_file: rename: {e}"));
+                }
+
+                let metadata_type = parse_frontmatter_type(&cmd.content);
+                if let Err(e) = id_store.agent_native_memory_upsert(
+                    &agent.id,
+                    &cmd.filename,
+                    &cmd.content,
+                    metadata_type.as_deref(),
+                    &dest.to_string_lossy(),
+                ) {
+                    tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:write_file: mirror upsert failed (non-fatal)");
                 }
 
                 tracing::info!(
@@ -602,6 +691,231 @@ mod tests {
             Some(v) => std::env::set_var("AGENTMUX_SHARED_DIR", v),
             None => std::env::remove_var("AGENTMUX_SHARED_DIR"),
         }
+    }
+
+    // ---- Durable sync integration tests ----------------------------------
+    // SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md §5: simulate two
+    // "channels" against the same agent.id by pointing each AppState's
+    // wstore at a different working_directory (so memory_dir_for_cwd
+    // resolves two different live paths) while sharing one id_store — the
+    // same topology production uses (each channel's own objects.db caches
+    // the same global AgentDefinition.id; one shared store.db backs id_store).
+
+    use crate::backend::rpc::engine::WshRpcEngine;
+    use crate::backend::storage::store::Store;
+    use crate::backend::storage::AgentDefinition;
+    use crate::backend::rpc_types::{RpcMessage};
+
+    fn agent_def(id: &str, working_directory: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: "Test Agent".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: working_directory.to_string(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        }
+    }
+
+    /// Build a channel's AppState: its own per-channel wstore (holding the
+    /// agent definition, keyed by the same `agent_id` every channel shares)
+    /// plus the given shared `id_store` (the durable mirror).
+    /// `claude_config_dir` must be a per-test temp directory — an empty
+    /// value would make `memory_dir_for_cwd` fall back to the REAL
+    /// `~/.agentmux/shared/providers/claude/`, writing test fixtures into
+    /// the developer's actual home directory (caught live: a prior version
+    /// of these tests left `-work-channel-a/` behind under the real home).
+    fn build_channel_state(
+        agent_id: &str,
+        working_directory: &str,
+        claude_config_dir: &std::path::Path,
+        id_store: Arc<Store>,
+    ) -> (Arc<WshRpcEngine>, tokio::sync::mpsc::UnboundedReceiver<RpcMessage>) {
+        let wstore = Arc::new(Store::open_in_memory().unwrap());
+        let mut def = agent_def(agent_id, working_directory);
+        wstore.agent_def_insert(&mut def).unwrap();
+        wstore
+            .agent_content_set(&crate::backend::storage::AgentContent {
+                agent_id: agent_id.to_string(),
+                content_type: "env".to_string(),
+                content: format!("CLAUDE_CONFIG_DIR={}\n", claude_config_dir.display()),
+                updated_at: 0,
+            })
+            .unwrap();
+
+        let mut state = crate::server::tests::test_state();
+        state.wstore = wstore.clone();
+        state.id_store = id_store;
+
+        let (engine, rx) = WshRpcEngine::new();
+        register_native_memory_handlers(&engine, &state);
+        (engine, rx)
+    }
+
+    async fn call_rpc<T: serde::de::DeserializeOwned>(
+        engine: &Arc<WshRpcEngine>,
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<RpcMessage>,
+        command: &str,
+        data: serde_json::Value,
+    ) -> T {
+        let req_id = format!("test-{}", uuid::Uuid::new_v4());
+        let msg = RpcMessage {
+            command: command.to_string(),
+            reqid: req_id.clone(),
+            data: Some(data),
+            ..Default::default()
+        };
+        engine.handle_message(msg);
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("handler timed out")
+            .expect("output channel closed");
+        assert_eq!(resp.resid, req_id, "unexpected response id");
+        assert!(resp.error.is_empty(), "handler returned error: {}", resp.error);
+        serde_json::from_value(resp.data.unwrap_or(serde_json::Value::Null)).expect("response deserialize")
+    }
+
+    async fn call_rpc_expect_error(
+        engine: &Arc<WshRpcEngine>,
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<RpcMessage>,
+        command: &str,
+        data: serde_json::Value,
+    ) -> String {
+        let req_id = format!("test-{}", uuid::Uuid::new_v4());
+        let msg = RpcMessage {
+            command: command.to_string(),
+            reqid: req_id.clone(),
+            data: Some(data),
+            ..Default::default()
+        };
+        engine.handle_message(msg);
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("handler timed out")
+            .expect("output channel closed");
+        assert_eq!(resp.resid, req_id);
+        assert!(!resp.error.is_empty(), "expected error, got success: {:?}", resp.data);
+        resp.error
+    }
+
+    #[tokio::test]
+    async fn a_file_written_from_one_channel_is_visible_from_another() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config_a = tempfile::tempdir().unwrap();
+        let config_b = tempfile::tempdir().unwrap();
+
+        let (engine_a, mut rx_a) = build_channel_state("agent-shared-1", "/work/channel-a", config_a.path(), shared_id_store.clone());
+        let (engine_b, mut rx_b) = build_channel_state("agent-shared-1", "/work/channel-b", config_b.path(), shared_id_store.clone());
+
+        call_rpc::<Option<serde_json::Value>>(
+            &engine_a,
+            &mut rx_a,
+            COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({
+                "agent_id": "agent-shared-1",
+                "filename": "MEMORY.md",
+                "content": "written from channel A",
+            }),
+        )
+        .await;
+
+        // Channel B's live FS never had this file — list must still surface
+        // it (via the shared mirror), and read_file must return its content.
+        let listed: NativeMemoryListResult = call_rpc(
+            &engine_b,
+            &mut rx_b,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-shared-1" }),
+        )
+        .await;
+        assert_eq!(listed.files.len(), 1, "channel B must see channel A's mirrored file");
+        assert_eq!(listed.files[0].filename, "MEMORY.md");
+
+        let read: NativeMemoryReadFileResult = call_rpc(
+            &engine_b,
+            &mut rx_b,
+            COMMAND_NATIVE_MEMORY_READ_FILE,
+            serde_json::json!({ "agent_id": "agent-shared-1", "filename": "MEMORY.md" }),
+        )
+        .await;
+        assert_eq!(read.content, "written from channel A");
+    }
+
+    #[tokio::test]
+    async fn live_fs_content_wins_over_a_stale_mirror_row() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config_a = tempfile::tempdir().unwrap();
+
+        let (engine_a, mut rx_a) = build_channel_state("agent-shared-2", "/work/channel-a", config_a.path(), shared_id_store.clone());
+
+        call_rpc::<Option<serde_json::Value>>(
+            &engine_a,
+            &mut rx_a,
+            COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-shared-2", "filename": "MEMORY.md", "content": "v1" }),
+        )
+        .await;
+        call_rpc::<Option<serde_json::Value>>(
+            &engine_a,
+            &mut rx_a,
+            COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-shared-2", "filename": "MEMORY.md", "content": "v2 — freshest" }),
+        )
+        .await;
+
+        // Directly stamp a stale mirror row behind the live FS's back — the
+        // read path must still prefer the live file, not this stale row.
+        shared_id_store
+            .agent_native_memory_upsert("agent-shared-2", "MEMORY.md", "stale mirror content", None, "/nowhere")
+            .unwrap();
+
+        let read: NativeMemoryReadFileResult = call_rpc(
+            &engine_a,
+            &mut rx_a,
+            COMMAND_NATIVE_MEMORY_READ_FILE,
+            serde_json::json!({ "agent_id": "agent-shared-2", "filename": "MEMORY.md" }),
+        )
+        .await;
+        assert_eq!(read.content, "v2 — freshest", "live FS must win over a stale mirror row");
+    }
+
+    #[tokio::test]
+    async fn read_file_errors_when_absent_from_both_live_fs_and_mirror() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config_a = tempfile::tempdir().unwrap();
+        let (engine, mut rx) = build_channel_state("agent-shared-3", "/work/channel-a", config_a.path(), shared_id_store);
+
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_READ_FILE,
+            serde_json::json!({ "agent_id": "agent-shared-3", "filename": "MEMORY.md" }),
+        )
+        .await;
+        assert!(err.contains("not found"), "unexpected error: {err}");
     }
 
     #[test]

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -486,7 +486,7 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                                 is_index: row.filename == "MEMORY.md",
                                 metadata_type: row.metadata_type,
                                 size_bytes: row.size_bytes as u64,
-                                modified_at: row.updated_at,
+                                modified_at: row.last_seen_mtime_ms,
                                 filename: row.filename,
                             });
                         }
@@ -959,6 +959,40 @@ mod tests {
         )
         .await;
         assert_eq!(read.content, "written from channel A");
+    }
+
+    #[tokio::test]
+    async fn list_reports_the_files_real_mtime_for_a_mirror_only_entry() {
+        // reagent P1 on PR #2459 (fifth pass): a mirror-only listing entry
+        // (no live copy on this channel) must report the FILE's real
+        // last-modified time (last_seen_mtime_ms), not the mirror row's own
+        // sync timestamp (updated_at) — those are two different clocks that
+        // just happen to be close together right after a write.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+
+        // A deliberately old, obviously-not-"just synced" mtime — upsert's
+        // own now_ms() for updated_at will always land far later than this.
+        const REAL_FILE_MTIME_MS: i64 = 12_345;
+        shared_id_store
+            .agent_native_memory_upsert("agent-mtime", "MEMORY.md", "content", None, "/elsewhere", 7, REAL_FILE_MTIME_MS)
+            .unwrap();
+
+        let (engine, mut rx) = build_channel_state("agent-mtime", "/work/channel-a", config.path(), shared_id_store);
+
+        let listed: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-mtime" }),
+        )
+        .await;
+        assert_eq!(listed.files.len(), 1);
+        assert_eq!(
+            listed.files[0].modified_at, REAL_FILE_MTIME_MS,
+            "mirror-only entries must report the file's real mtime, not the mirror's own sync timestamp"
+        );
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -335,13 +335,39 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     .unwrap_or_default();
                 let memory_dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
 
+                // Existing mirror metadata (no content) for this agent, keyed by
+                // filename — lets the loop below skip the expensive full-content
+                // read+upsert for a file whose size hasn't changed since it was
+                // last mirrored, instead of doing it unconditionally on every
+                // list call (reagent P1 on PR #2459: `list` fires on every Stash
+                // Memory tab open/refresh, so an unconditional full read + SQLite
+                // write per file would mean synchronous, potentially many-MB
+                // disk I/O on a call meant to be a lightweight metadata listing).
+                // A same-size-but-changed-content file is a known, accepted gap
+                // here — read_file always re-reads the live file fresh regardless,
+                // so this can only make the mirror (not the read path) briefly stale.
+                let mirrored_meta: std::collections::HashMap<String, i64> = id_store
+                    .agent_native_memory_list_meta(&agent.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|row| (row.filename, row.size_bytes))
+                    .collect();
+
                 let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
                 let mut live_filenames: std::collections::HashSet<String> = std::collections::HashSet::new();
-                // Treat both "dir doesn't exist" and the TOCTOU case where the dir
-                // is deleted between exists() and read_dir() as an empty result —
-                // the mirror merge below still runs, so a wiped live folder
-                // doesn't lose durability for files it mirrored previously.
-                let entries = std::fs::read_dir(&memory_dir).ok();
+                // Only a missing directory (never-yet-written, or wiped after this
+                // channel last had files) is treated as "no live files" — any
+                // other read_dir error (permissions, I/O) propagates, matching the
+                // pre-mirror behavior (reagent P2 on PR #2459: silently swallowing
+                // every error here would hide a real access problem behind what
+                // looks like an empty listing). The mirror merge below still runs
+                // regardless, so a wiped live folder doesn't lose durability for
+                // files it mirrored previously.
+                let entries = match std::fs::read_dir(&memory_dir) {
+                    Ok(e) => Some(e),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(e) => return Err(format!("agent:memory:list: read_dir: {e}")),
+                };
 
                 if let Some(entries) = entries {
                     for entry in entries {
@@ -372,30 +398,44 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                             .map(|d| d.as_millis() as i64)
                             .unwrap_or(0);
 
-                        // Read the full file (same cap as read_file) — both for
-                        // frontmatter parsing and to write through into the
-                        // durable mirror below.
-                        let content = {
+                        // Read up to 512 bytes for frontmatter type parsing — same
+                        // cheap preview the pre-mirror code used. Take + read_to_end
+                        // loops internally to fill the buffer.
+                        let preview_content = {
                             use std::io::Read;
                             std::fs::File::open(entry.path())
                                 .map(|f| {
-                                    let mut buf = Vec::new();
-                                    f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf).ok();
+                                    let mut buf = Vec::with_capacity(512);
+                                    f.take(512).read_to_end(&mut buf).ok();
                                     String::from_utf8_lossy(&buf).into_owned()
                                 })
                                 .unwrap_or_default()
                         };
-                        let metadata_type = parse_frontmatter_type(&content);
+                        let metadata_type = parse_frontmatter_type(&preview_content);
                         let is_index = name == "MEMORY.md";
 
-                        if let Err(e) = id_store.agent_native_memory_upsert(
-                            &agent.id,
-                            &name,
-                            &content,
-                            metadata_type.as_deref(),
-                            &entry.path().to_string_lossy(),
-                        ) {
-                            tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
+                        let unchanged_since_last_mirror = mirrored_meta.get(&name) == Some(&(size_bytes as i64));
+                        if !unchanged_since_last_mirror {
+                            let full_content = {
+                                use std::io::Read;
+                                std::fs::File::open(entry.path())
+                                    .map(|f| {
+                                        let mut buf = Vec::new();
+                                        f.take(MAX_MEMORY_FILE_BYTES).read_to_end(&mut buf).ok();
+                                        String::from_utf8_lossy(&buf).into_owned()
+                                    })
+                                    .unwrap_or_default()
+                            };
+                            let full_metadata_type = parse_frontmatter_type(&full_content);
+                            if let Err(e) = id_store.agent_native_memory_upsert(
+                                &agent.id,
+                                &name,
+                                &full_content,
+                                full_metadata_type.as_deref(),
+                                &entry.path().to_string_lossy(),
+                            ) {
+                                tracing::warn!(agent_id = %agent.id, filename = %name, error = %e, "agent:memory:list: mirror upsert failed (non-fatal)");
+                            }
                         }
                         live_filenames.insert(name.clone());
 
@@ -916,6 +956,80 @@ mod tests {
         )
         .await;
         assert!(err.contains("not found"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_propagates_a_real_read_dir_error_instead_of_treating_it_as_empty() {
+        // reagent P2 on PR #2459: `std::fs::read_dir(&memory_dir).ok()` used to
+        // swallow every error (permissions, I/O — not just the legitimate
+        // "directory doesn't exist yet" case), silently reporting an empty
+        // listing instead of surfacing a real access problem. Force a
+        // non-NotFound read_dir error by making the "memory" path a regular
+        // file instead of a directory.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+
+        // memory_dir_for_cwd sanitizes "/work/channel-a" to "-work-channel-a".
+        let projects_dir = config.path().join("projects").join("-work-channel-a");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        std::fs::write(projects_dir.join("memory"), b"not a directory").unwrap();
+
+        let (engine, mut rx) = build_channel_state("agent-baddir", "/work/channel-a", config.path(), shared_id_store);
+
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-baddir" }),
+        )
+        .await;
+        assert!(err.contains("read_dir"), "expected a propagated read_dir error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_does_not_re_upsert_an_unchanged_file_on_a_second_call() {
+        // reagent P1 on PR #2459: list() must not do a full-content read +
+        // SQLite write for every file on every call — only for a file whose
+        // size differs from what's already mirrored. Two back-to-back list()
+        // calls on an untouched file should produce exactly one mirror write.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        let (engine, mut rx) = build_channel_state("agent-unchanged", "/work/channel-a", config.path(), shared_id_store.clone());
+
+        let memory_dir = config.path().join("projects").join("-work-channel-a").join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+        std::fs::write(memory_dir.join("MEMORY.md"), "stable content").unwrap();
+
+        let _: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-unchanged" }),
+        )
+        .await;
+        let first_updated_at = shared_id_store
+            .agent_native_memory_list_meta("agent-unchanged")
+            .unwrap()[0]
+            .updated_at;
+
+        let _: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-unchanged" }),
+        )
+        .await;
+        let second_updated_at = shared_id_store
+            .agent_native_memory_list_meta("agent-unchanged")
+            .unwrap()[0]
+            .updated_at;
+
+        assert_eq!(
+            first_updated_at, second_updated_at,
+            "an unchanged file must not be re-upserted into the mirror on a second list() call"
+        );
     }
 
     #[test]

--- a/docs/reports/REPORT_ARMORY_STASH_MEMORY_SYNC_STATUS_2026_08_07.md
+++ b/docs/reports/REPORT_ARMORY_STASH_MEMORY_SYNC_STATUS_2026_08_07.md
@@ -1,0 +1,288 @@
+# Report: Armory/Stash as source of truth vs. native memory — status and history
+
+**Date:** 2026-08-07
+**Author:** Agent2
+**Status:** Research/status doc — no code changes. Written to ground a design
+decision, not to implement one.
+**Trigger:** User's proposed premise (verbatim, for traceability):
+
+> The source of truth for agents running in agentmux are the agent stash and
+> armory (which themselves should be in sync) .. the memories written to
+> local claude info needs to be in strict sync. if possible, can the memory
+> folder be changed, if not, they need to be strickely replicated. lets
+> collect the history in light of this premise, and write a status doc to
+> file.
+
+---
+
+## 0. Bottom line up front
+
+- **"Armory" and "Stash" are not two stores that need syncing with each
+  other — they are two views over the same four SQLite-backed tables**
+  (`db_accounts`, `db_bundles`, `db_skills`, `db_mcp_servers`). Armory = the
+  catalog; Stash = one agent's bindings into that catalog. For three of the
+  four entities, "Armory and Stash in sync" is already structurally
+  guaranteed by construction, not something to build. See §2.
+- **Native memory is not part of that system at all.** It's the Claude Code
+  CLI's own autonomous scratchpad — plain markdown files on disk, written by
+  Claude during a session, with zero code path connecting it to
+  `db_bundles`/Armory/Stash today. See §3.
+- **This is not an oversight — it was a deliberate original design
+  decision**, stated explicitly in the (now-archived) spec that first
+  separated these concepts: *"A Memory Bundle must never contain a fact
+  Claude discovered, and a native memory file must never contain a rule a
+  human intended to enforce."* Adopting the new premise means consciously
+  reversing that call, not just filling in a gap. See §4.
+- **On the folder-relocation question:** partially yes, but it doesn't
+  matter. `CLAUDE_CONFIG_DIR` (the root) is already redirectable and already
+  agent/identity-scoped by AgentMux. The sub-path under that root
+  (`projects/<cwd-hash>/memory/`) is fixed by Claude Code's own convention
+  and can't be pointed at an arbitrary location. But AgentMux already
+  computes that exact path itself and reads/writes it directly today (that's
+  how Stash's "Memory" tab works) — so no filesystem trick is needed either
+  way. "Strict sync," if adopted, is an application-level job (an explicit
+  reconciliation step), not a filesystem one. See §5.
+- **Before extending the sync guarantee to native memory, Armory/Stash have
+  three known bugs where they're already not honestly in sync with the agent's
+  actual runtime config** — worth fixing first, since the new premise's first
+  clause ("stash and armory should be in sync with each other") already has
+  open exceptions today. See §6.
+
+---
+
+## 1. History, chronologically
+
+The naming and architecture have gone through several deliberate phases,
+each captured in its own spec:
+
+| Date | Doc | What changed |
+|---|---|---|
+| 2026-06-19 | `docs/specs/archive/SPEC_MEMORY_IDENTITY_ARCH_2026_06_19.md` | **Origin document.** Named the "Memory" collision explicitly (config presets vs. native memory files) and the "Identity" collision (credential library vs. per-agent keychain). Proposed the rename that became "Bundles," and stated the layer-separation invariant quoted in §0/§4. |
+| 2026-06-19–24 | `SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md`, `SPEC_TRUST_CENTER_MODALS_IDENTITY_MEMORY_SEED_2026_06_19.md`, `SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md`, `SPEC_GLOBAL_IDENTITY_MEMORY_DRONE_2026_06_24.md` | Built out the "Global Brain" (is_global bundle injection) and the native-memory placeholder modal in parallel, as two visibly distinct features from day one. |
+| 2026-07-02 | `SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md`, `SPEC_RENAME_TRUST_CENTER_TO_ARMORY_2026_07_02.md` | Trust Center → Armory; Memory-bundle-presets → Bundles. Table renamed `db_memory_bundles` → `db_bundles`; Rust method names deliberately kept as `bundle_memory_*` (internal/external naming decoupled on purpose). |
+| 2026-07-10–16 | `SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS_2026_07_10.md`, `SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md`, `SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md`, **`SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md`**, `SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md`, `SPEC_ARMORY_ACCOUNTS_NO_MODALS_2026_07_16.md` | Phase 4/5: storage rename completed; Armory's separate "Identities" tab **removed** and per-agent data pushed entirely out of Armory (the precedent §2 below relies on); responsive layout; Accounts tab de-modalized. |
+| 2026-07-20 | **`ARCHITECTURE_ARMORY_2026_07_20.md`** | Canonical reference, written once the shape stabilized. States the governing principle: *"Armory holds shared, reusable resources... What deliberately does NOT live in Armory: per-agent-instance data."* Documents all 4 live Armory entities' binding mechanisms side by side (§2 below is built from this). |
+| 2026-07-23 | `docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md` | First to name the three-way "Memory" collision precisely (Armory Memories tab / AgentSetupModal Memories tab / Armory Bundles tab) and flag the Accounts dead-write-path bug (§6.1 below). |
+| 2026-07-27 | `docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md` | Renamed the per-agent modal "the agent armory" → **Stash** (this doc's naming source). Confirms Stash's MCP/Skills/Startup tabs are filtered views into the *same* shared tables Armory manages — genuinely "in sync" by construction — while Accounts and (native) Memory are the two tabs that are actually agent-scoped data, not shared-catalog views. |
+| 2026-07-27–28 | `REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md`, `REPORT_MCP_SKILLS_BIND_DOES_NOT_GATE_CONFIG_2026_07_28.md` | Found and documented the bind/unbind-doesn't-gate-runtime-config bug (§6.2 below) — Armory/Stash's UI state and the agent's actual materialized config can already disagree today. |
+| 2026-08-05 | `SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md` (unrelated subsystem, but the closest existing precedent for *this* premise) | For a different pair of stores (pane scrollback vs. the model's actual context), adopted the principle *"never let the two disagree silently"* rather than forcing them to always match (acknowledged as not fully achievable) — record every divergence explicitly instead. Cited here because it's the nearest existing precedent for how this codebase has previously handled "two sources of truth that can drift," and is worth weighing against a "strict sync" framing. |
+
+**No spec, report, or commit anywhere in this history proposes connecting
+Armory/Stash to native memory.** Every document either treats native memory
+as correctly out-of-scope for Armory (by the same "reusable resource vs.
+per-agent data" principle that removed the Identities tab), or documents the
+three-way naming collision as debt without proposing a functional merge.
+This is genuinely new territory, not a plan that already exists and needs
+executing.
+
+---
+
+## 2. Is Armory already "in sync with" Stash?
+
+Yes, structurally, for three of the four Armory entities — because they are
+implemented as one table plus a join table, not two tables:
+
+| Entity | Armory shows | Stash shows | Same underlying rows? |
+|---|---|---|---|
+| Bundles | All rows in `db_bundles`, full CRUD | The one bundle picked via `memory_id`, read-only select | Yes |
+| Skills | All rows in `db_skills` (catalog CRUD + global promote) | This agent's own + globally-visible skills, bind/unbind | Yes — `db_agent_skills_ref` join |
+| MCP Servers | All rows in `db_mcp_servers` (catalog CRUD + global promote) | This agent's own + globally-visible servers, bind/unbind | Yes — `db_agent_mcp_ref` join |
+| Accounts | All rows in `db_accounts` | This agent's provider→account assignment | **No** — see §6.1, this is the one broken case |
+
+So "Armory and Stash should be in sync" is already true by construction for
+Bundles/Skills/MCP — there's a single read/write path (`Store::bundle_memory_*`,
+`skill_*`, `mcp_server_*`), and both surfaces query the same rows. The actual
+open risk isn't Armory-vs-Stash drift; it's **catalog state vs. materialized
+runtime config** drift — covered in §6.
+
+---
+
+## 3. What native memory actually is, mechanically
+
+- **What writes it:** the Claude Code CLI itself, autonomously, during a
+  session — via its own memory tool. AgentMux does not decide when or what
+  gets written; it only exposes a viewer/editor (Stash's "Memory" tab,
+  `AgentNativeMemoryModal` → `native_memory_handlers.rs`'s
+  `memory:list/read_file/write_file` RPCs).
+- **Where it lives:** `$CLAUDE_CONFIG_DIR/projects/<sanitized-cwd>/memory/`.
+  The sanitization/hashing scheme (`memory_dir_for_cwd`,
+  `agentmux-srv/src/server/native_memory_handlers.rs:46-66`) deliberately
+  mirrors Claude Code's own `sessionStoragePortable.ts` convention — this is
+  Claude's path-naming rule, replicated, not a path AgentMux invented.
+  `CLAUDE_CONFIG_DIR` itself is already resolved per-agent/per-identity
+  (`claude_config_dir_for_identity`, same file, lines 175-193): unbound agents
+  get `~/.agentmux/shared/providers/claude`, identity-bound agents get
+  `~/.agentmux/shared/identities/<id>/claude`.
+- **What reads it:** Claude Code itself, at the start of every session
+  (`MEMORY.md` auto-loads; topic files load on demand). Nothing in AgentMux's
+  own config-generation path (`agent_config.rs`, `agent_open.rs`) reads or
+  writes this directory — it is completely outside the CLAUDE.md/`.mcp.json`
+  materialization pipeline that Bundles/Skills/MCP go through at every
+  launch.
+- **Confirmed: zero existing code path connects it to Armory/Bundles.**
+  `bundle_self_get_impl` only ever touches `db_bundles`; the native-memory RPC
+  handlers only ever touch the on-disk directory. The only code that
+  "knows about" both is a shared agent/identity-lookup helper used for
+  routing requests to the right agent — not for moving content between them.
+
+---
+
+## 4. The original design invariant this premise would revise
+
+The archived origin spec (`SPEC_MEMORY_IDENTITY_ARCH_2026_06_19.md` §5.1)
+states the intended relationship between these two things explicitly, in a
+table titled "Layer separation invariant":
+
+| What | Written by | Injected as |
+|---|---|---|
+| Rules / policies / tool configs | Human, via Bundles | `CLAUDE.md` at every launch |
+| Discovered facts / patterns | Claude, autonomously | `MEMORY.md` at session start |
+
+> **The invariant:** A Memory Bundle must never contain a fact Claude
+> discovered, and a native memory file must never contain a rule a human
+> intended to enforce. If that drift happens, a quarterly review should
+> promote facts to bundles or prune them.
+
+This is a considered, explicit design choice: the two are supposed to stay
+**categorically separate** (rules vs. facts), reconciled only by an
+occasional human review, not kept in continuous sync. The new premise —
+"the memories written to local claude info need to be in strict sync [with
+Armory/Stash]" — is a real proposal to change that, not a bug fix for
+something that was supposed to already work this way. Worth being explicit
+about which of two things is actually being asked for, since they imply very
+different designs:
+
+- **(a) Durability/portability sync** — ensure the *same* native memory
+  content is reliably reachable for a given agent no matter which
+  channel/instance/build it's opened from, and never silently lost, by
+  treating Armory/Stash's own agent-identity records as the anchor that
+  resolves *where* that agent's memory lives. This does not touch content —
+  Claude still owns what's written — it just makes location resolution and
+  persistence as reliable as everything else Armory/Stash already manage.
+- **(b) Content sync** — treat Bundle content as authoritative and push it
+  into (or reconcile it against) the native memory files, or vice versa. This
+  directly reverses the invariant above and would need a real answer to "what
+  happens when Claude writes a fact that contradicts a synced-in rule."
+
+§0/§5 below assume (a), since it's what the concrete ask ("can the folder be
+changed," "strictly replicated") technically describes — a location/durability
+problem — but this is the single most important thing to confirm before any
+implementation starts.
+
+---
+
+## 5. Answering "can the memory folder be changed?"
+
+**Root: yes, already done.** `CLAUDE_CONFIG_DIR` is fully AgentMux-controlled
+per agent/identity today (§3). This is the lever that already exists for
+"which `~/.claude`-equivalent tree does this agent use."
+
+**Sub-path: no, and it doesn't need to be.** The `projects/<cwd-hash>/memory/`
+structure under that root is a Claude Code CLI convention, not a setting —
+there's no flag or env var that decouples the memory folder from the
+cwd-encoding, and nothing in this codebase's own research
+(`docs/research/claude-code-presentation-layer.md`) or history proposes a
+symlink/relocate workaround. But this is moot: AgentMux's own
+`memory_dir_for_cwd`/`memory_dir_for_agent` already **replicates Claude's
+exact algorithm**, so AgentMux can always independently compute and directly
+read/write the exact folder Claude Code itself will use — that's the entire
+mechanism Stash's "Memory" tab already relies on today. There is no need to
+relocate anything to get direct access; direct access already exists.
+
+**What's actually missing, if (a) from §4 is the goal**, is not filesystem
+access — it's:
+1. A guarantee that `memory_dir_for_agent`'s two-tier lookup (persisted
+   `db_agents` instance row → global named-agent-registry fallback) always
+   resolves to the *same* folder for the *same* logical agent, across
+   whatever channel/instance/build it's opened in — i.e., extending the same
+   "agents are global, not per-channel" guarantee CLAUDE.md already states
+   for agent definitions/registry to native memory's location-resolution
+   path specifically, and confirming (with a test) that it holds.
+2. Optionally, a periodic or on-close capture of the on-disk memory content
+   into a durable, AgentMux-owned record (so a wiped/corrupted local
+   filesystem doesn't lose it) — this would be actual replication, not just
+   location-consistency, and is the literal reading of "strictly replicated."
+
+---
+
+## 6. Existing gaps in "Armory/Stash in sync with runtime reality" (fix candidates, independent of native memory)
+
+These predate this premise and are worth listing because the premise's first
+clause — Armory and Stash should be in sync with each other and, implicitly,
+with what an agent actually runs with — already has open exceptions:
+
+### 6.1 Accounts: Stash writes a column nothing reads (bug)
+
+`Stash → Accounts` (`AgentIdentityModalPanel`) writes provider assignments
+into the legacy `AgentDefinition.accounts` JSON blob. The actual spawn-time
+resolver (`identity/resolver.rs::resolve_bindings_for_instance`) reads
+**only** `db_agent_identity_links`, written exclusively by the agent-launch
+flow. Result: the modal looks fully functional (pick a provider, assign an
+account, see it save) but has zero effect on what the agent actually launches
+with. Documented in `ARCHITECTURE_ARMORY_2026_07_20.md` §1 and
+`REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md` §2.2. Not yet
+fixed.
+
+### 6.2 MCP/Skills: unbind doesn't gate runtime config (bug)
+
+`bound_to_agent` — the flag every Bind/Unbind toggle in Armory and Stash's
+MCP Servers/Skills tabs is built on — has no effect on `agent_open.rs`'s
+config generation, which injects **every** global MCP server/skill into
+**every** agent unconditionally, regardless of bind state. Unbinding flips the
+UI badge; the item keeps being injected into the agent's next generated
+config regardless. Documented in
+`docs/reports/REPORT_MCP_SKILLS_BIND_DOES_NOT_GATE_CONFIG_2026_07_28.md`,
+mitigated today with UI copy only ("this doesn't do what it looks like yet"),
+not fixed — a real fix needs a backfill migration first (§ that report's own
+recommended follow-up, not repeated here).
+
+### 6.3 Bundles: non-global binding is pull-only, not materialized
+
+`is_global` bundles auto-inject into every agent's CLAUDE.md at launch. A
+non-global bundle bound via `db_agent_instances.memory_id`, by contrast, is
+only ever *fetchable on demand* (`bundle.self.get`) — nothing reads
+`memory_id` at config-generation time to actually inject that bundle's
+instructions into CLAUDE.md the way every other bound entity gets
+materialized. Documented in `ARCHITECTURE_ARMORY_2026_07_20.md` §2. Not a
+bug exactly (the architecture doc calls it "the weakest binding, but not
+inert" — an agent/caller *can* pull it explicitly), but it's the one entity
+whose "bound" state and "materialized" state most visibly diverge.
+
+### 6.4 Cosmetic, lowest priority
+
+`ArmorySection` id/label mismatch (`id:"brain"` renders as "Memories,"
+`id:"memories"` renders as "Bundles") — residue of the Phase 5 label-only
+rename, purely a code-readability hazard, no user-facing or behavioral
+effect. Flagged in two reports, not yet fixed, explicitly low-risk/low-priority
+in both.
+
+---
+
+## 7. Open questions before implementing anything
+
+1. **Confirm which reading of "strict sync" (§4) is intended** — durability/
+   location-consistency, or actual content reconciliation between Bundles and
+   native memory. These are different-sized projects with different risk
+   profiles, and the second one reverses a stated design invariant rather
+   than closing a gap.
+2. **If content sync is actually wanted:** what should happen when Claude's
+   autonomously-written memory contradicts a human-authored bundle rule?
+   The original invariant's answer was "neither automatically wins — a human
+   reconciles it during periodic review." Any automated sync needs an
+   explicit new answer to this, or it needs to pick one side as always
+   authoritative.
+3. **Should §6's three pre-existing gaps be fixed first?** They're smaller,
+   already-scoped, already-diagnosed (each report above has a concrete
+   recommended fix), and closing them would make "Armory and Stash are in
+   sync with runtime reality" true in more cases than it is today — arguably
+   a prerequisite for trusting them as "the source of truth" the new premise
+   wants to lean on.
+4. **If durability/location-consistency (§5) is the goal:** is there a known
+   failure case today — e.g. a per-build-channel instance genuinely losing or
+   failing to find an agent's native memory folder — or is this precautionary?
+   Worth a quick reproduction check (open the same agent from two different
+   channels/instances, compare `memory_dir_for_agent`'s resolved path) before
+   scoping a fix, since §5 already shows the underlying mechanism *should*
+   resolve consistently by construction — confirming whether it actually does
+   in practice would sharpen whether this is a real bug or a defense-in-depth
+   ask.

--- a/docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md
+++ b/docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md
@@ -1,0 +1,206 @@
+# SPEC: Durable, location-consistent, transparent native memory
+
+**Date:** 2026-08-07
+**Status:** Proposed
+**Depends on:** `docs/reports/REPORT_ARMORY_STASH_MEMORY_SYNC_STATUS_2026_08_07.md`
+(history + current-state analysis; read that first for full context — this
+doc only restates what's load-bearing for the design below).
+
+---
+
+## 0. Decision (resolves that report's §7 open questions)
+
+> "durability, location-consistency. we dont care how, we want it
+> transparent, the user doesnt know about claude's system paths, he sees all
+> the memory claude writes into his stash/armory"
+
+Resolved:
+- **Not content-sync.** Claude still owns *what* gets written; nothing here
+  reconciles native memory against Bundle content, and the original
+  "facts vs. rules" invariant (prior report §4) stands unchanged.
+- **Durability + location-consistency, mechanism unspecified** — my call to
+  make, outcome is what's fixed: no data loss, no silent "this agent has no
+  memory" when it actually does, and zero user-visible awareness of
+  `CLAUDE_CONFIG_DIR`/cwd-hash mechanics.
+- **Surfaces in Stash, not Armory.** Stash's existing "Memory" tab
+  (`AgentNativeMemoryModal`) is per-agent and already the right place per the
+  architecture's own principle (per-agent data lives outside Armory).
+  Duplicating it into Armory would deepen the three-way "Memory" naming
+  collision the prior report documents. Read "stash/armory" in the ask as
+  "the app's management UI," not a literal requirement for two surfaces —
+  **flagging this explicitly since it's the one place I'm resolving an
+  ambiguity rather than just picking a mechanism.**
+
+---
+
+## 1. Root cause, precisely
+
+`agentmux-srv/src/server/native_memory_handlers.rs`'s three RPC handlers
+(`agent:memory:list/read_file/write_file` — Stash's Memory tab) already key
+off `agent.id`, the stable, global `AgentDefinition` id
+(`wstore.agent_def_get(&cmd.agent_id)`, lines 306-309/410-413/470-473) — this
+part is already channel-independent, no fix needed.
+
+What's **not** stable is the *live filesystem path* they compute fresh on
+every call: `memory_dir_for_cwd(config_dir, agent.working_directory)`. Both
+inputs are legitimately channel-relative by design:
+
+- `agent.working_directory` — for a live (not-yet-persisted) agent, resolved
+  via `memory_dir_from_registry` as `source_agents_base.join(working_dir)` —
+  **`source_agents_base` is explicitly "the channel/dev instance it lives
+  in"** (the function's own doc comment, line 145). Each channel has its own
+  agents-base directory by design (`CLAUDE.md`'s per-build-channel isolation
+  section) — a fresh local build's filesystem *cannot* have another build's
+  directory tree, structurally.
+- `config_dir` (`CLAUDE_CONFIG_DIR`) — resolved per identity
+  (`claude_config_dir_for_identity`), stable *for a given identity binding*,
+  but an identity's own root (`~/.agentmux/shared/identities/<id>/claude`)
+  still sits under a shared-dir tree that can itself be relocated between
+  channels (`AGENTMUX_SHARED_DIR`).
+
+So: **the same logical agent (same `AgentDefinition.id`), opened from two
+different channels/instances, computes two different on-disk memory paths by
+construction.** This isn't a bug in the resolution logic — it's a direct,
+correct consequence of per-channel filesystem isolation applied to a path
+formula that depends on a channel-relative input. No amount of fixing the
+*formula* changes this; the fix has to stop depending on the live path being
+the only copy of the truth.
+
+## 2. Design
+
+### 2.1 A durable mirror, keyed by the one thing that's already stable
+
+Add `db_agent_native_memory` (global-scoped store, alongside `db_bundles`/
+`db_accounts`/etc.), keyed by `(agent_id, filename)` where `agent_id` is the
+same `AgentDefinition.id` the RPC handlers already resolve to:
+
+```
+db_agent_native_memory(
+    agent_id      TEXT NOT NULL,   -- AgentDefinition.id (FK, ON DELETE CASCADE)
+    filename      TEXT NOT NULL,   -- e.g. "MEMORY.md", "user_role.md"
+    content       TEXT NOT NULL,
+    metadata_type TEXT,            -- cached frontmatter `metadata.type`, avoids re-parsing on every list
+    size_bytes    INTEGER NOT NULL,
+    updated_at    INTEGER NOT NULL,-- ms epoch, last time THIS row was written
+    last_seen_path TEXT,           -- debugging aid: the live FS path this content was last read from
+    PRIMARY KEY (agent_id, filename)
+)
+```
+
+Migration `m0020_agent_native_memory_mirror.rs`, `MigrationScope::Global`
+(matches `db_bundles`/`db_accounts` — these are cross-channel, not per-instance
+tables), following `m0019`'s pattern (`Migration` trait, `id()`/`scope()`/
+`description()`/`up()`).
+
+### 2.2 Read path: merge live FS + durable mirror, write through on every read
+
+Both `agent:memory:list` and `agent:memory:read_file` currently only touch
+the live FS. Change them to:
+
+1. Read whatever's live on disk (unchanged — same `read_dir`/`File::open`
+   calls, same symlink/size-cap/TOCTOU handling already in place).
+2. **Write through**: upsert every live file's current content into
+   `db_agent_native_memory` keyed by `(agent.id, filename)` — a plain
+   `INSERT ... ON CONFLICT (agent_id, filename) DO UPDATE`, cheap, no new
+   round trip beyond one extra local SQLite write already on the same
+   request.
+3. **Merge for the response**: union the live-FS filename set with the
+   mirror's filename set for this `agent.id`. For a name present in both,
+   serve the live-FS version (it's the freshest — Claude may have written
+   moments ago, before step 2 even ran). For a name present **only** in the
+   mirror (i.e. this channel's live FS doesn't have it — a different
+   channel's write, or the live folder was wiped), serve the mirrored
+   content transparently, with no distinguishing UI treatment. The user
+   never sees "not found on this channel" — they see the file.
+
+This means: the *very first* time any channel/instance opens Stash → Memory
+for a given agent, this mirror starts filling in. From that point forward,
+every subsequent open (even from a different channel) sees the union.
+`write_file` (the Stash UI's own Save button) does the same upsert on its
+write path — trivial, since it's already writing content it has in hand.
+
+### 2.3 What this does and doesn't cover
+
+- **Covers:** durability across channel/instance switches for any file that
+  has been *viewed* (list or read) at least once from any channel — which
+  in practice means every file, since listing already happens every time the
+  Memory tab opens.
+- **Does not cover:** a fact Claude writes autonomously, in a session that
+  is *never reopened* in the Stash Memory tab before that channel's
+  filesystem is wiped/replaced. This is a real, accepted gap under "we don't
+  care how" — closing it fully would need either a live filesystem watcher
+  on the memory directory (meaningfully more complexity: a watcher process,
+  debouncing, handling watch-target deletion) or hooking into the
+  persistent-controller's own I/O (deeper coupling to the provider process
+  lifecycle). Not proposed here; flagged as a known residual risk, and an
+  easy follow-up if it turns out to matter in practice (§4).
+
+### 2.4 Why not just relocate the folder instead
+
+Covered in the prior report's §5 in full; restated briefly because it's the
+literal first half of the ask. `CLAUDE_CONFIG_DIR` (the root) is already
+redirectable and already identity-scoped. The `projects/<cwd-hash>/memory/`
+structure under it is a fixed Claude Code CLI convention — no flag or env
+var decouples memory from the cwd-encoding, and there's no known symlink/
+relocate trick in this codebase's own prior research. It doesn't matter:
+AgentMux already computes and can always directly reach the exact path
+Claude Code itself will use (that's the entire mechanism §1's handlers rely
+on today) — there was never a need to relocate anything to get read/write
+access. The actual gap was durability across channels, which §2.1–2.2 solves
+independently of where the live folder happens to sit.
+
+## 3. Rollout
+
+- **Backfill:** none needed. The mirror starts empty and fills in
+  organically the first time each agent's Memory tab is opened post-deploy —
+  no migration needs to walk existing live memory folders (there's no
+  reliable way to enumerate "every agent that ever existed across every
+  channel" from a fresh install anyway; organic backfill-on-read is the only
+  option that's actually complete over time).
+- **Agent deletion:** `ON DELETE CASCADE` on `agent_id` — mirror rows die
+  with the agent definition, matching every other per-agent table.
+- **Identity rebinding** (an agent's bound account changes, moving its
+  `CLAUDE_CONFIG_DIR` root): the live FS path changes, but the mirror is
+  keyed by `agent_id` alone, not by path — old content stays visible
+  (merged in) even though the live folder it originally came from is now
+  unreachable under the new identity. This is correct per the "user sees
+  everything Claude has ever written for this agent" goal, though worth
+  flagging as a case where the merge does real work, not just an unused
+  safety net.
+- **No behavior change for the App-API path** (`memory_dir_for_agent`, used
+  by `bundle.self.get`-adjacent callers under a *slug*, not the RPC handlers'
+  UUID). Out of scope for this pass — it's a programmatic surface, not the
+  Stash UI the ask is about. Worth a follow-up if a caller there turns out
+  to need the same guarantee.
+
+## 4. Non-goals / explicit follow-ups if this turns out to be insufficient
+
+- Real-time capture of Claude's autonomous writes between tab opens (§2.3).
+- Any UI signal distinguishing "live" vs. "mirrored-only" content — the goal
+  is the user never has to think about the difference, so deliberately not
+  building an affordance that would surface it.
+- Extending the same merge to `memory_dir_for_agent`'s App-API consumers.
+- Anything about Bundle/native-memory content reconciliation (explicitly
+  out of scope per §0).
+
+## 5. Test plan
+
+- Unit: `db_agent_native_memory` upsert-on-read behaves correctly for (a) a
+  brand-new file, (b) a re-read of an unchanged file (no spurious
+  `updated_at` churn beyond what content-hash comparison would avoid — or
+  accept the churn if simplicity wins; call this out as an implementation
+  judgment call, not load-bearing), (c) a file whose live-FS copy is deleted
+  after being mirrored once (list still returns it, read still returns its
+  last-known content).
+- Unit: merge logic — live-FS-only file, mirror-only file, and a file present
+  in both with different content (live wins) all produce the expected
+  `list`/`read_file` results.
+- Integration: simulate two "channels" against the same `agent.id` by
+  pointing `memory_dir_for_cwd`'s inputs at two different temp directories in
+  the same test — write via channel A, list via channel B, confirm channel
+  B's list includes channel A's file with correct content, with no
+  channel-awareness in the response shape.
+- Manual: create an agent, write a memory file via Stash, then simulate a
+  channel switch (e.g. open the same agent from a different local `task
+  package` build) and confirm the file is still visible in that build's
+  Stash Memory tab without any error state or "not found."

--- a/docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md
+++ b/docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md
@@ -157,8 +157,15 @@ independently of where the live folder happens to sit.
   reliable way to enumerate "every agent that ever existed across every
   channel" from a fresh install anyway; organic backfill-on-read is the only
   option that's actually complete over time).
-- **Agent deletion:** `ON DELETE CASCADE` on `agent_id` — mirror rows die
-  with the agent definition, matching every other per-agent table.
+- **Agent deletion:** no FK, no cascade. `db_agent_definitions` lives in a
+  separate SQLite file from this table (duplicated into both objects.db and
+  the shared store.db — §2.1), and SQLite can't enforce a foreign key across
+  database files. Orphaned rows after an agent's deleted are inert rather
+  than actively cleaned up: every RPC handler that would read this table
+  first resolves and 404s on `agent_def_get`, so a dangling mirror row is
+  never reached, let alone surfaced. (Updated from the original "ON DELETE
+  CASCADE" draft above once the cross-database-file constraint surfaced
+  during implementation — reagent P2 on PR #2459.)
 - **Identity rebinding** (an agent's bound account changes, moving its
   `CLAUDE_CONFIG_DIR` root): the live FS path changes, but the mirror is
   keyed by `agent_id` alone, not by path — old content stays visible


### PR DESCRIPTION
## Summary
- Implements SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md: makes native memory (Claude Code's own autonomous memory files, surfaced in Stash's Memory tab) durable and location-consistent across AgentMux channels/instances.
- Root cause: `agent:memory:list/read_file/write_file` only ever touched the live filesystem path, which is channel-relative by design (`agent.working_directory` resolves against the channel's own agents base) — so the same agent opened from two channels/builds resolves two different memory dirs, and appears to have no memory on whichever channel it wasn't last used from.
- Adds `db_agent_native_memory` (keyed by the stable `AgentDefinition.id`, not any live path) as a durable mirror — `SHARED_STORE_SCHEMA_VERSION` v6 / `OBJECT_SCHEMA_VERSION` v14, duplicated into both schemas the same way `db_agent_credentials` already is, for `id_store`'s pre-`0011_shared_store_backfill` fallback.
- All three RPC handlers write through into the mirror on every file they touch; `list`/`read_file` merge the live-FS view with the mirror (live wins when both have the file) so content written from one channel stays visible from another with no distinguishing UI treatment — the user never sees "not found on this channel."
- Also includes the status report + spec docs this was scoped from (written earlier in the same initiative, previously uncommitted).

## Test plan
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test --workspace -- --test-threads=1` — all green (2047+ passed)
- [x] Store-level unit tests for upsert/read/list-meta (`agent_native_memory.rs`)
- [x] End-to-end RPC integration tests simulating two channels sharing one `id_store` but different live-FS paths for the same `agent_id`: a file written from channel A is visible (list + read) from channel B; live FS wins over a stale mirror row; read_file errors cleanly when absent from both

<!-- agentmux:agent_id=agent2 -->