### PR TITLE
fix(agent-pane): Working shows instantly on send; drop redundant Running-in-background footer state

### DIFF
--- a/.changesets/1786336124-fix-agent-pane-working-shows-instantly-on-send-drop-redundan-51jh.md
+++ b/.changesets/1786336124-fix-agent-pane-working-shows-instantly-on-send-drop-redundan-51jh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): Working shows instantly on send; drop redundant Running-in-background footer state

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1226,12 +1226,7 @@ const AgentPresentationView = ({
         () => showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]()),
     );
     const workingRowVisible = createMemo(
-        () =>
-            workingRowLoading() ||
-            agentAtoms().sessionStatsAtom[0]() != null ||
-            // Attached-task state ("Running in background · Ns") renders in
-            // the same row — see AgentWorkingRow's attachedSince prop.
-            agentAtoms().attachedTaskAtom[0]() != null,
+        () => workingRowLoading() || agentAtoms().sessionStatsAtom[0]() != null,
     );
 
     onMount(() => {
@@ -1806,7 +1801,6 @@ const AgentPresentationView = ({
                             currentTool={agentAtoms().currentToolAtom[0]()}
                             currentToolArg={agentAtoms().currentToolArgAtom[0]()}
                             toolPromoted={hasPromotedTool()}
-                            attachedSince={agentAtoms().attachedTaskAtom[0]()?.since ?? null}
                             sessionStats={agentAtoms().sessionStatsAtom[0]()}
                             turnTokens={agentAtoms().turnTokensAtom[0]()}
                             launchPhase={status.launchPhase()}

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -79,15 +79,6 @@ interface AgentWorkingRowProps {
      *  launchPhase to "waiting-for-login-completion" too, so without this the
      *  row rendered a second, redundant Cancel button alongside AuthUrlBox's. */
     hasAuthUrl?: boolean;
-    /** Unix ms the current attached-task episode began (reducer
-     *  `attachedTask.since`), or null when nothing long-running is attached.
-     *  When set and the turn is otherwise idle, the row shows a calm
-     *  "Running in background · Ns" state instead of "✓ Worked" / nothing —
-     *  the honest third status for a live dev server / background shell,
-     *  distinct from both "Working…" (turn in flight) and idle. See
-     *  SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md §6.2 and
-     *  retro-persistent-agent-working-status-stuck-2026-07-16.md. */
-    attachedSince?: number | null;
 }
 
 // reagent P2 on PR #2304: "waiting-for-login-link" (tier 1's own up-to-15s
@@ -152,6 +143,19 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     const [typing, setTyping] = createSignal(false);
     const REVEAL_CHAR_MS = 28;
 
+    // The very first text after ENTERING the loading state renders in full
+    // instantly — the type-out reveal is a transition effect for text
+    // changes while already visibly working (tool → tool → phrase). Playing
+    // it on entry meant "Working…" trailed the Enter keypress by
+    // ~REVEAL_CHAR_MS × 8 ≈ 250ms of a nearly-empty row, reading as "the
+    // indicator comes up late" even though the state flip is synchronous
+    // with the send (user report 2026-08-10). Plain (non-reactive) flag:
+    // only the loading edge below writes it, only the reveal effect reads it.
+    let revealInstantly = true;
+    createEffect(() => {
+        if (!props.loading) revealInstantly = true;
+    });
+
     // The shimmer class is ALWAYS on (baked into the class attribute below);
     // this effect only toggles `.is-typing`, which overlays opaque white
     // text during the reveal. Toggling the shimmer class itself on every
@@ -162,7 +166,8 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     // (found in the sandbox, sandbox/working-shimmer.html on this machine).
     createEffect(() => {
         const text = leftText();
-        if (reducedMotion() || !text) {
+        if (reducedMotion() || !text || revealInstantly) {
+            revealInstantly = false;
             setRevealed(text.length);
             setTyping(false);
             return;
@@ -250,38 +255,23 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
             CANCELLABLE_LAUNCH_PHASES.has(props.launchPhase.kind),
     );
 
-    // Attached-task state wins over the "✓ Worked" summary: a live dev
-    // server / background shell is the pane's current truth; the completed
-    // turn's stats return once the task ends (attachedSince → null).
-    const attachedElapsed = createMemo((): string | null => {
-        const s = props.attachedSince;
-        if (s == null) return null;
-        return formatElapsedCompact((tick(), Date.now()) - s);
-    });
-
+    // No dedicated "Running in background" state here — the ActivityDock's
+    // own running row (pinned above the composer, same data source) IS the
+    // indicator for a live attached task; a footer copy of it was redundant
+    // (user feedback 2026-08-10, reverting the render half of #2489 — the
+    // reducer axis itself stays, for the watchdog/Swarm consumers).
     return (
         <Show
             when={props.loading}
             fallback={
-                <Show
-                    when={attachedElapsed()}
-                    fallback={
-                        <Show when={workedSummary()}>
-                            <span class="agent-working-row agent-working-row--worked">
-                                <span class="agent-working-row-left">{workedSummary()}</span>
-                                <span class="agent-working-row-right">
-                                    <Show when={workedSecondary()}>
-                                        <span class="agent-working-row-secondary">{workedSecondary()}</span>
-                                    </Show>
-                                </span>
-                            </span>
-                        </Show>
-                    }
-                >
-                    <span class="agent-working-row agent-working-row--attached">
-                        <span class="agent-spinner-dot" />
-                        <span class="agent-working-row-left">Running in background</span>
-                        <span class="agent-working-row-right">{attachedElapsed()}</span>
+                <Show when={workedSummary()}>
+                    <span class="agent-working-row agent-working-row--worked">
+                        <span class="agent-working-row-left">{workedSummary()}</span>
+                        <span class="agent-working-row-right">
+                            <Show when={workedSecondary()}>
+                                <span class="agent-working-row-secondary">{workedSecondary()}</span>
+                            </Show>
+                        </span>
                     </span>
                 </Show>
             }

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -390,35 +390,6 @@
             }
         }
 
-        // Attached-task state — the turn is idle but ≥1 agent-declared
-        // long-running activity (dev server, background shell, subagent)
-        // is still alive. Calmer than --loading (secondary text, slow
-        // pulse) so it reads as "healthy, running" rather than "busy" —
-        // SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md §6.2.
-        &--attached {
-            color: var(--secondary-text-color);
-            background: var(--elevated-bg-color);
-
-            .agent-working-row-left {
-                flex: 1;
-                min-width: 0;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                opacity: 0.75;
-            }
-
-            .agent-working-row-right {
-                flex-shrink: 0;
-                margin-left: var(--space-2);
-                opacity: 0.55;
-            }
-
-            .agent-spinner-dot {
-                // Same pulse, half tempo — alive, not working.
-                animation-duration: 2.4s;
-            }
-        }
     }
 
 


### PR DESCRIPTION
## Summary

Two working-indicator refinements from live use of the dev build:

**1. "Working…" appears the instant you press Enter.** The `TurnStart` state flip was already synchronous with the send (verified via `[wave-turn]` telemetry — `Idle → Submitting cmd=TurnStart` with zero suppressions), but the row's type-out reveal played on *entry* into the loading state: ~28ms × 8 chars ≈ 250ms of a nearly-empty row, perceived as the indicator lagging the keypress. The reveal now fires only on text *transitions* while already visibly working (tool → tool → phrase); the first text renders in full immediately. Reduced-motion behavior unchanged.

**2. Remove the "Running in background" footer state (#2489's render half).** User feedback: the ActivityDock's running row — same data source, pinned right above the composer — already IS the indicator for a live attached task, with strictly more affordance (full command since #2493, live log, stop button). The footer copy was redundant by construction. The reducer axis (`attachedTask`), its dispatch wiring, and its tests remain — the state's other consumers (liveness-watchdog exemption per the spec's item 3, Swarm surfacing) are tracked follow-ups that need it.

## Verification

- `tsc --noEmit` clean.
- Live via Vite hot reload in the running dev instance.

<!-- agentmux:agent_id=camper -->