### PR TITLE
feat(agent-pane): Undo for Esc-cleared composer drafts — right-click menu + Ctrl/Cmd+Z

### DIFF
--- a/.changesets/1786337657-feat-agent-pane-undo-for-esc-cleared-composer-drafts-right-c-9jcl.md
+++ b/.changesets/1786337657-feat-agent-pane-undo-for-esc-cleared-composer-drafts-right-c-9jcl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): Undo for Esc-cleared composer drafts — right-click menu + Ctrl/Cmd+Z

--- a/frontend/app/store/contextmenu.ts
+++ b/frontend/app/store/contextmenu.ts
@@ -118,17 +118,29 @@ async function getClipboardURL(): Promise<URL | null> {
     }
 }
 
-async function showTextInputContextMenu(e: MouseEvent): Promise<void> {
+/**
+ * @param leadingItems caller-supplied items rendered ABOVE the standard
+ * Cut/Copy/Paste block (separated from it) — e.g. the agent composer's
+ * "Undo" (AgentFooter.tsx). When provided, the menu shows even if none of
+ * the standard items are enabled (an empty composer still offers Undo).
+ */
+async function showTextInputContextMenu(e: MouseEvent, leadingItems?: ContextMenuItem[]): Promise<void> {
     e.preventDefault();
     e.stopPropagation();
     const canPaste = canEnablePaste();
     const canCopy = canEnableCopy();
     const canCut = canEnableCut();
     const clipboardURL = await getClipboardURL();
-    if (!canPaste && !canCopy && !canCut && !clipboardURL) {
+    if (!canPaste && !canCopy && !canCut && !clipboardURL && !leadingItems?.length) {
         return;
     }
     let menu: ContextMenuItem[] = [];
+    if (leadingItems?.length) {
+        menu.push(...leadingItems);
+        if (canCut || canCopy || canPaste || clipboardURL) {
+            menu.push({ type: "separator" });
+        }
+    }
     if (canCut) {
         menu.push({ label: "Cut", role: "cut" });
     }

--- a/frontend/app/view/agent/components/AgentFooter.test.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.test.tsx
@@ -1,0 +1,86 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Esc-clear / Undo regression tests for AgentFooter (reagent P1 / codex P2
+ * on PR #2497): `escClearedDraft` must be invalidated by any edit or send
+ * after the Esc-clear, so Ctrl/Cmd+Z can't resurrect stale text once a new
+ * message has been typed, deleted back to empty, or sent.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentFooter } from "./AgentFooter";
+
+afterEach(() => {
+    cleanup();
+});
+
+function keyOn(el: Element, key: string, opts: KeyboardEventInit = {}): void {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...opts }));
+}
+
+function getComposer(): HTMLTextAreaElement {
+    return screen.getByPlaceholderText(/Send message to/) as HTMLTextAreaElement;
+}
+
+describe("AgentFooter Esc-clear Undo", () => {
+    it("Ctrl+Z restores the draft right after an Esc-clear", async () => {
+        render(() => <AgentFooter agentName="Test" />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+
+        await user.click(ta);
+        await user.type(ta, "hello");
+        keyOn(ta, "Escape");
+        expect(ta.value).toBe("");
+
+        keyOn(ta, "z", { ctrlKey: true });
+        expect(ta.value).toBe("hello");
+    });
+
+    it("does not resurrect a stale Esc-cleared draft after typing something new and deleting it back to empty", async () => {
+        render(() => <AgentFooter agentName="Test" />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+
+        await user.click(ta);
+        await user.type(ta, "hello");
+        keyOn(ta, "Escape");
+        expect(ta.value).toBe("");
+
+        await user.type(ta, "B");
+        await user.type(ta, "{Backspace}");
+        expect(ta.value).toBe("");
+
+        // Bug (reagent P1 / codex P2): escClearedDraft was never invalidated
+        // by this new edit, so Ctrl+Z would resurrect the stale "hello"
+        // instead of falling through to native undo.
+        keyOn(ta, "z", { ctrlKey: true });
+        expect(ta.value).toBe("");
+    });
+
+    it("does not resurrect a stale Esc-cleared draft after sending a new message", async () => {
+        const onSendMessage = vi.fn();
+        render(() => <AgentFooter agentName="Test" onSendMessage={onSendMessage} />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+
+        await user.click(ta);
+        await user.type(ta, "hello");
+        keyOn(ta, "Escape");
+        expect(ta.value).toBe("");
+
+        await user.type(ta, "world");
+        keyOn(ta, "Enter");
+        expect(onSendMessage).toHaveBeenCalledWith("world");
+        expect(ta.value).toBe("");
+
+        // Bug (reagent P1): handleSend never invalidated escClearedDraft, so
+        // Ctrl+Z after sending would resurrect the pre-Esc "hello" draft.
+        keyOn(ta, "z", { ctrlKey: true });
+        expect(ta.value).toBe("");
+    });
+});

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -670,6 +670,37 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         });
     });
 
+    // Draft cleared by Esc, held for Undo. Plain (non-reactive) — read
+    // fresh at Ctrl/Cmd+Z time and at context-menu-build time, never
+    // rendered. One level deep is deliberate: Esc-clear is the only
+    // destructive programmatic edit (it bypasses the browser's native undo
+    // stack via direct .value assignment); ordinary typing keeps native
+    // undo, which the shortcut falls through to below.
+    let escClearedDraft: string | null = null;
+    const undoComposer = (): void => {
+        if (!textareaRef) return;
+        textareaRef.focus();
+        if (escClearedDraft != null && textareaRef.value.length === 0) {
+            setComposerValue(escClearedDraft);
+            escClearedDraft = null;
+            return;
+        }
+        // No snapshot to restore — fall through to the browser's own undo
+        // (covers plain typed edits; a no-op if its stack is empty).
+        document.execCommand("undo");
+    };
+    /** "Undo" entry for the composer's right-click menu — leading item
+     *  above the standard Cut/Copy/Paste block (contextmenu.ts). Enabled
+     *  when there's an Esc-cleared draft to restore or any text native
+     *  undo could plausibly act on. */
+    const composerUndoItems = (): ContextMenuItem[] => [
+        {
+            label: "Undo",
+            enabled: escClearedDraft != null || (textareaRef?.value.length ?? 0) > 0,
+            click: undoComposer,
+        },
+    ];
+
     const handleSend = () => {
         if (!textareaRef) return;
         const message = textareaRef.value;
@@ -821,6 +852,18 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             handleSend();
             return;
         }
+        // Undo an Esc-clear — platform-standard shortcut (Ctrl+Z on
+        // Windows/Linux, Cmd+Z on macOS). Only intercepted when the
+        // composer is empty and a cleared draft exists: in every other
+        // state the event falls through to the browser's native undo for
+        // ordinary typed edits.
+        if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "z") {
+            if (textareaRef && textareaRef.value.length === 0 && escClearedDraft != null) {
+                e.preventDefault();
+                undoComposer();
+            }
+            return;
+        }
         if (e.key === "Escape") {
             // Esc semantics (SPEC_AGENT_PANE_FOLLOWUPS item #9):
             //  - textarea has text → clear it, stay focused
@@ -828,6 +871,11 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             if (!textareaRef) return;
             if (textareaRef.value.trim().length > 0) {
                 e.preventDefault();
+                // Snapshot for Undo (Ctrl/Cmd+Z or the right-click menu) —
+                // the programmatic clear below bypasses the browser's own
+                // undo stack (direct .value assignment), so without this
+                // an accidental Esc destroyed the draft irrecoverably.
+                escClearedDraft = textareaRef.value;
                 writeComposerValue("");
                 setIsBangCmd(false);
                 // Clearing exits history navigation — park the cursor at the
@@ -880,7 +928,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     // here silently shows a useless disabled-Copy menu instead
                     // of letting the user paste. See
                     // docs/specs/REPORT_CONTEXT_MENU_GAP_AUDIT_2026_08_07.md.
-                    onContextMenu={showTextInputContextMenu}
+                    onContextMenu={(e) => void showTextInputContextMenu(e, composerUndoItems())}
                     rows={1}
                 />
                 {/* Pinned to the composer's right edge instead of the pane's

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -543,6 +543,12 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // it never trips the history-cursor reset in handleInput.
     const setComposerValue = (text: string): void => {
         if (!textareaRef) return;
+        // Consumes the Esc-cleared snapshot — the undo-restore call below
+        // reads `escClearedDraft` as its `text` argument BEFORE this runs, so
+        // nulling it here doesn't affect that write. Every other caller
+        // (ghost-text accept, history recall) is a fresh edit that should
+        // supersede a stale snapshot the same way typing does.
+        escClearedDraft = null;
         writeComposerValue(text);
         textareaRef.setSelectionRange(text.length, text.length);
         setIsBangCmd(text.startsWith("!"));
@@ -559,6 +565,12 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // again from the newest sent message. (Programmatic recall writes the
         // value without dispatching `input`, so it doesn't reach here.)
         histPos = sentHistory.length;
+        // Any real keystroke (typed or voice-dispatched) supersedes the
+        // Esc-cleared snapshot — an empty box reached by typing-then-deleting
+        // is no longer "the direct result of Esc", so Ctrl/Cmd+Z must fall
+        // through to native undo instead of resurrecting stale text. (reagent
+        // P1 / codex P2 on PR #2497.)
+        escClearedDraft = null;
         // Perf marks per SPEC_INPUT_RESPONSIVENESS §7.1. Target: handler
         // body P95 < 5 ms. The mark span ends BEFORE the RAF enqueue so
         // we measure only the synchronous handler cost.
@@ -676,13 +688,19 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // destructive programmatic edit (it bypasses the browser's native undo
     // stack via direct .value assignment); ordinary typing keeps native
     // undo, which the shortcut falls through to below.
+    //
+    // Invalidated (set back to null) by handleInput, setComposerValue, and
+    // handleSend — any edit or send after the Esc-clear means a later empty
+    // box is no longer "the direct result of" that Esc-clear, so it must not
+    // resurrect stale text. (reagent P1 / codex P2 on PR #2497.)
     let escClearedDraft: string | null = null;
     const undoComposer = (): void => {
         if (!textareaRef) return;
         textareaRef.focus();
         if (escClearedDraft != null && textareaRef.value.length === 0) {
+            // setComposerValue nulls escClearedDraft itself (it reads this
+            // argument before doing so) — no separate reset needed here.
             setComposerValue(escClearedDraft);
-            escClearedDraft = null;
             return;
         }
         // No snapshot to restore — fall through to the browser's own undo
@@ -719,6 +737,10 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             histPos = sentHistory.length;
             histDraft = "";
             writeComposerValue("");
+            // A sent message supersedes any pending Esc-cleared snapshot —
+            // the now-empty box must not resurrect old text via Ctrl/Cmd+Z.
+            // (reagent P1 on PR #2497.)
+            escClearedDraft = null;
             setAutocompletePrefix(null);
             setIsBangCmd(false);
             // Scroll the new user message into view. SolidJS flushes the


### PR DESCRIPTION
## Summary

Esc in the agent composer clears everything typed — and because the clear is a programmatic `.value` write, the browser's native undo stack can't restore it. An accidental Esc destroyed the draft with no recovery (user report 2026-08-10).

- **Snapshot on Esc-clear** (one level deep — Esc-clear is the only destructive programmatic edit; ordinary typing keeps native undo).
- **"Undo" in the composer's right-click menu** — `showTextInputContextMenu` gains an optional `leadingItems` param (rendered above the standard Cut/Copy/Paste block, menu shows even when the standard items are all disabled). Explicit `click` handler, no reliance on native menu roles.
- **Platform-standard shortcut**: Ctrl+Z (Windows/Linux) / Cmd+Z (macOS). Intercepted ONLY when the composer is empty and a cleared draft exists — every other state falls through to the browser's own undo, so normal text-edit undo is untouched. `keyutil.ts` already whitelists Cmd:z as an input-owned key; no keymodel conflict.

## Verification

- `tsc --noEmit` clean.
- Live verification pending: the dev instance was down when this was authored; a fresh `task dev` is coming up now — will confirm type → Esc → Ctrl+Z restore and the right-click Undo entry there before/shortly after merge.

<!-- agentmux:agent_id=camper -->