### PR TITLE
fix(agent-pane): scrub ghost 'running' tool nodes at turn end

### DIFF
--- a/.changesets/1786325635-fix-agent-pane-scrub-ghost-running-tool-nodes-at-turn-end-st-a582.md
+++ b/.changesets/1786325635-fix-agent-pane-scrub-ghost-running-tool-nodes-at-turn-end-st-a582.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): scrub ghost 'running' tool nodes at turn end (stuck dock rows)

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -865,6 +865,42 @@ describe("agent document reducer", () => {
             expect(r.events).toEqual([]);
         });
 
+        // Turn-end scope (scope: "tools-only") — dispatched shortly after
+        // every TurnEnd (agent-view.tsx): a foreground tool call cannot
+        // outlive its turn, so a still-running tool node observed after the
+        // turn ended is provably an orphan (the "running · 45m git status"
+        // ghost dock row, user report 2026-08-10). Everything with a
+        // session-bounded lifecycle must survive this mid-session pass.
+        it("tools-only scope scrubs running tools but leaves thinking tail, live shells, and questions alone", () => {
+            const s0 = seed([
+                tool("ghost", { status: "running" }),
+                tool("answered", { status: "awaiting_answer" }),
+                shell("dev-server", { status: "running" }),
+                thinkingMd("tail-think", "mid-thought"),
+            ]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999, scope: "tools-only" });
+            expect((r.state.nodes[0] as ToolNode).status).toBe("canceled");
+            // Session-bounded lifecycles untouched:
+            expect((r.state.nodes[1] as ToolNode).status).toBe("awaiting_answer");
+            expect((r.state.nodes[2] as ShellNode).status).toBe("running");
+            expect((r.state.nodes[3] as any).metadata.thinking).toBe(true);
+            expect(r.events).toEqual([
+                {
+                    type: "orphans-scrubbed",
+                    markdownCanceled: 0,
+                    toolsCanceled: 1,
+                    resolvedToolNodes: [{ id: "ghost", status: "canceled", toolName: "Bash" }],
+                },
+            ]);
+        });
+
+        it("tools-only scope is a no-op when no tool is running", () => {
+            const s0 = seed([shell("dev-server", { status: "running" }), thinkingMd("tail-think")]);
+            const r = update(s0, { type: "ScrubOrphanedInProgress", at: 9999, scope: "tools-only" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
         it("scrubs tool-running anywhere in doc but leaves prior thinking alone", () => {
             // Realistic snapshot of an app-killed session: prior
             // turn's thinking → text → new turn's tool started but

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -64,6 +64,14 @@ function scrubOrphanedInProgress(
          * on PR #1104 (HistoryLoaded.loadOlder pagination case).
          */
         hasContentAfter?: boolean;
+        /**
+         * Restrict the sweep to running `tool` nodes — the turn-end
+         * scrub scope. Thinking markdown, shells, and awaiting_answer
+         * questions have session-bounded (not turn-bounded) lifecycles
+         * and must survive a mid-session pass. See the
+         * `ScrubOrphanedInProgress` command's doc comment.
+         */
+        toolsOnly?: boolean;
     },
 ): {
     nodes: DocumentNode[];
@@ -97,11 +105,13 @@ function scrubOrphanedInProgress(
     // Tools have an explicit status field so scrub them anywhere
     // they appear with status:"running".
     const hasContentAfter = opts?.hasContentAfter === true;
+    const toolsOnly = opts?.toolsOnly === true;
     const lastIdx = hasContentAfter ? -1 : nodes.length - 1;
 
     for (let i = 0; i < nodes.length; i++) {
         const n = nodes[i];
         if (
+            !toolsOnly &&
             n.type === "markdown" &&
             n.metadata?.thinking === true &&
             i === lastIdx
@@ -140,7 +150,7 @@ function scrubOrphanedInProgress(
         // still be answerable — a one-shot agent that just asked (SessionEnd
         // fires while the question is the tail) or a resumable reopened
         // session. Using the same last-node heuristic as the thinking scrub.
-        if (n.type === "tool" && n.status === "awaiting_answer" && i !== lastIdx) {
+        if (!toolsOnly && n.type === "tool" && n.status === "awaiting_answer" && i !== lastIdx) {
             if (!next) next = nodes.slice();
             next[i] = {
                 ...n,
@@ -152,7 +162,7 @@ function scrubOrphanedInProgress(
             resolvedToolNodes.push({ id: n.id, status: "success", toolName: n.toolName ?? n.tool });
             continue;
         }
-        if (n.type === "shell" && n.status === "running") {
+        if (!toolsOnly && n.type === "shell" && n.status === "running") {
             if (!next) next = nodes.slice();
             next[i] = { ...n, status: "stopped", exitedAt: at, log: { ...n.log, open: false } };
             toolsCanceled++;
@@ -639,7 +649,11 @@ export function update(
             // exists for explicit dispatchers and for testability.
             // Idempotent: returns state unchanged if nothing's
             // in-progress.
-            const scrub = scrubOrphanedInProgress(state.nodes, command.at);
+            const scrub = scrubOrphanedInProgress(
+                state.nodes,
+                command.at,
+                command.scope === "tools-only" ? { toolsOnly: true } : undefined,
+            );
             if (!scrub) return { state, events: [] };
             return {
                 state: { ...state, nodes: scrub.nodes },

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -138,9 +138,20 @@ export type AgentDocumentCommand =
      * Idempotent — running it twice is a no-op against the
      * already-scrubbed state.
      *
+     * `scope: "tools-only"` narrows the sweep to `tool` nodes with
+     * `status === "running"` — dispatched shortly after every TurnEnd
+     * (agent-view.tsx): a foreground tool call cannot outlive its turn
+     * (it blocks it) and a backgrounded harness call resolves its
+     * ToolNode immediately, so a running tool node observed after the
+     * turn ended is provably an orphan (rejected call / dropped
+     * tool_result). Thinking markdown, shells (turn-independent — a
+     * live MCP shell legitimately spans turns), and awaiting_answer
+     * questions are deliberately untouched in this scope; their
+     * lifecycles are session-bounded, not turn-bounded.
+     *
      * Spec: docs/specs/SPEC_ORPHAN_THINKING_NODES_2026_05_27.md.
      */
-    | { type: "ScrubOrphanedInProgress"; at: number }
+    | { type: "ScrubOrphanedInProgress"; at: number; scope?: "tools-only" }
     /**
      * Force one specific `ToolNode` to `status: "canceled"`, regardless of
      * how long it's been running or whether a session boundary has

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -845,6 +845,31 @@ const AgentPresentationView = ({
         }
     }
 
+    // Turn-end ghost-tool scrub (user report 2026-08-10: a ~1s `git status`
+    // call stuck as a "running \u00b7 45m" dock row for the rest of the session).
+    // A foreground tool call cannot outlive its turn \u2014 it blocks it \u2014 and a
+    // backgrounded harness call resolves its ToolNode immediately, so a tool
+    // node still `running` shortly AFTER TurnEnd is provably an orphan
+    // (rejected call / dropped tool_result). scrubOrphanedInProgress
+    // otherwise only runs at session boundaries (SessionEnd/HistoryLoaded),
+    // which is why the ghost survived all session. The 2s delay absorbs any
+    // tail flush still in flight; the working guard skips the pass when a
+    // new turn already started (its running tools are legit). tools-only
+    // scope: thinking markdown, shells (turn-independent), and questions
+    // keep their session-bounded lifecycles.
+    createEffect(on(turnJustEndedAtom, (n) => {
+        if (n === 0) return;
+        const timer = setTimeout(() => {
+            if (workingFromPhase(agentAtoms().turnPhaseAtom[0]())) return;
+            dispatchDocIfRegistered(model.blockId, {
+                type: "ScrubOrphanedInProgress",
+                at: Date.now(),
+                scope: "tools-only",
+            });
+        }, 2_000);
+        onCleanup(() => clearTimeout(timer));
+    }));
+
     // Posts a permanent, visible line into the pane's own conversation \u2014
     // distinct from `log()`, which routes to the hidden activity-log/shell-
     // terminal channel (see docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md


### PR DESCRIPTION
## Summary

Live report (2026-08-10): a `cd … && git remote -v && git status && git branch --show-current` call — a ~1-second command — showed as **running · 45m** in the ActivityDock. The OS process tree under the agent had zero children: the process was long gone, but its ToolNode was stuck at `running` because the `tool_result` never matched, and `scrubOrphanedInProgress` only runs at session boundaries (SessionEnd / HistoryLoaded). Known gap from `RETRO_TASK_DEV_IDLE_KILL_FALSE_POSITIVE_2026_07_31.md` §"stuck dock entry", follow-up finally implemented.

**The invariant that makes this safe:** a foreground tool call blocks its turn (cannot outlive it), and a backgrounded harness call resolves its ToolNode immediately — so a tool node still `running` shortly *after* TurnEnd is provably an orphan.

- `ScrubOrphanedInProgress` gains `scope: "tools-only"`: running tools scrub; thinking markdown, live MCP shells (turn-independent by design), and `awaiting_answer` questions keep their session-bounded lifecycles.
- `agent-view.tsx` dispatches it 2s after every turn-end edge (`turnJustEndedAtom`), skipped if a new turn already started.

Also protects the attached-task axis (#2489) from being pinned on by the same ghost — it consumes the same running-tool signal.

## Verification

- `tsc --noEmit` clean.
- 87/87 document-reducer tests, incl. 2 new: tools-only scrubs the ghost while leaving shell/thinking/question nodes untouched; no-op when nothing is running.
- Live diagnosis of the triggering incident: dock row's command header (from #2493) identified the call; `Get-CimInstance` process-tree walk confirmed no matching OS process.

<!-- agentmux:agent_id=camper -->