### PR TITLE
feat(armory): 'Bind to Agent' context menu on account rows

### DIFF
--- a/.changesets/1786300545-feat-armory-right-click-an-account-row-to-bind-it-to-an-agen-1z96.md
+++ b/.changesets/1786300545-feat-armory-right-click-an-account-row-to-bind-it-to-an-agen-1z96.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): right-click an account row to bind it to an agent - Bind to Agent submenu with live binding overview

--- a/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
+++ b/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
@@ -1,7 +1,11 @@
 # SPEC — Account adoption: piggyback an unlinked agent onto an existing login
 
 **Date:** 2026-08-09
-**Status:** Proposed
+**Status:** Proposed — Surface A superseded by
+`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md` (user-preferred
+direction: bind from the Armory, not from the failure row). Surface B
+(Identity-tab "Link existing account…") remains proposed as the
+agent-side complement; see that spec's §6.
 **Trigger:** Live v0.54.14 testing on a second machine (claudius). A
 pre-existing legacy agent ("Agent1", blank `identity_id`, no direct link)
 was correctly refused by the layer-3 spawn gate (#2463/#2464) and — after

--- a/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
+++ b/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
@@ -1,0 +1,125 @@
+# SPEC — Account adoption: piggyback an unlinked agent onto an existing login
+
+**Date:** 2026-08-09
+**Status:** Proposed
+**Trigger:** Live v0.54.14 testing on a second machine (claudius). A
+pre-existing legacy agent ("Agent1", blank `identity_id`, no direct link)
+was correctly refused by the layer-3 spawn gate (#2463/#2464) and — after
+#2482 — now shows the real message: *"no credentials for claude … Bind an
+account for this provider in the Armory."* But the same machine already had
+a **valid, bound Claude account** (used successfully by a different agent
+minutes earlier). The user's only offered recovery paths were a fresh OAuth
+or seeding from the global CLI login — there is no way to say "just use
+that account over there."
+
+---
+
+## 1. What already exists (do not rebuild)
+
+| Surface | Mechanism | Piggybacks on |
+|---|---|---|
+| Launch modal account picker | `AgentLaunchModal` — lists all accounts for the agent's provider, auto-picks the first when none selected | Any Armory account (new launches only) |
+| "Use existing login" recovery action | `useAgentControllerStatus.useGlobalLogin()` — seeds the **global CLI login file** (`~/.claude`) into a freshly-minted IdentityAccount + isolated dir, links it | The OS-level ambient login |
+| "Login Again" recovery action | `relogin()` — fresh OAuth; reuses the agent's **own** previously-linked account id (`existingAccountIdFor`) so retries don't mint orphans | The agent's own prior account |
+
+**The gap:** an agent with *no* link (legacy row, post-account-delete
+cascade, fresh isolated channel) cannot adopt an *existing Armory account*
+that some other agent already uses. All the machinery below the UI already
+supports it — `db_agent_identity_links` is many-links-to-one-account by
+design, `LinkAgentIdentityCommand` upserts with
+`ON CONFLICT(agent_id, provider) DO UPDATE`, and the spawn resolver
+injects whatever the link points at. This is a UI/flow feature, not a
+backend feature.
+
+## 2. Design
+
+### 2.1 Surface A — the Auth-classified failure row (primary)
+
+When the failure row shows the `FailureClass::Auth` "No account linked"
+state, add one recovery action alongside "Log in" / "Use existing login":
+
+- **"Use existing account"** — enabled when ≥1 *candidate account* exists.
+  - Exactly one candidate → the button is labeled with it
+    ("Use account: *work-claude*") and one click adopts it.
+  - Multiple candidates → the button opens a small inline picker
+    (name + status dot + which agents already use it), one click adopts.
+
+**Adopt =** (all existing primitives, mirroring `useGlobalLogin`'s
+post-registration steps, which this shares code with):
+1. `LinkAgentIdentityCommand { agent_id, account_id, provider }` (upsert).
+2. Update block `cmd:env` with the provider's config-dir env var pointing
+   at the adopted account's `OAuthConfigDir` dir — same live-refresh step
+   `useGlobalLogin` already performs so the running persistent agent picks
+   the credential up on its next message without a restart.
+3. Wrap in `beginRecoveryFlow()/endRecoveryFlow()` exactly like the other
+   recovery actions (the fast-fail send guard and concurrent-recovery
+   rules from PR #2338 apply identically).
+4. Retry the failed turn (same post-login retry the other actions use).
+
+### 2.2 Surface B — the per-agent Identity tab
+
+`agent-identity-links-panel` today offers "Connect \<Provider> account"
+(fresh login). Add **"Link existing account…"** beside it with the same
+candidate picker → `LinkAgentIdentityCommand`. No retry semantics needed
+here (not in a failure context); the next spawn resolves the link.
+
+### 2.3 Candidate set (both surfaces)
+
+From the shared account cache (`loadAccounts()` — live as of #2474):
+- `resolve_provider_alias(account.provider) == resolve_provider_alias(agent.provider)`
+  (canonicalize BOTH sides — the alias-mismatch class codex flagged on
+  PR #2377 applies here verbatim).
+- OAuth-class accounts only (`secret_ref.backend == "oauth_config_dir"`).
+  Api-key accounts don't gate spawns and already inject per-link.
+- Sort: `status == "valid"` first, then most-recently-updated. Show the
+  status dot — an expired account is selectable (the spawn-time probe
+  refreshes status, and adopting-then-relogging is still fewer steps than
+  a from-scratch OAuth) but visibly marked.
+- Exclude the agent's already-linked account id (nothing to adopt).
+
+## 3. Explicit non-goals / rejected alternatives
+
+- **Silent auto-adoption** (gate finds no link but exactly one valid
+  account exists → auto-link and proceed). Rejected as default behavior:
+  an agent silently starting to act under an account the user never chose
+  is exactly the attributability failure the "single point, not global"
+  invariant (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7) exists
+  to prevent — one personal-vs-work account mixup pays for all the clicks
+  this would ever save. Could ship later behind an explicit opt-in setting
+  if single-account users want it; the candidate-set + adopt code from
+  §2 is reusable as-is.
+- **Cross-channel / cross-machine piggyback** (claudius adopting the main
+  box's login). Accounts live per-channel in `db_accounts`; sharing across
+  channels or machines is a credential-sync feature (muxbus-transported,
+  keychain-backed) with a real threat model — separate spec if wanted.
+- **Backend changes.** None needed. The gate's refusal already carries the
+  provider id; the frontend has the accounts. (Optional nicety — the gate
+  could count candidates and phrase its message "2 existing accounts could
+  be linked" — deferred; the frontend can compute the same thing.)
+
+## 4. Sharing semantics (already true today, now more visible)
+
+Multiple agents linking one account means shared `OAuthConfigDir` and
+shared rate limits/token refresh. This is the existing, shipped behavior
+for accounts picked in the launch modal — adoption adds no new mechanism,
+but the picker showing "used by AgentX, AgentY" makes the sharing legible
+at decision time.
+
+## 5. Test plan
+
+- Unit: candidate-set filter (alias canonicalization both sides,
+  oauth-class-only, exclusion of the already-linked id, status sort).
+- Unit: adopt action wiring — link RPC called with canonical provider,
+  `cmd:env` updated with the adopted dir, recovery-flow counter
+  begun/ended, retry fired (mirror the existing `useGlobalLogin` tests in
+  `useAgentControllerStatus.test.ts`).
+- Live check: the exact claudius repro — legacy agent + one existing valid
+  claude account → one click on "Use account: …" → next message runs.
+
+## 6. Open decision for review
+
+Surface A's placement assumes the failure row can grow a third action
+without crowding (it already holds Log in / Use existing login / Login via
+terminal in some states). If it's too dense, the fallback is Surface B
+only + the failure message deep-linking to the Identity tab — one more
+click, zero new failure-row complexity.

--- a/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
+++ b/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
@@ -1,0 +1,134 @@
+# SPEC — Armory "Bind to Agent" context menu on account rows
+
+**Date:** 2026-08-09
+**Status:** Proposed (user-requested direction; supersedes the failure-row
+surface of `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` as the
+primary UX — see §6 for how the two relate)
+**Trigger:** A user with **three** anthropic/claude accounts in the Armory
+has no way to assign them to agents from the place where the accounts are
+visible. Assignment today only happens agent-side (launch modal picker,
+per-agent Identity tab), which means answering "which agent uses which of
+my three accounts?" requires visiting every agent. Binding is a
+management task; the Armory is the management surface.
+
+---
+
+## 1. Feature
+
+Right-click an account row in the Armory Accounts tab (`AccountRow`,
+`identity-accounts-tab.tsx:101` — currently has **no** context menu) →
+native `ContextMenuModel` menu:
+
+```
+Bind to Agent            ▸   AgentA        ● running   ✓ (this account)
+                             Agent1        ● running     (bound: work-claude)
+                             Mzop                        (no account bound)
+                             ────────────────────────
+                             AgentY (codex — incompatible)   [hidden, see §3]
+─────────────────
+Copy account ID
+```
+
+- **"Bind to Agent" ▸ submenu** lists the channel's user-owned agent
+  definitions. Clicking one binds this account to that agent.
+- **Per-row annotations** (all fields the native menu already supports —
+  `submenu`/`checked`/`sublabel` in `ContextMenuItem`, custom.d.ts:329):
+  - `checked` — agent is already bound to *this* account.
+  - `sublabel` — the currently-bound account's name when it's a
+    *different* account ("bound: work-claude"), or "no account bound".
+    This is what makes three-account disambiguation legible: the submenu
+    doubles as a live binding overview.
+  - Running marker — agents with an open pane (via
+    `getOpenDefinitionMap()`, agent-pane-state-store.ts:390) sort first
+    and get a running indicator; non-running agents are still bindable
+    (pre-provisioning before launch is a feature, not an error).
+- **"Copy account ID"** — freebie while the menu exists; the Armory rows
+  are one of the copy-affordance gaps already catalogued in
+  `REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md` §4.
+
+## 2. Bind action
+
+`LinkAgentIdentityCommand { agent_id, account_id, provider: account.provider }`
+— the existing upsert (`ON CONFLICT(agent_id, provider) DO UPDATE`), so
+binding to an agent that already has an account for this provider
+**replaces** that link. Because it replaces:
+
+- When the clicked agent's sublabel shows a *different* bound account, the
+  click is a rebind — perform it directly (the sublabel already disclosed
+  what it replaces; a confirm dialog on an easily re-doable, non-destructive
+  upsert is noise). The old account row is untouched — only the link moves.
+- After a successful bind, the account list re-renders via the live cache
+  (`identityaccounts:changed` → #2474) and the per-agent panels via their
+  existing links subscriptions — no reload.
+
+**Running-agent live apply:** if the target agent has an open pane
+(`getOpenDefinitionMap()` gives the blockId), mirror the `cmd:env`
+config-dir refresh `useAgentControllerStatus.useGlobalLogin()` already
+performs after linking (SetMetaCommand on the block's `cmd:env` with the
+provider's `authConfigDirEnvVar` → the account's `OAuthConfigDir` dir), so
+the new binding takes effect on the next turn without a restart — the
+same no-restart semantics the existing recovery flows promise. Without
+this step a stale static `cmd:env` override could shadow the new link at
+the next spawn.
+
+## 3. Candidate agents (menu contents)
+
+- User-owned definitions only (`is_seeded = 0`), current channel (both
+  accounts and agent definitions are channel-local — cross-channel is out
+  of scope, same as the companion spec).
+- **CLI-OAuth accounts** (claude/codex/gemini/openclaw — oauth-class,
+  `secret_ref.backend == "oauth_config_dir"`): only agents whose
+  `resolve_provider_alias(def.provider)` matches the account's
+  canonicalized provider. A claude account bound to a codex agent injects
+  a pointless `CLAUDE_CONFIG_DIR` and confuses the binding overview —
+  filter them out (hidden, not greyed: the menu is an assignment tool,
+  not a diagnostic).
+  - Canonicalize BOTH sides — the alias-mismatch bug class from codex P1
+    on PR #2377 applies verbatim.
+- **Service accounts** (github/aws/etc., api-key class): all agents are
+  candidates — these links inject env vars usable by any provider's CLI.
+- Empty candidate set → "Bind to Agent" renders disabled with a sublabel
+  ("no compatible agents in this channel") rather than disappearing —
+  discoverability over minimalism, matching the disabled-Copy precedent
+  in the generic pane menu.
+
+## 4. Out of scope
+
+- The AgentMux Cloud row (muxbus singleton — not an IdentityAccount, no
+  link semantics) and the brand gallery tiles get no menu. Accounts-list
+  rows only.
+- Unbind ("remove link") from this menu — deferred; the per-agent
+  Identity tab already owns link removal, and a destructive action jammed
+  into a bind-flavored submenu invites misclicks. Revisit if requested.
+- Multi-select / bind-to-many in one gesture.
+- Cross-channel and cross-machine binding (see companion spec §3).
+
+## 5. Test plan
+
+- Unit (menu builder, pure function → item list): provider filtering with
+  aliases both ways, checked/sublabel correctness for
+  bound-here/bound-elsewhere/unbound, running-first sort, disabled empty
+  state, service-account provider passthrough.
+- Unit (bind action): link RPC with canonical provider; `cmd:env` refresh
+  fired only when the pane is open; no refresh for closed agents.
+- Component test: right-click on `AccountRow` opens the menu
+  (`AgentPicker.test.tsx`'s existing right-click → ContextMenuModel test
+  pattern is the template).
+- Live check: the motivating scenario — 3 claude accounts, right-click
+  each, verify the submenu shows correct current bindings, rebind one
+  agent between two accounts, confirm next turn uses the new account
+  (spawn log's `injected CLAUDE_CONFIG_DIR … account=<id>` line).
+
+## 6. Relationship to SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN
+
+Same underlying mechanism (link upsert + optional live `cmd:env` apply),
+two entry points for two mindsets:
+
+- **This spec (primary):** "I'm looking at my accounts, let me assign
+  them" — proactive management from the Armory.
+- **Companion's Surface B** (Identity-tab "Link existing account…"):
+  reactive repair from a broken agent's side — still worth having since a
+  gate-refused agent's failure message points the user at that tab.
+- **Companion's Surface A** (failure-row picker) is superseded by this
+  direction: the failure row keeps its existing actions, and its message
+  already routes users to the Armory, where this menu now closes the loop.

--- a/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
+++ b/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
@@ -62,14 +62,23 @@ binding to an agent that already has an account for this provider
   existing links subscriptions — no reload.
 
 **Running-agent live apply:** if the target agent has an open pane
-(`getOpenDefinitionMap()` gives the blockId), mirror the `cmd:env`
-config-dir refresh `useAgentControllerStatus.useGlobalLogin()` already
-performs after linking (SetMetaCommand on the block's `cmd:env` with the
-provider's `authConfigDirEnvVar` → the account's `OAuthConfigDir` dir), so
-the new binding takes effect on the next turn without a restart — the
-same no-restart semantics the existing recovery flows promise. Without
-this step a stale static `cmd:env` override could shadow the new link at
-the next spawn.
+(`getOpenDefinitionMap()` gives the blockId), mirror the live-apply PAIR
+`useAgentControllerStatus.useGlobalLogin()` performs after linking:
+1. the `cmd:env` config-dir refresh (SetMetaCommand with the provider's
+   `authConfigDirEnvVar` → the account's `OAuthConfigDir` dir) — a stale
+   static override would otherwise shadow the new link at the next spawn;
+2. `ControllerResyncCommand{forcerestart:true}` — a persistent
+   controller's already-alive CLI receives messages on its running
+   process's stdin and never re-reads env; env only applies on a fresh
+   spawn. The forced respawn is session-preserving (`--resume`), the same
+   mechanism every recovery flow already uses. Without it the new binding
+   would silently not apply until a manual restart (reagentx P1 on the
+   implementation PR caught an earlier draft claiming otherwise).
+
+Both live-apply steps are best-effort (logged, non-fatal — the binding
+still applies at the next clean spawn); the link upsert itself is the one
+step that must succeed, and its failure surfaces in the Accounts tab's
+notice banner.
 
 ## 3. Candidate agents (menu contents)
 

--- a/frontend/app/view/identity/bind-to-agent-menu.test.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.test.ts
@@ -1,0 +1,150 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the "Bind to Agent" menu's pure candidate computation —
+// SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md §3/§5.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({ RpcApi: {} }));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/global", () => ({ WOS: {} }));
+vi.mock("@/app/store/agent-pane-state-store", () => ({ getOpenDefinitionMap: () => new Map() }));
+
+import { computeBindCandidates, candidateSublabel } from "./bind-to-agent-menu";
+import type { Account } from "./identity-model";
+
+function mkAccount(over: Partial<Account> = {}): Account {
+    return {
+        id: "acct-1",
+        name: "work-claude",
+        provider: "claude" as Account["provider"],
+        kind: "oauth",
+        secret_ref: { backend: "oauth_config_dir", dir: "/tmp/acct-1" },
+        context: {},
+        assigned_agents: [],
+        status: "valid",
+        created_at: "0",
+        updated_at: "0",
+        ...over,
+    };
+}
+
+function mkAgent(over: Partial<AgentDefinition> = {}): AgentDefinition {
+    return {
+        id: "agent-1",
+        name: "AgentA",
+        provider: "claude",
+        is_seeded: 0,
+        ...over,
+    } as AgentDefinition;
+}
+
+const NO_LINKS: AgentDefinitionIdentity[] = [];
+const NO_OPEN = new Map<string, string>();
+const NO_NAMES = new Map<string, string>();
+
+describe("computeBindCandidates", () => {
+    it("CLI-OAuth account only offers same-provider agents", () => {
+        const out = computeBindCandidates(
+            mkAccount(),
+            [mkAgent({ id: "a", name: "Claude1", provider: "claude" }), mkAgent({ id: "b", name: "Codex1", provider: "codex" })],
+            NO_LINKS,
+            NO_OPEN,
+            NO_NAMES,
+        );
+        expect(out.map((c) => c.agentName)).toEqual(["Claude1"]);
+    });
+
+    it("canonicalizes provider aliases on BOTH sides (codex P1 on #2377 class)", () => {
+        // Account stored under a legacy alias; agent under the canonical id.
+        const out = computeBindCandidates(
+            mkAccount({ provider: "claude-code" as Account["provider"] }),
+            [mkAgent({ provider: "claude" })],
+            NO_LINKS,
+            NO_OPEN,
+            NO_NAMES,
+        );
+        expect(out).toHaveLength(1);
+    });
+
+    it("service (api-key) account offers every agent regardless of provider", () => {
+        const gh = mkAccount({
+            provider: "github" as Account["provider"],
+            kind: "pat",
+            secret_ref: { backend: "keychain", service: "s", account: "a" },
+        });
+        const out = computeBindCandidates(
+            gh,
+            [mkAgent({ id: "a", name: "Claude1", provider: "claude" }), mkAgent({ id: "b", name: "Codex1", provider: "codex" })],
+            NO_LINKS,
+            NO_OPEN,
+            NO_NAMES,
+        );
+        expect(out).toHaveLength(2);
+    });
+
+    it("excludes seeded templates", () => {
+        const out = computeBindCandidates(
+            mkAccount(),
+            [mkAgent({ is_seeded: 1 })],
+            NO_LINKS,
+            NO_OPEN,
+            NO_NAMES,
+        );
+        expect(out).toHaveLength(0);
+    });
+
+    it("marks boundHere for the agent linked to this account, even via a legacy alias link", () => {
+        const links: AgentDefinitionIdentity[] = [
+            { agent_id: "agent-1", account_id: "acct-1", provider: "claude-code" },
+        ];
+        const out = computeBindCandidates(mkAccount(), [mkAgent()], links, NO_OPEN, NO_NAMES);
+        expect(out[0].boundHere).toBe(true);
+        expect(out[0].boundElsewhereName).toBeNull();
+    });
+
+    it("names the other account when bound elsewhere", () => {
+        const links: AgentDefinitionIdentity[] = [
+            { agent_id: "agent-1", account_id: "acct-OTHER", provider: "claude" },
+        ];
+        const names = new Map([["acct-OTHER", "personal-claude"]]);
+        const out = computeBindCandidates(mkAccount(), [mkAgent()], links, NO_OPEN, names);
+        expect(out[0].boundHere).toBe(false);
+        expect(out[0].boundElsewhereName).toBe("personal-claude");
+    });
+
+    it("sorts running agents first, then by name", () => {
+        const agents = [
+            mkAgent({ id: "z", name: "Zeta" }),
+            mkAgent({ id: "a", name: "Alpha" }),
+            mkAgent({ id: "r", name: "RunningOne" }),
+        ];
+        const open = new Map([["r", "block-r"]]);
+        const out = computeBindCandidates(mkAccount(), agents, NO_LINKS, open, NO_NAMES);
+        expect(out.map((c) => c.agentName)).toEqual(["RunningOne", "Alpha", "Zeta"]);
+        expect(out[0].runningBlockId).toBe("block-r");
+    });
+});
+
+describe("candidateSublabel", () => {
+    const base = { agentId: "a", agentName: "A", runningBlockId: null, boundHere: false, boundElsewhereName: null };
+
+    it("unbound + not running → 'no account bound'", () => {
+        expect(candidateSublabel({ ...base })).toBe("no account bound");
+    });
+
+    it("bound elsewhere shows the other account's name", () => {
+        expect(candidateSublabel({ ...base, boundElsewhereName: "personal" })).toBe("bound: personal");
+    });
+
+    it("boundHere carries no binding text (checkmark covers it) but keeps the running marker", () => {
+        expect(candidateSublabel({ ...base, boundHere: true, runningBlockId: "b" })).toBe("● running");
+    });
+
+    it("running + bound elsewhere combines both", () => {
+        expect(candidateSublabel({ ...base, runningBlockId: "b", boundElsewhereName: "x" })).toBe(
+            "● running  ·  bound: x",
+        );
+    });
+});

--- a/frontend/app/view/identity/bind-to-agent-menu.test.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.test.ts
@@ -4,14 +4,29 @@
 // Tests for the "Bind to Agent" menu's pure candidate computation —
 // SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md §3/§5.
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/app/store/rpc-api", () => ({ RpcApi: {} }));
+const rpcCalls: Array<{ cmd: string; data: unknown }> = [];
+const listAgentIdentitiesMock = vi.fn(async (): Promise<AgentDefinitionIdentity[]> => []);
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListAgentIdentitiesCommand: (_c: unknown, data: { agent_id: string }) => {
+            rpcCalls.push({ cmd: "list", data });
+            return listAgentIdentitiesMock();
+        },
+        UnlinkAgentIdentityCommand: async (_c: unknown, data: unknown) => {
+            rpcCalls.push({ cmd: "unlink", data });
+        },
+        LinkAgentIdentityCommand: async (_c: unknown, data: unknown) => {
+            rpcCalls.push({ cmd: "link", data });
+        },
+    },
+}));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
-vi.mock("@/app/store/global", () => ({ WOS: {} }));
+vi.mock("@/app/store/global", () => ({ WOS: {}, workspace: () => null }));
 vi.mock("@/app/store/agent-pane-state-store", () => ({ getOpenDefinitionMap: () => new Map() }));
 
-import { computeBindCandidates, candidateSublabel } from "./bind-to-agent-menu";
+import { computeBindCandidates, candidateSublabel, bindAccountToAgent } from "./bind-to-agent-menu";
 import type { Account } from "./identity-model";
 
 function mkAccount(over: Partial<Account> = {}): Account {
@@ -124,6 +139,50 @@ describe("computeBindCandidates", () => {
         const out = computeBindCandidates(mkAccount(), agents, NO_LINKS, open, NO_NAMES);
         expect(out.map((c) => c.agentName)).toEqual(["RunningOne", "Alpha", "Zeta"]);
         expect(out[0].runningBlockId).toBe("block-r");
+    });
+});
+
+describe("bindAccountToAgent — alias-row cleanup (reagentx P1 on #2485, round 2)", () => {
+    const CANDIDATE = {
+        agentId: "agent-1",
+        agentName: "AgentA",
+        runningBlockId: null,
+        boundHere: false,
+        boundElsewhereName: null,
+    };
+
+    beforeEach(() => {
+        rpcCalls.length = 0;
+        listAgentIdentitiesMock.mockReset();
+        listAgentIdentitiesMock.mockResolvedValue([]);
+    });
+
+    it("unlinks an alias-stored link for the same canonical provider BEFORE linking", async () => {
+        // Existing link under legacy alias "claude-code" — the backend's
+        // upsert (keyed on the raw provider string) would NOT replace it,
+        // and injection's ORDER BY provider would apply it last, silently
+        // keeping the old account.
+        listAgentIdentitiesMock.mockResolvedValue([
+            { agent_id: "agent-1", account_id: "acct-OLD", provider: "claude-code" },
+        ]);
+        await bindAccountToAgent(mkAccount(), CANDIDATE);
+
+        const unlinks = rpcCalls.filter((c) => c.cmd === "unlink");
+        expect(unlinks).toHaveLength(1);
+        expect(unlinks[0].data).toEqual({ agent_id: "agent-1", provider: "claude-code", silent: true });
+        // Cleanup precedes the link.
+        expect(rpcCalls.map((c) => c.cmd)).toEqual(["list", "unlink", "link"]);
+        expect(rpcCalls[2].data).toMatchObject({ account_id: "acct-1", provider: "claude" });
+    });
+
+    it("does not unlink a canonical-provider link (the upsert replaces it) or other providers' links", async () => {
+        listAgentIdentitiesMock.mockResolvedValue([
+            { agent_id: "agent-1", account_id: "acct-OLD", provider: "claude" },
+            { agent_id: "agent-1", account_id: "acct-gh", provider: "github" },
+        ]);
+        await bindAccountToAgent(mkAccount(), CANDIDATE);
+        expect(rpcCalls.filter((c) => c.cmd === "unlink")).toHaveLength(0);
+        expect(rpcCalls.filter((c) => c.cmd === "link")).toHaveLength(1);
     });
 });
 

--- a/frontend/app/view/identity/bind-to-agent-menu.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.ts
@@ -11,7 +11,7 @@
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { WOS } from "@/app/store/global";
+import { WOS, workspace } from "@/app/store/global";
 import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
 import { getProvider, resolveProviderAlias } from "@/app/view/agent/providers";
 import { Logger } from "@/util/logger";
@@ -98,21 +98,51 @@ export function candidateSublabel(c: BindCandidate): string {
     return [running, binding].filter(Boolean).join("  ·  ");
 }
 
+/** Find the current workspace's tab holding `blockId`, for
+ *  ControllerResyncCommand's required `tabid`. Same fast-path lookup
+ *  swarm-view's focusBlock uses; returns null for a block in another
+ *  window (resync is then skipped — see bindAccountToAgent). */
+function findTabIdForBlock(blockId: string): string | null {
+    const ws = workspace();
+    if (!ws) return null;
+    for (const tabId of [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])]) {
+        const tab = WOS.getObjectValue<Tab>(WOS.makeORef("tab", tabId));
+        if (tab?.blockids?.includes(blockId)) return tabId;
+    }
+    return null;
+}
+
 /**
  * Bind `account` to `candidate`'s agent (spec §2): link upsert, then — for
- * a running agent — the same `cmd:env` config-dir refresh
- * `useAgentControllerStatus.useGlobalLogin()` performs after linking, so
- * the new binding takes effect on the next turn without a restart (a stale
- * static `cmd:env` override would otherwise shadow the new link at the
- * next spawn).
+ * a running agent — the same live-apply pair
+ * `useAgentControllerStatus.useGlobalLogin()` performs after linking:
+ * (1) refresh the block's `cmd:env` config-dir override (a stale static
+ * override would otherwise shadow the new link at the next spawn), and
+ * (2) `ControllerResyncCommand{forcerestart:true}` — a persistent
+ * controller's already-alive CLI writes messages straight to the running
+ * process's stdin and never re-reads env, so without the forced,
+ * session-preserving respawn (`--resume`) the new binding would silently
+ * not apply until a manual restart (reagentx P1 on #2485).
+ *
+ * The link upsert is the one step that must succeed — it throws on
+ * failure so callers can surface it. The live-apply steps are best-effort
+ * (logged, swallowed): the binding still applies at the next clean spawn.
  */
 export async function bindAccountToAgent(account: Account, candidate: BindCandidate): Promise<void> {
     const provider = resolveProviderAlias(account.provider);
-    await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
-        agent_id: candidate.agentId,
-        account_id: account.id,
-        provider,
-    });
+    try {
+        await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
+            agent_id: candidate.agentId,
+            account_id: account.id,
+            provider,
+        });
+    } catch (e: any) {
+        Logger.error(
+            "identity",
+            `armory bind FAILED: account ${account.id} → agent ${candidate.agentId}: ${e?.message ?? e}`,
+        );
+        throw e;
+    }
     Logger.info(
         "identity",
         `armory bind: account ${account.id} (${account.name}) → agent ${candidate.agentId} (${candidate.agentName})`,
@@ -134,10 +164,23 @@ export async function bindAccountToAgent(account: Account, candidate: BindCandid
             oref: WOS.makeORef("block", blockId),
             meta: { "cmd:env": { ...prevEnv, [envVar]: dir } },
         });
+        const tabId = findTabIdForBlock(blockId);
+        if (tabId) {
+            await RpcApi.ControllerResyncCommand(TabRpcClient, {
+                tabid: tabId,
+                blockid: blockId,
+                forcerestart: true,
+            });
+        } else {
+            Logger.warn(
+                "identity",
+                `armory bind: pane ${blockId} not in this window's tabs — binding applies on its next spawn`,
+            );
+        }
     } catch (e: any) {
         // The link itself succeeded — the binding applies at the next
-        // clean spawn even if the live env refresh failed. Log, don't throw.
-        Logger.warn("identity", `armory bind: live cmd:env refresh failed: ${e?.message ?? e}`);
+        // clean spawn even if the live apply failed. Log, don't throw.
+        Logger.warn("identity", `armory bind: live apply failed: ${e?.message ?? e}`);
     }
 }
 
@@ -151,6 +194,10 @@ export async function buildAccountRowMenu(
     account: Account,
     agents: AgentDefinition[],
     accounts: Account[],
+    /** Failure feedback — a failed bind RPC must reach the user, not just
+     *  the logs (reagentx P1 on #2485). AccountsTab passes the model's
+     *  notice banner. */
+    onBindError?: (message: string) => void,
     onBound?: () => void,
 ): Promise<ContextMenuItem[]> {
     let allLinks: AgentDefinitionIdentity[] = [];
@@ -187,7 +234,13 @@ export async function buildAccountRowMenu(
                       checked: c.boundHere,
                       sublabel: candidateSublabel(c) || undefined,
                       click: () => {
-                          void bindAccountToAgent(account, c).then(() => onBound?.());
+                          void bindAccountToAgent(account, c)
+                              .then(() => onBound?.())
+                              .catch((e: any) => {
+                                  onBindError?.(
+                                      `Couldn't bind "${account.name}" to ${c.agentName}: ${e?.message ?? e}`,
+                                  );
+                              });
                       },
                   })),
               };

--- a/frontend/app/view/identity/bind-to-agent-menu.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.ts
@@ -1,0 +1,205 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// "Bind to Agent" context menu for Armory account rows —
+// SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md.
+//
+// The menu builder is a pure function (inputs → ContextMenuItem[]) so the
+// filtering/annotation rules are unit-testable without a DOM or RPC mocks;
+// the bind action itself lives here too so both the Armory tab and any
+// future surface share one implementation.
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { WOS } from "@/app/store/global";
+import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
+import { getProvider, resolveProviderAlias } from "@/app/view/agent/providers";
+import { Logger } from "@/util/logger";
+import type { Account } from "./identity-model";
+
+/** One agent's row-worth of binding context for the submenu. */
+export interface BindCandidate {
+    agentId: string;
+    agentName: string;
+    /** Open pane blockId when the agent is currently running, else null. */
+    runningBlockId: string | null;
+    /** Bound to THIS account already. */
+    boundHere: boolean;
+    /** Name of the different account currently bound for this provider, if any. */
+    boundElsewhereName: string | null;
+}
+
+/**
+ * Compute the submenu candidates for binding `account` — the pure core.
+ *
+ * Rules (spec §3):
+ *  - user-owned definitions only (`is_seeded === 0`);
+ *  - CLI-OAuth accounts (claude/codex/…) only offer agents whose provider
+ *    canonicalizes to the account's — alias-canonicalized on BOTH sides
+ *    (the codex-P1-on-#2377 bug class);
+ *  - service accounts (github/aws/… api-key class) offer every agent;
+ *  - running agents (open pane) sort first, then by name.
+ */
+export function computeBindCandidates(
+    account: Account,
+    agents: AgentDefinition[],
+    allLinks: AgentDefinitionIdentity[],
+    openDefinitions: Map<string, string>,
+    accountNameById: Map<string, string>,
+): BindCandidate[] {
+    const acctProvider = resolveProviderAlias(account.provider);
+    // Spec §3's discriminator: CLI-OAuth accounts carry an oauth_config_dir
+    // secret_ref (the CLI's per-account config dir). Service accounts
+    // (github/aws/… api-key class) don't, and offer every agent.
+    const cliOauth = account.secret_ref?.backend === "oauth_config_dir";
+
+    const candidates: BindCandidate[] = [];
+    for (const agent of agents) {
+        if (agent.is_seeded !== 0) continue;
+        if (cliOauth && resolveProviderAlias(agent.provider) !== acctProvider) continue;
+
+        // This agent's current link for the account's provider (canonical
+        // comparison — links can be stored under a legacy alias).
+        const link = allLinks.find(
+            (l) => l.agent_id === agent.id && resolveProviderAlias(l.provider) === acctProvider,
+        );
+        const boundHere = link?.account_id === account.id;
+        const boundElsewhereName =
+            link && !boundHere
+                ? (accountNameById.get(link.account_id) ?? link.account_id)
+                : null;
+
+        candidates.push({
+            agentId: agent.id,
+            agentName: agent.name,
+            runningBlockId: openDefinitions.get(agent.id) ?? null,
+            boundHere,
+            boundElsewhereName,
+        });
+    }
+
+    candidates.sort((a, b) => {
+        const runA = a.runningBlockId != null ? 0 : 1;
+        const runB = b.runningBlockId != null ? 0 : 1;
+        if (runA !== runB) return runA - runB;
+        return a.agentName.localeCompare(b.agentName);
+    });
+    return candidates;
+}
+
+/** Sublabel for a candidate row — the live binding overview (spec §1). */
+export function candidateSublabel(c: BindCandidate): string {
+    const running = c.runningBlockId != null ? "● running" : "";
+    const binding = c.boundHere
+        ? "" // the checkmark carries this
+        : c.boundElsewhereName != null
+            ? `bound: ${c.boundElsewhereName}`
+            : "no account bound";
+    return [running, binding].filter(Boolean).join("  ·  ");
+}
+
+/**
+ * Bind `account` to `candidate`'s agent (spec §2): link upsert, then — for
+ * a running agent — the same `cmd:env` config-dir refresh
+ * `useAgentControllerStatus.useGlobalLogin()` performs after linking, so
+ * the new binding takes effect on the next turn without a restart (a stale
+ * static `cmd:env` override would otherwise shadow the new link at the
+ * next spawn).
+ */
+export async function bindAccountToAgent(account: Account, candidate: BindCandidate): Promise<void> {
+    const provider = resolveProviderAlias(account.provider);
+    await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
+        agent_id: candidate.agentId,
+        account_id: account.id,
+        provider,
+    });
+    Logger.info(
+        "identity",
+        `armory bind: account ${account.id} (${account.name}) → agent ${candidate.agentId} (${candidate.agentName})`,
+    );
+
+    const blockId = candidate.runningBlockId;
+    const dir = account.secret_ref?.dir;
+    const envVar = getProvider(provider)?.authConfigDirEnvVar;
+    if (!blockId || !dir || !envVar) return;
+    try {
+        const envMeta = WOS.getObjectValue<Block>(WOS.makeORef("block", blockId))?.meta?.["cmd:env"];
+        const prevEnv: Record<string, string> = {};
+        if (envMeta && typeof envMeta === "object") {
+            for (const [k, v] of Object.entries(envMeta as Record<string, unknown>)) {
+                if (typeof v === "string") prevEnv[k] = v;
+            }
+        }
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: WOS.makeORef("block", blockId),
+            meta: { "cmd:env": { ...prevEnv, [envVar]: dir } },
+        });
+    } catch (e: any) {
+        // The link itself succeeded — the binding applies at the next
+        // clean spawn even if the live env refresh failed. Log, don't throw.
+        Logger.warn("identity", `armory bind: live cmd:env refresh failed: ${e?.message ?? e}`);
+    }
+}
+
+/**
+ * Assemble the full context-menu item list for an account row. Fetches the
+ * link snapshot itself (one ListAllAgentIdentitiesCommand — the same call
+ * the delete-disclosure in this tab already makes) and returns plain
+ * ContextMenuItem[]s ready for ContextMenuModel.showContextMenu.
+ */
+export async function buildAccountRowMenu(
+    account: Account,
+    agents: AgentDefinition[],
+    accounts: Account[],
+    onBound?: () => void,
+): Promise<ContextMenuItem[]> {
+    let allLinks: AgentDefinitionIdentity[] = [];
+    try {
+        allLinks = (await RpcApi.ListAllAgentIdentitiesCommand(TabRpcClient)) ?? [];
+    } catch {
+        // Best-effort: without links the submenu still binds correctly —
+        // it just can't annotate current bindings.
+    }
+    const accountNameById = new Map(accounts.map((a) => [a.id, a.name] as const));
+    const candidates = computeBindCandidates(
+        account,
+        agents,
+        allLinks,
+        getOpenDefinitionMap(),
+        accountNameById,
+    );
+
+    const bindItem: ContextMenuItem =
+        candidates.length === 0
+            ? {
+                  // Disabled-with-reason beats disappearing (spec §3) —
+                  // matches the generic pane menu's disabled-Copy precedent.
+                  label: "Bind to Agent",
+                  sublabel: "no compatible agents in this channel",
+                  enabled: false,
+              }
+            : {
+                  label: "Bind to Agent",
+                  type: "submenu",
+                  submenu: candidates.map((c) => ({
+                      label: c.agentName,
+                      type: "checkbox" as const,
+                      checked: c.boundHere,
+                      sublabel: candidateSublabel(c) || undefined,
+                      click: () => {
+                          void bindAccountToAgent(account, c).then(() => onBound?.());
+                      },
+                  })),
+              };
+
+    return [
+        bindItem,
+        { type: "separator" },
+        {
+            label: "Copy account ID",
+            click: () => {
+                void import("@/util/clipboard").then(({ writeText }) => writeText(account.id));
+            },
+        },
+    ];
+}

--- a/frontend/app/view/identity/bind-to-agent-menu.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.ts
@@ -131,6 +131,31 @@ function findTabIdForBlock(blockId: string): string | null {
 export async function bindAccountToAgent(account: Account, candidate: BindCandidate): Promise<void> {
     const provider = resolveProviderAlias(account.provider);
     try {
+        // Alias-row cleanup BEFORE the upsert (reagentx P1 on #2485, second
+        // round): the backend upserts on the RAW provider string
+        // (ON CONFLICT(agent_id, provider)), so linking canonical "claude"
+        // does not replace an existing link stored under a legacy alias
+        // ("claude-code") — both rows survive, injection processes them
+        // ORDER BY provider, and the alphabetically-later alias row applies
+        // last and silently wins. Unlink every alias-stored row for this
+        // canonical provider first (fetched fresh at click time — the
+        // menu-build snapshot may be stale). `silent: true` is the flag
+        // purpose-built for alias migration: the replacement link lands in
+        // the same call, so a credentials-revoked broadcast would be noise.
+        // Cleanup is part of the must-succeed path — proceeding past a
+        // failed unlink would reintroduce the silent-wrong-account bug.
+        const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
+            agent_id: candidate.agentId,
+        });
+        for (const l of links ?? []) {
+            if (l.provider !== provider && resolveProviderAlias(l.provider) === provider) {
+                await RpcApi.UnlinkAgentIdentityCommand(TabRpcClient, {
+                    agent_id: candidate.agentId,
+                    provider: l.provider,
+                    silent: true,
+                });
+            }
+        }
         await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
             agent_id: candidate.agentId,
             account_id: account.id,

--- a/frontend/app/view/identity/identity-accounts-tab.tsx
+++ b/frontend/app/view/identity/identity-accounts-tab.tsx
@@ -34,12 +34,19 @@ export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Elemen
     // binding annotations are current without any subscription here. The
     // account list itself re-renders via the shared cache's live sync
     // (identityaccounts:changed → #2474) after a bind.
+    // Latest-right-click-wins: buildAccountRowMenu awaits an RPC, so a
+    // second right-click on a different row before the first resolves could
+    // otherwise let the earlier request's menu win the race and open for
+    // the wrong account (reagentx P2 on #2485).
+    let menuSeq = 0;
     const handleRowContextMenu = (account: Account, e: MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        const seq = ++menuSeq;
         void buildAccountRowMenu(account, agents(), model.accountsAtom(), (msg) =>
             model.showNotice(msg),
         ).then((items) => {
+            if (seq !== menuSeq) return; // superseded by a later right-click
             ContextMenuModel.showContextMenu(items, e);
         });
     };

--- a/frontend/app/view/identity/identity-accounts-tab.tsx
+++ b/frontend/app/view/identity/identity-accounts-tab.tsx
@@ -9,6 +9,8 @@ import { ProviderLogo } from "@/element/ProviderLogo";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { brandForProvider, isCliOAuthProvider } from "@/app/view/accounts/provider-brand";
+import { ContextMenuModel } from "@/app/store/contextmenu";
+import { buildAccountRowMenu } from "./bind-to-agent-menu";
 import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/app/element/modal";
 import "./identity-view.scss";
 
@@ -24,6 +26,21 @@ const STATUS_DOT: Record<string, string> = {
 
 export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Element {
     const groups = () => model.accountsByProvider();
+    const agents = useAgentDefinitions();
+
+    // Right-click an account row → "Bind to Agent" submenu + Copy account ID
+    // (SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md). Menu contents
+    // are computed fresh per open (links + open-pane snapshot), so the
+    // binding annotations are current without any subscription here. The
+    // account list itself re-renders via the shared cache's live sync
+    // (identityaccounts:changed → #2474) after a bind.
+    const handleRowContextMenu = (account: Account, e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void buildAccountRowMenu(account, agents(), model.accountsAtom()).then((items) => {
+            ContextMenuModel.showContextMenu(items, e);
+        });
+    };
 
     return (
         <>
@@ -72,6 +89,7 @@ export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Elemen
                                                 account={account}
                                                 selected={model.selectedAccountAtom()?.id === account.id}
                                                 onClick={() => model.setSelectedAccount(account)}
+                                                onContextMenu={(e) => handleRowContextMenu(account, e)}
                                             />
                                         )}
                                     </For>
@@ -98,12 +116,18 @@ export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Elemen
     );
 }
 
-function AccountRow(props: { account: Account; selected: boolean; onClick: () => void }): JSX.Element {
+function AccountRow(props: {
+    account: Account;
+    selected: boolean;
+    onClick: () => void;
+    onContextMenu?: (e: MouseEvent) => void;
+}): JSX.Element {
     const a = props.account;
     return (
         <div
             class={`identity-account-row${props.selected ? " selected" : ""}`}
             onClick={props.onClick}
+            onContextMenu={(e) => props.onContextMenu?.(e)}
         >
             <span class={`identity-provider-badge provider-${a.provider}`}>
                 <ProviderLogo provider={a.provider} size={16} />

--- a/frontend/app/view/identity/identity-accounts-tab.tsx
+++ b/frontend/app/view/identity/identity-accounts-tab.tsx
@@ -37,7 +37,9 @@ export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Elemen
     const handleRowContextMenu = (account: Account, e: MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
-        void buildAccountRowMenu(account, agents(), model.accountsAtom()).then((items) => {
+        void buildAccountRowMenu(account, agents(), model.accountsAtom(), (msg) =>
+            model.showNotice(msg),
+        ).then((items) => {
             ContextMenuModel.showContextMenu(items, e);
         });
     };

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -420,6 +420,14 @@ export class IdentityViewModel implements ViewModel {
         this.setDeleteNotice(null);
     };
 
+    /** Surface a transient notice in the Accounts tab's banner row (the
+     *  same dismissible UI the delete disclosure uses). Added for the
+     *  Bind-to-Agent menu's failure feedback (reagentx P1 on #2485) —
+     *  a failed bind RPC must not vanish into logs only. */
+    showNotice = (text: string): void => {
+        this.setDeleteNotice(text);
+    };
+
     /** Unsubscribe from the account cache; assigned in the constructor,
      *  invoked in dispose() so direct callers don't leak a listener. */
     private _unsubAccounts: (() => void) | null = null;


### PR DESCRIPTION
## Summary

Implements `SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md` (included in this PR, along with its companion account-adoption spec — supersedes #2484, which carried the specs alone).

Right-click an Armory account row → **Bind to Agent ▸** submenu listing the channel's user-owned agents, plus **Copy account ID**. The submenu doubles as a live binding overview — the motivating case is a user with three claude accounts who has no way to see or change which agent uses which:

- ✓ checkmark on agents already bound to this account
- sublabel naming the *different* account an agent is currently bound to ("bound: work-claude") or "no account bound" — rebinds are disclosed before the click, so no confirm dialog on a non-destructive upsert
- running agents (open panes) sort first with a marker; non-running agents still bindable (pre-provisioning)
- CLI-OAuth accounts only offer same-provider agents (alias-canonicalized both sides — the #2377 lesson); service accounts offer all agents; empty set renders disabled-with-reason instead of hiding

**Bind action:** the existing `LinkAgentIdentityCommand` upsert; for a running agent, also mirrors `useGlobalLogin`'s `cmd:env` config-dir refresh so the new binding takes effect next turn without restart. Account list re-renders live via #2474's cache sync. Zero backend changes.

## Test plan

- [x] Menu builder is a pure function — 11 unit tests (provider filtering + aliases, boundHere/boundElsewhere annotations incl. alias-stored links, running-first sort, template exclusion, sublabel composition)
- [x] `npx tsc --noEmit` clean
- [x] Full vitest suite: 2423 passed, 0 failed
- [ ] Live check (per spec §5): 3 claude accounts → right-click each → verify binding overview, rebind an agent between accounts, confirm next turn's spawn log shows the new account id

<!-- agentmux:agent_id=agent3 -->