### PR TITLE
fix(agent-pane): runtime dropup stays open on select for real, add close button

### DIFF
--- a/.changesets/1786161250-fix-agent-pane-runtime-dropup-stays-open-on-select-for-real--bg6y.md
+++ b/.changesets/1786161250-fix-agent-pane-runtime-dropup-stays-open-on-select-for-real--bg6y.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): runtime dropup stays open on select for real, add close button

--- a/docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md
+++ b/docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md
@@ -1,0 +1,320 @@
+# SPEC: Explicit close button on the Runtime (Mode/Model/Effort) dropup
+
+**Date:** 2026-08-07
+**Status:** Draft — ready for review
+**Author:** AgentX (agent)
+**Trigger:** User request — *"when changing the model panel, we dont want it
+to auto close after selection, because sometimes the user wants to change
+multiple entries. instead add a close button and also clicking away will
+close it too."*
+**Amends:** `docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md` §5, §9.2,
+§11 — read that spec first. This one only adds what's missing; it does not
+re-litigate anything already decided there.
+
+---
+
+## 0. Scope check against current `main` — two of three asks are already shipped
+
+Before scoping new work, I verified the panel's current behavior against
+`frontend/app/view/agent/components/AgentRuntimeDropup.tsx` on `main`
+directly (not just the base spec's intent):
+
+| User ask | Current state | Evidence |
+|---|---|---|
+| Don't auto-close after selecting a value | **Already true.** `applySelection` (`AgentRuntimeDropup.tsx:166-173`) calls `updateRuntime(...)` and never calls `setOpen(false)`. A code comment directly above it (`:163-165`) states this is deliberate, citing the base spec's §9.2. | `AgentRuntimeDropup.tsx:163-173` |
+| Clicking away closes it | **Already true.** `handleClickOutside` (`:213-217`) calls `setOpen(false)` on any `mousedown` whose target is outside both the trigger and the panel, wired for the panel's open lifetime (`:231-241`). | `AgentRuntimeDropup.tsx:213-217, 231-241` |
+| An explicit close button | **Missing.** No button with a close affordance exists anywhere in the panel's JSX (`:293-339`). The only ways to close today are `Esc`, outside-click, re-clicking the trigger, or focus leaving the panel by any means (`handleFocusChange`, `:224-226` — see §4 below, this is a fourth, *implicit* close path worth knowing about even though it's not part of this ask). | `AgentRuntimeDropup.tsx:293-339` |
+
+**This spec's actual scope is narrow: add a close button.** If you're seeing
+close-on-select in a running build, that build predates the base spec
+shipping (or predates commit `9f86d917`'s three-pill precursor) — worth
+confirming the build version before assuming there's a regression to chase
+down separately from this spec.
+
+---
+
+## 1. Why a close button, given outside-click and Esc already work
+
+Outside-click and `Esc` are real, working close paths — but neither is
+*discoverable* the way a visible affordance is, and this panel is unusual
+among the app's popups in an important way: **it deliberately stays open
+across multiple interactions** (§9.2 of the base spec), unlike every
+single-value picker in the app (`FlyoutMenu`, `SlashCommandPicker`, native
+context menus) that closes itself the instant you're done. A user who
+hasn't internalized "this one's different, it waits for you" may not think
+to reach for `Esc` or click elsewhere — an explicit, visible close button
+removes that ambiguity and matches the one first-class precedent already in
+the codebase for "stays open, dismiss when you're done" panels: `Modal`'s
+`showCloseButton` (`frontend/app/element/modal.tsx:416-426`,
+`.modal-panel-close-btn` in `frontend/app/element/modal.scss:164-190`).
+
+No non-modal popover in this codebase has a close button today
+(`HostPopover`, `TokenBreakdownPopover`, generic `PopoverMenu` all rely on
+outside-click/Esc alone) — this would be the first. That's fine: this panel
+is also the first non-modal popover in the app designed to stay open across
+multiple selections, so it's the first one that actually needs one.
+
+---
+
+## 2. Design
+
+### 2.1 Placement and visual treatment
+
+A small `✕` icon button, absolutely positioned in the panel's top-right
+corner — adapted from `Modal`'s pattern but scaled down to match this
+panel's much more compact chrome (10px base font, `min-width: 180px`,
+2px-scale row padding — see `_composer-strip.scss:151-159` — vs. Modal's
+28px button meant for a full-size dialog).
+
+```
+┌─ mode ────────────────────────╮✕┐
+│  ✓ Bypass (no prompts)         │
+│    Auto (AI classifier)        │
+│    ...                         │
+├─ model ────────────────────────┤
+│    ...                         │
+└─────────────────────────────────┘
+```
+
+Proposed CSS (new rule, `_composer-strip.scss`, near the existing
+`.agent-runtime-dropup-*` block):
+
+```scss
+.agent-runtime-dropup-close-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm, 4px);
+    color: var(--secondary-text-color);
+    font-size: 9px;
+    line-height: 1;
+    cursor: default;
+    transition: all var(--motion-fast);
+
+    &:hover {
+        color: var(--main-text-color);
+        background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+        border-color: var(--border-color);
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--shadow-focus-ring);
+    }
+}
+```
+
+Same interaction states as `Modal`'s button (hover tint, focus ring), same
+`✕` glyph, just re-scaled — no new visual language introduced.
+
+**Overlap check (implementation must verify visually):** the panel's
+`min-width` is only 180px and section headers/rows are left-aligned but can
+run close to the right edge (e.g. a long model label, or the
+`.agent-runtime-dropup-description` text — `_composer-strip.scss:177-185`).
+A 16×16px button inset 2px from the top-right corner is small, but confirm
+in `task dev` that it doesn't visually collide with the top section header's
+text or a `current`-row's check icon. If it does, the fix is a few px of
+`padding-right` on `.menu.agent-runtime-dropup-panel` or on
+`.agent-runtime-dropup-section`, not a redesign.
+
+### 2.2 DOM structure — and why it can't just be prepended like `Modal`'s button
+
+`Modal`'s close button is simply the first child of `.modal-panel`
+(`modal.tsx:416-426`, before `{props.children}`) because `.modal-panel` has
+no ARIA role of its own. **This panel is different**: the outer element
+currently carries `role="listbox"` directly
+(`AgentRuntimeDropup.tsx:297-301`), and every row is `role="option"`
+(`:316`). Per the ARIA authoring practices for the listbox pattern, a
+`role="listbox"` element's children should be its options (and an optional
+label) — an interactive `<button>` dropped in as a sibling of the option
+rows, inside the same `role="listbox"` container, is a structurally invalid
+listbox and would confuse screen-reader listbox navigation (arrow-key
+option traversal, `aria-activedescendant`-style expectations, etc.).
+
+**Fix: split the single `role="listbox"` div into two nested elements.**
+The outer element keeps the `ref`/positioning/`data-pane-overlay` (unchanged
+by this spec) but drops `role="listbox"`; a new inner wrapper around just
+the `<For>` rows carries `role="listbox"` and `aria-label="Runtime
+settings"` instead. The close button becomes a sibling of that inner
+wrapper — both children of the same outer positioned div — so
+`floatingEl.contains(closeButton)` still holds true for `handleClickOutside`
+and `handleFocusChange`'s containment checks (§2.3), and `computeMenuPosition`
+/`autoUpdate` still measure the correct outer boundary.
+
+```tsx
+// Before (AgentRuntimeDropup.tsx:293-339, abbreviated):
+<Show when={open()}>
+    <Portal>
+        <div ref={registerFloating} class="menu agent-runtime-dropup-panel"
+             style={floatingStyle()} data-pane-overlay
+             role="listbox" aria-label="Runtime settings">
+            <For each={build().rows}>{...}</For>
+        </div>
+    </Portal>
+</Show>
+
+// After:
+<Show when={open()}>
+    <Portal>
+        <div ref={registerFloating} class="menu agent-runtime-dropup-panel"
+             style={floatingStyle()} data-pane-overlay>
+            <button type="button" class="agent-runtime-dropup-close-btn"
+                    aria-label="Close" onClick={() => setOpen(false)}>
+                {"✕"}
+            </button>
+            <div role="listbox" aria-label="Runtime settings">
+                <For each={build().rows}>{...}</For>
+            </div>
+        </div>
+    </Portal>
+</Show>
+```
+
+The inner `role="listbox"` wrapper needs no new class/styling of its own —
+it's a plain `<div>`; all existing `.agent-runtime-dropup-*` rules keep
+targeting the same descendants they already do, since none of them depend
+on the removed div being the *direct* listbox-role holder, only on being
+inside `.agent-runtime-dropup-panel`.
+
+### 2.3 Behavior — purely additive, no existing close path changes
+
+- `onClick={() => setOpen(false)}` — same direct call every other close path
+  already uses (`handleKeyDown`'s `Escape` branch, `handleClickOutside`,
+  `handleFocusChange`, `toggleOpen`'s re-click branch — all just call
+  `setOpen(false)`). No new state, no new close-reason tracking needed.
+- **No conflict with `handleClickOutside`:** the button is a DOM descendant
+  of `floatingEl` (the div `registerFloating` refs), so a `mousedown` on it
+  is caught by the `floatingEl?.contains(target)` check (`:215`) and
+  `handleClickOutside` is a no-op for that event — the button's own
+  `onClick` is what closes the panel, not the outside-click listener firing
+  redundantly.
+- **No conflict with `handleFocusChange`:** clicking the button does move
+  DOM focus onto it, which is still "inside" per `focusWithinDropup()`
+  (`:183-187`, checks `floatingEl?.contains(active)`) — so this handler
+  doesn't fire mid-click. Once `setOpen(false)` runs and the `<Show>` tears
+  the panel down, the `createEffect` at `:231-241` cleans up all three
+  document listeners via its `onCleanup`, same teardown path every other
+  close reason already goes through.
+- **Keyboard reachability:** the button is a real `<button>`, so it's in the
+  native Tab order — placing it as the *first* child (matching `Modal`'s
+  convention exactly, §2.2) means it's the first Tab stop after the trigger,
+  before any option row. It is **not** part of `build().options` — the
+  arrow-key/letter-jump navigation model (`move`, `handleKeyDown`'s
+  letter-jump branch) is unchanged and continues to only walk option rows.
+  `Esc` remains the fast keyboard-only close path; the button is a
+  mouse/discoverability affordance, same division of labor `Modal` already
+  has (`Esc` closes a modal too, independent of its close button).
+
+### 2.4 Alternative considered and rejected: a header row instead of a floating corner button
+
+A full-width header row (`Runtime` title text + right-aligned `✕`) was
+considered, matching how some apps title every popover. **Rejected:** the
+base spec was explicit that "Runtime" as a word appears only in the trigger's
+`aria-label` and in docs — never as visible panel chrome (§2 of the base
+spec) — adding a visible title now would be scope creep beyond what was
+asked (a close button, not a redesign), and would add a full extra row of
+vertical space to a panel whose entire design language up to now is
+deliberately tight (2px row padding, 9-10px fonts). The corner-button
+approach adds a close affordance with zero extra vertical space and zero new
+visible text.
+
+---
+
+## 3. Edge cases
+
+| Case | Behavior |
+|---|---|
+| Panel open, user clicks the close button | Closes immediately via the same `setOpen(false)` every other path uses — no different from `Esc`. |
+| Panel open, user selects a value, then clicks close | Selection already applied via `applySelection` (unchanged §9.2 behavior) before the close click is a separate, later event — no ordering issue since these are two independent user actions, not one combined gesture. |
+| Keyboard-only user | `Esc` remains the primary close path (unchanged); the button is additionally Tab-reachable and `Enter`/`Space`-activatable as a native `<button>`, so it's not mouse-only, just not part of the arrow-key option list (§2.3). |
+| Screen reader | Panel's listbox semantics stay valid post-restructure (§2.2) — the button sits outside the `role="listbox"` subtree, announced as an ordinary button ("Close, button"), not as a spurious listbox option. |
+| Narrow viewport | No interaction with the existing `_composer-strip.scss` container-query breakpoints (§3.4 of the base spec) — this only changes the panel's own internal layout, not the trigger/composer-strip sizing rules. |
+
+---
+
+## 4. Related but out of scope
+
+`handleFocusChange` (`AgentRuntimeDropup.tsx:224-226`) closes the panel
+whenever DOM focus moves outside it **by any means**, not just a click —
+e.g. a programmatic `.focus()` call elsewhere in the app (the file's own
+comment cites `AgentFooter`'s `acceptCompletion()` as a real example,
+`:176-182`). This is a fourth, already-existing close trigger, broader than
+literal "clicking away." It isn't part of what was asked (which named
+clicking away and an explicit button specifically) and changing it isn't
+implied by this request — flagged here only so whoever implements this
+knows it exists and isn't surprised by it during testing (e.g. tabbing out
+of the panel closes it even without a click, independent of this spec's
+changes).
+
+---
+
+## 5. Testing
+
+**No test file exists for this component today**
+(`AgentRuntimeDropup.test.tsx` does not exist; confirmed via
+`grep -rl "AgentRuntimeDropup" frontend --include="*.test.*"` returning no
+hits). This spec's implementation should add one, not extend one. Minimum
+coverage, following this codebase's `@solidjs/testing-library` conventions
+(e.g. `DocumentRow.test.tsx`, `AgentDocumentVirtualList.resize.test.tsx`):
+
+1. Selecting an option does **not** close the panel (regression guard for
+   the already-shipped §9.2 behavior — currently has zero coverage of its
+   own, worth locking in while touching this file).
+2. Clicking the new close button closes the panel (`open` signal reflected
+   via the trigger's `aria-expanded` or the panel's presence in the DOM).
+3. Click-outside still closes the panel (existing behavior, currently
+   untested — worth covering in the same pass).
+4. The close button is not present with `role="option"`/inside the
+   `role="listbox"` subtree (structural assertion for §2.2's restructure).
+5. Clicking the close button does not double-fire — i.e. `setOpen` is
+   called in a way that's idempotent/harmless even if `handleClickOutside`
+   also runs for the same event (defensive test, since §2.3 argues this
+   can't happen, but the interaction is subtle enough to be worth pinning
+   down explicitly rather than trusting the reasoning alone).
+
+---
+
+## 6. Acceptance criteria
+
+1. The panel has a visible `✕` close button in its top-right corner,
+   present whenever the panel is open.
+2. Clicking it closes the panel via the same `setOpen(false)` path every
+   other close reason already uses — no new close-state machinery.
+3. Selecting a Mode/Model/Effort value continues to leave the panel open
+   (already true on `main` — this spec must not regress it).
+4. Click-outside and `Esc` continue to close the panel (already true on
+   `main` — this spec must not regress either).
+5. The panel's listbox semantics remain valid post-change: `role="listbox"`
+   wraps only the option rows, not the close button.
+6. New test coverage exists for this component (§5) — this file currently
+   has none.
+
+---
+
+## 7. Files this change touches
+
+```
+# Modified
+frontend/app/view/agent/components/AgentRuntimeDropup.tsx    add close button + role="listbox" restructure (§2.2, §2.3)
+frontend/app/view/agent/styles/_composer-strip.scss          add .agent-runtime-dropup-close-btn (§2.1)
+
+# New
+frontend/app/view/agent/components/AgentRuntimeDropup.test.tsx   new — no prior coverage (§5)
+
+# Unchanged (reused, not modified)
+docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md            §9.2's "stays open" decision is amended-by, not replaced-by, this spec
+frontend/app/view/agent/runtime-apply.ts                      applyRuntimeChange — no changes needed
+frontend/app/element/modal.tsx / modal.scss                   close-button pattern referenced, not imported — this panel isn't a Modal
+```
+
+---
+
+*End of spec. Ready for review + go/no-go decision.*

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.test.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.test.tsx
@@ -1,0 +1,139 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * No prior coverage existed for this component (see
+ * docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md §5).
+ * Covers both fixes from that spec plus the pre-existing §9.2 "stays open on
+ * select" contract, which had never been pinned down by a test either:
+ *
+ *   1. Selecting a value does NOT close the panel (regression guard for the
+ *      already-shipped SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md §9.2 decision,
+ *      and for the focus-blur bug that was silently defeating it in
+ *      practice — see AgentRuntimeDropup.tsx's onMouseDown comment on the
+ *      option row).
+ *   2. The new close button closes the panel.
+ *   3. Click-outside still closes the panel.
+ *   4. The close button sits outside the role="listbox" subtree.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentRuntimeDropup } from "./AgentRuntimeDropup";
+
+vi.mock("../runtime-apply", () => ({
+    applyRuntimeChange: vi.fn().mockResolvedValue(undefined),
+}));
+
+afterEach(() => cleanup());
+
+function renderDropup() {
+    return render(() => (
+        <AgentRuntimeDropup blockId="block-1" blockAtom={() => undefined} providerId="claude" />
+    ));
+}
+
+async function openPanel(): Promise<void> {
+    const trigger = screen.getByRole("button", { name: /Runtime settings/i });
+    await userEvent.click(trigger);
+}
+
+describe("AgentRuntimeDropup — stays open across selections", () => {
+    // jsdom doesn't reproduce the real-browser quirk this guards against
+    // (clicking a non-focusable element blurs the active element to
+    // <body>), so the higher-level "stays open" tests below can't actually
+    // detect a regression of the onMouseDown fix by themselves — they'd
+    // keep passing even with it removed. This test instead asserts the
+    // mechanism directly: the row's mousedown handler must call
+    // preventDefault(), which is what stops a real browser from blurring
+    // focus out of the panel in the first place. dispatchEvent (which
+    // fireEvent wraps) returns false when preventDefault() was called on a
+    // cancelable event.
+    it("calls preventDefault on an option row's mousedown, to stop the browser from blurring focus out of the panel", async () => {
+        renderDropup();
+        await openPanel();
+
+        const row = screen.getAllByRole("option")[0];
+        const notPrevented = fireEvent.mouseDown(row);
+        expect(notPrevented).toBe(false);
+    });
+
+    it("does not close the panel when an option row is clicked", async () => {
+        renderDropup();
+        await openPanel();
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+        const row = screen.getAllByRole("option")[0];
+        await userEvent.click(row);
+
+        // Still present — the real bug this test guards against closed the
+        // panel here despite applySelection() never calling setOpen(false).
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("does not close when several options are clicked in sequence", async () => {
+        renderDropup();
+        await openPanel();
+
+        const rows = screen.getAllByRole("option");
+        await userEvent.click(rows[0]);
+        await userEvent.click(rows[1]);
+        await userEvent.click(rows[2]);
+
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+});
+
+describe("AgentRuntimeDropup — close button", () => {
+    it("closes the panel when clicked", async () => {
+        renderDropup();
+        await openPanel();
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+        const closeBtn = screen.getByRole("button", { name: "Close" });
+        await userEvent.click(closeBtn);
+
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("is not inside the role=listbox subtree", async () => {
+        renderDropup();
+        await openPanel();
+
+        const listbox = screen.getByRole("listbox");
+        const closeBtn = screen.getByRole("button", { name: "Close" });
+        expect(listbox.contains(closeBtn)).toBe(false);
+    });
+
+    it("does not appear as a role=option row", async () => {
+        renderDropup();
+        await openPanel();
+
+        for (const option of screen.getAllByRole("option")) {
+            expect(option).not.toHaveAttribute("aria-label", "Close");
+        }
+    });
+});
+
+describe("AgentRuntimeDropup — click outside", () => {
+    it("closes the panel on an outside click", async () => {
+        renderDropup();
+        await openPanel();
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+        fireEvent.mouseDown(document.body);
+
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("does not close on a click inside the panel (option row)", async () => {
+        renderDropup();
+        await openPanel();
+
+        const row = screen.getAllByRole("option")[0];
+        fireEvent.mouseDown(row);
+
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+});

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -19,7 +19,11 @@
  * (live-overlaid from the providers.models RPC, same as the prior three-pill
  * implementation) so an API-sourced catalog surfaces new labels automatically.
  *
- * Spec: docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md.
+ * Also closes via an explicit button (top-right of the panel) in addition to
+ * Esc/outside-click/re-clicking the trigger.
+ *
+ * Spec: docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md,
+ * docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md.
  */
 
 import { assertMenuInPaintableArea, computeMenuPosition } from "@/app/util/menu-position";
@@ -297,43 +301,66 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
                         class="menu agent-runtime-dropup-panel"
                         style={floatingStyle()}
                         data-pane-overlay
-                        role="listbox"
-                        aria-label="Runtime settings"
                     >
-                        <For each={build().rows}>
-                            {(row) => {
-                                if (row.kind === "header") {
-                                    return <div class="agent-runtime-dropup-section">{row.section}</div>;
-                                }
-                                const optIndex = () =>
-                                    build().options.findIndex(
-                                        (o) => o.section === row.section && o.value === row.value
+                        {/* Sibling of the listbox below, not a child of it — a
+                            role="listbox" should only contain role="option"
+                            rows (plus an optional label); an interactive
+                            button dropped inside it would be an invalid
+                            listbox structure for assistive tech. Placed first
+                            (matching Modal's showCloseButton convention) so
+                            it's the first Tab stop after the trigger. */}
+                        <button
+                            type="button"
+                            class="agent-runtime-dropup-close-btn"
+                            aria-label="Close"
+                            onClick={() => setOpen(false)}
+                        >
+                            {"✕"}
+                        </button>
+                        <div role="listbox" aria-label="Runtime settings">
+                            <For each={build().rows}>
+                                {(row) => {
+                                    if (row.kind === "header") {
+                                        return <div class="agent-runtime-dropup-section">{row.section}</div>;
+                                    }
+                                    const optIndex = () =>
+                                        build().options.findIndex(
+                                            (o) => o.section === row.section && o.value === row.value
+                                        );
+                                    return (
+                                        <div
+                                            class="menu-item agent-runtime-dropup-row"
+                                            classList={{ active: optIndex() === selectedOptIndex() }}
+                                            role="option"
+                                            aria-selected={row.current}
+                                            onMouseEnter={() => setSelectedOptIndex(optIndex())}
+                                            // These rows are plain non-focusable divs — without this, a
+                                            // mousedown here blurs the trigger and shifts
+                                            // document.activeElement to <body> (outside the panel), which
+                                            // handleFocusChange reads as "focus left" and closes on. That
+                                            // made every selection close the panel despite §9.2's
+                                            // stays-open decision already being implemented correctly —
+                                            // this was a second, independent close path.
+                                            onMouseDown={(e) => e.preventDefault()}
+                                            onClick={() => {
+                                                const idx = optIndex();
+                                                setSelectedOptIndex(idx);
+                                                void applySelection(idx);
+                                            }}
+                                        >
+                                            <i
+                                                class={`fa-solid fa-fw menu-item-icon menu-item-check${row.current ? " fa-check" : ""}`}
+                                                style={row.color ? { color: row.color } : undefined}
+                                            />
+                                            <span class="label">{row.label}</span>
+                                            <Show when={row.description}>
+                                                <span class="agent-runtime-dropup-description">{row.description}</span>
+                                            </Show>
+                                        </div>
                                     );
-                                return (
-                                    <div
-                                        class="menu-item agent-runtime-dropup-row"
-                                        classList={{ active: optIndex() === selectedOptIndex() }}
-                                        role="option"
-                                        aria-selected={row.current}
-                                        onMouseEnter={() => setSelectedOptIndex(optIndex())}
-                                        onClick={() => {
-                                            const idx = optIndex();
-                                            setSelectedOptIndex(idx);
-                                            void applySelection(idx);
-                                        }}
-                                    >
-                                        <i
-                                            class={`fa-solid fa-fw menu-item-icon menu-item-check${row.current ? " fa-check" : ""}`}
-                                            style={row.color ? { color: row.color } : undefined}
-                                        />
-                                        <span class="label">{row.label}</span>
-                                        <Show when={row.description}>
-                                            <span class="agent-runtime-dropup-description">{row.description}</span>
-                                        </Show>
-                                    </div>
-                                );
-                            }}
-                        </For>
+                                }}
+                            </For>
+                        </div>
                     </div>
                 </Portal>
             </Show>

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -158,6 +158,44 @@
     }
 }
 
+// Explicit close affordance — the panel deliberately stays open across
+// selections (§9.2 of SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md), unlike every
+// other popup in the app, so it gets the one thing no other non-modal
+// popover here has: a visible way to say "done." Scaled down from Modal's
+// own .modal-panel-close-btn (modal.scss) to match this panel's much more
+// compact chrome (10px base font, 2px row padding) rather than reusing its
+// 28px sizing. See docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md.
+.agent-runtime-dropup-close-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--secondary-text-color);
+    font-size: 9px;
+    line-height: 1;
+    cursor: default;
+    transition: all var(--motion-fast);
+
+    &:hover {
+        color: var(--main-text-color);
+        background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+        border-color: var(--border-color);
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--shadow-focus-ring);
+    }
+}
+
 .agent-runtime-dropup-section {
     padding: var(--space-1) var(--space-1-5) 2px;
     font-size: 9px;


### PR DESCRIPTION
## Summary

Follow-up to `docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md`, which itself amends `docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md` §9.2. Two fixes for the Mode/Model/Effort runtime panel (`AgentRuntimeDropup`):

1. **Root cause of "closes right after I pick a value."** The panel's own §9.2 decision already says selection shouldn't close the panel, and `applySelection()` never calls `setOpen(false)` — but the option rows are plain non-focusable `<div>`s, so clicking one lets the browser's default mousedown behavior blur the trigger and shift `document.activeElement` to `<body>`. `handleFocusChange` treats that as "focus left the panel" and closes it — a second, independent close path the original §9.2 decision never accounted for. Fixed with `onMouseDown={(e) => e.preventDefault()}` on each row, the standard fix for this exact browser quirk in menu/listbox implementations.
2. **Added an explicit close (✕) button**, scaled down from `Modal`'s `showCloseButton` pattern to match this panel's compact chrome. Required splitting the single `role="listbox"` element into an outer positioned wrapper (holding the button) and an inner `role="listbox"` div (holding just the option rows) — dropping an interactive button in as a sibling of the `role="option"` rows would be an invalid listbox structure for assistive tech.

## Test plan

- [x] New `AgentRuntimeDropup.test.tsx` — this component had zero prior coverage. Covers: selection keeps the panel open, the close button works and sits outside the listbox subtree, click-outside still works.
- [x] The focus-blur fix needed a mechanism-level test (asserting `mousedown`'s `preventDefault` directly) since jsdom doesn't reproduce the real-browser blur-to-`<body>` quirk — confirmed via mutation testing (temporarily removed the fix) that the higher-level "stays open" tests alone do NOT fail without it, so they wouldn't have caught this bug on their own; the direct mechanism test does.
- [x] `npx vitest run frontend/app/view/agent/` — 1020/1020 passing
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=agentx -->