### PR TITLE
fix(agent-pane): tool preview scrollbar sits flush at the panel edge

### DIFF
--- a/.changesets/1786193214-fix-agent-pane-tool-preview-scrollbar-sits-flush-at-the-pane-b8yi.md
+++ b/.changesets/1786193214-fix-agent-pane-tool-preview-scrollbar-sits-flush-at-the-pane-b8yi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): tool preview scrollbar sits flush at the panel edge

--- a/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
@@ -1,0 +1,192 @@
+# SPEC: Tool preview common-indentation stripping (dedent)
+
+**Date:** 2026-08-08
+**Status:** Proposed (analysis complete — not yet implemented)
+**Scope:** `frontend/app/view/agent/components/ToolOverlayLog.tsx`,
+`frontend/app/view/agent/components/DiffViewer.tsx`, one new shared util
+(+ tests)
+**Related:** `SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md`
+(refinement #1 of this series — this is refinement #2)
+
+---
+
+## 1. Report
+
+When a tool preview shows a snippet from the middle of a file — a `Read`
+with `offset`, or an `Edit` whose `old_string`/`new_string` sit deep inside
+a nested scope — every displayed line carries the file's original leading
+indentation. A hunk whose shallowest line is, say, three scopes deep wastes
+12-24 columns of the preview on indentation that carries no information
+*within the preview*: the reader can't see the enclosing scopes anyway, and
+the preview's usable width (already at a premium; see refinement #1) is
+spent on empty space.
+
+Wanted: strip the indentation that is common to every line in the preview,
+so the **shallowest line renders flush-left** and only the *relative*
+indentation between displayed lines — the part that actually encodes
+structure — is kept.
+
+## 2. Where preview content comes from (traced, not guessed)
+
+All final-result rendering happens in the per-tool renderers of
+`ToolOverlayLog.tsx` (registered via `tool-renderers/registry.ts`):
+
+| Tool | Renderer | Content source | Indentation reality |
+|---|---|---|---|
+| Read | `renderRead` (ToolOverlayLog.tsx:450) → `HighlightedCode` or `Markdown` | `result.content` — passed through raw from the CLI's `tool_result` | **Line-number-prefixed**: verified from a real session transcript, each line is `N\t<raw line>` (e.g. `80\t        unsetEnv: [...]`). The code after the tab keeps full original indentation. Mid-file reads (offset) are the worst case. |
+| Edit | `renderEdit` (:442) → `DiffViewer` | `params.old_string`/`new_string`; `result.diff` "is always undefined in the current pipeline" (DiffViewer.tsx:42-44) — the diff is built client-side via LCS (`buildDiffFromParams`, :83) | Both strings are raw mid-file snippets sharing the target's deep indentation. |
+| Write | `renderWrite` (:499) → `HighlightedCode` or `Markdown` | `params.content` — the full file being written | Whole files start at column 0; common indent is ~always 0. Dedent is a natural no-op. |
+| Bash | `renderBash` → `BashOutputViewer` | stdout/stderr | **Out of scope** — command output has no "file indentation" semantic; leading whitespace can be meaningful (e.g. aligned table output). |
+| Grep/Glob | `renderSearch` → `CompactResult` | independent match lines from arbitrary file positions | **Out of scope** for this pass — each match line is independent, so "common" indent across unrelated lines is semantically weak. Candidate follow-up: per-line leading-whitespace trim with an ellipsis affordance, decided separately. |
+| Streaming chunks (`ChunkList`) | any running tool | incremental chunks | **Out of scope** — dedent needs the full visible text to know the common prefix; applying it per-chunk mid-stream would shift alignment as lines arrive. Final-result rendering replaces the chunk view on completion, which is where dedent applies. |
+
+No dedent/strip-indent utility exists anywhere in `frontend/` today
+(searched).
+
+### 2.1 The Read line-number prefix — a forcing constraint
+
+Because `result.content` lines are `N\t<code>`, a naive
+common-prefix-of-the-whole-line dedent would find no common whitespace (the
+line starts with a digit) and do nothing. The dedent must therefore split
+each Read line into `(number-prefix, code)` and dedent the code portion.
+
+**Implementer must first verify in a live pane what the current Read
+preview actually renders** (one Read of a mid-file section in `task dev`):
+the working assumption from the transcript sample is that the `N\t` prefix
+is rendered verbatim today (Shiki highlights it as part of the code). Two
+consequences if confirmed:
+
+- The markdown Read path (`.md`/`.mdx` → `<Markdown text={capped.text}/>`,
+  ToolOverlayLog.tsx:481-483) is feeding *numbered* lines into a markdown
+  renderer — that's a pre-existing rendering bug of its own (a `1\t# Title`
+  line is not a heading). Fixing that fully is its own change; this spec
+  only requires that dedent not make it *worse* (see §3.3).
+- Whether to keep rendering the number gutter at all (vs stripping it, vs
+  promoting it to a styled non-selectable gutter element like the editor
+  has) is a **separate refinement** — deliberately not decided here. This
+  spec's algorithm preserves whatever prefix policy is in place: it
+  dedents the code portion and leaves the prefix handling unchanged.
+
+## 3. Design
+
+### 3.1 New shared utility — `dedent.ts`
+
+`frontend/app/view/agent/components/dedent.ts`, two pure functions, unit
+tested:
+
+```ts
+/** Longest common leading-whitespace prefix across all non-blank lines.
+ *  Compared LITERALLY (string prefix), so tabs vs spaces never get
+ *  conflated via an assumed tab width: "\t\tfoo" and "    foo" share no
+ *  prefix and the dedent is a no-op — correct, since we can't know how
+ *  wide a tab renders. Blank / whitespace-only lines are ignored for the
+ *  computation and emptied in the output. */
+export function stripCommonIndent(text: string): string;
+
+/** Read-tool variant: if every non-blank line matches /^\s*\d+\t/, split
+ *  off that prefix, apply stripCommonIndent to the code portions, and
+ *  rejoin prefix + code. Otherwise falls through to stripCommonIndent on
+ *  the whole text. */
+export function stripCommonIndentNumbered(text: string): string;
+```
+
+Algorithm for `stripCommonIndent` (single pass over lines):
+
+1. Split on `\n`. Collect the leading-whitespace run (`/^[ \t]*/`) of each
+   non-blank line; the common prefix is the shortest such run that is a
+   literal prefix of all the others (equivalently: fold with
+   longest-common-prefix, whitespace-only by construction).
+2. If the common prefix is empty → return the input unchanged (fast path;
+   covers Write and already-flush content with zero allocation churn).
+3. Otherwise remove that exact prefix from every non-blank line; blank
+   lines pass through as-is.
+
+### 3.2 Application points
+
+1. **Read** (`renderRead`): `capped.text` →
+   `stripCommonIndentNumbered(capped.text)` — **after** `capText`, so the
+   common indent is computed over the *visible* lines only (a deeper hidden
+   tail must not reduce the dedent of what's shown; head-cap keeps the
+   first `MAX_TOOL_OUTPUT_LINES` lines, ToolOverlayLog.tsx:456).
+   Applies to both the Shiki path and the markdown path.
+   - `detectLanguage(filePath, firstLine)` (:476) keeps receiving the
+     original first line — language detection by shebang/content should
+     see the raw text; only the *displayed* string is dedented.
+2. **Edit** (`DiffViewer`): dedent `old_string` and `new_string` with **one
+   shared prefix** (compute over the concatenation of both strings' lines,
+   then strip from each) *before* `buildDiffFromParams` — a shared prefix
+   preserves add/del alignment; independent dedents could skew one side by
+   a level and manufacture phantom diff noise. The `result.diff`-present
+   branch (currently dead per the file's own comment) passes through
+   untouched.
+3. **Write** (`renderWrite`): same call as Read (numbered variant is
+   harmless — Write content has no number prefixes, so it falls through to
+   the plain path, which is a no-op for column-0 files). Included for
+   uniformity so a hypothetical indented Write (e.g. a snippet-shaped
+   file) behaves consistently.
+
+### 3.3 What dedent must NOT do
+
+- **No per-line trimming.** Only the *common* prefix is removed; relative
+  indentation is sacred — that's the "only retain what is necessary" half
+  of the requirement.
+- **No tab-width assumptions.** Literal prefix comparison only (§3.1). A
+  file mixing tabs and spaces at the same depth dedents by whatever prefix
+  is genuinely shared, possibly nothing. Correct > clever.
+- **No markdown-path regression.** For `.md` Reads, dedent runs on the
+  code portion after number-prefix splitting, same as the Shiki path. If
+  the live-pane check (§2.1) reveals the markdown path renders numbered
+  lines today, file the gutter/prefix question as its own follow-up rather
+  than expanding this change's blast radius.
+- **No streaming-path changes.** `ChunkList` and `BashOutputViewer` are
+  untouched.
+
+## 4. Risks
+
+1. **Copy behavior changes**: selecting + copying from a dedented preview
+   yields dedented text. For a preview (not an editor surface) this is the
+   expected reading-oriented trade-off; the file itself is one click away
+   via the path header. Called out so it's a decision, not an accident.
+2. **Shiki cache**: `HighlightedCode` caches per-node via WeakMap keyed on
+   the node — the dedented string is stable per render input, so caching
+   is unaffected.
+3. **Diff correctness**: the shared-prefix rule (§3.2.2) is the one place
+   dedent could corrupt meaning if done per-side; the unit tests must
+   cover an old/new pair whose sides have *different* minimum depths
+   (e.g. new_string adds a shallower wrapper line) and assert the shared
+   prefix is the min of the two.
+4. **Pathological inputs**: single-line content, all-blank content, empty
+   string, CRLF line endings (`\r` must not be treated as part of the
+   indent — normalize by treating `\r?$` as line end, or strip on `\n` and
+   tolerate a trailing `\r` in the whitespace regex). All unit-test cases.
+
+## 5. Test plan
+
+Unit (vitest, `dedent.test.ts`):
+- [ ] Uniform space indent stripped to flush; relative levels preserved.
+- [ ] Tab-indented content stripped by literal tab prefix.
+- [ ] Mixed tab/space with no true common prefix → unchanged.
+- [ ] Blank lines ignored for computation, emptied in output.
+- [ ] Numbered (`N\t`) Read-shaped input: prefix preserved, code dedented.
+- [ ] Non-uniformly-numbered input falls through to plain dedent.
+- [ ] Shared-prefix diff dedent with asymmetric old/new depths.
+- [ ] Empty / single-line / CRLF inputs.
+
+Visual (per the live-pane check that's a precondition anyway):
+- [ ] Read of a mid-file deeply-nested section: shallowest line flush,
+      structure preserved, horizontal scrollbar appears less often.
+- [ ] Edit of a deeply-nested hunk: add/del lines aligned, no phantom
+      indentation diffs.
+- [ ] Write of a normal file: pixel-identical to before (no-op path).
+- [ ] Read of a `.md` file: not worse than current rendering.
+
+## 6. Summary
+
+One pure utility (literal longest-common-whitespace-prefix stripping, with
+a numbered-line variant for Read's verified `N\t` content shape), applied
+at three call sites after capping: Read and Write displays dedent their
+visible text, and DiffViewer dedents `old_string`/`new_string` with a
+single shared prefix before building its LCS diff. Bash, Grep/Glob, and
+streaming chunks are explicitly out of scope. The pre-existing
+numbered-lines-through-Markdown oddity and the "should the number gutter
+exist at all" question are surfaced but deferred to their own refinement.

--- a/docs/specs/SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md
@@ -1,0 +1,234 @@
+# SPEC: Tool preview scrollbar-to-edge padding removal
+
+**Date:** 2026-08-08
+**Status:** Implemented (same day)
+**Scope:** `frontend/app/view/agent/styles/_document-nodes.scss`,
+`frontend/app/view/agent/styles/_tool-overlay-portal.scss`
+**Related:**
+- `SPEC_TOOL_PREVIEW_REFINEMENTS_2026_06_26.md` (prior preview-polish pass)
+- `SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md` (established
+  `.agent-tool-overlay-log` as the single scroll container per tool block)
+- `SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md` /
+  `SPEC_TERM_SCROLLBAR_ZERO_GAP_2026_06_10.md` (the two prior
+  scrollbar-at-edge fixes; same design goal — the scrollbar should read as
+  sitting AT the surface's edge, not floating inside it)
+
+This is refinement #1 of a tool-preview polish series (user ask: "refine the
+preview for Read, Bash, Write, and any other that has a preview; first,
+get rid of the extra padding between the preview's scrollbar and the edge").
+Further refinements will get their own specs.
+
+---
+
+## 1. Report
+
+In the agent pane, every expanded tool-call preview (Read, Bash, Write,
+Edit, Grep/Glob, Agent, Task, and the compact default) shows its vertical
+scrollbar floating ~8px inboard of the preview surface's right edge, with
+dead space on **both** sides of the scrollbar track. The preview surface
+(the subtly-shaded panel) visibly continues past the scrollbar, which reads
+as misaligned — a native scroll surface puts its scrollbar flush at the
+container's edge (editor pane, terminal, and the main conversation scroll
+all already do this in AgentMux).
+
+## 2. Structure and measurements (traced, not guessed)
+
+All tool previews share **one** scroll container. There are no per-tool
+scrollbars (deliberate — the double-scrollbar bug fix, see
+`SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md` §"single scroll
+container"). The DOM/CSS chain:
+
+```
+.agent-view .agent-tool-block
+└── .agent-tool-panel                      _document-nodes.scss:349
+      padding: 6px 8px;                    ← outer inset, all four sides
+      max-height: 50vh; overflow: hidden;
+      background: color-mix(...)           ← the visible "preview surface"
+    ├── .agent-tool-overlay-header         _tool-overlay-portal.scss:17
+    │     padding: var(--space-1) var(--space-2);   (4px 8px)
+    └── .agent-tool-overlay-log            _tool-overlay-portal.scss:40
+          overflow-x: auto; overflow-y: auto;
+          padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
+          (6px top/bottom, 10px right, 8px left)
+        └── per-tool content (.agent-tool-read / .agent-bash / .agent-diff
+            / .agent-tool-write / .agent-tool-search / CompactResult ...)
+```
+
+The scrollbar is a real (layout-space-reserving, non-overlay) WebKit
+scrollbar, 7px wide via the universal rule `*::-webkit-scrollbar { width:
+7px }` (`app.scss:87-90`); its track is transparent
+(`--scrollbar-background-color`, `theme.scss`). A `::-webkit-scrollbar`
+renders inside its owning element's own box, at the right edge of
+`.agent-tool-overlay-log` — **not** at the edge of the panel.
+
+So the right-edge stack, from panel edge inward, is:
+
+| Layer | Width | Source |
+|---|---|---|
+| `.agent-tool-panel` right padding | 8px | `_document-nodes.scss:349` (`padding: 6px 8px`) |
+| scrollbar (in the log's box) | 7px | `app.scss:87` |
+| `.agent-tool-overlay-log` right padding | 10px | `_tool-overlay-portal.scss:46` |
+| → content | | |
+
+**The reported "extra padding between the scrollbar and the edge" is the
+panel's 8px right padding** — it insets the log's entire box (scrollbar
+included) from the visible surface edge. The log's own 10px sits on the
+*other* side of the scrollbar (content ↔ scrollbar breathing room — less
+objectionable, but oddly larger than the 8px left inset, and stacked with
+the 8px it produces a ~25px total right inset for content vs 16px on the
+left).
+
+The same 8px story repeats vertically: the panel's 6px bottom padding
+insets the horizontal scrollbar (the log is also `overflow-x: auto`) and
+cuts the vertical track 6px short of the surface's bottom edge.
+
+## 3. Goal
+
+The scroll container's border box should coincide with the preview
+surface's edges, so:
+
+- the vertical scrollbar sits flush at the panel's right edge (zero gap
+  outboard of the track), running the full height of the scrollable region;
+- the horizontal scrollbar (when present) sits flush at the panel's bottom
+  edge;
+- content keeps sane breathing room on the inner side of the scrollbar and
+  a **symmetric** left/right text inset;
+- no behavior change to scrolling, collapse animation, or the
+  single-scroll-container invariant.
+
+## 4. Proposed change
+
+Move the panel's inset onto its children so the log's box (and therefore
+its scrollbars) reaches the panel edges:
+
+### 4.1 `.agent-tool-panel` (`_document-nodes.scss:349`)
+
+```scss
+- padding: 6px 8px;
++ padding: 0;
+```
+
+The `--hidden` collapse variant already only zeroes `padding-top`/
+`padding-bottom` (`_document-nodes.scss:~397`); with base padding 0 those
+declarations become no-ops — harmless, and the `padding 120ms` entry in the
+`transition` list simply has nothing to animate. Leave both in place (the
+shell-block mirror in `_shell-node.scss:39` never had padding, so this also
+converges the two panel variants).
+
+### 4.2 `.agent-tool-overlay-log` (`_tool-overlay-portal.scss:46`)
+
+```scss
+- padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
++ padding: var(--space-1-5) var(--space-1) var(--space-1-5) var(--space-2);
+```
+
+- Left stays `--space-2` (8px) — content keeps its text inset, now measured
+  from the true surface edge (content inset goes 16px → 8px, gaining ~8px
+  of usable preview width per side; a win for code lines).
+- Right becomes `--space-1` (4px) — this is now purely the content ↔
+  scrollbar gap; the scrollbar itself provides the edge separation. 4px
+  matches the visual role (compare: the main conversation's content ↔
+  scrollbar gap). If 4px feels tight against the 7px thumb in practice,
+  `--space-1-5` (6px) is the fallback — decide by eye at implementation
+  time, not in this spec.
+- Top/bottom stay `--space-1-5` (6px) — the vertical inset the panel used
+  to provide, now carried by the log itself so the track runs edge to edge
+  while the *content* keeps its vertical breathing room.
+
+### 4.3 `.agent-tool-overlay-header` (`_tool-overlay-portal.scss:17-23`)
+
+No change to its own `padding: var(--space-1) var(--space-2)` — but note
+two knock-on effects of 4.1, both desirable:
+
+- header text inset drops 16px → 8px, now aligning with the log content's
+  left inset instead of sitting 8px further in (the old 16px was two
+  paddings stacking, not a design choice);
+- the header's `border-bottom` extends to the panel's full width instead of
+  stopping 8px short of each edge (full-bleed divider — consistent with how
+  `.agent-bash-cmd` / `.agent-diff-header` section bars will now also reach
+  the edge).
+
+### 4.4 Explicitly out of scope for the CSS change
+
+- `.agent-activity-log` (`_shell-node.scss:326`) — ActivityRow's live
+  activity feed reuses the `agent-tool-overlay-log` class
+  (`ActivityRow.tsx:211,235,254`) but overrides `padding`, `max-height`,
+  and `overflow-y` with its own single-class rule that wins on cascade
+  order (`shell-node` is `@use`d after `tool-overlay-portal`,
+  `agent-view.scss:10` vs `:33`). It is therefore **unaffected** by 4.2.
+  Its own 8px-right-padding-inside-a-scroll-container has the same smell,
+  but it renders inside a differently-shaped surface (the shell/activity
+  block) — align it in a follow-up if the visual result of this spec looks
+  right, rather than batching it in blind.
+- `PersistentShellBlock.tsx:154` — uses the log class inside
+  `.agent-shell-block .agent-tool-panel`, whose panel mirror never had
+  padding (`_shell-node.scss:39`). It gets 4.2's right-padding tightening
+  automatically and needs no separate edit. Include it in the visual pass.
+- The 7px scrollbar width/track/thumb styling (`app.scss`) — unchanged;
+  this spec repositions the scrollbar, it doesn't restyle it.
+
+## 5. Risks / things the implementer must check
+
+1. **FLIP height animation** (`ToolOverlayLog.tsx:342`, `flipHeight`) —
+   measures and animates the log's `height` and briefly forces
+   `overflow-y: hidden`. Padding is inside the measured box; changing it
+   changes measured heights but not the mechanism. No code change expected;
+   verify expand/collapse still animates smoothly.
+2. **Preview zoom** (`fontScale` inline `font-size` on the log,
+   `ToolOverlayLog.tsx:308`) — padding is px-based and unaffected by
+   font-size scaling; confirm Ctrl+scroll zoom inside a preview doesn't
+   reveal layout oddities at the new tighter right edge.
+3. **Stick-to-bottom scroll logic** (`onScroll`, `ToolOverlayLog.tsx`)
+   — reads scrollTop/scrollHeight; padding-neutral. No change expected.
+4. **Per-tool inner chrome now reaching the edge**: `.agent-bash-cmd`'s
+   command bar, `.agent-bash-exit`, `.agent-diff-header`, and bordered
+   content boxes (`.agent-tool-read-content`'s 1px border,
+   `.agent-tool-search-results`) will sit 8px closer to the panel edge on
+   both sides. This is the intended full-bleed direction, but eyeball each
+   of Read (code + markdown variants), Bash, Write, Edit/diff (plain +
+   Shiki-highlighted), Grep/Glob, and the compact default — the spec's
+   whole premise is that these share one shell, so one CSS edit moves all
+   of them at once.
+5. **Responsive tiers** (`_responsive.scss:58`) — only overrides
+   `max-height` at wide widths; no padding interaction.
+6. **Awaiting-approval / failed states** — the header renders only in
+   non-success states; check one of these states so the header's new
+   full-width divider and 8px inset are seen together with the log.
+
+## 6. Test plan
+
+Visual (via `task dev`, or `scripts\dev-agent.cmd` from an agent shell),
+with an agent producing real tool calls:
+
+- [ ] Read (a `.rs`/`.ts` file → Shiki path, and a `.md` file → markdown
+      path): scrollbar flush at panel right edge; no dead strip outboard of
+      the track; content ↔ scrollbar gap looks intentional.
+- [ ] Bash with long output: vertical scrollbar flush; cmd header bar and
+      exit-code bar span edge to edge; with a long unwrapped line,
+      horizontal scrollbar flush at the panel bottom edge.
+- [ ] Write: same checks as Read.
+- [ ] Edit (diff, both plain and highlighted): add/del line backgrounds
+      extend to the new content width; no clipped diff markers.
+- [ ] Grep/Glob + a default/compact tool: bordered result boxes look right
+      at the new inset.
+- [ ] Expand/collapse a panel (pin + auto-expand paths): 120ms collapse
+      still animates cleanly; no flash from the padding change.
+- [ ] Ctrl+scroll preview zoom at min/max scale: no overlap of content and
+      scrollbar.
+- [ ] Persistent shell block's build log (reuses the log class): unchanged
+      or improved; no regression from 4.2's right-padding change.
+- [ ] Activity feed (ActivityRow): confirm visually unchanged (its own
+      padding override wins), guarding §4.4's cascade claim.
+- [ ] One non-success state (denied/failed) for the header divider width.
+- [ ] `npx tsc --noEmit` + frontend tests — CSS-only change, expect clean.
+
+## 7. Summary
+
+One 8px `padding` on `.agent-tool-panel` is the entire reported bug: it
+insets the shared scroll container — scrollbar and all — from the preview
+surface's edge, and every tool preview inherits it because they all render
+inside that one panel + one scroll container. Zero the panel's padding,
+re-home the vertical inset onto the log, and tighten the log's
+scrollbar-side padding; the header and per-tool section bars then land
+full-bleed as a natural consequence. One SCSS file edit for the mechanism
+(4.1), one for the log (4.2), everything else is verification.

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -362,7 +362,15 @@
             // shade is what the user actually sees for every tool type.
             background: color-mix(in srgb, var(--main-text-color) 4%, var(--main-bg-color));
             border-radius: 0;
-            padding: 6px 8px;
+            // Zero padding — the inset lives on the children
+            // (.agent-tool-overlay-header / .agent-tool-overlay-log) so the
+            // log's scrollbars sit flush at THIS surface's edges. A
+            // ::-webkit-scrollbar renders inside its owning element's box,
+            // so any padding here pushes the scroll container — track and
+            // all — inboard of the visible panel edge, leaving a dead strip
+            // outboard of the scrollbar.
+            // SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md.
+            padding: 0;
             max-height: 50vh;
             min-height: 0;
             overflow: hidden;

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -43,7 +43,15 @@
     overflow-x: auto;
     overflow-y: auto;
     overscroll-behavior: contain;
-    padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
+    // The enclosing .agent-tool-panel has ZERO padding (see its comment in
+    // _document-nodes.scss) so this box — and therefore its scrollbars —
+    // reaches the panel's edges. This padding is the content's own inset,
+    // measured from the true surface edge: left/top/bottom carry the
+    // breathing room the panel used to provide; right is deliberately
+    // smaller because it only separates content from the scrollbar (the
+    // scrollbar itself now provides the edge separation).
+    // SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md.
+    padding: var(--space-1-5) var(--space-1) var(--space-1-5) var(--space-2);
 
     .agent-tool-log-line {
         margin: 0;


### PR DESCRIPTION
## Summary
- First of a tool-preview refinement series: removes the dead strip between every tool preview's scrollbar and the preview surface's edge.
- Root cause (measured in `docs/specs/SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md`, included): all tool previews (Read, Bash, Write, Edit, Grep/Glob, Agent, Task, default) share one scroll container, `.agent-tool-overlay-log`, inside `.agent-tool-panel` whose `padding: 6px 8px` inset the log's entire box — scrollbar included — 8px inboard of the visible surface edge. A `::-webkit-scrollbar` renders inside its owning element's box, so the panel padding is what floated the track away from the edge.
- Fix: panel padding → 0; the log carries the inset itself (left/top/bottom unchanged breathing room, right tightened to 4px since it now only separates content from the scrollbar). Two SCSS declarations changed total.
- Intended side effects: the overlay header's divider and per-tool section bars (bash cmd/exit rows, diff header) now run full-bleed across the panel, and preview content gains ~8px usable width per side (content inset was a double-stacked 16px, now 8px, matching the header).
- Not affected (verified via cascade order, documented in the spec): ActivityRow's live activity feed reuses the log class but overrides padding with a later-imported rule.

## Test plan
- [x] `npx stylelint` on both edited files — identical error output before/after (all pre-existing grandfathered issues; zero new)
- [x] `npx vitest run` — 2385 passed, 0 failed
- [ ] Visual pass per the spec's §6 matrix (Read code/markdown, Bash long output + horizontal scroll, Write, Edit plain/highlighted diff, Grep/Glob, expand/collapse animation, preview zoom, persistent shell block, one failed/denied state) — reviewer or post-merge dev-build check

<!-- agentmux:agent_id=agent2 -->