### PR TITLE
fix(build): fail production builds when VITE_MUXBUS_CLIENT_ID resolves empty

### DIFF
--- a/.changesets/1786194007-fix-build-fail-production-builds-when-vite-muxbus-client-id--v10c.md
+++ b/.changesets/1786194007-fix-build-fail-production-builds-when-vite-muxbus-client-id--v10c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): fail production builds when VITE_MUXBUS_CLIENT_ID resolves empty

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,42 @@ function platformResolve(): Plugin {
 }
 
 /**
+ * Fails a production build outright when VITE_MUXBUS_CLIENT_ID resolves
+ * empty. The MuxBus Cloud UI (HostPopover / AgentMuxConnectPanel /
+ * accounts-manager) is gated on `isConfigured()` — client ID baked in at
+ * compile time — so a build that silently loses the env var ships with the
+ * entire MuxBus section invisibly absent, indistinguishable from a good
+ * build until someone notices missing UI. That exact failure shipped in the
+ * 2026-08-05 portable (frontend/.env.production was present and correct,
+ * but that one build run didn't load it — cause transient, never
+ * reproduced). The env file is committed, so a correctly-functioning build
+ * can never trip this; if it fires, the env pipeline itself is broken and
+ * the build MUST not ship.
+ *
+ * Production mode only: `--mode dev` builds and the dev server are never
+ * blocked (dev loads .env.development live, and a dev loop shouldn't die
+ * over cloud-login config).
+ */
+function requireMuxBusClientId(): Plugin {
+    return {
+        name: "require-muxbus-client-id",
+        apply: "build",
+        configResolved(config) {
+            if (config.mode !== "production") return;
+            if (!config.env.VITE_MUXBUS_CLIENT_ID) {
+                throw new Error(
+                    "[require-muxbus-client-id] VITE_MUXBUS_CLIENT_ID is empty in a production build. " +
+                        "It should have been loaded from frontend/.env.production (committed). " +
+                        "An empty ID compiles isConfigured() to false and silently hides all MuxBus Cloud UI — " +
+                        "refusing to build. Check envDir resolution and that nothing in the build " +
+                        "environment shadows VITE_MUXBUS_CLIENT_ID with an empty value.",
+                );
+            }
+        },
+    };
+}
+
+/**
  * Strips redundant KaTeX font formats (TTF, WOFF) from the build output.
  * KaTeX CSS lists woff2/woff/ttf as @font-face fallbacks; CEF's bundled
  * Chromium only needs woff2, so the others are dead weight (~876 KB).
@@ -148,6 +184,7 @@ export default defineConfig({
         },
     },
     plugins: [
+        requireMuxBusClientId(),
         platformResolve(),
         tsconfigPaths(),
         svgr({


### PR DESCRIPTION
## Summary

The 2026-08-05 Desktop portable shipped with the **entire MuxBus Cloud UI invisibly absent** — the HostPopover section, the per-agent Identity panel section, and the Armory Accounts tile all gone. Root cause (forensically confirmed against the shipped bundle): that one build run didn't load `frontend/.env.production`, so `VITE_MUXBUS_CLIENT_ID` compiled to `""`, `isConfigured()` folded to `false`, and the `<Show>` gates hid everything. The minifier even dead-code-eliminated the whole login path (the Cognito domain string is absent from the shipped bundle too), which is what made a bad build byte-for-byte indistinguishable from a good one until a user noticed missing UI.

The env file was present and correct at the build commit, the tree was clean (no `.dirty` label), and rebuilds from the same checkout bake the ID correctly today — the env loss was transient and unreproducible. Which is exactly why this needs a guard rather than a one-off fix.

## Change

New `requireMuxBusClientId()` Vite plugin: **production builds now fail loudly at config time** if the resolved env lacks the client ID, with a message pointing at the env pipeline. Since `frontend/.env.production` is committed, a correctly-functioning build can never trip this — if it fires, the build environment is broken and the artifact must not ship. `--mode dev` builds and the dev server are never blocked.

## Test plan

- [x] Production build with `VITE_MUXBUS_CLIENT_ID=` shadowed empty (the exact suspected Aug 5 failure mode) → build **fails** with the guard's message, exit 1
- [x] Normal production build → passes; verified `26odoigu…` client ID present in the output bundle
- [x] `--mode dev` build with the same empty shadow → guard does not fire, build proceeds

<!-- agentmux:agent_id=agenty-0629j -->