### PR TITLE
fix(agent-stream): don't end the turn on mid-turn narration text (stop_reason gate)

### DIFF
--- a/.changesets/1786194396-fix-agent-stream-don-t-end-the-turn-on-mid-turn-narration-te-coie.md
+++ b/.changesets/1786194396-fix-agent-stream-don-t-end-the-turn-on-mid-turn-narration-te-coie.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-stream): don't end the turn on mid-turn narration text (stop_reason gate)

--- a/frontend/app/view/agent/providers/claude-translator.test.ts
+++ b/frontend/app/view/agent/providers/claude-translator.test.ts
@@ -51,6 +51,61 @@ describe("ClaudeTranslator", () => {
             expect(events).toHaveLength(0);
         });
 
+        it("does NOT end the turn on a text-only frame stamped stop_reason 'tool_use' (mid-turn narration)", () => {
+            // 2026-08-08 recurrence: the CLI emits one assistant frame PER
+            // content block, so narration text before a tool call arrives as
+            // its own text-only frame — with the API message's stop_reason
+            // ("tool_use") stamped on it. That frame must not settle the UI
+            // to "Worked": the tool call from the same message is still
+            // coming in the next frame. 377 of 409 text-only frames in a
+            // real captured session were this kind.
+            const t = new ClaudeTranslator();
+            const events = t.translate({
+                type: "assistant",
+                message: {
+                    content: [{ type: "text", text: "Now let me check the config file." }],
+                    stop_reason: "tool_use",
+                },
+            });
+            expect(events).toHaveLength(0);
+        });
+
+        it("ends the turn on a text-only frame stamped stop_reason 'end_turn' (genuine final)", () => {
+            const t = new ClaudeTranslator();
+            const events = t.translate({
+                type: "assistant",
+                message: {
+                    content: [{ type: "text", text: "All done — the fix is merged." }],
+                    stop_reason: "end_turn",
+                },
+            });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("session_end");
+        });
+
+        it("ends the turn on a text-only frame with NO stop_reason (older CLI compat — cannot reintroduce #1757 stuck-forever)", () => {
+            const t = new ClaudeTranslator();
+            const events = t.translate({
+                type: "assistant",
+                message: { content: [{ type: "text", text: "Done." }] },
+            });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("session_end");
+        });
+
+        it("ends the turn on stop_reason 'stop_sequence' (terminal, just not end_turn)", () => {
+            const t = new ClaudeTranslator();
+            const events = t.translate({
+                type: "assistant",
+                message: {
+                    content: [{ type: "text", text: "output" }],
+                    stop_reason: "stop_sequence",
+                },
+            });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("session_end");
+        });
+
         it("does NOT emit session_end when tool_use is accompanied by text in the same message", () => {
             const t = new ClaudeTranslator();
             const events = t.translate({

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -238,7 +238,21 @@ export class ClaudeTranslator implements OutputTranslator {
         // SPEC_PERSISTENT_TURN_END_TEXT_GATE_2026_07_30.md. In subprocess
         // (--print) mode the "result" event fires a duplicate TurnEnd, which
         // is a no-op (first-done-wins in the reducer).
-        if (!hasToolUse && hasText) {
+        //
+        // stop_reason check (2026-08-08 recurrence of the same symptom the
+        // text gate was built for): the CLI splits each API message into ONE
+        // assistant frame PER content block — a real session showed zero
+        // combined [text, tool_use] frames across 1,790 assistant frames.
+        // Narration text preceding a tool call therefore arrives as its own
+        // text-only frame (hasText, no tool_use) and passed the gate, ending
+        // the turn mid-work — 377 of 409 text-only frames in that session
+        // were this mid-turn kind, all stamped stop_reason "tool_use", while
+        // genuine finals carry "end_turn"/"stop_sequence". Only suppress on
+        // an AFFIRMATIVE "tool_use" — null/undefined (an older CLI that
+        // doesn't stamp it) and every terminal reason still end the turn, so
+        // this cannot reintroduce #1757's stuck-forever failure; the 180s
+        // liveness watchdog remains the backstop either way.
+        if (!hasToolUse && hasText && message.stop_reason !== "tool_use") {
             events.push({ type: "session_end", stats: {} });
         }
         return events;


### PR DESCRIPTION
## Summary

Recurrence of the premature-"Worked" symptom that `SPEC_PERSISTENT_TURN_END_TEXT_GATE_2026_07_30.md` / #2369 fixed: status flips from "Working…" to "Worked" while the agent is clearly mid-work (tool calls still coming). User-reported with the exact invariant this fix encodes: *"the agent will always output a normal text message at the end — 'Worked' can never happen except after a text output."*

**Root cause — the #2369 text gate is intact but the CLI's frame shape defeats it.** Verified against a real captured session (1,790 assistant frames): the CLI emits **one assistant frame per content block** — zero combined `[text, tool_use]` frames exist in the whole session. So narration text preceding a tool call ("Now let me check the config…") arrives as its own text-only frame, passes the `hasText && !hasToolUse` gate, and fires `session_end` mid-turn. **377 of 409 text-only frames in that session were this mid-turn kind** — every one a premature "Worked" flip.

**The fix, from the same data:** every frame is stamped with its API message's `stop_reason`. All 377 mid-turn text frames carry `"tool_use"`; genuine finals carry `"end_turn"` (32) or `"stop_sequence"` (1). New gate:

```ts
if (!hasToolUse && hasText && message.stop_reason !== "tool_use")
```

Only an **affirmative** `"tool_use"` suppresses — `null`/`undefined` (an older CLI that doesn't stamp it) and every terminal reason still end the turn, so this cannot reintroduce #1757's stuck-forever failure; the 180s liveness watchdog remains the backstop either way.

## Test plan

- [x] 4 new tests: mid-turn narration (`stop_reason: "tool_use"`) suppressed; `end_turn`, `stop_sequence`, and missing-`stop_reason` all still end the turn
- [x] Mutation-tested: reverting the gate to the old condition makes the narration test fail (confirmed, then restored)
- [x] `npx vitest run frontend/app/view/agent/providers/claude-translator.test.ts` — 31/31
- [x] `npx vitest run frontend/app/view/agent/` — 1024/1024
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=agentx -->