### PR TITLE
fix(dev): Vite watcher ignores never matched (34x handle reduction); cool down handle-anomaly warns

### DIFF
--- a/.changesets/1786303976-fix-dev-vite-watcher-ignores-never-matched-34x-handle-reduct-nwt0.md
+++ b/.changesets/1786303976-fix-dev-vite-watcher-ignores-never-matched-34x-handle-reduct-nwt0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dev): Vite watcher ignores never matched (34x handle reduction); cool down handle-anomaly warns

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -142,6 +142,17 @@ const HANDLE_WARN_AGENTMUX: u32 = 20_000;
 const HANDLE_WARN_EXTERNAL: u32 = 50_000;
 #[cfg(target_os = "windows")]
 const HANDLE_TOP_N: usize = 3;
+/// Minimum gap between repeat WARNs for the SAME still-anomalous PID. The
+/// first live run of this detector (2026-08-09) re-warned every 30s
+/// attribution cycle — and more under the urgent-on-pressure path — for
+/// two persisting Vite-process anomalies, drowning the log. One warn per
+/// PID per this window keeps the signal (a persisting anomaly still
+/// re-surfaces regularly, and the info line's `handles_top` carries the
+/// count every cycle regardless) without the spam. A PID that drops below
+/// threshold and re-crosses later warns immediately again (its entry is
+/// pruned while healthy).
+#[cfg(target_os = "windows")]
+const HANDLE_WARN_COOLDOWN: Duration = Duration::from_secs(600);
 
 /// One process's handle-count sample for anomaly classification.
 #[cfg(target_os = "windows")]
@@ -184,6 +195,44 @@ fn classify_handle_anomalies(samples: &[HandleSample]) -> Vec<HandleAnomaly> {
     anomalies.sort_by(|a, b| b.handles.cmp(&a.handles));
     anomalies
 }
+
+/// Pure cooldown gate for anomaly WARNs, factored out for unit testing.
+/// Returns the indices (into `anomalies`) that should warn THIS cycle, and
+/// updates `last_warned` accordingly. Entries for PIDs that are no longer
+/// anomalous are pruned first — both so the map can't grow unbounded across
+/// process churn, and so a process that recovers and later re-crosses the
+/// threshold warns immediately rather than being silently inside a stale
+/// cooldown window.
+#[cfg(target_os = "windows")]
+fn filter_anomalies_for_warn(
+    anomalies: &[HandleAnomaly],
+    last_warned: &mut HashMap<u32, Instant>,
+    now: Instant,
+    cooldown: Duration,
+) -> Vec<usize> {
+    let current: HashSet<u32> = anomalies.iter().map(|a| a.pid).collect();
+    last_warned.retain(|pid, _| current.contains(pid));
+
+    let mut warn = Vec::new();
+    for (i, anomaly) in anomalies.iter().enumerate() {
+        let due = match last_warned.get(&anomaly.pid) {
+            Some(&at) => now.duration_since(at) >= cooldown,
+            None => true,
+        };
+        if due {
+            last_warned.insert(anomaly.pid, now);
+            warn.push(i);
+        }
+    }
+    warn
+}
+
+/// Process-lifetime state for the cooldown above. A plain static rather
+/// than threading it through the loop: `log_memory_attribution` is only
+/// ever called from the single sysinfo loop task, so contention is nil.
+#[cfg(target_os = "windows")]
+static LAST_HANDLE_WARN: std::sync::OnceLock<std::sync::Mutex<HashMap<u32, Instant>>> =
+    std::sync::OnceLock::new();
 
 /// Open-query-close a process's total handle count. Returns `None` for
 /// PIDs we can't open (protected/system processes) — expected, skipped
@@ -305,7 +354,16 @@ fn log_memory_attribution(sys: &mut sysinfo::System, commit_used_gb: f64, commit
         .collect::<Vec<_>>()
         .join(", ");
 
-    for anomaly in classify_handle_anomalies(&handle_samples) {
+    let anomalies = classify_handle_anomalies(&handle_samples);
+    let warn_indices = {
+        let mut last = LAST_HANDLE_WARN
+            .get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap();
+        filter_anomalies_for_warn(&anomalies, &mut last, Instant::now(), HANDLE_WARN_COOLDOWN)
+    };
+    for i in warn_indices {
+        let anomaly = &anomalies[i];
         if anomaly.is_agentmux {
             tracing::warn!(
                 target: "mem_attribution",
@@ -530,6 +588,58 @@ mod handle_anomaly_tests {
         // itself — a running process always has at least a few handles.
         let count = process_handle_count(std::process::id());
         assert!(count.is_some_and(|c| c > 0), "got {count:?}");
+    }
+
+    fn anomaly(pid: u32) -> HandleAnomaly {
+        HandleAnomaly { pid, name: format!("proc{pid}.exe"), handles: 99_999, is_agentmux: false }
+    }
+
+    #[test]
+    fn cooldown_warns_immediately_on_first_sight_then_suppresses() {
+        let mut last = HashMap::new();
+        let t0 = Instant::now();
+        let cooldown = Duration::from_secs(600);
+        let anomalies = vec![anomaly(1)];
+
+        assert_eq!(filter_anomalies_for_warn(&anomalies, &mut last, t0, cooldown), vec![0]);
+        // Same anomaly, next 30s cycle — suppressed.
+        let t1 = t0 + Duration::from_secs(30);
+        assert!(filter_anomalies_for_warn(&anomalies, &mut last, t1, cooldown).is_empty());
+        // Past the cooldown — warns again.
+        let t2 = t0 + cooldown;
+        assert_eq!(filter_anomalies_for_warn(&anomalies, &mut last, t2, cooldown), vec![0]);
+    }
+
+    #[test]
+    fn cooldown_is_per_pid_not_global() {
+        let mut last = HashMap::new();
+        let t0 = Instant::now();
+        let cooldown = Duration::from_secs(600);
+
+        assert_eq!(filter_anomalies_for_warn(&[anomaly(1)], &mut last, t0, cooldown), vec![0]);
+        // A DIFFERENT pid appearing 30s later warns immediately, even though
+        // pid 1 is mid-cooldown.
+        let t1 = t0 + Duration::from_secs(30);
+        let both = vec![anomaly(1), anomaly(2)];
+        assert_eq!(filter_anomalies_for_warn(&both, &mut last, t1, cooldown), vec![1]);
+    }
+
+    #[test]
+    fn recovered_pid_recrossing_the_threshold_warns_immediately() {
+        let mut last = HashMap::new();
+        let t0 = Instant::now();
+        let cooldown = Duration::from_secs(600);
+
+        assert_eq!(filter_anomalies_for_warn(&[anomaly(1)], &mut last, t0, cooldown), vec![0]);
+        // pid 1 drops below threshold (absent from anomalies) — its entry is
+        // pruned...
+        let t1 = t0 + Duration::from_secs(30);
+        assert!(filter_anomalies_for_warn(&[], &mut last, t1, cooldown).is_empty());
+        assert!(last.is_empty(), "healthy pid's entry must be pruned");
+        // ...so re-crossing 30s later (well inside what would have been the
+        // old cooldown window) warns immediately.
+        let t2 = t0 + Duration::from_secs(60);
+        assert_eq!(filter_anomalies_for_warn(&[anomaly(1)], &mut last, t2, cooldown), vec![0]);
     }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -175,7 +175,28 @@ export default defineConfig({
             // and the original docs/retro/RETRO_CEF_BUILD_RACE_2026_04_24.md.
             // No functional loss: nothing under target/ is ever meant to
             // trigger a frontend HMR reload.
-            ignored: ["dist/**", "target/**", "**/*.md", "**/*.json"],
+            //
+            // ANCHORED TO THE REPO ROOT, ABSOLUTE, FORWARD-SLASHED — not the
+            // relative "dist/**" form this originally used. Chokidar matches
+            // ignore globs against ABSOLUTE paths, so a relative pattern
+            // matches nothing, silently. Worse, even "**/dist/**" fails when
+            // the repo lives under a dot-directory (every agent checkout is
+            // under ~/.agentmux/...): picomatch's `**` refuses to traverse
+            // dot-segments like ".agentmux" without dot:true, which chokidar
+            // doesn't set. Empirically verified: with the relative patterns,
+            // a `task dev` Vite process on such a checkout accumulated 75K+
+            // Windows handles in ~1h (caught by mem_attribution's new
+            // handle-count anomaly WARN, 2026-08-09) because it was watching
+            // dist/cef-dev's entire extracted CEF runtime — meaning the
+            // #2424 race fix above was also silently ineffective there. An
+            // absolute pattern spells the dot-directories out literally, so
+            // `**` never has to traverse them.
+            ignored: [
+                `${path.resolve(__dirname).replace(/\\/g, "/")}/dist/**`,
+                `${path.resolve(__dirname).replace(/\\/g, "/")}/target/**`,
+                `${path.resolve(__dirname).replace(/\\/g, "/")}/**/*.md`,
+                `${path.resolve(__dirname).replace(/\\/g, "/")}/**/*.json`,
+            ],
         },
     },
     css: {


### PR DESCRIPTION
## Summary

Two follow-ups from the handle-leak diagnostics' first live run (#2483), which immediately flagged two `task dev` Vite processes at **75K and 129K Windows handles**:

### 1. `vite.config.ts`'s `server.watch.ignored` patterns were ALL no-ops

Chokidar matches ignore globs against **absolute paths**, so the relative `"dist/**"`/`"target/**"` forms matched nothing, silently. Worse, even the canonical `"**/dist/**"` form fails on any checkout under a dot-directory (every agent checkout lives under `~/.agentmux/...`): picomatch's `**` refuses to traverse dot-segments like `.agentmux` without `dot:true`, which chokidar doesn't set. Both failure modes verified empirically against picomatch directly.

Net effect: the watcher was watching `dist/cef-dev`'s entire extracted CEF runtime (and `target/`) — which also means **#2424's watcher-vs-CEF-extraction race fix was silently ineffective on these checkouts**. Fix: anchor all four patterns to the absolute, forward-slashed repo root — the dot-directories become literal pattern text, which matches fine.

**Live A/B on this machine** (`task dev`, same checkout, watcher settled):
| | handles |
|---|---|
| before (relative globs) | 75,005 (~1h uptime, climbing) |
| after (absolute globs) | **2,196** (stable across repeated samples) |

This is also a real lead on the user-observed "commit drops when I exit AgentMux" pagefile pattern — Vite dev-server processes are part of `task dev`'s tree, and each was holding tens of thousands of kernel handles it shouldn't have.

### 2. Handle-anomaly WARNs cool down per-PID (10 min)

The first live run re-warned every 30s attribution cycle (plus the urgent-on-pressure path) for a persisting anomaly. Now one WARN per PID per 10 minutes; the info line's `handles_top` still carries counts every cycle so trend data is not lost. A PID that recovers below threshold is pruned from the cooldown map, so a later re-crossing warns immediately. Pure `filter_anomalies_for_warn` factored out + 3 unit tests.

**Live-verified in the same dev run**: 7 attribution cycles, the still-anomalous external Vite (129K handles) warned exactly once.

## Test plan

- [x] 3 new cooldown unit tests (immediate first warn / per-PID independence / prune-on-recovery)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2075/2075
- [x] Live A/B of the Vite fix and the cooldown, numbers above
- [x] No frontend JSON imports exist, so the (now actually working) `*.json` ignore can't break HMR for imported modules

<!-- agentmux:agent_id=agentx -->