### PR TITLE
fix(app-api): window rename validates existence; naming routes return real status codes

### DIFF
--- a/.changesets/1786197197-fix-app-api-window-rename-validates-existence-naming-routes--olxd.md
+++ b/.changesets/1786197197-fix-app-api-window-rename-validates-existence-naming-routes--olxd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(app-api): window rename validates existence; naming routes return real status codes

--- a/agentmux-srv/src/reducer/window.rs
+++ b/agentmux-srv/src/reducer/window.rs
@@ -109,19 +109,34 @@ pub(super) fn handle_switch_workspace(
 /// through the reducer's broadcast bus" so the WaveObjUpdate bridge
 /// can fan out to the frontend.
 ///
-/// The validation is best-effort: reducer state's `windows` map only
-/// holds windows for which a workspace mapping has been registered
-/// (via `handle_create_window`). Windows created via wcore-direct
-/// paths (legacy bootstrap) won't appear there but still exist in
-/// wstore. So we don't error on missing — the persist subscriber's
-/// `apply_window_meta_updated` will silently no-op if the window
-/// genuinely doesn't exist in wstore either, matching the
-/// idempotency contract for the bridge to broadcast (or skip).
+/// Validates the window exists, matching its three sibling meta arms
+/// (`handle_update_workspace_meta` / `handle_update_tab_meta` /
+/// `handle_update_block_meta`) — this arm used to be the sole outlier
+/// with no guard, which made `POST /api/v1/window/name` report success
+/// for well-formed-but-nonexistent window ids (the persist subscriber's
+/// `apply_window_meta_updated` silently no-ops on a wstore miss, so
+/// nothing downstream caught it either). The guard is safe because
+/// `state.windows` reliably mirrors real windows: every runtime
+/// creation goes through `handle_create_window`, and
+/// `persist::bootstrap_state_from_wstore` hydrates pre-existing windows
+/// (including the wcore-seeded first-launch window, created before
+/// hydration runs) at startup. The old "wcore-direct paths won't appear
+/// here" caveat this comment used to carry predates that hydration.
+/// SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md §3.1.
 pub(super) fn handle_update_window_meta(
     state: &mut State,
     window_id: String,
     meta_patch: serde_json::Value,
 ) -> Vec<Event> {
+    if !state.windows.contains_key(&window_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("UpdateWindowMeta: window not found: {}", window_id),
+            fatal: false,
+            version: v,
+        }];
+    }
     let v = state.bump_version();
     vec![Event::WindowMetaUpdated {
         window_id,
@@ -229,6 +244,55 @@ mod tests {
             &ctx(1),
         );
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn update_window_meta_errors_on_unknown_window() {
+        // Regression for SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md §2.1:
+        // this arm used to emit WindowMetaUpdated unconditionally, so a
+        // well-formed-but-nonexistent window id sailed through to a silent
+        // persist no-op and POST /api/v1/window/name reported success.
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::UpdateWindowMeta {
+                window_id: "00000000-dead-beef-0000-000000000000".into(),
+                meta_patch: serde_json::json!({ "window:displayname": "phantom" }),
+            },
+            &ctx(1),
+        );
+        assert!(
+            matches!(&events[0], Event::Error { message, .. } if message.contains("window not found")),
+            "expected window-not-found error, got {:?}",
+            events
+        );
+    }
+
+    #[test]
+    fn update_window_meta_emits_event_for_known_window() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "a");
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id,
+            },
+            &ctx(2),
+        );
+        let events = update(
+            &mut state,
+            Command::UpdateWindowMeta {
+                window_id: "win-1".into(),
+                meta_patch: serde_json::json!({ "window:displayname": "named" }),
+            },
+            &ctx(3),
+        );
+        assert!(
+            matches!(&events[0], Event::WindowMetaUpdated { window_id, .. } if window_id == "win-1"),
+            "expected WindowMetaUpdated, got {:?}",
+            events
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1061,11 +1061,12 @@ async fn handle_window_name(
             json!({ "window:displayname": name }),
         ],
     };
-    let result = service::run_service_call(&state, &call).await;
-    if let Some(err) = result.error {
-        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": err }))).into_response();
-    }
-    Json(json!({ "success": true, "window_id": window_id, "name": name })).into_response()
+    finish_name_call(
+        &state,
+        call,
+        json!({ "success": true, "window_id": window_id, "name": name }),
+    )
+    .await
 }
 
 /// Trim a user-supplied name and clamp to `max` chars; `None` if empty.
@@ -1189,9 +1190,27 @@ async fn finish_name_call(
 ) -> Response {
     let result = service::run_service_call(state, &call).await;
     if let Some(err) = result.error {
-        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": err }))).into_response();
+        return (name_call_error_status(&err), Json(json!({ "error": err }))).into_response();
     }
     Json(ok_body).into_response()
+}
+
+/// Map a naming service-call error to an HTTP status. The service layer
+/// returns plain `String` errors, so this matches on error text — the same
+/// established pattern as `app_api_error_status` above, but with not-found
+/// split out as a real 404 (that helper lumps it into 400): a caller
+/// holding a stale window/tab/workspace id from an earlier `Layout` call
+/// is a not-found, not a malformed request. Everything unrecognized stays
+/// 500 (genuine service faults, e.g. SQLite write failures).
+/// SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md §3.2.
+fn name_call_error_status(e: &str) -> StatusCode {
+    if e.contains("not found") {
+        StatusCode::NOT_FOUND
+    } else if e.contains("invalid") {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
 }
 
 /// `GET /api/v1/layout` — read-only window → workspace → tab → pane tree.

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -514,6 +514,90 @@ async fn self_endpoint_missing_block_id_is_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
+// ── SPEC_WINDOW_NAME_API_HARDENING_2026_08_08 — phantom ids + status codes ──
+
+fn window_name_request(body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/window/name")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+/// A well-formed UUID that matches no window must 404, not report
+/// success — this used to sail through the guardless reducer arm into a
+/// silent persist no-op (spec §2.1, found by live probe).
+#[tokio::test]
+async fn window_name_phantom_uuid_is_404() {
+    let app = test_router();
+    let resp = app
+        .oneshot(window_name_request(serde_json::json!({
+            "window_id": "00000000-dead-beef-0000-000000000000",
+            "name": "phantom",
+        })))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// A malformed (non-UUID) window id is a caller error, not a server fault.
+#[tokio::test]
+async fn window_name_malformed_id_is_400() {
+    let app = test_router();
+    let resp = app
+        .oneshot(window_name_request(serde_json::json!({
+            "window_id": "no-such-window-xyz",
+            "name": "ghost",
+        })))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Happy path: renaming the seeded window succeeds and persists
+/// `window:displayname` in wstore. srv_state is hydrated from wstore via
+/// the same `bootstrap_state_from_wstore` production runs, so the new
+/// reducer existence guard sees the seeded window exactly as it would live.
+#[tokio::test]
+async fn window_name_renames_seeded_window_and_persists() {
+    let state = test_state();
+    crate::persist::bootstrap_state_from_wstore(&state.srv_state, &state.wstore).await;
+    let wstore = state.wstore.clone();
+    let window = wstore
+        .get_all::<crate::backend::obj::Window>()
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("seeded window");
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(window_name_request(serde_json::json!({
+            "window_id": window.oid,
+            "name": "renamed-by-test",
+        })))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["success"], true);
+    assert_eq!(json["name"], "renamed-by-test");
+
+    let reread = wstore
+        .get::<crate::backend::obj::Window>(&window.oid)
+        .unwrap()
+        .expect("window still exists");
+    assert_eq!(
+        reread.meta.get("window:displayname").and_then(|v| v.as_str()),
+        Some("renamed-by-test"),
+        "display name must be persisted in wstore meta"
+    );
+}
+
 // ── SPEC_864 Phase 2 — UpdateObject routes layout pushes through the reducer ──
 
 /// End-to-end over the HTTP service: a frontend-style full-row layout push

--- a/docs/specs/SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md
+++ b/docs/specs/SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md
@@ -1,0 +1,144 @@
+# SPEC: Window-name App API hardening (phantom-id success + status codes)
+
+**Date:** 2026-08-08
+**Status:** Proposed (fix implemented same day for §3.1-§3.2; §4 deferred)
+**Scope:** `agentmux-srv/src/reducer/window.rs`, `agentmux-srv/src/server/mod.rs`
+**Related:** `SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md` (title composition),
+`SPEC_TEST_API_ACCESS.md` (dev `authkey.dev` cross-instance access),
+`docs/specs/SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28` (MCP `SetName` tool)
+
+---
+
+## 1. Context
+
+Agents can retitle AgentMux windows via `POST /api/v1/window/name` (the
+route behind MCP `SetName(target: "window")`), including windows of *other*
+instances in dev builds via the `authkey.dev` bridge. Live probing of this
+surface (2026-08-08, against a running `task dev` main instance) confirmed
+the core is solid — same `UpdateObjectMeta` path as the human InstancePanel
+rename, persisted meta, instant reactive title update — and found two
+defects plus three deferred product gaps.
+
+## 2. Defects found (probed live, then root-caused in source)
+
+### 2.1 Phantom window ids return `200 {"success": true}`
+
+`POST /api/v1/window/name` with a **well-formed UUID that matches no
+window** succeeds silently. Nothing changes anywhere; the caller gets a
+false positive. An agent holding a stale `window_id` from an earlier
+`Layout` call (window closed since) believes its rename worked.
+
+Root cause chain:
+
+1. `handle_window_name` → `object.UpdateObjectMeta` →
+   `Command::UpdateWindowMeta` dispatched to the srv reducer
+   (`server/service/object.rs:291-341`).
+2. The reducer's window arm (`reducer/window.rs::handle_update_window_meta`,
+   line 120) **has no existence guard** — it unconditionally emits
+   `WindowMetaUpdated`. This is the *sole outlier* in its family: the
+   workspace (`workspace.rs:132`), tab (`tab.rs:485`), and block
+   (`block.rs:148`) meta arms all return an `Event::Error` for unknown
+   ids. The comment at `object.rs:288` ("Reducer is pass-through
+   (validates entity exists; emits event)") documents the intended
+   contract the window arm silently violates.
+3. The persist subscriber's `apply_window_meta_updated`
+   (`persist_subscriber.rs:989`) then swallows the miss:
+   `let Some(window) = wstore.get(...) else { return Ok(()) }`.
+
+So: reducer doesn't validate, persistence silently no-ops, handler reports
+success.
+
+**Safety of the fix**: `persist::bootstrap_state_from_wstore`
+(`persist.rs:198-237`) loads every window from wstore into
+`state.windows` at startup, and `CreateWindow` inserts at runtime — the
+reducer state reliably mirrors real windows, so an existence guard cannot
+false-404 a live window. (A window whose `workspaceid` dangles is skipped
+at bootstrap, per the comment at `persist.rs:195` — such a window becomes
+un-renamable, the same exposure the tab/block guards already accept for
+their own orphans.)
+
+### 2.2 Malformed ids return `500`; not-found (post-fix) would too
+
+`POST /api/v1/window/name` with `window_id: "no-such-window-xyz"` returns
+`500 {"error": "invalid object id: ..."}` — a caller mistake reported as a
+server fault. All four naming handlers (`window/name`, `tab/name`,
+`pane/title`, `workspace/name`) share this via `finish_name_call`
+(`server/mod.rs`), which maps **every** service error to 500. Once §2.1's
+guard exists, its "window not found" error would also surface as 500
+without a status mapper.
+
+## 3. Fix (this change)
+
+### 3.1 Existence guard in the reducer's window-meta arm
+
+`reducer/window.rs::handle_update_window_meta` gains the same guard its
+three siblings have:
+
+```rust
+if !state.windows.contains_key(&window_id) {
+    let v = state.bump_version();
+    return vec![Event::Error {
+        code: ErrorCode::InvalidCommand,
+        message: format!("UpdateWindowMeta: window not found: {}", window_id),
+        fatal: false,
+        version: v,
+    }];
+}
+```
+
+Blast radius note: `UpdateWindowMeta` is also dispatched from
+`window_create.rs:304` (post-create meta stamp) — that call site runs
+after `CreateWindow` inserted the window into reducer state, so the guard
+is a no-op there. The frontend InstancePanel rename targets windows from
+the live windows list, which exist by construction.
+
+### 3.2 Status mapping for the naming-route family
+
+`finish_name_call` (and `handle_window_name`'s inlined equivalent, which
+this change converges onto `finish_name_call`) maps service-error text the
+same way the existing `app_api_error_status` precedent does, but with
+not-found split out properly:
+
+- contains `"not found"` → **404**
+- contains `"invalid"` (e.g. `invalid object id`) → **400**
+- otherwise → 500 (genuine server faults)
+
+String matching on error text is the established pattern here
+(`app_api_error_status`, `server/mod.rs:852`) — the service layer returns
+plain `String` errors; introducing a structured error enum across
+`run_service_call` is out of scope for a hardening pass.
+
+### 3.3 Tests
+
+- Reducer: phantom window id → `Event::Error`, no `WindowMetaUpdated`;
+  existing window → `WindowMetaUpdated` emitted (guard doesn't regress the
+  happy path).
+- HTTP (`server/tests.rs` router tests): `POST /api/v1/window/name` with a
+  well-formed phantom UUID → **404**; malformed id → **400**; real window
+  (seeded into both wstore and `srv_state`) → 200 and
+  `window:displayname` persisted in wstore.
+
+## 4. Deferred (product decisions, not defects — file separately if wanted)
+
+1. **No clear-to-default.** Empty name is rejected (400), matching the
+   InstancePanel spec's "empty → silent revert" (§2.2.2) — neither surface
+   can restore the automatic title tier (workspace name / "Window N") once
+   a display name is set. For agent automation (temporary status titles) an
+   explicit `{"name": null}` or `DELETE /api/v1/window/name` would be
+   needed. Product call; parity today is consistent.
+2. **Dev-instance discovery is convention-based.** Reaching another dev
+   instance requires knowing `~/.agentmux/dev/<branch>/<hash>/data/authkey.dev`
+   and probing liveness yourself — stale authfiles linger after instance
+   death. A `muxlog ls`-style "list live dev instances + endpoints" helper
+   (or an `alive`-stamped authfile) would make cross-instance control
+   ergonomic. Deliberately unfixed here: it's a new surface, not hardening.
+3. **64-char clamp splits graphemes.** `chars().take(64)` can cut an
+   emoji/ZWJ sequence mid-cluster. Cosmetic; fix opportunistically if the
+   clamp code is ever touched again.
+
+## 5. Verification
+
+- `cargo test --workspace -- --test-threads=1` (CI-equivalent) green.
+- Live re-probe against a dev instance after the fix ships in a dev build:
+  phantom UUID → 404, malformed → 400, real window → 200 + title updates.
+  (The original probe transcript that found §2.1/§2.2 is the baseline.)


### PR DESCRIPTION
## Summary
- Live-probing the window-title App API (via a dev instance's `authkey.dev` bridge) found that `POST /api/v1/window/name` with a **well-formed UUID matching no window** returns `200 {"success": true}` while changing nothing — a false positive for any agent holding a stale `window_id`.
- Root cause: the reducer's `UpdateWindowMeta` arm was the **only** meta arm with no existence guard (workspace/tab/block all validate and error), and the persist subscriber silently no-ops on a wstore miss — so nothing anywhere caught the phantom. The code comment at the dispatch site even documents the intended contract ("validates entity exists") that this arm violated.
- Fix 1: add the same guard its three sibling arms have. Verified safe: `bootstrap_state_from_wstore` hydrates every pre-existing window (including the wcore-seeded first-launch window, which is created before hydration runs) and all runtime creation goes through `CreateWindow` — the old "wcore-direct paths won't appear in reducer state" comment predates that hydration and is updated accordingly.
- Fix 2: the naming-route family (`window/name`, `tab/name`, `pane/title`, `workspace/name`) mapped every service error to 500. `finish_name_call` now maps "not found" → 404 and "invalid" (e.g. malformed object id) → 400, following the existing `app_api_error_status` text-matching precedent; `handle_window_name`'s inlined duplicate of `finish_name_call` is converged onto it.
- Spec with the probe transcript baseline + deferred follow-ups (clear-to-default parity, dev-instance discovery ergonomics, grapheme-safe clamping): `docs/specs/SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md`.

## Test plan
- [x] New reducer tests: phantom window id → `Event::Error`; known window → `WindowMetaUpdated` (happy path unregressed)
- [x] New HTTP tests: phantom UUID → 404; malformed id → 400; seeded window (srv_state hydrated via the same `bootstrap_state_from_wstore` production runs) → 200 + `window:displayname` persisted in wstore
- [x] `cargo test --workspace -- --test-threads=1` — all green (2067 passed, 0 failed; run with isolated AGENTMUX_* env)

<!-- agentmux:agent_id=agent2 -->