### PR TITLE
fix(agent-stream): flush the turn's tail before TurnEnd so panes don't stick on Working

### DIFF
--- a/.changesets/1786195522-fix-agent-stream-flush-the-turn-s-tail-before-turnend-so-pan-0j4n.md
+++ b/.changesets/1786195522-fix-agent-stream-flush-the-turn-s-tail-before-turnend-so-pan-0j4n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-stream): flush the turn's tail before TurnEnd so panes don't stick on Working

--- a/frontend/app/view/agent/stream-flush-queue.test.ts
+++ b/frontend/app/view/agent/stream-flush-queue.test.ts
@@ -1,0 +1,117 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Coverage for `flushNow()` — the synchronous flush added for the
+ * session_end path (turn-tail flush race: the turn's own trailing document
+ * nodes must land BEFORE TurnEnd settles the phase, or the reducer's
+ * StreamFlushObserved re-promotion reads them as a new round and the pane
+ * sticks on a false "Working…" after the turn genuinely ended). No test
+ * file existed for this module before.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStreamFlushQueue } from "./stream-flush-queue";
+import type { DocumentNode } from "./types";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { DockNodeStatusCommand: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+type Dispatched = { kind: "doc" | "pane"; command: any };
+
+function makeModel() {
+    const dispatched: Dispatched[] = [];
+    const model = {
+        blockId: "block-1",
+        dispatchDoc: (command: any) => { dispatched.push({ kind: "doc", command }); },
+        dispatchPane: (command: any) => { dispatched.push({ kind: "pane", command }); },
+    };
+    return { model: model as any, dispatched };
+}
+
+const textNode = (id: string): DocumentNode => ({ type: "markdown", id, content: "hi" }) as DocumentNode;
+
+describe("StreamFlushQueue.flushNow", () => {
+    let rafQueue: FrameRequestCallback[];
+
+    beforeEach(() => {
+        rafQueue = [];
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+            rafQueue.push(cb);
+            return rafQueue.length;
+        });
+        vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+            rafQueue[id - 1] = () => {};
+        });
+    });
+
+    afterEach(() => vi.unstubAllGlobals());
+
+    function flushRaf() {
+        const pending = rafQueue;
+        rafQueue = [];
+        for (const cb of pending) cb(0);
+    }
+
+    it("flushes pending nodes synchronously, without waiting for the RAF", () => {
+        const { model, dispatched } = makeModel();
+        const q = createStreamFlushQueue(model);
+
+        q.pushNewNode(textNode("n1"));
+        q.scheduleFlush();
+        expect(dispatched).toHaveLength(0); // still queued behind the RAF
+
+        q.flushNow();
+
+        const kinds = dispatched.map((d) => d.command.type);
+        expect(kinds).toContain("StreamFlush");
+        expect(kinds).toContain("StreamFlushObserved");
+        const flush = dispatched.find((d) => d.command.type === "StreamFlush")!;
+        expect(flush.command.newNodes.map((n: DocumentNode) => n.id)).toEqual(["n1"]);
+    });
+
+    it("the armed RAF does not double-dispatch after flushNow", () => {
+        const { model, dispatched } = makeModel();
+        const q = createStreamFlushQueue(model);
+
+        q.pushNewNode(textNode("n1"));
+        q.scheduleFlush();
+        q.flushNow();
+        const countAfterFlushNow = dispatched.length;
+
+        flushRaf();
+
+        // No second StreamFlush/StreamFlushObserved — a duplicate (even an
+        // empty one) landing after TurnEnd would re-promote Done → Streaming,
+        // the exact bug flushNow exists to prevent.
+        expect(dispatched).toHaveLength(countAfterFlushNow);
+    });
+
+    it("is a no-op with nothing pending (never dispatches an empty StreamFlushObserved)", () => {
+        const { model, dispatched } = makeModel();
+        const q = createStreamFlushQueue(model);
+
+        q.flushNow();
+
+        expect(dispatched).toHaveLength(0);
+    });
+
+    it("a later scheduleFlush with new content still flushes normally (genuine next round unaffected)", () => {
+        const { model, dispatched } = makeModel();
+        const q = createStreamFlushQueue(model);
+
+        q.pushNewNode(textNode("n1"));
+        q.flushNow();
+        const afterFirst = dispatched.length;
+
+        q.pushNewNode(textNode("n2"));
+        q.scheduleFlush();
+        flushRaf();
+
+        expect(dispatched.length).toBeGreaterThan(afterFirst);
+        const flushes = dispatched.filter((d) => d.command.type === "StreamFlush");
+        expect(flushes[1].command.newNodes.map((n: DocumentNode) => n.id)).toEqual(["n2"]);
+    });
+});

--- a/frontend/app/view/agent/stream-flush-queue.ts
+++ b/frontend/app/view/agent/stream-flush-queue.ts
@@ -76,6 +76,21 @@ export interface StreamFlushQueue {
     pushShellExit(shellId: string, status: ShellNode["status"], exitCode: number, exitedAt: number): void;
     /** Arm the shared RAF if one isn't already pending. THE single requestAnimationFrame call site for this hook. */
     scheduleFlush(): void;
+    /**
+     * Flush everything pending synchronously, right now, instead of waiting
+     * for the armed RAF. Exists for exactly one caller: the `session_end`
+     * path must land the turn's own trailing document nodes BEFORE
+     * dispatching `TurnEnd` — otherwise the tail flush arrives a frame
+     * after the phase settles to Done.completed, and the reducer's
+     * StreamFlushObserved re-promotion (deliberately kept by #2420 for
+     * genuine multi-round continuations) reads the turn's own tail as "the
+     * agent picked up another round," leaving the pane stuck on "Working…"
+     * after the turn genuinely ended (log-confirmed: TurnEnd at t, Done →
+     * Streaming via StreamFlushObserved at t+6ms, then nothing). Safe to
+     * call with an RAF still armed: the eventual RAF callback finds empty
+     * queues and no-ops, so no empty StreamFlushObserved is ever dispatched.
+     */
+    flushNow(): void;
     /** Cancel any in-flight RAF and clear every pending queue (nodes, chunks, shell state). Used by the truncate-reset path. */
     resetAll(): void;
     /**
@@ -190,6 +205,13 @@ export function createStreamFlushQueue(model: AgentPaneModel): StreamFlushQueue 
         pushShellChunk(shellId, chunk) { pendingShellChunks.push({ shellId, chunk }); },
         pushShellExit(shellId, status, exitCode, exitedAt) { pendingShellExits.push({ shellId, status, exitCode, exitedAt }); },
         scheduleFlush,
+        flushNow() {
+            // Cancel the armed RAF too (not just rely on its empty-queue
+            // no-op) so the id doesn't linger pointing at an already-served
+            // frame.
+            if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
+            flushPendingNodes();
+        },
         resetAll() {
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             pendingNew = [];

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -520,6 +520,19 @@ export function useAgentStream({
                     // NEXT turn creates fresh nodes instead of appending to the
                     // previous response (which sits above the user's message).
                     if (event.type === "session_end") {
+                        // Land the turn's own trailing document nodes BEFORE
+                        // TurnEnd settles the phase. Without this, the tail
+                        // sits in the RAF queue while finalizeTurn dispatches
+                        // TurnEnd synchronously; the flush then arrives a
+                        // frame later in Done.completed, where the reducer's
+                        // StreamFlushObserved re-promotion reads it as a new
+                        // round — a permanent false "Working…" after any turn
+                        // whose final text shares the last stream batch with
+                        // its session_end (log-confirmed live: TurnEnd at t,
+                        // Done → Streaming at t+6ms, then nothing). Genuine
+                        // multi-round continuations still re-promote — their
+                        // flushes arrive after this point.
+                        queue.flushNow();
                         finalizeTurn(event.stats ?? null);
                         continue;
                     }


### PR DESCRIPTION
## Summary

User-reported (and live-log-confirmed on this machine): a pane shows "Working…" after its turn has genuinely ended, with the agent fully idle. The exact trace from the reporting pane:

```
13:19:17.210  Streaming → Done   cmd=TurnEnd
13:19:17.216  Done → Streaming   cmd=StreamFlushObserved  toolsActive=0
(then nothing — phantom Working until the 180s watchdog, which ReconcileTurnActive can immediately re-promote, so it oscillates)
```

**Mechanism:** `session_end` dispatches `TurnEnd` synchronously (`useTurnLifecycle.ts:113`), but the turn's final text nodes are still sitting in the RAF flush queue (`stream-flush-queue.ts`). They flush a frame later, landing in `Done.completed` — where the reducer's `StreamFlushObserved` re-promotion (deliberately kept by #2420 for genuine multi-round continuations, `reducer.ts:206-260`) reads the turn's own tail as "the agent picked up another round" and re-enters `Streaming`, with no further `session_end` ever coming.

**Fix:** ordering, not heuristics — `queue.flushNow()` before `finalizeTurn()`, so the tail lands while still `Streaming` and only then does `TurnEnd` settle the phase. The re-promotion mechanism itself is untouched; a genuine next round's flushes arrive after this point and still re-promote correctly. `flushNow` cancels the armed RAF, and the RAF path already no-ops on empty queues, so no duplicate or empty `StreamFlushObserved` can land after `TurnEnd`.

Distinct from today's #2469 (premature "Worked" via the stop_reason gate) — that fixed the turn ending too *early*; this fixes it never visually ending at all. Both bugs were live in the reported build.

## Test plan

- [x] New `stream-flush-queue.test.ts` (module had zero coverage): synchronous flush, no RAF double-dispatch after `flushNow`, empty-queue no-op (no empty `StreamFlushObserved`), and a genuine next-round flush still flowing normally
- [x] `npx vitest run frontend/app/view/agent/` — 79/79 files passing
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=agentx -->