### PR TITLE
docs: spec — spawn generations + message identity for the persistent-controller race cluster

### DIFF
--- a/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
+++ b/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
@@ -1,0 +1,157 @@
+# SPEC — Persistent controller: spawn generations + message identity (closes the #2360 race cluster)
+
+**Date:** 2026-08-09
+**Status:** Proposed
+**Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs` + one
+shared-API touch (`session_recovery`) + a narrow translator touch (#2368).
+**Closes (in phases):** #2363, #2365, #2366, #2367, #2368 — the five
+deferred follow-ups from PR #2360's stale-resume retry work (14 review
+rounds; each issue's "why not fixed inline" reasoning is preserved and
+honored below).
+
+---
+
+## 1. The unifying diagnosis
+
+All five issues are shrapnel from the same two missing primitives:
+
+**(A) No spawn identity.** Every cleanup and retry decision keys on
+`block_id` (or ambient `Inner` state) alone — none can express "the
+process *I* belong to" vs "whatever process is live *now*":
+- #2363 — the dying process's exit-handler cleanup
+  (`clear_active_pid`, muxbus unregister) can wipe the *fallback
+  respawn's* fresh registration.
+- #2367 — a confirmed stale-resume retry can `DeliverDirect` into an
+  unrelated process spawned during the exit-handler's cleanup window,
+  reversing accepted input order.
+- #2366 — the fallback's `session_id` handling guesses from ambient state
+  because it doesn't know which sid the *dying spawn specifically*
+  attempted to resume.
+
+**(B) No message identity.** Queue membership is checked by content
+equality (`m == first`), so identical payloads ("ok", "continue")
+collide — #2365.
+
+**(C)** #2368 is the UX shadow of the same machinery: the doomed first
+attempt's error frame renders before the transparent retry's real
+response. The controller already *knows* a retry is in flight at the
+moment the first process exits; that knowledge just never reaches the
+frame that gets persisted.
+
+## 2. New primitives
+
+### 2.1 `spawn_generation: u64` (monotonic, per controller instance)
+
+- Incremented in `spawn_process` each time a real spawn is attempted;
+  the value is captured by everything belonging to that spawn: the
+  process-waiter/exit-handler, the stdout/stderr reader tasks, and the
+  registration calls it makes.
+- `PersistentInner` records `current_generation` alongside `stdin_tx`,
+  set when a spawn's stdin becomes live.
+
+### 2.2 `seq: u64` on queued messages (monotonic, per controller instance)
+
+- Assigned at push time on `QueuedMessage`; threaded through
+  `pending_resume_retry` / `confirmed_stale_resume_retry` (their
+  `Vec<String>` becomes a small `{seq, json}` struct) and
+  `retry_after_resume_failure`'s signature — exactly the shape #2365's
+  suggested fix describes.
+
+### 2.3 `attempted_resume_sid` threading
+
+- `spawn_process` already computes `attempted_resume_sid` locally; it
+  gets stored on the spawn's own context (with its generation) so the
+  exit-handler and `respawn_once_for_leftover_queue` can compare against
+  the *specific* sid the dead process attempted — #2366's suggested fix,
+  including its warning: only a sid *confirmed* stale by the CLI may be
+  poisoned; a mismatch means plain-clear only (never poison a sid the
+  fallback can't prove dead — that was round 13's reverted regression).
+
+## 3. The fixes, phase by phase
+
+### Phase 1 — generation-aware cleanup (#2363)
+
+`session_recovery::clear_active_pid` and the muxbus unregister path gain
+an expected-identity guard (PID or generation): cleanup only takes effect
+if the currently-recorded registration still matches what this exiting
+process instance registered. This touches `session_recovery`'s shared API
+(used by other controller types) — per #2363's own note, non-persistent
+callers pass a "always match" sentinel so their behavior is unchanged;
+only persistent.rs opts into the guard.
+
+### Phase 2 — seq-based retry matching (#2365)
+
+Replace `pending_send_messages.iter().any(|m| m == first)` in
+`decide_retry_batch_action` with seq matching. Pure mechanical follow-on
+from §2.2. No behavioral change except in the content-collision case.
+
+### Phase 3 — generation-aware retry decision (#2367)
+
+`decide_retry_batch_action` compares the retry batch's originating
+generation (captured when `confirmed_stale_resume_retry` was set) against
+`current_generation`:
+- `stdin_tx` live AND same lineage expectations → existing behavior.
+- `stdin_tx` live but from a NEWER generation (an unrelated spawn
+  legitimately raced ahead during the cleanup window) → **prepend the
+  batch to the queue** (the issue's own analysis: "prepending behind it,
+  not delivering direct, would be correct") rather than `DeliverDirect`.
+  This sidesteps #2360-round-14's rejected `spawning_in_progress = true`
+  pre-assert (which starved the retry) — the bool stays untouched; the
+  generation comparison is what disambiguates.
+
+### Phase 4 — attempted-sid-aware fallback (#2366)
+
+`respawn_once_for_leftover_queue` receives the dying spawn's
+`attempted_resume_sid` + generation. Before its clear:
+- If `inner.session_id == attempted_resume_sid` (the sid the CLI
+  actually rejected) → poison-equivalent for THIS respawn only (a
+  "refuse hydration for this one spawn" flag, not the permanent
+  `poison_resume` — honoring the round-13 revert reasoning).
+- Else (stdout-reader captured a different/newer sid, or trigger wasn't
+  resume-related) → leave `session_id` alone entirely; the fallback
+  spawns fresh regardless via the per-spawn no-resume flag rather than by
+  mutating shared state it can't attribute.
+
+The stdout-reader race window also narrows for free: readers carry their
+generation, and `try_capture_session_id` drops captures from a
+generation older than `current_generation`.
+
+### Phase 5 — suppress the doomed attempt's error frame (#2368)
+
+Prerequisite (the issue's own verification list): confirm from a live
+repro's blockfile which of the three candidate channels renders the
+bubble (CLI's own `is_error` result frame vs backend translator fallback
+vs health-transition). Then: at the moment the exit-handler takes
+`confirmed_stale_resume_retry` (it provably knows a retry will fire), it
+suppresses/tags that first attempt's error `result` frame before it is
+persisted to the blockfile — mirroring the `STATUS_DONE` suppression
+PR #2360 already does from the same knowledge point. If the frame
+arrives earlier (CLI stdout before exit), the tag instead rewrites it at
+retry-confirmation time to a non-error "resumed as a fresh conversation"
+disclosure node — disclosed, not silent, per the original retro's
+wording. Note #2482 already improved the flash's *text* (real refusal
+message instead of the generic string); this phase removes/downgrades the
+flash itself.
+
+## 4. Ordering and PR strategy
+
+Phases 1–2 are independent and small → one PR.
+Phases 3–4 build on the generation plumbing → second PR.
+Phase 5 depends on live-repro confirmation → third PR (smallest, but
+gated on evidence, not code).
+
+Every phase adds targeted unit tests against the decision functions
+(`decide_send_action` / `decide_retry_batch_action` are already
+pure-ish and tested); the race windows themselves get deterministic
+tests by driving the decision functions with explicitly-constructed
+generation/seq states rather than by racing real processes.
+
+## 5. Non-goals
+
+- No change to `spawning_in_progress` semantics (round-14's analysis of
+  why pre-asserting it starves the retry stands).
+- No change to other controller types beyond the opt-in sentinel in
+  `session_recovery`.
+- Not addressing #2405 (Job-Object registration) — separate mechanism,
+  separate issue, even though it lives in the same exit-handler
+  neighborhood.

--- a/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
+++ b/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
@@ -1,157 +1,122 @@
-# SPEC — Persistent controller: spawn generations + message identity (closes the #2360 race cluster)
+# SPEC — Persistent controller race cluster: gap audit + remaining fixes
 
-**Date:** 2026-08-09
+**Date:** 2026-08-09 (rewritten same day after a current-code audit — see §1)
 **Status:** Proposed
-**Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs` + one
-shared-API touch (`session_recovery`) + a narrow translator touch (#2368).
-**Closes (in phases):** #2363, #2365, #2366, #2367, #2368 — the five
-deferred follow-ups from PR #2360's stale-resume retry work (14 review
-rounds; each issue's "why not fixed inline" reasoning is preserved and
-honored below).
+**Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`,
+`session_recovery.rs` (one guarded variant), verification-and-close work
+for two issues.
+**Covers:** #2363, #2365, #2366, #2367, #2368 — the five deferred
+follow-ups from PR #2360's stale-resume retry work.
 
 ---
 
-## 1. The unifying diagnosis
+## 1. Audit result: the cluster is half-fixed already
 
-All five issues are shrapnel from the same two missing primitives:
+The five issues describe the code as of 2026-07-30. On 2026-08-05,
+PR #2373 landed `persistent_resume.rs` — an event-driven state machine
+that replaced the racy shared fields (`pending_resume_retry`,
+`confirmed_stale_resume_retry`, `pending_error_result_line`) with
+generation-tagged transitions. It introduced exactly the "spawn
+generation" primitive the original issues asked for
+(`PersistentInner::spawn_generation`, bumped per spawn attempt;
+generation-mismatched events are ignored). An earlier draft of this spec
+proposed building that primitive from scratch; this rewrite reflects
+what actually remains.
 
-**(A) No spawn identity.** Every cleanup and retry decision keys on
-`block_id` (or ambient `Inner` state) alone — none can express "the
-process *I* belong to" vs "whatever process is live *now*":
-- #2363 — the dying process's exit-handler cleanup
-  (`clear_active_pid`, muxbus unregister) can wipe the *fallback
-  respawn's* fresh registration.
-- #2367 — a confirmed stale-resume retry can `DeliverDirect` into an
-  unrelated process spawned during the exit-handler's cleanup window,
-  reversing accepted input order.
-- #2366 — the fallback's `session_id` handling guesses from ambient state
-  because it doesn't know which sid the *dying spawn specifically*
-  attempted to resume.
+| Issue | Status after #2373 | Remaining work |
+|---|---|---|
+| #2366 (fallback races stdout-reader sid capture) | **Likely fixed** — `ResumeState::AwaitingOutcome` carries `attempted_sid` per generation; stale-generation capture events are dropped by `update()` | Verify the fallback path reads through the state machine (not ambient `inner.session_id`), add a regression test if missing, close |
+| #2368 (visible error flash before retry's response) | **Likely fixed** — `held_error_line` holds the doomed attempt's terminal error line until the retry decision resolves; module doc cites #2368 as its motivating bug | Live-verify on a fresh stale-resume repro (the issue's own verification list); close, or file the narrower residue |
+| #2363 (cleanup wipes fallback respawn's registration) | **Narrowed** — exit-handler cleanup now gated on `is_current_generation` (persistent.rs:2787/2812) | The gate is read once under the lock while the fallback respawn registers on a parallel task — the original window survives in miniature. Close it properly: §2 |
+| #2365 (content-equality queue matching) | **Unchanged** — `pending_send_messages.iter().any(\|m\| m == first)` at persistent.rs:1563 | §3 |
+| #2367 (retry DeliverDirects into a newer unrelated spawn) | **Unchanged** — `decide_retry_batch_action` (persistent.rs:1542) has no generation input; a live `stdin_tx` at retry time is by definition a newer process, and the batch is sent straight into it | §4 |
 
-**(B) No message identity.** Queue membership is checked by content
-equality (`m == first`), so identical payloads ("ok", "continue")
-collide — #2365.
+## 2. Fix #2363 — compare-and-clear cleanup (small, mechanical)
 
-**(C)** #2368 is the UX shadow of the same machinery: the doomed first
-attempt's error frame renders before the transparent retry's real
-response. The controller already *knows* a retry is in flight at the
-moment the first process exits; that knowledge just never reaches the
-frame that gets persisted.
+`update_object_meta` runs inside `Store::with_tx` (one connection lock
+across read+merge+write — see object_helpers.rs:90's doc comment), so a
+true CAS is available with no new locking:
 
-## 2. New primitives
+- `session_recovery::clear_active_pid_if(wstore, block_id, expected_pid)`
+  — inside one `with_tx`: read `session:active_pid`, clear **only if it
+  still equals `expected_pid`** (the PID this exit-handler's own process
+  registered). The unconditional `clear_active_pid` stays for callers
+  that genuinely mean "clear whatever's there" (shutdown paths).
+- The muxbus side (`unregister_block` / `registry::remove`): same
+  expected-identity guard, keyed on whatever the registration API
+  records (agent_id + PID or generation) — needs a small registry API
+  read before committing to the exact shape.
+- persistent.rs's exit-handler passes its own spawn's PID/generation.
+  Other controller types keep calling the unconditional variants —
+  zero behavior change outside persistent.
 
-### 2.1 `spawn_generation: u64` (monotonic, per controller instance)
+## 3. Fix #2365 — `seq` on queued messages (small, mechanical)
 
-- Incremented in `spawn_process` each time a real spawn is attempted;
-  the value is captured by everything belonging to that spawn: the
-  process-waiter/exit-handler, the stdout/stderr reader tasks, and the
-  registration calls it makes.
-- `PersistentInner` records `current_generation` alongside `stdin_tx`,
-  set when a spawn's stdin becomes live.
+Per the issue's own suggested fix, unchanged by #2373:
+- `seq: u64` on `QueuedMessage`, assigned from a per-controller
+  monotonic counter at push time.
+- `RetryPayload.messages` (persistent_resume.rs) becomes
+  `Vec<QueuedRetryEntry { seq, json }>`; `retry_after_resume_failure` /
+  `decide_retry_batch_action` take the seq through.
+- Line 1563's content match becomes a seq match.
 
-### 2.2 `seq: u64` on queued messages (monotonic, per controller instance)
+## 4. Fix #2367 — generation-aware retry decision (the real design work)
 
-- Assigned at push time on `QueuedMessage`; threaded through
-  `pending_resume_retry` / `confirmed_stale_resume_retry` (their
-  `Vec<String>` becomes a small `{seq, json}` struct) and
-  `retry_after_resume_failure`'s signature — exactly the shape #2365's
-  suggested fix describes.
+`decide_retry_batch_action` gains the retry batch's originating
+generation (available from the state machine's `ProcessExited`
+transition that fired it). Decision table:
 
-### 2.3 `attempted_resume_sid` threading
+- `stdin_tx.is_some()` and `inner.spawn_generation == retry_generation`:
+  impossible by construction (the retry's process exited) — debug-assert.
+- `stdin_tx.is_some()` and `spawn_generation > retry_generation`: an
+  unrelated spawn raced ahead during the exit-handler's cleanup window.
+  **Open design question** — the issue's suggested "prepend behind it"
+  needs a drain trigger to avoid starvation (nothing drains
+  `pending_send_messages` while a healthy process is running; the queue
+  only drains post-spawn). Options, to be settled during implementation
+  with a test for each candidate:
+  1. **DeliverDirect + disclosure** (accept the reorder, persist a
+     visible "delivered after later input" marker) — smallest change,
+     honest, no starvation risk.
+  2. **Prepend + explicit flush**: prepend the batch, then immediately
+     drain the queue through the live `stdin_tx` in batch order — this
+     preserves intra-batch order and delivers exactly once, and the
+     "reorder" relative to the newer process's first message already
+     happened (it was accepted first by a live process) — nothing can
+     un-send it. Likely the right call: it degrades gracefully to
+     option 1's semantics while keeping the queue as the single
+     ordering authority.
+  3. Reserve-claim state (the issue's option b) — most invasive; only
+     if 1/2 prove insufficient under test.
+- Spawner/queued branches unchanged.
 
-- `spawn_process` already computes `attempted_resume_sid` locally; it
-  gets stored on the spawn's own context (with its generation) so the
-  exit-handler and `respawn_once_for_leftover_queue` can compare against
-  the *specific* sid the dead process attempted — #2366's suggested fix,
-  including its warning: only a sid *confirmed* stale by the CLI may be
-  poisoned; a mismatch means plain-clear only (never poison a sid the
-  fallback can't prove dead — that was round 13's reverted regression).
+## 5. Verify-and-close work (#2366, #2368)
 
-## 3. The fixes, phase by phase
+- **#2366**: trace `respawn_once_for_leftover_queue`'s current
+  session-id handling against the state machine. If it still clears
+  ambient `inner.session_id` without consulting `attempted_sid`, apply
+  the issue's threading fix (the data now exists in
+  `AwaitingOutcome.attempted_sid`); if it already routes through the
+  machine, add the regression test the issue asks for and close.
+- **#2368**: live repro on a build with a deliberately stale `--resume`
+  (the claudius test bed makes this easy: carry a session id across
+  channels), watch the blockfile for the doomed attempt's error frame.
+  If `held_error_line` fully suppresses it, close with the evidence.
+  Note #2482 (merged) independently improved the flash's *text* for any
+  path that still renders one.
 
-### Phase 1 — generation-aware cleanup (#2363)
+## 6. PR strategy
 
-`session_recovery::clear_active_pid` and the muxbus unregister path gain
-an expected-identity guard (PID or generation): cleanup only takes effect
-if the currently-recorded registration still matches what this exiting
-process instance registered. This touches `session_recovery`'s shared API
-(used by other controller types) — per #2363's own note, non-persistent
-callers pass a "always match" sentinel so their behavior is unchanged;
-only persistent.rs opts into the guard.
+1. **PR A**: §2 + §3 (both small, independent, mechanical) + the §5
+   regression tests where the verification shows they're missing.
+2. **PR B**: §4 (the design-question fix), after PR A's plumbing.
+3. #2366/#2368 closed with evidence via PR A's tests or plain issue
+   comments if nothing is missing.
 
-### Phase 2 — seq-based retry matching (#2365)
+## 7. Non-goals
 
-Replace `pending_send_messages.iter().any(|m| m == first)` in
-`decide_retry_batch_action` with seq matching. Pure mechanical follow-on
-from §2.2. No behavioral change except in the content-collision case.
-
-### Phase 3 — generation-aware retry decision (#2367)
-
-`decide_retry_batch_action` compares the retry batch's originating
-generation (captured when `confirmed_stale_resume_retry` was set) against
-`current_generation`:
-- `stdin_tx` live AND same lineage expectations → existing behavior.
-- `stdin_tx` live but from a NEWER generation (an unrelated spawn
-  legitimately raced ahead during the cleanup window) → **prepend the
-  batch to the queue** (the issue's own analysis: "prepending behind it,
-  not delivering direct, would be correct") rather than `DeliverDirect`.
-  This sidesteps #2360-round-14's rejected `spawning_in_progress = true`
-  pre-assert (which starved the retry) — the bool stays untouched; the
-  generation comparison is what disambiguates.
-
-### Phase 4 — attempted-sid-aware fallback (#2366)
-
-`respawn_once_for_leftover_queue` receives the dying spawn's
-`attempted_resume_sid` + generation. Before its clear:
-- If `inner.session_id == attempted_resume_sid` (the sid the CLI
-  actually rejected) → poison-equivalent for THIS respawn only (a
-  "refuse hydration for this one spawn" flag, not the permanent
-  `poison_resume` — honoring the round-13 revert reasoning).
-- Else (stdout-reader captured a different/newer sid, or trigger wasn't
-  resume-related) → leave `session_id` alone entirely; the fallback
-  spawns fresh regardless via the per-spawn no-resume flag rather than by
-  mutating shared state it can't attribute.
-
-The stdout-reader race window also narrows for free: readers carry their
-generation, and `try_capture_session_id` drops captures from a
-generation older than `current_generation`.
-
-### Phase 5 — suppress the doomed attempt's error frame (#2368)
-
-Prerequisite (the issue's own verification list): confirm from a live
-repro's blockfile which of the three candidate channels renders the
-bubble (CLI's own `is_error` result frame vs backend translator fallback
-vs health-transition). Then: at the moment the exit-handler takes
-`confirmed_stale_resume_retry` (it provably knows a retry will fire), it
-suppresses/tags that first attempt's error `result` frame before it is
-persisted to the blockfile — mirroring the `STATUS_DONE` suppression
-PR #2360 already does from the same knowledge point. If the frame
-arrives earlier (CLI stdout before exit), the tag instead rewrites it at
-retry-confirmation time to a non-error "resumed as a fresh conversation"
-disclosure node — disclosed, not silent, per the original retro's
-wording. Note #2482 already improved the flash's *text* (real refusal
-message instead of the generic string); this phase removes/downgrades the
-flash itself.
-
-## 4. Ordering and PR strategy
-
-Phases 1–2 are independent and small → one PR.
-Phases 3–4 build on the generation plumbing → second PR.
-Phase 5 depends on live-repro confirmation → third PR (smallest, but
-gated on evidence, not code).
-
-Every phase adds targeted unit tests against the decision functions
-(`decide_send_action` / `decide_retry_batch_action` are already
-pure-ish and tested); the race windows themselves get deterministic
-tests by driving the decision functions with explicitly-constructed
-generation/seq states rather than by racing real processes.
-
-## 5. Non-goals
-
-- No change to `spawning_in_progress` semantics (round-14's analysis of
-  why pre-asserting it starves the retry stands).
-- No change to other controller types beyond the opt-in sentinel in
-  `session_recovery`.
-- Not addressing #2405 (Job-Object registration) — separate mechanism,
-  separate issue, even though it lives in the same exit-handler
-  neighborhood.
+- No rework of `persistent_resume.rs`'s state machine semantics — it is
+  the fix for half this cluster; this spec only builds on it.
+- No change to `spawning_in_progress` semantics (round-14's starvation
+  analysis stands).
+- Not addressing #2405 (Job-Object registration) — separate mechanism.

--- a/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
+++ b/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
@@ -87,24 +87,31 @@ transition that fired it). Decision table:
   impossible by construction (the retry's process exited) — debug-assert.
 - `stdin_tx.is_some()` and `spawn_generation > retry_generation`: an
   unrelated spawn raced ahead during the exit-handler's cleanup window.
-  **Open design question** — the issue's suggested "prepend behind it"
-  needs a drain trigger to avoid starvation (nothing drains
-  `pending_send_messages` while a healthy process is running; the queue
-  only drains post-spawn). Options, to be settled during implementation
-  with a test for each candidate:
+  Two candidate resolutions, to be settled during implementation with a
+  test for each (a bare "prepend behind it" is NOT one of them — nothing
+  drains `pending_send_messages` while a healthy process runs, so an
+  unflushed prepend starves; and a naive prepend-then-flush races
+  concurrent `DeliverDirect` sends mid-batch, as reagentx flagged on
+  this spec's round 3):
   1. **DeliverDirect + disclosure** (accept the reorder, persist a
      visible "delivered after later input" marker) — smallest change,
-     honest, no starvation risk.
-  2. **Prepend + explicit flush**: prepend the batch, then immediately
-     drain the queue through the live `stdin_tx` in batch order — this
-     preserves intra-batch order and delivers exactly once, and the
-     "reorder" relative to the newer process's first message already
-     happened (it was accepted first by a live process) — nothing can
-     un-send it. Likely the right call: it degrades gracefully to
-     option 1's semantics while keeping the queue as the single
-     ordering authority.
-  3. Reserve-claim state (the issue's option b) — most invasive; only
-     if 1/2 prove insufficient under test.
+     honest, no starvation risk, no new state.
+  2. **Drain-claim + flush** (the issue's own option b, now concrete):
+     a new `drain_claim: bool` on `PersistentInner`, orthogonal to
+     `spawning_in_progress`. `decide_retry_batch_action` sets it under
+     the same lock acquisition in which it decides; while it is held,
+     `decide_send_action`'s `DeliverDirect` branch routes to `Queued`
+     instead (exactly how it already treats `spawning_in_progress`).
+     The retry path then flushes the batch plus anything queued behind
+     it through `stdin_tx` in order and clears the claim. An
+     already-in-flight `DeliverDirect` that was *decided* before the
+     claim was set can still land mid-batch — that residue is bounded
+     to sends that were already racing the process exit itself, i.e.
+     option 1's semantics as the floor, with strictly better ordering
+     in every other interleaving.
+  Preference: option 2 — it makes the queue the single ordering
+  authority; option 1 remains the fallback if 2's tests surface
+  something worse.
 - Spawner/queued branches unchanged.
 
 ## 5. Verify-and-close work (#2366, #2368)
@@ -134,6 +141,11 @@ transition that fired it). Decision table:
 
 - No rework of `persistent_resume.rs`'s state machine semantics — it is
   the fix for half this cluster; this spec only builds on it.
-- No change to `spawning_in_progress` semantics (round-14's starvation
-  analysis stands).
+- No change to `spawning_in_progress` **semantics** — round-14's
+  starvation analysis stands: it is never pre-asserted or repurposed for
+  the retry claim. §4 option 2's `drain_claim` is a NEW, orthogonal
+  state deliberately added instead of overloading that bool; the only
+  touch to existing behavior is `decide_send_action` treating a held
+  drain claim the same way it already treats an in-progress spawn
+  (queue behind it).
 - Not addressing #2405 (Job-Object registration) — separate mechanism.

--- a/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
+++ b/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
@@ -58,7 +58,24 @@ Per the issue's own suggested fix, unchanged by #2373:
 - `RetryPayload.messages` (persistent_resume.rs) becomes
   `Vec<QueuedRetryEntry { seq, json }>`; `retry_after_resume_failure` /
   `decide_retry_batch_action` take the seq through.
-- Line 1563's content match becomes a seq match.
+
+**All three content-equality sites convert** (reagentx P1 on this spec's
+review caught that the first draft listed only the third; a fresh grep
+found one more beyond that):
+1. persistent.rs:742 — `decide_send_action`'s `skip_if_already_queued`
+   dedup (`.any(|m| m == json_str)`). Collision consequence is the worst
+   of the three: a genuinely different, identical-text message is
+   treated as "already queued" and **silently dropped**. Callers that
+   re-deliver (muxbus steering) pass the original seq so exact-identity
+   dedup still works.
+2. persistent.rs:837 — `release_spawn_claim_and_drain_queue` removing
+   the failed spawn's own trigger (`.position(|m| m == own_message)`).
+   Collision consequence: the WRONG entry (someone else's
+   identical-text message) is discarded and the spawn's own trigger
+   stays queued — a drop plus a potential duplicate delivery.
+3. persistent.rs:1563 — `decide_retry_batch_action`'s
+   `first_already_queued` check (the site #2365 originally reported;
+   reordering consequence).
 
 ## 4. Fix #2367 — generation-aware retry decision (the real design work)
 


### PR DESCRIPTION
Consolidated design for the five deferred follow-ups from PR #2360's stale-resume retry work (#2363, #2365, #2366, #2367, #2368).

Core insight: all five are shrapnel from two missing primitives — **spawn identity** (cleanup/retry decisions key on block_id alone, so they can't distinguish "the process I belong to" from "whatever is live now") and **message identity** (queue membership checked by content equality). The spec introduces a per-controller spawn-generation counter + per-message sequence numbers, then fixes each race against those primitives, honoring every "why not fixed inline" constraint documented in the issues (the round-13 poison revert, the round-14 spawning_in_progress starvation analysis).

Phased delivery: (1) generation-aware cleanup, (2) seq-based retry matching, (3) generation-aware retry decision, (4) attempted-sid-aware fallback, (5) the #2368 error-flash suppression — gated on live-repro confirmation of which channel renders the bubble.

Docs only — implementation PRs follow per phase.

<!-- agentmux:agent_id=agent3 -->