### PR TITLE
feat(agent-pane): backgrounded Bash tasks get a live dock row until their task-notification lands

### DIFF
--- a/.changesets/1786365605-feat-agent-pane-backgrounded-bash-tasks-get-a-live-dock-row--6epe.md
+++ b/.changesets/1786365605-feat-agent-pane-backgrounded-bash-tasks-get-a-live-dock-row--6epe.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): backgrounded Bash tasks get a live dock row until their task-notification lands

--- a/frontend/app/view/agent/activity/attached-task.test.ts
+++ b/frontend/app/view/agent/activity/attached-task.test.ts
@@ -99,3 +99,38 @@ describe("earliestLiveAttachedStartMs", () => {
         expect(earliestLiveAttachedStartMs(nodes, subs, "block-1", 10_000)).toBe(500);
     });
 });
+
+// ── Backgrounded calls reach the axis by construction (issue #2490) ──
+
+describe("backgrounded Bash calls (issue #2490)", () => {
+    it("an accepted background launch counts as live attached work from its call time", () => {
+        const bg = mkBash({
+            id: "toolu_bg",
+            status: "success",
+            params: { command: "task dev", run_in_background: true },
+            timestamp: 1000,
+            duration: 0.4,
+        });
+        // Sub-second and terminal — invisible to the duration heuristic,
+        // but a declared background task must still light the axis.
+        expect(hasLiveAttachedActivity([bg], [], "block-1", 2000)).toBe(true);
+        expect(earliestLiveAttachedStartMs([bg], [], "block-1", 2000)).toBe(1000);
+    });
+
+    it("its task-notification ends the episode", () => {
+        const bg = mkBash({
+            id: "toolu_bg",
+            status: "success",
+            params: { command: "task dev", run_in_background: true },
+            timestamp: 1000,
+            duration: 0.4,
+        });
+        const notification: DocumentNode = {
+            type: "user_message",
+            id: "user-1",
+            message: "<task-notification>\n<tool-use-id>toolu_bg</tool-use-id>\n<status>completed</status>\n</task-notification>",
+            timestamp: 900_000,
+        };
+        expect(hasLiveAttachedActivity([bg, notification], [], "block-1", 950_000)).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/activity/tool-adapter.test.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.test.ts
@@ -147,3 +147,90 @@ describe("hasRunningPromotedTool", () => {
         expect(hasRunningPromotedTool([], 1_000_000)).toBe(false);
     });
 });
+
+// ── Backgrounded calls (issue #2490) ──────────────────────────────────
+
+function mkBgBash(overrides: Partial<ToolNode> = {}): ToolNode {
+    return mkBash({
+        id: "toolu_bg1",
+        status: "success",
+        params: { command: "task dev", run_in_background: true },
+        timestamp: 1000,
+        duration: 0.4,
+        ...overrides,
+    });
+}
+
+function mkNotification(toolUseId: string, status: string, timestamp = 500_000): DocumentNode {
+    return {
+        type: "user_message",
+        id: `user-${toolUseId}`,
+        message:
+            `<task-notification>\n<task-id>b12345</task-id>\n<tool-use-id>${toolUseId}</tool-use-id>\n` +
+            `<output-file>C:\tmp\b12345.output</output-file>\n<status>${status}</status>\n` +
+            `<summary>Background command finished</summary>\n</task-notification>`,
+        timestamp,
+    };
+}
+
+describe("toolActivities — backgrounded calls", () => {
+    it("shows an accepted background launch as running immediately, no 30s threshold", () => {
+        const nodes: DocumentNode[] = [mkBgBash()];
+        // Well under the promotion threshold — an ordinary sub-second call
+        // would be invisible; a declared background task must not be.
+        const acts = toolActivities(nodes, 2000);
+        expect(acts).toHaveLength(1);
+        expect(acts[0].status).toBe("running");
+        expect(acts[0].startedAt).toBe(1000);
+        expect(acts[0].endedAt).toBeUndefined();
+        expect(acts[0].title).toBe("task dev");
+    });
+
+    it("stays running until ITS OWN task-notification lands — another call's doesn't end it", () => {
+        const nodes: DocumentNode[] = [mkBgBash({ id: "toolu_a" }), mkNotification("toolu_other", "completed")];
+        const acts = toolActivities(nodes, 2000);
+        expect(acts).toHaveLength(1);
+        expect(acts[0].status).toBe("running");
+    });
+
+    it("ends as done/error per the notification's status, endedAt = notification time", () => {
+        const completed = toolActivities(
+            [mkBgBash({ id: "toolu_ok" }), mkNotification("toolu_ok", "completed", 600_000)],
+            700_000,
+        );
+        expect(completed[0].status).toBe("done");
+        expect(completed[0].endedAt).toBe(600_000);
+
+        const failed = toolActivities(
+            [mkBgBash({ id: "toolu_bad" }), mkNotification("toolu_bad", "failed", 600_000)],
+            700_000,
+        );
+        expect(failed[0].status).toBe("error");
+    });
+
+    it("ends as stopped on a notification with an unrecognized status — never running forever", () => {
+        const acts = toolActivities(
+            [mkBgBash({ id: "toolu_x" }), mkNotification("toolu_x", "killed")],
+            700_000,
+        );
+        expect(acts[0].status).toBe("stopped");
+    });
+
+    it("a REFUSED background launch is not a live task — ordinary duration rules apply", () => {
+        // status failed = the harness rejected the command; sub-second, so
+        // the threshold gate drops it entirely.
+        const nodes: DocumentNode[] = [mkBgBash({ status: "failed" })];
+        expect(toolActivities(nodes, 2000)).toEqual([]);
+    });
+
+    it("a foreground call is untouched by an unrelated notification in the document", () => {
+        const nodes: DocumentNode[] = [
+            mkBash({ id: "fg", timestamp: 1000 }),
+            mkNotification("toolu_other", "completed"),
+        ];
+        const acts = toolActivities(nodes, 1000 + TOOL_PROMOTION_MS);
+        expect(acts).toHaveLength(1);
+        expect(acts[0].id).toBe("fg");
+        expect(acts[0].status).toBe("running");
+    });
+});

--- a/frontend/app/view/agent/activity/tool-adapter.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.ts
@@ -29,13 +29,52 @@
  */
 
 import { extractToolDetail } from "../stream-parser";
-import type { DocumentNode, ToolNode } from "../types";
+import type { BashParams, DocumentNode, ToolNode } from "../types";
 import type { ActivityStatus, PinnedActivity } from "./types";
 
 export const TOOL_PROMOTION_MS = 30_000;
 
 function isBashToolNode(n: DocumentNode): n is ToolNode {
     return n.type === "tool" && n.tool === "Bash" && n.timestamp != null;
+}
+
+/**
+ * True for a Bash call the harness ran detached (issue #2490): its
+ * `tool_use.input` carried `run_in_background: true` and the tool_result
+ * came back accepted ("Command running in background with ID: …"). The
+ * ToolNode is terminal within ~a second, but the real process tree keeps
+ * running until a `<task-notification>` lands — so, unlike an ordinary
+ * call, terminal-with-success here means STARTED, not finished. A failed
+ * launch (`status: "failed"` — the harness refused the command) is not a
+ * live background task and falls through to the ordinary duration rules.
+ */
+function isAcceptedBackgroundLaunch(n: ToolNode): boolean {
+    return (n.params as BashParams | undefined)?.run_in_background === true && n.status === "success";
+}
+
+/**
+ * Terminal outcomes of backgrounded calls, keyed by originating
+ * `tool_use_id`. The harness reports a background task's ACTUAL
+ * completion as a plain user message whose whole payload is a
+ * `<task-notification>` block naming the `<tool-use-id>` it belongs to
+ * and a `<status>` — that message (not the instant tool_result) is the
+ * background task's real end-of-life signal. Parsed leniently: a
+ * notification without a recognizable status still ends the task
+ * (as "stopped") rather than leaving a finished process shown as
+ * running forever.
+ */
+function backgroundCompletions(nodes: ReadonlyArray<DocumentNode>): Map<string, { status: ActivityStatus; endedAt?: number }> {
+    const out = new Map<string, { status: ActivityStatus; endedAt?: number }>();
+    for (const n of nodes) {
+        if (n.type !== "user_message" || !n.message.includes("<task-notification>")) continue;
+        const toolUseId = /<tool-use-id>([^<]+)<\/tool-use-id>/.exec(n.message)?.[1];
+        if (!toolUseId) continue;
+        const rawStatus = /<status>([^<]+)<\/status>/.exec(n.message)?.[1];
+        const status: ActivityStatus =
+            rawStatus === "completed" ? "done" : rawStatus === "failed" ? "error" : "stopped";
+        out.set(toolUseId, { status, endedAt: n.timestamp });
+    }
+    return out;
 }
 
 /** True while `n` is running and has already crossed the promotion
@@ -90,11 +129,40 @@ export function toolToActivity(n: ToolNode): PinnedActivity {
 /** Every Bash tool call that has ever crossed `TOOL_PROMOTION_MS` — running
  *  ones past the threshold, plus finished ones whose total duration cleared
  *  it (still returned after they finish so the dock's own RETENTION_MS
- *  window, not this function, decides when the row actually disappears). */
+ *  window, not this function, decides when the row actually disappears).
+ *
+ *  PLUS every accepted backgrounded call (issue #2490): those are
+ *  agent-declared long-running work, so they get a dock row immediately
+ *  (no 30s threshold — the duration heuristic exists to auto-detect
+ *  undeclared long work, and a declared background task needs no
+ *  detection) that stays `running` until the harness's
+ *  `<task-notification>` for this exact `tool_use_id` lands. The
+ *  attached-task axis (attached-task.ts) picks these up with no changes,
+ *  by construction — spec §4 of
+ *  SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md. */
 export function toolActivities(nodes: ReadonlyArray<DocumentNode>, now: number): PinnedActivity[] {
     const out: PinnedActivity[] = [];
+    let completions: Map<string, { status: ActivityStatus; endedAt?: number }> | null = null;
     for (const n of nodes) {
         if (!isBashToolNode(n)) continue;
+        if (isAcceptedBackgroundLaunch(n)) {
+            // Built lazily: the vast majority of documents contain no
+            // backgrounded calls, and scanning every user message for
+            // notifications on every recompute would be pure waste there.
+            completions ??= backgroundCompletions(nodes);
+            const completion = completions.get(n.id);
+            const activity = toolToActivity(n);
+            if (completion) {
+                out.push({ ...activity, status: completion.status, endedAt: completion.endedAt });
+            } else {
+                // Still running for real, whatever the instant
+                // tool_result said — override the terminal status the
+                // plain mapping derived, and drop the endedAt derived
+                // from the launch acknowledgment's duration.
+                out.push({ ...activity, status: "running", endedAt: undefined });
+            }
+            continue;
+        }
         if (!everCrossedThreshold(n, now)) continue;
         out.push(toolToActivity(n));
     }

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -122,6 +122,20 @@ interface WriteParams {
 export interface BashParams {
     command: string;
     timeout?: number;
+    /**
+     * True when the harness runs this command detached: the tool_result
+     * returns almost immediately ("Command running in background with
+     * ID: …") while the real process tree keeps running, and a
+     * `<task-notification>` user message carrying this call's
+     * `tool_use_id` arrives when it actually finishes. The flag was
+     * always present in the wire `tool_use.input` and flows through
+     * `ToolNode.params` untouched — this field just names it so
+     * tool-adapter.ts can give backgrounded calls a dock row that
+     * tracks the REAL lifetime instead of the instant tool_result
+     * (issue #2490; docs/status/STATUS_ATTACHED_TASK_AXIS_AND_DEV_LOOP_2026_08_09.md
+     * rung 2).
+     */
+    run_in_background?: boolean;
 }
 
 interface GrepParams {


### PR DESCRIPTION
## Summary

Rung 2 of `docs/status/STATUS_ATTACHED_TASK_AXIS_AND_DEV_LOOP_2026_08_09.md` — closes #2490, the ladder's "single highest-leverage gap."

A `run_in_background: true` Bash call's ToolNode goes terminal in under a second (the harness acknowledges with "Command running in background with ID: …"), so the 30s duration-promotion (`tool-adapter.ts`) never fired and the actual long-lived process tree (`task dev` → cargo → Vite → launcher) was completely invisible to the dock and to the attached-task axis (#2489).

### What this does

- **`BashParams.run_in_background`** — the flag was always present in the wire `tool_use.input` and flows through `ToolNode.params` untouched; this names it in the type.
- **tool-adapter background branch** — an ACCEPTED background launch (flag + tool_result success) gets a dock row **immediately** (no 30s threshold: the duration heuristic exists to auto-detect *undeclared* long work; a declared background task needs no detection) and stays `running` until the harness's `<task-notification>` user message carrying this call's own `<tool-use-id>` lands. `<status>` completed/failed → done/error; unrecognized → stopped (never running-forever). A REFUSED launch (tool_result failed) is not a live task and falls through to the ordinary duration rules.
- **Attached-task axis pickup is free** — `hasLiveAttachedActivity` consumes `toolActivities` (spec §4 of SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md), so the #2489 "Running in background" state now lights up for exactly the dev-server case that motivated the ladder, with zero axis changes.
- `hasRunningPromotedTool`/`nextToolPromotionAt` deliberately untouched — both operate on still-`running` ToolNodes; a background launch is terminal within a second, and the working-row suppression contract ("the call the row would be describing") doesn't apply to it.

### Wire shapes (verified against real transcripts — 62 backgrounded calls in one session)

- tool_use: `input.run_in_background: true`
- instant tool_result: `"Command running in background with ID: <task-id>. Output is being written to: <path>. You will be notified when it completes. …"`
- completion: a user message whose whole payload is `<task-notification>` with `<task-id>`, `<tool-use-id>` (exact join key back to the originating call), `<output-file>`, `<status>`, `<summary>`.

## Verification

- 6 new adapter tests (immediate visibility with no threshold, per-tool-use-id completion matching, done/error/stopped mapping, refused launch excluded, foreground calls isolated from unrelated notifications) + 2 attached-task axis tests (a background task lights the axis from its call time; its own notification ends the episode).
- Full frontend suite: **2465 passed** (164 files). `tsc --noEmit` clean.
- Live verification note: a real `task dev` via harness background Bash should now show a dock row + the footer's "Running in background" after the turn ends — worth confirming in a running build alongside the still-pending #2489 live check.

Remaining ladder rungs after this: #2491 (bashwrap idle-kill exemption for declared long-running tasks), #2492 (survive session teardown).

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)