### PR TITLE
docs(specs): adopt closed Status vocabulary (docs-lifecycle Phase 1) + restamp 44 code-verified specs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ Project documentation organized by type.
 | `specs/` | Specs, design explorations, and implementation plans, from draft through implemented |
 | `status/` | Point-in-time subsystem status snapshots |
 
+Spec `**Status:**` lines use a closed vocabulary (`draft | proposed | active | implemented | living | historical | superseded`) — the rule, and the reader guardrail that goes with it, live in [`docs/specs/README.md`](specs/README.md#status-field).
+
 In practice nearly all specs — draft and implemented alike — live under `docs/specs/`, not the
 top-level `specs/` directory; treat the latter as legacy/lower-traffic rather than "the approved
 tier." There is no `docs-internal/` directory in this repo.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,3 +4,42 @@ Draft specs, design explorations, and implementation plans. These are work-in-pr
 
 Once a spec is approved and ready for implementation, move it to the top-level `specs/` directory.
 Once implementation is complete, move it to `specs/archive/`.
+
+## Status field
+
+This is the actual rule, not a suggestion (docs-lifecycle hardening Phase 1 —
+see `SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md`):
+
+Every spec carries a `**Status:**` line whose **first word** is one of the
+closed enum:
+
+```
+draft | proposed | active | implemented | living | historical | superseded
+```
+
+- `draft` — still being written; not yet ready for review.
+- `proposed` — written and reviewable; nothing has shipped.
+- `active` — partially implemented / implementation in progress. The line
+  **must say what shipped (PR #s) and what remains.**
+- `implemented` — shipped. The line **must cite the implementing PR(s).**
+- `living` — continuously maintained reference; has no terminal state.
+- `historical` — records a past state or effort; kept for the record, not a
+  plan for anyone.
+- `superseded` — replaced by another doc. **REQUIRES** a `**Superseded-by:**`
+  line pointing at a real path in this repo (a broken pointer is worse than
+  none).
+
+After the enum word, a dash and free text is encouraged — evidence, dates,
+PR numbers, what remains. Example:
+
+```
+**Status:** active — Phase 0 shipped in PR #2394; Phases 1-6 not started. Verified 2026-08-10.
+```
+
+### Reader guardrail
+
+Statuses rot (this doc's parent spec found shipped features still marked
+"no code yet" 48 hours after landing). Before trusting a spec's Status — or
+any checkable claim in it (a file path, "Phase N done", "PR merged") —
+**spot-verify against current code.** A Status line is a claim about the
+code; nothing re-verifies it automatically once written.

--- a/docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md
+++ b/docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md
@@ -1,7 +1,7 @@
 # Spec: ABF Import UI (Phase 3) — Selective Import + Collision Handling
 
 **Date:** 2026-08-02
-**Status:** Spec — not yet implemented.
+**Status:** implemented — PR #2382 (selective import + collision handling, 3-step modal); verified in code 2026-08-10.
 **Relationship to prior work:** builds on
 `docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md`, whose §4.1
 explicitly scoped Phase 2 to "backend + RPC only... no UI (Phase 3, still

--- a/docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md
+++ b/docs/specs/SPEC_ABF_V0_1_SINGLE_FILE_AND_IMPORTER_2026_08_01.md
@@ -1,7 +1,7 @@
 # Spec: ABF v0.1 — Single-File Format + Importer (Phase 2)
 
 **Date:** 2026-08-01
-**Status:** Spec — implementation follows in this same effort (Phase 2, §4 below).
+**Status:** implemented — backend/bundle_import.rs + bundle.import RPC; extended by the Phase-3 UI (PR #2382). Verified 2026-08-10.
 **Relationship to prior work:** refines and partially supersedes
 `docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md` §5 (the
 original ABF proposal). That report's research (§1–§4, §7) stands unchanged —

--- a/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
+++ b/docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md
@@ -1,11 +1,8 @@
 # SPEC — Account adoption: piggyback an unlinked agent onto an existing login
 
 **Date:** 2026-08-09
-**Status:** Proposed — Surface A superseded by
-`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md` (user-preferred
-direction: bind from the Armory, not from the failure row). Surface B
-(Identity-tab "Link existing account…") remains proposed as the
-agent-side complement; see that spec's §6.
+**Status:** superseded — the chosen direction shipped as the Bind-to-Agent context menu (PR #2485); this spec's failure-row/Identity-tab adoption surfaces were not built. Verified 2026-08-10.
+**Superseded-by:** docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
 **Trigger:** Live v0.54.14 testing on a second machine (claudius). A
 pre-existing legacy agent ("Agent1", blank `identity_id`, no direct link)
 was correctly refused by the layer-3 spawn gate (#2463/#2464) and — after

--- a/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
@@ -1,9 +1,7 @@
 # SPEC: Vault Icon on the Agent-Setup Button + Responsive Tabs in the Per-Agent "Armory"
 
 **Date:** 2026-07-20 (corrected 2026-07-21, extended 2026-07-21 §7)
-**Status:** §1-6 implemented and merged (PR #2253). §7 (eliminating horizontal
-scroll) is a live follow-up — live-tested by Asaf via `task dev`, found real
-horizontal scrolling on every tab, planned in §7, not yet implemented.
+**Status:** implemented — PR #2253 including §7 (horizontal-scroll elimination); modal since renamed Stash (#2314). Verified 2026-08-10.
 **Scope:** `frontend/app/view/agent/agent-model.ts`,
 `frontend/app/view/agent/components/AgentSetupModal.tsx` / `.scss`,
 `frontend/app/view/agent/components/AgentNativeMemoryModal.tsx` / `.scss`,

--- a/docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md
+++ b/docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-26
 **Author:** AgentA
-**Status:** Decided — ready for implementation. Open questions in §8 resolved 2026-07-26; implementation tracked against §9's acceptance criteria.
+**Status:** implemented — PR #2304 (LaunchAuthState never-silent mount notifications); verified in code 2026-08-10.
 **Depends on / relates to:**
 - [`SPEC_LAUNCH_AUTH_STATE_MACHINE_2026_05_14.md`](SPEC_LAUNCH_AUTH_STATE_MACHINE_2026_05_14.md) — the **pre-launch modal's** `AuthState` reducer (bundle/identity selection before a pane exists). Sibling machine, not the same one — see §7.
 - [`PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md`](PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md) — the three-tier `runProviderLogin` fallback this spec builds notifications on top of.

--- a/docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+++ b/docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
@@ -1,8 +1,7 @@
 # SPEC: Align pane scrollback with actual model context, and make cross-instance opens honest
 
 **Date:** 2026-08-05
-**Status:** Proposed — design for Part A below; implemented in this PR. Parts B/C
-scoped but deferred (see §6).
+**Status:** active — Part A (session-outcome transcript event) shipped in PR #2426; Parts B (rehydrate-before-resume) and C (session_id backfill) not started. Verified 2026-08-10. See also SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md, which builds on Part A.
 **Severity:** Medium — no data loss, but a real correctness gap: the pane can
 imply the agent remembers a conversation it does not, with no visible signal
 that anything went wrong.

--- a/docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md
+++ b/docs/specs/SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md
@@ -1,6 +1,6 @@
 # Agent Recurring-Task / Polling Primitives — Design Hardening
 **Date:** 2026-08-04
-**Status:** Phase 0 implemented (same-day follow-up PR) — Phases 1-2 still proposed, not started.
+**Status:** active — Phase 0 shipped (Loop/Cron descriptions + max_age_secs bound); Phases 1-2 (durable:bool unification, tool renames) not started. Verified 2026-08-10.
 **Scope:** `agentmux-mcp` (`Loop` tool), `agentmux-srv` (`Cron`, `/agentmux/reactive/inject`, `wrap_jekt_message`)
 **Trigger:** Live use of `mcp__agentmux__Loop` this session to babysit a GitHub PR's review status (poll every 1m, react when approved+mergeable). Concretely: ~20+ fires, most reporting "no change," each one arriving as a full agent-to-agent JEKT message with the complete envelope overhead; no way to express "wake me only when the review state changes" declaratively; no automatic detection of the ~26-consecutive-unchanged-checks stretch that made the loop unproductive; the human directly observed and flagged this as "poorly designed" in the moment.
 

--- a/docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md
+++ b/docs/specs/SPEC_AGENT_RUNTIME_DROPUP_CLOSE_BUTTON_2026_08_07.md
@@ -1,7 +1,7 @@
 # SPEC: Explicit close button on the Runtime (Mode/Model/Effort) dropup
 
 **Date:** 2026-08-07
-**Status:** Draft — ready for review
+**Status:** implemented — PR #2460; verified in code 2026-08-10.
 **Author:** AgentX (agent)
 **Trigger:** User request — *"when changing the model panel, we dont want it
 to auto close after selection, because sometimes the user wants to change

--- a/docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
+++ b/docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
@@ -1,7 +1,7 @@
 # Spec: Continuous AgentWorkingRow background through the scrollbar gutter
 
 **Date:** 2026-08-06
-**Status:** Proposed (analysis only — not yet implemented)
+**Status:** implemented — PR #2439 (backdrop-layer fix); verified in code 2026-08-10.
 **Scope:** `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/styles/_control-bar.scss`, `frontend/app/view/agent/styles/_document.scss`
 **Related:** `SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md` §3.2 (introduced the floating-overlay architecture this spec builds on), the `.agent-working-row-anchor` z-index-obscures-scrollbar comment in `_control-bar.scss` (the earlier bug this spec must not reintroduce)
 

--- a/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
+++ b/docs/specs/SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md
@@ -1,9 +1,7 @@
 # SPEC — Armory "Bind to Agent" context menu on account rows
 
 **Date:** 2026-08-09
-**Status:** Proposed (user-requested direction; supersedes the failure-row
-surface of `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` as the
-primary UX — see §6 for how the two relate)
+**Status:** implemented — PR #2485; verified in code 2026-08-10.
 **Trigger:** A user with **three** anthropic/claude accounts in the Armory
 has no way to assign them to agents from the place where the accounts are
 visible. Assignment today only happens agent-side (launch modal picker,

--- a/docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
@@ -1,7 +1,7 @@
 # SPEC: Auto-timeout for AskUserQuestion — 30s countdown, auto-select the recommended option
 
 **Date:** 2026-08-06
-**Status:** Proposed — all open questions resolved (§5); ready for implementation.
+**Status:** implemented — PR #2441; verified in code 2026-08-10.
 **Severity:** Low-Medium — no data-loss risk, but an unanswered question
 blocks the agent's turn indefinitely today, which defeats unattended/overnight
 runs and any workflow where the human isn't watching the pane.

--- a/docs/specs/SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md
+++ b/docs/specs/SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md
@@ -1,6 +1,6 @@
 # Spec: an orthogonal "attached task" status axis, sibling to `TurnPhase`
 
-**Status:** Design — reducer-level slice implemented this pass (types + reducer + tests); dispatch wiring (ActivityDock → reducer) and `AgentFooter`/Swarm rendering deliberately deferred, see §6.
+**Status:** active — reducer slice + dispatch wiring + hasRunningPromotedTool shipped (PR #2489); the AgentFooter render from #2489 was deliberately reverted 2026-08-10 (dock running-row is the indicator); §6 item 4 (Swarm pane / muxspect surfacing) not started. Verified 2026-08-10.
 **Author:** Agent A (agenta-07017)
 **Builds on:**
 - `docs/specs/REPORT_LONGRUNNING_TOOLCALL_DOCK_VISIBILITY_2026_07_16.md` (Agent2) — original analysis, §6/§7 design direction.

--- a/docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md
+++ b/docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md
@@ -1,9 +1,6 @@
 # Spec: CEF proprietary codec support (H.264/AAC) across Windows/macOS/Linux
 
-**Status:** Draft — design only, no implementation. Written after two
-research passes confirming the exact CI/build architecture; contains a
-correction to the original request's premise (see "Key finding" below)
-that should be confirmed before implementation starts.
+**Status:** implemented — Windows #2308, macOS rebuild (tag cef-macos-arm64-148.23.23-codecs) closed via #2347/#2399, Linux release cut, CI resolver #2353; H.264/AAC verified on all three platforms. Verified 2026-08-10.
 **Author:** Agent2
 **Date:** 2026-07-26
 **Related:** `docs/reports/REPORT_CEF_PROPRIETARY_CODEC_GAP_2026_07_26.md`

--- a/docs/specs/SPEC_CEF_PROPRIETARY_CODECS_MACOS_BUILD_2026_07_27.md
+++ b/docs/specs/SPEC_CEF_PROPRIETARY_CODECS_MACOS_BUILD_2026_07_27.md
@@ -1,6 +1,6 @@
 # Spec: Execute the macOS leg of issue #2311 (codec-enabled patched CEF)
 
-**Status:** Draft — execution runbook, no build run yet.
+**Status:** implemented — build completed and tagged (see STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md); verified 2026-08-10.
 **Author:** AgentO
 **Date:** 2026-07-27
 **Issue:** [agentmuxai/agentmux#2311](https://github.com/agentmuxai/agentmux/issues/2311)

--- a/docs/specs/SPEC_CODEX_JSONL_CONTRACT_2026_08_08.md
+++ b/docs/specs/SPEC_CODEX_JSONL_CONTRACT_2026_08_08.md
@@ -1,7 +1,7 @@
 # Codex CLI JSONL Adapter Contract
 
 **Date:** 2026-08-08
-**Status:** Draft
+**Status:** implemented — PR #2476 (codex-translator.ts + tests); verified in code 2026-08-10.
 **Scope:** Codex CLI subprocess output, turn lifecycle, session continuity, translation, and fixtures
 **Target:** AgentMux Codex provider (`styledOutputFormat: "codex-json"`)
 **Current AgentMux pin:** `@openai/codex@0.116.0`

--- a/docs/specs/SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md
+++ b/docs/specs/SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md
@@ -1,7 +1,7 @@
 # Codex Provider Integration: Claude-Parity Lifecycle
 
 **Date:** 2026-08-08
-**Status:** Draft
+**Status:** active — Slices A (JSONL adapter) + B (provider argv/resume) shipped in PR #2476; Slices C (Docker identity projection), D (Armory/Stash Codex account UX), E (provider-native materializer), F (Docker smoke) not started. Verified 2026-08-10.
 **Scope:** Codex provider registration, Armory accounts, Agent Stash bindings,
 authentication isolation, Docker projection, provider-native configuration, and
 delivery slices

--- a/docs/specs/SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-30
 **Type:** UI responsiveness spec
-**Status:** Proposed — audited and designed, not yet implemented
+**Status:** implemented — PR #2372 (container-query two-row grid); verified in code 2026-08-10.
 **Scope:** `frontend/app/view/agent/components/AgentComposerStrip.tsx` +
 `frontend/app/view/agent/styles/_composer-strip.scss`
 **Trigger:** User request — *"refine the responsiveness of the stats bar above the agent pane's

--- a/docs/specs/SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md
+++ b/docs/specs/SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md
@@ -1,6 +1,6 @@
 # Docs Lifecycle Audit & Hardening Plan
 **Date:** 2026-08-03
-**Status:** Phase 0 implemented (this PR, commit `d7ed5c08`) — Phases 1-5 still proposed, not started.
+**Status:** active — Phase 0 shipped in PR #2394; Phase 1 (closed Status vocabulary) shipped 2026-08-10 in docs/specs/README.md together with a verified restamp of ~40 July-August specs; Phases 2-3 and 5 not started; Phase 4 partially covered by the reader guardrail in docs/specs/README.md.
 **Scope:** `docs/` and `specs/` (both top-level trees)
 **Related:** [`docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md`](./SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md) — written the same day, deliberately the same shape. Both audits found the identical underlying pattern: **a marker that claims a state (a migration flag / a `Status:` field) is trusted without ever being checked against ground truth, and nothing re-verifies it once written.** For migrations that's a stale `.flag` file; for docs it's a `Status: Draft` line nobody revisits. The hardening approach below deliberately mirrors that doc's phasing for the same reason: one-shot fixes rot, self-verifying systems don't.
 

--- a/docs/specs/SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md
+++ b/docs/specs/SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md
@@ -1,6 +1,6 @@
 # Plan: MCP-opened markdown blank-preview investigation + Editor-pane reuse
 
-**Status:** Proposed
+**Status:** active — Part 2 pane reuse shipped (PR #2404) and Part 1 dead-meta cleanup shipped (PR #2403); Part 1's blank-preview root-cause fix remains open pending a live repro. Verified 2026-08-10.
 **Author:** AgentY
 **Date:** 2026-08-03
 **Related:** `docs/analysis/ANALYSIS_EDITOR_MD_BUGS_2026_06_20.md` (the original

--- a/docs/specs/SPEC_MACOS_TAB_REDOCK_PARITY_2026_07_24.md
+++ b/docs/specs/SPEC_MACOS_TAB_REDOCK_PARITY_2026_07_24.md
@@ -1,11 +1,7 @@
 # macOS Tab Redock Parity — Implementation Scoping
 
 **Date:** 2026-07-24 (revised same day — see §0.1 "Scope correction")
-**Status:** Scoping only — no code written. This is Phase 7 of
-  `docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md` §6,
-  broken out into its own implementation-ready plan because that
-  phase was previously "design-only" (a cross-platform API table,
-  no concrete architecture for this codebase).
+**Status:** implemented — PR #2310 (CGEventTap tracking); §5 landing-bounce animation remains a known follow-up. Verified 2026-08-10.
 **Trigger:** User: *"lets work on the tab redock .. i believe it
   was implemented for windows by not macos"* → confirmed via
   investigation → *"which has better performance? engineering cost

--- a/docs/specs/SPEC_MEDIA_PANE_V2_AGENT_WORKFLOW_GAPS_2026_07_28.md
+++ b/docs/specs/SPEC_MEDIA_PANE_V2_AGENT_WORKFLOW_GAPS_2026_07_28.md
@@ -1,6 +1,6 @@
 # Spec: Media pane v2 — gaps found running a real agent video-editing workflow through it
 
-**Status:** Proposed
+**Status:** proposed — verified unimplemented as of 2026-08-10 (docs-only commit #2344; no transcode/thumbnail/gallery code).
 **Author:** AgentY
 **Date:** 2026-07-28
 **Related:** `docs/specs/SPEC_MEDIA_PANE_2026_07_26.md` (v1 — implemented, PR #2299;

--- a/docs/specs/SPEC_MEDIA_PANE_V3_BROWSER_AND_CUSTOM_TRANSPORT_2026_07_29.md
+++ b/docs/specs/SPEC_MEDIA_PANE_V3_BROWSER_AND_CUSTOM_TRANSPORT_2026_07_29.md
@@ -1,6 +1,6 @@
 # Spec: Media pane v3 — persistent browser + custom playback/scrub UI
 
-**Status:** Proposed
+**Status:** proposed — verified unimplemented as of 2026-08-10 (docs-only commit #2346; no PlaybackTransport anywhere).
 **Author:** AgentY
 **Date:** 2026-07-29
 **Related:** `docs/specs/SPEC_MEDIA_PANE_2026_07_26.md` (v1 — implemented,

--- a/docs/specs/SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03.md
+++ b/docs/specs/SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03.md
@@ -1,6 +1,6 @@
 # Spec: Media pane v4 — agent-facing `OpenMedia` MCP tool
 
-**Status:** Proposed (implemented — see note below)
+**Status:** implemented — PR #2398 (OpenMedia MCP tool); verified in code 2026-08-10.
 **Author:** AgentY
 
 > **2026-08-07 audit note:** Implemented — `OpenMedia` MCP tool is live in

--- a/docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md
+++ b/docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md
@@ -1,6 +1,6 @@
 # Migration System Audit & Hardening Plan
 **Date:** 2026-08-03
-**Status:** Phase 0 implemented (this PR, commits `28a925c4`/`f9505afb`) — Phases 1-6 still proposed, not started.
+**Status:** active — Phase 0 shipped in PR #2394; Phases 1-6 not started (migration failure is still non-fatal at bootstrap.rs). Verified 2026-08-10.
 **Scope:** agentmux-srv, agentmux-launcher, agentmux-cef
 **Related:** [`docs/specs/SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md`](./SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md) — written the same day, deliberately the same shape. Both audits found the identical underlying pattern: a marker that claims a state (a migration flag / a doc's `Status:` field) is trusted without ever being checked against ground truth, and nothing re-verifies it once written.
 **Trigger:** Live incident — a launched agent ("Agent1", channel `local-main-b28b7a-9172ff88`, srv v0.54.9 / commit `1899c5ed`) failed to start, and a `FOREIGN KEY constraint failed` warning on `linkagentidentity` appeared in the logs around the same time.

--- a/docs/specs/SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md
+++ b/docs/specs/SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md
@@ -1,6 +1,6 @@
 # Spec: multi-tier discovery + remote API invocation over muxbus
 
-**Status:** Proposed (audit + design)
+**Status:** active — §1 Tier-2b same-host cross-channel discovery shipped (PR #2350); §2 LAN pinned identity, §3 cloud directory, §4 typed RPC invocation layer not started. Verified 2026-08-10.
 **Author:** AgentY
 **Date:** 2026-07-29
 **Related:** `docs/specs/SPEC_MUXBUS_DELIVERY_HIERARCHY_2026_06_15.md`,

--- a/docs/specs/SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md
+++ b/docs/specs/SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md
@@ -9,7 +9,7 @@ could not see or explain it. Notable: `SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_202
 own stated trigger (§ header) was **the same bug** — "the user asked to locate
 '2 stuck sleep dock items.'" This is a recurring, still-unsolved pain point,
 not a one-off.
-**Status:** Proposed (implemented — see note below)
+**Status:** implemented — PR #2432 (muxspect dock / dock clear); verified in code 2026-08-10.
 
 > **2026-08-07 audit note:** Implemented within a day — `muxspect dock`/
 > `dock clear` commands are live in `muxspect.mjs`. Status field was never

--- a/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
+++ b/docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md
@@ -6,7 +6,7 @@
 dock items," and neither `muxlog` nor any existing RPC could answer "what is
 this running instance doing right now, and which instance is even hosting
 this conversation." That gap is the direct motivation for this spec.
-**Status:** Proposed when written; **since implemented and shipping** (PR #2380 landed `list`/`describe`; PR #2390, "surface last persisted spawn/execution error in list/describe", extends it further — both merged as of 2026-08-03). Confirmed via direct live use in this session: `node ~/.agentmux/shell/muxspect.mjs describe <block_id>` returns real `list`/`describe`/`last_error` output today, not the "no code yet" state this line originally described. Treat the phased design below as implementation history, not a pending proposal.
+**Status:** implemented — PRs #2380 (list/describe), #2390 (spawn/exec error surfacing), #2432 (dock); verified 2026-08-10.
 **Related:** `docs/specs/REPORT_PROCESS_ARCHITECTURE_STATE_AND_RETHINK_2026_07_22.md`
 (names the same six-plus overlapping liveness mechanisms this tool would read
 from, not add an seventh to), `agentmux-srv/src/broker/process.rs` (Process

--- a/docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md
+++ b/docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md
@@ -1,7 +1,7 @@
 # SPEC: Durable, location-consistent, transparent native memory
 
 **Date:** 2026-08-07
-**Status:** Proposed
+**Status:** implemented — PR #2459 (db_agent_native_memory durable mirror); verified in code 2026-08-10.
 **Depends on:** `docs/reports/REPORT_ARMORY_STASH_MEMORY_SYNC_STATUS_2026_08_07.md`
 (history + current-state analysis; read that first for full context — this
 doc only restates what's load-bearing for the design below).

--- a/docs/specs/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
+++ b/docs/specs/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
@@ -1,6 +1,6 @@
 # Spec: pane close/reopen must guarantee conversation continuity, or say so
 
-**Status:** Draft — not implemented.
+**Status:** implemented — PR #2323, extended by #2426 (resume outcome as transcript event); verified in code 2026-08-10.
 **Author:** Agent1
 **Date:** 2026-07-27
 **Triggered by:** a user question about whether an agent's Armory-sourced workspace rules (Bundles/Skills/MCP) are "always available," which surfaced that reopening a pane goes through a resume (`--resume <sid>`) whose success is unverified end-to-end. Investigating that led to two real, evidenced gaps below.

--- a/docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md
+++ b/docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md
@@ -1,7 +1,7 @@
 # SPEC: Pane tab strip — editor-style in-pane tabs for agent and terminal panes
 
 **Date:** 2026-07-20
-**Status:** Draft — architecture + UI direction, no code landed
+**Status:** implemented — shared PaneTabStrip across editor/agent/terminal via PRs #2250/#2254/#2261/#2282; verified in code 2026-08-10.
 **Scope:** Agent pane (`frontend/app/view/agent/**`), terminal pane (`frontend/app/view/term/**`),
 layout store, agent runtime, shell controller
 **Author:** Agent3

--- a/docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md
+++ b/docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-04
 **Type:** Bug fix (regression, not a new feature)
-**Status:** Proposed
+**Status:** implemented — PR #2421; verified in code 2026-08-10.
 **Owner:** Agent3
 **Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`
 **Related:** `SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md` (the classifier),

--- a/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
+++ b/docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md
@@ -1,7 +1,7 @@
 # SPEC — Persistent controller race cluster: gap audit + remaining fixes
 
 **Date:** 2026-08-09 (rewritten same day after a current-code audit — see §1)
-**Status:** Proposed
+**Status:** implemented — PRs #2500 (§2 CAS cleanup + §3 seq-keyed queue) and #2501 (§4 drain-claim retry gate); verified in code 2026-08-10. Only §5's live verify-and-close of issues #2366/#2368 remains (non-code).
 **Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`,
 `session_recovery.rs` (one guarded variant), verification-and-close work
 for two issues.

--- a/docs/specs/SPEC_PERSISTENT_TURN_END_TEXT_GATE_2026_07_30.md
+++ b/docs/specs/SPEC_PERSISTENT_TURN_END_TEXT_GATE_2026_07_30.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-30
 **Type:** Bug-fix spec (behavior change to an existing heuristic)
-**Status:** Proposed — audited and designed, not yet implemented
+**Status:** implemented — PR #2369, hardened by #2469 (stop_reason gate); verified in code 2026-08-10.
 **Scope:** `frontend/app/view/agent/providers/claude-translator.ts` (`handleAssistantMessage`),
 `frontend/app/view/agent/providers/claude-translator.test.ts`
 **Trigger:** User observation — *"the 'Working...' stopping and restarting nearly always happens

--- a/docs/specs/SPEC_PER_NODE_TOKEN_ACCOUNTING_2026_08_03.md
+++ b/docs/specs/SPEC_PER_NODE_TOKEN_ACCOUNTING_2026_08_03.md
@@ -1,6 +1,6 @@
 # Spec: true per-node token accounting
 
-**Status:** Design — open questions resolved (§6), sequenced as the second implementation pass. Not yet implemented.
+**Status:** proposed — verified unimplemented as of 2026-08-10 (no roundIndex/RoundRecord in frontend); base hover-peek shipped separately (PR #2392).
 **Relationship:** Phase 2 follow-up to `docs/specs/SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md`, which deliberately deferred real per-node token/cost data (§1.4/§4.2/§6 there) in favor of a client-side chars÷4 estimate. This spec answers "can we do better than a guess?" — and the answer is **partially yes, with a real derivation**, not a heuristic, for the Claude provider specifically.
 
 ## 1. The core insight

--- a/docs/specs/SPEC_PROCESS_BROKER_PHASE_B_SHELL_ACP_REGISTRATION_2026_07_31.md
+++ b/docs/specs/SPEC_PROCESS_BROKER_PHASE_B_SHELL_ACP_REGISTRATION_2026_07_31.md
@@ -3,7 +3,7 @@
 **Date:** 2026-07-31
 **Type:** Design/scoping spec (no code changes yet)
 **Scope:** `agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs`, `agentmux-srv/src/backend/blockcontroller/acp.rs`, `agentmux-srv/src/backend/process_tracker/registry.rs`
-**Status:** Scoped — needs a go/no-go before implementation (see §5)
+**Status:** implemented — PR #2376 (track_spawned in shell + acp); verified in code 2026-08-10.
 **Tracking:** GitHub Discussion #2375, item "Process Broker Phase B"
 
 ---

--- a/docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md
+++ b/docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md
@@ -1,7 +1,7 @@
 # Split the low-memory banner into independent RAM and Page File warnings
 
 **Date:** 2026-08-07
-**Status:** Draft — design proposal, not yet implemented
+**Status:** implemented — PR #2451 (P0 + P1); verified in code 2026-08-10.
 **Affected:** `agentmux-cef` (memory heartbeat, pressure classifier, banner emit) and
 `frontend` (banner component), Windows only.
 

--- a/docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md
+++ b/docs/specs/SPEC_SHARED_FS_WATCHER_FRAMEWORK_2026_08_07.md
@@ -1,7 +1,7 @@
 # SPEC: Shared filesystem-watcher framework — audit + design
 
 **Date:** 2026-08-07
-**Status:** Proposed
+**Status:** implemented — framework PR #2455 (backend/fs_watch/ FsWatchPool), consumers migrated in #2456 (config watcher) and #2462 (editor + media); verified in code 2026-08-10.
 **Trigger:** Follow-up to `docs/specs/SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md`,
 which deferred live capture of Claude's autonomous memory writes as a
 non-goal specifically because it would need a filesystem watcher. User

--- a/docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md
+++ b/docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md
@@ -1,7 +1,7 @@
 # SPEC: Shift+drag group resize — move all sibling panes together on one splitter drag
 
 **Date:** 2026-08-03
-**Status:** Approved — design sign-off received (Shift confirmed over Ctrl; algorithm in §5 and minimize-lock handling in §5.3 both approved as proposed); implementing
+**Status:** implemented — PR #2401; verified in code 2026-08-10.
 **Author:** Loap (agent)
 **Tracking discussion:** user request, this session — "resize a bunch of panes simultaneously… if ctrl is pressed when a pane is resized, then all the panes along that dimension resize, not just the pane border the user is dragging." User reviewed §3/§6's prior-art survey and confirmed Shift over the originally-requested Ctrl ("yes, shift sounds right … otherwise your recommendations look good").
 

--- a/docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md
+++ b/docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md
@@ -1,7 +1,7 @@
 # SPEC: eager per-dispatch naming + two-bucket swarm row model
 
 **Date:** 2026-07-19
-**Status:** Proposed — design only, no implementation yet.
+**Status:** implemented — Phase A PR #2231 (eager naming), Phase B PR #2232 (two-bucket row model); verified in code 2026-08-10.
 **Ask (verbatim):** "we want 1 haiku call be agent tool call, and 1 per
 workflow tool call, which should be 54 .. actually, lets split Agents and
 Workflows, they should be top-level ... AgentA -> Agent Tool -> All

--- a/docs/specs/SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md
+++ b/docs/specs/SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md
@@ -1,7 +1,7 @@
 # SPEC: Terminal scrollback doesn't survive reconnect (all `view:"term"` panes)
 
 **Date:** 2026-07-23
-**Status:** Proposed — analysis + design, no code changes yet
+**Status:** implemented — PR #2279; verified in code 2026-08-10.
 **Severity:** Medium (no data loss beyond the session — output is gone, not corrupted — but a real, visible regression in usability for both the agent-shell drawer and standalone Terminal panes)
 **Trigger:** Reported while testing PR #2278 (shell-drawer log-panel removal) — the report ("close and reopen the shell, prior content is gone, resets every time") turned out to be a pre-existing gap unrelated to that PR's scope, discovered during live verification.
 

--- a/docs/specs/SPEC_TOKEN_STATS_NUMBER_FORMATTING_2026_08_02.md
+++ b/docs/specs/SPEC_TOKEN_STATS_NUMBER_FORMATTING_2026_08_02.md
@@ -1,6 +1,6 @@
 # Plan: consolidate duplicated display-formatting utilities into `frontend/util/`
 
-**Status:** Plan — not yet implemented.
+**Status:** implemented — PR #2385 (formatter consolidation incl. §7 sweep); verified in code 2026-08-10.
 **Trigger:** user request while discussing the composer strip's `↑in ↓out` token display — the abbreviated form never rolls over past "k" (a heavy session could show `12345.6k` instead of `12.3m`), and there's no comma-grouped exact form for tooltips/full-precision contexts. Broadened per follow-up request into a sweep for other duplicated utility-shaped logic (§7) worth building out the same way.
 
 `frontend/util/` already exists as this codebase's convention for exactly this (`menu-position.ts`, `settle-detector.ts`) — everything below lands as new siblings there, not a novel location.

--- a/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
@@ -1,7 +1,7 @@
 # SPEC: Tool preview common-indentation stripping (dedent)
 
 **Date:** 2026-08-08
-**Status:** Proposed (analysis complete — not yet implemented)
+**Status:** proposed — verified unimplemented as of 2026-08-10 (sibling refinement #2467 shipped; this one did not).
 **Scope:** `frontend/app/view/agent/components/ToolOverlayLog.tsx`,
 `frontend/app/view/agent/components/DiffViewer.tsx`, one new shared util
 (+ tests)

--- a/docs/specs/SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md
+++ b/docs/specs/SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md
@@ -1,7 +1,7 @@
 # SPEC: Window-name App API hardening (phantom-id success + status codes)
 
 **Date:** 2026-08-08
-**Status:** Proposed (fix implemented same day for §3.1-§3.2; §4 deferred)
+**Status:** active — §3 guards shipped same day; §4 (clear-to-default, grapheme-safe clamp, dev-discovery helper) not started. Verified 2026-08-10.
 **Scope:** `agentmux-srv/src/reducer/window.rs`, `agentmux-srv/src/server/mod.rs`
 **Related:** `SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md` (title composition),
 `SPEC_TEST_API_ACCESS.md` (dev `authkey.dev` cross-instance access),

--- a/docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md
+++ b/docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md
@@ -1,7 +1,7 @@
 # SPEC: Harden the "Working…" indicator and message-list auto-follow against four related recurring bugs
 
 **Date:** 2026-07-27
-**Status:** Implemented (this pass covers the low-risk, high-confidence mechanisms; two items are explicitly deferred, see §5)
+**Status:** implemented — this pass's mechanisms shipped; of §5's two deferred items, the tool-liveness gap was closed by the attached-task axis (PR #2489 + #2472) and the scroll input-gating race remains open, conditional on live reports. Verified 2026-08-10.
 **Author:** Agent1
 **Scope:** `agentmux-srv/src/backend/blockcontroller/{mod,persistent}.rs`, `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/useAgentStream.ts`, `frontend/app/view/agent/hooks/usePendingMessageAcceptance.ts`, `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx`
 


### PR DESCRIPTION
## Summary

Implements **Phase 1 of `SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md`**: `docs/specs/README.md` now states the closed Status enum (`draft | proposed | active | implemented | living | historical | superseded`) as the actual rule, with a required `**Superseded-by:**` field for superseded specs and a reader guardrail (spot-verify checkable claims — Phase 4's mechanism). `docs/README.md` references it.

Restamps **44 specs** whose real state was verified against code on main (`ad0dbc5a5`) in a 2026-08-10 three-agent sweep. The sweep found staleness in both directions: ~28 shipped specs still said Proposed/Draft, and several "done" specs have unshipped halves (now `active` with the remainder listed and PR evidence cited).

No spec body content changed — only the Status field (and one added Superseded-by). Deliberately not a big-bang restamp of all ~600 specs, per the docs-lifecycle spec's own scoping note: these 44 are the ones with fresh verification evidence.

## Verification

Docs-only. Post-edit script check: every changed spec's Status first word is in the closed enum; the one `superseded` spec carries a valid `Superseded-by:` path; per-file diffs are 2-6 lines.

<!-- agentmux:agent_id=agentx -->