### PR TITLE
chore: release v0.55.1 (patch override)

### DIFF
--- a/.changesets/1786271733-feat-agent-assign-every-agent-a-display-color-backfill-exist-c85h.md
+++ b/.changesets/1786271733-feat-agent-assign-every-agent-a-display-color-backfill-exist-c85h.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): assign every agent a display color, backfill existing agents

--- a/.changesets/1786303976-fix-dev-vite-watcher-ignores-never-matched-34x-handle-reduct-nwt0.md
+++ b/.changesets/1786303976-fix-dev-vite-watcher-ignores-never-matched-34x-handle-reduct-nwt0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dev): Vite watcher ignores never matched (34x handle reduction); cool down handle-anomaly warns

--- a/.changesets/1786314154-fix-agent-pane-new-tab-keeps-the-existing-conversation-as-a--r7z4.md
+++ b/.changesets/1786314154-fix-agent-pane-new-tab-keeps-the-existing-conversation-as-a--r7z4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): new-tab '+' keeps the existing conversation as a visible tab instead of replacing the pane

--- a/.changesets/1786314573-feat-agent-pane-wire-the-attached-task-status-axis-running-i-9kc6.md
+++ b/.changesets/1786314573-feat-agent-pane-wire-the-attached-task-status-axis-running-i-9kc6.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): wire the attached-task status axis — 'Running in background' instead of stuck 'Working…'

--- a/.changesets/1786324878-fix-agent-pane-expanded-dock-row-shows-the-full-command-word-pzr5.md
+++ b/.changesets/1786324878-fix-agent-pane-expanded-dock-row-shows-the-full-command-word-pzr5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): expanded dock row shows the full command word-wrapped at the top

--- a/.changesets/1786325635-fix-agent-pane-scrub-ghost-running-tool-nodes-at-turn-end-st-a582.md
+++ b/.changesets/1786325635-fix-agent-pane-scrub-ghost-running-tool-nodes-at-turn-end-st-a582.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): scrub ghost 'running' tool nodes at turn end (stuck dock rows)

--- a/.changesets/1786336124-fix-agent-pane-working-shows-instantly-on-send-drop-redundan-51jh.md
+++ b/.changesets/1786336124-fix-agent-pane-working-shows-instantly-on-send-drop-redundan-51jh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): Working shows instantly on send; drop redundant Running-in-background footer state

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.0"
+version = "0.55.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,16 @@
 # AgentMux Version History
 
+## 0.55.1 — 2026-08-09
+
+- feat(agent): assign every agent a display color, backfill existing agents
+- fix(dev): Vite watcher ignores never matched (34x handle reduction); cool down handle-anomaly warns
+- fix(agent-pane): new-tab '+' keeps the existing conversation as a visible tab instead of replacing the pane
+- feat(agent-pane): wire the attached-task status axis — 'Running in background' instead of stuck 'Working…'
+- fix(agent-pane): expanded dock row shows the full command word-wrapped at the top
+- fix(agent-pane): scrub ghost 'running' tool nodes at turn end (stuck dock rows)
+- fix(agent-pane): Working shows instantly on send; drop redundant Running-in-background footer state
+
+
 ## 0.55.0 — 2026-08-09
 
 - fix(statusbar): shorten the Disk pill's hover tooltip to match the other stat pills

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.0",
+      "version": "0.55.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Forced patch release (0.55.0 -> 0.55.1) via `scripts/release.sh --as patch`, consuming all 7 pending changesets even though two are `feat`-typed (would normally compute a minor bump). Per the script's documented override behavior, the higher-typed changes are still consumed and changelogged, just shipped under the lower patch version.
- Included changes: agent display colors, Vite watcher handle-count fix, agent-pane new-tab/dock/working-state fixes.

## Test plan
- [x] `scripts/verify-release-consistency.sh` passes — all 5 version locations agree at 0.55.1
- [x] `Cargo.lock` resynced via `cargo update --workspace`
- [x] `package-lock.json` synced to 0.55.1
- [ ] CI build/test suite (pending)

<!-- agentmux:agent_id=korp -->