### PR TITLE
chore: release v0.54.13

### DIFF
--- a/.changesets/1785512603-feat-process-tracker-register-shellcontroller-acpcontroller--4sqs.md
+++ b/.changesets/1785512603-feat-process-tracker-register-shellcontroller-acpcontroller--4sqs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(process-tracker): register ShellController/AcpController spawns with process_tracker::registry (Process Broker Phase B, shell+acp coverage)

--- a/.changesets/1786077015-feat-agent-pane-askuserquestion-auto-selects-the-recommended-ier2.md
+++ b/.changesets/1786077015-feat-agent-pane-askuserquestion-auto-selects-the-recommended-ier2.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): AskUserQuestion auto-selects the recommended option after 30s

--- a/.changesets/1786093177-fix-agent-pane-flush-askquestion-disconnected-banner-margins-293h.md
+++ b/.changesets/1786093177-fix-agent-pane-flush-askquestion-disconnected-banner-margins-293h.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): flush AskQuestion/disconnected-banner margins and remove scrollbar padding gap

--- a/.changesets/1786124150-fix-ci-pin-emnapi-devdependencies-to-fix-npm-ci-eusage-on-li-q07e.md
+++ b/.changesets/1786124150-fix-ci-pin-emnapi-devdependencies-to-fix-npm-ci-eusage-on-li-q07e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): pin @emnapi/* devDependencies to fix npm ci EUSAGE on Linux

--- a/.changesets/1786127483-docs-clarify-pr-agent-id-tag-is-load-bearing-only-for-the-ge-5bce.md
+++ b/.changesets/1786127483-docs-clarify-pr-agent-id-tag-is-load-bearing-only-for-the-ge-5bce.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: clarify PR agent_id tag is load-bearing only for the generic GitHub account

--- a/.changesets/1786127987-fix-swarm-drop-redundant-agent-id-tag-on-solo-feeds-colorize-7dlw.md
+++ b/.changesets/1786127987-fix-swarm-drop-redundant-agent-id-tag-on-solo-feeds-colorize-7dlw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): drop redundant agent-id tag on solo feeds, colorize ANSI in activity feed

--- a/.changesets/1786156343-feat-memory-split-low-memory-banner-into-independent-ram-and-53if.md
+++ b/.changesets/1786156343-feat-memory-split-low-memory-banner-into-independent-ram-and-53if.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(memory): split low-memory banner into independent RAM and Page File signals

--- a/.changesets/1786157012-feat-backend-add-shared-fswatchpool-filesystem-watcher-frame-lgn0.md
+++ b/.changesets/1786157012-feat-backend-add-shared-fswatchpool-filesystem-watcher-frame-lgn0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(backend): add shared FsWatchPool filesystem-watcher framework

--- a/.changesets/1786157802-fix-backend-migrate-config-watcher-fs-onto-the-shared-fswatc-zlu4.md
+++ b/.changesets/1786157802-fix-backend-migrate-config-watcher-fs-onto-the-shared-fswatc-zlu4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(backend): migrate config_watcher_fs onto the shared FsWatchPool

--- a/.changesets/1786158722-feat-context-menu-swarm-copy-menu-agent-pane-composer-paste--7b7y.md
+++ b/.changesets/1786158722-feat-context-menu-swarm-copy-menu-agent-pane-composer-paste--7b7y.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(context-menu): Swarm copy menu, agent-pane composer paste menu, and shared Cut/Copy/Paste fix for every in-pane text input missing it

--- a/.changesets/1786159108-fix-backend-migrate-editor-and-media-file-watchers-onto-the--zhu6.md
+++ b/.changesets/1786159108-fix-backend-migrate-editor-and-media-file-watchers-onto-the--zhu6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(backend): migrate editor and media file watchers onto the shared FsWatchPool

--- a/.changesets/1786160984-feat-backend-durable-cross-channel-native-memory-mirror-09og.md
+++ b/.changesets/1786160984-feat-backend-durable-cross-channel-native-memory-mirror-09og.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(backend): durable, cross-channel native memory mirror

--- a/.changesets/1786161250-fix-agent-pane-runtime-dropup-stays-open-on-select-for-real--bg6y.md
+++ b/.changesets/1786161250-fix-agent-pane-runtime-dropup-stays-open-on-select-for-real--bg6y.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): runtime dropup stays open on select for real, add close button

--- a/.changesets/1786163386-chore-cleanup-pass-remove-dead-rust-fields-and-frontend-expo-xtno.md
+++ b/.changesets/1786163386-chore-cleanup-pass-remove-dead-rust-fields-and-frontend-expo-xtno.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore: cleanup pass - remove dead Rust fields and frontend exports

--- a/.changesets/1786190173-fix-identity-close-two-single-point-enforcement-gaps-legacy--ne7m.md
+++ b/.changesets/1786190173-fix-identity-close-two-single-point-enforcement-gaps-legacy--ne7m.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): close two single-point-enforcement gaps — legacy identity_id sentinel FK-crash and blank identity_id bypassing the layer-3 auth gate

--- a/.changesets/1786192763-fix-agent-pane-open-the-shell-drawer-below-the-composer-text-s58i.md
+++ b/.changesets/1786192763-fix-agent-pane-open-the-shell-drawer-below-the-composer-text-s58i.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): open the Shell drawer below the composer text input

--- a/.changesets/1786193214-fix-agent-pane-tool-preview-scrollbar-sits-flush-at-the-pane-b8yi.md
+++ b/.changesets/1786193214-fix-agent-pane-tool-preview-scrollbar-sits-flush-at-the-pane-b8yi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): tool preview scrollbar sits flush at the panel edge

--- a/.changesets/1786194007-fix-build-fail-production-builds-when-vite-muxbus-client-id--v10c.md
+++ b/.changesets/1786194007-fix-build-fail-production-builds-when-vite-muxbus-client-id--v10c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(build): fail production builds when VITE_MUXBUS_CLIENT_ID resolves empty

--- a/.changesets/1786194396-fix-agent-stream-don-t-end-the-turn-on-mid-turn-narration-te-coie.md
+++ b/.changesets/1786194396-fix-agent-stream-don-t-end-the-turn-on-mid-turn-narration-te-coie.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-stream): don't end the turn on mid-turn narration text (stop_reason gate)

--- a/.changesets/1786195522-fix-agent-stream-flush-the-turn-s-tail-before-turnend-so-pan-0j4n.md
+++ b/.changesets/1786195522-fix-agent-stream-flush-the-turn-s-tail-before-turnend-so-pan-0j4n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-stream): flush the turn's tail before TurnEnd so panes don't stick on Working

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.12"
+version = "0.54.13"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.12"
+version = "0.54.13"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.12"
+version = "0.54.13"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.12"
+version = "0.54.13"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.12"
+version = "0.54.13"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.12"
+version = "0.54.13"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.12"
+version = "0.54.13"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,29 @@
 # AgentMux Version History
 
+## 0.54.13 — 2026-08-08
+
+- feat(process-tracker): register ShellController/AcpController spawns with process_tracker::registry (Process Broker Phase B, shell+acp coverage)
+- feat(agent-pane): AskUserQuestion auto-selects the recommended option after 30s
+- fix(agent-pane): flush AskQuestion/disconnected-banner margins and remove scrollbar padding gap
+- fix(ci): pin @emnapi/* devDependencies to fix npm ci EUSAGE on Linux
+- docs: clarify PR agent_id tag is load-bearing only for the generic GitHub account
+- fix(swarm): drop redundant agent-id tag on solo feeds, colorize ANSI in activity feed
+- feat(memory): split low-memory banner into independent RAM and Page File signals
+- feat(backend): add shared FsWatchPool filesystem-watcher framework
+- fix(backend): migrate config_watcher_fs onto the shared FsWatchPool
+- feat(context-menu): Swarm copy menu, agent-pane composer paste menu, and shared Cut/Copy/Paste fix for every in-pane text input missing it
+- fix(backend): migrate editor and media file watchers onto the shared FsWatchPool
+- feat(backend): durable, cross-channel native memory mirror
+- fix(agent-pane): runtime dropup stays open on select for real, add close button
+- chore: cleanup pass - remove dead Rust fields and frontend exports
+- fix(identity): close two single-point-enforcement gaps — legacy identity_id sentinel FK-crash and blank identity_id bypassing the layer-3 auth gate
+- fix(agent-pane): open the Shell drawer below the composer text input
+- fix(agent-pane): tool preview scrollbar sits flush at the panel edge
+- fix(build): fail production builds when VITE_MUXBUS_CLIENT_ID resolves empty
+- fix(agent-stream): don't end the turn on mid-turn narration text (stop_reason gate)
+- fix(agent-stream): flush the turn's tail before TurnEnd so panes don't stick on Working
+
+
 ## 0.54.12 — 2026-08-07
 
 - feat(agent): wire in-app OAuth login into credential-loss relogin, retiring AuthUrlBox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.12",
+  "version": "0.54.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.12",
+      "version": "0.54.13",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.12",
+  "version": "0.54.13",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR via `task release -- --as patch` (RFC #857 Phase 2 changesets workflow).

- Consumes all 20 pending `.changesets/` entries and appends them to `VERSION_HISTORY.md` under `## 0.54.13`
- Bumps package.json, Cargo.toml, package-lock.json, Cargo.lock — all 5 version locations verified in agreement by release.sh
- **Deliberate `--as patch` override:** queued `feat` (minor-level) changesets ship under a patch version by operator instruction; release.sh emitted its lower-bump warning as expected

Replaces #2470, which bumped directly with bump-wrapper and failed the release-consistency gate (VERSION_HISTORY.md was never updated).

<!-- agentmux:agent_id=korp -->