### PR TITLE
chore: release v0.55.0

### DIFF
--- a/.changesets/1786279599-fix-statusbar-shorten-the-disk-pill-s-hover-tooltip-to-match-wvw3.md
+++ b/.changesets/1786279599-fix-statusbar-shorten-the-disk-pill-s-hover-tooltip-to-match-wvw3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): shorten the Disk pill's hover tooltip to match the other stat pills

--- a/.changesets/1786279910-fix-backend-editor-media-file-watchers-no-longer-misfire-on--wwrq.md
+++ b/.changesets/1786279910-fix-backend-editor-media-file-watchers-no-longer-misfire-on--wwrq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(backend): editor/media file watchers no longer misfire on a macOS remove

--- a/.changesets/1786282080-fix-agent-pane-surface-the-spawn-gate-s-actual-refusal-text--mqeh.md
+++ b/.changesets/1786282080-fix-agent-pane-surface-the-spawn-gate-s-actual-refusal-text--mqeh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): surface the spawn gate's actual refusal text instead of the bare 'Agent encountered an error'

--- a/.changesets/1786297813-feat-diagnostics-mem-attribution-logs-unattributed-commit-ga-45dr.md
+++ b/.changesets/1786297813-feat-diagnostics-mem-attribution-logs-unattributed-commit-ga-45dr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(diagnostics): mem_attribution logs unattributed commit gap + handle-count anomalies

--- a/.changesets/1786300545-feat-armory-right-click-an-account-row-to-bind-it-to-an-agen-1z96.md
+++ b/.changesets/1786300545-feat-armory-right-click-an-account-row-to-bind-it-to-an-agen-1z96.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): right-click an account row to bind it to an agent - Bind to Agent submenu with live binding overview

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.14"
+version = "0.55.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.14"
+version = "0.55.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.14"
+version = "0.55.0"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.14"
+version = "0.55.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.14"
+version = "0.55.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.14"
+version = "0.55.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.14"
+version = "0.55.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,14 @@
 # AgentMux Version History
 
+## 0.55.0 — 2026-08-09
+
+- fix(statusbar): shorten the Disk pill's hover tooltip to match the other stat pills
+- fix(backend): editor/media file watchers no longer misfire on a macOS remove
+- fix(agent-pane): surface the spawn gate's actual refusal text instead of the bare 'Agent encountered an error'
+- feat(diagnostics): mem_attribution logs unattributed commit gap + handle-count anomalies
+- feat(armory): right-click an account row to bind it to an agent - Bind to Agent submenu with live binding overview
+
+
 ## 0.54.14 — 2026-08-09
 
 - feat(statusbar): Disk readout explains its % in the tooltip; click opens a per-drive free-space popover
@@ -2381,6 +2390,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.54.14 | 2026-08-09 | 171.9 MiB | 370.8 MiB | |
 | 0.52.2 | 2026-07-09 | 171.6 MiB | 369.5 MiB | |
 | 0.52.1 | 2026-07-09 | 171.6 MiB | 369.5 MiB | |
 | 0.44.0 | 2026-06-10 | 163.9 MiB | 349.8 MiB | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.14",
+  "version": "0.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.14",
+      "version": "0.55.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.14",
+  "version": "0.55.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Release v0.55.0 (minor — standard changesets flow, two feat-level changes)

Consumes 5 pending changesets:

- feat(armory): right-click an account row → 'Bind to Agent' submenu with live binding overview (#2485)
- feat(diagnostics): mem_attribution logs unattributed commit gap
- fix(agent-pane): surface the spawn gate's actual refusal text instead of the bare "Agent encountered an error" (#2482)
- fix(statusbar): shorten the disk pill's hover tooltip
- fix(backend): editor/media file watchers no longer misfire

Version 0.54.14 → 0.55.0 across all five version locations. Only PR touching version files, per the changesets protocol.

<!-- agentmux:agent_id=agent3 -->