### PR TITLE
fix(armory): accounts appear live everywhere without a reload

### DIFF
--- a/.changesets/1786197128-fix-armory-accounts-appear-live-everywhere-subscribe-the-sha-c7w1.md
+++ b/.changesets/1786197128-fix-armory-accounts-appear-live-everywhere-subscribe-the-sha-c7w1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): accounts appear live everywhere - subscribe the shared account cache to identityaccounts:changed

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -20,7 +20,6 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 
-import { waveEventSubscribe } from "@/app/store/wps";
 import { createLaunchFlowStore, accountsForProvider, realMemories } from "@/app/store/launch-flow-state";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
@@ -29,7 +28,7 @@ import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slu
 import { getProvider } from "../providers";
 import { PreLaunchAuthPanel } from "./PreLaunchAuthPanel";
 import { AuthFlowController } from "../auth";
-import { refreshAccountCache } from "@/app/view/identity/identity-model";
+import { refreshAccountCache, subscribeAccountChanges } from "@/app/view/identity/identity-model";
 import { useContinueOrNewMode } from "../hooks/useContinueOrNewMode";
 import { useLaunchAuthGate } from "../hooks/useLaunchAuthGate";
 
@@ -207,17 +206,17 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     const memories = () => flow.state.memories.list;
 
     // Cross-tab + cross-pane reactivity: the shared account cache
-    // (`identity-model.ts`) isn't itself subscribed to the backend's
-    // `identityaccounts:changed` broadcast — callers refresh it
-    // explicitly. Subscribe here so an account created/verified from
-    // another tab (or this modal's own OAuth/API-key flows) keeps the
-    // dropdown + status live without a manual reopen. Replaces the
-    // old `identitybundlebindings:changed:<id>` subscription (bundle
-    // bindings no longer exist in this flow).
+    // (`identity-model.ts`) self-subscribes to the backend's
+    // `identityaccounts:changed` broadcast as of #2474 and refreshes
+    // itself, so this modal only needs to mirror cache updates into its
+    // flow state — no separate event subscription or second RPC round-trip
+    // (this replaces the hand-rolled `waveEventSubscribe` workaround that
+    // predated the cache's own live sync). Keeps the dropdown + status
+    // live when an account is created/verified from another tab or this
+    // modal's own OAuth/API-key flows, without a manual reopen.
     createEffect(() => {
-        const unsub = waveEventSubscribe({
-            eventType: "identityaccounts:changed",
-            handler: () => void loadAccountsIntoForm(),
+        const unsub = subscribeAccountChanges((list) => {
+            flow.dispatch({ type: "AccountsLoaded", list });
         });
         onCleanup(unsub);
     });

--- a/frontend/app/view/identity/identity-model.livesync.test.ts
+++ b/frontend/app/view/identity/identity-model.livesync.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the account-cache live sync: primeAccountCache() must install
+// exactly one app-lifetime subscription to the backend's
+// `identityaccounts:changed` broadcast, and that subscription's handler
+// must refresh the cache — so accounts created by backend-originated flows
+// (in-app OAuth login persist, API-key verify, upserts from another tab)
+// appear in the Armory / launch modal / pickers without a reload.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const subscribeCalls: Array<{ eventType: string; handler: () => void }> = [];
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: () => void }) => {
+        subscribeCalls.push(sub);
+        return () => {};
+    }),
+}));
+
+const listAccountsMock = vi.fn(async () => [] as unknown[]);
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListIdentityAccountsCommand: (...args: unknown[]) => listAccountsMock(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { primeAccountCache, loadAccounts, subscribeAccountChanges } from "./identity-model";
+
+describe("account cache live sync (identityaccounts:changed)", () => {
+    beforeEach(() => {
+        listAccountsMock.mockClear();
+    });
+
+    it("primeAccountCache installs exactly one identityaccounts:changed subscription, even when called twice", () => {
+        primeAccountCache();
+        primeAccountCache();
+        const accountSubs = subscribeCalls.filter((s) => s.eventType === "identityaccounts:changed");
+        expect(accountSubs.length).toBe(1);
+    });
+
+    it("the broadcast handler refreshes the cache and notifies cache listeners", async () => {
+        primeAccountCache();
+        const sub = subscribeCalls.find((s) => s.eventType === "identityaccounts:changed");
+        expect(sub).toBeDefined();
+
+        listAccountsMock.mockResolvedValueOnce([
+            {
+                id: "550e8400-e29b-41d4-a716-446655440000",
+                name: "new-account",
+                provider: "claude",
+                kind: "oauth",
+                display_name: "",
+                secret_ref: { oauth_config_dir: { dir: "/tmp/x" } },
+                context: {},
+                status: "valid",
+                created_at: 0,
+                updated_at: 0,
+            },
+        ]);
+
+        const seen: unknown[][] = [];
+        const unsub = subscribeAccountChanges((accounts) => seen.push(accounts as unknown[]));
+
+        listAccountsMock.mockClear();
+        sub!.handler();
+        // refreshAccountCache is async — give the microtask queue a tick.
+        await vi.waitFor(() => expect(listAccountsMock).toHaveBeenCalledTimes(1));
+        await vi.waitFor(() => expect(seen.length).toBeGreaterThan(0));
+        expect(loadAccounts().some((a) => a.name === "new-account")).toBe(true);
+        unsub();
+    });
+});

--- a/frontend/app/view/identity/identity-model.livesync.test.ts
+++ b/frontend/app/view/identity/identity-model.livesync.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/app/store/wps", () => ({
 const listAccountsMock = vi.fn(async () => [] as unknown[]);
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
-        ListIdentityAccountsCommand: (...args: unknown[]) => listAccountsMock(...args),
+        ListIdentityAccountsCommand: () => listAccountsMock(),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -70,5 +70,42 @@ describe("account cache live sync (identityaccounts:changed)", () => {
         await vi.waitFor(() => expect(seen.length).toBeGreaterThan(0));
         expect(loadAccounts().some((a) => a.name === "new-account")).toBe(true);
         unsub();
+    });
+
+    it("a superseded refresh does not overwrite a newer one (latest-call-wins, codex P2 on #2474)", async () => {
+        const { refreshAccountCache } = await import("./identity-model");
+        const mkRow = (name: string) => ({
+            id: "550e8400-e29b-41d4-a716-446655440001",
+            name,
+            provider: "claude",
+            kind: "oauth",
+            display_name: "",
+            secret_ref: { oauth_config_dir: { dir: "/tmp/x" } },
+            context: {},
+            status: "valid",
+            created_at: 0,
+            updated_at: 0,
+        });
+
+        // First (older) request resolves LAST — after the second (newer)
+        // request already landed. Without the seq guard, "older" would
+        // overwrite "newer" in the cache.
+        let releaseOlder!: (rows: unknown[]) => void;
+        const olderGate = new Promise<unknown[]>((res) => (releaseOlder = res));
+        listAccountsMock.mockImplementationOnce(() => olderGate);
+        listAccountsMock.mockResolvedValueOnce([mkRow("newer")]);
+
+        const older = refreshAccountCache();
+        const newer = refreshAccountCache();
+        await newer;
+        expect(loadAccounts().some((a) => a.name === "newer")).toBe(true);
+
+        releaseOlder([mkRow("older")]);
+        const olderResult = await older;
+        // Cache keeps the newer snapshot; the superseded call returns the
+        // live (newer) cache rather than its own stale fetch.
+        expect(loadAccounts().some((a) => a.name === "newer")).toBe(true);
+        expect(loadAccounts().some((a) => a.name === "older")).toBe(false);
+        expect(olderResult.some((a) => a.name === "newer")).toBe(true);
     });
 });

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -302,10 +302,24 @@ function accountToBackend(a: Account): Partial<IdentityAccount> {
     };
 }
 
-/** Pull the latest account list from the DB and update the cache. */
+/** Pull the latest account list from the DB and update the cache.
+ *
+ * Latest-call-wins: two rapid `identityaccounts:changed` broadcasts (or a
+ * broadcast racing a CRUD method's own refresh) launch overlapping RPCs,
+ * and the backend handles requests on separate tasks — the request that
+ * captured the OLDER account snapshot can resolve last. Without this
+ * guard it would overwrite the newer result with no further broadcast to
+ * correct it, leaving every consumer stale (codex P2 on #2474). A
+ * superseded call skips the cache write and returns the live cache
+ * (fresher than its own stale fetch) so awaiting callers still see the
+ * newest data.
+ */
+let _refreshSeq = 0;
 export async function refreshAccountCache(): Promise<Account[]> {
+    const seq = ++_refreshSeq;
     try {
         const rows = await RpcApi.ListIdentityAccountsCommand(TabRpcClient, {});
+        if (seq !== _refreshSeq) return _accountCache; // superseded by a newer refresh
         const mapped = rows.map(backendToAccount);
         setCache(mapped);
         return mapped;

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -11,6 +11,7 @@ import { BlockNodeModel } from "@/app/block/blocktypes";
 import { createSignal, type Accessor, type Setter } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { Logger } from "@/util/logger";
 import { brandForProvider } from "@/app/view/accounts/provider-brand";
 
@@ -314,9 +315,32 @@ export async function refreshAccountCache(): Promise<Account[]> {
     }
 }
 
+let _liveSyncInstalled = false;
+
 /** Run once at app startup. Idempotent — repeated calls just refresh. */
 export function primeAccountCache(): void {
     void refreshAccountCache();
+    // Live sync: refresh the cache on every backend `identityaccounts:changed`
+    // broadcast, so accounts created/edited/deleted by ANY path — the in-app
+    // OAuth login persist, API-key verify, upsert/delete RPCs from another
+    // tab, the spawn-time expiry probe — propagate to every cache consumer
+    // (Armory Accounts tab, launch modal, pickers) without a reload.
+    // Previously the cache was only refreshed by its own CRUD methods'
+    // explicit calls, so backend-originated account creation (e.g. completing
+    // an in-app OAuth login) left the Armory stale until reopen/reload, and
+    // each consumer that wanted liveness had to hand-roll its own event
+    // subscription (AgentLaunchModal did exactly that).
+    //
+    // App-lifetime subscription, deliberately never unsubscribed — the cache
+    // itself is module-level app-lifetime state. Guarded so repeated
+    // primeAccountCache() calls don't stack duplicate handlers.
+    if (!_liveSyncInstalled) {
+        _liveSyncInstalled = true;
+        waveEventSubscribe({
+            eventType: "identityaccounts:changed",
+            handler: () => void refreshAccountCache(),
+        });
+    }
 }
 
 // ── ViewModel ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

New/changed accounts didn't appear in the Armory (or the per-agent identity panel, or account pickers) until a reload. Found while live-testing the #2463 auth fixes on a fresh isolated-auth dev build.

## Root cause

The shared account cache (`identity-model.ts`) is the single source every account view reads from — but it was only refreshed by its own CRUD methods' explicit `refreshAccountCache()` calls. It never subscribed to the backend's `identityaccounts:changed` broadcast, so any backend-originated change (completing an in-app OAuth login via `identity_auth_persist.rs`, API-key verify, upsert/delete from another tab, the spawn-time expiry probe) left every consumer stale. `AgentLaunchModal` had already hand-rolled a private subscription to work around exactly this — its own comment documents the gap: *"the shared account cache (identity-model.ts) isn't itself subscribed to the backend's identityaccounts:changed broadcast — callers refresh it explicitly."*

## Fix

`primeAccountCache()` (already called once at app startup, after event subscriptions initialize) now also installs a single app-lifetime `identityaccounts:changed` subscription that refreshes the cache. Every consumer wired via `subscribeAccountChanges()`/`accountsAtom` — Armory Accounts tab, per-agent identity links panel, pickers — goes live automatically, with no per-view subscriptions needed. Guarded against duplicate installation on repeated calls.

Backend event coverage verified before relying on it: upsert, key-verify, OAuth login persist, delete, and the expiry probe all already publish the event.

## Test plan

- [x] New `identity-model.livesync.test.ts`: exactly one subscription installed even across repeated `primeAccountCache()` calls; the broadcast handler refreshes the cache and notifies cache listeners
- [x] `npx tsc --noEmit` — clean
- [x] Full vitest suite: 2390+ passing; two unrelated tests flaked in different full runs (each passes in isolation, machine was concurrently running a dev instance) — CI on a quiet runner is the arbiter
- [ ] Live check on the running dev build: complete an in-app OAuth login → account appears in Armory immediately

<!-- agentmux:agent_id=agent3 -->