### PR TITLE
feat(statusbar): Disk readout explains its % in the tooltip; click opens a per-drive popover

### DIFF
--- a/.changesets/1786195261-feat-statusbar-disk-readout-explains-its-in-the-tooltip-clic-toq5.md
+++ b/.changesets/1786195261-feat-statusbar-disk-readout-explains-its-in-the-tooltip-clic-toq5.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(statusbar): Disk readout explains its % in the tooltip; click opens a per-drive free-space popover

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -5,9 +5,7 @@
 //! and publishes them via the WPS broker. Sampling interval is configurable
 //! via the `telemetry:interval` setting (0.1s–2.0s, default 1.0s).
 
-use std::collections::HashMap;
-#[cfg(target_os = "windows")]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -301,6 +299,13 @@ fn get_pagefile_volume_data(_values: &mut HashMap<String, f64>) {
                 "disk:pagefile_system_managed".to_string(),
                 if system_managed { 1.0 } else { 0.0 },
             );
+            // Marks which disk:vol:<mount>:* volume (get_disk_data) the
+            // pagefile-volume gauge above refers to, so the status bar can
+            // name the drive ("C:") in its Disk readout without a separate
+            // string channel — the values map is f64-only, so the letter
+            // rides in the key. Mount format matches sysinfo's Windows
+            // mount_point() ("C:\").
+            _values.insert(format!("disk:vol:{}:\\:watch", drive), 1.0);
         }
     }
 }
@@ -460,6 +465,35 @@ impl NetState {
 /// sysinfo Disk::usage() returns deltas (bytes since last refresh) so we
 /// divide by elapsed time to get rates.
 fn get_disk_data(disks: &Disks, elapsed_secs: f64, values: &mut HashMap<String, f64>) {
+    // Per-volume capacity/free, keyed by mount point:
+    //   disk:vol:<mount>:free_gb / disk:vol:<mount>:total_gb
+    // (e.g. `disk:vol:C:\:free_gb` — the mount's own colons/backslashes are
+    // fine inside the key; consumers anchor on the `disk:vol:` prefix and the
+    // known suffix). Feeds the status bar's Disk popover (per-drive free
+    // space). Deduped by mount point — sysinfo can list one volume once per
+    // physical disk it spans — and zero-capacity entries (empty card
+    // readers, unformatted media) are skipped rather than shown as "0G".
+    let mut seen_mounts: HashSet<&std::path::Path> = HashSet::new();
+    for disk in disks.list() {
+        let mount = disk.mount_point();
+        if !seen_mounts.insert(mount) {
+            continue;
+        }
+        let total = disk.total_space();
+        if total == 0 {
+            continue;
+        }
+        let mount_str = mount.to_string_lossy();
+        values.insert(
+            format!("disk:vol:{}:free_gb", mount_str),
+            disk.available_space() as f64 / BYTES_PER_GB,
+        );
+        values.insert(
+            format!("disk:vol:{}:total_gb", mount_str),
+            total as f64 / BYTES_PER_GB,
+        );
+    }
+
     if elapsed_secs <= 0.0 {
         return;
     }

--- a/frontend/app/statusbar/DiskVolumesPopover.tsx
+++ b/frontend/app/statusbar/DiskVolumesPopover.tsx
@@ -21,6 +21,11 @@ import { diskFreeColor, formatDiskGb, parseDiskVolumes, type DiskVolume } from "
 
 interface DiskVolumesPopoverProps {
     anchorRect: DOMRect | null;
+    /** Parent's latest parsed snapshot — seeds the list so opening the panel
+     *  shows data immediately instead of "Reading drives…" until the next
+     *  sysinfo tick (the WPS route suppresses event replay for this second
+     *  subscription, so a fresh mount would otherwise start empty). */
+    initialVolumes?: DiskVolume[];
     ref?: (el: HTMLDivElement) => void;
 }
 
@@ -31,7 +36,7 @@ export const DiskVolumesPopover = (props: DiskVolumesPopoverProps): JSX.Element 
     // bar overlaps — same primitive as CpuCoresPopover / TokenBreakdownPopover.
     usePaneOverlay(() => rootRef);
 
-    const [volumes, setVolumes] = createSignal<DiskVolume[]>([]);
+    const [volumes, setVolumes] = createSignal<DiskVolume[]>(props.initialVolumes ?? []);
 
     onMount(() => {
         const unsub = waveEventSubscribe({

--- a/frontend/app/statusbar/DiskVolumesPopover.tsx
+++ b/frontend/app/statusbar/DiskVolumesPopover.tsx
@@ -1,0 +1,131 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DiskVolumesPopover — click-opened panel anchored under the status-bar Disk
+ * readout. Lists every mounted volume with its free space. The backend
+ * publishes per-volume capacity in the same `sysinfo`/`local` event the rest
+ * of the status bar consumes (`disk:vol:<mount>:free_gb` / `:total_gb`, see
+ * sysinfo.rs::get_disk_data), so this is a pure-frontend view — the sibling
+ * of CpuCoresPopover's per-core panel, sharing its positioning + airspace
+ * pattern (usePaneOverlay, computeMenuPosition top-end, autoUpdate).
+ */
+
+import { createSignal, Index, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { autoUpdate } from "@floating-ui/dom";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { computeMenuPosition } from "@/app/util/menu-position";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { WpsEvent } from "@/app/store/wps-events";
+import { diskFreeColor, formatDiskGb, parseDiskVolumes, type DiskVolume } from "./disk-volumes";
+
+interface DiskVolumesPopoverProps {
+    anchorRect: DOMRect | null;
+    ref?: (el: HTMLDivElement) => void;
+}
+
+export const DiskVolumesPopover = (props: DiskVolumesPopoverProps): JSX.Element => {
+    let rootRef: HTMLDivElement | undefined;
+
+    // Airspace cut so the popover paints over any browser-pane HWND the status
+    // bar overlaps — same primitive as CpuCoresPopover / TokenBreakdownPopover.
+    usePaneOverlay(() => rootRef);
+
+    const [volumes, setVolumes] = createSignal<DiskVolume[]>([]);
+
+    onMount(() => {
+        const unsub = waveEventSubscribe({
+            eventType: WpsEvent.SysInfo,
+            scope: "local",
+            handler: (event) => {
+                const vals = (event as WaveEvent)?.data?.values;
+                if (vals == null) return;
+                setVolumes(parseDiskVolumes(vals));
+            },
+        });
+        onCleanup(() => unsub?.());
+    });
+
+    // ── Positioning (mirrors CpuCoresPopover / TokenBreakdownPopover) ────────
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
+    });
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerFloating = (el: HTMLDivElement) => {
+        rootRef = el;
+        props.ref?.(el);
+        requestAnimationFrame(() => {
+            const r = props.anchorRect;
+            if (!r || !(el instanceof Element)) return;
+            const update = async () => {
+                const cur = props.anchorRect;
+                if (!cur) return;
+                const pos = await computeMenuPosition({ anchor: cur, placement: "top-end", avoidNativePanes: false }, el);
+                setFloatingStyle(pos.style);
+            };
+            cleanupAutoUpdate?.();
+            cleanupAutoUpdate = autoUpdate(
+                { getBoundingClientRect: () => props.anchorRect ?? r },
+                el,
+                update,
+            );
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
+
+    const usedPct = (v: DiskVolume): number => {
+        if (v.totalGb <= 0) return 0;
+        return Math.min(100, Math.max(0, ((v.totalGb - v.freeGb) / v.totalGb) * 100));
+    };
+
+    return (
+        <div
+            ref={registerFloating}
+            class="disk-volumes-popover"
+            role="dialog"
+            aria-label="Free space per disk drive"
+            data-pane-overlay
+            style={{ ...floatingStyle(), width: "300px" }}
+        >
+            <div class="disk-volumes-header">
+                <span class="disk-volumes-title">Disk Space</span>
+                <span class="disk-volumes-count">
+                    {volumes().length} {volumes().length === 1 ? "drive" : "drives"}
+                </span>
+            </div>
+
+            <Show
+                when={volumes().length > 0}
+                fallback={<div class="disk-volumes-empty">Reading drives…</div>}
+            >
+                <div class="disk-volumes-list">
+                    <Index each={volumes()}>
+                        {(v) => (
+                            <div class="disk-volume">
+                                <span class="disk-volume-label">{v().label}</span>
+                                <span class="disk-volume-bar" aria-hidden="true">
+                                    <span
+                                        class="disk-volume-bar-fill"
+                                        style={{ width: `${usedPct(v())}%` }}
+                                    />
+                                </span>
+                                <span
+                                    class="disk-volume-free"
+                                    style={{ color: diskFreeColor(v().freeGb, v().totalGb) }}
+                                >
+                                    {formatDiskGb(v().freeGb)} free of {formatDiskGb(v().totalGb)}
+                                </span>
+                            </div>
+                        )}
+                    </Index>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+DiskVolumesPopover.displayName = "DiskVolumesPopover";

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -4,6 +4,7 @@
 @use "./token-usage";
 @use "./instance-panel";
 @use "./cpu-cores-popover";
+@use "./disk-volumes-popover";
 @use "./maintenance-section";
 
 .status-bar {

--- a/frontend/app/statusbar/SystemStats.tsx
+++ b/frontend/app/statusbar/SystemStats.tsx
@@ -6,7 +6,9 @@ import { WpsEvent } from "@/app/store/wps-events";
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { CpuCoresPopover } from "./CpuCoresPopover";
+import { DiskVolumesPopover } from "./DiskVolumesPopover";
 import { cpuColor } from "./cpu-color";
+import { diskTooltip, parseDiskVolumes, type DiskVolume } from "./disk-volumes";
 
 type SysStats = {
     cpu: number;
@@ -73,6 +75,9 @@ function pagefileDiskColor(freePct: number | null, systemManaged: boolean): stri
 
 const SystemStats = (): JSX.Element => {
     const [stats, setStats] = createSignal<SysStats | null>(null);
+    // Per-volume list — feeds the Disk readout's tooltip (naming the drive
+    // the % refers to) and is re-parsed live inside DiskVolumesPopover.
+    const [diskVolumes, setDiskVolumes] = createSignal<DiskVolume[]>([]);
 
     // Per-core CPU panel — opened by clicking the CPU readout. Mirrors the
     // TokenUsageIndicator → TokenBreakdownPopover interaction.
@@ -90,6 +95,21 @@ const SystemStats = (): JSX.Element => {
         setCpuPanelOpen(true);
     };
 
+    // Per-drive Disk panel — same interaction as the CPU panel above.
+    const [diskPanelOpen, setDiskPanelOpen] = createSignal(false);
+    const [diskAnchorRect, setDiskAnchorRect] = createSignal<DOMRect | null>(null);
+    let diskButtonRef: HTMLButtonElement | undefined;
+    let diskPopoverRef: HTMLDivElement | undefined;
+
+    const toggleDiskPanel = () => {
+        if (diskPanelOpen()) {
+            setDiskPanelOpen(false);
+            return;
+        }
+        if (diskButtonRef) setDiskAnchorRect(diskButtonRef.getBoundingClientRect());
+        setDiskPanelOpen(true);
+    };
+
     // Close on outside click (ignoring the button + popover) and on Esc.
     createEffect(() => {
         if (!cpuPanelOpen()) return;
@@ -102,6 +122,27 @@ const SystemStats = (): JSX.Element => {
             if (e.key === "Escape") {
                 e.stopPropagation();
                 setCpuPanelOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", onDown, true);
+        window.addEventListener("keydown", onKey, true);
+        onCleanup(() => {
+            document.removeEventListener("mousedown", onDown, true);
+            window.removeEventListener("keydown", onKey, true);
+        });
+    });
+
+    createEffect(() => {
+        if (!diskPanelOpen()) return;
+        const onDown = (e: MouseEvent) => {
+            const t = e.target as Node;
+            if (diskButtonRef?.contains(t) || diskPopoverRef?.contains(t)) return;
+            setDiskPanelOpen(false);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.stopPropagation();
+                setDiskPanelOpen(false);
             }
         };
         document.addEventListener("mousedown", onDown, true);
@@ -134,6 +175,7 @@ const SystemStats = (): JSX.Element => {
                     pagefileVolumeFreePct: vals["disk:pagefile_volume:free_pct"] ?? null,
                     pagefileSystemManaged: (vals["disk:pagefile_system_managed"] ?? 0) > 0,
                 });
+                setDiskVolumes(parseDiskVolumes(vals));
             },
         });
         onCleanup(() => unsub?.());
@@ -195,26 +237,39 @@ const SystemStats = (): JSX.Element => {
                             PF {formatMemBytes(s().commitUsed)}/{formatMemBytes(s().commitTotal)}
                         </span>
                     </Show>
-                    {/* SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 — surfaces the
-                        CAUSE the PF gauge above can't see: a system-managed page file
-                        that wants to grow but can't because its volume is low on free
-                        space. Only rendered once the backend has a reading (Windows-only
-                        gauge; absent elsewhere). */}
+                    {/* Free-space share of the system drive (the volume Windows backs
+                        its page file with — SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29
+                        §5.2 P0 is why THIS volume is the one watched, and the color
+                        thresholds still encode that risk). The tooltip deliberately
+                        explains only what the number is — free ÷ capacity, with live
+                        figures — the page-file significance belongs to the PF gauge's
+                        own tooltip. Click opens the per-drive breakdown (all volumes,
+                        free space each), mirroring the CPU per-core panel. Only
+                        rendered once the backend has a reading (Windows-only gauge;
+                        absent elsewhere). */}
                     <Show when={s().pagefileVolumeFreePct != null}>
                         <span class="stat-separator">|</span>
-                        <span
-                            class="stat-mono stat-pagefile-disk"
+                        <button
+                            type="button"
+                            ref={diskButtonRef}
+                            class="stat-mono stat-pagefile-disk stat-disk-button"
                             style={{ color: pagefileDiskColor(s().pagefileVolumeFreePct, s().pagefileSystemManaged) }}
-                            data-tip={
-                                (s().pagefileSystemManaged
-                                    ? "Free space on the page-file volume. Low free space can silently cap how large Windows lets the page file (and therefore the commit limit above) grow. "
-                                    : "Free space on the page-file volume. The page file here is a fixed size, so this isn't a growth-ceiling risk. ") +
-                                (s().pagefileVolumeFreeGb != null ? `${formatMemBytes(s().pagefileVolumeFreeGb!)} free.` : "")
-                            }
-                            aria-label="Page-file volume free disk space"
+                            onClick={toggleDiskPanel}
+                            data-tip={diskTooltip(diskVolumes())}
+                            aria-label="Free disk space, click for per-drive breakdown"
+                            aria-haspopup="dialog"
+                            aria-expanded={diskPanelOpen()}
                         >
                             Disk {Math.round(s().pagefileVolumeFreePct!)}%
-                        </span>
+                        </button>
+                        <Show when={diskPanelOpen()}>
+                            <Portal>
+                                <DiskVolumesPopover
+                                    anchorRect={diskAnchorRect()}
+                                    ref={(el) => { diskPopoverRef = el; }}
+                                />
+                            </Portal>
+                        </Show>
                     </Show>
                     {/* Network indicator stays mounted even at 0/0 so the user
                         can glance at the bar and see "nothing going in or out",

--- a/frontend/app/statusbar/SystemStats.tsx
+++ b/frontend/app/statusbar/SystemStats.tsx
@@ -266,6 +266,7 @@ const SystemStats = (): JSX.Element => {
                             <Portal>
                                 <DiskVolumesPopover
                                     anchorRect={diskAnchorRect()}
+                                    initialVolumes={diskVolumes()}
                                     ref={(el) => { diskPopoverRef = el; }}
                                 />
                             </Portal>

--- a/frontend/app/statusbar/_disk-volumes-popover.scss
+++ b/frontend/app/statusbar/_disk-volumes-popover.scss
@@ -1,0 +1,115 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Status-bar Disk readout button + per-drive panel — sibling of
+// _cpu-cores-popover.scss (same chrome, simpler content: one row tier).
+
+// Clickable Disk readout in the status bar (the <button> wrapping "Disk n%").
+.stat-disk-button {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    padding: 0 2px;
+    margin: 0;
+    cursor: default;
+    border-radius: 0;
+    transition: background 80ms ease;
+
+    &:hover {
+        background: var(--hover-bg-color);
+    }
+
+    &:focus-visible {
+        outline: 1px solid var(--accent-color);
+        outline-offset: -1px;
+    }
+}
+
+.disk-volumes-popover {
+    background: var(--modal-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    color: var(--main-text-color);
+    font-size: 12px;
+    zoom: var(--zoomfactor);
+    z-index: var(--zindex-modal-wrapper);
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-2) 0;
+    user-select: none;
+
+    .disk-volumes-header {
+        padding: 0 var(--space-3) var(--space-1-5);
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-2);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .disk-volumes-title {
+        font-weight: 600;
+        font-size: 13px;
+    }
+
+    .disk-volumes-count {
+        color: var(--secondary-text-color);
+        font-size: 11px;
+    }
+
+    .disk-volumes-empty {
+        padding: var(--space-3);
+        color: var(--secondary-text-color);
+    }
+
+    .disk-volumes-list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        padding: var(--space-2) var(--space-3) var(--space-1);
+        max-height: 300px;
+        overflow-y: auto;
+    }
+
+    .disk-volume {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .disk-volume-label {
+        flex: 0 0 44px;
+        font-family: var(--monofontfamily, monospace);
+        color: var(--main-text-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    // Used-share bar: fill = used fraction, so a nearly-full drive reads as a
+    // nearly-full bar at a glance (free space is spelled out in the text).
+    .disk-volume-bar {
+        flex: 1 1 auto;
+        height: 6px;
+        background: color-mix(in srgb, var(--border-color) 60%, transparent);
+        overflow: hidden;
+        display: inline-block;
+    }
+
+    .disk-volume-bar-fill {
+        display: block;
+        height: 100%;
+        background: color-mix(in srgb, var(--accent-color) 45%, var(--secondary-text-color));
+    }
+
+    .disk-volume-free {
+        flex: 0 0 auto;
+        font-family: var(--monofontfamily, monospace);
+        font-size: 11px;
+        white-space: nowrap;
+    }
+}

--- a/frontend/app/statusbar/disk-volumes.test.ts
+++ b/frontend/app/statusbar/disk-volumes.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { diskFreeColor, diskTooltip, formatDiskGb, parseDiskVolumes } from "./disk-volumes";
+
+describe("parseDiskVolumes", () => {
+    it("parses Windows mounts whose own colons/backslashes sit inside the key", () => {
+        const vols = parseDiskVolumes({
+            "disk:vol:C:\\:free_gb": 120.5,
+            "disk:vol:C:\\:total_gb": 460.2,
+            "disk:vol:D:\\:free_gb": 900,
+            "disk:vol:D:\\:total_gb": 1000,
+        });
+        expect(vols).toEqual([
+            { label: "C:", freeGb: 120.5, totalGb: 460.2, isWatch: false },
+            { label: "D:", freeGb: 900, totalGb: 1000, isWatch: false },
+        ]);
+    });
+
+    it("parses unix-style mounts, keeping bare '/' intact", () => {
+        const vols = parseDiskVolumes({
+            "disk:vol:/:free_gb": 40,
+            "disk:vol:/:total_gb": 100,
+            "disk:vol:/home:free_gb": 10,
+            "disk:vol:/home:total_gb": 50,
+        });
+        expect(vols.map((v) => v.label)).toEqual(["/", "/home"]);
+    });
+
+    it("flags the watch volume and ignores unrelated sysinfo keys", () => {
+        const vols = parseDiskVolumes({
+            cpu: 12,
+            "disk:read": 1.5,
+            "disk:pagefile_volume:free_pct": 26,
+            "disk:vol:C:\\:free_gb": 120,
+            "disk:vol:C:\\:total_gb": 460,
+            "disk:vol:C:\\:watch": 1,
+            "disk:vol:D:\\:free_gb": 900,
+            "disk:vol:D:\\:total_gb": 1000,
+        });
+        expect(vols.find((v) => v.label === "C:")?.isWatch).toBe(true);
+        expect(vols.find((v) => v.label === "D:")?.isWatch).toBe(false);
+    });
+
+    it("drops a volume missing either side of the pair instead of fabricating a 0", () => {
+        const vols = parseDiskVolumes({
+            "disk:vol:C:\\:free_gb": 120,
+            // total missing — torn/partial tick
+            "disk:vol:D:\\:total_gb": 1000,
+            // free missing
+        });
+        expect(vols).toEqual([]);
+    });
+
+    it("sorts by label", () => {
+        const vols = parseDiskVolumes({
+            "disk:vol:E:\\:free_gb": 1,
+            "disk:vol:E:\\:total_gb": 2,
+            "disk:vol:C:\\:free_gb": 1,
+            "disk:vol:C:\\:total_gb": 2,
+        });
+        expect(vols.map((v) => v.label)).toEqual(["C:", "E:"]);
+    });
+});
+
+describe("formatDiskGb", () => {
+    it("formats terabytes, gigabytes, and megabytes", () => {
+        expect(formatDiskGb(1536)).toBe("1.5T");
+        expect(formatDiskGb(320.44)).toBe("320.4G");
+        expect(formatDiskGb(0.5)).toBe("512M");
+    });
+});
+
+describe("diskTooltip", () => {
+    it("names the watch drive with live figures and never mentions the page file", () => {
+        const tip = diskTooltip([
+            { label: "C:", freeGb: 120.5, totalGb: 460.2, isWatch: true },
+            { label: "D:", freeGb: 900, totalGb: 1000, isWatch: false },
+        ]);
+        expect(tip).toContain("C:");
+        expect(tip).toContain("120.5G free of 460.2G");
+        expect(tip).toContain("free ÷ capacity");
+        expect(tip.toLowerCase()).not.toContain("page");
+        expect(tip).not.toContain("PF");
+    });
+
+    it("falls back to a generic explanation when no watch volume is known yet", () => {
+        const tip = diskTooltip([]);
+        expect(tip).toContain("free ÷ capacity");
+        expect(tip.toLowerCase()).not.toContain("page");
+    });
+});
+
+describe("diskFreeColor", () => {
+    it("brackets match the pill's own thresholds: <8% error, <15% warning", () => {
+        expect(diskFreeColor(7, 100)).toBe("var(--error-color)");
+        expect(diskFreeColor(14, 100)).toBe("var(--warning-color)");
+        expect(diskFreeColor(50, 100)).toBe("var(--secondary-text-color)");
+        expect(diskFreeColor(1, 0)).toBe("var(--secondary-text-color)"); // no capacity → no judgment
+    });
+});

--- a/frontend/app/statusbar/disk-volumes.ts
+++ b/frontend/app/statusbar/disk-volumes.ts
@@ -1,0 +1,92 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Pure helpers behind the status bar's Disk readout + per-drive popover.
+// Kept free of Solid/DOM so the parsing/formatting is unit-testable
+// (same split as memory-pressure-banner's pure fns).
+
+export interface DiskVolume {
+    /** Display label — mount point with a trailing backslash trimmed ("C:" from "C:\"). */
+    label: string;
+    freeGb: number;
+    totalGb: number;
+    /** True for the volume the status-bar Disk % refers to (the backend's watch target). */
+    isWatch: boolean;
+}
+
+// Matches disk:vol:<mount>:<field> — the mount itself may contain colons and
+// backslashes ("C:\"), so the field suffix anchors the parse and the mount is
+// whatever sits between the fixed prefix and the last-colon suffix.
+const VOL_KEY = /^disk:vol:(.+):(free_gb|total_gb|watch)$/;
+
+/** Trim a mount point for display: "C:\" → "C:", "/home/" stays "/home", "/" stays "/". */
+function displayLabel(mount: string): string {
+    if (mount.length > 1 && (mount.endsWith("\\") || mount.endsWith("/"))) {
+        return mount.slice(0, -1);
+    }
+    return mount;
+}
+
+/**
+ * Parse the sysinfo event's `disk:vol:*` keys into a sorted volume list.
+ * Volumes missing either free or total (torn/partial tick) are dropped
+ * rather than rendered with a fabricated 0.
+ */
+export function parseDiskVolumes(vals: Record<string, number>): DiskVolume[] {
+    const partial = new Map<string, { freeGb?: number; totalGb?: number; isWatch?: boolean }>();
+    for (const key in vals) {
+        const m = VOL_KEY.exec(key);
+        if (!m) continue;
+        const mount = m[1];
+        const entry = partial.get(mount) ?? {};
+        if (m[2] === "free_gb") entry.freeGb = vals[key];
+        else if (m[2] === "total_gb") entry.totalGb = vals[key];
+        else entry.isWatch = (vals[key] ?? 0) > 0;
+        partial.set(mount, entry);
+    }
+    const out: DiskVolume[] = [];
+    for (const [mount, e] of partial) {
+        if (e.freeGb == null || e.totalGb == null || e.totalGb <= 0) continue;
+        out.push({ label: displayLabel(mount), freeGb: e.freeGb, totalGb: e.totalGb, isWatch: !!e.isWatch });
+    }
+    out.sort((a, b) => a.label.localeCompare(b.label));
+    return out;
+}
+
+/** Free-space size for humans: 1.5T / 320.4G / 512M. */
+export function formatDiskGb(gb: number): string {
+    if (gb >= 1024) return `${(gb / 1024).toFixed(1)}T`;
+    if (gb >= 1) return `${gb.toFixed(1)}G`;
+    return `${Math.round(gb * 1024)}M`;
+}
+
+/**
+ * Tooltip for the status-bar Disk % readout. Explains what the number IS —
+ * free ÷ capacity on the named drive — with the live figures. Deliberately
+ * says nothing about the page file: that operational significance lives in
+ * the PF gauge's own tooltip, not here.
+ */
+export function diskTooltip(volumes: DiskVolume[]): string {
+    const watch = volumes.find((v) => v.isWatch);
+    if (watch) {
+        return (
+            `Free space on ${watch.label} — ${formatDiskGb(watch.freeGb)} free of ` +
+            `${formatDiskGb(watch.totalGb)} (% = free ÷ capacity). Click for all drives.`
+        );
+    }
+    return "Free share of the system drive (% = free ÷ capacity). Click for all drives.";
+}
+
+/**
+ * Row color by free share: red under 8% free, amber under 15%, muted
+ * otherwise — same brackets the Disk readout itself uses
+ * (SystemStats.tsx::pagefileDiskColor), so a drive that turns the pill
+ * amber shows the same amber inside the popover.
+ */
+export function diskFreeColor(freeGb: number, totalGb: number): string {
+    if (totalGb <= 0) return "var(--secondary-text-color)";
+    const freePct = (freeGb / totalGb) * 100;
+    if (freePct < 8) return "var(--error-color)";
+    if (freePct < 15) return "var(--warning-color)";
+    return "var(--secondary-text-color)";
+}


### PR DESCRIPTION
## Summary

Per direct user feedback on the status bar's Disk pill:

1. **Hover no longer talks about the page file.** The tooltip now explains what the number actually is — free ÷ capacity on the named drive, with live figures: *"Free space on C: — 120.5G free of 460.2G (% = free ÷ capacity). Click for all drives."* The page-file significance stays on the PF gauge's own tooltip where it belongs. Pill metric and color thresholds unchanged.
2. **Clicking the pill opens a per-drive breakdown** — every mounted volume with free/total and a used-share bar — mirroring the CPU readout's per-core panel (same positioning/airspace/outside-click/Esc pattern, `DiskVolumesPopover` as the sibling of `CpuCoresPopover`).

Backend: `get_disk_data` additionally emits per-volume capacity keyed by mount point (`disk:vol:<mount>:free_gb` / `:total_gb`), deduped by mount point and skipping zero-capacity media (empty card readers). `get_pagefile_volume_data` marks its watch volume (`disk:vol:<mount>:watch`) so the tooltip can name the drive — the values map is f64-only, so the letter rides in the key.

Parsing/formatting/color helpers are pure (`disk-volumes.ts`), covering the tricky Windows case where the mount's own colons/backslashes sit inside the key (`disk:vol:C:\:free_gb`) and dropping torn half-pairs rather than rendering a fabricated 0.

## Test plan

- [x] `vitest` — 9/9 new tests pass (`disk-volumes.test.ts`)
- [x] `tsc --noEmit` — clean
- [x] `cargo check -p agentmux-srv` — clean
- [x] Full production vite build — clean (new SCSS compiles)

<!-- agentmux:agent_id=agenty-0629j -->