### PR TITLE
feat(agent-pane): Agent History view — read-only full-history reader with day separators

### DIFF
--- a/.changesets/1786372533-feat-agent-pane-agent-history-view-read-only-full-history-re-74vs.md
+++ b/.changesets/1786372533-feat-agent-pane-agent-history-view-read-only-full-history-re-74vs.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): Agent History view — read-only full-history reader with day separators; 'Earlier conversations' link row

--- a/docs/specs/SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
+++ b/docs/specs/SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md
@@ -1,7 +1,7 @@
 # SPEC: Session-scoped pane scrollback + a full "Agent History" view
 
 **Date:** 2026-08-09
-**Status:** active — P1 (session-scope clamp §3.1-3.3 + `resumed`-divider demotion §3.5 + static preserved-note on the fresh divider) shipped in PR #2507; §4.4's `output.tsidx` capture + replay stamping implemented 2026-08-10 (this restores hover-peek times after reopen). Remaining: the Agent History view itself (§4.1-4.3, day separators, §3.4 link row) and P3.
+**Status:** active — P1 shipped in PR #2507 (session-scope clamp + `resumed`-divider demotion); §4.4's `output.tsidx` capture + replay stamping shipped in PR #2508; P2's Agent History view (§4.1-4.3 `bodyMode` swap, day separators, §3.4 link row, control-bar entry) implemented 2026-08-10. Remaining: P3 (§4.5 archives section, jump-to-date, link-row session count).
 **Severity:** Medium — UX/correctness follow-up, no data loss involved
 **Extends:** `SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md` (Part A shipped the
 honest *"New session started"* divider this spec builds on)

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -71,3 +71,59 @@
     user-select: none;
     cursor: default;
 }
+
+// ── Agent History view (spec §4 — read-only full-stream reader) ──────────
+// Fills the pane body where the live transcript + composer normally sit.
+// `.agent-history-body` is the positioning parent for the reused
+// `.agent-document` (absolutely positioned to fill, same contract as
+// `.agent-document-scroll-region`).
+.agent-history-view {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.agent-history-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 6px 10px;
+    flex: 0 0 auto;
+    border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+
+    .agent-history-back {
+        background: none;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+        border-radius: 6px;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+        font-size: 11.5px;
+        padding: 3px 9px;
+        cursor: pointer;
+
+        &:hover {
+            color: var(--main-text-color, #fff);
+            border-color: var(--accent-color, rgba(88, 148, 255, 0.6));
+        }
+    }
+
+    .agent-history-title {
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.55));
+    }
+
+    .agent-history-meta {
+        font-size: 11px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.32));
+        margin-left: auto;
+    }
+}
+
+.agent-history-body {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -48,6 +48,7 @@ import { useNextPromptSuggestion } from "./hooks/useNextPromptSuggestion";
 import { useAgentCommands } from "./hooks/useAgentCommands";
 import { useAgentFailure } from "./hooks/useAgentFailure";
 import { PaneRow } from "./components/PaneRow";
+import { AgentHistoryView } from "./history/AgentHistoryView";
 import { PaneTabStrip } from "@/app/element/PaneTabStrip";
 import { PaneTabRenameInput } from "@/app/element/PaneTabRenameInput";
 import { useForkSet } from "./fork/useForkSet";
@@ -604,6 +605,13 @@ const AgentPresentationView = ({
     const [layoutView, setLayoutView] = createSignal<LayoutView | null>(null);
     registerLayoutPane(model.blockId, { layout: setLayoutView, zoom: () => {} });
     onCleanup(() => unregisterLayoutPane(model.blockId));
+
+    // Body mode (spec §4.2): "history" swaps the transcript + composer
+    // subtree for the read-only Agent History reader. The live subtree
+    // unmounts (its stream subscription with it — never doubled); on
+    // return, the normal mount/restore path catches the pane up. Always
+    // reopens "live" — a transient reading posture, not persisted state.
+    const [bodyMode, setBodyMode] = createSignal<"live" | "history">("live");
     // DEV-only: CDP validation hook — lets engineers run
     // `__agentLayout()` in the console to snapshot the slice state.
     if (import.meta.env.DEV) {
@@ -1732,6 +1740,36 @@ const AgentPresentationView = ({
             />
 
 
+            <Show
+                when={bodyMode() === "live"}
+                fallback={
+                    <AgentHistoryView
+                        blockId={model.blockId}
+                        outputFormat={outputFormat}
+                        agentName={agentName}
+                        onClose={() => setBodyMode("live")}
+                    />
+                }
+            >
+            {/* §3.4 link row — shown once the working scrollback was clamped
+                at a fresh session boundary. The one UI consumer of
+                history.scopeClamped: prior history is preserved and one
+                click away, so the clamp never reads as data loss. */}
+            <Show when={history.scopeClamped()}>
+                <PaneRow
+                    sigil="⌛"
+                    title="Earlier conversations"
+                    meta="preserved from before this session started"
+                    accent="neutral"
+                    actions={[{
+                        label: "Open Agent History",
+                        title: "Browse this agent's full history",
+                        onClick: () => setBodyMode("history"),
+                        primary: true,
+                    }]}
+                    onActivate={() => setBodyMode("history")}
+                />
+            </Show>
             {/* Scroll region wrapper — .agent-document (inside AgentDocumentView)
                 is absolutely positioned to fill this box, and AgentWorkingRow
                 floats over its bottom edge instead of pushing it up as a
@@ -2043,6 +2081,7 @@ const AgentPresentationView = ({
                             blockId={model.blockId}
                             blockAtom={block}
                             providerId={provider()?.id ?? ""}
+                            onOpenHistory={() => setBodyMode("history")}
                         />
                         {/* Drag-to-height drawer wrapping the terminal — the actual
                             scrollable/resizable content. */}
@@ -2076,6 +2115,7 @@ const AgentPresentationView = ({
                     </div>
                 </Show>
             </div>
+            </Show>
             {/* AgentActionBar (Add / Import / Export) lives in the
                 AgentPicker view only. Once an agent is loaded the user
                 is working in the conversation; the action bar would

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -747,6 +747,16 @@ const AgentPresentationView = ({
         log,
     });
 
+    // True when content older than the working session exists out of view:
+    // set by the restore/pagination clamp paths (scopeClamped) OR derived
+    // from a live clamp — after the reducer's StreamFlush trim, the fresh
+    // session_outcome divider is always the first document node.
+    const earlierHistoryAvailable = createMemo(() => {
+        if (history.scopeClamped()) return true;
+        const first = agentAtoms().documentAtom[0]()[0];
+        return first?.type === "session_outcome" && first.outcome === "fresh";
+    });
+
     // Auth + launch flow state and the onCleanup that kills the CLI
     // if the pane closes mid-login.
     // `getDocument` is read-only; for writes we MUST dispatch through
@@ -1619,6 +1629,12 @@ const AgentPresentationView = ({
     useAgentKeyboard({
         blockId: model.blockId,
         onToggleSearch: () => {
+            // Search targets the LIVE document (its highlight + jumpTo are
+            // bound to the live AgentDocumentView, which unmounts in
+            // history mode) — opening it there would search a hidden
+            // document and dispatch scroll commands to an unmounted list
+            // (reagent P1 on PR #2509). History-mode search is P3 scope.
+            if (bodyMode() !== "live") return;
             // Second Ctrl+F press closes and clears state.
             if (search.visible()) {
                 search.close();
@@ -1729,17 +1745,6 @@ const AgentPresentationView = ({
 
             {/* Tab strip now lives in AgentViewWrapper — see its comment. */}
 
-            <AgentSearchBar
-                visible={search.visible}
-                onSearch={search.performSearch}
-                onNext={search.next}
-                onPrev={search.prev}
-                onClose={search.close}
-                matchIndex={search.currentIndex}
-                matchCount={search.matchCount}
-            />
-
-
             <Show
                 when={bodyMode() === "live"}
                 fallback={
@@ -1751,11 +1756,28 @@ const AgentPresentationView = ({
                     />
                 }
             >
-            {/* §3.4 link row — shown once the working scrollback was clamped
-                at a fresh session boundary. The one UI consumer of
-                history.scopeClamped: prior history is preserved and one
-                click away, so the clamp never reads as data loss. */}
-            <Show when={history.scopeClamped()}>
+            {/* Search bar lives INSIDE the live branch: its highlight +
+                jumpTo target the live document and would act on a hidden,
+                unmounted list in history mode (reagent P1 on PR #2509). */}
+            <AgentSearchBar
+                visible={search.visible}
+                onSearch={search.performSearch}
+                onNext={search.next}
+                onPrev={search.prev}
+                onClose={search.close}
+                matchIndex={search.currentIndex}
+                matchCount={search.matchCount}
+            />
+
+            {/* §3.4 link row — shown when the working scrollback is clamped
+                at a fresh session boundary: either detected during
+                restore/pagination (history.scopeClamped) or arrived LIVE —
+                the reducer's StreamFlush clamp leaves the fresh boundary as
+                the document's first node, so deriving from the document
+                covers the live path the RPC-side signal can't see
+                (codex P2 on PR #2509). Prior history stays one click away,
+                so the clamp never reads as data loss. */}
+            <Show when={earlierHistoryAvailable()}>
                 <PaneRow
                     sigil="⌛"
                     title="Earlier conversations"

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -23,9 +23,12 @@ interface AgentControlBarProps {
     blockId: string;
     blockAtom: () => Block | undefined;
     providerId: string;
+    /** Open the pane's Agent History view (spec §4.2 entry point) —
+     *  reachable even when the pane has no session boundary. */
+    onOpenHistory?: () => void;
 }
 
-export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControlBarProps): JSX.Element => {
+export const AgentControlBar = ({ blockId, blockAtom, providerId, onOpenHistory }: AgentControlBarProps): JSX.Element => {
     const [archiveBusy, setArchiveBusy] = createSignal(false);
     const [exportBusy, setExportBusy] = createSignal(false);
     const [restoreBusy, setRestoreBusy] = createSignal(false);
@@ -94,8 +97,24 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
         }
     };
 
-    // Only show for Claude provider (Phase 1)
-    if (providerId !== "claude") return null;
+    // Only show session-management controls for Claude (Phase 1) — but the
+    // Agent History entry is provider-agnostic (the transcript zone exists
+    // for every provider), so it renders before the gate.
+    if (providerId !== "claude") {
+        return (
+            <Show when={onOpenHistory}>
+                <div class="agent-session-row">
+                    <button
+                        class="agent-session-btn"
+                        title="Browse this agent's full recorded history, across sessions"
+                        onClick={() => onOpenHistory?.()}
+                    >
+                        View full history
+                    </button>
+                </div>
+            </Show>
+        ) as unknown as JSX.Element;
+    }
 
     // 4.1 Graceful degradation: warn when session grows unwieldy (500K lines).
     // Browser still handles this via content-visibility, but we surface the state
@@ -246,6 +265,15 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
                         >
                             {exportBusy() ? "Exporting…" : "Export"}
                         </button>
+                        <Show when={onOpenHistory}>
+                            <button
+                                class="agent-session-btn"
+                                title="Browse this agent's full recorded history, across sessions"
+                                onClick={() => onOpenHistory?.()}
+                            >
+                                View full history
+                            </button>
+                        </Show>
                     </div>
                 </div>
             </Show>

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -265,15 +265,25 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId, onOpenHistory 
                         >
                             {exportBusy() ? "Exporting…" : "Export"}
                         </button>
-                        <Show when={onOpenHistory}>
-                            <button
-                                class="agent-session-btn"
-                                title="Browse this agent's full recorded history, across sessions"
-                                onClick={() => onOpenHistory?.()}
-                            >
-                                View full history
-                            </button>
-                        </Show>
+                    </div>
+                </div>
+            </Show>
+
+            {/* ── Agent History entry — deliberately UNCONDITIONAL (not
+                nested in the session-actions row): archived and 500K+-line
+                sessions hide that row but are exactly the states where the
+                full-history reader matters most (reagent P1 on PR #2509). */}
+            <Show when={onOpenHistory}>
+                <div class="agent-session-row">
+                    <span class="agent-session-row-label">History</span>
+                    <div class="agent-session-actions">
+                        <button
+                            class="agent-session-btn"
+                            title="Browse this agent's full recorded history, across sessions"
+                            onClick={() => onOpenHistory?.()}
+                        >
+                            View full history
+                        </button>
                     </div>
                 </div>
             </Show>

--- a/frontend/app/view/agent/history/AgentHistoryView.tsx
+++ b/frontend/app/view/agent/history/AgentHistoryView.tsx
@@ -61,13 +61,22 @@ export interface AgentHistoryViewProps {
 }
 
 export function AgentHistoryView(props: AgentHistoryViewProps) {
-    // Raw parsed nodes (no dividers) + the id set that dedupes page
-    // overlaps, mirroring the reducer's HistoryLoaded contract without
-    // involving the store.
+    // The accumulated RAW LINES (+ parallel stamps), reparsed wholesale
+    // into nodes on every page load. Wholesale — not per-page with an id
+    // dedup — because ClaudeCodeStreamParser generates counter-based ids
+    // (node_0, user_0, …) that restart for every parser instance: two
+    // independently-parsed pages collide on ids for UNRELATED messages,
+    // and any per-page dedup silently drops real history (codex P1 on
+    // PR #2509). One parse over the full accumulated range keeps ids
+    // unique and accumulator state (text/thinking runs spanning a page
+    // boundary) correct. Cost: O(loaded lines) per page-up, bounded by
+    // the reader's own pagination — fine for a reading posture.
     const [rawNodes, setRawNodes] = createSignal<DocumentNode[]>([]);
-    const seenIds = new Set<string>();
+    let accLines: string[] = [];
+    let accStamps: (number | undefined)[] = [];
     const [historyOffset, setHistoryOffset] = createSignal(0);
     const [totalLines, setTotalLines] = createSignal(0);
+    const [loading, setLoading] = createSignal(true);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
     const [loadError, setLoadError] = createSignal<string | null>(null);
 
@@ -97,10 +106,19 @@ export function AgentHistoryView(props: AgentHistoryViewProps) {
     registerLayoutPane(layoutKey, { layout: setLayoutView, zoom: () => {} });
     onCleanup(() => unregisterLayoutPane(layoutKey));
 
-    const parsePage = (lines: string[], stamps?: number[]): DocumentNode[] =>
-        parseHistoryLines(lines, props.outputFormat(), props.agentName?.(), stamps, {
-            includeResumedOutcomes: true,
-        }).nodes;
+    /** Reparse the full accumulated line range into nodes (see the
+     *  wholesale-reparse rationale on `rawNodes`). */
+    const reparseAccumulated = (): DocumentNode[] =>
+        parseHistoryLines(
+            accLines,
+            props.outputFormat(),
+            props.agentName?.(),
+            accStamps as number[],
+            { includeResumedOutcomes: true },
+        ).nodes;
+
+    const stampsOf = (resp: { lines?: string[]; stamps?: number[] }): (number | undefined)[] =>
+        resp.stamps ?? new Array((resp.lines ?? []).length).fill(undefined);
 
     onMount(() => {
         let mounted = true;
@@ -116,7 +134,10 @@ export function AgentHistoryView(props: AgentHistoryViewProps) {
                 if (!mounted) return;
                 const total = countResp?.count ?? 0;
                 setTotalLines(total);
-                if (total === 0) return;
+                if (total === 0) {
+                    setLoading(false);
+                    return;
+                }
 
                 const offset = Math.max(0, total - HISTORY_PAGE);
                 const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
@@ -126,16 +147,19 @@ export function AgentHistoryView(props: AgentHistoryViewProps) {
                     limit: total - offset,
                 }, { timeout: 30_000 });
                 if (!mounted) return;
-                const nodes = parsePage(resp.lines ?? [], resp.stamps);
+                accLines = resp.lines ?? [];
+                accStamps = stampsOf(resp);
+                const nodes = reparseAccumulated();
                 batch(() => {
-                    for (const n of nodes) seenIds.add(n.id);
                     setRawNodes(nodes);
                     setHistoryOffset(Math.min(offset, typeof resp.total === "number" ? resp.total : offset));
                     if (typeof resp.total === "number") setTotalLines(resp.total);
+                    setLoading(false);
                 });
             } catch (err) {
                 if (!mounted) return;
                 setLoadError((err as Error | undefined)?.message ?? String(err));
+                setLoading(false);
             }
         })();
     });
@@ -152,10 +176,11 @@ export function AgentHistoryView(props: AgentHistoryViewProps) {
                 offset: newOffset,
                 limit: currentOffset - newOffset,
             }, { timeout: 15_000 });
-            const pageNodes = parsePage(resp.lines ?? [], resp.stamps).filter((n) => !seenIds.has(n.id));
+            accLines = [...(resp.lines ?? []), ...accLines];
+            accStamps = [...stampsOf(resp), ...accStamps];
+            const nodes = reparseAccumulated();
             batch(() => {
-                for (const n of pageNodes) seenIds.add(n.id);
-                if (pageNodes.length > 0) setRawNodes((prev) => [...pageNodes, ...prev]);
+                setRawNodes(nodes);
                 setHistoryOffset(newOffset);
             });
         } catch {
@@ -178,13 +203,19 @@ export function AgentHistoryView(props: AgentHistoryViewProps) {
                 </button>
                 <div class="agent-history-title">Agent History</div>
                 <div class="agent-history-meta">
-                    {historyOffset() === 0 && totalLines() > 0
-                        ? "full history loaded"
-                        : totalLines() > 0
-                            ? `${totalLines()} lines · scroll up for earlier`
-                            : loadError()
-                                ? `couldn't load history: ${loadError()}`
-                                : "no recorded history"}
+                    {/* Explicit loading state first — without it the initial
+                        async window renders "no recorded history", which is
+                        indistinguishable from a genuinely empty agent
+                        (reagent P2 on PR #2509). */}
+                    {loading()
+                        ? "loading history…"
+                        : loadError()
+                            ? `couldn't load history: ${loadError()}`
+                            : historyOffset() === 0 && totalLines() > 0
+                                ? "full history loaded"
+                                : totalLines() > 0
+                                    ? `${totalLines()} lines · scroll up for earlier`
+                                    : "no recorded history"}
                 </div>
             </div>
             <div class="agent-history-body">

--- a/frontend/app/view/agent/history/AgentHistoryView.tsx
+++ b/frontend/app/view/agent/history/AgentHistoryView.tsx
@@ -1,0 +1,202 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentHistoryView — the read-only, full-stream transcript reader for one
+ * agent (spec §4.1). Rendered by agent-view.tsx as the pane's alternate
+ * body (`bodyMode: "history"`); the live transcript + composer subtree is
+ * unmounted while this is open, so the live stream subscription is never
+ * doubled.
+ *
+ * Deliberately NOT a consumer of the agent-document reducer store: the
+ * reader has no live stream, no truncate/dedup races, and must render the
+ * stream boundary-blind (the working view's session-scope clamp — reducer
+ * `clampToSessionScope` — must NOT apply here). It holds plain local
+ * signals and feeds them straight from `parseHistoryLines` with
+ * `includeResumedOutcomes: true`, then injects `day_divider` rows at
+ * render time. The virtual list + row renderers are reused as-is via
+ * `AgentDocumentView` under a synthetic layout key (`<blockId>:history`)
+ * so the live pane's layout slot is untouched.
+ *
+ * Spec: SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.
+ */
+
+import { batch, createEffect, createMemo, createSignal, onCleanup, onMount, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import {
+    registerPane as registerLayoutPane,
+    unregisterPane as unregisterLayoutPane,
+    type LayoutView,
+} from "@/app/store/agent-pane-layout-store";
+import { AgentDocumentView } from "../components/AgentDocumentView";
+import { parseHistoryLines } from "../parseHistoryLines";
+import { injectDayDividers } from "./day-dividers";
+import type { DocumentNode, DocumentState, FilterState } from "../types";
+
+/** Lines per fetch. Larger than the live pane's 200 — a reading posture
+ *  wants fewer load-older stops; still bounded well under the backend's
+ *  10k per-request cap. */
+const HISTORY_PAGE = 600;
+
+const HISTORY_FILTER: FilterState = {
+    // The reader shows the honest full record — thinking included is a
+    // deliberate divergence from the live default (readers came here to
+    // peruse everything; the filter bar is not mounted in history mode).
+    showThinking: true,
+    showSuccessfulTools: true,
+    showFailedTools: true,
+    showIncoming: true,
+    showOutgoing: true,
+};
+
+export interface AgentHistoryViewProps {
+    /** The live pane's block id — used for the transcript reads (they
+     *  resolve the agent's global zone via this block's meta). */
+    blockId: string;
+    outputFormat: Accessor<string>;
+    agentName?: Accessor<string>;
+    /** Return to the live conversation (`bodyMode: "live"`). */
+    onClose: () => void;
+}
+
+export function AgentHistoryView(props: AgentHistoryViewProps) {
+    // Raw parsed nodes (no dividers) + the id set that dedupes page
+    // overlaps, mirroring the reducer's HistoryLoaded contract without
+    // involving the store.
+    const [rawNodes, setRawNodes] = createSignal<DocumentNode[]>([]);
+    const seenIds = new Set<string>();
+    const [historyOffset, setHistoryOffset] = createSignal(0);
+    const [totalLines, setTotalLines] = createSignal(0);
+    const [loadingOlder, setLoadingOlder] = createSignal(false);
+    const [loadError, setLoadError] = createSignal<string | null>(null);
+
+    // The rendered document: raw nodes + day separators, recomputed as a
+    // pure pass (§4.4 — dividers are render-time synthetics).
+    const displayNodes = createMemo(() => injectDayDividers(rawNodes()));
+
+    // Local document atoms for the reused view components. The document
+    // atom is projected from displayNodes; DocumentState is this reader's
+    // own expansion/pin state, independent of the live pane's.
+    const [docNodes, setDocNodes] = createSignal<DocumentNode[]>([]);
+    createEffect(() => setDocNodes(displayNodes()));
+    const [docState, setDocState] = createSignal<DocumentState>({
+        collapsedNodes: new Set<string>(),
+        pinnedNodes: new Set<string>(),
+        expandedTools: new Set<string>(),
+        scrollPosition: 0,
+        selectedNode: null,
+        filter: HISTORY_FILTER,
+    });
+
+    // Own layout slot under a synthetic key so the live pane's slot (keyed
+    // by the real blockId) is untouched. Required for the virtual list to
+    // position rows at all.
+    const layoutKey = `${props.blockId}:history`;
+    const [layoutView, setLayoutView] = createSignal<LayoutView | null>(null);
+    registerLayoutPane(layoutKey, { layout: setLayoutView, zoom: () => {} });
+    onCleanup(() => unregisterLayoutPane(layoutKey));
+
+    const parsePage = (lines: string[], stamps?: number[]): DocumentNode[] =>
+        parseHistoryLines(lines, props.outputFormat(), props.agentName?.(), stamps, {
+            includeResumedOutcomes: true,
+        }).nodes;
+
+    onMount(() => {
+        let mounted = true;
+        onCleanup(() => {
+            mounted = false;
+        });
+        (async () => {
+            try {
+                const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
+                    block_id: props.blockId,
+                    filename: "output",
+                }, { timeout: 5000 });
+                if (!mounted) return;
+                const total = countResp?.count ?? 0;
+                setTotalLines(total);
+                if (total === 0) return;
+
+                const offset = Math.max(0, total - HISTORY_PAGE);
+                const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                    block_id: props.blockId,
+                    filename: "output",
+                    offset,
+                    limit: total - offset,
+                }, { timeout: 30_000 });
+                if (!mounted) return;
+                const nodes = parsePage(resp.lines ?? [], resp.stamps);
+                batch(() => {
+                    for (const n of nodes) seenIds.add(n.id);
+                    setRawNodes(nodes);
+                    setHistoryOffset(Math.min(offset, typeof resp.total === "number" ? resp.total : offset));
+                    if (typeof resp.total === "number") setTotalLines(resp.total);
+                });
+            } catch (err) {
+                if (!mounted) return;
+                setLoadError((err as Error | undefined)?.message ?? String(err));
+            }
+        })();
+    });
+
+    const loadOlder = async (): Promise<void> => {
+        const currentOffset = historyOffset();
+        if (currentOffset === 0 || loadingOlder()) return;
+        setLoadingOlder(true);
+        try {
+            const newOffset = Math.max(0, currentOffset - HISTORY_PAGE);
+            const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                block_id: props.blockId,
+                filename: "output",
+                offset: newOffset,
+                limit: currentOffset - newOffset,
+            }, { timeout: 15_000 });
+            const pageNodes = parsePage(resp.lines ?? [], resp.stamps).filter((n) => !seenIds.has(n.id));
+            batch(() => {
+                for (const n of pageNodes) seenIds.add(n.id);
+                if (pageNodes.length > 0) setRawNodes((prev) => [...pageNodes, ...prev]);
+                setHistoryOffset(newOffset);
+            });
+        } catch {
+            // Non-fatal — the affordance stays and the user can retry by
+            // scrolling again; same soft-fail posture as the live pane.
+        } finally {
+            setLoadingOlder(false);
+        }
+    };
+
+    return (
+        <div class="agent-history-view">
+            <div class="agent-history-header">
+                <button
+                    class="agent-history-back"
+                    title="Back to conversation"
+                    onClick={() => props.onClose()}
+                >
+                    ← Back to conversation
+                </button>
+                <div class="agent-history-title">Agent History</div>
+                <div class="agent-history-meta">
+                    {historyOffset() === 0 && totalLines() > 0
+                        ? "full history loaded"
+                        : totalLines() > 0
+                            ? `${totalLines()} lines · scroll up for earlier`
+                            : loadError()
+                                ? `couldn't load history: ${loadError()}`
+                                : "no recorded history"}
+                </div>
+            </div>
+            <div class="agent-history-body">
+                <AgentDocumentView
+                    documentAtom={[docNodes, setDocNodes]}
+                    documentStateAtom={[docState, setDocState]}
+                    onLoadOlder={loadOlder}
+                    loadingOlder={loadingOlder}
+                    blockId={layoutKey}
+                    layoutView={layoutView}
+                />
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/history/day-dividers.test.ts
+++ b/frontend/app/view/agent/history/day-dividers.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { injectDayDividers } from "./day-dividers";
+import type { DocumentNode } from "../types";
+
+const md = (id: string, timestamp?: number): DocumentNode => ({
+    type: "markdown",
+    id,
+    content: id,
+    ...(timestamp != null ? { timestamp } : {}),
+});
+
+// Local-noon timestamps avoid any timezone edge in the expectations.
+const day = (y: number, m: number, d: number): number => new Date(y, m - 1, d, 12).getTime();
+
+describe("injectDayDividers (§4.4)", () => {
+    it("inserts a divider at each local-day change", () => {
+        const out = injectDayDividers([
+            md("a", day(2026, 8, 9)),
+            md("b", day(2026, 8, 9)),
+            md("c", day(2026, 8, 10)),
+        ]);
+        expect(out.map((n) => n.type)).toEqual([
+            "day_divider", "markdown", "markdown", "day_divider", "markdown",
+        ]);
+        expect(out[0].id).toBe("day-2026-08-09");
+        expect(out[3].id).toBe("day-2026-08-10");
+    });
+
+    it("carries the last known day forward across untimestamped nodes", () => {
+        const out = injectDayDividers([
+            md("a", day(2026, 8, 9)),
+            md("b"), // unknown — inherits Aug 9, no divider
+            md("c", day(2026, 8, 9)),
+        ]);
+        expect(out.filter((n) => n.type === "day_divider")).toHaveLength(1);
+    });
+
+    it("leading untimestamped nodes produce no divider", () => {
+        const out = injectDayDividers([md("a"), md("b", day(2026, 8, 10))]);
+        expect(out.map((n) => n.type)).toEqual(["markdown", "day_divider", "markdown"]);
+    });
+
+    it("ids are stable across recomputation with prepended pages", () => {
+        const newer = [md("c", day(2026, 8, 10))];
+        const first = injectDayDividers(newer);
+        const merged = injectDayDividers([md("a", day(2026, 8, 9)), ...newer]);
+        const idsIn = (nodes: DocumentNode[]) =>
+            nodes.filter((n) => n.type === "day_divider").map((n) => n.id);
+        expect(idsIn(first)).toEqual(["day-2026-08-10"]);
+        expect(idsIn(merged)).toEqual(["day-2026-08-09", "day-2026-08-10"]);
+    });
+
+    it("empty input → empty output", () => {
+        expect(injectDayDividers([])).toEqual([]);
+    });
+});

--- a/frontend/app/view/agent/history/day-dividers.ts
+++ b/frontend/app/view/agent/history/day-dividers.ts
@@ -1,0 +1,70 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Day-separator injection for the Agent History view.
+ *
+ * Rule (spec §4.4): emit a `day_divider` row whenever the best-known
+ * timestamp crosses a local-calendar-day boundary between consecutive
+ * nodes, where best-known = the node's own timestamp if present, else the
+ * last preceding known timestamp (carried forward). Untimestamped runs
+ * group under the last known day rather than inventing times — for
+ * pre-tsidx legacy content that resolves to "the day the surrounding
+ * stamped records landed", which is honest and only ever applies to
+ * pre-upgrade history.
+ *
+ * Dividers are render-time synthetics: recomputed over the full node list
+ * on every change (the reader tops out at a few thousand nodes — one
+ * linear pass), never persisted, never dispatched anywhere. Ids are
+ * `day-<YYYY-MM-DD>` so a pagination prepend recomputes to the identical
+ * node instead of duplicating.
+ *
+ * Spec: SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.4.
+ */
+
+import type { DayDividerNode, DocumentNode } from "../types";
+
+/** Local-calendar day key + label + midnight for a unix-ms timestamp. */
+function dayOf(ms: number): { key: string; label: string; midnight: number } {
+    const d = new Date(ms);
+    const y = d.getFullYear();
+    const m = d.getMonth();
+    const day = d.getDate();
+    const key = `${y}-${String(m + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    const label = d.toLocaleDateString(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+    return { key, label, midnight: new Date(y, m, day).getTime() };
+}
+
+/**
+ * Return `nodes` with `day_divider` rows inserted at every best-known
+ * local-day change. Nodes with no known timestamp (absent or 0) inherit
+ * the last seen day; leading untimestamped nodes (no day known yet)
+ * produce no divider.
+ */
+export function injectDayDividers(nodes: ReadonlyArray<DocumentNode>): DocumentNode[] {
+    const out: DocumentNode[] = [];
+    let currentDayKey: string | null = null;
+    for (const node of nodes) {
+        const ts = (node as { timestamp?: number }).timestamp;
+        if (ts != null && ts > 0) {
+            const day = dayOf(ts);
+            if (day.key !== currentDayKey) {
+                currentDayKey = day.key;
+                const divider: DayDividerNode = {
+                    type: "day_divider",
+                    id: `day-${day.key}`,
+                    dayLabel: day.label,
+                    timestamp: day.midnight,
+                };
+                out.push(divider);
+            }
+        }
+        out.push(node);
+    }
+    return out;
+}

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -115,6 +115,13 @@ export interface UseHistoryPagination {
      * exactly like a same-block reopen, so its writes are safe and expected.
      */
     snapshotIsForeignBlock: Accessor<boolean>;
+    /**
+     * True once the working scrollback has been clamped at a `fresh`
+     * session-outcome boundary (restore, NDJSON fallback, or a loadOlder
+     * page hitting one). Drives the §3.4 "Earlier conversations" link row
+     * into the Agent History view — the only UI consumer of the clamp.
+     */
+    scopeClamped: Accessor<boolean>;
 }
 
 const PAGE_SIZE = 200;
@@ -141,6 +148,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
     const [snapshotIsForeignBlock, setSnapshotIsForeignBlock] = createSignal(false);
+    const [scopeClamped, setScopeClamped] = createSignal(false);
 
     /**
      * Load the previous page of history and prepend to the document.
@@ -186,6 +194,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
             // stays on disk for the Agent History view (P2).
             if (lastFreshBoundaryIndex(newNodes) >= 0) {
                 setHistoryOffset(0);
+                setScopeClamped(true);
                 opts.log("history", `session boundary reached — older history is out of the working session's scope`);
             } else {
                 setHistoryOffset(newOffset);
@@ -381,13 +390,14 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         // than the window are out of scope too, so
                         // load-older must not page into them. Offset 0
                         // makes loadOlder a no-op.
-                        const scopeClamped = lastFreshBoundaryIndex(nodes) >= 0;
-                        setHistoryOffset(scopeClamped ? 0 : clampedStart);
+                        const windowClamped = lastFreshBoundaryIndex(nodes) >= 0;
+                        if (windowClamped) setScopeClamped(true);
+                        setHistoryOffset(windowClamped ? 0 : clampedStart);
                         setHistoryTotal(available);
                         opts.log(
                             "history",
                             `v2 restore: ${nodes.length} nodes from lines [${clampedStart}, ${available})` +
-                            (scopeClamped
+                            (windowClamped
                                 ? " (clamped to session scope — older history via Agent History)"
                                 : clampedStart > 0 ? ` (${clampedStart} older lines available via load-older)` : "") +
                             (ds?.collapsedNodeIds?.length ? `, ${ds.collapsedNodeIds.length} collapsed` : ""),
@@ -503,7 +513,12 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 // serve.
                 const available = rangeResp.total ?? total;
                 // Same session-scope edge as the v2-restore path above.
-                setHistoryOffset(lastFreshBoundaryIndex(nodes) >= 0 ? 0 : offset);
+                if (lastFreshBoundaryIndex(nodes) >= 0) {
+                    setScopeClamped(true);
+                    setHistoryOffset(0);
+                } else {
+                    setHistoryOffset(offset);
+                }
                 setHistoryTotal(available);
 
                 opts.log("history", `loaded ${nodes.length} of ${available} previous messages`);
@@ -540,5 +555,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
         loadingOlder,
         loadOlder,
         snapshotIsForeignBlock,
+        scopeClamped,
     };
 }

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -207,6 +207,16 @@ describe("parseHistoryLines", () => {
             // The surrounding conversation still replays.
             expect(nodes.filter((n) => n.type === "markdown").length).toBeGreaterThan(0);
         });
+
+        it("materializes resumed outcomes when includeResumedOutcomes is set (Agent History view, §4.1)", () => {
+            const lines = [outcomeLine("resumed")];
+            const { nodes } = parseHistoryLines(lines, "claude-stream-json", undefined, undefined, {
+                includeResumedOutcomes: true,
+            });
+            const outcomes = nodes.filter((n) => n.type === "session_outcome");
+            expect(outcomes).toHaveLength(1);
+            expect((outcomes[0] as { outcome: string }).outcome).toBe("resumed");
+        });
     });
 
     describe("compact_boundary replay (Codex P2, PR #2378 round 2)", () => {

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -61,6 +61,14 @@ export function parseHistoryLines(
     outputFormat: string,
     agentName?: string,
     stamps?: number[],
+    opts?: {
+        /**
+         * Materialize `resumed` session outcomes as nodes. False (default)
+         * for the working view (§3.5 demotion); true for the Agent History
+         * view, where process-restart landmarks are useful context (§4.1).
+         */
+        includeResumedOutcomes?: boolean;
+    },
 ): ParsedHistory {
     const translator = createTranslator(outputFormat);
     // isReplay: true — thinking/tool_call events carry no wire timestamp of
@@ -194,12 +202,12 @@ export function parseHistoryLines(
             // user-invisible process recycles and its persisted line lands
             // AFTER the first post-resume exchange — as a divider row it
             // announces a non-event in the wrong place. The line stays in
-            // the stream (diagnostics + the P2 history view will render it
-            // subtly); only the node materialization is skipped. The
-            // flushPending() above still runs — the accumulator split at
-            // this line predates this change and keeps replay/live node
-            // ids aligned.
-            if (data && data.outcome !== "resumed") {
+            // the stream; only the node materialization is skipped, unless
+            // the caller is the Agent History view (`includeResumedOutcomes`),
+            // where restart landmarks are useful. The flushPending() above
+            // still runs — the accumulator split at this line predates this
+            // change and keeps replay/live node ids aligned.
+            if (data && (data.outcome !== "resumed" || opts?.includeResumedOutcomes)) {
                 const parsedTs = typeof rawEvent.timestamp === "string" ? Date.parse(rawEvent.timestamp) : NaN;
                 const node: SessionOutcomeNode = {
                     type: "session_outcome",

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1754,6 +1754,40 @@
 // warning-color treatment as .agent-compaction-started so a discontinuity
 // the user should actually notice reads as visually distinct from routine
 // continuity, not just another neutral marker in the transcript.
+// Calendar-day separator (Agent History view). Same centered-rule shape as
+// .agent-session-outcome but visually lighter — a date chip, no detail line.
+.agent-day-divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px var(--space-2);
+    user-select: none;
+    position: relative;
+
+    &::before,
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        width: 32%;
+        height: 1px;
+        background: var(--border-color, rgba(255, 255, 255, 0.08));
+    }
+
+    &::before { left: 0; }
+    &::after  { right: 0; }
+
+    .agent-day-divider-label {
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.35));
+        padding: 1px 9px;
+        border-radius: 9px;
+        background: var(--panel-bg-color, rgba(255, 255, 255, 0.04));
+    }
+}
+
 .agent-session-outcome {
     display: flex;
     flex-direction: column;

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -53,7 +53,7 @@ export type InitState = {
 /**
  * Document node types that make up the agent's markdown document
  */
-export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | ShellNode | AgentErrorNode | ContextCompactedNode | CompactionStartedNode | JektMessageNode | SessionOutcomeNode;
+export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | ShellNode | AgentErrorNode | ContextCompactedNode | CompactionStartedNode | JektMessageNode | SessionOutcomeNode | DayDividerNode;
 
 /**
  * Raw markdown text block
@@ -452,6 +452,22 @@ export interface SessionOutcomeNode {
     outcome: "resumed" | "fresh";
     attemptedSid: string;
     actualSid: string | null;
+    timestamp: number;
+}
+
+/**
+ * Calendar-day separator in the Agent History view. A render-time synthetic
+ * (injected by `injectDayDividers`, never persisted, never part of the live
+ * document store) — id `day-<YYYY-MM-DD>` is content-derived so pagination
+ * prepends recompute to the identical node instead of duplicating.
+ * Spec: SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md §4.4.
+ */
+export interface DayDividerNode {
+    type: "day_divider";
+    id: string;
+    /** Human label, e.g. "Sun, Aug 10 2026". */
+    dayLabel: string;
+    /** Local midnight of the day, unix ms. */
     timestamp: number;
 }
 

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -300,6 +300,16 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     );
                 })()}
             </Show>
+            <Show when={props.node() && props.node().type === "day_divider"}>
+                {(() => {
+                    const n = props.node() as Extract<DocumentNode, { type: "day_divider" }>;
+                    return (
+                        <div class="agent-day-divider">
+                            <div class="agent-day-divider-label">{n.dayLabel}</div>
+                        </div>
+                    );
+                })()}
+            </Show>
             <Show when={props.node() && props.node().type === "session_outcome"}>
                 {(() => {
                     const n = props.node() as Extract<DocumentNode, { type: "session_outcome" }>;

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -117,5 +117,9 @@ export function currentExpansion(
         case "session_outcome":
             // Fixed-height divider — never collapsible, same as context_compacted.
             return OPEN_DEFAULT;
+
+        case "day_divider":
+            // Fixed-height calendar separator — never collapsible.
+            return OPEN_DEFAULT;
     }
 }

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -153,6 +153,8 @@ export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     jekt_message: false,
     // One-shot marker, same as context_compacted — not chunked.
     session_outcome: false,
+    // Render-time synthetic calendar separator (Agent History view) — static.
+    day_divider: false,
 };
 
 /**
@@ -173,6 +175,7 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "context_compacted": return 48;
         case "compaction_started": return 32;
         case "session_outcome":   return 48;
+        case "day_divider":       return 32;
     }
 }
 
@@ -214,6 +217,7 @@ export function estimateNodeForState(
             case "context_compacted": return 48;
             case "compaction_started": return 32;
             case "session_outcome":   return 48;
+            case "day_divider":       return 32;
         }
     }
     // expanded
@@ -229,5 +233,6 @@ export function estimateNodeForState(
         case "context_compacted": return 48;
         case "compaction_started": return 32;
         case "session_outcome":   return 48;
+        case "day_divider":       return 32;
     }
 }


### PR DESCRIPTION
## Summary

Completes P2 of `SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md` (on top of #2507's session-scoped clamp and #2508's tsidx timestamps): the full retained history is now **perusable in-pane**.

- **`bodyMode` swap (§4.2).** The agent pane gains `"live" | "history"`; history mode swaps the transcript + composer subtree for `AgentHistoryView` and unmounts the live subtree (stream subscription never doubled). Not a new pane type/widget — a mode of the agent pane; always reopens live.
- **`AgentHistoryView` (§4.1/4.3).** Read-only, boundary-blind reader over the agent's full transcript stream. Deliberately bypasses the reducer store — the working view's session-scope clamp must not apply here, and a read-only reader has none of the races the store exists to serialize. Plain local signals fed by `parseHistoryLines` (new `includeResumedOutcomes` option — `resumed` markers render here as subtle restart landmarks while staying demoted in the working view), rendered through the reused `AgentDocumentView` + virtual list under a synthetic layout key (`<blockId>:history`) so the live pane's layout slot is untouched. Pages 600 lines at a time back to line 0.
- **Day separators (§4.4).** New `day_divider` render-time synthetic node injected wherever the best-known timestamp (own, else carried forward) crosses a local calendar day — exact for post-#2508 content, session-start-day granularity for pre-sidecar history. Stable `day-<YYYY-MM-DD>` ids merge across pagination recomputes.
- **Entry points (§3.4 + §4.2).** The scope clamp is no longer silent: `useHistoryPagination` surfaces `scopeClamped`, which gates an "Earlier conversations — Open Agent History" `PaneRow` above the working scrollback. Plus a provider-agnostic "View full history" button in `AgentControlBar` (rendered before the Claude-only gate, so non-Claude panes get it too).

Remaining after this: P3 only (archives section wiring, jump-to-date, link-row session count).

## Verification

- New tests: 5 `injectDayDividers` cases (day-change insertion, carry-forward, leading-unknown, id stability across prepends, empty) + `includeResumedOutcomes` parse case.
- Full agent-view suite: **1084 tests / 84 files pass**; `tsc --noEmit` clean. No backend changes.
- Live-drive note: the view composes the existing virtual list/renderers against the same RPCs the live pane already exercises; a `task dev` walkthrough (open history from the link row and the control bar, scroll to line 0, day chips + resumed markers visible, back to live resumes streaming) is the remaining manual check — happy to run it on the next dev-instance session.

<!-- agentmux:agent_id=agentx -->