### PR TITLE
fix(identity): close two single-point-enforcement gaps (#2463)

### DIFF
--- a/.changesets/1786190173-fix-identity-close-two-single-point-enforcement-gaps-legacy--ne7m.md
+++ b/.changesets/1786190173-fix-identity-close-two-single-point-enforcement-gaps-legacy--ne7m.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): close two single-point-enforcement gaps — legacy identity_id sentinel FK-crash and blank identity_id bypassing the layer-3 auth gate

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -38,9 +38,14 @@ use super::secret::resolve_secret;
 /// 1. Look up the active `AgentInstance` for this block. If none
 ///    exists, the caller didn't go through the launch modal — return
 ///    immediately, no injection.
-/// 2. Read its `identity_id`. Empty / "blank" → no injection (the
-///    user picked the blank singleton at launch, meaning "use ambient
-///    creds").
+/// 2. Read its `identity_id`. Empty / "blank" no longer short-circuits to
+///    ambient creds (see #2463 — this used to bypass the layer-3 gate
+///    entirely, so whether a spawn required a bound account depended on
+///    whether a stray ambient credential happened to exist on the test
+///    machine). It now falls through to the same steps below, which gate
+///    purely on the agent definition's own provider — identical to how a
+///    non-empty-but-unresolvable `identity_id` (e.g. a legacy sentinel)
+///    already behaved.
 /// 3. Read the `db_agent_identity_links` rows for the instance's definition.
 /// 4. For each binding: fetch the account, resolve its `SecretRef`,
 ///    look up the provider's env-var matrix, write each var into
@@ -246,23 +251,29 @@ pub fn inject_identity_env_with_broker(
     };
 
     // Step 2: identity_id check.
+    //
+    // #2463 Finding 2: this used to `return Ok(())` here (silent ambient-
+    // creds fallback), which bypassed the layer-3 "must have a bound
+    // account" gate below entirely — a genuinely brand-new agent launched
+    // with no account selected got identity_id="" and spawned on whatever
+    // ambient credential happened to be sitting on disk, with nothing
+    // bound in Armory. Observed behavior therefore depended on whether the
+    // test machine happened to have a stray credential file, not on any
+    // actual policy decision. The UI no longer produces empty/"blank"
+    // identity_id for new launches (identity is required at submit-time —
+    // SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md), so seeing one here
+    // means a legacy continuation row or a UI regression; either way it
+    // must be gated the same as any other unresolvable identity_id rather
+    // than silently bypassed. `resolve_bindings_for_instance` below keys
+    // strictly off `instance.definition_id`, not `identity_id`, so falling
+    // through here is safe regardless of what identity_id contains.
     if instance.identity_id.is_empty() || instance.identity_id == "blank" {
-        // Empty or legacy "blank" sentinel → ambient creds (no
-        // injection). The UI no longer produces these for new
-        // launches (identity is now required at submit-time —
-        // SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md), so seeing
-        // one here means either a legacy continuation row or a UI
-        // regression. Warn so the regression is visible in logs.
-        // Deliberately NOT gated by layer 3: this sentinel predates the
-        // managed-account model and was an explicit "ambient creds"
-        // choice at launch time, not a silent fallback.
         tracing::warn!(
             target: "identity",
-            "instance {} has empty/blank identity_id — falling back to ambient creds. \
-             Legacy row or UI regression?",
+            "instance {} has empty/blank identity_id — falling through to the \
+             layer-3 gate instead of ambient creds. Legacy row or UI regression?",
             block_id
         );
-        return Ok(());
     }
 
     // Layer-3 gate inputs: the agent definition's ambient opt-in flag and
@@ -1022,49 +1033,57 @@ mod tests {
     }
 
     #[test]
-    fn inject_blank_identity_does_nothing() {
+    fn inject_blank_identity_is_gated_same_as_any_other_unresolvable_identity() {
+        // #2463 Finding 2: this test used to assert the OPPOSITE — that a
+        // blank identity_id was NOT gated by layer 3 and silently fell
+        // back to ambient creds even with use_ambient_login=0. That let a
+        // brand-new agent launch with no account selected spawn on
+        // whatever ambient credential happened to be on disk, with
+        // nothing bound in Armory — observably different behavior on two
+        // machines running the identical code, purely as a function of
+        // which one had a stray credential file. A blank/empty
+        // identity_id must be gated exactly like any other unresolvable
+        // one (see `spawn_blocked_when_oauth_def_provider_has_no_binding_
+        // and_flag_false`, the non-blank equivalent of this test).
         let store = make_store();
-        // Need a definition for the FK on db_agent_instances.
-        let mut def = crate::backend::storage::store::AgentDefinition {
-            id: "def-1".to_string(),
-            slug: String::new(),
-            name: "T".to_string(),
-            icon: "✦".to_string(),
-            provider: "claude".to_string(),
-            description: String::new(),
-            working_directory: String::new(),
-            shell: String::new(),
-            provider_flags: String::new(),
-            auto_start: 0,
-            restart_on_crash: 0,
-            idle_timeout_minutes: 0,
-            created_at: 0,
-            agent_type: String::new(),
-            environment: String::new(),
-            agent_bus_id: String::new(),
-            is_seeded: 0,
-            accounts: String::new(),
-            parent_id: String::new(),
-            branch_label: String::new(),
-            updated_at: 0,
-            user_hidden: 0,
-            container_image: String::new(),
-            container_volumes: "[]".to_string(),
-            container_name: String::new(),
-            use_ambient_login: 0,
-        };
+        let mut def = gate_def(0);
         store.agent_def_insert(&mut def).unwrap();
 
         insert_block_for_agent(&store, "block-blank", "def-1");
-        let mut inst = make_instance("block-blank", "blank");
+        let inst = make_instance("block-blank", "blank");
         store.instance_create(&inst).unwrap();
-        let _ = inst; // keep clippy happy
 
         let mut env: HashMap<String, String> = HashMap::new();
-        // The blank sentinel is the pre-managed-accounts explicit "ambient
-        // creds" launch choice — NOT gated by layer 3 (Ok even with
-        // use_ambient_login=0).
-        inject_identity_env(store.clone(), store, "block-blank", &mut env).unwrap();
+        let res = inject_identity_env(store.clone(), store, "block-blank", &mut env);
+
+        assert_eq!(
+            res,
+            Err(SpawnGateError::MissingCredentials { provider: "claude".to_string() }),
+        );
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn inject_empty_identity_is_gated_same_as_blank() {
+        // Same as the blank case above, but the genuinely-empty string —
+        // what a real brand-new-agent launch with no account selected
+        // actually produces (#2463 Finding 2's exact repro), as opposed to
+        // the legacy "blank" singleton literal.
+        let store = make_store();
+        let mut def = gate_def(0);
+        store.agent_def_insert(&mut def).unwrap();
+
+        insert_block_for_agent(&store, "block-empty", "def-1");
+        let inst = make_instance("block-empty", "");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        let res = inject_identity_env(store.clone(), store, "block-empty", &mut env);
+
+        assert_eq!(
+            res,
+            Err(SpawnGateError::MissingCredentials { provider: "claude".to_string() }),
+        );
         assert!(env.is_empty());
     }
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -18,6 +18,7 @@ import { readActivitySummary } from "@/app/store/activitySummary";
 import { buildConfigFiles } from "./agent-config-builder";
 import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-launch-env";
 import { looksLikeRealAccountId } from "./identity-carry-over";
+import { loadAccounts } from "@/app/view/identity/identity-model";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -657,19 +658,23 @@ export class AgentViewModel implements ViewModel {
             // fails gracefully and just logs a warning. See
             // docs/specs/SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md.
             //
-            // #2463 Finding 1: `looksLikeRealAccountId` (not just `!==
-            // "blank"`) is the defense-in-depth check here — every known
-            // call site already filters its own `accountId` before it
-            // reaches `launchAgentDefinition`, but a non-UUID sentinel
-            // ("default", a stale bundle id, any future legacy literal)
-            // reaching this RPC throws `FOREIGN KEY constraint failed`
-            // against `db_accounts`, which this try/catch silently
-            // swallows — so validating here too means a missed call site
-            // fails safe (no link attempt, no swallowed crash) instead of
-            // depending on every caller remembering to filter.
+            // #2463 Finding 1: defense-in-depth — every known call site
+            // already filters its own `accountId` before it reaches
+            // `launchAgentDefinition`, but a stale reference reaching this
+            // RPC throws `FOREIGN KEY constraint failed` against
+            // `db_accounts`, which this try/catch silently swallows. A
+            // UUID-shape check alone (`looksLikeRealAccountId`) isn't
+            // enough: pre-#1624-PR-C identity-bundle ids were ALSO
+            // UUID-formatted, just not account ids (codex P1 on this fix's
+            // PR) — cross-checking against the live account cache closes
+            // that gap too, so a missed/future call site fails safe
+            // instead of depending on every caller filtering perfectly.
             try {
                 const accountId = overrides?.accountId;
-                if (looksLikeRealAccountId(accountId)) {
+                if (
+                    looksLikeRealAccountId(accountId) &&
+                    loadAccounts().some((a) => a.id === accountId)
+                ) {
                     await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
                         agent_id: agent.id,
                         account_id: accountId,

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -18,7 +18,7 @@ import { readActivitySummary } from "@/app/store/activitySummary";
 import { buildConfigFiles } from "./agent-config-builder";
 import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-launch-env";
 import { realAccountIdOrEmpty } from "./identity-carry-over";
-import { loadAccounts } from "@/app/view/identity/identity-model";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -663,15 +663,17 @@ export class AgentViewModel implements ViewModel {
             // `launchAgentDefinition`, but a stale reference reaching this
             // RPC throws `FOREIGN KEY constraint failed` against
             // `db_accounts`, which this try/catch silently swallows.
-            // `realAccountIdOrEmpty` cross-checks against the live account
-            // cache (not just UUID shape — a legacy identity-bundle id
+            // `realAccountIdOrEmpty` cross-checks against a fresh account
+            // fetch (not just UUID shape — a legacy identity-bundle id
             // would pass a shape-only check too, codex P1 on this fix's
-            // PR), so a missed/future call site fails safe instead of
-            // depending on every caller filtering perfectly.
+            // PR; not the synchronous loadAccounts() cache either, which
+            // can still be mid-priming — reagentx P2 on the same PR), so a
+            // missed/future call site fails safe instead of depending on
+            // every caller filtering perfectly.
             try {
                 const accountId = realAccountIdOrEmpty(
                     overrides?.accountId ?? "",
-                    loadAccounts().map((a) => a.id),
+                    (await refreshAccountCache()).map((a) => a.id),
                 );
                 if (accountId) {
                     await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -17,6 +17,7 @@ import type { LaunchOverrides } from "./components/AgentLaunchModal";
 import { readActivitySummary } from "@/app/store/activitySummary";
 import { buildConfigFiles } from "./agent-config-builder";
 import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-launch-env";
+import { looksLikeRealAccountId } from "./identity-carry-over";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -602,13 +603,15 @@ export class AgentViewModel implements ViewModel {
                     definition_id: agent.id,
                     block_id: blockId,
                     // PR-F.3: launch modal carries the user's bundle
-                    // picks. Empty / "blank" → backend resolver short-
-                    // circuits so the agent inherits ambient creds.
-                    // Issue #1624 PR-C Part B — `accountId` replaces
-                    // the old bundle-id `identityId`; this column
-                    // keeps its name (`identity_id`) since it's a
-                    // legacy `db_agent_instances` field, not part of
-                    // the new direct-link system.
+                    // picks. Empty / "blank" no longer buys ambient-creds
+                    // fallback — the backend resolver's layer-3 gate now
+                    // requires a real bound account for any oauth-class
+                    // provider regardless of identity_id's value (#2463
+                    // Finding 2). Issue #1624 PR-C Part B — `accountId`
+                    // replaces the old bundle-id `identityId`; this column
+                    // keeps its name (`identity_id`) since it's a legacy
+                    // `db_agent_instances` field, not part of the new
+                    // direct-link system.
                     identity_id: overrides?.accountId,
                     memory_id: overrides?.memoryId,
                     // v8: named-agent continuation. The instance name
@@ -653,9 +656,20 @@ export class AgentViewModel implements ViewModel {
             // stale bundle id instead of a real account id — the RPC
             // fails gracefully and just logs a warning. See
             // docs/specs/SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md.
+            //
+            // #2463 Finding 1: `looksLikeRealAccountId` (not just `!==
+            // "blank"`) is the defense-in-depth check here — every known
+            // call site already filters its own `accountId` before it
+            // reaches `launchAgentDefinition`, but a non-UUID sentinel
+            // ("default", a stale bundle id, any future legacy literal)
+            // reaching this RPC throws `FOREIGN KEY constraint failed`
+            // against `db_accounts`, which this try/catch silently
+            // swallows — so validating here too means a missed call site
+            // fails safe (no link attempt, no swallowed crash) instead of
+            // depending on every caller remembering to filter.
             try {
                 const accountId = overrides?.accountId;
-                if (accountId && accountId !== "blank") {
+                if (looksLikeRealAccountId(accountId)) {
                     await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
                         agent_id: agent.id,
                         account_id: accountId,

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -17,7 +17,7 @@ import type { LaunchOverrides } from "./components/AgentLaunchModal";
 import { readActivitySummary } from "@/app/store/activitySummary";
 import { buildConfigFiles } from "./agent-config-builder";
 import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-launch-env";
-import { looksLikeRealAccountId } from "./identity-carry-over";
+import { realAccountIdOrEmpty } from "./identity-carry-over";
 import { loadAccounts } from "@/app/view/identity/identity-model";
 
 export class AgentViewModel implements ViewModel {
@@ -662,19 +662,18 @@ export class AgentViewModel implements ViewModel {
             // already filters its own `accountId` before it reaches
             // `launchAgentDefinition`, but a stale reference reaching this
             // RPC throws `FOREIGN KEY constraint failed` against
-            // `db_accounts`, which this try/catch silently swallows. A
-            // UUID-shape check alone (`looksLikeRealAccountId`) isn't
-            // enough: pre-#1624-PR-C identity-bundle ids were ALSO
-            // UUID-formatted, just not account ids (codex P1 on this fix's
-            // PR) — cross-checking against the live account cache closes
-            // that gap too, so a missed/future call site fails safe
-            // instead of depending on every caller filtering perfectly.
+            // `db_accounts`, which this try/catch silently swallows.
+            // `realAccountIdOrEmpty` cross-checks against the live account
+            // cache (not just UUID shape — a legacy identity-bundle id
+            // would pass a shape-only check too, codex P1 on this fix's
+            // PR), so a missed/future call site fails safe instead of
+            // depending on every caller filtering perfectly.
             try {
-                const accountId = overrides?.accountId;
-                if (
-                    looksLikeRealAccountId(accountId) &&
-                    loadAccounts().some((a) => a.id === accountId)
-                ) {
+                const accountId = realAccountIdOrEmpty(
+                    overrides?.accountId ?? "",
+                    loadAccounts().map((a) => a.id),
+                );
+                if (accountId) {
                     await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
                         agent_id: agent.id,
                         account_id: accountId,

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -275,8 +275,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 instanceName: row.instance_name,
                 agentType: (def.agent_type as "host" | "container") || "host",
                 environment: def.agent_type === "container" ? "docker" : "local",
-                accountId: row.identity_id,
-                memoryId: row.memory_id,
+                // #2463 Finding 1: a legacy row's identity_id can carry a
+                // non-UUID sentinel ("default", "blank", "") from before
+                // the account-linking system — forwarding it unfiltered as
+                // accountId crashes the write-through's FOREIGN KEY insert
+                // (see identity-carry-over.ts's header comment). Same guard
+                // already used for the auto-continue path below.
+                accountId: looksLikeRealAccountId(row.identity_id) ? row.identity_id : "",
+                memoryId: looksLikeRealAccountId(row.memory_id) ? row.memory_id : "",
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
                 // Carry the CLI-emitted session id forward so the new
@@ -307,8 +313,9 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 instanceName: branchLabel,
                 agentType: (forkedDef.agent_type as "host" | "container") || "host",
                 environment: forkedDef.agent_type === "container" ? "docker" : "local",
-                accountId: row.identity_id,
-                memoryId: row.memory_id,
+                // #2463 Finding 1 — see handleReattach's comment above.
+                accountId: looksLikeRealAccountId(row.identity_id) ? row.identity_id : "",
+                memoryId: looksLikeRealAccountId(row.memory_id) ? row.memory_id : "",
             });
         } finally {
             setLaunching(null);

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -43,11 +43,28 @@ import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
 import { looksLikeRealAccountId } from "../identity-carry-over";
+import { loadAccounts } from "@/app/view/identity/identity-model";
 import { AgentCard } from "./AgentCard";
 import { AgentActionBar } from "./AgentActionBar";
 import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
 import type { LaunchOverrides } from "./AgentLaunchModal";
 import { MyAgentsList } from "./MyAgentsList";
+
+// ── Carried-over identity_id validation (#2463 Finding 1) ──────────────────
+//
+// `looksLikeRealAccountId`'s UUID-shape check alone isn't sufficient here:
+// pre-#1624-PR-C identity-bundle ids were ALSO UUID-formatted, just not
+// account ids — a legacy row carrying one would pass the shape check, still
+// hit LinkAgentIdentityCommand's FOREIGN KEY constraint against db_accounts,
+// and still get silently swallowed by the write-through's try/catch (codex
+// P1 on this fix). Cross-checking against the live account cache closes
+// that gap. `loadAccounts()` is a synchronous best-effort read of a cache
+// primed at app startup — by the time a user clicks reattach/fork on an
+// existing row, priming has long since completed.
+function realAccountIdOrEmpty(id: string): string {
+    if (!looksLikeRealAccountId(id)) return "";
+    return loadAccounts().some((a) => a.id === id) ? id : "";
+}
 
 // ── useAgentDefinitions hook ───────────────────────────────────────────────────────
 
@@ -276,13 +293,18 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 agentType: (def.agent_type as "host" | "container") || "host",
                 environment: def.agent_type === "container" ? "docker" : "local",
                 // #2463 Finding 1: a legacy row's identity_id can carry a
-                // non-UUID sentinel ("default", "blank", "") from before
-                // the account-linking system — forwarding it unfiltered as
-                // accountId crashes the write-through's FOREIGN KEY insert
-                // (see identity-carry-over.ts's header comment). Same guard
-                // already used for the auto-continue path below.
-                accountId: looksLikeRealAccountId(row.identity_id) ? row.identity_id : "",
-                memoryId: looksLikeRealAccountId(row.memory_id) ? row.memory_id : "",
+                // stale/legacy value from before the account-linking system
+                // — forwarding it unfiltered as accountId crashes the
+                // write-through's FOREIGN KEY insert (see
+                // identity-carry-over.ts's header comment and
+                // realAccountIdOrEmpty's above). memory_id does NOT need
+                // this: unlike account_id it has no FK constraint, and
+                // legitimate bundle ids are routinely non-UUID ("blank",
+                // "seed-*" — memory_bundles.rs/bundle.rs) rather than legacy
+                // garbage, so filtering it would silently drop a real
+                // carry-over (reagent P2 on this PR).
+                accountId: realAccountIdOrEmpty(row.identity_id),
+                memoryId: row.memory_id,
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
                 // Carry the CLI-emitted session id forward so the new
@@ -314,8 +336,9 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 agentType: (forkedDef.agent_type as "host" | "container") || "host",
                 environment: forkedDef.agent_type === "container" ? "docker" : "local",
                 // #2463 Finding 1 — see handleReattach's comment above.
-                accountId: looksLikeRealAccountId(row.identity_id) ? row.identity_id : "",
-                memoryId: looksLikeRealAccountId(row.memory_id) ? row.memory_id : "",
+                // memoryId intentionally unfiltered — same reasoning.
+                accountId: realAccountIdOrEmpty(row.identity_id),
+                memoryId: row.memory_id,
             });
         } finally {
             setLaunching(null);

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -42,8 +42,8 @@ import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
 import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
-import { looksLikeRealAccountId, realAccountIdOrEmpty } from "../identity-carry-over";
-import { loadAccounts } from "@/app/view/identity/identity-model";
+import { realAccountIdOrEmpty } from "../identity-carry-over";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { AgentCard } from "./AgentCard";
 import { AgentActionBar } from "./AgentActionBar";
 import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
@@ -280,13 +280,16 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 // stale/legacy value from before the account-linking system
                 // — forwarding it unfiltered as accountId crashes the
                 // write-through's FOREIGN KEY insert (see
-                // identity-carry-over.ts's realAccountIdOrEmpty). memory_id
-                // does NOT need this: unlike account_id it has no FK
-                // constraint, and legitimate bundle ids are routinely
+                // identity-carry-over.ts's realAccountIdOrEmpty).
+                // refreshAccountCache() (not the synchronous loadAccounts()
+                // cache, which can still be mid-priming — reagentx P2 on
+                // #2464) guarantees a fresh list to check against.
+                // memory_id does NOT need this: unlike account_id it has no
+                // FK constraint, and legitimate bundle ids are routinely
                 // non-UUID ("blank", "seed-*" — memory_bundles.rs/bundle.rs)
                 // rather than legacy garbage, so filtering it would silently
                 // drop a real carry-over (reagent P2 on this PR).
-                accountId: realAccountIdOrEmpty(row.identity_id, loadAccounts().map((a) => a.id)),
+                accountId: realAccountIdOrEmpty(row.identity_id, (await refreshAccountCache()).map((a) => a.id)),
                 memoryId: row.memory_id,
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
@@ -320,7 +323,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 environment: forkedDef.agent_type === "container" ? "docker" : "local",
                 // #2463 Finding 1 — see handleReattach's comment above.
                 // memoryId intentionally unfiltered — same reasoning.
-                accountId: realAccountIdOrEmpty(row.identity_id, loadAccounts().map((a) => a.id)),
+                accountId: realAccountIdOrEmpty(row.identity_id, (await refreshAccountCache()).map((a) => a.id)),
                 memoryId: row.memory_id,
             });
         } finally {
@@ -443,13 +446,21 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     (a, b) => (b.started_at ?? 0) - (a.started_at ?? 0),
                 )[0];
                 if (mostRecent) {
-                    // See identity-carry-over.ts — a UUID-shape check,
-                    // not a per-literal blacklist, so legacy sentinels
-                    // like "default" (which would otherwise fail
-                    // linkagentidentity's FOREIGN KEY constraint) are
-                    // filtered along with "blank"/"".
-                    accountId = looksLikeRealAccountId(mostRecent.identity_id) ? mostRecent.identity_id : "";
-                    memoryId = looksLikeRealAccountId(mostRecent.memory_id) ? mostRecent.memory_id : "";
+                    // See identity-carry-over.ts's realAccountIdOrEmpty —
+                    // cross-checks against a fresh account fetch (not the
+                    // synchronous loadAccounts() cache, which can still be
+                    // mid-priming this early after app startup — reagentx
+                    // P2 on #2464) so a legacy sentinel like "default", or
+                    // a UUID-shaped-but-not-a-real-account legacy bundle
+                    // id, can't slip through and still fail
+                    // linkagentidentity's FOREIGN KEY constraint.
+                    // memoryId is intentionally NOT filtered — see
+                    // handleReattach's comment above.
+                    accountId = realAccountIdOrEmpty(
+                        mostRecent.identity_id,
+                        (await refreshAccountCache()).map((a) => a.id),
+                    );
+                    memoryId = mostRecent.memory_id;
                 }
             } catch {
                 // best-effort — fall through with empty bundles.

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -42,29 +42,13 @@ import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
 import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
-import { looksLikeRealAccountId } from "../identity-carry-over";
+import { looksLikeRealAccountId, realAccountIdOrEmpty } from "../identity-carry-over";
 import { loadAccounts } from "@/app/view/identity/identity-model";
 import { AgentCard } from "./AgentCard";
 import { AgentActionBar } from "./AgentActionBar";
 import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
 import type { LaunchOverrides } from "./AgentLaunchModal";
 import { MyAgentsList } from "./MyAgentsList";
-
-// ── Carried-over identity_id validation (#2463 Finding 1) ──────────────────
-//
-// `looksLikeRealAccountId`'s UUID-shape check alone isn't sufficient here:
-// pre-#1624-PR-C identity-bundle ids were ALSO UUID-formatted, just not
-// account ids — a legacy row carrying one would pass the shape check, still
-// hit LinkAgentIdentityCommand's FOREIGN KEY constraint against db_accounts,
-// and still get silently swallowed by the write-through's try/catch (codex
-// P1 on this fix). Cross-checking against the live account cache closes
-// that gap. `loadAccounts()` is a synchronous best-effort read of a cache
-// primed at app startup — by the time a user clicks reattach/fork on an
-// existing row, priming has long since completed.
-function realAccountIdOrEmpty(id: string): string {
-    if (!looksLikeRealAccountId(id)) return "";
-    return loadAccounts().some((a) => a.id === id) ? id : "";
-}
 
 // ── useAgentDefinitions hook ───────────────────────────────────────────────────────
 
@@ -296,14 +280,13 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 // stale/legacy value from before the account-linking system
                 // — forwarding it unfiltered as accountId crashes the
                 // write-through's FOREIGN KEY insert (see
-                // identity-carry-over.ts's header comment and
-                // realAccountIdOrEmpty's above). memory_id does NOT need
-                // this: unlike account_id it has no FK constraint, and
-                // legitimate bundle ids are routinely non-UUID ("blank",
-                // "seed-*" — memory_bundles.rs/bundle.rs) rather than legacy
-                // garbage, so filtering it would silently drop a real
-                // carry-over (reagent P2 on this PR).
-                accountId: realAccountIdOrEmpty(row.identity_id),
+                // identity-carry-over.ts's realAccountIdOrEmpty). memory_id
+                // does NOT need this: unlike account_id it has no FK
+                // constraint, and legitimate bundle ids are routinely
+                // non-UUID ("blank", "seed-*" — memory_bundles.rs/bundle.rs)
+                // rather than legacy garbage, so filtering it would silently
+                // drop a real carry-over (reagent P2 on this PR).
+                accountId: realAccountIdOrEmpty(row.identity_id, loadAccounts().map((a) => a.id)),
                 memoryId: row.memory_id,
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
@@ -337,7 +320,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 environment: forkedDef.agent_type === "container" ? "docker" : "local",
                 // #2463 Finding 1 — see handleReattach's comment above.
                 // memoryId intentionally unfiltered — same reasoning.
-                accountId: realAccountIdOrEmpty(row.identity_id),
+                accountId: realAccountIdOrEmpty(row.identity_id, loadAccounts().map((a) => a.id)),
                 memoryId: row.memory_id,
             });
         } finally {

--- a/frontend/app/view/agent/hooks/useContinueOrNewMode.ts
+++ b/frontend/app/view/agent/hooks/useContinueOrNewMode.ts
@@ -96,7 +96,19 @@ export function useContinueOrNewMode(opts: UseContinueOrNewModeOpts) {
     const continueLocksIdentity = createMemo(() => flowContinueLocksIdentity(flow.state));
     const continueLocksMemory = createMemo(() => flowContinueLocksMemory(flow.state));
 
+    // Sequencing guard (reagentx P1 on #2464): handleContinueSelect awaits
+    // an RPC round-trip (refreshAccountCache) before dispatching, which it
+    // didn't when this was fully synchronous. Without this, two calls in
+    // flight at once (e.g. the user changes the dropdown selection again
+    // before the first fetch resolves) could resolve out of order, and a
+    // stale call finishing last would dispatch over a newer selection —
+    // silently locking the form to the wrong prior instance's account
+    // while the UI shows a different one. Only the most-recently-STARTED
+    // call is allowed to dispatch; every earlier in-flight call drops its
+    // result silently once superseded.
+    let continueSelectSeq = 0;
     const handleContinueSelect = async (rawId: string) => {
+        const seq = ++continueSelectSeq;
         const id = rawId === "" ? null : rawId;
         const row =
             id === null
@@ -131,6 +143,7 @@ export function useContinueOrNewMode(opts: UseContinueOrNewModeOpts) {
                   memoryId: row.memory_id,
               }
             : undefined;
+        if (seq !== continueSelectSeq) return; // superseded by a later call — drop this stale dispatch
         flow.dispatch({ type: "ContinueOfChanged", continueOfId: id, carry });
     };
 

--- a/frontend/app/view/agent/hooks/useContinueOrNewMode.ts
+++ b/frontend/app/view/agent/hooks/useContinueOrNewMode.ts
@@ -26,7 +26,8 @@ import {
     continueLocksMemory as flowContinueLocksMemory,
     type LaunchFlowStore,
 } from "@/app/store/launch-flow-state";
-import { looksLikeRealAccountId } from "@/app/view/agent/identity-carry-over";
+import { realAccountIdOrEmpty } from "@/app/view/agent/identity-carry-over";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
 
 export interface UseContinueOrNewModeOpts {
     /** The launch-flow reactive store — pass BY REFERENCE (the whole
@@ -95,7 +96,7 @@ export function useContinueOrNewMode(opts: UseContinueOrNewModeOpts) {
     const continueLocksIdentity = createMemo(() => flowContinueLocksIdentity(flow.state));
     const continueLocksMemory = createMemo(() => flowContinueLocksMemory(flow.state));
 
-    const handleContinueSelect = (rawId: string) => {
+    const handleContinueSelect = async (rawId: string) => {
         const id = rawId === "" ? null : rawId;
         const row =
             id === null
@@ -109,9 +110,12 @@ export function useContinueOrNewMode(opts: UseContinueOrNewModeOpts) {
         // already falls back to "re-pick" here rather than needing a
         // backend resolution step. Forwarding one of these as accountId
         // causes a real FOREIGN KEY failure in linkagentidentity (see
-        // identity-carry-over.ts), so this is a UUID-shape allowlist, not
-        // a per-literal blacklist — it covers every legacy sentinel, not
-        // just the ones observed so far.
+        // identity-carry-over.ts's realAccountIdOrEmpty). A UUID-shape
+        // check alone isn't enough — a pre-#1624-PR-C identity-bundle id
+        // was also UUID-formatted, just not an account id — so this cross-
+        // checks against a fresh account fetch (reagentx P2 on #2464,
+        // flagging this call site was still on the shape-only check while
+        // AgentPicker.tsx's sibling call sites got the stronger one).
         //
         // memoryId intentionally does NOT get the same treatment: unlike
         // account_id, memory_id has no FK constraint, and legitimate
@@ -123,7 +127,7 @@ export function useContinueOrNewMode(opts: UseContinueOrNewModeOpts) {
         const carry = row
             ? {
                   name: row.instance_name,
-                  accountId: looksLikeRealAccountId(row.identity_id) ? row.identity_id : "",
+                  accountId: realAccountIdOrEmpty(row.identity_id, (await refreshAccountCache()).map((a) => a.id)),
                   memoryId: row.memory_id,
               }
             : undefined;

--- a/frontend/app/view/agent/hooks/useContinueOrNewMode.ts
+++ b/frontend/app/view/agent/hooks/useContinueOrNewMode.ts
@@ -101,22 +101,30 @@ export function useContinueOrNewMode(opts: UseContinueOrNewModeOpts) {
             id === null
                 ? null
                 : (namedAgents() ?? []).find((r) => r.instance_id === id) ?? null;
-        // Legacy rows may carry "" or "blank" identity_id/memory_id
-        // from before the blank-removal, or (pre-issue-#1624-PR-C rows)
-        // a legacy sentinel like "default" that no longer resolves to
-        // a real account. Treat all of these as "no carry-over" so the
-        // user must pick a real account for the continuation — an
-        // unresolvable carried id already falls back to "re-pick" here
-        // rather than needing a backend resolution step. Forwarding one
-        // of these as accountId causes a real FOREIGN KEY failure in
-        // linkagentidentity (see identity-carry-over.ts), so this is a
-        // UUID-shape allowlist, not a per-literal blacklist — it covers
-        // every legacy sentinel, not just the ones observed so far.
+        // Legacy rows may carry "" or "blank" identity_id from before the
+        // blank-removal, or (pre-issue-#1624-PR-C rows) a legacy sentinel
+        // like "default" that no longer resolves to a real account. Treat
+        // all of these as "no carry-over" so the user must pick a real
+        // account for the continuation — an unresolvable carried id
+        // already falls back to "re-pick" here rather than needing a
+        // backend resolution step. Forwarding one of these as accountId
+        // causes a real FOREIGN KEY failure in linkagentidentity (see
+        // identity-carry-over.ts), so this is a UUID-shape allowlist, not
+        // a per-literal blacklist — it covers every legacy sentinel, not
+        // just the ones observed so far.
+        //
+        // memoryId intentionally does NOT get the same treatment: unlike
+        // account_id, memory_id has no FK constraint, and legitimate
+        // bundle ids are routinely non-UUID ("blank", "seed-*" —
+        // memory_bundles.rs/bundle.rs) rather than legacy garbage — a
+        // UUID-shape filter here would silently drop a real carry-over
+        // (reagentx P2 on #2464, which found the same mistake newly
+        // introduced elsewhere).
         const carry = row
             ? {
                   name: row.instance_name,
                   accountId: looksLikeRealAccountId(row.identity_id) ? row.identity_id : "",
-                  memoryId: looksLikeRealAccountId(row.memory_id) ? row.memory_id : "",
+                  memoryId: row.memory_id,
               }
             : undefined;
         flow.dispatch({ type: "ContinueOfChanged", continueOfId: id, carry });

--- a/frontend/app/view/agent/identity-carry-over.test.ts
+++ b/frontend/app/view/agent/identity-carry-over.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { looksLikeRealAccountId } from "./identity-carry-over";
+import { looksLikeRealAccountId, realAccountIdOrEmpty } from "./identity-carry-over";
 
 describe("looksLikeRealAccountId", () => {
     it("accepts a real UUID v4", () => {
@@ -38,5 +38,31 @@ describe("looksLikeRealAccountId", () => {
         // Wrong dash placement / wrong length.
         expect(looksLikeRealAccountId("550e8400e29b-41d4-a716-446655440000")).toBe(false);
         expect(looksLikeRealAccountId("550e8400-e29b-41d4-a716-44665544000")).toBe(false);
+    });
+});
+
+describe("realAccountIdOrEmpty", () => {
+    const REAL_ID = "550e8400-e29b-41d4-a716-446655440000";
+    // A pre-#1624-PR-C identity-bundle id — UUID-shaped, but not an
+    // account id (codex P1 on #2464: looksLikeRealAccountId alone can't
+    // tell these apart from a real account id).
+    const LEGACY_BUNDLE_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+    it("returns the id when it's UUID-shaped and present in the known list", () => {
+        expect(realAccountIdOrEmpty(REAL_ID, [REAL_ID, "other-id"])).toBe(REAL_ID);
+    });
+
+    it("returns empty for a UUID-shaped id not in the known list (legacy bundle id)", () => {
+        expect(realAccountIdOrEmpty(LEGACY_BUNDLE_ID, [REAL_ID])).toBe("");
+    });
+
+    it("returns empty for a non-UUID sentinel regardless of the known list", () => {
+        expect(realAccountIdOrEmpty("default", [REAL_ID])).toBe("");
+        expect(realAccountIdOrEmpty("blank", [REAL_ID])).toBe("");
+        expect(realAccountIdOrEmpty("", [REAL_ID])).toBe("");
+    });
+
+    it("returns empty when the known list is empty", () => {
+        expect(realAccountIdOrEmpty(REAL_ID, [])).toBe("");
     });
 });

--- a/frontend/app/view/agent/identity-carry-over.ts
+++ b/frontend/app/view/agent/identity-carry-over.ts
@@ -1,23 +1,47 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Whether a carried-over identity/memory id from a prior agent instance
-// looks like a real id worth reusing on a continuation/reattach launch.
+// Whether a carried-over identity id from a prior agent instance looks
+// like a real account id worth reusing on a continuation/reattach launch.
 //
-// Real account ids and memory bundle ids are always UUID v4 strings
-// (agentmux-srv/src/identity/oauth_client.rs, agentmux-srv/src/server/
-// app_api/identity.rs). Legacy rows can carry "", the "blank" singleton,
-// the pre-#1624-PR-C "default" sentinel, or any other now-meaningless
-// literal from an older identity/memory scheme — none of these are ever
-// real ids. A UUID-shape check classifies all of them (and any future,
-// not-yet-observed legacy literal) as "no carry-over" in one place,
-// instead of the incomplete per-literal blacklist (`!== "blank"` only)
-// this replaces at both call sites. Forwarding an unresolvable id like
-// "default" as an account_id causes a real backend failure —
-// `linkagentidentity`'s FOREIGN KEY (account_id -> db_accounts(id))
-// constraint — since no such row exists or should exist.
+// ONLY account ids — this is NOT a general-purpose "is this a real id"
+// check, and is not valid for memory bundle ids (`db_bundles` seeds a
+// permanent `id='blank'` row and reserves a `seed-*` id prefix for
+// workspace-default bundles — both legitimate, both non-UUID; see
+// memory_bundles.rs / bundle.rs). A prior version of this comment claimed
+// memory bundle ids were "always UUID v4" too, which is wrong and led to
+// this check being (incorrectly) applied to memory_id at some call sites —
+// reagentx P2 on #2464 caught the applied instance, but the claim itself
+// was already stale before that.
+//
+// Real account ids ARE always UUID v4 strings (agentmux-srv/src/identity/
+// oauth_client.rs, agentmux-srv/src/server/app_api/identity.rs). Legacy
+// rows can carry "", the "blank" singleton, the pre-#1624-PR-C "default"
+// sentinel, or any other now-meaningless literal from an older identity
+// scheme — none of these are ever real account ids. A UUID-shape check
+// classifies all of them (and any future, not-yet-observed legacy
+// literal) as "no carry-over" in one place, instead of the incomplete
+// per-literal blacklist (`!== "blank"` only) this replaces at both call
+// sites. Forwarding an unresolvable id like "default" as an account_id
+// causes a real backend failure — `linkagentidentity`'s FOREIGN KEY
+// (account_id -> db_accounts(id)) constraint — since no such row exists
+// or should exist.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function looksLikeRealAccountId(id: string | null | undefined): boolean {
     return typeof id === "string" && UUID_RE.test(id);
+}
+
+// A UUID shape alone isn't sufficient to trust a carried-over account id:
+// pre-#1624-PR-C identity-bundle ids were ALSO UUID-formatted, just not
+// account ids (codex P1 on #2464) — a legacy row carrying one would pass
+// `looksLikeRealAccountId` but still fail to resolve as a real account,
+// hitting the same FOREIGN KEY failure this module exists to prevent.
+// Cross-checking against the caller's own known-accounts list closes that
+// gap. Takes the id list as a parameter (rather than reading a cache
+// internally) so this stays a pure, directly-testable function — callers
+// pass `loadAccounts().map(a => a.id)` (identity-model.ts) or equivalent.
+export function realAccountIdOrEmpty(id: string, knownAccountIds: readonly string[]): string {
+    if (!looksLikeRealAccountId(id)) return "";
+    return knownAccountIds.includes(id) ? id : "";
 }


### PR DESCRIPTION
Closes #2463's two confirmed findings.

## Finding 1 — legacy `identity_id` sentinels FK-crash the write-through

`AgentPicker.tsx`'s `handleReattach`/`handleFork` forwarded `row.identity_id` unfiltered as `accountId`, so a legacy sentinel (`"default"`, a stale bundle id) reached `LinkAgentIdentityCommand` and threw `FOREIGN KEY constraint failed` against the now-empty `db_accounts` table in an isolated-auth channel — silently swallowed by the write-through's `try/catch`, leaving the user staring at a generic "Agent encountered an error."

`looksLikeRealAccountId` already exists and is already used for exactly this at the two call sites in `useContinueOrNewMode.ts` and the auto-continue path in this same file (`AgentPicker.tsx:438`) — its own header comment literally describes this bug class ("Forwarding an unresolvable id like 'default' as an account_id causes a real backend failure"). It just never made it to `handleReattach`/`handleFork`. Guarded both, plus added the same check as defense-in-depth inside the write-through itself (`agent-model.ts`), so a future/missed call site fails safe instead of crashing.

## Finding 2 — blank `identity_id` bypassed the layer-3 auth gate entirely

`inject_identity_env_with_broker` short-circuited to `Ok(())` (silent ambient-credential fallback) for empty/`"blank"` `identity_id`, before the "must have a bound account" gate ever ran. A brand-new agent launched with no account selected got `identity_id: ""` and spawned on whatever ambient credential happened to exist on disk — with nothing bound in Armory. This is exactly why a Windows tester and a Linux tester saw contradictory results from the identical code: same bypass, different outcome purely as a function of whether a stray credential file happened to exist on that machine.

Removed the short-circuit. Empty/blank now falls through to the same gate a non-empty-but-unresolvable `identity_id` (e.g. `"default"`) already correctly went through — safe because `resolve_bindings_for_instance` keys off `definition_id`, not `identity_id`, so the fallthrough doesn't depend on what `identity_id` actually contains.

Together: a fresh isolated-auth channel now correctly and consistently requires signing in, instead of either crashing (Finding 1) or silently working depending on legacy row shape / ambient credential presence (Finding 2).

## Not addressed

The issue's third point — the resulting spawn refusal sometimes surfaces as a generic "Agent encountered an error" instead of the Auth-classified "No account linked" banner — was explicitly flagged by the issue's own author as unconfirmed/not root-caused, and I couldn't nail it down from static reading either. Traced as far as I could: `failure::classify()` exists, has the correct substring-matching logic for `SpawnGateError`'s `Display` text, and is wired into several call sites (`runner.rs`, `persistent.rs`, `health.rs`, `host_spawn.rs`) — but confirming which path this specific first-turn-of-a-fresh-channel case takes needs a live repro. Worth flagging: this fix makes that refusal path fire *more* often (fewer spawns silently bypass the gate now), so it's more likely to be hit going forward. Left as a follow-up rather than a speculative fix to auth-error-UX code.

## Test plan

- [x] `cargo test -p agentmux-srv` — 2062 passed, 0 failed, 5 ignored. Rewrote the test that encoded the old (buggy) "blank bypasses the gate" behavior into the corrected assertion, added a companion test for the empty-string case.
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` (targeted: identity-carry-over, AgentPicker, agent-model) — 17 passed, 0 failed

<!-- agentmux:agent_id=agent3 -->