### PR TITLE
fix(persistent): close the race-cluster residues — CAS cleanup, seq-keyed queue identity, generation-gated sid adoption (PR A)

### DIFF
--- a/.changesets/1786343784-fix-persistent-compare-and-clear-cleanup-seq-keyed-queue-ide-4dlc.md
+++ b/.changesets/1786343784-fix-persistent-compare-and-clear-cleanup-seq-keyed-queue-ide-4dlc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(persistent): compare-and-clear cleanup, seq-keyed queue identity, generation-gated sid adoption (#2363/#2365/#2366)

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -45,6 +45,17 @@ pub const PERSISTENT_OUTPUT_SUBJECT: &str = "output";
 
 pub const BLOCK_CONTROLLER_PERSISTENT: &str = "persistent";
 
+/// Draws the next process-wide registration nonce (≥ 1) for a persistent
+/// spawn's muxbus/registry registrations — see the doc comment at the
+/// `my_registration_nonce` binding in `spawn_process` for why this is a
+/// srv-wide counter rather than the controller-local spawn generation
+/// (codex P1 on PR #2500: generations restart per controller instance
+/// and can collide across a `resync_controller` replacement).
+fn next_registration_nonce() -> u64 {
+    static NEXT_REGISTRATION_NONCE: AtomicU64 = AtomicU64::new(0);
+    NEXT_REGISTRATION_NONCE.fetch_add(1, Ordering::Relaxed) + 1
+}
+
 /// Builds the NDJSON line for a `persistent_resume::ResumeEffect::
 /// EmitSessionOutcome` — a free function (not a method) so it's callable
 /// directly from the stdout-reader, process-waiter, and stop-path match
@@ -2035,6 +2046,19 @@ impl PersistentSubprocessController {
             };
             (generation, effects)
         };
+        // Identity for this spawn's muxbus/registry registrations
+        // (`registration_nonce` on `AgentRegistration`/`AgentEntry`).
+        // Deliberately NOT `my_generation`: the generation is
+        // controller-LOCAL (starts at 0 per controller instance), so a
+        // replacement controller for this same block
+        // (`resync_controller` stops the old one asynchronously and
+        // constructs a new one immediately) restarts at generation 1 —
+        // the old and new processes could then share a generation, and
+        // the old exit-handler's compare-and-remove would accept the
+        // replacement's fresh registration as its own and delete it
+        // (codex P1 on PR #2500). A process-wide counter can never
+        // collide across controller instances.
+        let my_registration_nonce = next_registration_nonce();
         // reagentx P1 (round 7 on this PR): this fresh spawn can supersede
         // a PRIOR generation that was still AwaitingOutcome/ConfirmedRetry
         // with a held error line (see `resolve_superseded_generation`'s
@@ -2177,12 +2201,14 @@ impl PersistentSubprocessController {
         // See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
         let agent_id_for_muxbus = muxbus_agent_id_from_env(&config.env_vars);
         if let Some(ref agent_id) = agent_id_for_muxbus {
-            // `_generated` variants record `my_generation` so this exact
-            // spawn's exit-handler can compare-and-remove its own
-            // registrations instead of blindly wiping a fallback
-            // respawn's fresh ones (issue #2363).
+            // `_with_nonce` variants record this spawn's process-wide
+            // registration nonce so this exact spawn's exit-handler can
+            // compare-and-remove its own registrations instead of
+            // blindly wiping a fallback respawn's (or replacement
+            // controller's) fresh ones (issue #2363; codex P1 on PR
+            // #2500 for why not the controller-local generation).
             match crate::backend::reactive::get_global_handler()
-                .register_agent_generated(agent_id, &self.block_id, Some(&self.tab_id), my_generation)
+                .register_agent_with_nonce(agent_id, &self.block_id, Some(&self.tab_id), my_registration_nonce)
             {
                 Ok(()) => {
                     tracing::info!(
@@ -2197,18 +2223,18 @@ impl PersistentSubprocessController {
                     // exactly like that handler does.
                     if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
                         let data_dir = crate::backend::base::get_wave_data_dir();
-                        crate::backend::reactive::registry::write_generated(
+                        crate::backend::reactive::registry::write_with_nonce(
                             &data_dir,
                             agent_id,
                             &local_url,
                             &self.block_id,
-                            my_generation,
+                            my_registration_nonce,
                         );
-                        crate::backend::reactive::registry::write_shared_from_env_generated(
+                        crate::backend::reactive::registry::write_shared_from_env_with_nonce(
                             agent_id,
                             &local_url,
                             &self.block_id,
-                            my_generation,
+                            my_registration_nonce,
                         );
                     }
                 }
@@ -2722,6 +2748,10 @@ impl PersistentSubprocessController {
         // unconditional clear could wipe a fallback respawn's fresh
         // registration (issue #2363, see clear_active_pid_if_pid).
         let pid_wait = pid;
+        // This exact spawn's registration identity, for the guarded
+        // muxbus/registry removals below (issue #2363 / codex P1 on PR
+        // #2500 — see `my_registration_nonce`'s own doc comment).
+        let nonce_wait = my_registration_nonce;
 
         tokio::spawn(async move {
             tokio::select! {
@@ -2907,25 +2937,28 @@ impl PersistentSubprocessController {
                         // respawn has ALREADY re-registered, the guards below
                         // leave its fresh registration in place.
                         // All removals are compare-and-remove keyed on this
-                        // spawn's generation (issue #2363): the
-                        // `is_current_generation` gate above was read once,
-                        // and a fallback/retry respawn's fresh registration
-                        // can land on a parallel task between that read and
-                        // these calls — an unconditional removal here would
-                        // wipe the NEW spawn's entry with nothing left to
-                        // re-register it.
+                        // spawn's process-wide registration nonce (issue
+                        // #2363): the `is_current_generation` gate above
+                        // was read once, and a fallback/retry respawn's
+                        // fresh registration can land on a parallel task
+                        // between that read and these calls — an
+                        // unconditional removal here would wipe the NEW
+                        // spawn's entry with nothing left to re-register
+                        // it. Nonce, not generation: a replacement
+                        // controller's spawn restarts at generation 1 and
+                        // could collide with ours (codex P1 on PR #2500).
                         let registration_was_ours = crate::backend::reactive::get_global_handler()
-                            .unregister_block_if_generation(&block_id_wait, my_generation_wait);
+                            .unregister_block_if_nonce(&block_id_wait, nonce_wait);
                         if let Some(ref agent_id) = agent_id_wait {
                             let data_dir = crate::backend::base::get_wave_data_dir();
-                            crate::backend::reactive::registry::remove_if_generation(
+                            crate::backend::reactive::registry::remove_if_nonce(
                                 &data_dir,
                                 agent_id,
-                                my_generation_wait,
+                                nonce_wait,
                             );
-                            crate::backend::reactive::registry::remove_shared_from_env_if_generation(
+                            crate::backend::reactive::registry::remove_shared_from_env_if_nonce(
                                 agent_id,
-                                my_generation_wait,
+                                nonce_wait,
                             );
                             // The cloud subscriber's agent set records no
                             // per-agent identity to compare against, so the
@@ -3282,25 +3315,28 @@ impl PersistentSubprocessController {
 
                         // Deregister from muxbus (see the clean-exit arm above).
                         // All removals are compare-and-remove keyed on this
-                        // spawn's generation (issue #2363): the
-                        // `is_current_generation` gate above was read once,
-                        // and a fallback/retry respawn's fresh registration
-                        // can land on a parallel task between that read and
-                        // these calls — an unconditional removal here would
-                        // wipe the NEW spawn's entry with nothing left to
-                        // re-register it.
+                        // spawn's process-wide registration nonce (issue
+                        // #2363): the `is_current_generation` gate above
+                        // was read once, and a fallback/retry respawn's
+                        // fresh registration can land on a parallel task
+                        // between that read and these calls — an
+                        // unconditional removal here would wipe the NEW
+                        // spawn's entry with nothing left to re-register
+                        // it. Nonce, not generation: a replacement
+                        // controller's spawn restarts at generation 1 and
+                        // could collide with ours (codex P1 on PR #2500).
                         let registration_was_ours = crate::backend::reactive::get_global_handler()
-                            .unregister_block_if_generation(&block_id_wait, my_generation_wait);
+                            .unregister_block_if_nonce(&block_id_wait, nonce_wait);
                         if let Some(ref agent_id) = agent_id_wait {
                             let data_dir = crate::backend::base::get_wave_data_dir();
-                            crate::backend::reactive::registry::remove_if_generation(
+                            crate::backend::reactive::registry::remove_if_nonce(
                                 &data_dir,
                                 agent_id,
-                                my_generation_wait,
+                                nonce_wait,
                             );
-                            crate::backend::reactive::registry::remove_shared_from_env_if_generation(
+                            crate::backend::reactive::registry::remove_shared_from_env_if_nonce(
                                 agent_id,
-                                my_generation_wait,
+                                nonce_wait,
                             );
                             // The cloud subscriber's agent set records no
                             // per-agent identity to compare against, so the

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -214,6 +214,14 @@ struct PersistentInner {
     /// spawn or arrived while someone else's spawn was already in flight.
     /// Drained by `release_spawn_claim_and_drain_queue`.
     pending_send_messages: VecDeque<QueuedMessage>,
+    /// Monotonic counter behind `QueuedMessage::seq` (issue #2365) —
+    /// pre-incremented at every fresh enqueue, so real seqs start at 1
+    /// and are never reused for this controller's lifetime. Redelivery
+    /// paths (a stale-resume retry batch) preserve a message's original
+    /// seq instead of drawing a new one — that preservation is what
+    /// makes "already queued?" an identity check rather than a content
+    /// comparison.
+    next_message_seq: u64,
     /// True while the drain (`drain_queue_after_successful_spawn`) is
     /// between successfully sending a message on the live stdin channel
     /// and finishing its OWN follow-up append of that message into
@@ -256,6 +264,15 @@ struct PersistentInner {
 }
 
 impl PersistentInner {
+    /// Draws the next message seq (issue #2365) — pre-incremented, so
+    /// real seqs start at 1 and 0 can serve as "never a valid seq" in
+    /// tests. Must be called under the same lock acquisition as the
+    /// enqueue it identifies.
+    fn take_next_message_seq(&mut self) -> u64 {
+        self.next_message_seq += 1;
+        self.next_message_seq
+    }
+
     /// Applies one `persistent_resume::ResumeEvent` to `self.resume`,
     /// storing the resulting state back and returning the effects for
     /// the caller to execute. The one and only place `self.resume` is
@@ -373,7 +390,24 @@ impl PersistentInner {
             is_confirmed_success,
         });
         let just_resolved_tracking = was_tracking && matches!(self.resume, persistent_resume::ResumeState::NotTracking { .. });
-        let adopted = sid_is_new && (session_id_was_none || just_resolved_tracking);
+        // Ambient adoption is gated on generation currency (issue #2366):
+        // the state machine already drops a stale generation's
+        // `SessionCaptured` for TRACKING purposes, but the
+        // `session_id_was_none` arm below used to adopt regardless — so a
+        // doomed generation's still-draining stdout reader, echoing its
+        // stale attempted sid moments after `respawn_once_for_leftover_
+        // queue`'s plain clear of `session_id` (see that function's
+        // round-13 comment, which deferred exactly this race), could
+        // re-install the stale sid into ambient state. `resume_poisoned`
+        // doesn't cover that: the fallback path deliberately does NOT
+        // poison (the death may have nothing to do with a stale resume),
+        // and the fallback respawn passes `resume_retry_payload: None`,
+        // so a later spawn re-attaching `--resume <stale-sid>` would
+        // fail with nothing re-armed to catch it. A newer spawn owns the
+        // session identity by definition — a superseded generation's
+        // capture must never adopt.
+        let is_current_generation = generation == self.spawn_generation;
+        let adopted = is_current_generation && sid_is_new && (session_id_was_none || just_resolved_tracking);
         if adopted {
             self.session_id = Some(sid.to_string());
         }
@@ -389,8 +423,12 @@ enum SendAction {
     DeliverDirect,
     /// Nobody else is currently spawning — this caller claimed the
     /// exclusive right to do so and its message has already been enqueued
-    /// for the post-spawn drain.
-    BecomeSpawner,
+    /// for the post-spawn drain. `own_seq` is that enqueued message's
+    /// `QueuedMessage::seq`, handed back so the caller can later tell
+    /// `release_spawn_claim_and_drain_queue` exactly which entry was its
+    /// own (issue #2365 — content matching could discard a different,
+    /// identical-text message instead).
+    BecomeSpawner { own_seq: u64 },
     /// Another caller is already spawning — this message has been
     /// enqueued for that caller's own post-spawn drain to deliver.
     Queued,
@@ -406,17 +444,24 @@ enum SendAction {
 /// blockfile transcript.
 #[derive(Clone, Debug)]
 struct QueuedMessage {
+    /// Queue identity (issue #2365): assigned once from
+    /// `PersistentInner::next_message_seq` at first enqueue and preserved
+    /// verbatim across redelivery (`QueuedRetryEntry::seq` carries it
+    /// through a stale-resume retry batch), so dedup / own-message /
+    /// seed checks are exact identity — two genuinely different messages
+    /// with identical text can never be conflated.
+    seq: u64,
     json_str: String,
     already_persisted: bool,
 }
 
 impl QueuedMessage {
-    fn fresh(json_str: String) -> Self {
-        Self { json_str, already_persisted: false }
+    fn fresh(seq: u64, json_str: String) -> Self {
+        Self { seq, json_str, already_persisted: false }
     }
 
-    fn already_persisted(json_str: String) -> Self {
-        Self { json_str, already_persisted: true }
+    fn already_persisted(seq: u64, json_str: String) -> Self {
+        Self { seq, json_str, already_persisted: true }
     }
 }
 
@@ -532,6 +577,7 @@ impl PersistentSubprocessController {
                 resume: persistent_resume::ResumeState::default(),
                 spawning_in_progress: false,
                 pending_send_messages: VecDeque::new(),
+                next_message_seq: 0,
                 drain_send_in_flight: false,
                 current_pid: None,
                 stdin_tx: None,
@@ -733,21 +779,35 @@ impl PersistentSubprocessController {
     /// if that spawn's own drain hasn't reached it yet; blindly queueing
     /// another copy there let a fallback spawn eventually deliver the
     /// same prompt twice.
-    fn decide_send_action(&self, json_str: &str, skip_if_already_queued: bool) -> SendAction {
+    /// `skip_if_seq_queued`: `Some(seq)` marks this call a KNOWN
+    /// re-delivery of the message originally enqueued under `seq` — skip
+    /// enqueueing if that exact entry is still queued, and preserve the
+    /// original seq (not a fresh one) if it must be re-queued, so the
+    /// message keeps one identity for its whole lifetime (issue #2365:
+    /// the old content-equality check here treated a genuinely
+    /// different, identical-text message as "already queued" and
+    /// silently dropped it).
+    fn decide_send_action(&self, json_str: &str, skip_if_seq_queued: Option<u64>) -> SendAction {
         let mut inner = self.inner.lock().unwrap();
         if inner.stdin_tx.is_some() && !inner.spawning_in_progress {
             SendAction::DeliverDirect
         } else if inner.spawning_in_progress {
-            let already_queued =
-                skip_if_already_queued && inner.pending_send_messages.iter().any(|m| m == json_str);
+            let already_queued = skip_if_seq_queued
+                .is_some_and(|seq| inner.pending_send_messages.iter().any(|m| m.seq == seq));
             if !already_queued {
-                inner.pending_send_messages.push_back(QueuedMessage::fresh(json_str.to_string()));
+                let seq = skip_if_seq_queued.unwrap_or_else(|| inner.take_next_message_seq());
+                inner
+                    .pending_send_messages
+                    .push_back(QueuedMessage::fresh(seq, json_str.to_string()));
             }
             SendAction::Queued
         } else {
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh(json_str.to_string()));
-            SendAction::BecomeSpawner
+            let own_seq = skip_if_seq_queued.unwrap_or_else(|| inner.take_next_message_seq());
+            inner
+                .pending_send_messages
+                .push_back(QueuedMessage::fresh(own_seq, json_str.to_string()));
+            SendAction::BecomeSpawner { own_seq }
         }
     }
 
@@ -755,9 +815,10 @@ impl PersistentSubprocessController {
     /// returning `BecomeSpawner`. `spawn_succeeded` distinguishes two very
     /// different situations:
     ///
-    /// - **Failed spawn**: discards only `own_message` — the specific
-    ///   message THIS spawner pushed when it claimed `BecomeSpawner`, found
-    ///   by content match rather than assumed to be at the front. codex P2
+    /// - **Failed spawn**: discards only the entry with `own_seq` — the
+    ///   specific message THIS spawner pushed when it claimed
+    ///   `BecomeSpawner` (`SendAction::BecomeSpawner::own_seq`), found by
+    ///   queue identity rather than assumed to be at the front. codex P2
     ///   on PR #2360 (round 14, commit 8c2bc99ab): the queue is NOT always
     ///   empty at the moment a new spawner claims it — the "second stall"
     ///   path (`drain_queue_after_successful_spawn` with
@@ -769,13 +830,10 @@ impl PersistentSubprocessController {
     ///   message" in that case discarded an OLDER, unrelated, already-
     ///   accepted prompt instead of the actually-failed one — silent data
     ///   loss, plus handing the wrong (already-failed) message to the
-    ///   fallback respawn. Matching by content instead of position fixes
-    ///   this whenever the two differ, which is the overwhelming common
-    ///   case; the narrow residual case of two GENUINELY DIFFERENT messages
-    ///   sharing identical content (e.g. two "yes" replies) is the same
-    ///   content-identity-ambiguity gap already tracked in #2365 — this fix
-    ///   doesn't need to (and doesn't try to) close that, since either
-    ///   duplicate is content-equivalent to discard here. codex P1 on PR
+    ///   fallback respawn. Originally fixed by matching content instead
+    ///   of position, which still left two GENUINELY DIFFERENT messages
+    ///   sharing identical text (e.g. two "yes" replies) ambiguous; seq
+    ///   matching (issue #2365) closes that residue too. codex P1 on PR
     ///   #2360 (sixth review pass): leaving this message queued let an
     ///   unrelated LATER successful spawn silently execute a prompt the
     ///   caller was already told had failed (`send_message`/
@@ -808,7 +866,7 @@ impl PersistentSubprocessController {
     /// frontend the turn ended — the ORIGINAL exit deliberately suppressed
     /// its own terminal-status publish expecting the retry to eventually
     /// publish one.
-    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool, retry_config: PersistentSpawnConfig, own_message: &str) {
+    fn release_spawn_claim_and_drain_queue(&self, spawn_succeeded: bool, retry_config: PersistentSpawnConfig, own_seq: u64) {
         if !spawn_succeeded {
             // Discard only `own_message` — see this function's own doc
             // comment above for why position (front) is not a safe
@@ -834,7 +892,7 @@ impl PersistentSubprocessController {
             // leave the claim held and hand off to the fallback respawn.
             let leftovers = {
                 let mut inner = self.inner.lock().unwrap();
-                if let Some(idx) = inner.pending_send_messages.iter().position(|m| m == own_message) {
+                if let Some(idx) = inner.pending_send_messages.iter().position(|m| m.seq == own_seq) {
                     inner.pending_send_messages.remove(idx);
                 } else {
                     // Shouldn't normally happen — defensively log rather
@@ -890,13 +948,14 @@ impl PersistentSubprocessController {
             // (b) records the ACTUAL seeded/triggering message a SECOND
             // time (once via `spawn_process`'s synchronous seed, once via
             // this drain's own append) — a confirmed stale-resume retry
-            // would then redeliver that one message TWICE. Matching by
-            // content instead correctly identifies the seeded entry
-            // regardless of where it sits, exactly once (via
-            // `seed_already_matched`, so a later, genuinely-different
-            // delivery that happens to share identical content isn't ALSO
-            // wrongly skipped — same known, accepted content-identity
-            // limits as #2365).
+            // would then redeliver that one message TWICE. Originally
+            // fixed by matching content (with `seed_already_matched` as a
+            // one-shot so an identical-text later delivery wasn't ALSO
+            // skipped); now matched by queue identity
+            // (`QueuedMessage::seq`, issue #2365), which identifies the
+            // seeded entry exactly regardless of position or duplicate
+            // text. The one-shot flag is kept as cheap defense-in-depth —
+            // seqs are never reused, so it can no longer fire twice.
             let mut seed_already_matched = false;
             let stalled_with_leftovers = loop {
                 let next = {
@@ -928,11 +987,11 @@ impl PersistentSubprocessController {
                     }
                     break stalled;
                 };
-                let QueuedMessage { json_str, already_persisted } = queued;
+                let QueuedMessage { seq, json_str, already_persisted } = queued;
                 let delivered_copy = json_str.clone();
                 let is_the_seed = !seed_already_matched && {
                     let inner = inner_arc.lock().unwrap();
-                    inner.resume.is_seeded_message(inner.spawn_generation, &delivered_copy)
+                    inner.resume.is_seeded_message(inner.spawn_generation, seq)
                 };
                 if is_the_seed {
                     seed_already_matched = true;
@@ -957,7 +1016,7 @@ impl PersistentSubprocessController {
                     // up. Same claim-retention rule as above.
                     let mut inner = inner_arc.lock().unwrap();
                     inner.drain_send_in_flight = false;
-                    inner.pending_send_messages.push_front(QueuedMessage { json_str: e.0, already_persisted });
+                    inner.pending_send_messages.push_front(QueuedMessage { seq, json_str: e.0, already_persisted });
                     let stalled = !inner.pending_send_messages.is_empty();
                     if !(stalled && allow_fallback_respawn) {
                         inner.spawning_in_progress = false;
@@ -992,7 +1051,7 @@ impl PersistentSubprocessController {
                     let generation = inner.spawn_generation;
                     inner.apply_resume_event(persistent_resume::ResumeEvent::MessageAppendedToRetryBatch {
                         generation,
-                        json: delivered_copy.clone(),
+                        entry: persistent_resume::QueuedRetryEntry { seq, json: delivered_copy.clone() },
                     });
                 }
                 inner_arc.lock().unwrap().drain_send_in_flight = false;
@@ -1163,7 +1222,7 @@ impl PersistentSubprocessController {
         });
         let json_str = json_msg.to_string();
 
-        match self.decide_send_action(&json_str, false) {
+        match self.decide_send_action(&json_str, None) {
             SendAction::Queued => {
                 // Persistence happens later, inside the drain, at the
                 // exact moment this message is actually delivered — see
@@ -1206,7 +1265,7 @@ impl PersistentSubprocessController {
                 self.emit_message_accepted(config.message_id.as_deref());
                 Ok(())
             }
-            SendAction::BecomeSpawner => {
+            SendAction::BecomeSpawner { own_seq } => {
                 // `resume_retry_payload` is stashed SYNCHRONOUSLY inside
                 // spawn_process, before any background task exists —
                 // reagentx P1 on PR #2360: stashing it after spawn_process
@@ -1222,8 +1281,10 @@ impl PersistentSubprocessController {
                 // `--resume`, which is what the retry payload is for.
                 let message_id = config.message_id.clone();
                 let retry_config = config.clone();
-                let own_message = json_str.clone();
-                let spawn_result = self.spawn_process(config, Some(json_str));
+                let spawn_result = self.spawn_process(
+                    config,
+                    Some(persistent_resume::QueuedRetryEntry { seq: own_seq, json: json_str }),
+                );
                 // Only emit "accepted" on success — codex P2 on PR #2360
                 // (sixth review pass, round 4): an earlier cut of this fix
                 // persisted unconditionally here, letting a rejected spawn
@@ -1239,7 +1300,7 @@ impl PersistentSubprocessController {
                     self.mark_turn_active_and_publish();
                     self.emit_message_accepted(message_id.as_deref());
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config, &own_message);
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config, own_seq);
                 spawn_result
             }
         }
@@ -1322,11 +1383,11 @@ impl PersistentSubprocessController {
     fn retry_after_resume_failure(
         &self,
         mut config: PersistentSpawnConfig,
-        mut json_strs: Vec<String>,
+        mut entries: Vec<persistent_resume::QueuedRetryEntry>,
         held_error_line: Option<String>,
     ) {
         config.session_id = String::new();
-        let Some(first) = (!json_strs.is_empty()).then(|| json_strs.remove(0)) else {
+        let Some(first) = (!entries.is_empty()).then(|| entries.remove(0)) else {
             // Nothing to retry at all (shouldn't happen in practice —
             // the batch always has at least the triggering message) —
             // but if it ever does, this is a no-op, not a launch, so any
@@ -1336,7 +1397,7 @@ impl PersistentSubprocessController {
             }
             return;
         };
-        let rest = json_strs;
+        let rest = entries;
 
         match self.decide_retry_batch_action(&first, &rest) {
             SendAction::DeliverDirect => {
@@ -1348,7 +1409,7 @@ impl PersistentSubprocessController {
                 {
                     let mut inner = self.inner.lock().unwrap();
                     let tx = inner.stdin_tx.clone();
-                    for msg in std::iter::once(first).chain(rest) {
+                    for entry in std::iter::once(first).chain(rest) {
                         // codex P2 on PR #2360 (round 15, commit
                         // fdb8db6fd): once ANY earlier message in this
                         // batch has failed direct delivery, stop
@@ -1363,7 +1424,8 @@ impl PersistentSubprocessController {
                         // `!any_failed` short-circuits every remaining
                         // message straight to the queued branch, in
                         // order, once the first failure is hit.
-                        let delivered = !any_failed && tx.as_ref().is_some_and(|tx| tx.try_send(msg.clone()).is_ok());
+                        let delivered = !any_failed
+                            && tx.as_ref().is_some_and(|tx| tx.try_send(entry.json.clone()).is_ok());
                         if !delivered {
                             any_failed = true;
                             // codex P2 on PR #2360 (sixth review pass,
@@ -1375,7 +1437,9 @@ impl PersistentSubprocessController {
                             // process that died again in this exact gap)
                             // would lose it permanently despite already
                             // having been reported as accepted.
-                            inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg));
+                            inner
+                                .pending_send_messages
+                                .push_back(QueuedMessage::already_persisted(entry.seq, entry.json));
                         }
                     }
                     if any_failed {
@@ -1470,7 +1534,7 @@ impl PersistentSubprocessController {
                 // specific original error text.
                 drop(held_error_line);
             }
-            SendAction::BecomeSpawner => {
+            SendAction::BecomeSpawner { own_seq } => {
                 // Only clear inner.session_id now that THIS retry is
                 // actually about to spawn — codex P2 on PR #2360 (sixth
                 // review pass, round 3): clearing it unconditionally up
@@ -1491,7 +1555,7 @@ impl PersistentSubprocessController {
                         "failed to respawn after a stale --resume session id"
                     ),
                 }
-                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config, &first);
+                self.release_spawn_claim_and_drain_queue(spawn_result.is_ok(), retry_config, own_seq);
                 if spawn_result.is_err() {
                     // Surface this, or the pane hangs forever with NO
                     // signal at all — codex P2 on PR #2360 (fifth review
@@ -1539,7 +1603,11 @@ impl PersistentSubprocessController {
     /// the same batch, since two entries can legitimately be identical
     /// (the user genuinely sent the same text twice) and both need
     /// redelivering (codex P2 on PR #2360, sixth review pass, round 6).
-    fn decide_retry_batch_action(&self, first: &str, rest: &[String]) -> SendAction {
+    fn decide_retry_batch_action(
+        &self,
+        first: &persistent_resume::QueuedRetryEntry,
+        rest: &[persistent_resume::QueuedRetryEntry],
+    ) -> SendAction {
         let mut inner = self.inner.lock().unwrap();
         if inner.stdin_tx.is_some() && !inner.spawning_in_progress {
             SendAction::DeliverDirect
@@ -1560,18 +1628,19 @@ impl PersistentSubprocessController {
             // `push_back` ever touches this queue elsewhere. In that
             // case `rest` belongs immediately after it (same batch,
             // preserving order), not ahead of it.
-            let first_already_queued = inner.pending_send_messages.iter().any(|m| m == first);
+            let first_already_queued =
+                inner.pending_send_messages.iter().any(|m| m.seq == first.seq);
             if first_already_queued {
-                for (i, msg) in rest.iter().enumerate() {
+                for (i, entry) in rest.iter().enumerate() {
                     inner
                         .pending_send_messages
-                        .insert(i + 1, QueuedMessage::already_persisted(msg.clone()));
+                        .insert(i + 1, QueuedMessage::already_persisted(entry.seq, entry.json.clone()));
                 }
             } else {
                 let mut front: VecDeque<QueuedMessage> = VecDeque::new();
-                front.push_back(QueuedMessage::already_persisted(first.to_string()));
-                for msg in rest {
-                    front.push_back(QueuedMessage::already_persisted(msg.clone()));
+                front.push_back(QueuedMessage::already_persisted(first.seq, first.json.clone()));
+                for entry in rest {
+                    front.push_back(QueuedMessage::already_persisted(entry.seq, entry.json.clone()));
                 }
                 front.append(&mut inner.pending_send_messages);
                 inner.pending_send_messages = front;
@@ -1579,11 +1648,15 @@ impl PersistentSubprocessController {
             SendAction::Queued
         } else {
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::already_persisted(first.to_string()));
-            for msg in rest {
-                inner.pending_send_messages.push_back(QueuedMessage::already_persisted(msg.clone()));
+            inner
+                .pending_send_messages
+                .push_back(QueuedMessage::already_persisted(first.seq, first.json.clone()));
+            for entry in rest {
+                inner
+                    .pending_send_messages
+                    .push_back(QueuedMessage::already_persisted(entry.seq, entry.json.clone()));
             }
-            SendAction::BecomeSpawner
+            SendAction::BecomeSpawner { own_seq: first.seq }
         }
     }
 
@@ -1860,7 +1933,11 @@ impl PersistentSubprocessController {
     /// Spawn the persistent CLI process. Called only while the caller
     /// holds the exclusive spawn claim (`spawning_in_progress`, see
     /// `decide_send_action`) — never directly.
-    fn spawn_process(&self, config: PersistentSpawnConfig, resume_retry_payload: Option<String>) -> Result<(), String> {
+    fn spawn_process(
+        &self,
+        config: PersistentSpawnConfig,
+        resume_retry_payload: Option<persistent_resume::QueuedRetryEntry>,
+    ) -> Result<(), String> {
         // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows
         let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
 
@@ -2100,8 +2177,12 @@ impl PersistentSubprocessController {
         // See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
         let agent_id_for_muxbus = muxbus_agent_id_from_env(&config.env_vars);
         if let Some(ref agent_id) = agent_id_for_muxbus {
+            // `_generated` variants record `my_generation` so this exact
+            // spawn's exit-handler can compare-and-remove its own
+            // registrations instead of blindly wiping a fallback
+            // respawn's fresh ones (issue #2363).
             match crate::backend::reactive::get_global_handler()
-                .register_agent(agent_id, &self.block_id, Some(&self.tab_id))
+                .register_agent_generated(agent_id, &self.block_id, Some(&self.tab_id), my_generation)
             {
                 Ok(()) => {
                     tracing::info!(
@@ -2116,16 +2197,18 @@ impl PersistentSubprocessController {
                     // exactly like that handler does.
                     if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
                         let data_dir = crate::backend::base::get_wave_data_dir();
-                        crate::backend::reactive::registry::write(
+                        crate::backend::reactive::registry::write_generated(
                             &data_dir,
                             agent_id,
                             &local_url,
                             &self.block_id,
+                            my_generation,
                         );
-                        crate::backend::reactive::registry::write_shared_from_env(
+                        crate::backend::reactive::registry::write_shared_from_env_generated(
                             agent_id,
                             &local_url,
                             &self.block_id,
+                            my_generation,
                         );
                     }
                 }
@@ -2635,6 +2718,10 @@ impl PersistentSubprocessController {
         // This exact spawn's identity — see `stop_requested_generation`'s
         // doc comment for why the retry decision below needs it.
         let my_generation_wait = my_generation;
+        // This exact spawn's OS pid, for the compare-and-clear below — the
+        // unconditional clear could wipe a fallback respawn's fresh
+        // registration (issue #2363, see clear_active_pid_if_pid).
+        let pid_wait = pid;
 
         tokio::spawn(async move {
             tokio::select! {
@@ -2815,25 +2902,51 @@ impl PersistentSubprocessController {
 
                         // Deregister from muxbus so later sends fall through to the
                         // lower tiers instead of resolving to a dead block. Mirrors
-                        // the shell controller's exit path. Done regardless of
-                        // whether a retry follows — this exact process's
-                        // resources are gone either way, and spawn_process's own
-                        // fresh registration (if a retry follows) doesn't clean
-                        // up state belonging to THIS dying process.
-                        crate::backend::reactive::get_global_handler()
-                            .unregister_block(&block_id_wait);
+                        // the shell controller's exit path. This exact process's
+                        // resources are gone either way; if a retry/fallback
+                        // respawn has ALREADY re-registered, the guards below
+                        // leave its fresh registration in place.
+                        // All removals are compare-and-remove keyed on this
+                        // spawn's generation (issue #2363): the
+                        // `is_current_generation` gate above was read once,
+                        // and a fallback/retry respawn's fresh registration
+                        // can land on a parallel task between that read and
+                        // these calls — an unconditional removal here would
+                        // wipe the NEW spawn's entry with nothing left to
+                        // re-register it.
+                        let registration_was_ours = crate::backend::reactive::get_global_handler()
+                            .unregister_block_if_generation(&block_id_wait, my_generation_wait);
                         if let Some(ref agent_id) = agent_id_wait {
                             let data_dir = crate::backend::base::get_wave_data_dir();
-                            crate::backend::reactive::registry::remove(&data_dir, agent_id);
-                            crate::backend::reactive::registry::remove_shared_from_env(agent_id);
-                            if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
-                                sub.remove_agent(agent_id);
+                            crate::backend::reactive::registry::remove_if_generation(
+                                &data_dir,
+                                agent_id,
+                                my_generation_wait,
+                            );
+                            crate::backend::reactive::registry::remove_shared_from_env_if_generation(
+                                agent_id,
+                                my_generation_wait,
+                            );
+                            // The cloud subscriber's agent set records no
+                            // per-agent identity to compare against, so the
+                            // in-memory registration's outcome above stands
+                            // in: if a newer spawn already re-registered,
+                            // its cloud subscription must survive too.
+                            if registration_was_ours {
+                                if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
+                                    sub.remove_agent(agent_id);
+                                }
                             }
                         }
 
                         // Clear active pid — clean exit, no recovery needed.
+                        // Compare-and-clear (issue #2363): only if the
+                        // recorded pid is still THIS process's — a fallback
+                        // respawn may have re-registered a fresh pid on a
+                        // parallel task between the generation gate above
+                        // and this call.
                         if let Some(ref wstore) = wstore_wait {
-                            super::session_recovery::clear_active_pid(wstore, &block_id_wait);
+                            super::session_recovery::clear_active_pid_if_pid(wstore, &block_id_wait, pid_wait);
                         }
                     }
 
@@ -3168,20 +3281,47 @@ impl PersistentSubprocessController {
                         health_wait.set_exited(-1);
 
                         // Deregister from muxbus (see the clean-exit arm above).
-                        crate::backend::reactive::get_global_handler()
-                            .unregister_block(&block_id_wait);
+                        // All removals are compare-and-remove keyed on this
+                        // spawn's generation (issue #2363): the
+                        // `is_current_generation` gate above was read once,
+                        // and a fallback/retry respawn's fresh registration
+                        // can land on a parallel task between that read and
+                        // these calls — an unconditional removal here would
+                        // wipe the NEW spawn's entry with nothing left to
+                        // re-register it.
+                        let registration_was_ours = crate::backend::reactive::get_global_handler()
+                            .unregister_block_if_generation(&block_id_wait, my_generation_wait);
                         if let Some(ref agent_id) = agent_id_wait {
                             let data_dir = crate::backend::base::get_wave_data_dir();
-                            crate::backend::reactive::registry::remove(&data_dir, agent_id);
-                            crate::backend::reactive::registry::remove_shared_from_env(agent_id);
-                            if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
-                                sub.remove_agent(agent_id);
+                            crate::backend::reactive::registry::remove_if_generation(
+                                &data_dir,
+                                agent_id,
+                                my_generation_wait,
+                            );
+                            crate::backend::reactive::registry::remove_shared_from_env_if_generation(
+                                agent_id,
+                                my_generation_wait,
+                            );
+                            // The cloud subscriber's agent set records no
+                            // per-agent identity to compare against, so the
+                            // in-memory registration's outcome above stands
+                            // in: if a newer spawn already re-registered,
+                            // its cloud subscription must survive too.
+                            if registration_was_ours {
+                                if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
+                                    sub.remove_agent(agent_id);
+                                }
                             }
                         }
 
                         // Clear active pid — user-initiated stop, no recovery needed.
+                        // Compare-and-clear (issue #2363), same as the
+                        // clean-exit arm: the `is_current_generation` gate
+                        // above was read once under the lock, and a fallback
+                        // respawn's re-registration can land between that
+                        // read and this call.
                         if let Some(ref wstore) = wstore_wait {
-                            super::session_recovery::clear_active_pid(wstore, &block_id_wait);
+                            super::session_recovery::clear_active_pid_if_pid(wstore, &block_id_wait, pid_wait);
                         }
                     }
                 }
@@ -3412,6 +3552,12 @@ mod send_input_tests {
         )
     }
 
+    /// Shorthand for a retry-batch entry with an explicit queue seq
+    /// (issue #2365 — retry batches carry identity, not just text).
+    fn qentry(seq: u64, json: &str) -> persistent_resume::QueuedRetryEntry {
+        persistent_resume::QueuedRetryEntry { seq, json: json.to_string() }
+    }
+
     // codex P1 on PR #2360 (round 16, commit ce1642d90): `stop_process`
     // must record which generation a stop was requested for even when
     // there's no live `kill_tx` to send through — see
@@ -3443,7 +3589,7 @@ mod send_input_tests {
                         session_id: "dead-sid".to_string(),
                         message_id: None,
                     },
-                    messages: vec!["{}".to_string()],
+                    messages: vec![qentry(1, "{}")],
                 },
             });
         }
@@ -3665,7 +3811,7 @@ mod send_input_tests {
             session_id: "dead-sid".to_string(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, vec!["{}".to_string()], None);
+        c.retry_after_resume_failure(config, vec![qentry(1, "{}")], None);
 
         assert_eq!(
             c.inner.lock().unwrap().session_id,
@@ -3851,8 +3997,8 @@ mod send_input_tests {
     #[test]
     fn decide_send_action_becomes_spawner_when_nothing_is_in_flight() {
         let c = controller();
-        let action = c.decide_send_action("msg-a", false);
-        assert!(matches!(action, SendAction::BecomeSpawner));
+        let action = c.decide_send_action("msg-a", None);
+        assert!(matches!(action, SendAction::BecomeSpawner { .. }));
         let inner = c.inner.lock().unwrap();
         assert!(inner.spawning_in_progress, "must claim the exclusive spawn right");
         assert_eq!(
@@ -3867,7 +4013,7 @@ mod send_input_tests {
         let c = controller();
         c.inner.lock().unwrap().spawning_in_progress = true;
 
-        let action = c.decide_send_action("msg-b", false);
+        let action = c.decide_send_action("msg-b", None);
         assert!(
             matches!(action, SendAction::Queued),
             "a second caller must queue instead of independently deciding to spawn"
@@ -3887,8 +4033,8 @@ mod send_input_tests {
         let c = controller();
         c.inner.lock().unwrap().spawning_in_progress = true;
 
-        c.decide_send_action("hello", false);
-        let action = c.decide_send_action("hello", false);
+        c.decide_send_action("hello", None);
+        let action = c.decide_send_action("hello", None);
 
         assert!(matches!(action, SendAction::Queued));
         let inner = c.inner.lock().unwrap();
@@ -3901,32 +4047,66 @@ mod send_input_tests {
 
     /// codex P1 on PR #2360 (sixth review pass, round 4): unlike a genuine
     /// new message, `retry_after_resume_failure`'s payload is a KNOWN
-    /// re-delivery of content that may ALREADY be sitting in the queue —
+    /// re-delivery of a message that may ALREADY be sitting in the queue —
     /// pushed by the very spawn attempt whose failure triggered this
     /// retry, if that spawn's own drain hasn't reached it yet. Blindly
-    /// queueing another copy (as the `false`/`send_message` path
+    /// queueing another copy (as the `None`/`send_message` path
     /// correctly does for a genuine new message) would let a fallback
-    /// spawn eventually deliver the same prompt twice. `skip_if_already_
-    /// queued=true` (what `retry_after_resume_failure` always passes)
-    /// must therefore skip re-enqueueing an identical, already-present
-    /// entry.
+    /// spawn eventually deliver the same prompt twice. Passing the
+    /// original entry's seq must therefore skip re-enqueueing while that
+    /// exact entry is still present (issue #2365: matched by identity,
+    /// not text).
     #[test]
     fn decide_send_action_dedups_a_known_retry_of_an_already_queued_message() {
         let c = controller();
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("original-payload".to_string()));
+            inner
+                .pending_send_messages
+                .push_back(QueuedMessage::fresh(7, "original-payload".to_string()));
         }
 
-        let action = c.decide_send_action("original-payload", true);
+        let action = c.decide_send_action("original-payload", Some(7));
 
         assert!(matches!(action, SendAction::Queued));
         let inner = c.inner.lock().unwrap();
         assert_eq!(
             inner.pending_send_messages.len(),
             1,
-            "a retry of content already queued must not add a duplicate copy"
+            "a retry of a message still queued under its own seq must not add a duplicate copy"
+        );
+    }
+
+    /// Issue #2365 regression: the dedup must key on the entry's seq, not
+    /// its text — a DIFFERENT message that happens to share identical
+    /// content with the retried one must not satisfy the check (the old
+    /// content-equality version silently dropped the retry here).
+    #[test]
+    fn decide_send_action_does_not_dedup_a_retry_against_an_identical_text_different_message() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawning_in_progress = true;
+            // A genuinely different message (seq 9) with the same text as
+            // the retried entry (seq 7).
+            inner
+                .pending_send_messages
+                .push_back(QueuedMessage::fresh(9, "original-payload".to_string()));
+        }
+
+        let action = c.decide_send_action("original-payload", Some(7));
+
+        assert!(matches!(action, SendAction::Queued));
+        let inner = c.inner.lock().unwrap();
+        assert_eq!(
+            inner.pending_send_messages.len(),
+            2,
+            "identical text under a different seq is a different message — the retry must still be queued"
+        );
+        assert_eq!(
+            inner.pending_send_messages[1].seq, 7,
+            "the re-queued retry must keep its original seq, not draw a fresh one"
         );
     }
 
@@ -3939,12 +4119,16 @@ mod send_input_tests {
         let c = controller();
         c.inner.lock().unwrap().spawning_in_progress = true;
 
-        let action = c.decide_send_action("not-yet-queued", true);
+        let action = c.decide_send_action("not-yet-queued", Some(42));
 
         assert!(matches!(action, SendAction::Queued));
         let inner = c.inner.lock().unwrap();
         assert_eq!(inner.pending_send_messages.len(), 1);
         assert_eq!(inner.pending_send_messages[0], "not-yet-queued");
+        assert_eq!(
+            inner.pending_send_messages[0].seq, 42,
+            "a re-queued known redelivery must preserve its original seq"
+        );
     }
 
     #[test]
@@ -3953,7 +4137,7 @@ mod send_input_tests {
         let (tx, _rx) = mpsc::channel::<String>(4);
         c.inner.lock().unwrap().stdin_tx = Some(tx);
 
-        let action = c.decide_send_action("msg-c", false);
+        let action = c.decide_send_action("msg-c", None);
         assert!(matches!(action, SendAction::DeliverDirect));
         let inner = c.inner.lock().unwrap();
         assert!(
@@ -3983,7 +4167,7 @@ mod send_input_tests {
             inner.spawning_in_progress = true;
         }
 
-        let action = c.decide_send_action("msg-late-arrival", false);
+        let action = c.decide_send_action("msg-late-arrival", None);
         assert!(
             matches!(action, SendAction::Queued),
             "must queue, not deliver direct, while a drain for an earlier message is still active"
@@ -3999,7 +4183,7 @@ mod send_input_tests {
     #[test]
     fn decide_send_action_marks_a_fresh_message_as_not_yet_persisted() {
         let c = controller();
-        c.decide_send_action("hello", false);
+        c.decide_send_action("hello", None);
         let inner = c.inner.lock().unwrap();
         assert!(
             !inner.pending_send_messages[0].already_persisted,
@@ -4014,7 +4198,7 @@ mod send_input_tests {
     #[test]
     fn decide_retry_batch_action_marks_every_entry_as_already_persisted() {
         let c = controller();
-        c.decide_retry_batch_action("hello", &["world".to_string()]);
+        c.decide_retry_batch_action(&qentry(1, "hello"), &[qentry(2, "world")]);
         let inner = c.inner.lock().unwrap();
         assert!(inner.pending_send_messages[0].already_persisted);
         assert!(inner.pending_send_messages[1].already_persisted);
@@ -4067,8 +4251,8 @@ mod send_input_tests {
                 let c = StdArc::clone(&c);
                 let spawner_count = StdArc::clone(&spawner_count);
                 let queued_count = StdArc::clone(&queued_count);
-                std::thread::spawn(move || match c.decide_send_action(&format!("msg-{i}"), false) {
-                    SendAction::BecomeSpawner => {
+                std::thread::spawn(move || match c.decide_send_action(&format!("msg-{i}"), None) {
+                    SendAction::BecomeSpawner { .. } => {
                         spawner_count.fetch_add(1, AtomicOrdering::SeqCst);
                     }
                     SendAction::Queued => {
@@ -4109,14 +4293,14 @@ mod send_input_tests {
             let mut inner = c.inner.lock().unwrap();
             inner.stdin_tx = Some(tx);
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("second".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "second".to_string()));
         }
 
         // Never used for a fallback spawn in this test — the drain fully
         // succeeds without ever stalling. `own_message` is only consulted
         // on the failed-spawn path, so its value doesn't matter here.
-        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config(), "first");
+        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config(), 0);
 
         assert_eq!(rx.recv().await.unwrap(), "first");
         assert_eq!(rx.recv().await.unwrap(), "second");
@@ -4177,13 +4361,13 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("stuck-one".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("stuck-two".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "stuck-one".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "stuck-two".to_string()));
             // stdin_tx stays None — simulates the process this claim was
             // spawning for having already died before the drain ran.
         }
 
-        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config(), "stuck-one");
+        c.release_spawn_claim_and_drain_queue(true, unreachable_fallback_config(), 0);
         // Let the spawned background task, and the fallback respawn
         // attempt it triggers, run to completion.
         tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
@@ -4222,11 +4406,11 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("the-one-that-failed".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("queued-by-someone-else".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "the-one-that-failed".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "queued-by-someone-else".to_string()));
         }
 
-        c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config(), "the-one-that-failed");
+        c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config(), 1);
 
         let inner = c.inner.lock().unwrap();
         assert!(
@@ -4266,14 +4450,14 @@ mod send_input_tests {
             // Simulates leftovers surviving a prior "second stall" release
             // (queue non-empty, claim already given up by that path) plus a
             // later BecomeSpawner appending its own message behind them.
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("older-leftover-from-a-different-caller".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("this-spawners-own-message-that-just-failed".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "older-leftover-from-a-different-caller".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "this-spawners-own-message-that-just-failed".to_string()));
         }
 
         c.release_spawn_claim_and_drain_queue(
             false,
             unreachable_fallback_config(),
-            "this-spawners-own-message-that-just-failed",
+            2,
         );
 
         let inner = c.inner.lock().unwrap();
@@ -4326,19 +4510,19 @@ mod send_input_tests {
             {
                 let mut inner = c.inner.lock().unwrap();
                 inner.spawning_in_progress = true;
-                inner.pending_send_messages.push_back(QueuedMessage::fresh("the-one-that-failed".to_string()));
+                inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "the-one-that-failed".to_string()));
             }
 
             let handles: Vec<_> = (0..8)
                 .map(|i| {
                     let c = StdArc::clone(&c);
                     std::thread::spawn(move || {
-                        let _ = c.decide_send_action(&format!("racer-{iteration}-{i}"), false);
+                        let _ = c.decide_send_action(&format!("racer-{iteration}-{i}"), None);
                     })
                 })
                 .collect();
 
-            c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config(), "the-one-that-failed");
+            c.release_spawn_claim_and_drain_queue(false, unreachable_fallback_config(), 1);
 
             for h in handles {
                 h.join().unwrap();
@@ -4387,7 +4571,7 @@ mod send_input_tests {
             session_id: "dead-sid".to_string(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, vec!["{}".to_string()], None);
+        c.retry_after_resume_failure(config, vec![qentry(1, "{}")], None);
 
         assert_eq!(
             c.inner.lock().unwrap().session_id.as_deref(),
@@ -4421,7 +4605,7 @@ mod send_input_tests {
         };
         c.retry_after_resume_failure(
             config,
-            vec!["msg-1".to_string(), "msg-2".to_string(), "msg-3".to_string()],
+            vec![qentry(1, "msg-1"), qentry(2, "msg-2"), qentry(3, "msg-3")],
             None,
         );
 
@@ -4453,7 +4637,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, vec!["stuck".to_string()], None);
+        c.retry_after_resume_failure(config, vec![qentry(1, "stuck")], None);
 
         let inner = c.inner.lock().unwrap();
         assert_eq!(
@@ -4493,7 +4677,7 @@ mod send_input_tests {
         };
         c.retry_after_resume_failure(
             config,
-            vec!["msg-1".to_string(), "msg-2".to_string(), "msg-3".to_string()],
+            vec![qentry(1, "msg-1"), qentry(2, "msg-2"), qentry(3, "msg-3")],
             None,
         );
 
@@ -4535,7 +4719,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, vec!["stuck".to_string()], None);
+        c.retry_after_resume_failure(config, vec![qentry(1, "stuck")], None);
 
         assert!(
             c.inner.lock().unwrap().spawning_in_progress,
@@ -4581,7 +4765,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, vec!["{}".to_string()], Some("boom\n".to_string()));
+        c.retry_after_resume_failure(config, vec![qentry(1, "{}")], Some("boom\n".to_string()));
 
         let flushed = filestore
             .read_file(&block_id, PERSISTENT_OUTPUT_SUBJECT)
@@ -4636,7 +4820,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(config, vec!["stuck".to_string()], Some("boom\n".to_string()));
+        c.retry_after_resume_failure(config, vec![qentry(1, "stuck")], Some("boom\n".to_string()));
         tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
 
         let flushed = filestore
@@ -4677,15 +4861,15 @@ mod send_input_tests {
             let mut inner = c.inner.lock().unwrap();
             inner.stdin_tx = Some(tx);
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("second".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "second".to_string()));
             // Simulates spawn_process's own synchronous stash for "first"
             // — the message that triggered this spawn.
             let generation = inner.spawn_generation;
             inner.apply_resume_event(persistent_resume::ResumeEvent::SpawnedWithResume {
                 generation,
                 attempted_sid: "sid".to_string(),
-                retry: persistent_resume::RetryPayload { config: retry_config.clone(), messages: vec!["first".to_string()] },
+                retry: persistent_resume::RetryPayload { config: retry_config.clone(), messages: vec![qentry(1, "first")] },
             });
         }
 
@@ -4703,7 +4887,7 @@ mod send_input_tests {
         match &inner.resume {
             persistent_resume::ResumeState::AwaitingOutcome { retry, .. } => assert_eq!(
                 retry.messages,
-                vec!["first".to_string(), "second".to_string()],
+                vec![qentry(1, "first"), qentry(2, "second")],
                 "must contain the ORIGINAL message exactly once plus every later delivery, in order"
             ),
             other => panic!("expected AwaitingOutcome, got {other:?}"),
@@ -4742,8 +4926,8 @@ mod send_input_tests {
             inner.spawning_in_progress = true;
             // Simulates a "second stall" leaving an older leftover queued
             // ahead of this spawn's own triggering message.
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("older-leftover".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("new-trigger".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "older-leftover".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "new-trigger".to_string()));
             // spawn_process's own synchronous stash — seeded with the
             // ACTUAL trigger message, not whatever happens to sit at the
             // front of the queue.
@@ -4753,7 +4937,7 @@ mod send_input_tests {
                 attempted_sid: "sid".to_string(),
                 retry: persistent_resume::RetryPayload {
                     config: retry_config.clone(),
-                    messages: vec!["new-trigger".to_string()],
+                    messages: vec![qentry(2, "new-trigger")],
                 },
             });
         }
@@ -4775,11 +4959,11 @@ mod send_input_tests {
             "must contain exactly the older leftover plus the trigger, no omission, no duplication: {delivered:?}"
         );
         assert!(
-            delivered.contains(&"older-leftover".to_string()),
+            delivered.iter().any(|e| e.json == "older-leftover"),
             "the older leftover must not be silently dropped from the retry batch"
         );
         assert_eq!(
-            delivered.iter().filter(|m| *m == "new-trigger").count(),
+            delivered.iter().filter(|e| e.json == "new-trigger").count(),
             1,
             "the actual trigger message must not be recorded twice"
         );
@@ -4809,15 +4993,15 @@ mod send_input_tests {
             let mut inner = c.inner.lock().unwrap();
             inner.stdin_tx = Some(tx);
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("second".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(2, "second".to_string()));
             // Simulates poison_resume having ALREADY promoted the tentative
             // retry to confirmed before the drain got to "second".
             let generation = inner.spawn_generation;
             inner.apply_resume_event(persistent_resume::ResumeEvent::SpawnedWithResume {
                 generation,
                 attempted_sid: "sid".to_string(),
-                retry: persistent_resume::RetryPayload { config: retry_config.clone(), messages: vec!["first".to_string()] },
+                retry: persistent_resume::RetryPayload { config: retry_config.clone(), messages: vec![qentry(1, "first")] },
             });
             inner.apply_resume_event(persistent_resume::ResumeEvent::ResumeUnreachable {
                 generation,
@@ -4840,7 +5024,7 @@ mod send_input_tests {
         };
         assert_eq!(
             delivered,
-            &vec!["first".to_string(), "second".to_string()],
+            &vec![qentry(1, "first"), qentry(2, "second")],
             "must still be tracking this spawn's delivered messages, even though it was already confirmed"
         );
     }
@@ -4853,8 +5037,8 @@ mod send_input_tests {
     #[test]
     fn decide_retry_batch_action_enqueues_the_whole_batch_atomically() {
         let c = controller();
-        let action = c.decide_retry_batch_action("first", &["second".to_string(), "third".to_string()]);
-        assert!(matches!(action, SendAction::BecomeSpawner));
+        let action = c.decide_retry_batch_action(&qentry(1, "first"), &[qentry(2, "second"), qentry(3, "third")]);
+        assert!(matches!(action, SendAction::BecomeSpawner { .. }));
         let inner = c.inner.lock().unwrap();
         assert_eq!(
             inner.pending_send_messages.iter().cloned().collect::<Vec<_>>(),
@@ -4873,7 +5057,7 @@ mod send_input_tests {
         c.inner.lock().unwrap().spawning_in_progress = true;
 
         let action =
-            c.decide_retry_batch_action("hello", &["hello".to_string(), "hello".to_string()]);
+            c.decide_retry_batch_action(&qentry(1, "hello"), &[qentry(2, "hello"), qentry(3, "hello")]);
 
         assert!(matches!(action, SendAction::Queued));
         let inner = c.inner.lock().unwrap();
@@ -4893,16 +5077,20 @@ mod send_input_tests {
         {
             let mut inner = c.inner.lock().unwrap();
             inner.spawning_in_progress = true;
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("first".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "first".to_string()));
         }
 
-        let action = c.decide_retry_batch_action("first", &["second".to_string()]);
+        let action = c.decide_retry_batch_action(&qentry(1, "first"), &[qentry(2, "second")]);
 
         assert!(matches!(action, SendAction::Queued));
         let inner = c.inner.lock().unwrap();
         assert_eq!(
-            inner.pending_send_messages.iter().cloned().collect::<Vec<_>>(),
-            vec!["first".to_string(), "second".to_string()],
+            inner
+                .pending_send_messages
+                .iter()
+                .map(|m| (m.seq, m.json_str.clone()))
+                .collect::<Vec<_>>(),
+            vec![(1, "first".to_string()), (2, "second".to_string())],
             "the already-queued first entry must not be duplicated, but the rest of the batch must still be appended"
         );
     }
@@ -4923,10 +5111,10 @@ mod send_input_tests {
             // started, while the retry's own trigger ("A") had already
             // been popped and delivered (and is no longer in the queue —
             // it's now tracked only in the confirmed retry batch).
-            inner.pending_send_messages.push_back(QueuedMessage::fresh("later-message".to_string()));
+            inner.pending_send_messages.push_back(QueuedMessage::fresh(1, "later-message".to_string()));
         }
 
-        let action = c.decide_retry_batch_action("A", &[]);
+        let action = c.decide_retry_batch_action(&qentry(2, "A"), &[]);
 
         assert!(matches!(action, SendAction::Queued));
         let inner = c.inner.lock().unwrap();
@@ -4963,6 +5151,7 @@ mod resume_poison_tests {
             resume: persistent_resume::ResumeState::default(),
             spawning_in_progress: false,
             pending_send_messages: VecDeque::new(),
+            next_message_seq: 0,
             drain_send_in_flight: false,
             current_pid: None,
             stdin_tx: None,
@@ -4986,11 +5175,62 @@ mod resume_poison_tests {
     }
 
     fn spawned_with_resume(inner: &mut PersistentInner, generation: u64, attempted_sid: &str) {
+        // Mirror production's invariant (`spawn_process` bumps
+        // `spawn_generation` in the same lock acquisition that applies
+        // the spawn event): ambient adoption in `try_capture_session_id`
+        // is gated on generation currency (issue #2366), so a helper
+        // that left `spawn_generation` at 0 would make every capture
+        // look stale.
+        inner.spawn_generation = generation;
         inner.apply_resume_event(persistent_resume::ResumeEvent::SpawnedWithResume {
             generation,
             attempted_sid: attempted_sid.to_string(),
-            retry: persistent_resume::RetryPayload { config: dummy_spawn_config(), messages: vec!["{}".to_string()] },
+            retry: persistent_resume::RetryPayload { config: dummy_spawn_config(), messages: vec![persistent_resume::QueuedRetryEntry { seq: 1, json: "{}".to_string() }] },
         });
+    }
+
+    /// Issue #2366 regression: a superseded generation's still-draining
+    /// stdout reader must not re-install its stale sid into ambient
+    /// `session_id` after a fallback respawn's plain clear.
+    /// `respawn_once_for_leftover_queue` deliberately does NOT poison
+    /// (the death may be unrelated to a stale resume — see its round-13
+    /// comment), so `resume_poisoned` cannot catch this echo; only the
+    /// generation gate can.
+    #[test]
+    fn a_stale_generations_capture_does_not_adopt_into_ambient_session_id() {
+        let mut inner = inner_with_session_id(Some("stale-sid"));
+        spawned_with_resume(&mut inner, 1, "stale-sid");
+
+        // The gen-1 process died; the fallback respawn cleared the
+        // ambient sid and spawned gen 2 fresh (no --resume, so no new
+        // resume tracking).
+        inner.session_id = None;
+        inner.spawn_generation = 2;
+        inner.apply_resume_event(persistent_resume::ResumeEvent::SpawnedFresh { generation: 2 });
+
+        // Gen 1's stdout reader finally drains its buffered echo of the
+        // stale attempted sid.
+        let (adopted, _effects) = inner.try_capture_session_id("stale-sid", 1, false);
+
+        assert!(!adopted, "a superseded generation's echo must not be adopted");
+        assert_eq!(
+            inner.session_id, None,
+            "ambient session_id must stay clear for the live generation's own capture"
+        );
+    }
+
+    /// Control case for the gate above: the CURRENT generation's capture
+    /// into a cleared ambient sid must still adopt normally.
+    #[test]
+    fn the_current_generations_capture_still_adopts_after_a_clear() {
+        let mut inner = inner_with_session_id(None);
+        inner.spawn_generation = 2;
+        inner.apply_resume_event(persistent_resume::ResumeEvent::SpawnedFresh { generation: 2 });
+
+        let (adopted, _effects) = inner.try_capture_session_id("fresh-sid", 2, false);
+
+        assert!(adopted, "the live generation's first capture must adopt");
+        assert_eq!(inner.session_id.as_deref(), Some("fresh-sid"));
     }
 
     // stderr wins the race: poisons the id and clears it from session_id,
@@ -5011,6 +5251,9 @@ mod resume_poison_tests {
     #[test]
     fn stdout_first_then_stderr_poison_still_clears() {
         let mut inner = inner_with_session_id(None);
+        // A capture for generation 1 can only originate from a gen-1
+        // spawn's own reader task (issue #2366's currency gate).
+        inner.spawn_generation = 1;
         let (captured, _effects) = inner.try_capture_session_id("dead-sid", 1, true);
         assert!(captured, "first capture with no prior state succeeds");
         assert_eq!(inner.session_id.as_deref(), Some("dead-sid"));
@@ -5024,6 +5267,9 @@ mod resume_poison_tests {
     #[test]
     fn different_fresh_session_id_is_captured_normally() {
         let mut inner = inner_with_session_id(None);
+        // A capture for generation 1 can only originate from a gen-1
+        // spawn's own reader task (issue #2366's currency gate).
+        inner.spawn_generation = 1;
         inner.poison_resume("dead-sid", 1);
 
         let (captured, _effects) = inner.try_capture_session_id("fresh-sid", 1, true);

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -265,6 +265,14 @@ struct PersistentInner {
     /// dedup a spawn-claim race, a job `spawning_in_progress` now fully
     /// owns. This counter exists for a different, narrower purpose: giving
     /// `stop_requested_generation` something stable to compare against.
+    ///
+    /// ALSO bumped (without a spawn) by
+    /// `clear_session_id_for_fresh_spawn` to atomically retire every
+    /// existing generation's reader tasks alongside a session-id clear —
+    /// see its doc comment (codex P1 on PR #2500, second round). The
+    /// resulting numbering gap is deliberate and inert: generations are
+    /// only ever compared for equality; the invariant is "never reused,"
+    /// not "no gaps."
     spawn_generation: u64,
     /// AskUserQuestion `can_use_tool` control_requests awaiting a user answer:
     /// `tool_use_id -> (request_id, questions JSON)`. Filled by the stdout
@@ -1113,6 +1121,37 @@ impl PersistentSubprocessController {
     /// function never pops anything itself — it isn't tied to a specific
     /// message the way the original spawn attempt was), so a genuinely
     /// later, unrelated send will still eventually pick it up.
+    /// Atomically clears the ambient session id AND reserves a fresh
+    /// spawn generation, so every reader task belonging to any EXISTING
+    /// generation is stale from this point on. Used by both fresh-start
+    /// respawn paths (`respawn_once_for_leftover_queue`,
+    /// `retry_after_resume_failure`'s `BecomeSpawner` arm) in place of a
+    /// bare `session_id = None`.
+    ///
+    /// codex P1 on PR #2500 (second round): clearing alone left a window
+    /// — until `spawn_process`'s own generation bump, which happens AFTER
+    /// the `--resume` decision reads `session_id` and after the process
+    /// is spawned — where the dying generation still equaled
+    /// `spawn_generation`, so its stdout reader's stale-sid echo passed
+    /// `try_capture_session_id`'s currency gate (issue #2366) and was
+    /// re-adopted: the supposedly fresh spawn could reattach
+    /// `--resume <stale-sid>` with no retry payload armed to catch the
+    /// repeat failure. Reserving the next generation in the same lock
+    /// acquisition as the clear closes the whole window.
+    ///
+    /// The reserved generation is never itself spawned (`spawn_process`
+    /// bumps again) — see `spawn_generation`'s doc comment for why the
+    /// gap is inert. A `stop_process` racing into the reserve window
+    /// records a `StopRequested` for the never-spawned generation, which
+    /// the resume state machine ignores; both callers only reach this
+    /// point after the prior generation's tracking has already resolved,
+    /// so no stop-intent is lost that wasn't equally lost before.
+    fn clear_session_id_for_fresh_spawn(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.spawn_generation += 1;
+        inner.session_id = None;
+    }
+
     fn respawn_once_for_leftover_queue(&self, mut config: PersistentSpawnConfig) {
         config.session_id = String::new();
         // reagentx P0 on PR #2360 (sixth review pass, round 11): clearing
@@ -1156,10 +1195,13 @@ impl PersistentSubprocessController {
         // affects THIS respawn's own `--resume` decision (already forced
         // empty via `config.session_id` above) and carries no such
         // permanent, over-broad risk. The narrower race the poisoning was
-        // meant to close is real but far rarer than the cases above;
-        // tracked as a documented follow-up instead of reintroducing this
-        // regression.
-        self.inner.lock().unwrap().session_id = None;
+        // meant to close — a still-racing reader task from the doomed
+        // process re-capturing the same sid right after a plain clear —
+        // is now closed WITHOUT poisoning: the clear also reserves a
+        // fresh spawn generation, making every existing generation's
+        // capture stale to `try_capture_session_id`'s currency gate (see
+        // `clear_session_id_for_fresh_spawn`'s own doc comment).
+        self.clear_session_id_for_fresh_spawn();
         let retry_config = config.clone();
         let spawn_result = self.spawn_process(config, None);
         match &spawn_result {
@@ -1555,7 +1597,10 @@ impl PersistentSubprocessController {
                 // `DeliverDirect` or `Queued` above — breaking in-memory
                 // session tracking and turn-end subagent reconciliation
                 // for that process's remaining lifetime.
-                self.inner.lock().unwrap().session_id = None;
+                // Clear + reserve a fresh generation in one lock
+                // acquisition (same race as the leftover-queue fallback —
+                // see `clear_session_id_for_fresh_spawn`).
+                self.clear_session_id_for_fresh_spawn();
                 let retry_config = config.clone();
                 let spawn_result = self.spawn_process(config, None);
                 match &spawn_result {
@@ -3592,6 +3637,38 @@ mod send_input_tests {
     /// (issue #2365 — retry batches carry identity, not just text).
     fn qentry(seq: u64, json: &str) -> persistent_resume::QueuedRetryEntry {
         persistent_resume::QueuedRetryEntry { seq, json: json.to_string() }
+    }
+
+    /// codex P1 on PR #2500 (second round): the fresh-start clear must
+    /// retire every existing generation IN THE SAME lock acquisition —
+    /// a bare `session_id = None` left the dying generation still equal
+    /// to `spawn_generation` until `spawn_process`'s own (later) bump,
+    /// so its stdout reader's stale echo passed the #2366 currency gate
+    /// during exactly the window where `spawn_process` reads
+    /// `session_id` for the `--resume` decision.
+    #[test]
+    fn fresh_spawn_clear_makes_the_dying_generations_capture_stale_immediately() {
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.spawn_generation = 1;
+            inner.session_id = Some("stale-sid".to_string());
+        }
+
+        // The fallback/retry path clears — BEFORE any new spawn exists.
+        c.clear_session_id_for_fresh_spawn();
+
+        // The gen-1 reader's buffered echo lands in the pre-spawn window.
+        let mut inner = c.inner.lock().unwrap();
+        let (adopted, _) = inner.try_capture_session_id("stale-sid", 1, false);
+
+        assert!(
+            !adopted,
+            "the dying generation must be stale from the instant of the clear, \
+             not only after spawn_process's own later bump"
+        );
+        assert_eq!(inner.session_id, None, "the fresh spawn must not see a --resume sid");
+        assert_eq!(inner.spawn_generation, 2, "the clear reserves the next generation");
     }
 
     // codex P1 on PR #2360 (round 16, commit ce1642d90): `stop_process`

--- a/agentmux-srv/src/backend/blockcontroller/persistent_resume.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent_resume.rs
@@ -35,6 +35,21 @@
 
 use super::persistent::PersistentSpawnConfig;
 
+/// One redeliverable stdin message in a [`RetryPayload`] batch: the
+/// formatted JSON plus its queue identity.
+///
+/// `seq` is the message's `QueuedMessage::seq` (issue #2365): assigned
+/// once from the controller's monotonic counter at first enqueue and
+/// preserved across redelivery, so every "is this message already
+/// queued / is this the seeded message" check is exact identity, never
+/// content equality — two genuinely different messages with identical
+/// text (two "yes" replies) can no longer be conflated.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct QueuedRetryEntry {
+    pub seq: u64,
+    pub json: String,
+}
+
 /// The spawn config + the growing batch of stdin messages to redeliver if
 /// this generation's `--resume` turns out to be stale. Named separately
 /// from the state enum so `MessageAppendedToRetryBatch` can grow it in
@@ -42,7 +57,7 @@ use super::persistent::PersistentSpawnConfig;
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct RetryPayload {
     pub config: PersistentSpawnConfig,
-    pub messages: Vec<String>,
+    pub messages: Vec<QueuedRetryEntry>,
 }
 
 /// One spawn attempt's resume/error-line lifecycle.
@@ -110,20 +125,24 @@ impl Default for ResumeState {
 }
 
 impl ResumeState {
-    /// Read-only accessor for the drain: is `delivered` the exact message
-    /// `spawn_process` originally seeded the retry batch with (its first
-    /// entry), for the given `generation`? Used to identify the
-    /// already-recorded seed by content (not position) before appending
-    /// any LATER message the drain delivers — see
+    /// Read-only accessor for the drain: is `delivered_seq` the exact
+    /// message `spawn_process` originally seeded the retry batch with
+    /// (its first entry), for the given `generation`? Used to identify
+    /// the already-recorded seed before appending any LATER message the
+    /// drain delivers. Matched by queue identity (`QueuedRetryEntry::seq`),
+    /// neither by position (see
     /// `PersistentSubprocessController::drain_queue_after_successful_spawn`'s
-    /// own doc comment for why content, not position, is what's checked.
-    pub(super) fn is_seeded_message(&self, generation: u64, delivered: &str) -> bool {
+    /// own doc comment for why the front of the queue isn't necessarily
+    /// the seed) nor by content (issue #2365 — a later, genuinely
+    /// different delivery sharing identical text must not be mistaken
+    /// for the seed).
+    pub(super) fn is_seeded_message(&self, generation: u64, delivered_seq: u64) -> bool {
         match self {
             ResumeState::AwaitingOutcome { generation: g, retry, .. }
             | ResumeState::ConfirmedRetry { generation: g, retry, .. }
                 if *g == generation =>
             {
-                retry.messages.first().map(String::as_str) == Some(delivered)
+                retry.messages.first().map(|e| e.seq) == Some(delivered_seq)
             }
             _ => false,
         }
@@ -166,7 +185,7 @@ pub(super) enum ResumeEvent {
     /// The drain appended another message to this generation's retry
     /// batch before it was known to be doomed (or after it was
     /// confirmed doomed but before the process actually exited).
-    MessageAppendedToRetryBatch { generation: u64, json: String },
+    MessageAppendedToRetryBatch { generation: u64, entry: QueuedRetryEntry },
     /// stderr reader saw "No conversation found" for this exact sid.
     ResumeUnreachable { generation: u64, sid: String },
     /// stdout reader saw a terminal `result`/`is_error:true` line.
@@ -368,9 +387,9 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
         // redelivered).
         (
             ResumeState::AwaitingOutcome { generation, attempted_sid, mut retry, held_error_line, stop_requested },
-            ResumeEvent::MessageAppendedToRetryBatch { generation: g, json },
+            ResumeEvent::MessageAppendedToRetryBatch { generation: g, entry },
         ) if generation == g => {
-            retry.messages.push(json);
+            retry.messages.push(entry);
             (
                 ResumeState::AwaitingOutcome { generation, attempted_sid, retry, held_error_line, stop_requested },
                 vec![],
@@ -378,9 +397,9 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
         }
         (
             ResumeState::ConfirmedRetry { generation, attempted_sid, mut retry, held_error_line, stop_requested },
-            ResumeEvent::MessageAppendedToRetryBatch { generation: g, json },
+            ResumeEvent::MessageAppendedToRetryBatch { generation: g, entry },
         ) if generation == g => {
-            retry.messages.push(json);
+            retry.messages.push(entry);
             (ResumeState::ConfirmedRetry { generation, attempted_sid, retry, held_error_line, stop_requested }, vec![])
         }
 
@@ -578,8 +597,14 @@ mod tests {
         }
     }
 
+    /// Shorthand for a retry-batch entry with an explicit queue seq
+    /// (issue #2365 — retry batches carry identity, not just text).
+    fn qentry(seq: u64, json: &str) -> QueuedRetryEntry {
+        QueuedRetryEntry { seq, json: json.to_string() }
+    }
+
     fn dummy_retry() -> RetryPayload {
-        RetryPayload { config: dummy_config(), messages: vec!["{}".to_string()] }
+        RetryPayload { config: dummy_config(), messages: vec![qentry(1, "{}")] }
     }
 
     fn spawned_with_resume(generation: u64) -> ResumeState {
@@ -820,11 +845,11 @@ mod tests {
     fn message_appended_while_awaiting_outcome_grows_the_batch() {
         let state = spawned_with_resume(1);
         let (state, effects) =
-            update(state, ResumeEvent::MessageAppendedToRetryBatch { generation: 1, json: "{\"m\":2}".to_string() });
+            update(state, ResumeEvent::MessageAppendedToRetryBatch { generation: 1, entry: qentry(2, "{\"m\":2}") });
         assert!(effects.is_empty());
         match state {
             ResumeState::AwaitingOutcome { retry, .. } => {
-                assert_eq!(retry.messages, vec!["{}".to_string(), "{\"m\":2}".to_string()])
+                assert_eq!(retry.messages, vec![qentry(1, "{}"), qentry(2, "{\"m\":2}")])
             }
             other => panic!("expected AwaitingOutcome, got {other:?}"),
         }
@@ -841,11 +866,11 @@ mod tests {
         let (state, _) =
             update(state, ResumeEvent::ResumeUnreachable { generation: 1, sid: "dead-sid".to_string() });
         let (state, effects) =
-            update(state, ResumeEvent::MessageAppendedToRetryBatch { generation: 1, json: "{\"m\":2}".to_string() });
+            update(state, ResumeEvent::MessageAppendedToRetryBatch { generation: 1, entry: qentry(2, "{\"m\":2}") });
         assert!(effects.is_empty());
         match state {
             ResumeState::ConfirmedRetry { retry, .. } => {
-                assert_eq!(retry.messages, vec!["{}".to_string(), "{\"m\":2}".to_string()])
+                assert_eq!(retry.messages, vec![qentry(1, "{}"), qentry(2, "{\"m\":2}")])
             }
             other => panic!("expected ConfirmedRetry, got {other:?}"),
         }
@@ -995,7 +1020,7 @@ mod tests {
         assert!(effects.is_empty(), "an ambiguous echo must not flush or fire anything");
         match &state {
             ResumeState::ConfirmedRetry { retry, .. } => {
-                assert_eq!(retry.messages, vec!["{}".to_string()], "the confirmed retry must survive intact")
+                assert_eq!(retry.messages, vec![qentry(1, "{}")], "the confirmed retry must survive intact")
             }
             other => panic!("expected the confirmed retry to survive an ambiguous echo, got {other:?}"),
         }

--- a/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
+++ b/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
@@ -111,6 +111,60 @@ pub fn clear_active_pid(wstore: &Arc<Store>, block_id: &str) {
     }
 }
 
+/// Clear `session:active_pid` **only if it still equals `expected_pid`** —
+/// a transactional compare-and-clear for exit-handlers that know which
+/// process instance they are cleaning up after.
+///
+/// Issue #2363: `PersistentSubprocessController`'s fallback respawn
+/// (`respawn_once_for_leftover_queue`) runs on a separate tokio task from
+/// the dying process's own exit-handler. The exit-handler's cleanup is
+/// gated on a spawn-generation check, but that gate is read once under the
+/// controller's lock while the fallback registers its own fresh PID in
+/// parallel — the unconditional [`clear_active_pid`] could then wipe the
+/// NEW process's registration, leaving it untracked for crash recovery
+/// until the next natural re-registration. The whole read-compare-clear
+/// here runs inside one `Store::with_tx` (a single connection lock across
+/// read+merge+write — see `object_helpers::update_object_meta`'s doc
+/// comment for the transactional contract), so a concurrent
+/// [`mark_active_pid`] strictly serializes against it: whichever commits
+/// second sees the other's completed write, and a mismatch means "a newer
+/// process already registered — leave it alone."
+///
+/// Best-effort like the unconditional variant: logs on failure, never
+/// panics. Returns nothing — callers do not branch on the outcome.
+pub fn clear_active_pid_if_pid(wstore: &Arc<Store>, block_id: &str, expected_pid: u32) {
+    let block_id_owned = block_id.to_string();
+    let result = wstore.with_tx(|tx| {
+        let mut block = tx.must_get::<Block>(&block_id_owned)?;
+        let current = block
+            .meta
+            .get(META_SESSION_ACTIVE_PID)
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if current != expected_pid as u64 {
+            // A newer process re-registered (or the pid was already
+            // cleared) — not ours to clear.
+            return Ok(false);
+        }
+        block.meta.remove(META_SESSION_ACTIVE_PID);
+        tx.update(&mut block)?;
+        Ok(true)
+    });
+    match result {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::info!(
+                block_id = %block_id,
+                expected_pid = expected_pid,
+                "session_recovery: active pid changed since this process registered — skipping clear"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(block_id = %block_id, error = %e, "session_recovery: compare-and-clear active pid failed");
+        }
+    }
+}
+
 /// Scan all blocks at server startup. For any agent block that still has
 /// `session:active_pid` set, transfer the flag to `session:was_interrupted`.
 ///

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -105,6 +105,20 @@ impl Handler {
         block_id: &str,
         tab_id: Option<&str>,
     ) -> Result<(), String> {
+        self.register_agent_generated(agent_id, block_id, tab_id, 0)
+    }
+
+    /// [`register_agent`], recording the registering persistent-controller
+    /// spawn's generation so its own exit-handler can later
+    /// compare-and-remove ([`unregister_block_if_generation`]) instead of
+    /// blindly wiping a fallback respawn's fresh registration (issue #2363).
+    pub fn register_agent_generated(
+        &mut self,
+        agent_id: &str,
+        block_id: &str,
+        tab_id: Option<&str>,
+        spawn_generation: u64,
+    ) -> Result<(), String> {
         if !validate_agent_id(agent_id) {
             return Err(format!("invalid agent ID: {}", agent_id));
         }
@@ -135,6 +149,7 @@ impl Handler {
                 tab_id: tab_id.map(|s| s.to_string()),
                 registered_at: now,
                 last_seen: now,
+                spawn_generation,
             },
         );
 
@@ -156,6 +171,40 @@ impl Handler {
             self.agent_to_block.remove(&agent_id);
             self.agent_info.remove(&agent_id);
         }
+    }
+
+    /// Unregister by block ID **only if** the current registration was
+    /// written by the spawn with `expected_generation` — a
+    /// compare-and-remove for persistent-controller exit-handlers (issue
+    /// #2363: the handler's `is_current_generation` gate is read once,
+    /// while a fallback respawn re-registers on a parallel task; an
+    /// unconditional [`unregister_block`] here could wipe the NEW spawn's
+    /// registration, leaving the live agent invisible to Tier-1 delivery
+    /// with nothing left to re-register it). Runs atomically under the
+    /// handler's own lock (via the outer wrapper). A registration with no
+    /// recorded generation (0 — HTTP/PTY paths) is never removed by this
+    /// variant: leaving a stale entry to the TTL sweep is strictly safer
+    /// than deleting a live one.
+    ///
+    /// Returns true if the registration was ours and was removed.
+    pub fn unregister_block_if_generation(&mut self, block_id: &str, expected_generation: u64) -> bool {
+        let Some(agent_id) = self.block_to_agent.get(block_id) else {
+            return false;
+        };
+        let matches = self
+            .agent_info
+            .get(agent_id)
+            .is_some_and(|info| expected_generation != 0 && info.spawn_generation == expected_generation);
+        if !matches {
+            tracing::info!(
+                block_id = %block_id,
+                expected_generation = expected_generation,
+                "reactive: registration generation changed since this spawn registered — skipping unregister"
+            );
+            return false;
+        }
+        self.unregister_block(block_id);
+        true
     }
 
     /// Update the last_seen timestamp for an agent.
@@ -542,12 +591,35 @@ impl ReactiveHandler {
             .register_agent(agent_id, block_id, tab_id)
     }
 
+    /// See the inner [`Handler::register_agent_generated`].
+    pub fn register_agent_generated(
+        &self,
+        agent_id: &str,
+        block_id: &str,
+        tab_id: Option<&str>,
+        spawn_generation: u64,
+    ) -> Result<(), String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .register_agent_generated(agent_id, block_id, tab_id, spawn_generation)
+    }
+
     pub fn unregister_agent(&self, agent_id: &str) {
         self.inner.lock().unwrap().unregister_agent(agent_id);
     }
 
     pub fn unregister_block(&self, block_id: &str) {
         self.inner.lock().unwrap().unregister_block(block_id);
+    }
+
+    /// See the inner [`Handler::unregister_block_if_generation`] — atomic
+    /// compare-and-remove under the handler lock (issue #2363).
+    pub fn unregister_block_if_generation(&self, block_id: &str, expected_generation: u64) -> bool {
+        self.inner
+            .lock()
+            .unwrap()
+            .unregister_block_if_generation(block_id, expected_generation)
     }
 
     /// Return the logical agent_id currently mapped to this block, if any.

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -105,19 +105,21 @@ impl Handler {
         block_id: &str,
         tab_id: Option<&str>,
     ) -> Result<(), String> {
-        self.register_agent_generated(agent_id, block_id, tab_id, 0)
+        self.register_agent_with_nonce(agent_id, block_id, tab_id, 0)
     }
 
     /// [`register_agent`], recording the registering persistent-controller
-    /// spawn's generation so its own exit-handler can later
-    /// compare-and-remove ([`unregister_block_if_generation`]) instead of
-    /// blindly wiping a fallback respawn's fresh registration (issue #2363).
-    pub fn register_agent_generated(
+    /// spawn's process-wide registration nonce
+    /// (`AgentRegistration::registration_nonce`) so its own exit-handler
+    /// can later compare-and-remove ([`unregister_block_if_nonce`])
+    /// instead of blindly wiping a fallback respawn's fresh registration
+    /// (issue #2363).
+    pub fn register_agent_with_nonce(
         &mut self,
         agent_id: &str,
         block_id: &str,
         tab_id: Option<&str>,
-        spawn_generation: u64,
+        registration_nonce: u64,
     ) -> Result<(), String> {
         if !validate_agent_id(agent_id) {
             return Err(format!("invalid agent ID: {}", agent_id));
@@ -149,7 +151,7 @@ impl Handler {
                 tab_id: tab_id.map(|s| s.to_string()),
                 registered_at: now,
                 last_seen: now,
-                spawn_generation,
+                registration_nonce,
             },
         );
 
@@ -174,32 +176,35 @@ impl Handler {
     }
 
     /// Unregister by block ID **only if** the current registration was
-    /// written by the spawn with `expected_generation` — a
+    /// written by the spawn with `expected_nonce` — a
     /// compare-and-remove for persistent-controller exit-handlers (issue
     /// #2363: the handler's `is_current_generation` gate is read once,
     /// while a fallback respawn re-registers on a parallel task; an
     /// unconditional [`unregister_block`] here could wipe the NEW spawn's
     /// registration, leaving the live agent invisible to Tier-1 delivery
-    /// with nothing left to re-register it). Runs atomically under the
-    /// handler's own lock (via the outer wrapper). A registration with no
-    /// recorded generation (0 — HTTP/PTY paths) is never removed by this
-    /// variant: leaving a stale entry to the TTL sweep is strictly safer
-    /// than deleting a live one.
+    /// with nothing left to re-register it). The nonce is process-wide
+    /// unique, so the guard also holds across controller replacement
+    /// (`resync_controller` — codex P1 on PR #2500), where a
+    /// controller-local generation would restart at 1 and collide. Runs
+    /// atomically under the handler's own lock (via the outer wrapper).
+    /// A registration with no recorded nonce (0 — HTTP/PTY paths) is
+    /// never removed by this variant: leaving a stale entry to the TTL
+    /// sweep is strictly safer than deleting a live one.
     ///
     /// Returns true if the registration was ours and was removed.
-    pub fn unregister_block_if_generation(&mut self, block_id: &str, expected_generation: u64) -> bool {
+    pub fn unregister_block_if_nonce(&mut self, block_id: &str, expected_nonce: u64) -> bool {
         let Some(agent_id) = self.block_to_agent.get(block_id) else {
             return false;
         };
         let matches = self
             .agent_info
             .get(agent_id)
-            .is_some_and(|info| expected_generation != 0 && info.spawn_generation == expected_generation);
+            .is_some_and(|info| expected_nonce != 0 && info.registration_nonce == expected_nonce);
         if !matches {
             tracing::info!(
                 block_id = %block_id,
-                expected_generation = expected_generation,
-                "reactive: registration generation changed since this spawn registered — skipping unregister"
+                expected_nonce = expected_nonce,
+                "reactive: registration changed hands since this spawn registered — skipping unregister"
             );
             return false;
         }
@@ -591,18 +596,18 @@ impl ReactiveHandler {
             .register_agent(agent_id, block_id, tab_id)
     }
 
-    /// See the inner [`Handler::register_agent_generated`].
-    pub fn register_agent_generated(
+    /// See the inner [`Handler::register_agent_with_nonce`].
+    pub fn register_agent_with_nonce(
         &self,
         agent_id: &str,
         block_id: &str,
         tab_id: Option<&str>,
-        spawn_generation: u64,
+        registration_nonce: u64,
     ) -> Result<(), String> {
         self.inner
             .lock()
             .unwrap()
-            .register_agent_generated(agent_id, block_id, tab_id, spawn_generation)
+            .register_agent_with_nonce(agent_id, block_id, tab_id, registration_nonce)
     }
 
     pub fn unregister_agent(&self, agent_id: &str) {
@@ -613,13 +618,13 @@ impl ReactiveHandler {
         self.inner.lock().unwrap().unregister_block(block_id);
     }
 
-    /// See the inner [`Handler::unregister_block_if_generation`] — atomic
+    /// See the inner [`Handler::unregister_block_if_nonce`] — atomic
     /// compare-and-remove under the handler lock (issue #2363).
-    pub fn unregister_block_if_generation(&self, block_id: &str, expected_generation: u64) -> bool {
+    pub fn unregister_block_if_nonce(&self, block_id: &str, expected_nonce: u64) -> bool {
         self.inner
             .lock()
             .unwrap()
-            .unregister_block_if_generation(block_id, expected_generation)
+            .unregister_block_if_nonce(block_id, expected_nonce)
     }
 
     /// Return the logical agent_id currently mapped to this block, if any.

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -48,18 +48,21 @@ pub struct AgentEntry {
     /// `docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md`.
     #[serde(default)]
     pub channel: String,
-    /// Spawn generation of the persistent-controller process this entry
-    /// was written for; 0 = not recorded (HTTP register handler, PTY
-    /// shell auto-register, pre-existing entries). Real generations are
-    /// always ≥ 1. Lets an exit-handler's cleanup compare-and-remove
-    /// ([`remove_if_generation`]) instead of deleting a fallback
-    /// respawn's fresh entry (issue #2363).
+    /// Process-wide unique nonce of the persistent-controller spawn this
+    /// entry was written for; 0 = not recorded (HTTP register handler,
+    /// PTY shell auto-register, pre-existing entries). Real nonces are
+    /// always ≥ 1, drawn from a single srv-wide counter — NOT the
+    /// controller-local spawn generation, which restarts for a
+    /// replacement controller and could collide across controller
+    /// instances (codex P1 on PR #2500). Lets an exit-handler's cleanup
+    /// compare-and-remove ([`remove_if_nonce`]) instead of deleting a
+    /// fallback respawn's fresh entry (issue #2363).
     #[serde(default)]
-    pub spawn_generation: u64,
+    pub registration_nonce: u64,
 }
 
 /// Serializes this process's own read-compare-remove sequences
-/// ([`remove_if_generation`] / [`remove_shared_if_generation`]) against
+/// ([`remove_if_nonce`] / [`remove_shared_if_nonce`]) against
 /// its own writes. Both the racing writer (a fallback respawn's
 /// re-registration) and the racing remover (the dying spawn's
 /// exit-handler) live in this same agentmux-srv process — each per-agent
@@ -119,17 +122,17 @@ fn agent_path(data_dir: &Path, agent_id: &str) -> PathBuf {
 /// existing `authkey.dev` file). On Windows, default ACLs inherit
 /// user-only on user-owned directories.
 pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
-    write_generated(data_dir, agent_id, local_url, block_id, 0);
+    write_with_nonce(data_dir, agent_id, local_url, block_id, 0);
 }
 
 /// [`write`], recording the registering persistent-controller spawn's
-/// generation — see `AgentEntry::spawn_generation` / issue #2363.
-pub fn write_generated(
+/// registration nonce — see `AgentEntry::registration_nonce` / issue #2363.
+pub fn write_with_nonce(
     data_dir: &Path,
     agent_id: &str,
     local_url: &str,
     block_id: &str,
-    spawn_generation: u64,
+    registration_nonce: u64,
 ) {
     let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let dir = agents_dir(data_dir);
@@ -144,7 +147,7 @@ pub fn write_generated(
         // Empty for entries in the per-channel registry — see the field's
         // doc comment on `AgentEntry`.
         channel: String::new(),
-        spawn_generation,
+        registration_nonce,
     };
     let path = agent_path(data_dir, agent_id);
     let Ok(json) = serde_json::to_string(&entry) else { return };
@@ -169,21 +172,23 @@ pub fn remove(data_dir: &Path, agent_id: &str) {
 }
 
 /// Remove an agent entry **only if** it was written by the spawn with
-/// `expected_generation` — compare-and-remove for persistent-controller
-/// exit-handlers (issue #2363). An entry with no recorded generation
+/// `expected_nonce` — compare-and-remove for persistent-controller
+/// exit-handlers (issue #2363; nonce is process-wide unique, so the
+/// guard holds across controller replacement too — codex P1 on PR
+/// #2500). An entry with no recorded nonce
 /// (0) is never removed by this variant: leaving a stale file to the
 /// TTL sweep ([`cleanup_stale`]) is strictly safer than deleting a live
 /// registration. Atomic w.r.t. this process's own writes via
 /// [`REGISTRY_OP_LOCK`].
-pub fn remove_if_generation(data_dir: &Path, agent_id: &str, expected_generation: u64) {
+pub fn remove_if_nonce(data_dir: &Path, agent_id: &str, expected_nonce: u64) {
     let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let matches = lookup(data_dir, agent_id)
-        .is_some_and(|e| expected_generation != 0 && e.spawn_generation == expected_generation);
+        .is_some_and(|e| expected_nonce != 0 && e.registration_nonce == expected_nonce);
     if !matches {
         tracing::info!(
             agent_id = %agent_id,
-            expected_generation = expected_generation,
-            "registry: entry generation changed since this spawn registered — skipping remove"
+            expected_nonce = expected_nonce,
+            "registry: entry changed hands since this spawn registered — skipping remove"
         );
         return;
     }
@@ -303,18 +308,18 @@ fn pid_alive(pid: u32) -> bool {
 /// concurrent writers for different channels of the same agent name
 /// cannot race or clobber each other.
 pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id: &str, channel: &str) {
-    write_shared_generated(shared_dir, agent_id, local_url, block_id, channel, 0);
+    write_shared_with_nonce(shared_dir, agent_id, local_url, block_id, channel, 0);
 }
 
 /// [`write_shared`], recording the registering persistent-controller
-/// spawn's generation — see `AgentEntry::spawn_generation` / issue #2363.
-pub fn write_shared_generated(
+/// spawn's registration nonce — see `AgentEntry::registration_nonce` / issue #2363.
+pub fn write_shared_with_nonce(
     shared_dir: &Path,
     agent_id: &str,
     local_url: &str,
     block_id: &str,
     channel: &str,
-    spawn_generation: u64,
+    registration_nonce: u64,
 ) {
     let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let dir = shared_agent_dir(shared_dir, agent_id);
@@ -328,7 +333,7 @@ pub fn write_shared_generated(
         updated_at: now_unix_millis(),
         auth_key: local_auth_key().to_string(),
         channel: channel.to_string(),
-        spawn_generation,
+        registration_nonce,
     };
     write_entry_file(&path, &entry);
 }
@@ -345,28 +350,28 @@ pub fn remove_shared(shared_dir: &Path, agent_id: &str, channel: &str) {
 }
 
 /// [`remove_shared`] **only if** this channel's entry was written by the
-/// spawn with `expected_generation` — see [`remove_if_generation`]
+/// spawn with `expected_nonce` — see [`remove_if_nonce`]
 /// (issue #2363). Cross-channel note: only this channel's own file is
 /// read and removed, matching [`write_shared`]'s single-writer contract,
 /// so the process-local [`REGISTRY_OP_LOCK`] still suffices.
-pub fn remove_shared_if_generation(
+pub fn remove_shared_if_nonce(
     shared_dir: &Path,
     agent_id: &str,
     channel: &str,
-    expected_generation: u64,
+    expected_nonce: u64,
 ) {
     let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let path = shared_channel_path(shared_dir, agent_id, channel);
     let matches = std::fs::read_to_string(&path)
         .ok()
         .and_then(|content| serde_json::from_str::<AgentEntry>(&content).ok())
-        .is_some_and(|e| expected_generation != 0 && e.spawn_generation == expected_generation);
+        .is_some_and(|e| expected_nonce != 0 && e.registration_nonce == expected_nonce);
     if !matches {
         tracing::info!(
             agent_id = %agent_id,
             channel = %channel,
-            expected_generation = expected_generation,
-            "registry: shared entry generation changed since this spawn registered — skipping remove"
+            expected_nonce = expected_nonce,
+            "registry: shared entry changed hands since this spawn registered — skipping remove"
         );
         return;
     }
@@ -396,26 +401,26 @@ pub fn remove_shared_from_env(agent_id: &str) {
     }
 }
 
-/// Convenience wrapper over [`write_shared_generated`] — see
+/// Convenience wrapper over [`write_shared_with_nonce`] — see
 /// [`write_shared_from_env`].
-pub fn write_shared_from_env_generated(
+pub fn write_shared_from_env_with_nonce(
     agent_id: &str,
     local_url: &str,
     block_id: &str,
-    spawn_generation: u64,
+    registration_nonce: u64,
 ) {
     if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
         let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
-        write_shared_generated(&shared_dir, agent_id, local_url, block_id, &channel, spawn_generation);
+        write_shared_with_nonce(&shared_dir, agent_id, local_url, block_id, &channel, registration_nonce);
     }
 }
 
-/// Convenience wrapper over [`remove_shared_if_generation`] — see
+/// Convenience wrapper over [`remove_shared_if_nonce`] — see
 /// [`write_shared_from_env`].
-pub fn remove_shared_from_env_if_generation(agent_id: &str, expected_generation: u64) {
+pub fn remove_shared_from_env_if_nonce(agent_id: &str, expected_nonce: u64) {
     if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
         let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
-        remove_shared_if_generation(&shared_dir, agent_id, &channel, expected_generation);
+        remove_shared_if_nonce(&shared_dir, agent_id, &channel, expected_nonce);
     }
 }
 

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -48,7 +48,26 @@ pub struct AgentEntry {
     /// `docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md`.
     #[serde(default)]
     pub channel: String,
+    /// Spawn generation of the persistent-controller process this entry
+    /// was written for; 0 = not recorded (HTTP register handler, PTY
+    /// shell auto-register, pre-existing entries). Real generations are
+    /// always ≥ 1. Lets an exit-handler's cleanup compare-and-remove
+    /// ([`remove_if_generation`]) instead of deleting a fallback
+    /// respawn's fresh entry (issue #2363).
+    #[serde(default)]
+    pub spawn_generation: u64,
 }
+
+/// Serializes this process's own read-compare-remove sequences
+/// ([`remove_if_generation`] / [`remove_shared_if_generation`]) against
+/// its own writes. Both the racing writer (a fallback respawn's
+/// re-registration) and the racing remover (the dying spawn's
+/// exit-handler) live in this same agentmux-srv process — each per-agent
+/// registry file has exactly one writing instance — so a process-local
+/// mutex is sufficient to make the compare-and-remove atomic; no file
+/// locking needed. Plain removes/writes for other controller types don't
+/// need the guard but take it anyway for uniformity (it's uncontended).
+static REGISTRY_OP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Process-wide auth key for the local AgentMux instance.
 ///
@@ -100,6 +119,19 @@ fn agent_path(data_dir: &Path, agent_id: &str) -> PathBuf {
 /// existing `authkey.dev` file). On Windows, default ACLs inherit
 /// user-only on user-owned directories.
 pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
+    write_generated(data_dir, agent_id, local_url, block_id, 0);
+}
+
+/// [`write`], recording the registering persistent-controller spawn's
+/// generation — see `AgentEntry::spawn_generation` / issue #2363.
+pub fn write_generated(
+    data_dir: &Path,
+    agent_id: &str,
+    local_url: &str,
+    block_id: &str,
+    spawn_generation: u64,
+) {
+    let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let dir = agents_dir(data_dir);
     let _ = std::fs::create_dir_all(&dir);
     let entry = AgentEntry {
@@ -112,6 +144,7 @@ pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
         // Empty for entries in the per-channel registry — see the field's
         // doc comment on `AgentEntry`.
         channel: String::new(),
+        spawn_generation,
     };
     let path = agent_path(data_dir, agent_id);
     let Ok(json) = serde_json::to_string(&entry) else { return };
@@ -131,6 +164,29 @@ pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
 
 /// Remove an agent entry from the shared registry.
 pub fn remove(data_dir: &Path, agent_id: &str) {
+    let _guard = REGISTRY_OP_LOCK.lock().unwrap();
+    let _ = std::fs::remove_file(agent_path(data_dir, agent_id));
+}
+
+/// Remove an agent entry **only if** it was written by the spawn with
+/// `expected_generation` — compare-and-remove for persistent-controller
+/// exit-handlers (issue #2363). An entry with no recorded generation
+/// (0) is never removed by this variant: leaving a stale file to the
+/// TTL sweep ([`cleanup_stale`]) is strictly safer than deleting a live
+/// registration. Atomic w.r.t. this process's own writes via
+/// [`REGISTRY_OP_LOCK`].
+pub fn remove_if_generation(data_dir: &Path, agent_id: &str, expected_generation: u64) {
+    let _guard = REGISTRY_OP_LOCK.lock().unwrap();
+    let matches = lookup(data_dir, agent_id)
+        .is_some_and(|e| expected_generation != 0 && e.spawn_generation == expected_generation);
+    if !matches {
+        tracing::info!(
+            agent_id = %agent_id,
+            expected_generation = expected_generation,
+            "registry: entry generation changed since this spawn registered — skipping remove"
+        );
+        return;
+    }
     let _ = std::fs::remove_file(agent_path(data_dir, agent_id));
 }
 
@@ -247,6 +303,20 @@ fn pid_alive(pid: u32) -> bool {
 /// concurrent writers for different channels of the same agent name
 /// cannot race or clobber each other.
 pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id: &str, channel: &str) {
+    write_shared_generated(shared_dir, agent_id, local_url, block_id, channel, 0);
+}
+
+/// [`write_shared`], recording the registering persistent-controller
+/// spawn's generation — see `AgentEntry::spawn_generation` / issue #2363.
+pub fn write_shared_generated(
+    shared_dir: &Path,
+    agent_id: &str,
+    local_url: &str,
+    block_id: &str,
+    channel: &str,
+    spawn_generation: u64,
+) {
+    let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let dir = shared_agent_dir(shared_dir, agent_id);
     let _ = std::fs::create_dir_all(&dir);
     let path = shared_channel_path(shared_dir, agent_id, channel);
@@ -258,6 +328,7 @@ pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id
         updated_at: now_unix_millis(),
         auth_key: local_auth_key().to_string(),
         channel: channel.to_string(),
+        spawn_generation,
     };
     write_entry_file(&path, &entry);
 }
@@ -267,7 +338,38 @@ pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id
 /// concurrent writer recreating it a moment later is harmless — the next
 /// write just re-creates the directory via `create_dir_all`).
 pub fn remove_shared(shared_dir: &Path, agent_id: &str, channel: &str) {
+    let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let path = shared_channel_path(shared_dir, agent_id, channel);
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(shared_agent_dir(shared_dir, agent_id));
+}
+
+/// [`remove_shared`] **only if** this channel's entry was written by the
+/// spawn with `expected_generation` — see [`remove_if_generation`]
+/// (issue #2363). Cross-channel note: only this channel's own file is
+/// read and removed, matching [`write_shared`]'s single-writer contract,
+/// so the process-local [`REGISTRY_OP_LOCK`] still suffices.
+pub fn remove_shared_if_generation(
+    shared_dir: &Path,
+    agent_id: &str,
+    channel: &str,
+    expected_generation: u64,
+) {
+    let _guard = REGISTRY_OP_LOCK.lock().unwrap();
+    let path = shared_channel_path(shared_dir, agent_id, channel);
+    let matches = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<AgentEntry>(&content).ok())
+        .is_some_and(|e| expected_generation != 0 && e.spawn_generation == expected_generation);
+    if !matches {
+        tracing::info!(
+            agent_id = %agent_id,
+            channel = %channel,
+            expected_generation = expected_generation,
+            "registry: shared entry generation changed since this spawn registered — skipping remove"
+        );
+        return;
+    }
     let _ = std::fs::remove_file(&path);
     let _ = std::fs::remove_dir(shared_agent_dir(shared_dir, agent_id));
 }
@@ -291,6 +393,29 @@ pub fn remove_shared_from_env(agent_id: &str) {
     if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
         let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
         remove_shared(&shared_dir, agent_id, &channel);
+    }
+}
+
+/// Convenience wrapper over [`write_shared_generated`] — see
+/// [`write_shared_from_env`].
+pub fn write_shared_from_env_generated(
+    agent_id: &str,
+    local_url: &str,
+    block_id: &str,
+    spawn_generation: u64,
+) {
+    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+        let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+        write_shared_generated(&shared_dir, agent_id, local_url, block_id, &channel, spawn_generation);
+    }
+}
+
+/// Convenience wrapper over [`remove_shared_if_generation`] — see
+/// [`write_shared_from_env`].
+pub fn remove_shared_from_env_if_generation(agent_id: &str, expected_generation: u64) {
+    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+        let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+        remove_shared_if_generation(&shared_dir, agent_id, &channel, expected_generation);
     }
 }
 

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -222,6 +222,48 @@ fn test_handler_unregister_block() {
     assert!(handler.get_agent("agent1").is_none());
 }
 
+/// Issue #2363 / codex P1 on PR #2500: the guarded unregister removes
+/// only its own spawn's registration — a newer spawn's (or replacement
+/// controller's) re-registration under a different nonce must survive a
+/// stale exit-handler's cleanup.
+#[test]
+fn test_handler_unregister_block_if_nonce_spares_a_newer_registration() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent_with_nonce("agent1", "block1", None, 5)
+        .unwrap();
+    // A fallback respawn (or a resync_controller replacement) re-registers
+    // the same agent/block under its own nonce before the dying spawn's
+    // exit-handler reaches cleanup.
+    handler
+        .register_agent_with_nonce("agent1", "block1", None, 6)
+        .unwrap();
+
+    assert!(
+        !handler.unregister_block_if_nonce("block1", 5),
+        "the stale spawn's cleanup must not claim the newer registration"
+    );
+    assert!(
+        handler.get_agent("agent1").is_some(),
+        "the newer registration must survive"
+    );
+
+    assert!(handler.unregister_block_if_nonce("block1", 6), "the owner may remove it");
+    assert!(handler.get_agent("agent1").is_none());
+}
+
+/// A registration with no recorded nonce (HTTP/PTY register paths pass 0)
+/// is never removed by the guarded variant — stale-entry leakage is
+/// strictly safer than deleting a live registration.
+#[test]
+fn test_handler_unregister_block_if_nonce_never_matches_nonceless_registrations() {
+    let mut handler = Handler::new();
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    assert!(!handler.unregister_block_if_nonce("block1", 0));
+    assert!(handler.get_agent("agent1").is_some());
+}
+
 #[test]
 fn test_handler_list_agents() {
     let mut handler = Handler::new();

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -89,6 +89,14 @@ pub struct AgentRegistration {
     pub tab_id: Option<String>,
     pub registered_at: u64,
     pub last_seen: u64,
+    /// Spawn generation of the persistent-controller process this
+    /// registration belongs to; 0 = not recorded (HTTP register handler,
+    /// PTY shell auto-register). Real generations are always ≥ 1
+    /// (`PersistentInner::spawn_generation` is pre-incremented). Lets the
+    /// exit-handler's cleanup compare-and-remove instead of blindly wiping
+    /// a fallback respawn's fresh registration (issue #2363).
+    #[serde(default)]
+    pub spawn_generation: u64,
 }
 
 /// List of registered agents.

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -89,14 +89,18 @@ pub struct AgentRegistration {
     pub tab_id: Option<String>,
     pub registered_at: u64,
     pub last_seen: u64,
-    /// Spawn generation of the persistent-controller process this
+    /// Process-wide unique nonce of the persistent-controller spawn this
     /// registration belongs to; 0 = not recorded (HTTP register handler,
-    /// PTY shell auto-register). Real generations are always ≥ 1
-    /// (`PersistentInner::spawn_generation` is pre-incremented). Lets the
-    /// exit-handler's cleanup compare-and-remove instead of blindly wiping
-    /// a fallback respawn's fresh registration (issue #2363).
+    /// PTY shell auto-register). Real nonces are always ≥ 1, drawn from a
+    /// single srv-wide counter (`persistent::next_registration_nonce`) —
+    /// NOT the controller-local spawn generation, which restarts at 1
+    /// for a replacement controller (`resync_controller`) and could
+    /// collide across controller instances for the same block (codex P1
+    /// on PR #2500). Lets the exit-handler's cleanup compare-and-remove
+    /// instead of blindly wiping a fallback respawn's (or replacement
+    /// controller's) fresh registration (issue #2363).
     #[serde(default)]
-    pub spawn_generation: u64,
+    pub registration_nonce: u64,
 }
 
 /// List of registered agents.


### PR DESCRIPTION
## Summary

**PR A** of `docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md` (§6's PR strategy) — the small/mechanical half of the persistent-controller race cluster (#2363, #2365, #2366). PR B (§4, the generation-aware retry decision for #2367) follows separately.

### #2363 — cleanup can no longer wipe a fallback respawn's fresh registration (spec §2)

The exit-handler's `is_current_generation` gate is read once under the lock while `respawn_once_for_leftover_queue` registers its fresh spawn on a parallel task — the original window survived in miniature. Every cleanup op is now compare-and-remove keyed on the dying spawn's own identity:

- `session_recovery::clear_active_pid_if_pid` — a true CAS inside one `Store::with_tx` on the recorded pid; both exit arms (clean-exit and user-stop) converted. The unconditional variant stays for shutdown-path callers.
- The muxbus in-memory registration (`AgentRegistration`), the per-channel file registry and the host-global shared registry (`AgentEntry`) now record the registering spawn's generation (`register_agent_generated` / `write_generated` / `write_shared_from_env_generated`), and removal only proceeds on a generation match (`unregister_block_if_generation` / `remove_if_generation` / `remove_shared_if_generation`, the file ops serialized against this process's own writes by a process-local lock — each per-agent registry file has exactly one writing instance). Generation-less entries (HTTP/PTY register paths, value 0) are never removed by the guarded variants: a stale file left to the TTL sweep is strictly safer than deleting a live registration.
- The cloud subscriber's agent set records no per-agent identity, so its removal keys off the in-memory guard's outcome — if a newer spawn already re-registered, its cloud subscription survives too.

### #2365 — queue identity is a seq, not text (spec §3)

`QueuedMessage` gains a per-controller monotonic `seq`, assigned at first enqueue and preserved verbatim through redelivery (`RetryPayload.messages` is now `Vec<QueuedRetryEntry { seq, json }>`). All three content-equality sites convert to identity checks, per the spec (including the two reagentx's review of the spec added beyond the originally-reported one):

1. `decide_send_action`'s known-redelivery dedup — now `Option<u64>`; a genuinely different, identical-text message can no longer be treated as "already queued" and silently dropped.
2. `release_spawn_claim_and_drain_queue`'s own-message discard — `SendAction::BecomeSpawner { own_seq }` hands the spawner its entry's identity; a failed spawn can no longer discard someone else's identical-text message.
3. `decide_retry_batch_action`'s first-already-queued check.

The drain's seed detection (`is_seeded_message`) also converts to seq, eliminating the identical-text ambiguity its own comment documented as an accepted limit.

### #2366 — verified NOT fully fixed; generation-gated ambient adoption (spec §5)

Traced `respawn_once_for_leftover_queue` against the #2373 state machine as the spec asked. The state machine does drop stale-generation `SessionCaptured` events for **tracking**, but ambient adoption in `try_capture_session_id` (`adopted = sid_is_new && (session_id_was_none || …)`) never consulted generation — so a superseded generation's still-draining stdout reader could re-install its stale sid into `inner.session_id` right after the fallback's plain clear (the exact race the round-13 comment deferred; `resume_poisoned` doesn't cover it because the fallback path deliberately doesn't poison). Adoption is now gated on `generation == spawn_generation`, with regression tests in both directions.

### #2368

Stays open — needs a live stale-resume repro (spec §5's verification list); not closable from unit tests.

## Verification

- `cargo test -p agentmux-srv`: **2093 passed, 0 failed** (plus 4 + 7 integration), including new regressions: identical-text-different-seq retry is not deduped; a re-queued redelivery preserves its original seq; a stale generation's capture does not adopt; the current generation's capture still does.
- `cargo fmt` not run: the touched files (like much of the package) are not rustfmt-clean on `main`; new code follows surrounding style to keep the diff reviewable.

Follow-ups tracked: #2367 (PR B), #2368 (live verify).

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)