### PR TITLE
feat(agent-pane): output.tsidx receive-time sidecar — replayed transcript nodes get real timestamps

### DIFF
--- a/.changesets/1786371477-feat-agent-pane-output-tsidx-receive-time-sidecar-replayed-t-wkfs.md
+++ b/.changesets/1786371477-feat-agent-pane-output-tsidx-receive-time-sidecar-replayed-t-wkfs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): output.tsidx receive-time sidecar — replayed transcript nodes get real timestamps (hover peek works after restore)

--- a/agentmux-srv/src/backend/agent_session/mod.rs
+++ b/agentmux-srv/src/backend/agent_session/mod.rs
@@ -37,7 +37,7 @@ pub use global_store::{
 pub use migrations::{migrate_block_zones_v1, migrate_promote_template_sessions_v1};
 pub use session_io::{
     append_session_output, heal_global_snapshot_source_block_ids, read_session_state,
-    write_session_state, OUTPUT_FILE, SNAPSHOT_FILE,
+    write_session_state, OUTPUT_FILE, SNAPSHOT_FILE, TSIDX_FILE,
 };
 pub use zone_naming::{agent_current_zone, is_valid_definition_id};
 

--- a/agentmux-srv/src/backend/agent_session/session_io.rs
+++ b/agentmux-srv/src/backend/agent_session/session_io.rs
@@ -18,6 +18,14 @@ use super::zone_naming::{agent_current_zone, is_valid_definition_id, validate_an
 pub const SNAPSHOT_FILE: &str = "output.state.json";
 /// Raw NDJSON stream for crash-recovery replay.
 pub const OUTPUT_FILE: &str = "output";
+/// Receive-time sidecar for `output`: one NDJSON `{"off":<byte offset of the
+/// appended batch>,"ms":<unix ms>}` record per append batch. A pure addition —
+/// `output`'s own format and every existing parser are untouched; a missing or
+/// corrupt sidecar degrades reads to "no stamps" (today's behavior). Gives
+/// replayed transcript nodes real timestamps (hover peek after restore, day
+/// separators). Spec:
+/// SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.4.
+pub const TSIDX_FILE: &str = "output.tsidx";
 
 /// Write `content` to `output.state.json` in `agent:<defId>:current`.
 /// Idempotent — creates the file if missing, overwrites otherwise.

--- a/agentmux-srv/src/backend/blockcontroller/shell/file_ops.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/file_ops.rs
@@ -10,6 +10,46 @@ use base64::Engine as _;
 use crate::backend::storage::filestore::FileStore;
 use crate::backend::wps;
 
+/// Current unix time in ms, or 0 if the clock is before the epoch (never in
+/// practice; 0 reads as "unknown" on the consumer side, same as no stamp).
+fn unix_ms_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Append one receive-time record to a zone's `output.tsidx` sidecar:
+/// NDJSON `{"off":<byte offset the batch starts at in output>,"ms":<unix ms>}`.
+/// Batch granularity is deliberate — one flush of one turn's output; sub-batch
+/// precision has no UI meaning
+/// (SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.4).
+/// Fire-and-forget like every other write on this path: any failure logs at
+/// debug and the transcript append is unaffected. Only called for agent
+/// transcript streams (never PTY `term` data).
+fn append_tsidx_entry(fs: &Arc<FileStore>, zone: &str, batch_start: u64, now_ms: i64) {
+    use crate::backend::agent_session::TSIDX_FILE;
+    use crate::backend::storage::error::StoreError;
+
+    if let Ok(None) = fs.stat(zone, TSIDX_FILE) {
+        if let Err(e) = fs.make_file(
+            zone,
+            TSIDX_FILE,
+            std::collections::HashMap::new(),
+            crate::backend::storage::filestore::FileOpts::default(),
+        ) {
+            if !matches!(e, StoreError::AlreadyExists) {
+                tracing::debug!(zone = %zone, error = %e, "tsidx: make_file failed; skipping stamp");
+                return;
+            }
+        }
+    }
+    let line = format!("{{\"off\":{batch_start},\"ms\":{now_ms}}}\n");
+    if let Err(e) = fs.append_data(zone, TSIDX_FILE, line.as_bytes()) {
+        tracing::debug!(zone = %zone, error = %e, "tsidx: append failed");
+    }
+}
+
 /// Persist `data` to the block's output file and the global transcript zone
 /// **without** publishing a WPS event. Used by the persistent controller to
 /// record user-message lines for future history loads (so that
@@ -25,9 +65,9 @@ pub fn persist_to_blockfile_silent(
     global_output_zone: Option<&str>,
 ) {
     if let Some(fs) = filestore {
-        let needs_create = match fs.stat(block_id, filename) {
-            Ok(None) => true,
-            Ok(Some(_)) => false,
+        let (needs_create, batch_start): (bool, u64) = match fs.stat(block_id, filename) {
+            Ok(None) => (true, 0),
+            Ok(Some(info)) => (false, info.size as u64),
             Err(e) => {
                 tracing::warn!(
                     block_id = %block_id, filename = %filename, error = %e,
@@ -53,11 +93,20 @@ pub fn persist_to_blockfile_silent(
                 }
             }
         }
-        if let Err(e) = fs.append_data(block_id, filename, data) {
-            tracing::warn!(
-                block_id = %block_id, filename = %filename, error = %e,
-                "persist_silent: append_data failed"
-            );
+        match fs.append_data(block_id, filename, data) {
+            Ok(()) => {
+                // Only agent transcript streams carry a global zone; those are
+                // the streams the tsidx sidecar exists for (§4.4).
+                if global_output_zone.is_some() {
+                    append_tsidx_entry(fs, block_id, batch_start, unix_ms_now());
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    block_id = %block_id, filename = %filename, error = %e,
+                    "persist_silent: append_data failed"
+                );
+            }
         }
     }
     if let Some(zone) = global_output_zone {
@@ -182,13 +231,27 @@ pub fn handle_append_block_file(
             }
         }
 
-        if let Err(e) = fs.append_data(block_id, filename, data) {
-            tracing::warn!(
-                block_id = %block_id,
-                filename = %filename,
-                error = %e,
-                "filestore append_data failed"
-            );
+        match fs.append_data(block_id, filename, data) {
+            Ok(()) => {
+                // Receive-time stamp for this batch (§4.4). Gated on
+                // `global_output_zone` — only agent transcript appends carry
+                // one; PTY `term` data and non-agent blocks never get a
+                // sidecar. `start_offset` is Some here (Error stat already
+                // returned above).
+                if global_output_zone.is_some() {
+                    if let Some(start) = start_offset {
+                        append_tsidx_entry(fs, block_id, start, unix_ms_now());
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    block_id = %block_id,
+                    filename = %filename,
+                    error = %e,
+                    "filestore append_data failed"
+                );
+            }
         }
         // Note: output.idx is NOT updated incrementally here. It is a lazily-built,
         // self-validating cache rebuilt by the read path whenever output grows (see
@@ -219,7 +282,7 @@ pub(super) fn mirror_append_to_global(gfs: &Arc<FileStore>, zone: &str, data: &[
     use crate::backend::agent_session::OUTPUT_FILE;
     use crate::backend::storage::error::StoreError;
 
-    match gfs.stat(zone, OUTPUT_FILE) {
+    let batch_start: u64 = match gfs.stat(zone, OUTPUT_FILE) {
         Ok(None) => {
             if let Err(e) = gfs.make_file(
                 zone,
@@ -232,15 +295,25 @@ pub(super) fn mirror_append_to_global(gfs: &Arc<FileStore>, zone: &str, data: &[
                     return;
                 }
             }
+            0
         }
-        Ok(Some(_)) => {}
+        Ok(Some(info)) => info.size as u64,
         Err(e) => {
             tracing::warn!(zone = %zone, error = %e, "global transcripts: stat failed; skipping mirror");
             return;
         }
-    }
-    if let Err(e) = gfs.append_data(zone, OUTPUT_FILE, data) {
-        tracing::warn!(zone = %zone, error = %e, "global transcripts: append_data failed");
+    };
+    match gfs.append_data(zone, OUTPUT_FILE, data) {
+        Ok(()) => {
+            // Global zones are agent transcripts by construction — always
+            // stamp (§4.4). Cross-channel mirrors from concurrent srv
+            // instances serialize on the store, so offsets stay monotonic;
+            // the read-side join sorts defensively regardless.
+            append_tsidx_entry(gfs, zone, batch_start, unix_ms_now());
+        }
+        Err(e) => {
+            tracing::warn!(zone = %zone, error = %e, "global transcripts: append_data failed");
+        }
     }
 }
 

--- a/agentmux-srv/src/backend/blockcontroller/shell/tests.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/tests.rs
@@ -605,6 +605,116 @@ use std::sync::Arc;
         assert_eq!(stat_after.size, (line1.len() + line2.len() + b"line three\n".len()) as i64);
     }
 
+    /// Helper: parse a zone's `output.tsidx` sidecar into (off, ms) pairs.
+    #[cfg(test)]
+    fn read_tsidx(fs: &FileStore, zone: &str) -> Vec<(u64, i64)> {
+        let raw = fs
+            .read_file(zone, crate::backend::agent_session::TSIDX_FILE)
+            .unwrap()
+            .unwrap();
+        String::from_utf8_lossy(&raw)
+            .lines()
+            .map(|l| {
+                let v: serde_json::Value = serde_json::from_str(l).unwrap();
+                (v["off"].as_u64().unwrap(), v["ms"].as_i64().unwrap())
+            })
+            .collect()
+    }
+
+    /// §4.4 of SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW
+    /// _2026_08_09.md: agent transcript appends (global_output_zone = Some)
+    /// stamp one `{off, ms}` tsidx record per batch, keyed at the batch's
+    /// start byte offset.
+    #[test]
+    fn tsidx_stamped_per_batch_for_agent_transcript_appends() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let broker = wps::Broker::new();
+        let fs = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "tsidx-agent-block";
+        let line1 = b"{\"a\":1}\n";
+        let line2 = b"{\"b\":2}\n";
+
+        // Zone name is irrelevant to the per-channel stamp — only its
+        // presence gates it. No global store is installed in this test, so
+        // the mirror side is a no-op.
+        handle_append_block_file(&broker, block_id, "output", line1, Some(&fs), Some("agent:tsidx-test:current"));
+        handle_append_block_file(&broker, block_id, "output", line2, Some(&fs), Some("agent:tsidx-test:current"));
+
+        let entries = read_tsidx(&fs, block_id);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, 0);
+        assert_eq!(entries[1].0, line1.len() as u64);
+        assert!(entries[0].1 > 0, "stamp must be a real unix-ms time");
+        assert!(entries[1].1 >= entries[0].1, "stamps monotonic");
+    }
+
+    /// PTY `term` data and non-agent blocks (global_output_zone = None) must
+    /// never grow a tsidx sidecar.
+    #[test]
+    fn tsidx_not_written_without_agent_zone() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let broker = wps::Broker::new();
+        let fs = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "tsidx-term-block";
+
+        handle_append_block_file(&broker, block_id, "term", b"prompt$ ", Some(&fs), None);
+        handle_append_block_file(&broker, block_id, "output", b"line\n", Some(&fs), None);
+
+        assert!(fs
+            .stat(block_id, crate::backend::agent_session::TSIDX_FILE)
+            .unwrap()
+            .is_none());
+    }
+
+    /// The global-zone mirror stamps its own tsidx, offset-keyed against the
+    /// GLOBAL zone's output (which can differ from the per-channel offsets).
+    #[test]
+    fn tsidx_stamped_by_global_mirror() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let gfs = Arc::new(FileStore::open_in_memory().unwrap());
+        let zone = "agent:tsidx-mirror:current";
+        let line1 = b"{\"a\":1}\n";
+        let line2 = b"{\"b\":2}\n";
+
+        mirror_append_to_global(&gfs, zone, line1);
+        mirror_append_to_global(&gfs, zone, line2);
+
+        let entries = read_tsidx(&gfs, zone);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, 0);
+        assert_eq!(entries[1].0, line1.len() as u64);
+    }
+
+    /// `persist_to_blockfile_silent` (user-message lines) stamps the
+    /// per-channel sidecar too — those lines are transcript content.
+    #[test]
+    fn tsidx_stamped_by_persist_silent() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let fs = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "tsidx-silent-block";
+        let line = b"{\"type\":\"user_message\"}\n";
+
+        super::file_ops::persist_to_blockfile_silent(
+            block_id,
+            "output",
+            line,
+            Some(&fs),
+            Some("agent:tsidx-silent:current"),
+        );
+
+        let entries = read_tsidx(&fs, block_id);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, 0);
+    }
+
     /// Minimal WpsClient that records every event delivered to it, so tests
     /// can assert on the broadcast payload (not just the FileStore side effect).
     struct RecordingClient {

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -456,6 +456,13 @@ pub struct CommandBlockfileReadRangeData {
 pub struct BlockfileReadRangeResult {
     pub lines: Vec<String>,
     pub total: u64,
+    /// Receive-time stamps (unix ms) parallel to `lines`, joined from the
+    /// `output.tsidx` sidecar; `0` = unknown for that line. Absent entirely
+    /// when no sidecar exists or the request didn't take the `output.idx`
+    /// fast path — old frontends ignore it, new frontends tolerate absence.
+    /// Spec: SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.4.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stamps: Option<Vec<i64>>,
 }
 
 /// Request for blockfile:read_state — read a sidecar JSON file

--- a/agentmux-srv/src/server/app_api/blockfile.rs
+++ b/agentmux-srv/src/server/app_api/blockfile.rs
@@ -171,7 +171,7 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                         // Empty result cases — answered from the index, no output read.
                         if limit == 0 || total_lines == 0 || (offset as u64) >= total_lines {
-                            return Some(BlockfileReadRangeResult { lines: vec![], total: total_lines });
+                            return Some(BlockfileReadRangeResult { lines: vec![], total: total_lines, stamps: None });
                         }
 
                         // entry(k) = byte offset of non-blank line k (past the 8-byte header).
@@ -203,7 +203,64 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             .filter(|l| !l.trim().is_empty())
                             .map(|l| l.to_string())
                             .collect();
-                        Some(BlockfileReadRangeResult { lines, total: total_lines })
+
+                        // Receive-time stamps for the returned lines, joined
+                        // from the output.tsidx sidecar (batch byte offset →
+                        // unix ms; see agent_session::TSIDX_FILE). Per line:
+                        // the newest batch stamp at-or-before the line's own
+                        // byte offset. Best-effort — any failure yields no
+                        // stamps, never a failed read.
+                        let stamps: Option<Vec<i64>> = (|| {
+                            use crate::backend::agent_session::TSIDX_FILE;
+                            let ts_stat = filestore.stat(&read_block, TSIDX_FILE).ok().flatten()?;
+                            if ts_stat.size == 0 {
+                                return None;
+                            }
+                            let raw_ts = filestore.read_file(&read_block, TSIDX_FILE).ok().flatten()?;
+                            let mut entries: Vec<(u64, i64)> = String::from_utf8_lossy(&raw_ts)
+                                .lines()
+                                .filter_map(|l| {
+                                    let v: serde_json::Value = serde_json::from_str(l.trim()).ok()?;
+                                    Some((v.get("off")?.as_u64()?, v.get("ms")?.as_i64()?))
+                                })
+                                .collect();
+                            if entries.is_empty() {
+                                return None;
+                            }
+                            // Appends serialize on the store so offsets are
+                            // already monotonic in practice; sort defensively
+                            // (cross-channel mirrors racing into the global
+                            // zone).
+                            entries.sort_by_key(|(off, _)| *off);
+
+                            // Byte offset of every returned line, read from
+                            // output.idx in one slice.
+                            let returned = lines.len() as u64;
+                            let (_, idx_raw) = filestore
+                                .read_at(
+                                    &read_block,
+                                    "output.idx",
+                                    OUTPUT_IDX_HEADER_LEN + (offset as u64 * 8) as i64,
+                                    (returned * 8) as i64,
+                                )
+                                .ok()?;
+                            if idx_raw.len() != (returned * 8) as usize {
+                                return None;
+                            }
+                            let stamps = idx_raw
+                                .chunks_exact(8)
+                                .map(|b| {
+                                    let line_off = u64::from_le_bytes(b.try_into().unwrap());
+                                    match entries.partition_point(|(off, _)| *off <= line_off) {
+                                        0 => 0,
+                                        p => entries[p - 1].1,
+                                    }
+                                })
+                                .collect();
+                            Some(stamps)
+                        })();
+
+                        Some(BlockfileReadRangeResult { lines, total: total_lines, stamps })
                     })();
                     if let Some(result) = idx_result {
                         tracing::debug!(
@@ -301,6 +358,7 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 Ok(Some(serde_json::to_value(&BlockfileReadRangeResult {
                     lines,
                     total,
+                    stamps: None,
                 }).unwrap()))
             })
         }),

--- a/docs/specs/SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
+++ b/docs/specs/SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
@@ -1,7 +1,7 @@
 # SPEC: Session-scoped pane scrollback + a full "Agent History" view
 
 **Date:** 2026-08-09
-**Status:** active — P1 (session-scope clamp §3.1-3.3 + `resumed`-divider demotion §3.5 + static preserved-note on the fresh divider) implemented 2026-08-10; the §3.4 link row is deferred with P2 per the P1 phasing note. P2 (Agent History view, `output.tsidx` timestamps) and P3 not started.
+**Status:** active — P1 (session-scope clamp §3.1-3.3 + `resumed`-divider demotion §3.5 + static preserved-note on the fresh divider) shipped in PR #2507; §4.4's `output.tsidx` capture + replay stamping implemented 2026-08-10 (this restores hover-peek times after reopen). Remaining: the Agent History view itself (§4.1-4.3, day separators, §3.4 link row) and P3.
 **Severity:** Medium — UX/correctness follow-up, no data loss involved
 **Extends:** `SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md` (Part A shipped the
 honest *"New session started"* divider this spec builds on)

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -165,7 +165,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 limit: loadLimit,
             }, { timeout: 15000 });
 
-            const { nodes: newNodes } = parseHistoryLines(resp.lines ?? [], opts.outputFormat(), opts.agentName?.());
+            const { nodes: newNodes } = parseHistoryLines(resp.lines ?? [], opts.outputFormat(), opts.agentName?.(), resp.stamps);
             if (newNodes.length > 0) {
                 // batch() ensures HistoryLoaded's documentAtom write is not a
                 // standalone runUpdates frame that could interleave with a
@@ -340,7 +340,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             limit: hwm - windowStart,
                         }, { timeout: 30_000 });
                         if (!mounted) return;
-                        const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat(), opts.agentName?.());
+                        const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat(), opts.agentName?.(), rangeResp.stamps);
                         batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes }));
                         // Hydrate the composer strip's context-fill bar from the
                         // resumed conversation's last known usage instead of
@@ -484,7 +484,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 }, { timeout: 15000 });
                 if (!mounted) return;
 
-                const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat(), opts.agentName?.());
+                const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat(), opts.agentName?.(), rangeResp.stamps);
                 if (nodes.length > 0) {
                     batch(() => opts.model.dispatchDoc({ type: "HistoryLoaded", nodes }));
                 }

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -112,6 +112,64 @@ describe("parseHistoryLines", () => {
         expect(lastSessionStats).toEqual({ input_tokens: 500, output_tokens: 50 });
     });
 
+    // §4.4 of SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW
+    // _2026_08_09.md: replayed nodes get receive-time stamps from the
+    // output.tsidx sidecar (`stamps` parallel to `lines`); wire timestamps
+    // win; 0/absent = unknown and must never stamp a node.
+    describe("tsidx receive-time stamping (§4.4)", () => {
+        it("stamps a timestamp-less replayed node from its line's batch time", () => {
+            const lines = [
+                line({ type: "text", content: "hello" }),
+                line({ type: "tool_call", tool: "Bash", id: "tool-1", params: { command: "ls" } }),
+            ];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json", undefined, [1_700_000_000_000, 1_700_000_001_000]);
+            expect((nodes[0] as { timestamp?: number }).timestamp).toBe(1_700_000_000_000);
+            expect((nodes[1] as ToolNode).timestamp).toBe(1_700_000_001_000);
+        });
+
+        it("a tool_result replacement preserves the tool_call's stamp", () => {
+            const lines = [
+                line({ type: "tool_call", tool: "Bash", id: "tool-1", params: { command: "ls" } }),
+                line({ type: "tool_result", tool: "Bash", id: "tool-1", status: "success", duration: 0.1 }),
+            ];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json", undefined, [111_000, 222_000]);
+            const tool = nodes[0] as ToolNode;
+            expect(tool.status).toBe("success");
+            expect(tool.timestamp).toBe(111_000);
+        });
+
+        it("a 0 stamp entry means unknown and does not stamp the node", () => {
+            const lines = [line({ type: "text", content: "hello" })];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json", undefined, [0]);
+            const ts = (nodes[0] as { timestamp?: number }).timestamp;
+            expect(ts === undefined || ts === 0).toBe(true);
+            expect(ts).not.toBe(1970); // sanity: nothing invents a time
+        });
+
+        it("absent stamps array leaves behavior unchanged", () => {
+            const lines = [line({ type: "text", content: "hello" })];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json");
+            expect(nodes).toHaveLength(1);
+        });
+
+        it("a wire timestamp wins over the batch stamp", () => {
+            const wire = "2026-08-09T12:00:00Z";
+            const lines = [
+                JSON.stringify({
+                    type: "system",
+                    subtype: "agentmux_session_outcome",
+                    outcome: "fresh",
+                    attempted_sid: "sid-1",
+                    actual_sid: null,
+                    timestamp: wire,
+                }),
+            ];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json", undefined, [999_000]);
+            const outcome = nodes.find((n) => n.type === "session_outcome") as { timestamp: number };
+            expect(outcome.timestamp).toBe(Date.parse(wire));
+        });
+    });
+
     // §3.5 of SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW
     // _2026_08_09.md: `fresh` outcomes materialize as divider nodes; `resumed`
     // outcomes are demoted — persisted line kept, no working-view node.

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -45,6 +45,14 @@ export interface ParsedHistory {
  *                     detection works during replay — an echoed outgoing jekt
  *                     (FROM == this agent) must rebuild as an outgoing bubble.
  *                     Optional; missing name falls back to "incoming".
+ * @param stamps       Receive-time stamps (unix ms) parallel to `lines`, from
+ *                     the backend's `output.tsidx` sidecar (`stamps` on
+ *                     blockfile:read_range). Used to timestamp replayed nodes
+ *                     whose wire frames carry no time of their own — a wire
+ *                     timestamp always wins over the batch stamp. 0 entries
+ *                     and an absent array both mean "unknown" and leave the
+ *                     node unstamped (never 0 → never a 1970 hover). Spec:
+ *                     SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.4.
  * @returns            Ordered DocumentNodes (deduped by node id) plus the
  *                      last `session_end` stats payload found, if any.
  */
@@ -52,6 +60,7 @@ export function parseHistoryLines(
     lines: string[],
     outputFormat: string,
     agentName?: string,
+    stamps?: number[],
 ): ParsedHistory {
     const translator = createTranslator(outputFormat);
     // isReplay: true — thinking/tool_call events carry no wire timestamp of
@@ -73,7 +82,34 @@ export function parseHistoryLines(
     // which is the same end state the live stream produces.
     const indexById = new Map<string, number>();
 
-    for (const line of lines) {
+    // Batch receive-time for line i, or undefined when unknown. 0 is the
+    // backend's "unknown" sentinel and must never leak onto a node (§4.4
+    // sentinel hygiene — hover gates on `!= null` and would render 1970).
+    const stampFor = (i: number): number | undefined => {
+        const s = stamps?.[i];
+        return typeof s === "number" && s > 0 ? s : undefined;
+    };
+    // Stamp a freshly-created node from its line's batch time when the wire
+    // frame carried no usable timestamp of its own.
+    const stampIfMissing = (node: DocumentNode, stampMs: number | undefined): DocumentNode => {
+        if (stampMs == null) return node;
+        const ts = (node as { timestamp?: number }).timestamp;
+        if (ts != null && ts !== 0) return node;
+        return { ...node, timestamp: stampMs } as DocumentNode;
+    };
+    // An in-place same-id replacement (tool_call → tool_result, accumulated
+    // text deltas) must not wipe the stamp the node got when it was first
+    // created — the replacement event is typically timestamp-less too.
+    const carryTimestamp = (prior: DocumentNode, replacement: DocumentNode): DocumentNode => {
+        const rts = (replacement as { timestamp?: number }).timestamp;
+        if (rts != null && rts !== 0) return replacement;
+        const pts = (prior as { timestamp?: number }).timestamp;
+        if (pts == null || pts === 0) return replacement;
+        return { ...replacement, timestamp: pts } as DocumentNode;
+    };
+
+    for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+        const line = lines[lineIdx];
         const trimmed = line.trim();
         if (!trimmed || !trimmed.startsWith("{")) continue;
 
@@ -127,7 +163,9 @@ export function parseHistoryLines(
                     id: contextCompactedNodeId(data),
                     tokensBefore: data.preTokens,
                     tokensAfter: data.postTokens,
-                    timestamp: Number.isNaN(parsedTs) ? 0 : parsedTs,
+                    // Wire timestamp wins; batch stamp fills the timestamp-less
+                    // case; 0 only when neither exists (type requires number).
+                    timestamp: Number.isNaN(parsedTs) ? (stampFor(lineIdx) ?? 0) : parsedTs,
                     source: "real",
                     trigger: data.trigger,
                     durationMs: data.durationMs,
@@ -171,7 +209,8 @@ export function parseHistoryLines(
                     outcome: data.outcome,
                     attemptedSid: data.attemptedSid,
                     actualSid: data.actualSid,
-                    timestamp: Number.isNaN(parsedTs) ? 0 : parsedTs,
+                    // Same wire-wins-then-stamp rule as context_compacted above.
+                    timestamp: Number.isNaN(parsedTs) ? (stampFor(lineIdx) ?? 0) : parsedTs,
                 };
                 const existing = indexById.get(node.id);
                 if (existing != null) {
@@ -206,10 +245,10 @@ export function parseHistoryLines(
                 // Replace at the original position so insertion order
                 // tracks where the id first appeared (which is where
                 // the live render would have placed it).
-                nodes[existing] = node;
+                nodes[existing] = carryTimestamp(nodes[existing], node);
             } else {
                 indexById.set(node.id, nodes.length);
-                nodes.push(node);
+                nodes.push(stampIfMissing(node, stampFor(lineIdx)));
             }
         }
     }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2290,6 +2290,10 @@ declare global {
     type BlockfileReadRangeResult = {
         lines: string[];
         total: number;
+        // Receive-time stamps (unix ms) parallel to `lines`; 0 = unknown.
+        // Absent when no output.tsidx sidecar exists (pre-upgrade history)
+        // or the read skipped the output.idx fast path.
+        stamps?: number[];
     };
 
     // wshrpc.CommandBlockfileReadStateData


### PR DESCRIPTION
## Summary

First slice of P2 of `SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md` (§4.4): **node timestamps become first-class and survive restore.**

**Backend.** Every agent-transcript append batch now also appends one NDJSON `{off, ms}` record to an `output.tsidx` sidecar in the same zone — covering `handle_append_block_file`, `persist_to_blockfile_silent` (user-message lines), and the global-zone mirror (offset-keyed against the global zone's own `output`). Deliberately a sidecar, not an envelope: `output`'s format and every existing parser are untouched, writes are fire-and-forget, and PTY `term` data never gets one (gated on `global_output_zone`). `blockfile:read_range`'s `output.idx` fast path joins the sidecar against each returned line's byte offset (one slice read + binary search) and returns an optional `stamps` array parallel to `lines` — old frontends ignore it, new frontends tolerate its absence.

**Frontend.** `parseHistoryLines` stamps freshly-created nodes from their line's batch time when the wire frame carries no timestamp; a wire timestamp always wins; same-id replacements (`tool_call` → `tool_result`, accumulated deltas) carry the stamp forward instead of wiping it; `0`/absent means unknown and never stamps a node — closing the 1970-hover sentinel hole. `useHistoryPagination` threads `stamps` through all three read paths.

**Net effect:** the hover-to-peek time display (#2392 lineage) — dead after any pane reopen because replayed nodes had no timestamps — now works on restored history for all post-upgrade content. Legacy pre-sidecar lines degrade to today's behavior (no backfill is possible; their receive times were never recorded). This is also the data source for the upcoming Agent History view's day separators.

## Verification

- Backend: 4 new tests (per-batch stamping + offset keying, term-data exclusion, global-mirror stamping, persist-silent stamping); full `cargo test -p agentmux-srv` suite green (2101 passed).
- Frontend: 5 new tests (batch stamping, wire-timestamp-wins, replacement stamp carry, 0-sentinel hygiene, absent-array no-op); affected suites green (142 tests); `tsc --noEmit` clean.
- Sidecar growth is one ~30-byte line per append batch; the read-side join reads it whole — worth a size cap/rotation only if profiling ever shows it hot (noted for P3 alongside archive rotation).

<!-- agentmux:agent_id=agentx -->