### PR TITLE
chore: release v0.55.2

### DIFF
--- a/.changesets/1786270894-feat-agent-add-codex-jsonl-and-resume-support-qtjh.md
+++ b/.changesets/1786270894-feat-agent-add-codex-jsonl-and-resume-support-qtjh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): add Codex JSONL and resume support

--- a/.changesets/1786337657-feat-agent-pane-undo-for-esc-cleared-composer-drafts-right-c-9jcl.md
+++ b/.changesets/1786337657-feat-agent-pane-undo-for-esc-cleared-composer-drafts-right-c-9jcl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): Undo for Esc-cleared composer drafts — right-click menu + Ctrl/Cmd+Z

--- a/.changesets/1786343784-fix-persistent-compare-and-clear-cleanup-seq-keyed-queue-ide-4dlc.md
+++ b/.changesets/1786343784-fix-persistent-compare-and-clear-cleanup-seq-keyed-queue-ide-4dlc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(persistent): compare-and-clear cleanup, seq-keyed queue identity, generation-gated sid adoption (#2363/#2365/#2366)

--- a/.changesets/1786347745-fix-persistent-retry-batch-flushes-under-a-drain-claim-queue-xn2c.md
+++ b/.changesets/1786347745-fix-persistent-retry-batch-flushes-under-a-drain-claim-queue-xn2c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(persistent): retry batch flushes under a drain claim — queue is the ordering authority (#2367)

--- a/.changesets/1786365605-feat-agent-pane-backgrounded-bash-tasks-get-a-live-dock-row--6epe.md
+++ b/.changesets/1786365605-feat-agent-pane-backgrounded-bash-tasks-get-a-live-dock-row--6epe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): backgrounded Bash tasks get a live dock row until their task-notification lands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.1"
+version = "0.55.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.1"
+version = "0.55.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.1"
+version = "0.55.2"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.1"
+version = "0.55.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.1"
+version = "0.55.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.1"
+version = "0.55.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.1"
+version = "0.55.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,14 @@
 # AgentMux Version History
 
+## 0.55.2 — 2026-08-10
+
+- feat(agent): add Codex JSONL and resume support
+- feat(agent-pane): Undo for Esc-cleared composer drafts — right-click menu + Ctrl/Cmd+Z
+- fix(persistent): compare-and-clear cleanup, seq-keyed queue identity, generation-gated sid adoption (#2363/#2365/#2366)
+- fix(persistent): retry batch flushes under a drain claim — queue is the ordering authority (#2367)
+- feat(agent-pane): backgrounded Bash tasks get a live dock row until their task-notification lands
+
+
 ## 0.55.1 — 2026-08-09
 
 - feat(agent): assign every agent a display color, backfill existing agents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.1",
+      "version": "0.55.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes all 5 pending changesets under an explicit `--as patch` override (all were patch-typed anyway):

- feat(agent): add Codex JSONL and resume support
- feat(agent-pane): Undo for Esc-cleared composer drafts
- fix(persistent): race-cluster PR A — CAS cleanup, seq-keyed queue identity, generation-gated sid adoption (#2500)
- fix(persistent): race-cluster PR B — drain-claim retry ordering (#2501)
- feat(agent-pane): backgrounded Bash dock visibility (#2502)

All five version locations agree at 0.55.2 (release script verified). Purpose: fresh portable for dogfooding the race-cluster + background-task-visibility work.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)