### PR TITLE
feat(agent-pane): session-scoped scrollback — clamp at fresh session boundary, demote 'Session continued' divider

### DIFF
--- a/.changesets/1786370383-feat-agent-pane-session-scoped-scrollback-clamp-at-fresh-ses-4ubt.md
+++ b/.changesets/1786370383-feat-agent-pane-session-scoped-scrollback-clamp-at-fresh-ses-4ubt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): session-scoped scrollback — clamp at fresh session boundary, demote 'Session continued' divider

--- a/docs/specs/SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
+++ b/docs/specs/SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
@@ -1,7 +1,7 @@
 # SPEC: Session-scoped pane scrollback + a full "Agent History" view
 
 **Date:** 2026-08-09
-**Status:** Proposed
+**Status:** active — P1 (session-scope clamp §3.1-3.3 + `resumed`-divider demotion §3.5 + static preserved-note on the fresh divider) implemented 2026-08-10; the §3.4 link row is deferred with P2 per the P1 phasing note. P2 (Agent History view, `output.tsidx` timestamps) and P3 not started.
 **Severity:** Medium — UX/correctness follow-up, no data loss involved
 **Extends:** `SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md` (Part A shipped the
 honest *"New session started"* divider this spec builds on)

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -1376,4 +1376,112 @@ describe("agent document reducer", () => {
             expect((r.state.nodes[0] as ShellNode).status).toBe("exited-ok");
         });
     });
+
+    // SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §3:
+    // the working document is clamped at the newest `fresh` session-outcome
+    // boundary — content the model provably does not have never renders as
+    // live scrollback. Display-scope only; the persisted stream is untouched.
+    describe("session-scope clamp (fresh session_outcome boundary)", () => {
+        const boundary = (id: string, outcome: "fresh" | "resumed"): DocumentNode => ({
+            type: "session_outcome",
+            id,
+            outcome,
+            attemptedSid: "sid-1",
+            actualSid: null,
+            timestamp: 0,
+        });
+
+        it("HistoryRestored clamps at the fresh boundary, keeping it as the first row", () => {
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                fromSnapshot: true,
+                nodes: [md("old1"), md("old2"), boundary("b1", "fresh"), md("new1")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["b1", "new1"]);
+            expect(r.events).toContainEqual({ type: "session-scope-trimmed", removedCount: 2 });
+        });
+
+        it("multiple fresh boundaries → the newest wins", () => {
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                fromSnapshot: true,
+                nodes: [md("s1"), boundary("b1", "fresh"), md("s2"), boundary("b2", "fresh"), md("s3")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["b2", "s3"]);
+        });
+
+        it("a resumed boundary is NOT a scope anchor", () => {
+            // resumed nodes are no longer materialized by the parse paths,
+            // but legacy v1 snapshots can still carry them — the reducer
+            // must not treat one as a clamp point (the model genuinely has
+            // the prior turns).
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                fromSnapshot: true,
+                nodes: [md("old1"), boundary("b1", "resumed"), md("new1")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["old1", "b1", "new1"]);
+            expect(r.events.some((e) => e.type === "session-scope-trimmed")).toBe(false);
+        });
+
+        it("no boundary → restore is untouched (legacy streams unchanged)", () => {
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                fromSnapshot: true,
+                nodes: [md("a"), md("b")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["a", "b"]);
+            expect(r.events.some((e) => e.type === "session-scope-trimmed")).toBe(false);
+        });
+
+        it("HistoryLoaded drops a strictly-older page wholesale when the document starts at a boundary", () => {
+            const start = seed([boundary("b1", "fresh"), md("live1")]);
+            const r = update(start, { type: "HistoryLoaded", nodes: [md("old1"), md("old2")] });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["b1", "live1"]);
+            expect(r.events).toContainEqual({ type: "session-scope-trimmed", removedCount: 2 });
+        });
+
+        it("HistoryLoaded keeps only the at-or-after-boundary part of a page containing one", () => {
+            const start = seed([md("live1")]);
+            const r = update(start, {
+                type: "HistoryLoaded",
+                nodes: [md("old1"), boundary("b1", "fresh"), md("post1")],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["b1", "post1", "live1"]);
+        });
+
+        it("StreamFlush with a live fresh boundary trims everything before it, including same-batch nodes", () => {
+            const start = seed([md("pre1"), md("pre2")]);
+            const r = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("queued-pre"), boundary("b1", "fresh"), md("post1")],
+                updatedNodes: [],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["b1", "post1"]);
+            expect(r.events).toContainEqual({ type: "session-scope-trimmed", removedCount: 3 });
+        });
+
+        it("re-flushing an already-first boundary is a no-op trim (idempotent)", () => {
+            const start = seed([boundary("b1", "fresh"), md("post1")]);
+            const r = update(start, {
+                type: "StreamFlush",
+                newNodes: [boundary("b1", "fresh")],
+                updatedNodes: [],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["b1", "post1"]);
+            expect(r.events.some((e) => e.type === "session-scope-trimmed")).toBe(false);
+        });
+
+        it("rebuilds nodeIdSet and nodeIndexById in lockstep after a clamp", () => {
+            const r = update(initialState(), {
+                type: "HistoryRestored",
+                fromSnapshot: true,
+                nodes: [md("old1"), boundary("b1", "fresh"), md("new1")],
+            });
+            expect(r.state.nodeIdSet).toEqual(new Set(["b1", "new1"]));
+            expect(r.state.nodeIndexById.get("b1")).toBe(0);
+            expect(r.state.nodeIndexById.get("new1")).toBe(1);
+            expect(r.state.nodeIndexById.has("old1")).toBe(false);
+        });
+    });
 });

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -14,6 +14,7 @@
  */
 
 import type { DocumentNode, ShellNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
+import { lastFreshBoundaryIndex } from "../../view/agent/session-outcome";
 import {
     AgentDocumentCommand,
     AgentDocumentState,
@@ -21,6 +22,40 @@ import {
     ReducerResult,
     TRUNCATE_GRACE_MS,
 } from "./types";
+
+/**
+ * Clamp a merged node list to the working scrollback's session scope:
+ * everything strictly before the LAST `session_outcome`/`fresh` node is
+ * dropped (the model has none of it — showing it as live scrollback is
+ * the misrepresentation
+ * SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
+ * §3 exists to fix). The boundary node itself stays as the first row.
+ *
+ * Returns `null` when no trim is needed (no fresh boundary, or it is
+ * already the first node) so hot-path callers can skip the state
+ * allocation. By induction every state this reducer produces is already
+ * clamped, so `HistoryLoaded`'s prepend of a strictly-older page reduces
+ * to "drop the whole page" whenever the existing document contains a
+ * boundary — that falls out of this same reverse-scan with no special
+ * case.
+ */
+function clampToSessionScope(nodes: DocumentNode[]): {
+    nodes: DocumentNode[];
+    nodeIdSet: Set<string>;
+    nodeIndexById: Map<string, number>;
+    removedCount: number;
+} | null {
+    const boundary = lastFreshBoundaryIndex(nodes);
+    if (boundary <= 0) return null;
+    const kept = nodes.slice(boundary);
+    const nodeIdSet = new Set<string>();
+    const nodeIndexById = new Map<string, number>();
+    for (let i = 0; i < kept.length; i++) {
+        nodeIdSet.add(kept[i].id);
+        nodeIndexById.set(kept[i].id, i);
+    }
+    return { nodes: kept, nodeIdSet, nodeIndexById, removedCount: boundary };
+}
 
 /**
  * Walk the document and mark orphaned in-progress nodes as canceled.
@@ -295,10 +330,29 @@ export function update(
                     resolvedToolNodes: scrubResult.resolvedToolNodes,
                 });
             }
+            // Session-scope clamp. Two shapes land here: the prepended page
+            // itself contains a fresh boundary (keep only from that
+            // boundary), or the existing document already starts at one
+            // (the whole strictly-older page drops). Both are the same
+            // reverse-scan — see clampToSessionScope.
+            const mergedLoaded = [...scrubbedFresh, ...state.nodes];
+            const loadClamp = clampToSessionScope(mergedLoaded);
+            if (loadClamp) {
+                loadEvents.push({ type: "session-scope-trimmed", removedCount: loadClamp.removedCount });
+                return {
+                    state: {
+                        ...state,
+                        nodes: loadClamp.nodes,
+                        nodeIdSet: loadClamp.nodeIdSet,
+                        nodeIndexById: loadClamp.nodeIndexById,
+                    },
+                    events: loadEvents,
+                };
+            }
             return {
                 state: {
                     ...state,
-                    nodes: [...scrubbedFresh, ...state.nodes],
+                    nodes: mergedLoaded,
                     nodeIdSet: nextIdSet,
                     nodeIndexById: nextIndexById,
                 },
@@ -374,6 +428,23 @@ export function update(
                     toolsCanceled: scrubResult.toolsCanceled,
                     resolvedToolNodes: scrubResult.resolvedToolNodes,
                 });
+            }
+            // Session-scope clamp — the restored window can span any number
+            // of fresh boundaries (the persisted stream is boundary-blind);
+            // the working view keeps only content from the newest one on.
+            const restoreClamp = clampToSessionScope(mergedNodes);
+            if (restoreClamp) {
+                restoreEvents.push({ type: "session-scope-trimmed", removedCount: restoreClamp.removedCount });
+                return {
+                    state: {
+                        ...state,
+                        nodes: restoreClamp.nodes,
+                        nodeIdSet: restoreClamp.nodeIdSet,
+                        nodeIndexById: restoreClamp.nodeIndexById,
+                        sessionPhase: "active",
+                    },
+                    events: restoreEvents,
+                };
             }
             return {
                 state: {
@@ -470,6 +541,41 @@ export function update(
             if (!next) {
                 return { state, events: [] };
             }
+            const flushEvents: ReducerResult["events"] = [
+                {
+                    type: "stream-flushed",
+                    appendedNew,
+                    collidedAndUpdated,
+                    updateApplied,
+                    updateDropped,
+                },
+            ];
+            // Session-scope clamp, gated on this batch actually carrying a
+            // fresh boundary so the per-chunk hot path pays one array scan
+            // of the (small) batch and nothing else. A live fresh outcome
+            // lands here as a newNode; clamping inside the same reduction —
+            // rather than a separate trim command dispatched after the
+            // flush — is what makes the trim race-free against
+            // still-queued pre-boundary nodes: they're in this same batch,
+            // ordered before the boundary, and get dropped with everything
+            // else. (Collided re-seen boundaries route to update against a
+            // state that is already clamped by induction — the scan below
+            // returns boundary index 0 and no-ops.)
+            if (command.newNodes.some((n) => n.type === "session_outcome" && n.outcome === "fresh")) {
+                const flushClamp = clampToSessionScope(next);
+                if (flushClamp) {
+                    flushEvents.push({ type: "session-scope-trimmed", removedCount: flushClamp.removedCount });
+                    return {
+                        state: {
+                            ...state,
+                            nodes: flushClamp.nodes,
+                            nodeIdSet: flushClamp.nodeIdSet,
+                            nodeIndexById: flushClamp.nodeIndexById,
+                        },
+                        events: flushEvents,
+                    };
+                }
+            }
             return {
                 state: {
                     ...state,
@@ -477,15 +583,7 @@ export function update(
                     nodeIdSet: nextIdSet ?? state.nodeIdSet,
                     nodeIndexById: indexById,
                 },
-                events: [
-                    {
-                        type: "stream-flushed",
-                        appendedNew,
-                        collidedAndUpdated,
-                        updateApplied,
-                        updateDropped,
-                    },
-                ],
+                events: flushEvents,
             };
         }
 

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -206,6 +206,19 @@ export type AgentDocumentEvent =
       }
     | { type: "user-cleared"; clearedCount: number }
     | {
+          /**
+           * The working scrollback was clamped at a `session_outcome`/
+           * `fresh` boundary: `removedCount` nodes strictly older than the
+           * boundary were dropped from the visible document (the persisted
+           * stream is untouched — display scope only). Emitted by
+           * HistoryRestored / HistoryLoaded / StreamFlush via
+           * `clampToSessionScope`. Spec:
+           * SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §3.
+           */
+          type: "session-scope-trimmed";
+          removedCount: number;
+      }
+    | {
           type: "orphans-scrubbed";
           /** Thinking-markdown nodes flipped to canceled. */
           markdownCanceled: number;

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -36,6 +36,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import type { AgentPaneModel } from "@/app/store/agent-pane-registration";
 import { parseHistoryLines } from "../parseHistoryLines";
+import { lastFreshBoundaryIndex } from "../session-outcome";
 
 import type { DocumentState, FilterState, LogFn } from "../types";
 
@@ -176,8 +177,20 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 batch(() => opts.model.dispatchDoc({ type: "HistoryLoaded", nodes: newNodes }));
             }
 
-            setHistoryOffset(newOffset);
-            opts.log("history", `loaded ${newNodes.length} older messages (offset ${newOffset})`);
+            // Session-scope edge: a fresh session-outcome boundary in this
+            // page means everything at offsets below it is content the
+            // model does not have — the reducer keeps only the
+            // at-or-after-boundary part of this page, and further
+            // load-older would only fetch pages the reducer drops
+            // wholesale. Stop paging here (spec §3.2). The full stream
+            // stays on disk for the Agent History view (P2).
+            if (lastFreshBoundaryIndex(newNodes) >= 0) {
+                setHistoryOffset(0);
+                opts.log("history", `session boundary reached — older history is out of the working session's scope`);
+            } else {
+                setHistoryOffset(newOffset);
+            }
+            opts.log("history", `loaded ${newNodes.length} older messages (offset ${historyOffset()})`);
         } catch (err: any) {
             opts.log("history", `failed to load older messages: ${err?.message ?? String(err)}`, "warn");
         } finally {
@@ -362,12 +375,21 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         // NDJSON replay path below.
                         const available = typeof rangeResp.total === "number" ? rangeResp.total : hwm;
                         const clampedStart = Math.min(windowStart, available);
-                        setHistoryOffset(clampedStart);
+                        // Session-scope edge (spec §3.2): a fresh boundary
+                        // inside the restored window means the reducer
+                        // clamped the visible document at it — lines older
+                        // than the window are out of scope too, so
+                        // load-older must not page into them. Offset 0
+                        // makes loadOlder a no-op.
+                        const scopeClamped = lastFreshBoundaryIndex(nodes) >= 0;
+                        setHistoryOffset(scopeClamped ? 0 : clampedStart);
                         setHistoryTotal(available);
                         opts.log(
                             "history",
                             `v2 restore: ${nodes.length} nodes from lines [${clampedStart}, ${available})` +
-                            (clampedStart > 0 ? ` (${clampedStart} older lines available via load-older)` : "") +
+                            (scopeClamped
+                                ? " (clamped to session scope — older history via Agent History)"
+                                : clampedStart > 0 ? ` (${clampedStart} older lines available via load-older)` : "") +
                             (ds?.collapsedNodeIds?.length ? `, ${ds.collapsedNodeIds.length} collapsed` : ""),
                         );
                         opts.model.dispatchPane({ type: "InitReady", at: Date.now() });
@@ -480,7 +502,8 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 // the frontend never asks for offsets the backend can't
                 // serve.
                 const available = rangeResp.total ?? total;
-                setHistoryOffset(offset);
+                // Same session-scope edge as the v2-restore path above.
+                setHistoryOffset(lastFreshBoundaryIndex(nodes) >= 0 ? 0 : offset);
                 setHistoryTotal(available);
 
                 opts.log("history", `loaded ${nodes.length} of ${available} previous messages`);

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -112,6 +112,45 @@ describe("parseHistoryLines", () => {
         expect(lastSessionStats).toEqual({ input_tokens: 500, output_tokens: 50 });
     });
 
+    // §3.5 of SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW
+    // _2026_08_09.md: `fresh` outcomes materialize as divider nodes; `resumed`
+    // outcomes are demoted — persisted line kept, no working-view node.
+    describe("agentmux_session_outcome replay (session-scoped scrollback §3.5)", () => {
+        const outcomeLine = (outcome: "fresh" | "resumed"): string =>
+            JSON.stringify({
+                type: "system",
+                subtype: "agentmux_session_outcome",
+                outcome,
+                attempted_sid: "sid-1",
+                actual_sid: null,
+                timestamp: "2026-08-09T12:00:00Z",
+            });
+
+        it("materializes a fresh outcome as a session_outcome node", () => {
+            const lines = [
+                line({ type: "text", content: "before" }),
+                outcomeLine("fresh"),
+                line({ type: "text", content: "after" }),
+            ];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json");
+            const outcomes = nodes.filter((n) => n.type === "session_outcome");
+            expect(outcomes).toHaveLength(1);
+            expect((outcomes[0] as { outcome: string }).outcome).toBe("fresh");
+        });
+
+        it("does NOT materialize a resumed outcome (demoted, §3.5)", () => {
+            const lines = [
+                line({ type: "text", content: "before" }),
+                outcomeLine("resumed"),
+                line({ type: "text", content: "after" }),
+            ];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json");
+            expect(nodes.some((n) => n.type === "session_outcome")).toBe(false);
+            // The surrounding conversation still replays.
+            expect(nodes.filter((n) => n.type === "markdown").length).toBeGreaterThan(0);
+        });
+    });
+
     describe("compact_boundary replay (Codex P2, PR #2378 round 2)", () => {
         // Before this fix, a raw `system`/`compact_boundary` frame had no
         // StreamEvent shape in the provider translator, so parseHistoryLines

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -150,7 +150,18 @@ export function parseHistoryLines(
         if (rawEvent.type === "system" && rawEvent.subtype === "agentmux_session_outcome") {
             parser.flushPending();
             const data = parseSessionOutcomeFrame(rawEvent);
-            if (data) {
+            // `resumed` outcomes are demoted out of the working transcript
+            // (SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW
+            // _2026_08_09.md §3.5): a confirmed resume fires on
+            // user-invisible process recycles and its persisted line lands
+            // AFTER the first post-resume exchange — as a divider row it
+            // announces a non-event in the wrong place. The line stays in
+            // the stream (diagnostics + the P2 history view will render it
+            // subtly); only the node materialization is skipped. The
+            // flushPending() above still runs — the accumulator split at
+            // this line predates this change and keeps replay/live node
+            // ids aligned.
+            if (data && data.outcome !== "resumed") {
                 const parsedTs = typeof rawEvent.timestamp === "string" ? Date.parse(rawEvent.timestamp) : NaN;
                 const node: SessionOutcomeNode = {
                     type: "session_outcome",

--- a/frontend/app/view/agent/session-outcome.ts
+++ b/frontend/app/view/agent/session-outcome.ts
@@ -72,3 +72,24 @@ export function sessionOutcomeLiveTimestamp(frameTimestamp: string | null | unde
     const parsed = typeof frameTimestamp === "string" ? Date.parse(frameTimestamp) : NaN;
     return Number.isNaN(parsed) ? Date.now() : parsed;
 }
+
+/**
+ * Index of the LAST `session_outcome` node with `outcome: "fresh"` in an
+ * ordered node list, or -1 if none. A `fresh` outcome is the working
+ * scrollback's scope anchor: the model has none of the content before it,
+ * so the working view must not show that content
+ * (SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
+ * §3.1). `resumed` outcomes are NOT anchors — the model genuinely has the
+ * prior turns. Structurally typed (not `DocumentNode[]`) so both the
+ * document reducer and the pagination hook can call it without an import
+ * cycle through the full node union.
+ */
+export function lastFreshBoundaryIndex(
+    nodes: ReadonlyArray<{ type: string; outcome?: string }>,
+): number {
+    for (let i = nodes.length - 1; i >= 0; i--) {
+        const n = nodes[i];
+        if (n.type === "session_outcome" && n.outcome === "fresh") return i;
+    }
+    return -1;
+}

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -455,7 +455,14 @@ export function useAgentStream({
                 if (rawEvent.type === "system" && rawEvent.subtype === "agentmux_session_outcome") {
                     parser.flushPending();
                     const sessionOutcome = parseSessionOutcomeFrame(rawEvent);
-                    if (sessionOutcome) {
+                    // `resumed` is demoted out of the working transcript —
+                    // same rule and rationale as parseHistoryLines.ts
+                    // (SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_
+                    // HISTORY_VIEW_2026_08_09.md §3.5). A `fresh` node that
+                    // does get pushed also triggers the reducer's
+                    // session-scope clamp inside the same StreamFlush that
+                    // lands it (reducer.ts, StreamFlush handler).
+                    if (sessionOutcome && sessionOutcome.outcome !== "resumed") {
                         const node: SessionOutcomeNode = {
                             type: "session_outcome",
                             id: sessionOutcomeNodeId(sessionOutcome),

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -303,6 +303,11 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
             <Show when={props.node() && props.node().type === "session_outcome"}>
                 {(() => {
                     const n = props.node() as Extract<DocumentNode, { type: "session_outcome" }>;
+                    // `resumed` nodes are no longer materialized in the
+                    // working document (§3.5 of the session-scoped-scrollback
+                    // spec — both parse paths skip them), so this branch only
+                    // sees `fresh` today. The resumed rendering is kept for
+                    // the P2 Agent History view, which materializes both.
                     const resumed = n.outcome === "resumed";
                     return (
                         <div class={resumed ? "agent-session-outcome" : "agent-session-outcome agent-session-outcome-fresh"}>
@@ -311,7 +316,7 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                             </div>
                             <Show when={!resumed}>
                                 <div class="agent-session-outcome-detail">
-                                    Prior conversation is not available to this agent
+                                    Prior conversation isn't available to this agent — it's preserved in the agent's history
                                 </div>
                             </Show>
                         </div>


### PR DESCRIPTION
## Summary

P1 of `SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md` (merged as #2499): the working pane now reflects the agent's **actual knowledge**.

- **Session-scope clamp (§3.1-3.3).** The visible document is clamped at the newest `fresh` session-outcome boundary. One reducer helper (`clampToSessionScope`) funnels all three merge paths — `HistoryRestored`, `HistoryLoaded`, `StreamFlush` — so restore, backward pagination, and live arrival all obey the same rule. The live path clamps *inside the same reduction* that lands the boundary node, making the trim race-free against same-batch pre-boundary nodes. `useHistoryPagination` stops paging past the boundary in all three of its paths. Display-scope only: the persisted stream (per-channel blockfile + global mirror) is untouched, and legacy streams with no boundary render exactly as before — no migration.
- **"Session continued" demoted (§3.5).** `resumed` outcomes fire on user-invisible process recycles and (because emission waits for `is_confirmed_success`) land *below* the first post-resume exchange — a mis-placed divider announcing a non-event. Both parse paths (`parseHistoryLines`, `useAgentStream`) now skip materializing them; the persisted line stays for diagnostics and for the P2 Agent History view, which will render them subtly.
- The fresh divider's detail line now reads "…preserved in the agent's history" (the §3.4 link row ships with P2, per the spec's P1 phasing note).

## Verification

- 9 new reducer tests (clamp-at-boundary, newest-wins, `resumed`-not-an-anchor, strictly-older-page drop, mid-page boundary, live trim incl. same-batch nodes, idempotent re-flush, id-set/index rebuild) + 2 new `parseHistoryLines` tests — all passing.
- Full affected suites: reducer + parseHistoryLines + session-outcome (125 tests), virtualization + useAgentStream + hooks (241 tests, 17 files) — all passing. `tsc --noEmit` clean.
- StreamFlush hot path unchanged unless a batch actually carries a fresh boundary (one `some()` scan of the small batch otherwise).

<!-- agentmux:agent_id=agentx -->