### PR TITLE
feat(agent): introduce model vendor as a concept distinct from harness

### DIFF
--- a/.changesets/1786370573-feat-agent-introduce-model-vendor-as-a-concept-distinct-from-6686.md
+++ b/.changesets/1786370573-feat-agent-introduce-model-vendor-as-a-concept-distinct-from-6686.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): introduce model vendor as a concept distinct from harness

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -196,6 +196,7 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(), // manifest doesn't declare this yet
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -442,6 +443,7 @@ fn reseed_if_needed(
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(), // manifest doesn't declare this yet
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {
@@ -451,6 +453,7 @@ fn reseed_if_needed(
             agent.provider = existing_agent.provider.clone();
             agent.agent_type = existing_agent.agent_type.clone();
             agent.environment = existing_agent.environment.clone();
+            agent.model_vendor_base_url = existing_agent.model_vendor_base_url.clone();
             agent.shell = if existing_agent.shell.is_empty() {
                 agent_def.shell.clone()
             } else {
@@ -549,6 +552,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut def).unwrap();
     }

--- a/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
+++ b/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
@@ -284,6 +284,7 @@ pub fn migrate_promote_template_sessions_v1(
                 container_volumes: template.container_volumes.clone(),
                 container_name: String::new(),
                 use_ambient_login: 0,
+                model_vendor_base_url: template.model_vendor_base_url.clone(),
             };
             if let Err(e) = wstore.agent_def_insert(&mut new_def) {
                 tracing::warn!(

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -466,6 +466,7 @@ fn insert_template(
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut def).unwrap();
     def
@@ -699,6 +700,7 @@ fn template_promote_does_not_reuse_clone_with_active_zone() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut user_clone).unwrap();
     // The user's clone has its OWN active conversation.
@@ -806,6 +808,7 @@ fn template_promote_preserves_user_continuation_on_clone() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
     // Seeded `:current` has the OLDER stale snapshot the prior
@@ -905,6 +908,7 @@ fn template_promote_recovers_partial_copy_at_zone() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
 
@@ -1006,6 +1010,7 @@ fn template_promote_promotes_newer_source_over_stale_destination() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
 
@@ -1126,6 +1131,7 @@ fn template_promote_idempotent_under_partial_failure_at_archive_move() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
     // Realistic partial-failure shape: run 1 copied :current
@@ -1263,6 +1269,7 @@ fn template_promote_skips_already_user_owned_definitions() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut user_def).unwrap();
     write_session_state(&filestore, &user_def.id, br#"{"nodes":[]}"#).unwrap();

--- a/agentmux-srv/src/backend/blockcontroller/core.rs
+++ b/agentmux-srv/src/backend/blockcontroller/core.rs
@@ -336,6 +336,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -73,6 +73,16 @@ pub struct ProviderConfig {
     pub npm_package: &'static str,
     /// Version string passed to `npm install`, e.g. `"latest"` or `"0.116.0"`.
     pub pinned_version: &'static str,
+    // ── Model vendor (harness vs. model vendor decoupling) ──────────────────
+    /// Environment variable this harness reads to redirect its model vendor
+    /// backend (e.g. Claude Code's `ANTHROPIC_BASE_URL`, pointing it at a
+    /// proxy/Bedrock/OpenRouter instead of Anthropic's default endpoint).
+    /// `None` when a harness isn't confirmed to support redirection — the
+    /// harness (CLI driving the session) and the model vendor (LLM backend
+    /// actually serving responses) are independent dimensions; this is the
+    /// declared capability side of that split. Set only where independently
+    /// verified, not guessed. See docs/specs for the harness/vendor concept.
+    pub base_url_env_var: Option<&'static str>,
 }
 
 impl ProviderConfig {
@@ -167,6 +177,9 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     // .github/workflows/container-image.yml `claude_version` default — enforced by
     // frontend/app/view/agent/providers/pin-consistency.test.ts.
     pinned_version: "2.1.198",
+    // Documented Claude Code behavior: redirects the CLI at a non-Anthropic
+    // (or proxied) backend — Bedrock, Vertex, OpenRouter, a custom proxy.
+    base_url_env_var: Some("ANTHROPIC_BASE_URL"),
 };
 
 static CODEX: ProviderConfig = ProviderConfig {
@@ -192,6 +205,7 @@ static CODEX: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "@openai/codex",
     pinned_version: "0.116.0",
+    base_url_env_var: None,
 };
 
 static GEMINI: ProviderConfig = ProviderConfig {
@@ -211,6 +225,7 @@ static GEMINI: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "@google/gemini-cli",
     pinned_version: "0.32.1",
+    base_url_env_var: None,
 };
 
 // Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
@@ -239,6 +254,11 @@ static QWEN: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "@qwen-code/qwen-code",
     pinned_version: "0.19.2",
+    // Note: qwen's default backend already routes through an OpenAI-compatible
+    // endpoint (see comment above) as a fixed part of its auth setup — but
+    // that's baked-in default routing, not a confirmed user-configurable
+    // override mechanism, so this stays unset rather than guessed.
+    base_url_env_var: None,
 };
 
 static KIMI: ProviderConfig = ProviderConfig {
@@ -263,6 +283,7 @@ static KIMI: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "",
     pinned_version: "",
+    base_url_env_var: None,
 };
 
 static OPENCLAW: ProviderConfig = ProviderConfig {
@@ -292,6 +313,7 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "openclaw",
     pinned_version: "2026.6.10",
+    base_url_env_var: None,
 };
 
 static PI: ProviderConfig = ProviderConfig {
@@ -309,6 +331,7 @@ static PI: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "@mariozechner/pi-coding-agent",
     pinned_version: "0.73.1",
+    base_url_env_var: None,
 };
 
 // Mux Code — AgentMux's first-party agentic coding CLI.
@@ -336,6 +359,7 @@ static MUX_CODE: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "@agentmuxai/muxcode",
     pinned_version: "0.1.0",
+    base_url_env_var: None,
 };
 
 // GitHub Copilot CLI — Microsoft's coding agent. Runs in ACP mode via
@@ -357,6 +381,7 @@ static COPILOT: ProviderConfig = ProviderConfig {
     unset_env: &[],
     npm_package: "@github/copilot",
     pinned_version: "1.0.65",
+    base_url_env_var: None,
 };
 
 // ─── Static registry ─────────────────────────────────────────────────────────
@@ -530,5 +555,25 @@ mod tests {
         assert_eq!(p.styled_output_format, "acp");
         assert_eq!(p.cli_command, "pi");
         assert_eq!(p.npm_package, "@mariozechner/pi-coding-agent");
+    }
+
+    // Harness vs. model vendor decoupling: only claude has a verified,
+    // documented way to redirect its backend (ANTHROPIC_BASE_URL). Every
+    // other provider is explicit None rather than a guessed env var name.
+    #[test]
+    fn claude_declares_base_url_env_var() {
+        let p = get_provider("claude").unwrap();
+        assert_eq!(p.base_url_env_var, Some("ANTHROPIC_BASE_URL"));
+    }
+
+    #[test]
+    fn non_claude_providers_have_no_base_url_env_var() {
+        for id in ["codex", "gemini", "qwen", "kimi", "openclaw", "pi", "copilot", "muxcode"] {
+            let p = get_provider(id).unwrap();
+            assert!(
+                p.base_url_env_var.is_none(),
+                "provider '{id}' should not declare base_url_env_var yet (unverified)"
+            );
+        }
     }
 }

--- a/agentmux-srv/src/backend/rpc_types/agent.rs
+++ b/agentmux-srv/src/backend/rpc_types/agent.rs
@@ -112,6 +112,13 @@ pub struct CommandAgentDefineData {
     /// JSON array of volume mount specs. Empty array (`"[]"`) for host agents.
     #[serde(default = "default_container_volumes")]
     pub container_volumes: String,
+    /// Redirects this agent's harness at a non-default model vendor backend
+    /// (e.g. a custom `ANTHROPIC_BASE_URL` for a `claude`-provider agent).
+    /// Empty (default) = use the harness's default vendor endpoint. Rejected
+    /// at define-time unless the resolved provider declares
+    /// `ProviderConfig::base_url_env_var` — see `agent_define_core`.
+    #[serde(default)]
+    pub model_vendor_base_url: String,
 }
 
 fn default_host_agent_type() -> String {

--- a/agentmux-srv/src/backend/rpc_types/agent.rs
+++ b/agentmux-srv/src/backend/rpc_types/agent.rs
@@ -114,11 +114,17 @@ pub struct CommandAgentDefineData {
     pub container_volumes: String,
     /// Redirects this agent's harness at a non-default model vendor backend
     /// (e.g. a custom `ANTHROPIC_BASE_URL` for a `claude`-provider agent).
-    /// Empty (default) = use the harness's default vendor endpoint. Rejected
-    /// at define-time unless the resolved provider declares
-    /// `ProviderConfig::base_url_env_var` — see `agent_define_core`.
+    /// `None` (the default — omitted or absent) = don't touch the stored
+    /// value; on a fresh insert this means "no override". `Some("")` is an
+    /// explicit clear back to "no override" — required so a caller can ever
+    /// undo a previously-set value or recover from a stale override left
+    /// behind by a provider change (see `agent_define_core`'s update
+    /// branch). `Some(url)` sets it, rejected at define-time unless the
+    /// resolved provider declares `ProviderConfig::base_url_env_var`.
+    /// Mirrors the existing `Option<T>` = "don't touch" idiom already used
+    /// by `CommandUpdateAgentDefinitionData::use_ambient_login`.
     #[serde(default)]
-    pub model_vendor_base_url: String,
+    pub model_vendor_base_url: Option<String>,
 }
 
 fn default_host_agent_type() -> String {

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -423,7 +423,20 @@ impl Store {
         let mut by_id: std::collections::HashMap<String, AgentDefinition> =
             local.into_iter().map(|d| (d.id.clone(), d)).collect();
         for rec in &global {
-            let def = super::def_registry_mirror::record_to_agent_definition(rec);
+            let mut def = super::def_registry_mirror::record_to_agent_definition(rec);
+            // model_vendor_base_url is deliberately channel-local only —
+            // DefinitionRecordV1 doesn't carry it, so record_to_agent_definition
+            // always returns "" for it. Without this, the global overlay
+            // silently wiped a same-channel agent's override on every read
+            // (including agent.open's spawn-time resolution), making the
+            // whole feature a no-op in default single-instance operation —
+            // not just the genuinely-cross-channel case this limitation is
+            // documented for. Preserve the local row's value when one
+            // exists; only a truly cross-channel agent (no local row) sees
+            // the empty default. (reagent P0 on PR #2505.)
+            if let Some(existing) = by_id.get(&def.id) {
+                def.model_vendor_base_url = existing.model_vendor_base_url.clone();
+            }
             by_id.insert(def.id.clone(), def);
         }
         let mut result: Vec<AgentDefinition> = by_id.into_values().collect();

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -117,6 +117,17 @@ pub struct AgentDefinition {
     /// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md (§2.2-§2.4).
     #[serde(default)]
     pub use_ambient_login: i64,
+    /// Redirects this agent's harness (CLI) at a non-default model vendor
+    /// backend — e.g. `"https://my-proxy.example.com"` for a `claude`-provider
+    /// agent, injected into `ANTHROPIC_BASE_URL` at spawn time. Empty string
+    /// (default) = use the harness's default vendor endpoint. Only settable
+    /// when the resolved provider declares `ProviderConfig::base_url_env_var`
+    /// (validated in `agent_define_core`) — see docs/specs for the harness
+    /// vs. model-vendor concept this formalizes. Schema v15. Channel-local:
+    /// does not currently survive a cross-channel reopen of the same agent
+    /// (known limitation, not wired into the registry mirror).
+    #[serde(default)]
+    pub model_vendor_base_url: String,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -299,7 +310,7 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login
+                    use_ambient_login, model_vendor_base_url
              FROM db_agent_definitions
              WHERE is_seeded = 0 AND parent_id = ?1
              ORDER BY updated_at DESC, created_at DESC",
@@ -360,7 +371,7 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login
+                    use_ambient_login, model_vendor_base_url
              FROM db_agent_definitions
              WHERE id = ?1",
         )?;
@@ -382,7 +393,7 @@ impl Store {
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_template_id, branch_label, updated_at,
                         user_hidden, container_image, container_volumes, container_name,
-                        use_ambient_login
+                        use_ambient_login, model_vendor_base_url
                  FROM db_agents
                  ORDER BY updated_at DESC, created_at ASC",
             )?;
@@ -548,9 +559,10 @@ impl Store {
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
              is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
-             container_image, container_volumes, container_name, use_ambient_login)
+             container_image, container_volumes, container_name, use_ambient_login,
+             model_vendor_base_url)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
+                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
             params![
                 agent.id,
                 agent.slug,
@@ -587,6 +599,7 @@ impl Store {
                 agent.container_volumes,
                 agent.container_name,
                 agent.use_ambient_login,
+                agent.model_vendor_base_url,
             ],
         )?;
         // Persist the stamped updated_at before we leave the lock so the
@@ -712,7 +725,7 @@ impl Store {
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_id, branch_label, updated_at,
                         user_hidden, container_image, container_volumes, container_name,
-                        use_ambient_login
+                        use_ambient_login, model_vendor_base_url
                  FROM db_agent_definitions
                  WHERE (lower(trim(name)) = ?1 OR slug = ?2)
                    AND is_seeded = 0
@@ -761,10 +774,11 @@ impl Store {
                     working_directory, shell, provider_flags, auto_start, restart_on_crash,
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
                     is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
-                    container_image, container_volumes, container_name, use_ambient_login)
+                    container_image, container_volumes, container_name, use_ambient_login,
+                    model_vendor_base_url)
                  VALUES
                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
+                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
                 params![
                     agent.id, agent.slug, agent.name, agent.icon, agent.provider,
                     agent.description, agent.working_directory, agent.shell,
@@ -776,6 +790,7 @@ impl Store {
                     agent.user_hidden,
                     agent.container_image, agent.container_volumes, agent.container_name,
                     agent.use_ambient_login,
+                    agent.model_vendor_base_url,
                 ],
             )?;
             agent.created_at
@@ -883,7 +898,7 @@ impl Store {
                  restart_on_crash=?9, idle_timeout_minutes=?10,
                  agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15,
                  container_image=?17, container_volumes=?18, container_name=?19,
-                 use_ambient_login=?20, branch_label=?21
+                 use_ambient_login=?20, branch_label=?21, model_vendor_base_url=?22
                  WHERE id=?16",
                 params![
                     agent.name,
@@ -907,6 +922,7 @@ impl Store {
                     agent.container_name,
                     agent.use_ambient_login,
                     agent.branch_label,
+                    agent.model_vendor_base_url,
                 ],
             )?
         };
@@ -2102,6 +2118,7 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
         container_volumes: row.get(23)?,
         container_name: row.get(24)?,
         use_ambient_login: row.get(25)?,
+        model_vendor_base_url: row.get(26)?,
     })
 }
 

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -316,6 +316,38 @@ mod tests {
         assert_eq!(skills[0].name, "greet");
     }
 
+    // reagent P0 on PR #2505: agent_def_list's global overlay unconditionally
+    // inserted the registry-derived def over the local one for every user
+    // agent id — including a same-channel agent that's ALSO mirrored into
+    // the global store (the normal case: every agent.define write
+    // auto-mirrors via registry_def_upsert). Since DefinitionRecordV1 never
+    // carries model_vendor_base_url (deliberately channel-local only), the
+    // overlay's always-"" value silently erased the local override on every
+    // read — including agent.open's spawn-time resolution — making the
+    // whole feature a no-op in default single-instance operation, not just
+    // the documented genuinely-cross-channel case.
+    #[test]
+    fn agent_def_list_preserves_local_model_vendor_base_url_over_the_global_overlay() {
+        let store = Store::open_in_memory().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let def_store = Arc::new(DefinitionStore::open(tmp.path().join("definitions")).unwrap());
+
+        let mut def = local_def("agent-1", "Vendor Agent");
+        def.model_vendor_base_url = "https://my-proxy.example.com".to_string();
+        store.agent_def_insert(&mut def).unwrap();
+        // Same id also present in the global store — the normal case, not
+        // the cross-channel-only case the earlier (buggy) comment assumed.
+        def_store.upsert(&global_user_agent("agent-1", "Vendor Agent")).unwrap();
+        store.set_def_registry(def_store);
+
+        let list = store.agent_def_list().unwrap();
+        let found = list.iter().find(|d| d.id == "agent-1").expect("agent must be listed");
+        assert_eq!(
+            found.model_vendor_base_url, "https://my-proxy.example.com",
+            "the global overlay must not wipe a same-channel agent's vendor override"
+        );
+    }
+
     fn local_def(id: &str, name: &str) -> AgentDefinition {
         AgentDefinition {
             id: id.to_string(),

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -118,6 +118,11 @@ pub(super) fn record_to_agent_definition(rec: &DefinitionRecord) -> AgentDefinit
         container_volumes: d.container_volumes.clone(),
         container_name: d.container_name.clone(),
         use_ambient_login: d.use_ambient_login,
+        // Deliberately not carried by DefinitionRecordV1 (see its module
+        // doc) — a model vendor override is channel-local only for now;
+        // a cross-channel agent reopened from the global registry starts
+        // with the harness's default vendor. Known limitation, not a bug.
+        model_vendor_base_url: String::new(),
     }
 }
 
@@ -339,6 +344,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -67,7 +67,7 @@ impl Store {
                 slug, branch_label, working_directory,
                 created_at, updated_at, is_seeded, user_hidden,
                 container_image, container_volumes, container_name,
-                use_ambient_login
+                use_ambient_login, model_vendor_base_url
              ) VALUES (
                 ?1, ?2, ?3, ?4,
                 ?5, ?6,
@@ -77,7 +77,7 @@ impl Store {
                 ?17, ?18, ?19,
                 ?20, ?21, ?22, ?23,
                 ?24, ?25, ?26,
-                ?27
+                ?27, ?28
              )
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
@@ -103,7 +103,8 @@ impl Store {
                 container_image = excluded.container_image,
                 container_volumes = excluded.container_volumes,
                 container_name = excluded.container_name,
-                use_ambient_login = excluded.use_ambient_login",
+                use_ambient_login = excluded.use_ambient_login,
+                model_vendor_base_url = excluded.model_vendor_base_url",
             params![
                 def.id,
                 def.name,
@@ -132,6 +133,7 @@ impl Store {
                 def.container_volumes,
                 def.container_name,
                 def.use_ambient_login,
+                def.model_vendor_base_url,
             ],
         )?;
         Ok(())
@@ -629,7 +631,7 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login
+                    use_ambient_login, model_vendor_base_url
              FROM db_agent_definitions WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], |row| {
@@ -660,6 +662,7 @@ impl Store {
                 container_volumes: row.get(23)?,
                 container_name: row.get(24)?,
                 use_ambient_login: row.get(25)?,
+                model_vendor_base_url: row.get(26)?,
             })
         });
         match result {

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -713,6 +713,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -89,7 +89,14 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 6;
 ///        duplication as db_agent_credentials, for the same id_store
 ///        fallback reason. See
 ///        docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md.
-pub const OBJECT_SCHEMA_VERSION: i64 = 14;
+///   v15 — model_vendor_base_url on both db_agent_definitions and db_agents:
+///        redirects a harness (CLI) at a non-default model vendor backend
+///        (e.g. ANTHROPIC_BASE_URL for a claude-provider agent) — the data-
+///        model side of formalizing harness vs. model-vendor as distinct
+///        concepts. Defaults to '' (use the harness's default vendor).
+///        Only settable via `agent.define`, validated against the resolved
+///        provider's `ProviderConfig::base_url_env_var`.
+pub const OBJECT_SCHEMA_VERSION: i64 = 15;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -225,7 +232,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             container_image      TEXT NOT NULL DEFAULT '',
             container_volumes    TEXT NOT NULL DEFAULT '[]',
             container_name       TEXT NOT NULL DEFAULT '',
-            use_ambient_login    INTEGER NOT NULL DEFAULT 0
+            use_ambient_login    INTEGER NOT NULL DEFAULT 0,
+            model_vendor_base_url TEXT NOT NULL DEFAULT ''
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_slug
             ON db_agent_definitions(slug);
@@ -405,7 +413,11 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             -- Explicit per-agent opt-in to the CLI's global (ambient) login
             -- when no oauth-class account resolves at spawn (schema v12,
             -- SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3).
-            use_ambient_login    INTEGER NOT NULL DEFAULT 0
+            use_ambient_login    INTEGER NOT NULL DEFAULT 0,
+
+            -- Redirects this agent's harness at a non-default model vendor
+            -- backend (schema v15) — see db_agent_definitions' column doc.
+            model_vendor_base_url TEXT NOT NULL DEFAULT ''
         );
         CREATE INDEX IF NOT EXISTS idx_agents_is_template
             ON db_agents(is_template);
@@ -589,6 +601,11 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         // gating — SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3).
         "ALTER TABLE db_agent_definitions ADD COLUMN use_ambient_login INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE db_agents ADD COLUMN use_ambient_login INTEGER NOT NULL DEFAULT 0",
+        // v15: model vendor override — redirects a harness at a non-default
+        // backend (e.g. ANTHROPIC_BASE_URL). Formalizes harness vs. model
+        // vendor as distinct concepts; see ProviderConfig::base_url_env_var.
+        "ALTER TABLE db_agent_definitions ADD COLUMN model_vendor_base_url TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agents ADD COLUMN model_vendor_base_url TEXT NOT NULL DEFAULT ''",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();
@@ -1048,6 +1065,16 @@ mod tests {
         count == 1
     }
 
+    fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
+        let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})")).unwrap();
+        let names: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        names.iter().any(|n| n == column)
+    }
+
     #[test]
     fn test_object_schema_creates_all_tables_and_singletons() {
         let conn = Connection::open_in_memory().unwrap();
@@ -1102,6 +1129,20 @@ mod tests {
             )
             .unwrap();
         assert_eq!(mem_count, 1);
+    }
+
+    #[test]
+    fn test_object_schema_has_model_vendor_base_url_on_both_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        run_object_schema(&conn).unwrap();
+        // Second pass: the ALTER TABLE array's duplicate-column guard must
+        // not error when the column already exists (fresh installs get it
+        // via CREATE TABLE; the ALTER is for upgrading pre-v15 databases).
+        run_object_schema(&conn).unwrap();
+
+        assert!(column_exists(&conn, "db_agent_definitions", "model_vendor_base_url"));
+        assert!(column_exists(&conn, "db_agents", "model_vendor_base_url"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -633,6 +633,7 @@ mod effective_skills_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
     }

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -318,6 +318,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -385,6 +386,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");
@@ -447,6 +449,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 
@@ -2339,6 +2342,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         // db_agents row exists, projected as template.
@@ -2379,6 +2383,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         // User-cloned def has is_seeded=0 + parent_id pointing at template.
@@ -2425,6 +2430,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         def.name = "New Name".to_string();
@@ -2472,6 +2478,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         def.branch_label = "New Branch".to_string();
@@ -2516,6 +2523,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
         assert_eq!(count_agents(&store, "id = 'tpl-del'"), 1);
@@ -2554,6 +2562,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
 
@@ -2640,6 +2649,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
 
@@ -2735,6 +2745,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let inst = AgentInstance {
@@ -2792,6 +2803,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let inst = AgentInstance {
@@ -2847,6 +2859,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl_a).unwrap();
         let mut tpl_b = tpl_a.clone();
@@ -2914,6 +2927,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
             };
             store.agent_def_insert(&mut d).unwrap();
         }
@@ -2956,6 +2970,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         // User-clone DEF of that template (Phase 1 created this).
@@ -3030,6 +3045,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let mut clone = AgentDefinition {

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -675,6 +675,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -748,6 +749,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -822,6 +824,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -885,6 +888,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login,
+            model_vendor_base_url: String::new(),
         }
     }
 
@@ -1127,6 +1131,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1210,6 +1215,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1275,6 +1281,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1338,6 +1345,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1411,6 +1419,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1488,6 +1497,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1577,6 +1587,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1660,6 +1671,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1735,6 +1747,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
 

--- a/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
+++ b/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
@@ -135,6 +135,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 

--- a/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
+++ b/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
@@ -174,6 +174,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut def).unwrap();
         def.id

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -127,6 +127,9 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // ambient opt-in is an explicit per-agent toggle (spec
                     // §2.2 edge case — no implicit ambient for fresh agents).
                     use_ambient_login: 0,
+                    // Not settable via this RPC yet — only `agent.define`
+                    // (the App-API/MCP path) can set a model vendor override.
+                    model_vendor_base_url: String::new(),
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 // Assign the agent its display color at creation
@@ -222,6 +225,11 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // accounts). The Agent setup modal's Accounts tab sends
                     // Some(0|1) to flip it. Spec §2.3.
                     use_ambient_login: cmd.use_ambient_login.unwrap_or(old.use_ambient_login),
+                    // Not carried by CommandUpdateAgentDefinitionData yet —
+                    // always preserve, same as container_name/parent_id
+                    // above, so a UI-driven save never silently wipes a
+                    // vendor override set via `agent.define`.
+                    model_vendor_base_url: old.model_vendor_base_url.clone(),
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -418,6 +426,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_volumes: "[]".to_string(),
                     container_name: String::new(),
                     use_ambient_login: 0,
+                    model_vendor_base_url: String::new(),
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
 
@@ -554,6 +563,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         container_volumes: "[]".to_string(),
                         container_name: String::new(),
                         use_ambient_login: 0,
+                        model_vendor_base_url: String::new(),
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -414,6 +414,7 @@ mod recent_sessions_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         let mut def_mut = def.clone();
         wstore.agent_def_insert(&mut def_mut).unwrap();
@@ -729,6 +730,7 @@ mod recent_sessions_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut tpl).unwrap();
 
@@ -759,6 +761,7 @@ mod recent_sessions_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut user_a).unwrap();
 

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -144,6 +144,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_volumes: template.container_volumes.clone(),
                     container_name: String::new(),
                     use_ambient_login: 0,
+                    model_vendor_base_url: template.model_vendor_base_url.clone(),
                 };
                 wstore
                     .agent_def_insert(&mut new_def)
@@ -352,6 +353,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_volumes: source.container_volumes.clone(),
                     container_name: String::new(),
                     use_ambient_login: 0,
+                    model_vendor_base_url: source.model_vendor_base_url.clone(),
                 };
                 wstore
                     .agent_def_insert(&mut fork)

--- a/agentmux-srv/src/server/app_api/agent_define.rs
+++ b/agentmux-srv/src/server/app_api/agent_define.rs
@@ -4,6 +4,24 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_agent_define(engine, state);
 }
 
+/// Rejects a non-empty `model_vendor_base_url` unless `provider_id`'s
+/// `ProviderConfig` declares support for redirection via
+/// `base_url_env_var`. Pure — no I/O — so it's directly unit-testable
+/// without the async `Store`/`Broker` harness `agent_define_core` needs.
+/// An empty `base_url` is always fine — that's "use the harness's default
+/// vendor endpoint," never rejected regardless of provider.
+pub(super) fn validate_vendor_base_url(provider_id: &str, base_url: &str) -> Result<(), String> {
+    if base_url.is_empty() {
+        return Ok(());
+    }
+    match providers::get_provider(provider_id) {
+        Some(p) if p.base_url_env_var.is_some() => Ok(()),
+        _ => Err(format!(
+            "agent.define: provider '{provider_id}' does not support a custom model vendor base URL"
+        )),
+    }
+}
+
 /// Infer a provider slug from a model name prefix.
 /// Only maps prefixes that correspond to a registered provider slug.
 /// Callers must still validate the result via `providers::get_provider`.
@@ -121,4 +139,35 @@ fn register_agent_define(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_base_url_is_always_valid() {
+        // Even for a provider with no base_url_env_var — "unset" never needs
+        // the capability to exist.
+        assert!(validate_vendor_base_url("codex", "").is_ok());
+        assert!(validate_vendor_base_url("claude", "").is_ok());
+        assert!(validate_vendor_base_url("nonexistent-provider", "").is_ok());
+    }
+
+    #[test]
+    fn non_empty_base_url_accepted_for_a_supporting_provider() {
+        assert!(validate_vendor_base_url("claude", "https://my-proxy.example.com").is_ok());
+    }
+
+    #[test]
+    fn non_empty_base_url_rejected_for_a_non_supporting_provider() {
+        let err = validate_vendor_base_url("codex", "https://my-proxy.example.com").unwrap_err();
+        assert!(err.contains("codex"));
+        assert!(err.contains("does not support"));
+    }
+
+    #[test]
+    fn non_empty_base_url_rejected_for_an_unknown_provider() {
+        assert!(validate_vendor_base_url("not-a-real-provider", "https://x").is_err());
+    }
 }

--- a/agentmux-srv/src/server/app_api/agent_define.rs
+++ b/agentmux-srv/src/server/app_api/agent_define.rs
@@ -171,3 +171,97 @@ mod tests {
         assert!(validate_vendor_base_url("not-a-real-provider", "https://x").is_err());
     }
 }
+
+// reagent P1 on PR #2505: agent.define's update path had no way to distinguish
+// "don't touch model_vendor_base_url" from "clear it" (a plain empty String
+// always meant "don't touch"). Combined with the authoritative validation
+// re-running on every update against whatever is currently stored, a provider
+// change away from a vendor-capable provider while an old override sat there
+// permanently blocked every future agent.define call for that agent — there
+// was no way to ever un-set the stale value. Fixed via Option<String>: `None`
+// = don't touch, `Some("")` = explicit clear.
+#[cfg(test)]
+mod agent_define_core_vendor_tests {
+    use super::*;
+    use crate::server::tests::test_state;
+
+    fn cmd(value: serde_json::Value) -> CommandAgentDefineData {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[tokio::test]
+    async fn omitting_the_field_on_update_does_not_clear_a_previously_set_override() {
+        let state = test_state();
+
+        let created = agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-test-agent",
+            "provider": "claude",
+            "model_vendor_base_url": "https://my-proxy.example.com",
+        }))).await.unwrap();
+        let def = state.wstore.agent_def_get(&created.definition_id).unwrap().unwrap();
+        assert_eq!(def.model_vendor_base_url, "https://my-proxy.example.com");
+
+        // Update that touches an unrelated field and omits model_vendor_base_url.
+        agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-test-agent",
+            "if_exists": "update",
+            "description": "just touching something else",
+        }))).await.unwrap();
+        let def = state.wstore.agent_def_get(&created.definition_id).unwrap().unwrap();
+        assert_eq!(
+            def.model_vendor_base_url, "https://my-proxy.example.com",
+            "an omitted field must not clear the stored override"
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_empty_string_clears_a_previously_set_override() {
+        let state = test_state();
+
+        let created = agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-clear-test",
+            "provider": "claude",
+            "model_vendor_base_url": "https://my-proxy.example.com",
+        }))).await.unwrap();
+
+        agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-clear-test",
+            "if_exists": "update",
+            "model_vendor_base_url": "",
+        }))).await.unwrap();
+        let def = state.wstore.agent_def_get(&created.definition_id).unwrap().unwrap();
+        assert_eq!(def.model_vendor_base_url, "", "explicit empty string must clear the override");
+    }
+
+    #[tokio::test]
+    async fn a_stale_override_left_by_a_provider_change_is_recoverable_not_a_permanent_block() {
+        let state = test_state();
+
+        let created = agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-poison-test",
+            "provider": "claude",
+            "model_vendor_base_url": "https://my-proxy.example.com",
+        }))).await.unwrap();
+
+        // Changing provider to one that doesn't support the override, without
+        // clearing it, must fail validation rather than silently succeeding.
+        let err = agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-poison-test",
+            "if_exists": "update",
+            "provider": "codex",
+        }))).await.unwrap_err();
+        assert!(err.contains("does not support"));
+
+        // The agent must not be permanently stuck: clearing the override in
+        // the SAME call that changes provider must succeed.
+        agent_define_core(state.wstore.clone(), state.broker.clone(), cmd(json!({
+            "name": "vendor-poison-test",
+            "if_exists": "update",
+            "provider": "codex",
+            "model_vendor_base_url": "",
+        }))).await.unwrap();
+        let def = state.wstore.agent_def_get(&created.definition_id).unwrap().unwrap();
+        assert_eq!(def.provider, "codex");
+        assert_eq!(def.model_vendor_base_url, "");
+    }
+}

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -31,6 +31,93 @@ fn agent_open_lock(agent_id: &str) -> Arc<tokio::sync::Mutex<()>> {
         .clone()
 }
 
+/// Resolve the `(env_var, value)` pair to inject for this agent's model
+/// vendor override, if any — redirects the harness at a non-default
+/// backend (e.g. `ANTHROPIC_BASE_URL` for a `claude`-provider agent).
+/// Pure — no I/O — so it's directly unit-testable without the full
+/// async spawn-time harness this is called from.
+///
+/// `None` when there's nothing to override (empty `model_vendor_base_url`)
+/// OR the provider doesn't declare `base_url_env_var` — the latter should
+/// already be impossible by the time an agent reaches spawn (rejected at
+/// `agent.define`), but this stays defensive rather than trusting that
+/// write-time validation is the only thing that can ever set this field.
+fn resolve_vendor_env_override(
+    provider: &providers::ProviderConfig,
+    agent: &AgentDefinition,
+) -> Option<(&'static str, String)> {
+    if agent.model_vendor_base_url.is_empty() {
+        return None;
+    }
+    provider
+        .base_url_env_var
+        .map(|var| (var, agent.model_vendor_base_url.clone()))
+}
+
+#[cfg(test)]
+mod resolve_vendor_env_override_tests {
+    use super::*;
+
+    fn base_agent(model_vendor_base_url: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: "a1".to_string(),
+            slug: "a1".to_string(),
+            name: "T".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            model_vendor_base_url: model_vendor_base_url.to_string(),
+        }
+    }
+
+    #[test]
+    fn returns_none_when_override_is_unset() {
+        let provider = providers::get_provider("claude").unwrap();
+        let agent = base_agent("");
+        assert!(resolve_vendor_env_override(provider, &agent).is_none());
+    }
+
+    #[test]
+    fn returns_the_env_var_and_value_for_a_supporting_provider() {
+        let provider = providers::get_provider("claude").unwrap();
+        let agent = base_agent("https://my-proxy.example.com");
+        assert_eq!(
+            resolve_vendor_env_override(provider, &agent),
+            Some(("ANTHROPIC_BASE_URL", "https://my-proxy.example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn returns_none_for_a_non_supporting_provider_even_if_the_field_is_set() {
+        // Defensive: shouldn't be reachable in practice (agent.define
+        // rejects this combination), but a non-supporting provider must
+        // never get a spurious env var injected.
+        let provider = providers::get_provider("codex").unwrap();
+        let agent = base_agent("https://my-proxy.example.com");
+        assert!(resolve_vendor_env_override(provider, &agent).is_none());
+    }
+}
+
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_agent_open(engine, state);
 }
@@ -203,6 +290,16 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
                 for (k, v) in provider.auth_extra_env {
                     env_vars.insert(k.to_string(), json!(v));
+                }
+                // Model vendor override (harness vs. model-vendor decoupling)
+                // — e.g. ANTHROPIC_BASE_URL for a claude-provider agent
+                // pointed at a proxy/Bedrock/OpenRouter instead of
+                // Anthropic's default endpoint. Inserted before the
+                // free-form env blob below so it wins if a definition-level
+                // KEY=VALUE line collides with it (structured field over
+                // free-form blob, same precedence as the auth entries above).
+                if let Some((var, value)) = resolve_vendor_env_override(provider, &agent) {
+                    env_vars.insert(var.to_string(), json!(value));
                 }
                 // Merge env vars from the definition's persisted env content blob (KEY=VALUE lines).
                 // Provider/auth entries inserted above take precedence; definition-level vars
@@ -748,6 +845,7 @@ mod write_agent_config_files_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -405,7 +405,8 @@ pub(crate) async fn agent_define_core(
     // agent's actual provider (not this possibly-defaulted `provider`,
     // which may not reflect an unspecified `cmd.provider` on an update
     // call) right before its own write — this check doesn't gate that path.
-    agent_define::validate_vendor_base_url(&provider, &cmd.model_vendor_base_url)?;
+    let cmd_model_vendor_base_url = cmd.model_vendor_base_url.clone().unwrap_or_default();
+    agent_define::validate_vendor_base_url(&provider, &cmd_model_vendor_base_url)?;
 
     // Build the new definition struct up-front so agent_def_find_or_insert
     // can use it as both the lookup key and the insert payload.
@@ -444,7 +445,7 @@ pub(crate) async fn agent_define_core(
         container_volumes: cmd.container_volumes.clone(),
         container_name: String::new(), // assigned by ContainerManager on first spawn
         use_ambient_login: 0,
-        model_vendor_base_url: cmd.model_vendor_base_url.clone(),
+        model_vendor_base_url: cmd_model_vendor_base_url.clone(),
     };
 
     // Atomic check-then-insert.
@@ -514,7 +515,13 @@ pub(crate) async fn agent_define_core(
                 if !cmd.description.is_empty() { updated.description = cmd.description.clone(); }
                 if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory.clone(); }
                 if !cmd.shell.is_empty()    { updated.shell = cmd.shell.clone(); }
-                if !cmd.model_vendor_base_url.is_empty() { updated.model_vendor_base_url = cmd.model_vendor_base_url.clone(); }
+                // `None` = don't touch; `Some(_)` (including `Some("")`) sets
+                // it explicitly — the caller MUST be able to pass `Some("")`
+                // to clear a stale override, or a provider change away from
+                // a vendor-capable provider (see validation below) would
+                // permanently block every future agent.define call for this
+                // agent, since there'd be no way to ever un-set the old value.
+                if let Some(url) = &cmd.model_vendor_base_url { updated.model_vendor_base_url = url.clone(); }
                 // Authoritative check for this write: validates the FINAL
                 // effective (provider, override) pair — catches both a
                 // freshly-supplied override against the real provider, and a

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -399,6 +399,14 @@ pub(crate) async fn agent_define_core(
         .unwrap_or_default()
         .as_millis() as i64;
 
+    // Gates the fresh-insert path below (the "no existing match" case, where
+    // `def` — built from `provider` — is what actually gets written). The
+    // "update" branch further down re-validates against the EXISTING
+    // agent's actual provider (not this possibly-defaulted `provider`,
+    // which may not reflect an unspecified `cmd.provider` on an update
+    // call) right before its own write — this check doesn't gate that path.
+    agent_define::validate_vendor_base_url(&provider, &cmd.model_vendor_base_url)?;
+
     // Build the new definition struct up-front so agent_def_find_or_insert
     // can use it as both the lookup key and the insert payload.
     // agent_def_find_or_insert holds a single mutex guard for the check +
@@ -436,6 +444,7 @@ pub(crate) async fn agent_define_core(
         container_volumes: cmd.container_volumes.clone(),
         container_name: String::new(), // assigned by ContainerManager on first spawn
         use_ambient_login: 0,
+        model_vendor_base_url: cmd.model_vendor_base_url.clone(),
     };
 
     // Atomic check-then-insert.
@@ -505,6 +514,14 @@ pub(crate) async fn agent_define_core(
                 if !cmd.description.is_empty() { updated.description = cmd.description.clone(); }
                 if !cmd.working_directory.is_empty() { updated.working_directory = cmd.working_directory.clone(); }
                 if !cmd.shell.is_empty()    { updated.shell = cmd.shell.clone(); }
+                if !cmd.model_vendor_base_url.is_empty() { updated.model_vendor_base_url = cmd.model_vendor_base_url.clone(); }
+                // Authoritative check for this write: validates the FINAL
+                // effective (provider, override) pair — catches both a
+                // freshly-supplied override against the real provider, and a
+                // provider change that leaves a stale override from before
+                // now invalid (the caller must clear it explicitly rather
+                // than silently carrying an inconsistent combination).
+                agent_define::validate_vendor_base_url(&updated.provider, &updated.model_vendor_base_url)?;
                 if !cmd.environment.is_empty() { updated.environment = cmd.environment.clone(); }
                 // name update intentionally omitted — the slug is immutable;
                 // renaming would create a slug mismatch. Use updateagent for renames.
@@ -1935,6 +1952,7 @@ mod identity_self_accounts_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         state.wstore.agent_def_insert(&mut def).unwrap();
 
@@ -2006,6 +2024,7 @@ mod identity_self_accounts_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         };
         state.wstore.agent_def_insert(&mut def).unwrap();
         state.wstore.identity_upsert(&sample_account("acct-good", "claude")).unwrap();

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -833,6 +833,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
         }
     }
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -11,6 +11,7 @@ import { SignalAtom } from "@/util/util";
 import { AgentViewWrapper } from "./agent-view";
 import { buildAgentPaneIcon } from "./components/AgentPaneIcon";
 import { PROVIDERS, resolveProviderAlias } from "./providers";
+import { resolveVendorEnvOverride } from "./providers/vendor-env";
 import { Logger } from "@/util/logger";
 import { buildInstanceSlug } from "./defaults/instance-slug";
 import type { LaunchOverrides } from "./components/AgentLaunchModal";
@@ -475,6 +476,18 @@ export class AgentViewModel implements ViewModel {
         }
         if (provider.authExtraEnv) {
             Object.assign(envVars, provider.authExtraEnv);
+        }
+        // Model vendor override (harness vs. model-vendor decoupling) — e.g.
+        // ANTHROPIC_BASE_URL for a claude-provider agent pointed at a proxy/
+        // Bedrock/OpenRouter instead of Anthropic's default endpoint. Mirrors
+        // agent_open.rs's resolve_vendor_env_override: only injected when
+        // both the agent has a non-empty override AND the provider declares
+        // support for it (should already be guaranteed by agent.define's
+        // validation, but this doesn't trust that as the only gate).
+        const vendorOverride = resolveVendorEnvOverride(agent.model_vendor_base_url, provider.baseUrlEnvVar);
+        if (vendorOverride) {
+            const [envVar, value] = vendorOverride;
+            envVars[envVar] = value;
         }
         // Only set exit delay for subprocess mode — persistent processes must stay alive
         if (provider.controllerType !== "persistent") {

--- a/frontend/app/view/agent/providers/catalog.ts
+++ b/frontend/app/view/agent/providers/catalog.ts
@@ -80,6 +80,10 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         unsetEnv: ["CLAUDECODE"],
         authConfigDirEnvVar: "CLAUDE_CONFIG_DIR",
         authDirName: "claude",
+        // Documented Claude Code behavior: redirects the CLI at a non-Anthropic
+        // (or proxied) backend — Bedrock, Vertex, OpenRouter, a custom proxy.
+        // Mirrors agentmux-srv/src/backend/providers.rs `base_url_env_var`.
+        baseUrlEnvVar: "ANTHROPIC_BASE_URL",
         launchArgs: ["-p", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
         resumeFlag: "--resume",
         sessionIdField: "session_id",

--- a/frontend/app/view/agent/providers/types.ts
+++ b/frontend/app/view/agent/providers/types.ts
@@ -119,4 +119,16 @@ export interface ProviderDefinition {
      * docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md.
      */
     models?: ProviderModel[];
+    /**
+     * Env var this harness reads to redirect its model vendor backend (e.g.
+     * Claude Code's `ANTHROPIC_BASE_URL`, pointing it at a proxy/Bedrock/
+     * OpenRouter instead of Anthropic's default endpoint). Omit when a
+     * harness isn't confirmed to support redirection — the harness (CLI
+     * driving the session) and the model vendor (LLM backend actually
+     * serving responses) are independent dimensions; this is the declared
+     * capability side of that split. Mirrors Rust's
+     * `ProviderConfig::base_url_env_var` — set only where independently
+     * verified, not guessed.
+     */
+    baseUrlEnvVar?: string;
 }

--- a/frontend/app/view/agent/providers/vendor-env.test.ts
+++ b/frontend/app/view/agent/providers/vendor-env.test.ts
@@ -1,0 +1,23 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { resolveVendorEnvOverride } from "./vendor-env";
+
+describe("resolveVendorEnvOverride", () => {
+    it("returns null when the agent has no override set", () => {
+        expect(resolveVendorEnvOverride(undefined, "ANTHROPIC_BASE_URL")).toBeNull();
+        expect(resolveVendorEnvOverride("", "ANTHROPIC_BASE_URL")).toBeNull();
+    });
+
+    it("returns null when the provider doesn't declare a base URL env var", () => {
+        expect(resolveVendorEnvOverride("https://my-proxy.example.com", undefined)).toBeNull();
+    });
+
+    it("returns the [envVar, value] pair when both are present", () => {
+        expect(resolveVendorEnvOverride("https://my-proxy.example.com", "ANTHROPIC_BASE_URL")).toEqual([
+            "ANTHROPIC_BASE_URL",
+            "https://my-proxy.example.com",
+        ]);
+    });
+});

--- a/frontend/app/view/agent/providers/vendor-env.ts
+++ b/frontend/app/view/agent/providers/vendor-env.ts
@@ -1,0 +1,26 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Resolve the `[envVar, value]` pair to inject for an agent's model vendor
+ * override, if any — redirects the harness at a non-default backend (e.g.
+ * `ANTHROPIC_BASE_URL` for a `claude`-provider agent). Pure — no I/O — so
+ * it's directly unit-testable without agent-model.ts's heavy launch-flow
+ * dependencies (RpcApi, block stores, etc.).
+ *
+ * `null` when there's nothing to override (no `modelVendorBaseUrl`) OR the
+ * provider doesn't declare `baseUrlEnvVar` — the latter should already be
+ * impossible by the time an agent reaches launch (rejected at
+ * `agent.define`), but this stays defensive rather than trusting that
+ * write-time validation is the only thing that can ever set this field.
+ * Mirrors agentmux-srv's `resolve_vendor_env_override`.
+ */
+export function resolveVendorEnvOverride(
+    modelVendorBaseUrl: string | undefined,
+    baseUrlEnvVar: string | undefined,
+): [string, string] | null {
+    if (!modelVendorBaseUrl || !baseUrlEnvVar) {
+        return null;
+    }
+    return [baseUrlEnvVar, modelVendorBaseUrl];
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -326,6 +326,15 @@ declare global {
          * SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3.
          */
         use_ambient_login?: number;
+        /**
+         * Redirects this agent's harness (CLI) at a non-default model vendor
+         * backend — e.g. a custom `ANTHROPIC_BASE_URL` for a claude-provider
+         * agent. Empty/absent = use the harness's default vendor endpoint.
+         * Schema v15. Only settable via `agent.define` today; the human
+         * "New Agent"/edit UI (createagent/updateagent) doesn't surface it
+         * yet — see `agent_define_core`'s `validate_vendor_base_url`.
+         */
+        model_vendor_base_url?: string;
     };
 
     // ── v6: identity, instance, junction ────────────────────────────────────


### PR DESCRIPTION
## Summary

AgentMux's "provider" concept conflates two independent things: the **harness** (the CLI driving a session — `claude`, `codex`, `gemini`...) and the **model vendor** (the LLM backend actually serving responses — Anthropic, a proxy, Bedrock...). Claude Code already supports `ANTHROPIC_BASE_URL` to point at a non-Anthropic-hosted backend, so harness ≠ vendor in reality — but the data model had no explicit "model vendor" concept. Confirmed via full-repo grep: `ANTHROPIC_BASE_URL` appeared nowhere in the codebase before this PR.

A generic, unstructured escape hatch already existed (`CommandAgentDefineData.env`, a free-form `KEY=VALUE` env blob merged at spawn time), so the gap wasn't mechanical — it was that there was no **explicit, discoverable, validated, first-class concept**: no way to query which agents use a non-default vendor, no validation that the chosen provider even supports redirection, nothing typed or surfaced in `agent.define`'s result.

## What this adds

- **`ProviderConfig.base_url_env_var`** (Rust) / **`ProviderDefinition.baseUrlEnvVar`** (TS): declares which env var (if any) a harness reads to redirect its backend. Only set for `claude` (`ANTHROPIC_BASE_URL`) — the one case independently verified as real, documented Claude Code behavior; explicit `None`/omitted everywhere else rather than guessed.
- **`AgentDefinition.model_vendor_base_url`**: per-agent override, schema v15 — added to **both** `db_agent_definitions` and `db_agents` (the dual-write mirror table `agent_def_list` actually reads from; a single-table ALTER would have silently no-op'd the feature after the first read).
- **Validation** in `agent_define_core`: rejects a non-empty override unless the resolved provider declares `base_url_env_var` support — a pure, unit-tested `validate_vendor_base_url` helper.
- **Actual env-var injection at spawn time, on BOTH paths**: Rust (`agent_open.rs`, the `agent.open` App-API/MCP path) and TypeScript (`agent-model.ts`'s `launchAgentDefinition`, the human "Launch Agent" UI path) — the feature works for real agent launches, not just MCP-spawned ones.

## Deliberately out of scope

This traces back to a spec found on an unmerged branch (`feat/harness-model-decoupling-antigravity`) whose core architectural observation is sound and independently verified here, but whose scope (onboarding a new "Antigravity" CLI harness with a hardcoded `--yolo` auto-approve flag) was explicitly rejected. This PR:
- **No new harness/CLI onboarding** — no Antigravity integration, no `--yolo`, no bypassing the tool-permission gate. Formalizes the concept using only providers AgentMux already trusts.
- **No UI wizard rework** — settable via `agent.define` only; the human "New Agent"/edit UI doesn't surface it yet (`createagent`/`updateagent` don't carry the field — `updateagent` explicitly preserves the existing value so a UI-driven save never silently wipes an override set via `agent.define`).
- **No cross-channel registry mirror** — channel-local only for now; a cross-channel reopen of the same agent won't carry the override. Documented limitation in `def_registry_mirror.rs`, not an oversight.

## Test plan

- [x] `cargo check --workspace --tests` — clean (all 6 workspace crates)
- [x] `cargo test -p agentmux-srv` — 2107 passed, 0 failed (includes 2 new `providers.rs` tests, 4 `agent_define.rs` validation tests, 3 `agent_open.rs` env-resolution tests, 1 schema test asserting the new column on both tables + idempotency)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2468 passed (includes 3 new `vendor-env.ts` tests; `pin-consistency.test.ts`/`provider-id-aliases.test.ts` — the drift guards between the Rust and TS provider catalogs — still pass)
- [ ] Not manually smoke-tested via `task dev` (full CEF rebuild) — verification here is thorough unit coverage of every new code path (validation, both injection sites, schema) rather than a live UI walkthrough; flagging this explicitly rather than claiming untested things work

<!-- agentmux:agent_id=camper -->