### PR TITLE
docs: specs for account⇄agent binding — Armory 'Bind to Agent' menu (primary) + account adoption (companion)

### DIFF
--- a/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
+++ b/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
@@ -1,7 +1,11 @@
 # SPEC — Account adoption: piggyback an unlinked agent onto an existing login
 
 **Date:** 2026-08-09
-**Status:** Proposed
+**Status:** Proposed — Surface A superseded by
+`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md` (user-preferred
+direction: bind from the Armory, not from the failure row). Surface B
+(Identity-tab "Link existing account…") remains proposed as the
+agent-side complement; see that spec's §6.
 **Trigger:** Live v0.54.14 testing on a second machine (claudius). A
 pre-existing legacy agent ("Agent1", blank `identity_id`, no direct link)
 was correctly refused by the layer-3 spawn gate (#2463/#2464) and — after

--- a/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
+++ b/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
@@ -1,0 +1,125 @@
+# SPEC — Account adoption: piggyback an unlinked agent onto an existing login
+
+**Date:** 2026-08-09
+**Status:** Proposed
+**Trigger:** Live v0.54.14 testing on a second machine (claudius). A
+pre-existing legacy agent ("Agent1", blank `identity_id`, no direct link)
+was correctly refused by the layer-3 spawn gate (#2463/#2464) and — after
+#2482 — now shows the real message: *"no credentials for claude … Bind an
+account for this provider in the Armory."* But the same machine already had
+a **valid, bound Claude account** (used successfully by a different agent
+minutes earlier). The user's only offered recovery paths were a fresh OAuth
+or seeding from the global CLI login — there is no way to say "just use
+that account over there."
+
+---
+
+## 1. What already exists (do not rebuild)
+
+| Surface | Mechanism | Piggybacks on |
+|---|---|---|
+| Launch modal account picker | `AgentLaunchModal` — lists all accounts for the agent's provider, auto-picks the first when none selected | Any Armory account (new launches only) |
+| "Use existing login" recovery action | `useAgentControllerStatus.useGlobalLogin()` — seeds the **global CLI login file** (`~/.claude`) into a freshly-minted IdentityAccount + isolated dir, links it | The OS-level ambient login |
+| "Login Again" recovery action | `relogin()` — fresh OAuth; reuses the agent's **own** previously-linked account id (`existingAccountIdFor`) so retries don't mint orphans | The agent's own prior account |
+
+**The gap:** an agent with *no* link (legacy row, post-account-delete
+cascade, fresh isolated channel) cannot adopt an *existing Armory account*
+that some other agent already uses. All the machinery below the UI already
+supports it — `db_agent_identity_links` is many-links-to-one-account by
+design, `LinkAgentIdentityCommand` upserts with
+`ON CONFLICT(agent_id, provider) DO UPDATE`, and the spawn resolver
+injects whatever the link points at. This is a UI/flow feature, not a
+backend feature.
+
+## 2. Design
+
+### 2.1 Surface A — the Auth-classified failure row (primary)
+
+When the failure row shows the `FailureClass::Auth` "No account linked"
+state, add one recovery action alongside "Log in" / "Use existing login":
+
+- **"Use existing account"** — enabled when ≥1 *candidate account* exists.
+  - Exactly one candidate → the button is labeled with it
+    ("Use account: *work-claude*") and one click adopts it.
+  - Multiple candidates → the button opens a small inline picker
+    (name + status dot + which agents already use it), one click adopts.
+
+**Adopt =** (all existing primitives, mirroring `useGlobalLogin`'s
+post-registration steps, which this shares code with):
+1. `LinkAgentIdentityCommand { agent_id, account_id, provider }` (upsert).
+2. Update block `cmd:env` with the provider's config-dir env var pointing
+   at the adopted account's `OAuthConfigDir` dir — same live-refresh step
+   `useGlobalLogin` already performs so the running persistent agent picks
+   the credential up on its next message without a restart.
+3. Wrap in `beginRecoveryFlow()/endRecoveryFlow()` exactly like the other
+   recovery actions (the fast-fail send guard and concurrent-recovery
+   rules from PR #2338 apply identically).
+4. Retry the failed turn (same post-login retry the other actions use).
+
+### 2.2 Surface B — the per-agent Identity tab
+
+`agent-identity-links-panel` today offers "Connect \<Provider> account"
+(fresh login). Add **"Link existing account…"** beside it with the same
+candidate picker → `LinkAgentIdentityCommand`. No retry semantics needed
+here (not in a failure context); the next spawn resolves the link.
+
+### 2.3 Candidate set (both surfaces)
+
+From the shared account cache (`loadAccounts()` — live as of #2474):
+- `resolve_provider_alias(account.provider) == resolve_provider_alias(agent.provider)`
+  (canonicalize BOTH sides — the alias-mismatch class codex flagged on
+  PR #2377 applies here verbatim).
+- OAuth-class accounts only (`secret_ref.backend == "oauth_config_dir"`).
+  Api-key accounts don't gate spawns and already inject per-link.
+- Sort: `status == "valid"` first, then most-recently-updated. Show the
+  status dot — an expired account is selectable (the spawn-time probe
+  refreshes status, and adopting-then-relogging is still fewer steps than
+  a from-scratch OAuth) but visibly marked.
+- Exclude the agent's already-linked account id (nothing to adopt).
+
+## 3. Explicit non-goals / rejected alternatives
+
+- **Silent auto-adoption** (gate finds no link but exactly one valid
+  account exists → auto-link and proceed). Rejected as default behavior:
+  an agent silently starting to act under an account the user never chose
+  is exactly the attributability failure the "single point, not global"
+  invariant (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7) exists
+  to prevent — one personal-vs-work account mixup pays for all the clicks
+  this would ever save. Could ship later behind an explicit opt-in setting
+  if single-account users want it; the candidate-set + adopt code from
+  §2 is reusable as-is.
+- **Cross-channel / cross-machine piggyback** (claudius adopting the main
+  box's login). Accounts live per-channel in `db_accounts`; sharing across
+  channels or machines is a credential-sync feature (muxbus-transported,
+  keychain-backed) with a real threat model — separate spec if wanted.
+- **Backend changes.** None needed. The gate's refusal already carries the
+  provider id; the frontend has the accounts. (Optional nicety — the gate
+  could count candidates and phrase its message "2 existing accounts could
+  be linked" — deferred; the frontend can compute the same thing.)
+
+## 4. Sharing semantics (already true today, now more visible)
+
+Multiple agents linking one account means shared `OAuthConfigDir` and
+shared rate limits/token refresh. This is the existing, shipped behavior
+for accounts picked in the launch modal — adoption adds no new mechanism,
+but the picker showing "used by AgentX, AgentY" makes the sharing legible
+at decision time.
+
+## 5. Test plan
+
+- Unit: candidate-set filter (alias canonicalization both sides,
+  oauth-class-only, exclusion of the already-linked id, status sort).
+- Unit: adopt action wiring — link RPC called with canonical provider,
+  `cmd:env` updated with the adopted dir, recovery-flow counter
+  begun/ended, retry fired (mirror the existing `useGlobalLogin` tests in
+  `useAgentControllerStatus.test.ts`).
+- Live check: the exact claudius repro — legacy agent + one existing valid
+  claude account → one click on "Use account: …" → next message runs.
+
+## 6. Open decision for review
+
+Surface A's placement assumes the failure row can grow a third action
+without crowding (it already holds Log in / Use existing login / Login via
+terminal in some states). If it's too dense, the fallback is Surface B
+only + the failure message deep-linking to the Identity tab — one more
+click, zero new failure-row complexity.

--- a/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
+++ b/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
@@ -1,0 +1,134 @@
+# SPEC — Armory "Bind to Agent" context menu on account rows
+
+**Date:** 2026-08-09
+**Status:** Proposed (user-requested direction; supersedes the failure-row
+surface of `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` as the
+primary UX — see §6 for how the two relate)
+**Trigger:** A user with **three** anthropic/claude accounts in the Armory
+has no way to assign them to agents from the place where the accounts are
+visible. Assignment today only happens agent-side (launch modal picker,
+per-agent Identity tab), which means answering "which agent uses which of
+my three accounts?" requires visiting every agent. Binding is a
+management task; the Armory is the management surface.
+
+---
+
+## 1. Feature
+
+Right-click an account row in the Armory Accounts tab (`AccountRow`,
+`identity-accounts-tab.tsx:101` — currently has **no** context menu) →
+native `ContextMenuModel` menu:
+
+```
+Bind to Agent            ▸   AgentA        ● running   ✓ (this account)
+                             Agent1        ● running     (bound: work-claude)
+                             Mzop                        (no account bound)
+                             ────────────────────────
+                             AgentY (codex — incompatible)   [hidden, see §3]
+─────────────────
+Copy account ID
+```
+
+- **"Bind to Agent" ▸ submenu** lists the channel's user-owned agent
+  definitions. Clicking one binds this account to that agent.
+- **Per-row annotations** (all fields the native menu already supports —
+  `submenu`/`checked`/`sublabel` in `ContextMenuItem`, custom.d.ts:329):
+  - `checked` — agent is already bound to *this* account.
+  - `sublabel` — the currently-bound account's name when it's a
+    *different* account ("bound: work-claude"), or "no account bound".
+    This is what makes three-account disambiguation legible: the submenu
+    doubles as a live binding overview.
+  - Running marker — agents with an open pane (via
+    `getOpenDefinitionMap()`, agent-pane-state-store.ts:390) sort first
+    and get a running indicator; non-running agents are still bindable
+    (pre-provisioning before launch is a feature, not an error).
+- **"Copy account ID"** — freebie while the menu exists; the Armory rows
+  are one of the copy-affordance gaps already catalogued in
+  `REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md` §4.
+
+## 2. Bind action
+
+`LinkAgentIdentityCommand { agent_id, account_id, provider: account.provider }`
+— the existing upsert (`ON CONFLICT(agent_id, provider) DO UPDATE`), so
+binding to an agent that already has an account for this provider
+**replaces** that link. Because it replaces:
+
+- When the clicked agent's sublabel shows a *different* bound account, the
+  click is a rebind — perform it directly (the sublabel already disclosed
+  what it replaces; a confirm dialog on an easily re-doable, non-destructive
+  upsert is noise). The old account row is untouched — only the link moves.
+- After a successful bind, the account list re-renders via the live cache
+  (`identityaccounts:changed` → #2474) and the per-agent panels via their
+  existing links subscriptions — no reload.
+
+**Running-agent live apply:** if the target agent has an open pane
+(`getOpenDefinitionMap()` gives the blockId), mirror the `cmd:env`
+config-dir refresh `useAgentControllerStatus.useGlobalLogin()` already
+performs after linking (SetMetaCommand on the block's `cmd:env` with the
+provider's `authConfigDirEnvVar` → the account's `OAuthConfigDir` dir), so
+the new binding takes effect on the next turn without a restart — the
+same no-restart semantics the existing recovery flows promise. Without
+this step a stale static `cmd:env` override could shadow the new link at
+the next spawn.
+
+## 3. Candidate agents (menu contents)
+
+- User-owned definitions only (`is_seeded = 0`), current channel (both
+  accounts and agent definitions are channel-local — cross-channel is out
+  of scope, same as the companion spec).
+- **CLI-OAuth accounts** (claude/codex/gemini/openclaw — oauth-class,
+  `secret_ref.backend == "oauth_config_dir"`): only agents whose
+  `resolve_provider_alias(def.provider)` matches the account's
+  canonicalized provider. A claude account bound to a codex agent injects
+  a pointless `CLAUDE_CONFIG_DIR` and confuses the binding overview —
+  filter them out (hidden, not greyed: the menu is an assignment tool,
+  not a diagnostic).
+  - Canonicalize BOTH sides — the alias-mismatch bug class from codex P1
+    on PR #2377 applies verbatim.
+- **Service accounts** (github/aws/etc., api-key class): all agents are
+  candidates — these links inject env vars usable by any provider's CLI.
+- Empty candidate set → "Bind to Agent" renders disabled with a sublabel
+  ("no compatible agents in this channel") rather than disappearing —
+  discoverability over minimalism, matching the disabled-Copy precedent
+  in the generic pane menu.
+
+## 4. Out of scope
+
+- The AgentMux Cloud row (muxbus singleton — not an IdentityAccount, no
+  link semantics) and the brand gallery tiles get no menu. Accounts-list
+  rows only.
+- Unbind ("remove link") from this menu — deferred; the per-agent
+  Identity tab already owns link removal, and a destructive action jammed
+  into a bind-flavored submenu invites misclicks. Revisit if requested.
+- Multi-select / bind-to-many in one gesture.
+- Cross-channel and cross-machine binding (see companion spec §3).
+
+## 5. Test plan
+
+- Unit (menu builder, pure function → item list): provider filtering with
+  aliases both ways, checked/sublabel correctness for
+  bound-here/bound-elsewhere/unbound, running-first sort, disabled empty
+  state, service-account provider passthrough.
+- Unit (bind action): link RPC with canonical provider; `cmd:env` refresh
+  fired only when the pane is open; no refresh for closed agents.
+- Component test: right-click on `AccountRow` opens the menu
+  (`AgentPicker.test.tsx`'s existing right-click → ContextMenuModel test
+  pattern is the template).
+- Live check: the motivating scenario — 3 claude accounts, right-click
+  each, verify the submenu shows correct current bindings, rebind one
+  agent between two accounts, confirm next turn uses the new account
+  (spawn log's `injected CLAUDE_CONFIG_DIR … account=<id>` line).
+
+## 6. Relationship to SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN
+
+Same underlying mechanism (link upsert + optional live `cmd:env` apply),
+two entry points for two mindsets:
+
+- **This spec (primary):** "I'm looking at my accounts, let me assign
+  them" — proactive management from the Armory.
+- **Companion's Surface B** (Identity-tab "Link existing account…"):
+  reactive repair from a broken agent's side — still worth having since a
+  gate-refused agent's failure message points the user at that tab.
+- **Companion's Surface A** (failure-row picker) is superseded by this
+  direction: the failure row keeps its existing actions, and its message
+  already routes users to the Armory, where this menu now closes the loop.


### PR DESCRIPTION
Design doc for letting an unlinked agent adopt an existing Armory account instead of forcing a fresh OAuth — motivated by the claudius v0.54.14 live test, where a legacy agent was correctly gate-refused while a valid claude account sat unused on the same machine.

Key points:
- Two of three piggyback surfaces already exist (launch-modal picker, seed-from-global-login); the gap is adopting an existing **Armory** account from the failure-recovery row and the Identity tab.
- Pure frontend feature: `LinkAgentIdentityCommand` upsert + the same `cmd:env` live-refresh step `useGlobalLogin` already does. No backend changes.
- Silent auto-adoption explicitly rejected as default (attributability / "single point, not global" §7); cross-machine sync explicitly out of scope.

Docs only — no code changes.

<!-- agentmux:agent_id=agent3 -->