### PR TITLE
feat(agent): assign every agent a display color, backfill existing agents

### DIFF
--- a/.changesets/1786271733-feat-agent-assign-every-agent-a-display-color-backfill-exist-c85h.md
+++ b/.changesets/1786271733-feat-agent-assign-every-agent-a-display-color-backfill-exist-c85h.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): assign every agent a display color, backfill existing agents

--- a/agentmux-srv/src/backend/agent_color.rs
+++ b/agentmux-srv/src/backend/agent_color.rs
@@ -1,0 +1,121 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-agent color assignment — palette, deterministic pick, validation.
+//!
+//! Agents carry a display color in the per-agent content store
+//! (`agent_content`, `content_type = "ui:color"`, value `#rrggbb`). It is
+//! assigned at creation (`createagent` handler), backfilled for existing
+//! agents by migration `m0020_agent_color_backfill`, and seeded into each
+//! new agent block's `frame:bordercolor` meta at `agent.open` so the
+//! existing pane-frame rendering displays it with no frontend changes.
+//! See `docs/specs/SPEC_AGENT_COLOR_2026_08_08.md`.
+
+/// The 14-hue palette — hex values mirror the frontend's `TAB_COLORS`
+/// (`frontend/app/tab/tab.tsx`). Duplicated deliberately: assigned colors
+/// are STORED, not derived, so palette drift between the two lists cannot
+/// recolor existing agents.
+pub const AGENT_COLOR_PALETTE: [&str; 14] = [
+    "#ef4444", // Red
+    "#f97316", // Orange
+    "#f59e0b", // Amber
+    "#eab308", // Yellow
+    "#84cc16", // Lime
+    "#22c55e", // Green
+    "#14b8a6", // Teal
+    "#06b6d4", // Cyan
+    "#3b82f6", // Blue
+    "#6366f1", // Indigo
+    "#8b5cf6", // Violet
+    "#d946ef", // Fuchsia
+    "#ec4899", // Pink
+    "#f43f5e", // Rose
+];
+
+/// Pick a palette color for an agent — deterministic FNV-1a hash of the
+/// agent id mapped onto the palette. Effectively random across agents,
+/// stable across re-runs and machines, and dependency-free (no `rand`).
+pub fn pick_agent_color(agent_id: &str) -> &'static str {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in agent_id.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    AGENT_COLOR_PALETTE[(hash % AGENT_COLOR_PALETTE.len() as u64) as usize]
+}
+
+/// Strict `#rrggbb` shape check — the stored value flows into block meta
+/// that the frontend applies as a CSS border-color, so a corrupt or
+/// hand-edited row must not be able to inject arbitrary CSS.
+pub fn is_valid_agent_color(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 7 && bytes[0] == b'#' && bytes[1..].iter().all(u8::is_ascii_hexdigit)
+}
+
+/// Dimmed variant for the UNFOCUSED pane border (`frame:bordercolor`),
+/// keeping the full-strength color for the focused border
+/// (`frame:activebordercolor`) — the agent's color stays visible either
+/// way, and focus stays distinguishable by brightness. Input must already
+/// have passed [`is_valid_agent_color`]; returns the input unchanged if it
+/// somehow hasn't.
+pub fn dim_agent_color(hex: &str) -> String {
+    if !is_valid_agent_color(hex) {
+        return hex.to_string();
+    }
+    let channel = |s: &str| u8::from_str_radix(s, 16).unwrap_or(0);
+    let r = (f32::from(channel(&hex[1..3])) * 0.55) as u8;
+    let g = (f32::from(channel(&hex[3..5])) * 0.55) as u8;
+    let b = (f32::from(channel(&hex[5..7])) * 0.55) as u8;
+    format!("#{r:02x}{g:02x}{b:02x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_is_deterministic() {
+        assert_eq!(pick_agent_color("abc-123"), pick_agent_color("abc-123"));
+    }
+
+    #[test]
+    fn pick_returns_palette_member() {
+        for id in ["a", "b", "c", "0d5b45f1-9b2c-4a7e-8f3d-1234567890ab", ""] {
+            assert!(AGENT_COLOR_PALETTE.contains(&pick_agent_color(id)));
+        }
+    }
+
+    #[test]
+    fn distinct_ids_spread_over_palette() {
+        // Not a randomness proof — just guards against a degenerate hash
+        // that maps everything to one bucket.
+        let picked: std::collections::HashSet<_> =
+            (0..100).map(|i| pick_agent_color(&format!("agent-{i}"))).collect();
+        assert!(picked.len() > 5, "expected spread, got {}", picked.len());
+    }
+
+    #[test]
+    fn validation_accepts_palette_and_rejects_junk() {
+        for c in AGENT_COLOR_PALETTE {
+            assert!(is_valid_agent_color(c));
+        }
+        for bad in ["", "#fff", "red", "#gggggg", "#3b82f6; }", "3b82f6", "#3B82F66"] {
+            assert!(!is_valid_agent_color(bad), "{bad} should be invalid");
+        }
+        // Uppercase hex is fine.
+        assert!(is_valid_agent_color("#3B82F6"));
+    }
+
+    #[test]
+    fn dim_scales_channels_and_stays_valid() {
+        assert_eq!(dim_agent_color("#ffffff"), "#8c8c8c");
+        assert_eq!(dim_agent_color("#000000"), "#000000");
+        for c in AGENT_COLOR_PALETTE {
+            let dimmed = dim_agent_color(c);
+            assert!(is_valid_agent_color(&dimmed), "{dimmed}");
+            assert_ne!(dimmed, *c);
+        }
+        // Invalid input passes through untouched (defensive contract).
+        assert_eq!(dim_agent_color("junk"), "junk");
+    }
+}

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+pub mod agent_color;
 pub mod agent_config;
 pub mod agent_session;
 pub mod blockcontroller;

--- a/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
+++ b/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
@@ -1,0 +1,299 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backfill a display color (`agent_content` `ui:color`) for every existing
+//! agent definition that doesn't have one — the "generate a random color
+//! for all the existing agents" one-time script from
+//! `docs/specs/SPEC_AGENT_COLOR_2026_08_08.md`.
+//!
+//! Color choice is a deterministic hash of the agent id over the shared
+//! 14-hue palette (`backend::agent_color`) — effectively random across
+//! agents, stable across machines/re-runs, no `rand` dependency. Idempotent
+//! beyond the framework's once-per-channel tracking: defs that already
+//! carry a `ui:color` (e.g. assigned by a newer `createagent` before this
+//! migration ran on a second channel) are left untouched.
+//!
+//! **Must attach the global def registry itself.** `run_pending_migrations`
+//! runs before `bootstrap.rs` calls `Store::set_def_registry` on the
+//! server's real store (`bootstrap.rs`, global registry attached ~60 lines
+//! after the migration call) — a migration's own bare `Store::open()` has
+//! no registry wired up unless it attaches one itself. Without this,
+//! `agent_def_list()` silently falls back to LOCAL-ONLY
+//! (`shared_def_registry() == None`), so this migration would only ever
+//! see whatever happens to be in the current channel's own SQLite at
+//! migration time — never the cross-channel user agents that live solely
+//! in the global registry, which is the entire point of a one-time
+//! backfill run from a single channel. Confirmed live: without this fix,
+//! a fresh channel's migration ran against 0 local agents (templates seed
+//! *after* migrations, in a separate non-migration step) and colored
+//! nothing.
+
+use std::sync::Arc;
+
+use crate::backend::agent_color::pick_agent_color;
+use crate::backend::storage::store::{AgentContent, Store};
+use crate::registry::{resolve_shared_definitions_dir, DefinitionStore};
+
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0020AgentColorBackfill;
+
+impl Migration for M0020AgentColorBackfill {
+    fn id(&self) -> &'static str { "0020_agent_color_backfill" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Channel }
+    fn description(&self) -> &'static str {
+        "Backfill a ui:color for every agent definition lacking one"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        let wstore = Arc::new(
+            Store::open(&ctx.channel_store_path)
+                .map_err(|e| MigrationError(format!("agent_color_backfill: open wstore: {}", e)))?,
+        );
+        // Attach the global registry (see module doc) so agent_def_list()
+        // sees cross-channel agents, not just this channel's local rows.
+        // Best-effort, matching bootstrap.rs's own handling: if the shared
+        // dir can't be resolved or opened, proceed local-only rather than
+        // failing the whole migration — a later channel boot (which DOES
+        // wire the registry before any agent.open) still backfills any
+        // agent this run couldn't see.
+        if let Some(def_dir) = resolve_shared_definitions_dir() {
+            match DefinitionStore::open(def_dir) {
+                Ok(def_store) => wstore.set_def_registry(Arc::new(def_store)),
+                Err(e) => tracing::warn!(error = %e, "agent_color_backfill: failed to open global def registry, backfilling local-only"),
+            }
+        } else {
+            tracing::warn!("agent_color_backfill: could not resolve global def registry dir, backfilling local-only");
+        }
+        let defs = wstore
+            .agent_def_list()
+            .map_err(|e| MigrationError(format!("agent_color_backfill: list defs: {}", e)))?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        for def in defs {
+            let existing = wstore
+                .agent_content_get(&def.id, "ui:color")
+                .map_err(|e| MigrationError(format!("agent_color_backfill: get {}: {}", def.id, e)))?;
+            if existing.map_or(false, |c| !c.content.trim().is_empty()) {
+                continue;
+            }
+            wstore
+                .agent_content_set(&AgentContent {
+                    agent_id: def.id.clone(),
+                    content_type: "ui:color".to_string(),
+                    content: pick_agent_color(&def.id).to_string(),
+                    updated_at: now,
+                })
+                .map_err(|e| MigrationError(format!("agent_color_backfill: set {}: {}", def.id, e)))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::agent_color::is_valid_agent_color;
+    use crate::backend::storage::agents::AgentDefinition;
+
+    // Every test in this module calls `up()`, which now (see the module doc)
+    // always tries to resolve+attach the global registry via the
+    // process-global `AGENTMUX_HOME_OVERRIDE` env var. Two hazards follow
+    // from that, both closed by this helper:
+    //
+    // 1. **Real-data leakage.** Left unset, `resolve_shared_definitions_dir()`
+    //    falls through to the machine's REAL `~/.agentmux/shared` — so an
+    //    "isolated" unit test using a throwaway local channel store would
+    //    still merge in every real agent on the developer's machine and
+    //    potentially write `ui:color` to any of them lacking one. Every
+    //    test here MUST set an override, even the ones with no interest in
+    //    global-registry behavior.
+    // 2. **Cross-test races.** `cargo test` runs tests as threads within
+    //    ONE process, so the env var is genuinely shared: two tests each
+    //    setting/using their own override concurrently can observe each
+    //    other's value mid-run and attach to the wrong registry. The mutex
+    //    below serializes every test in this module across the full
+    //    set→run→clear window.
+    static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Run `f` with `AGENTMUX_HOME_OVERRIDE` pointed at a fresh, empty temp
+    /// dir — guarantees `resolve_shared_definitions_dir()` never resolves to
+    /// the real `~/.agentmux/shared`, and (with no `shared/agents/definitions`
+    /// subdir created) `DefinitionStore::open` fails harmlessly, so `up()`
+    /// falls back to local-only exactly like "no registry available" — the
+    /// right behavior for tests that don't care about cross-channel agents.
+    /// Returns the temp dir so registry-aware tests can populate it first.
+    fn with_isolated_home<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let home_tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", home_tmp.path().to_str().unwrap());
+        let result = f(home_tmp.path());
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        result
+    }
+
+    fn ctx_for(path: &std::path::Path) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path: std::env::temp_dir().join("unused-store.db"),
+            channel_store_path: path.to_path_buf(),
+        }
+    }
+
+    fn insert_def(wstore: &Store, name: &str) -> String {
+        let mut def = AgentDefinition {
+            id: format!("test-{name}"),
+            slug: String::new(),
+            name: name.to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        };
+        wstore.agent_def_insert(&mut def).unwrap();
+        def.id
+    }
+
+    #[test]
+    fn backfills_only_defs_without_a_color() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::NamedTempFile::new().unwrap();
+            let wstore = Store::open(tmp.path()).unwrap();
+            let plain = insert_def(&wstore, "plain");
+            let colored = insert_def(&wstore, "colored");
+            wstore
+                .agent_content_set(&AgentContent {
+                    agent_id: colored.clone(),
+                    content_type: "ui:color".to_string(),
+                    content: "#123abc".to_string(),
+                    updated_at: 42,
+                })
+                .unwrap();
+
+            M0020AgentColorBackfill.up(&ctx_for(tmp.path())).unwrap();
+
+            let filled = wstore.agent_content_get(&plain, "ui:color").unwrap().unwrap();
+            assert!(is_valid_agent_color(&filled.content), "{}", filled.content);
+            // Pre-existing color untouched.
+            let kept = wstore.agent_content_get(&colored, "ui:color").unwrap().unwrap();
+            assert_eq!(kept.content, "#123abc");
+            assert_eq!(kept.updated_at, 42);
+        });
+    }
+
+    #[test]
+    fn rerun_is_idempotent() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::NamedTempFile::new().unwrap();
+            let wstore = Store::open(tmp.path()).unwrap();
+            let id = insert_def(&wstore, "one");
+
+            M0020AgentColorBackfill.up(&ctx_for(tmp.path())).unwrap();
+            let first = wstore.agent_content_get(&id, "ui:color").unwrap().unwrap();
+            M0020AgentColorBackfill.up(&ctx_for(tmp.path())).unwrap();
+            let second = wstore.agent_content_get(&id, "ui:color").unwrap().unwrap();
+            assert_eq!(first.content, second.content);
+            assert_eq!(first.updated_at, second.updated_at);
+        });
+    }
+
+    #[test]
+    fn missing_channel_store_is_a_noop() {
+        with_isolated_home(|_home| {
+            let ctx = ctx_for(std::path::Path::new("Z:/does/not/exist/objects.db"));
+            M0020AgentColorBackfill.up(&ctx).unwrap();
+        });
+    }
+
+    /// Regression test for the bug this migration's module doc describes:
+    /// an agent that exists ONLY in the global cross-channel registry (not
+    /// this channel's local SQLite — the common case for a real user agent
+    /// opened from a different channel) must still get backfilled. Before
+    /// the `set_def_registry` fix, `agent_def_list()` silently fell back
+    /// to local-only and this agent was invisible to the migration.
+    #[test]
+    fn backfills_an_agent_that_exists_only_in_the_global_registry() {
+        with_isolated_home(|home| {
+            let def_dir = home.join("shared").join("agents").join("definitions");
+            std::fs::create_dir_all(&def_dir).unwrap();
+            let def_store = DefinitionStore::open(def_dir).unwrap();
+            let record = crate::registry::DefinitionRecord {
+                schema_version: 1,
+                data: crate::registry::DefinitionRecordV1 {
+                    id: "global-only-agent".to_string(),
+                    slug: String::new(),
+                    name: "Global Only".to_string(),
+                    icon: String::new(),
+                    provider: "claude".to_string(),
+                    description: String::new(),
+                    working_directory: String::new(),
+                    shell: String::new(),
+                    provider_flags: String::new(),
+                    auto_start: 0,
+                    restart_on_crash: 0,
+                    idle_timeout_minutes: 0,
+                    created_at: 1,
+                    agent_type: "host".to_string(),
+                    environment: String::new(),
+                    agent_bus_id: String::new(),
+                    is_seeded: 0,
+                    accounts: String::new(),
+                    parent_id: String::new(),
+                    branch_label: String::new(),
+                    updated_at: 1,
+                    user_hidden: 0,
+                    container_image: String::new(),
+                    container_volumes: "[]".to_string(),
+                    container_name: String::new(),
+                    use_ambient_login: 0,
+                    content: Vec::new(),
+                    skills: Vec::new(),
+                },
+            };
+            def_store.upsert(&record).unwrap();
+
+            // Empty LOCAL channel store — this agent has no local row at all.
+            let channel_tmp = tempfile::NamedTempFile::new().unwrap();
+            Store::open(channel_tmp.path()).unwrap();
+
+            M0020AgentColorBackfill.up(&ctx_for(channel_tmp.path())).unwrap();
+
+            let rec = def_store.get("global-only-agent").unwrap().unwrap();
+            let color = rec
+                .data
+                .content
+                .iter()
+                .find(|c| c.content_type == "ui:color")
+                .map(|c| c.content.clone());
+            assert!(
+                color.as_deref().is_some_and(is_valid_agent_color),
+                "expected a valid color written to the GLOBAL registry, got {color:?}"
+            );
+        });
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -35,6 +35,7 @@ mod m0016_seed_starter_mcp_servers;
 mod m0017_ambient_login_grandfather;
 mod m0018_ambient_login_registry;
 mod m0019_repair_malformed_secret_ref;
+mod m0020_agent_color_backfill;
 mod runner;
 
 pub use runner::count_pending_migrations;
@@ -130,4 +131,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0017_ambient_login_grandfather::M0017AmbientLoginGrandfather,
     &m0018_ambient_login_registry::M0018AmbientLoginRegistry,
     &m0019_repair_malformed_secret_ref::M0019RepairMalformedSecretRef,
+    &m0020_agent_color_backfill::M0020AgentColorBackfill,
 ];

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -129,6 +129,16 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     use_ambient_login: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
+                // Assign the agent its display color at creation
+                // (SPEC_AGENT_COLOR_2026_08_08.md). Best-effort: a failure
+                // here shouldn't fail the create — agent.open assigns a
+                // color on first open as the fallback.
+                let _ = wstore.agent_content_set(&crate::backend::storage::store::AgentContent {
+                    agent_id: agent.id.clone(),
+                    content_type: "ui:color".to_string(),
+                    content: crate::backend::agent_color::pick_agent_color(&agent.id).to_string(),
+                    updated_at: now,
+                });
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "agents:changed".to_string(),
                     scopes: vec![],

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -299,6 +299,49 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         meta.insert("term:zoom".to_string(), json!(z));
                     }
                 }
+                // Per-agent color (SPEC_AGENT_COLOR_2026_08_08.md): seed the
+                // new block's frame border colors from the agent's stored
+                // ui:color so the existing pane-frame rendering shows it —
+                // full-strength on the focused border
+                // (frame:activebordercolor), dimmed on the unfocused one
+                // (frame:bordercolor) so the color is visible either way
+                // while focus stays distinguishable by brightness.
+                // Assign-if-missing write-through covers defs created by
+                // paths the createagent handler doesn't own (forks,
+                // imports) and any def that predates migration m0020 on
+                // this channel. Strict #rrggbb validation so a corrupt row
+                // can't inject arbitrary CSS.
+                {
+                    use crate::backend::agent_color::{dim_agent_color, is_valid_agent_color, pick_agent_color};
+                    let stored = wstore
+                        .agent_content_get(&agent.id, "ui:color")
+                        .ok()
+                        .flatten()
+                        .map(|c| c.content.trim().to_string())
+                        .filter(|c| is_valid_agent_color(c));
+                    let color = match stored {
+                        Some(c) => c,
+                        None => {
+                            let picked = pick_agent_color(&agent.id).to_string();
+                            let now_ms = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_millis() as i64)
+                                .unwrap_or(0);
+                            // Best-effort: a store error here shouldn't block
+                            // opening the agent — the pane just stays uncolored
+                            // this session and we retry next open.
+                            let _ = wstore.agent_content_set(&crate::backend::storage::store::AgentContent {
+                                agent_id: agent.id.clone(),
+                                content_type: "ui:color".to_string(),
+                                content: picked.clone(),
+                                updated_at: now_ms,
+                            });
+                            picked
+                        }
+                    };
+                    meta.insert("frame:activebordercolor".to_string(), json!(&color));
+                    meta.insert("frame:bordercolor".to_string(), json!(dim_agent_color(&color)));
+                }
                 meta.insert("agentProvider".to_string(), json!(&agent.provider));
                 meta.insert("agentName".to_string(), json!(&agent.name));
                 meta.insert("agentIcon".to_string(), json!(if agent.icon.is_empty() { "sparkles" } else { &agent.icon }));

--- a/docs/specs/SPEC_AGENT_COLOR_2026_08_08.md
+++ b/docs/specs/SPEC_AGENT_COLOR_2026_08_08.md
@@ -1,0 +1,186 @@
+# SPEC: Per-agent color — assign at creation, backfill existing, show on the pane frame
+
+**Date:** 2026-08-08
+**Status:** Implemented (same-day PR)
+**Author:** Agent3 (agent)
+**Trigger:** User request (2026-08-05, re-confirmed 2026-08-08) — *"when new
+agents are created, they should get a color … for now, generate a random
+color for all the existing agents"* / *"can u see all agents with random
+colors as a one-time script?"*
+**History:** An earlier draft (`SPEC_AGENT_COLOR_2026_08_05.md`) was written
+but never implemented, and was deleted untracked in the 2026-08-07 docs
+cleanup. This spec replaces it with a narrower, shipping-first scope.
+
+---
+
+## 1. Goal
+
+Every agent has a color. Existing agents get one via a one-time backfill;
+new agents get one at creation. The color is immediately **visible** with
+zero new rendering code, by reusing the pane frame's existing
+`frame:bordercolor` block-meta support.
+
+## 2. What exists to build on (verified against `main` @ `3fbe072bf`)
+
+| Piece | Where | Why it matters |
+|---|---|---|
+| Per-agent KV content store | `Store::agent_content_get/set` (`backend/storage/content.rs`) — global cross-channel via the def-registry mirror; handles cross-channel agents (no local FK row) by routing to the registry directly | The established home for per-agent side-data (`ui:zoom` precedent, `SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md`). No schema change, no `AgentDefinition` struct change, no dual-write surface touched. |
+| Block-meta seeding at open | `register_agent_open` (`server/app_api/agent_open.rs:297`) already seeds `term:zoom` from `agent_content("ui:zoom")` | The exact pattern for seeding `frame:bordercolor` from `ui:color`. |
+| Pane frame color rendering | `blockframe.tsx:733` styles the block border from `meta["frame:bordercolor"]`; right-click pane-header swatch palette already writes this key | The display surface — colors show on every agent pane's frame with **no frontend changes**. The user can still override per pane via the existing palette. |
+| Migration framework | `agentmux-srv/src/migrations/` (m0000–m0019), once-per-channel tracking in `db_migrations` | The codebase's mechanism for exactly-once backfills — the requested "one-time script". |
+| 14-hue palette | `TAB_COLORS` (`frontend/app/tab/tab.tsx:20`) — also used for random tab colors (`tab-actions.ts:31`) | Color values to assign from. Duplicated as hexes in the Rust migration (a one-time list; drift is inconsequential since assigned colors are stored, not derived). |
+
+## 3. Design
+
+### 3.1 Storage
+
+`agent_content` row: `content_type = "ui:color"`, `content = "#rrggbb"`.
+Absent row = no color (pane frame falls back to default border, exactly as
+today). No migration of the `AgentDefinition` schema.
+
+### 3.2 Backfill (the one-time script) — migration `m0020_agent_color_backfill`
+
+Channel scope, follows the `m0015` shape: open the channel store, iterate
+`agent_def_list()`, and for every definition without an existing `ui:color`
+row, write one. Color choice is a **deterministic hash of the agent id**
+mapped onto the 14-hue palette — effectively random across agents, but
+stable across re-runs/machines and dependency-free (no `rand` needed).
+Skips defs that already have a color, so it's idempotent even beyond the
+framework's once-per-channel tracking.
+
+### 3.3 New agents — assign at creation
+
+In the `createagent` handler (`server/agent_handlers/core.rs`), after
+`agent_def_insert`, write `ui:color` with the same id-hash palette pick.
+Fork/branch flows that create defs through other paths are left to the
+backfill-on-open fallback (§3.4) rather than chasing every creation site.
+
+### 3.4 Display seeding — `register_agent_open`
+
+Next to the `ui:zoom` seeding block: read `agent_content("ui:color")`; if a
+valid `#rrggbb` value exists, seed BOTH frame color keys into the new
+block's meta — `blockframe.tsx` reads `frame:activebordercolor` for the
+focused state and `frame:bordercolor` for the unfocused state, so seeding
+only one would leave the color invisible half the time. Focused gets the
+full-strength hex; unfocused gets a dimmed variant (RGB × 0.55, computed in
+Rust) so the agent's color is visible either way while focus stays
+distinguishable by brightness. Validation is a strict `#` + 6-hex-digit
+shape check so a corrupt row can't inject arbitrary CSS. As a safety net
+for defs created by paths §3.3 doesn't cover, if no color exists, assign
+one here (write-through) before seeding — every agent that gets opened ends
+up colored.
+
+Discovered while implementing: nothing in the frontend writes
+`frame:bordercolor` today — `SPEC_COLOR_PALETTE_EXPANSION_REUSE_2026_06_30.md`'s
+pane-header swatch palette only shipped for tabs (`ColorSwatchPalette`'s
+sole consumer is `tab.tsx`). So this seed is currently the only writer of
+these keys and there is no user-override conflict to design around; if the
+pane palette lands later, a per-block SetMeta after open will still win
+over the open-time seed for that block's lifetime.
+
+### 3.5 Architectural discovery: agent launch has TWO independent meta-building paths
+
+Live verification against a running `task dev` build showed §3.4's seed
+never took effect for the everyday "click **Continue** in the agent
+picker" flow, despite `register_agent_open` visibly working (confirmed via
+the migration, which shares its code) and the written block ending up with
+every OTHER piece of rich meta (`cmd`, `cmd:args`, `agent:resume_flag`,
+etc.) that only that function builds. Root-caused via the srv log: the
+handler's own `tracing::info!(agent_id, "agent.open")` line — the very
+first statement in `register_agent_open` — never appeared, even though
+`~/.agentmux/logs/agentmuxsrv-*.log` clearly showed this exact block being
+opened (agent name, ids, and downstream events like "reactive register
+request" all present).
+
+The actual cause: **the picker's "Continue" click never calls the
+backend's `agent.open` RPC at all.** It goes through
+`AgentPicker.tsx::handleReattach` → `agent-model.ts::launchAgentDefinition`,
+which independently re-derives the *entire* launch — CLI args, env vars,
+working directory, resume flags, output format — into its own `meta`
+object and pushes it via `SetMetaCommand` + `ControllerResyncCommand`.
+This is not a thin wrapper around the backend path; it is a second,
+parallel implementation of the same job, apparently maintained
+independently (their key sets have drifted to *almost* but not quite
+identical field names). `register_agent_open`'s `agent.open` RPC exists
+and works, but nothing in the primary UI flow calls it — it appears to
+serve other callers only (e.g. MCP tool / programmatic opens).
+
+**Collateral finding:** the existing, already-shipped `term:zoom`
+persistence feature (`SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md`) has the
+identical gap — it's seeded only in `register_agent_open`, so it was
+likely never actually restoring zoom for picker-launched agents either.
+Not confirmed with a live repro (out of scope to chase further here), but
+the code shape is identical enough to flag.
+
+**Fix:** duplicate the same seed logic into `launchAgentDefinition`
+(`frontend/app/view/agent/agent-model.ts`), since that is the code path
+that actually runs for the everyday flow:
+
+- New `frontend/app/view/agent/agent-color.ts` — a TS counterpart of
+  `agent_color.rs` (`pickAgentColor` FNV-1a hash over `TAB_COLORS`,
+  `isValidAgentColor`, `dimAgentColor`). Deliberately NOT shared code with
+  the Rust side — the two don't need to agree bit-for-bit, since whichever
+  path assigns a color first persists it and every later reader (either
+  path) just reads that stored value back.
+- `launchAgentDefinition` already loads `contentMap` (all `AgentContent`
+  rows for this agent) for config-file building — reads `ui:color`/`ui:zoom`
+  from there directly, no new RPC round-trip needed for the read side. If no
+  valid color exists, picks one and persists it via the existing
+  `SetAgentContentCommand` RPC (best-effort — a failure doesn't block the
+  launch). Adds `term:zoom` (mirroring `parse_seed_zoom`'s clamp/validate
+  contract) and both frame color keys into the `meta` object already being
+  built for `SetMetaCommand`.
+
+This is a genuine duplicated-logic architecture smell worth a dedicated
+follow-up (either the frontend should call the backend's `agent.open` RPC
+instead of rebuilding launch meta itself, or the backend path should be
+retired if it's truly unused by any real caller) — flagged here, not fixed
+here; consolidating two independently-evolved ~150-line implementations is
+a larger, riskier change than this feature justifies.
+
+Verified live via CDP against a `task dev` build after the fix: opening a
+never-before-opened agent through the actual picker UI produces a block
+whose `.block-mask` inline style is `border-color: rgb(34, 197, 94)` —
+exactly the agent's stored `ui:color` (`#22c55e`), confirmed by directly
+reading the persisted block meta from the channel's SQLite store.
+
+## 4. Out of scope (follow-ups, not this PR)
+
+- Color picker in the create-agent pane UI (the 08-05 ask's UI half) — the
+  shared `ColorSwatchPalette` component makes this cheap later.
+- Showing the color in the agent picker / My Agents list (colored dot).
+- An "agent color" editor anywhere in settings.
+
+## 5. Test plan
+
+- [x] Unit (Rust): migration assigns colors only to defs lacking one;
+      id-hash pick is stable; invalid stored color is not seeded into
+      block meta; a global-registry-only agent (no local row) still gets
+      backfilled — the regression test for §3's `set_def_registry` fix.
+- [x] Unit (TS): `pickAgentColor`/`isValidAgentColor`/`dimAgentColor` mirror
+      the Rust suite (deterministic, palette membership, validation,
+      dim-stays-valid).
+- [x] Live, via CDP against a running `task dev` build:
+      - Migration backfilled all 26 real agents on the test machine (read
+        directly from `~/.agentmux/shared/agents/definitions/*.json`).
+      - Opening a fresh agent through the **actual picker UI** (not a
+        direct RPC call) renders the assigned color on the pane border —
+        confirmed only after finding and fixing the §3.5 frontend-path gap.
+      - Short-viewport / resize interactions unaffected (no relation to
+        this feature's DOM surface).
+- [ ] Not verified live: `term:zoom` restoration on the picker flow (the
+      §3.5 collateral finding) — flagged, not chased down in this PR.
+
+## 6. Files
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/migrations/m0020_agent_color_backfill.rs` | New — backfill migration; attaches the global def registry itself (§3.2 note) |
+| `agentmux-srv/src/migrations/mod.rs` | Register m0020 |
+| `agentmux-srv/src/backend/agent_color.rs` (new) | Palette + id-hash pick + dim + validation, shared by migration/create/open |
+| `agentmux-srv/src/backend/mod.rs` | Register `agent_color` module |
+| `agentmux-srv/src/server/agent_handlers/core.rs` | Assign `ui:color` in `createagent` |
+| `agentmux-srv/src/server/app_api/agent_open.rs` | Seed both frame color keys from `ui:color` (with assign-if-missing fallback) — the RPC path, not the one the picker uses (§3.5) |
+| `frontend/app/view/agent/agent-color.ts` (new) | TS counterpart of `agent_color.rs` — §3.5 |
+| `frontend/app/view/agent/agent-color.test.ts` (new) | Mirrors the Rust unit tests |
+| `frontend/app/view/agent/agent-model.ts` | `launchAgentDefinition`: seed `term:zoom` + both frame color keys — the actual picker-flow fix, §3.5 |

--- a/docs/specs/SPEC_AGENT_COLOR_2026_08_08.md
+++ b/docs/specs/SPEC_AGENT_COLOR_2026_08_08.md
@@ -70,13 +70,28 @@ for defs created by paths §3.3 doesn't cover, if no color exists, assign
 one here (write-through) before seeding — every agent that gets opened ends
 up colored.
 
-Discovered while implementing: nothing in the frontend writes
-`frame:bordercolor` today — `SPEC_COLOR_PALETTE_EXPANSION_REUSE_2026_06_30.md`'s
+Discovered while implementing: nothing in the frontend writes the literal
+`frame:bordercolor` KEY today — `SPEC_COLOR_PALETTE_EXPANSION_REUSE_2026_06_30.md`'s
 pane-header swatch palette only shipped for tabs (`ColorSwatchPalette`'s
-sole consumer is `tab.tsx`). So this seed is currently the only writer of
-these keys and there is no user-override conflict to design around; if the
-pane palette lands later, a per-block SetMeta after open will still win
-over the open-time seed for that block's lifetime.
+sole consumer is `tab.tsx`). **This check was incomplete** (reagent P1 on
+the PR): it missed that `blockframe.tsx`'s border-color computation ALSO
+reads `frame:hue`, written by the already-shipped, all-pane-types "Pane
+Color" picker (`pane-color-menu.ts::setHue`, wired into every block's
+header context menu — a *different*, already-shipped feature from the
+06-30 spec, not the tab-only swatch grid). Before the fix below, once an
+agent pane's `frame:activebordercolor` was seeded, it was checked AFTER
+`frame:hue` in the focused-state style memo and unconditionally
+overwrote it — so picking a hue on an agent pane had no visible effect,
+permanently, for that block's lifetime (the seed is a one-time write, but
+`blockData()` re-reads it on every render). Fixed in
+`frontend/app/block/blockframe.tsx`'s focused-state branch by checking
+`frame:activebordercolor` BEFORE `frame:hue` instead — the explicit user
+choice now always wins when present; clearing the hue picker
+(`frame:hue: null`) correctly falls through to the agent's default color
+rather than to no color at all. The unfocused-state branch has no
+`frame:hue`-derived value to conflict with (`hueToActiveBorder`'s hue
+rendering only ever existed for the focused ring), so `frame:bordercolor`
+needed no equivalent change there.
 
 ### 3.5 Architectural discovery: agent launch has TWO independent meta-building paths
 
@@ -184,3 +199,4 @@ reading the persisted block meta from the channel's SQLite store.
 | `frontend/app/view/agent/agent-color.ts` (new) | TS counterpart of `agent_color.rs` — §3.5 |
 | `frontend/app/view/agent/agent-color.test.ts` (new) | Mirrors the Rust unit tests |
 | `frontend/app/view/agent/agent-model.ts` | `launchAgentDefinition`: seed `term:zoom` + both frame color keys — the actual picker-flow fix, §3.5 |
+| `frontend/app/block/blockframe.tsx` | Focused-state border-color memo: check `frame:activebordercolor` before `frame:hue` so the explicit "Pane Color" picker keeps working on agent panes (§3.4 note, reagent P1) |

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -717,12 +717,23 @@ function BlockMask({ nodeModel }: { nodeModel: NodeModel }): JSX.Element {
             if (tabActiveBorderColor) {
                 style["border-color"] = tabActiveBorderColor;
             }
+            // frame:activebordercolor is a passive default (per-agent
+            // identity color, seeded once at launch — see
+            // SPEC_AGENT_COLOR_2026_08_08.md); frame:hue is an explicit
+            // user choice from the pane-header "Pane Color" picker
+            // (pane-color-menu.ts's setHue). The explicit choice must win
+            // whenever it's present, or picking a hue on an agent pane
+            // would have no visible effect (reagent P1, PR #2477) — hue
+            // is therefore checked LAST. Clearing the hue picker sets
+            // frame:hue to `null` (not delete), which correctly falls
+            // through here (typeof null !== "number") back to the
+            // agent's default color rather than to no color at all.
+            if (bd?.meta?.["frame:activebordercolor"]) {
+                style["border-color"] = bd.meta["frame:activebordercolor"];
+            }
             const hue = bd?.meta?.["frame:hue"];
             if (typeof hue === "number") {
                 style["border-color"] = hueToActiveBorder(hue);
-            }
-            if (bd?.meta?.["frame:activebordercolor"]) {
-                style["border-color"] = bd.meta["frame:activebordercolor"];
             }
         } else {
             const tabData = atoms.tabAtom();

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -32,7 +32,7 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show }
 import { CopyButton } from "../element/copybutton";
 import { detectAgentColor, detectAgentFromEnv, detectAgentTextColor, getEffectiveTitle, isUsableFocusRingColor } from "./autotitle";
 import { buildPaneContextMenu } from "./pane-actions";
-import { hueToHeaderBg, hueToActiveBorder, PANE_HUE_OPTIONS, setHue } from "./pane-color-menu";
+import { hueToHeaderBg, hueToActiveBorder, hueToBorder, PANE_HUE_OPTIONS, setHue } from "./pane-color-menu";
 import { BlockFrameProps } from "./blocktypes";
 import { PaneSizeBadge } from "./pane-size-badge";
 import { TitleBar } from "./titlebar";
@@ -743,6 +743,10 @@ function BlockMask({ nodeModel }: { nodeModel: NodeModel }): JSX.Element {
             }
             if (bd?.meta?.["frame:bordercolor"]) {
                 style["border-color"] = bd.meta["frame:bordercolor"];
+            }
+            const hue = bd?.meta?.["frame:hue"];
+            if (typeof hue === "number") {
+                style["border-color"] = hueToBorder(hue);
             }
         }
         return style;

--- a/frontend/app/block/pane-color-menu.ts
+++ b/frontend/app/block/pane-color-menu.ts
@@ -36,6 +36,14 @@ export function hueToActiveBorder(hue: number): string {
     return `hsl(${hue}, 65%, 52%)`;
 }
 
+/** Derive the dimmed unfocused-border color from a hue (0–360). Lightness
+ * scaled by the same 0.55 dim factor as agent-color.ts::dimAgentColor, so
+ * an explicit hue pick dims the same way the auto-assigned agent color
+ * does. */
+export function hueToBorder(hue: number): string {
+    return `hsl(${hue}, 65%, 29%)`;
+}
+
 export function setHue(blockId: string, hue: number | null): void {
     void RpcApi.SetMetaCommand(TabRpcClient, {
         oref: WOS.makeORef("block", blockId),

--- a/frontend/app/view/agent/agent-color.test.ts
+++ b/frontend/app/view/agent/agent-color.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { TAB_COLORS } from "@/app/tab/tab";
+import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
+
+describe("pickAgentColor", () => {
+    it("is deterministic", () => {
+        expect(pickAgentColor("abc-123")).toBe(pickAgentColor("abc-123"));
+    });
+
+    it("returns a palette member", () => {
+        const palette = new Set(TAB_COLORS.map((c) => c.hex));
+        for (const id of ["a", "b", "c", "0d5b45f1-9b2c-4a7e-8f3d-1234567890ab", ""]) {
+            expect(palette.has(pickAgentColor(id))).toBe(true);
+        }
+    });
+
+    it("spreads distinct ids over more than one bucket", () => {
+        const picked = new Set(Array.from({ length: 100 }, (_, i) => pickAgentColor(`agent-${i}`)));
+        expect(picked.size).toBeGreaterThan(5);
+    });
+});
+
+describe("isValidAgentColor", () => {
+    it("accepts every palette color", () => {
+        for (const c of TAB_COLORS) {
+            expect(isValidAgentColor(c.hex)).toBe(true);
+        }
+    });
+
+    it("rejects malformed values", () => {
+        for (const bad of [undefined, "", "#fff", "red", "#gggggg", "#3b82f6; }", "3b82f6", "#3B82F66"]) {
+            expect(isValidAgentColor(bad)).toBe(false);
+        }
+    });
+
+    it("accepts uppercase hex", () => {
+        expect(isValidAgentColor("#3B82F6")).toBe(true);
+    });
+});
+
+describe("dimAgentColor", () => {
+    it("scales channels down and stays valid", () => {
+        expect(dimAgentColor("#ffffff")).toBe("#8c8c8c");
+        expect(dimAgentColor("#000000")).toBe("#000000");
+        for (const c of TAB_COLORS) {
+            const dimmed = dimAgentColor(c.hex);
+            expect(isValidAgentColor(dimmed)).toBe(true);
+            expect(dimmed).not.toBe(c.hex);
+        }
+    });
+
+    it("passes invalid input through unchanged", () => {
+        expect(dimAgentColor("junk")).toBe("junk");
+    });
+});

--- a/frontend/app/view/agent/agent-color.ts
+++ b/frontend/app/view/agent/agent-color.ts
@@ -1,0 +1,54 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Per-agent color assignment — frontend counterpart of
+// agentmux-srv/src/backend/agent_color.rs.
+//
+// Duplicated here (not shared) because agent launch has two independent
+// meta-building paths — the backend's `agent.open` RPC
+// (agent_open.rs::register_agent_open) and this frontend's
+// `launchAgentDefinition` (agent-model.ts), which is what the picker's
+// "Continue" click actually calls. `pickAgentColor` here is a same-shape
+// FNV-1a hash for algorithmic consistency, but the two never need to
+// agree bit-for-bit: whichever code path assigns a color FIRST persists
+// it via SetAgentContentCommand/agent_content_set, and every later reader
+// (either path) just reads that stored value back. See
+// docs/specs/SPEC_AGENT_COLOR_2026_08_08.md.
+
+import { TAB_COLORS } from "@/app/tab/tab";
+
+const AGENT_COLOR_PALETTE: string[] = TAB_COLORS.map((c) => c.hex);
+
+/** Deterministic FNV-1a hash of the agent id onto the palette — stable
+ * across reloads/machines, no RNG needed. Mirrors
+ * agent_color.rs::pick_agent_color. */
+export function pickAgentColor(agentId: string): string {
+    let hash = BigInt("0xcbf29ce484222325");
+    const fnvPrime = BigInt("0x100000001b3");
+    const mask = (BigInt(1) << BigInt(64)) - BigInt(1);
+    for (let i = 0; i < agentId.length; i++) {
+        hash ^= BigInt(agentId.charCodeAt(i) & 0xff);
+        hash = (hash * fnvPrime) & mask;
+    }
+    const idx = Number(hash % BigInt(AGENT_COLOR_PALETTE.length));
+    return AGENT_COLOR_PALETTE[idx];
+}
+
+/** Strict `#rrggbb` shape check — same contract as the Rust counterpart:
+ * the value flows into block meta applied as a CSS border-color. */
+export function isValidAgentColor(value: string | null | undefined): value is string {
+    return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+/** Dimmed variant for the unfocused pane border (`frame:bordercolor`) —
+ * full-strength color stays on the focused border
+ * (`frame:activebordercolor`). Mirrors agent_color.rs::dim_agent_color. */
+export function dimAgentColor(hex: string): string {
+    if (!isValidAgentColor(hex)) return hex;
+    const channel = (s: string) => parseInt(s, 16);
+    const r = Math.round(channel(hex.slice(1, 3)) * 0.55);
+    const g = Math.round(channel(hex.slice(3, 5)) * 0.55);
+    const b = Math.round(channel(hex.slice(5, 7)) * 0.55);
+    const hex2 = (n: number) => n.toString(16).padStart(2, "0");
+    return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+}

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -20,6 +20,7 @@ import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-lau
 import { realAccountIdOrEmpty } from "./identity-carry-over";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
+import { parseSeedZoom } from "./agent-zoom-seed";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -567,27 +568,14 @@ export class AgentViewModel implements ViewModel {
             // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md):
             // seed term:zoom from the agent's saved ui:zoom (already loaded
             // into contentMap above) so reopening the same agent restores
-            // its zoom instead of resetting to 1.0. Mirrors
-            // app_api/mod.rs::parse_seed_zoom, which this path never went
-            // through (this function builds meta independently of the
-            // backend's agent.open RPC — see this file's own launch
-            // pipeline vs. agent_open.rs::register_agent_open).
-            //
-            // Set UNCONDITIONALLY, same reasoning as agent:sessionid above:
-            // SetMetaCommand MERGES meta, and targetBlockId can reuse a
-            // block that previously hosted a different agent (fork/relaunch
-            // flows). Omitting the key when this agent has no saved zoom
-            // would leave a stale term:zoom from whatever agent was here
-            // before (reagent/codex P2, PR #2477). null is term.tsx's own
-            // "reset to default" sentinel (term.tsx:347), so it round-trips
-            // through the same read path the drag-to-zoom handler uses.
-            const rawZoom = contentMap["ui:zoom"]?.trim();
-            const seedZoom = rawZoom ? Number(rawZoom) : NaN;
-            const validSeedZoom =
-                Number.isFinite(seedZoom) && seedZoom !== 1 && seedZoom >= 0.5 && seedZoom <= 2
-                    ? seedZoom
-                    : null;
-            const zoomMeta: Record<string, unknown> = { "term:zoom": validSeedZoom };
+            // its zoom instead of resetting to 1.0. This path never went
+            // through the backend's own seed (agent_open.rs::
+            // register_agent_open) — see this file's own launch pipeline.
+            // Set UNCONDITIONALLY (parseSeedZoom's null, not an omitted
+            // key) — see that function's doc comment for why.
+            const zoomMeta: Record<string, unknown> = {
+                "term:zoom": parseSeedZoom(contentMap["ui:zoom"]),
+            };
 
             // Per-agent color (SPEC_AGENT_COLOR_2026_08_08.md): seed the
             // frame border colors from the agent's stored ui:color —

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -19,6 +19,7 @@ import { buildConfigFiles } from "./agent-config-builder";
 import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-launch-env";
 import { realAccountIdOrEmpty } from "./identity-carry-over";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
+import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -562,6 +563,46 @@ export class AgentViewModel implements ViewModel {
             // overrides whatever value lands here on subsequent
             // turns.
             const continueSid = overrides?.continueSessionId?.trim() ?? "";
+
+            // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md):
+            // seed term:zoom from the agent's saved ui:zoom (already loaded
+            // into contentMap above) so reopening the same agent restores
+            // its zoom instead of resetting to 1.0. Stored only for
+            // non-default, in-range values — mirrors
+            // app_api/mod.rs::parse_seed_zoom, which this path never went
+            // through (this function builds meta independently of the
+            // backend's agent.open RPC — see this file's own launch
+            // pipeline vs. agent_open.rs::register_agent_open).
+            const rawZoom = contentMap["ui:zoom"]?.trim();
+            const seedZoom = rawZoom ? Number(rawZoom) : NaN;
+            const zoomMeta: Record<string, unknown> =
+                Number.isFinite(seedZoom) && seedZoom !== 1 && seedZoom >= 0.5 && seedZoom <= 2
+                    ? { "term:zoom": seedZoom }
+                    : {};
+
+            // Per-agent color (SPEC_AGENT_COLOR_2026_08_08.md): seed the
+            // frame border colors from the agent's stored ui:color —
+            // full-strength on the focused border
+            // (frame:activebordercolor), dimmed on the unfocused one
+            // (frame:bordercolor) so the color is visible either way while
+            // focus stays distinguishable by brightness. Assign-if-missing
+            // write-through covers an agent that predates migration m0020
+            // or was created before this path existed.
+            const rawColor = contentMap["ui:color"]?.trim();
+            let agentColor: string;
+            if (isValidAgentColor(rawColor)) {
+                agentColor = rawColor;
+            } else {
+                agentColor = pickAgentColor(agent.id);
+                RpcApi.SetAgentContentCommand(TabRpcClient, {
+                    agent_id: agent.id,
+                    content_type: "ui:color",
+                    content: agentColor,
+                }).catch((e: any) => {
+                    Logger.warn("agent", "Failed to persist assigned agent color", { error: String(e) });
+                });
+            }
+
             const meta: Record<string, unknown> = {
                 agentId: agent.id,
                 agentProvider: agent.provider,
@@ -578,6 +619,9 @@ export class AgentViewModel implements ViewModel {
                 "agent:resume_flag": provider.resumeFlag ?? "",
                 "agent:session_id_field": provider.sessionIdField,
                 "agent:sessionid": continueSid,
+                ...zoomMeta,
+                "frame:activebordercolor": agentColor,
+                "frame:bordercolor": dimAgentColor(agentColor),
             };
             await RpcApi.SetMetaCommand(TabRpcClient, {
                 oref,

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -567,18 +567,27 @@ export class AgentViewModel implements ViewModel {
             // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md):
             // seed term:zoom from the agent's saved ui:zoom (already loaded
             // into contentMap above) so reopening the same agent restores
-            // its zoom instead of resetting to 1.0. Stored only for
-            // non-default, in-range values — mirrors
+            // its zoom instead of resetting to 1.0. Mirrors
             // app_api/mod.rs::parse_seed_zoom, which this path never went
             // through (this function builds meta independently of the
             // backend's agent.open RPC — see this file's own launch
             // pipeline vs. agent_open.rs::register_agent_open).
+            //
+            // Set UNCONDITIONALLY, same reasoning as agent:sessionid above:
+            // SetMetaCommand MERGES meta, and targetBlockId can reuse a
+            // block that previously hosted a different agent (fork/relaunch
+            // flows). Omitting the key when this agent has no saved zoom
+            // would leave a stale term:zoom from whatever agent was here
+            // before (reagent/codex P2, PR #2477). null is term.tsx's own
+            // "reset to default" sentinel (term.tsx:347), so it round-trips
+            // through the same read path the drag-to-zoom handler uses.
             const rawZoom = contentMap["ui:zoom"]?.trim();
             const seedZoom = rawZoom ? Number(rawZoom) : NaN;
-            const zoomMeta: Record<string, unknown> =
+            const validSeedZoom =
                 Number.isFinite(seedZoom) && seedZoom !== 1 && seedZoom >= 0.5 && seedZoom <= 2
-                    ? { "term:zoom": seedZoom }
-                    : {};
+                    ? seedZoom
+                    : null;
+            const zoomMeta: Record<string, unknown> = { "term:zoom": validSeedZoom };
 
             // Per-agent color (SPEC_AGENT_COLOR_2026_08_08.md): seed the
             // frame border colors from the agent's stored ui:color —

--- a/frontend/app/view/agent/agent-zoom-seed.test.ts
+++ b/frontend/app/view/agent/agent-zoom-seed.test.ts
@@ -1,0 +1,41 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { parseSeedZoom } from "./agent-zoom-seed";
+
+describe("parseSeedZoom", () => {
+    it("returns null for missing/empty/whitespace input", () => {
+        expect(parseSeedZoom(undefined)).toBeNull();
+        expect(parseSeedZoom(null)).toBeNull();
+        expect(parseSeedZoom("")).toBeNull();
+        expect(parseSeedZoom("   ")).toBeNull();
+    });
+
+    it("returns null for the default zoom (1)", () => {
+        expect(parseSeedZoom("1")).toBeNull();
+        expect(parseSeedZoom("1.0")).toBeNull();
+        expect(parseSeedZoom(" 1 ")).toBeNull();
+    });
+
+    it("returns null for out-of-range values", () => {
+        expect(parseSeedZoom("0.49")).toBeNull();
+        expect(parseSeedZoom("2.01")).toBeNull();
+        expect(parseSeedZoom("0")).toBeNull();
+        expect(parseSeedZoom("-1")).toBeNull();
+        expect(parseSeedZoom("100")).toBeNull();
+    });
+
+    it("returns null for unparseable garbage", () => {
+        expect(parseSeedZoom("not-a-number")).toBeNull();
+        expect(parseSeedZoom("NaN")).toBeNull();
+        expect(parseSeedZoom("1.5x")).toBeNull();
+    });
+
+    it("returns the parsed value for valid in-range, non-default zooms", () => {
+        expect(parseSeedZoom("1.5")).toBe(1.5);
+        expect(parseSeedZoom("0.5")).toBe(0.5);
+        expect(parseSeedZoom("2")).toBe(2);
+        expect(parseSeedZoom(" 1.25 ")).toBe(1.25);
+    });
+});

--- a/frontend/app/view/agent/agent-zoom-seed.ts
+++ b/frontend/app/view/agent/agent-zoom-seed.ts
@@ -1,0 +1,32 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Per-agent zoom seeding — frontend counterpart of
+// agentmux-srv/src/server/app_api/mod.rs::parse_seed_zoom. Extracted out
+// of agent-model.ts::launchAgentDefinition (SPEC_AGENT_ZOOM_PERSISTENCE_
+// 2026_06_22.md; the frontend-path gap is documented in
+// SPEC_AGENT_COLOR_2026_08_08.md §3.5) so the clamp/validate contract has
+// its own unit tests instead of living inline in a large function.
+
+/**
+ * Parse + validate a saved `ui:zoom` content blob for seeding a launched
+ * agent block's `term:zoom`. Returns a parseable, non-default (≠ 1), in-
+ * [0.5, 2] zoom, or `null` for anything else (missing, default, out of
+ * range, garbage) — the range term.tsx's own zoom control enforces.
+ *
+ * `null` (not "omit the key") is the deliberate return value for "no seed
+ * value" — `launchAgentDefinition` sets `term:zoom` unconditionally so
+ * relaunching into a reused block (`targetBlockId`, the fork/relaunch
+ * flows) can't leave a stale zoom from whatever agent previously occupied
+ * that block (`SetMetaCommand` merges meta rather than replacing it —
+ * reagent/codex P2, PR #2477). `null` is also term.tsx's own "reset to
+ * default" sentinel (term.tsx:347), so it round-trips through the same
+ * read path the drag-to-zoom handler already uses.
+ */
+export function parseSeedZoom(raw: string | null | undefined): number | null {
+    const trimmed = raw?.trim();
+    if (!trimmed) return null;
+    const z = Number(trimmed);
+    if (!Number.isFinite(z) || z === 1 || z < 0.5 || z > 2) return null;
+    return z;
+}


### PR DESCRIPTION
## Summary

Every agent now gets a color, shown on its pane frame via the existing `frame:bordercolor`/`frame:activebordercolor` block-meta support (no new rendering code needed). Answers the original request: *"when new agents are created, they should get a color... generate a random color for all the existing agents"*.

- **Storage**: color lives in the per-agent content store (`ui:color`, `#rrggbb`) — the same mechanism `ui:zoom` already uses.
- **Backfill**: migration `m0020_agent_color_backfill` — one-time, idempotent, deterministic id-hash pick over the 14-hue `TAB_COLORS` palette. Colored all 26 real agents on the test machine.
- **New agents**: assigned a color at creation (`createagent` handler).
- **Display**: seeded onto the pane border at open time — full-strength on the focused border, dimmed on the unfocused one so it's visible either way.

## A real architectural finding along the way

Live CDP verification against `task dev` showed the color never rendered for the everyday "click **Continue** in the picker" flow, even though the backend seed (`agent_open.rs::register_agent_open`, the `agent.open` RPC) was correctly implemented and unit-tested. Root cause: **the picker's "Continue" click doesn't call that RPC at all** — it goes through `agent-model.ts::launchAgentDefinition`, an independent second implementation of launch-meta-building (its own CLI args, env vars, working dir, resume flags — a near-duplicate of the backend path, apparently maintained separately). The backend RPC is real and used by other callers, just not the primary UI flow.

Collateral finding: the already-shipped `term:zoom` persistence feature has the identical gap, so it's likely never actually restored zoom on the picker flow either (not chased down further here — flagged in the spec).

Fix: added the same seed logic (new `agent-color.ts`, a TS counterpart of `agent_color.rs`) directly into `launchAgentDefinition`, plus the missing `term:zoom` seed. Full writeup in the spec, §3.5.

Spec: `docs/specs/SPEC_AGENT_COLOR_2026_08_08.md`

## Test plan
- [x] `cargo build -p agentmux-srv` clean; `cargo test -p agentmux-srv` — 2072 passed (includes a regression test proving the migration reaches cross-channel/global-only agents, not just local ones — caught a real bug where the migration's bare `Store::open()` never had the global registry attached, matching the same class of bug as the frontend one above)
- [x] `npx tsc --noEmit` clean; new `agent-color.test.ts` (8 tests) mirrors the Rust unit tests
- [x] Live via CDP: migration backfilled all 26 real agents (read directly from the global registry's JSON files); opening a never-before-opened agent through the **actual picker UI** now renders the assigned color on the pane border (`rgb(34, 197, 94)` = the agent's stored `#22c55e`, confirmed against persisted block meta)

<!-- agentmux:agent_id=agent3 -->