### PR TITLE
fix(backend): editor/media file watchers no longer misfire on a macOS remove

### DIFF
--- a/.changesets/1786279910-fix-backend-editor-media-file-watchers-no-longer-misfire-on--wwrq.md
+++ b/.changesets/1786279910-fix-backend-editor-media-file-watchers-no-longer-misfire-on--wwrq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(backend): editor/media file watchers no longer misfire on a macOS remove

--- a/agentmux-srv/src/backend/editor_file_watcher.rs
+++ b/agentmux-srv/src/backend/editor_file_watcher.rs
@@ -195,6 +195,23 @@ impl EditorFileWatcher {
             if block_ids.is_empty() {
                 return; // last watcher unsubscribed while we were debouncing
             }
+            // Belt-and-suspenders on top of the `Created | Modified` filter
+            // in `new()`'s event loop: on macOS, FSEvents (without the
+            // per-file-events flag `notify`'s recommended_watcher doesn't
+            // request) reports changes at directory granularity, and the
+            // crate's own heuristic for turning that into an EventKind can
+            // misclassify a plain `remove_file` as `Modify` rather than
+            // `Remove` — confirmed failing on macOS CI
+            // (test_removed_event_does_not_trigger_publish) while passing on
+            // Windows/Linux, whose backends report Remove correctly for this
+            // exact case. Re-check real existence at publish time rather
+            // than trusting the EventKind alone — this also correctly keeps
+            // firing for the legitimate "temp-write-then-rename" atomic-save
+            // pattern, since the file exists again well before DEBOUNCE
+            // elapses.
+            if !path.exists() {
+                return;
+            }
             publish_editor_file_changed(&this.broker, &path, &block_ids);
         });
     }

--- a/agentmux-srv/src/backend/media_file_watcher.rs
+++ b/agentmux-srv/src/backend/media_file_watcher.rs
@@ -196,6 +196,17 @@ impl MediaFileWatcher {
             if gen_counter.load(Ordering::SeqCst) != my_gen {
                 return; // superseded by a later event for this file
             }
+            // Belt-and-suspenders on top of the `Created | Modified` filter
+            // in `new()`'s event loop — see EditorFileWatcher::handle_fs_event's
+            // matching comment: on macOS, FSEvents' directory-granularity
+            // reporting can get a plain file removal reclassified as
+            // `Modify` by `notify`'s own heuristic (confirmed failing on
+            // macOS CI, test_removed_event_does_not_trigger_publish; passes
+            // on Windows/Linux). Re-check real existence at publish time
+            // instead of trusting the EventKind alone.
+            if !changed_path.exists() {
+                return;
+            }
             publish_media_file_changed(&this.broker, &changed_path, &matched_block_ids);
         });
     }


### PR DESCRIPTION
## Summary

Found while checking why last night's build wasn't fully clean: `CI — nightly cross-platform build + test` has been silently red on macOS since commit `e7778e084` (#2462, migrating these watchers onto the shared `FsWatchPool`) — masked because that workflow's macOS/Linux legs are `continue-on-error` (staged rollout policy, `ci-nightly-build.yml`). Both watchers' own `test_removed_event_does_not_trigger_publish` tests fail there: deleting a watched file **does** trigger a "file changed" publish on macOS, when it must not — the whole point of the test.

**Root cause:** `FsWatchPool` watches a file's parent directory (`subscribe_file`, non-recursive), and each watcher's event loop already filters to `Created | Modified` before ever considering a publish — `Remove` is meant to be excluded outright, and that filter is unchanged and correct. The gap is one level down: `notify`'s `recommended_watcher` doesn't request FSEvents' per-file-events flag, so on macOS a plain `remove_file()` is reported at directory granularity, and `notify`'s own heuristic for turning that into an `EventKind` can classify it as `Modify` rather than `Remove` for this exact pattern. Windows' `ReadDirectoryChangesW` and Linux's `inotify` both report `Remove` correctly here, which is why this was invisible on either platform until now.

**Fix:** don't trust the `EventKind` alone — re-check the file's real existence right before publishing (after the existing 300ms debounce), in both watchers. If it's gone, don't fire, matching the exact intent already documented at the `Created | Modified` filter itself. Doesn't affect the legitimate temp-write-then-rename atomic-save pattern — the file exists again well before the debounce elapses.

No test changes needed — the existing tests already assert the right thing; this makes the production code actually satisfy them on macOS too.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv -- editor_file_watcher media_file_watcher fs_watch` — 17/17 (Windows — expected to already pass here, this platform never had the bug)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — full suite, 2067/2067
- [ ] **macOS CI is the real verification** for this fix — I can't run macOS locally. Please check this PR's `CI (PR)` run's macOS leg (or the next nightly cross-platform run) for `test_removed_event_does_not_trigger_publish` passing in both `editor_file_watcher` and `media_file_watcher` before merging.

<!-- agentmux:agent_id=agentx -->