### PR TITLE
chore: release v0.54.14

### DIFF
--- a/.changesets/1786195261-feat-statusbar-disk-readout-explains-its-in-the-tooltip-clic-toq5.md
+++ b/.changesets/1786195261-feat-statusbar-disk-readout-explains-its-in-the-tooltip-clic-toq5.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(statusbar): Disk readout explains its % in the tooltip; click opens a per-drive free-space popover

--- a/.changesets/1786197128-fix-armory-accounts-appear-live-everywhere-subscribe-the-sha-c7w1.md
+++ b/.changesets/1786197128-fix-armory-accounts-appear-live-everywhere-subscribe-the-sha-c7w1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): accounts appear live everywhere - subscribe the shared account cache to identityaccounts:changed

--- a/.changesets/1786197197-fix-app-api-window-rename-validates-existence-naming-routes--olxd.md
+++ b/.changesets/1786197197-fix-app-api-window-rename-validates-existence-naming-routes--olxd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(app-api): window rename validates existence; naming routes return real status codes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.13"
+version = "0.54.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.13"
+version = "0.54.14"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.13"
+version = "0.54.14"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.13"
+version = "0.54.14"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.13"
+version = "0.54.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.13"
+version = "0.54.14"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.13"
+version = "0.54.14"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,12 @@
 # AgentMux Version History
 
+## 0.54.14 — 2026-08-09
+
+- feat(statusbar): Disk readout explains its % in the tooltip; click opens a per-drive free-space popover
+- fix(armory): accounts appear live everywhere - subscribe the shared account cache to identityaccounts:changed
+- fix(app-api): window rename validates existence; naming routes return real status codes
+
+
 ## 0.54.13 — 2026-08-08
 
 - feat(process-tracker): register ShellController/AcpController spawns with process_tracker::registry (Process Broker Phase B, shell+acp coverage)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.13",
+  "version": "0.54.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.13",
+      "version": "0.54.14",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.13",
+  "version": "0.54.14",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Release v0.54.14 (patch, forced override)

Consumes 3 pending changesets:

- fix(armory): accounts appear live everywhere — subscribe the shared account cache to `identityaccounts:changed` (#2474)
- fix(app-api): window rename validates existence, naming routes
- feat(statusbar): disk readout explains it's in the tooltip, clickable — *note: minor-level changeset shipped under a forced patch bump per release override*

Version 0.54.13 → 0.54.14 across all five version locations (package.json, Cargo.toml, both lockfiles, VERSION_HISTORY.md). This is the only PR touching version files, per the changesets protocol.

<!-- agentmux:agent_id=agent3 -->