### PR TITLE
fix(agent-pane): expanded dock row shows the full command word-wrapped at the top

### DIFF
--- a/.changesets/1786324878-fix-agent-pane-expanded-dock-row-shows-the-full-command-word-pzr5.md
+++ b/.changesets/1786324878-fix-agent-pane-expanded-dock-row-shows-the-full-command-word-pzr5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): expanded dock row shows the full command word-wrapped at the top

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -140,6 +140,20 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
         return undefined;
     });
 
+    // Full command for the expanded header — the collapsed row's title is
+    // ellipsis-truncated by CSS, so a long command (a heartbeat-wrapped
+    // dev launch, a multi-flag one-liner) is unidentifiable without this.
+    // Shell rows: `cmd` is the real command even when the row carries a
+    // custom display title. Tool rows: BashParams.command, falling back to
+    // the title (which toolToActivity derives from the same field).
+    const fullCommand = createMemo((): string | undefined => {
+        const a = props.activity();
+        if (!a) return undefined;
+        if (a.shell) return a.shell.cmd;
+        if (a.tool) return (a.tool.params as { command?: string } | undefined)?.command ?? a.title;
+        return undefined;
+    });
+
     // Expanded shell/tool log — same cap + renderer as PersistentShellBlock.
     // A promoted tool call's log is optional (only populated for tools that
     // stream partials — see ToolNode.log's own doc comment), unlike a
@@ -211,6 +225,14 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
                             class="agent-activity-log agent-tool-overlay-log"
                             onClick={(e) => e.stopPropagation()}
                         >
+                            {/* Full command, word-wrapped — the collapsed
+                                title truncates, so this header is how the
+                                user identifies WHAT is running (user report
+                                2026-08-10: long-running process in the dock
+                                was unidentifiable when expanded). */}
+                            <Show when={fullCommand()}>
+                                <div class="agent-activity-command">{fullCommand()}</div>
+                            </Show>
                             <Show when={capped().hiddenLines > 0}>
                                 <OutputHiddenMarker hidden={capped().hiddenLines} noun="line" from="tail" />
                             </Show>

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -330,6 +330,22 @@
     background: var(--block-bg-color, rgba(0, 0, 0, 0.18));
 }
 
+// Full-command header at the top of an expanded shell/tool row — the
+// collapsed title is ellipsis-truncated, so this is where a long command
+// becomes identifiable. Wraps instead of scrolling: the whole point is
+// reading it in full.
+.agent-activity-command {
+    font-family: var(--fixed-font, monospace);
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    padding: var(--space-1) 0 var(--space-1-5);
+    margin-bottom: var(--space-1);
+    border-bottom: 1px solid var(--border-color);
+    user-select: text;
+}
+
 .agent-activity-overflow {
     appearance: none;
     border: none;


### PR DESCRIPTION
## Summary

Expanding an ActivityDock row (long-running shell / promoted Bash call) jumped straight into the log — with the collapsed title ellipsis-truncated, a long command was unidentifiable. This adds a full-command header at the top of the expanded view: monospace, `pre-wrap` + `overflow-wrap: anywhere` so it wraps fully, user-selectable, separated from the log by a divider.

- Shell rows use `shell.cmd` (the real command, even when the row has a custom display title).
- Promoted tool rows use `BashParams.command`, falling back to the title.

Found live while watching a long-running process in a dev instance (user report 2026-08-10).

## Verification

- `tsc --noEmit` clean.
- Verified live via Vite hot reload in the running dev instance.

<!-- agentmux:agent_id=camper -->