### PR TITLE
fix(agent-pane): address codex P2s from #2507/#2508 — stats reset, tsidx archive lifecycle, exact stamp offsets

### DIFF
--- a/.changesets/1786373216-fix-agent-pane-address-codex-review-on-2507-2508-stats-reset-vgfo.md
+++ b/.changesets/1786373216-fix-agent-pane-address-codex-review-on-2507-2508-stats-reset-vgfo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): address codex review on #2507/#2508 — stats reset at fresh boundary, tsidx archive lifecycle, exact stamp offsets

--- a/agentmux-srv/src/backend/agent_session/archive.rs
+++ b/agentmux-srv/src/backend/agent_session/archive.rs
@@ -7,7 +7,7 @@ use crate::backend::storage::filestore::FileStore;
 
 use super::global_store::global_transcript_store;
 use super::helpers::{now_ms, write_zone_file};
-use super::session_io::{OUTPUT_FILE, SNAPSHOT_FILE};
+use super::session_io::{OUTPUT_FILE, SNAPSHOT_FILE, TSIDX_FILE};
 use super::zone_naming::{agent_archive_zone, is_valid_definition_id, validate_and_current};
 
 /// Archive `agent:<defId>:current` to `agent:<defId>:archive:<now_ms>`.
@@ -91,6 +91,13 @@ pub fn archive_session(
         if !output_bytes.is_empty() {
             write_zone_file(filestore, &archive_zone, OUTPUT_FILE, &output_bytes)?;
         }
+        // The tsidx sidecar travels with output (codex P2 on PR #2508):
+        // without it, archived history loses its receive-time stamps and —
+        // worse — a stale sidecar left in :current would mis-time the NEXT
+        // session (fresh output restarts at offset 0 under old entries).
+        // Best-effort: the sidecar is auxiliary and must never abort an
+        // archive.
+        copy_tsidx_best_effort(filestore, &current_zone, filestore, &archive_zone);
     }
 
     // Archive write succeeded. Now safe to clear the current zone.
@@ -109,6 +116,17 @@ pub fn archive_session(
                 definition_id = %definition_id,
                 error = %e,
                 "agent_session: failed to clear current output after archive (archive already persisted)"
+            );
+        }
+    }
+    // Clear the sidecar with output — a stale tsidx under a fresh (offset-0)
+    // output would mis-time the next session's lines (codex P2 on PR #2508).
+    if let Ok(Some(_)) = filestore.stat(&current_zone, TSIDX_FILE) {
+        if let Err(e) = filestore.delete_file(&current_zone, TSIDX_FILE) {
+            tracing::warn!(
+                definition_id = %definition_id,
+                error = %e,
+                "agent_session: failed to clear current tsidx after archive"
             );
         }
     }
@@ -164,6 +182,9 @@ pub fn archive_global_current(
     }
     if has_out {
         write_zone_file(filestore, &archive_zone, OUTPUT_FILE, out.as_ref().unwrap())?;
+        // Sidecar travels with output — same rationale as the per-channel
+        // path (codex P2 on PR #2508).
+        copy_tsidx_best_effort(gfs, &current_zone, filestore, &archive_zone);
     }
     tracing::info!(
         definition_id = %definition_id,
@@ -184,12 +205,29 @@ fn read_snapshot_bytes(store: &FileStore, zone: &str, name: &str) -> Result<Opti
     }
 }
 
+/// Copy the `output.tsidx` sidecar from `src` zone to `dst` zone,
+/// best-effort: absence is normal (pre-sidecar history), and no failure
+/// here may abort the surrounding archive — the sidecar is auxiliary
+/// timing data, not conversation content.
+fn copy_tsidx_best_effort(src_store: &FileStore, src_zone: &str, dst_store: &FileStore, dst_zone: &str) {
+    let bytes = match src_store.stat(src_zone, TSIDX_FILE) {
+        Ok(Some(f)) if f.size > 0 => match src_store.read_file(src_zone, TSIDX_FILE) {
+            Ok(Some(b)) if !b.is_empty() => b,
+            _ => return,
+        },
+        _ => return,
+    };
+    if let Err(e) = write_zone_file(dst_store, dst_zone, TSIDX_FILE, &bytes) {
+        tracing::warn!(src = %src_zone, dst = %dst_zone, error = %e, "agent_session: tsidx sidecar copy failed (archive content unaffected)");
+    }
+}
+
 /// Delete `output.state.json` + `output` from a per-channel `:current` zone,
 /// only for files that are present (so absence isn't logged as an error).
 /// Best-effort — used after the global-preferred archive has persisted the
 /// content, to retire this channel's (subset) copy.
 pub fn clear_local_current_zone(filestore: &FileStore, zone: &str) {
-    for name in [SNAPSHOT_FILE, OUTPUT_FILE] {
+    for name in [SNAPSHOT_FILE, OUTPUT_FILE, TSIDX_FILE] {
         match filestore.stat(zone, name) {
             Ok(Some(_)) => {
                 if let Err(e) = filestore.delete_file(zone, name) {
@@ -214,7 +252,7 @@ pub fn clear_global_current_zone(definition_id: &str) {
     let Ok(zone) = validate_and_current(definition_id) else {
         return;
     };
-    for name in [SNAPSHOT_FILE, OUTPUT_FILE] {
+    for name in [SNAPSHOT_FILE, OUTPUT_FILE, TSIDX_FILE] {
         // Only delete what's present, so an absent file isn't logged as an error.
         match gfs.stat(&zone, name) {
             Ok(Some(_)) => {

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -226,6 +226,31 @@ fn archive_moves_content_and_clears_current() {
 }
 
 #[test]
+fn archive_carries_and_clears_tsidx_sidecar() {
+    // codex P2 on PR #2508: the tsidx sidecar must travel with output on
+    // archive and be cleared from :current — a stale sidecar under a fresh
+    // (offset-0) output mis-times the next session's lines.
+    use super::session_io::TSIDX_FILE;
+    let fs = fresh_filestore();
+    let payload = br#"{"nodes":[]}"#;
+    write_session_state(&fs, "def-ts", payload).unwrap();
+    append_session_output(&fs, "def-ts", "raw1").unwrap();
+    let current_zone = agent_current_zone("def-ts");
+    write_zone_file(&fs, &current_zone, TSIDX_FILE, b"{\"off\":0,\"ms\":123}
+").unwrap();
+
+    let (zone, _) = archive_session(&fs, "def-ts").unwrap().expect("archived");
+
+    let archived_ts = fs.read_file(&zone, TSIDX_FILE).unwrap().unwrap();
+    assert_eq!(archived_ts, b"{\"off\":0,\"ms\":123}
+");
+    assert!(
+        fs.stat(&current_zone, TSIDX_FILE).unwrap().is_none(),
+        ":current tsidx must be cleared with output"
+    );
+}
+
+#[test]
 fn archive_on_empty_current_is_noop() {
     let fs = fresh_filestore();
     // Nothing was ever written.

--- a/agentmux-srv/src/backend/blockcontroller/shell/file_ops.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/file_ops.rs
@@ -65,9 +65,9 @@ pub fn persist_to_blockfile_silent(
     global_output_zone: Option<&str>,
 ) {
     if let Some(fs) = filestore {
-        let (needs_create, batch_start): (bool, u64) = match fs.stat(block_id, filename) {
-            Ok(None) => (true, 0),
-            Ok(Some(info)) => (false, info.size as u64),
+        let needs_create: bool = match fs.stat(block_id, filename) {
+            Ok(None) => true,
+            Ok(Some(_)) => false,
             Err(e) => {
                 tracing::warn!(
                     block_id = %block_id, filename = %filename, error = %e,
@@ -93,12 +93,15 @@ pub fn persist_to_blockfile_silent(
                 }
             }
         }
-        match fs.append_data(block_id, filename, data) {
-            Ok(()) => {
+        // append_data_at returns the offset the batch ACTUALLY landed at,
+        // read under the store's own lock - a caller-side pre-append stat
+        // can be stale under concurrent appenders (codex P2 on PR #2508).
+        match fs.append_data_at(block_id, filename, data) {
+            Ok(actual_start) => {
                 // Only agent transcript streams carry a global zone; those are
                 // the streams the tsidx sidecar exists for (§4.4).
                 if global_output_zone.is_some() {
-                    append_tsidx_entry(fs, block_id, batch_start, unix_ms_now());
+                    append_tsidx_entry(fs, block_id, actual_start.max(0) as u64, unix_ms_now());
                 }
             }
             Err(e) => {
@@ -231,17 +234,20 @@ pub fn handle_append_block_file(
             }
         }
 
-        match fs.append_data(block_id, filename, data) {
-            Ok(()) => {
+        match fs.append_data_at(block_id, filename, data) {
+            Ok(actual_start) => {
                 // Receive-time stamp for this batch (§4.4). Gated on
                 // `global_output_zone` — only agent transcript appends carry
                 // one; PTY `term` data and non-agent blocks never get a
-                // sidecar. `start_offset` is Some here (Error stat already
-                // returned above).
+                // sidecar. Stamped at the offset the append itself reports
+                // (read under the store lock), not the pre-append stat —
+                // codex P2 on PR #2508: the stat can go stale when writers
+                // interleave, and a mis-keyed stamp gives replayed lines
+                // another batch's time. (The broadcast event's `offset`
+                // still uses the pre-append stat — pre-existing contract,
+                // reconcile-only consumer, unchanged here.)
                 if global_output_zone.is_some() {
-                    if let Some(start) = start_offset {
-                        append_tsidx_entry(fs, block_id, start, unix_ms_now());
-                    }
+                    append_tsidx_entry(fs, block_id, actual_start.max(0) as u64, unix_ms_now());
                 }
             }
             Err(e) => {
@@ -282,7 +288,7 @@ pub(super) fn mirror_append_to_global(gfs: &Arc<FileStore>, zone: &str, data: &[
     use crate::backend::agent_session::OUTPUT_FILE;
     use crate::backend::storage::error::StoreError;
 
-    let batch_start: u64 = match gfs.stat(zone, OUTPUT_FILE) {
+    match gfs.stat(zone, OUTPUT_FILE) {
         Ok(None) => {
             if let Err(e) = gfs.make_file(
                 zone,
@@ -295,21 +301,21 @@ pub(super) fn mirror_append_to_global(gfs: &Arc<FileStore>, zone: &str, data: &[
                     return;
                 }
             }
-            0
         }
-        Ok(Some(info)) => info.size as u64,
+        Ok(Some(_)) => {}
         Err(e) => {
             tracing::warn!(zone = %zone, error = %e, "global transcripts: stat failed; skipping mirror");
             return;
         }
-    };
-    match gfs.append_data(zone, OUTPUT_FILE, data) {
-        Ok(()) => {
+    }
+    match gfs.append_data_at(zone, OUTPUT_FILE, data) {
+        Ok(actual_start) => {
             // Global zones are agent transcripts by construction — always
-            // stamp (§4.4). Cross-channel mirrors from concurrent srv
-            // instances serialize on the store, so offsets stay monotonic;
-            // the read-side join sorts defensively regardless.
-            append_tsidx_entry(gfs, zone, batch_start, unix_ms_now());
+            // stamp (§4.4), keyed at the offset this append actually
+            // landed at (codex P2 on PR #2508 — cross-channel mirrors from
+            // concurrent srv instances can interleave; the store-lock-read
+            // offset is exact where a pre-append stat is not).
+            append_tsidx_entry(gfs, zone, actual_start.max(0) as u64, unix_ms_now());
         }
         Err(e) => {
             tracing::warn!(zone = %zone, error = %e, "global transcripts: append_data failed");

--- a/agentmux-srv/src/backend/blockcontroller/shell/tests.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/tests.rs
@@ -691,6 +691,36 @@ use std::sync::Arc;
         assert_eq!(entries[1].0, line1.len() as u64);
     }
 
+    /// codex P2 on PR #2508: the tsidx stamp must be the offset the append
+    /// ACTUALLY landed at (append_data_at reads size + writes under one
+    /// store lock), so interleaved appends can't mislabel a batch.
+    #[test]
+    fn tsidx_offsets_match_actual_append_positions() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let broker = wps::Broker::new();
+        let fs = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "tsidx-offset-block";
+        let lines: [&[u8]; 3] = [b"{\"n\":1}
+", b"{\"nn\":22}
+", b"{\"nnn\":333}
+"];
+        for l in lines {
+            handle_append_block_file(&broker, block_id, "output", l, Some(&fs), Some("agent:tsidx-offsets:current"));
+        }
+        let entries = read_tsidx(&fs, block_id);
+        assert_eq!(entries.len(), 3);
+        let mut expected = 0u64;
+        for (i, l) in lines.iter().enumerate() {
+            assert_eq!(entries[i].0, expected, "entry {i} offset");
+            expected += l.len() as u64;
+        }
+        // And the offsets agree with the output file's actual size.
+        let stat = fs.stat(block_id, "output").unwrap().unwrap();
+        assert_eq!(stat.size as u64, expected);
+    }
+
     /// `persist_to_blockfile_silent` (user-message lines) stamps the
     /// per-channel sidecar too — those lines are transcript content.
     #[test]

--- a/agentmux-srv/src/backend/session_archive.rs
+++ b/agentmux-srv/src/backend/session_archive.rs
@@ -41,6 +41,12 @@ pub const META_SESSION_ARCHIVE_PATH: &str = "session:archive_path";
 
 /// FileStore filename for session output.
 const OUTPUT_FILENAME: &str = "output";
+/// Receive-time sidecar (see `agent_session::TSIDX_FILE`) — archived,
+/// deleted, and restored in lockstep with `output` (codex P2 on PR #2508):
+/// leaving it behind would mis-time a fresh session's lines (new output
+/// restarts at offset 0 under stale entries), and dropping it from the
+/// archive loses the timestamps the sidecar exists to preserve.
+const TSIDX_FILENAME: &str = crate::backend::agent_session::session_io::TSIDX_FILE;
 
 // ---------------------------------------------------------------------------
 // Shared helpers — used by both the RPC handlers and the sweep
@@ -146,6 +152,25 @@ pub fn archive_session_output(
             "session_archive: failed to delete filestore entry after archiving (meta already updated)"
         );
     }
+    // Sidecar follows output: archive its bytes next to the .jsonl.gz
+    // (best-effort — auxiliary timing data), then delete so a restarted
+    // session can't inherit stale offset stamps.
+    if let Ok(Some(ts_bytes)) = filestore.read_file(block_id, TSIDX_FILENAME) {
+        if !ts_bytes.is_empty() {
+            let ts_path = archive_dir.join(format!("{}.tsidx.gz", block_id));
+            if let Err(e) = write_gz(&ts_bytes, &ts_path) {
+                tracing::warn!(block_id = %block_id, error = %e, "session_archive: tsidx archive write failed (output archive unaffected)");
+            }
+        }
+    }
+    match filestore.stat(block_id, TSIDX_FILENAME) {
+        Ok(Some(_)) => {
+            if let Err(e) = filestore.delete_file(block_id, TSIDX_FILENAME) {
+                tracing::warn!(block_id = %block_id, error = %e, "session_archive: failed to delete tsidx sidecar after archiving");
+            }
+        }
+        _ => {}
+    }
 
     tracing::info!(
         block_id = %block_id,
@@ -195,6 +220,32 @@ pub fn restore_session_output(
     filestore
         .append_data(block_id, OUTPUT_FILENAME, &raw_bytes)
         .map_err(|e| format!("append_data: {e}"))?;
+
+    // Restore the tsidx sidecar when its archive exists (best-effort —
+    // pre-sidecar archives simply have none, and restored history without
+    // stamps degrades to the carry-forward day rule, not an error).
+    let ts_path = archive_path
+        .parent()
+        .map(|d| d.join(format!("{}.tsidx.gz", block_id)))
+        .filter(|p| p.exists());
+    let _ = filestore.delete_file(block_id, TSIDX_FILENAME); // ignore "not found"
+    if let Some(ts_path) = ts_path {
+        match read_gz(&ts_path) {
+            Ok(ts_bytes) if !ts_bytes.is_empty() => {
+                let created = filestore
+                    .make_file(block_id, TSIDX_FILENAME, FileMeta::default(), FileOpts::default());
+                if created.is_ok() {
+                    if let Err(e) = filestore.append_data(block_id, TSIDX_FILENAME, &ts_bytes) {
+                        tracing::warn!(block_id = %block_id, error = %e, "session_archive: tsidx restore append failed");
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(block_id = %block_id, error = %e, "session_archive: tsidx restore read failed");
+            }
+        }
+    }
 
     // Clear archive meta keys (keep the .gz as backup — don't delete it)
     let mut meta = MetaMapType::new();

--- a/agentmux-srv/src/backend/storage/filestore/core.rs
+++ b/agentmux-srv/src/backend/storage/filestore/core.rs
@@ -453,20 +453,46 @@ impl FileStore {
         if data.is_empty() {
             return Ok(());
         }
+        self.append_data_at(zone_id, name, data).map(|_| ())
+    }
 
+    /// Append data to the end of a file and return the byte offset the
+    /// batch actually landed at. Unlike a caller-side stat-then-append,
+    /// the size read and the part writes happen under ONE connection
+    /// lock, so the returned offset is exact even when concurrent
+    /// appenders interleave — codex P2 on PR #2508: the `output.tsidx`
+    /// sidecar keys batch receive-times by offset, and a racy pre-append
+    /// stat could stamp a batch with another batch's position.
+    pub fn append_data_at(
+        &self,
+        zone_id: &str,
+        name: &str,
+        data: &[u8],
+    ) -> Result<i64, StoreError> {
         let key = (zone_id.to_string(), name.to_string());
         let now = Self::now_ms();
 
-        let file = self.stat(zone_id, name)?.ok_or(StoreError::NotFound)?;
-        let new_size = file.size + data.len() as i64;
+        // Size read + writes under the same lock (self.stat would
+        // re-acquire this non-reentrant mutex, hence the direct query).
+        let conn = self.conn.lock().unwrap();
+        let file_size: i64 = match conn.query_row(
+            "SELECT size FROM db_wave_file WHERE zoneid = ?1 AND name = ?2",
+            params![zone_id, name],
+            |row| row.get(0),
+        ) {
+            Ok(s) => s,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Err(StoreError::NotFound),
+            Err(e) => return Err(e.into()),
+        };
+        if data.is_empty() {
+            return Ok(file_size);
+        }
+        let new_size = file_size + data.len() as i64;
 
         // Figure out which part to start writing at
-        let start_offset = file.size;
+        let start_offset = file_size;
         let start_part = (start_offset / PART_DATA_SIZE as i64) as i32;
         let offset_in_part = (start_offset % PART_DATA_SIZE as i64) as usize;
-
-        // Load the last part if we need to append to it
-        let conn = self.conn.lock().unwrap();
         let mut data_offset = 0usize;
         let mut current_part = start_part;
 
@@ -535,7 +561,7 @@ impl FileStore {
         }
         self.evict_to_cap();
 
-        Ok(())
+        Ok(start_offset)
     }
 
     /// Write metadata. If `merge` is true, only specified keys are updated;

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -95,6 +95,44 @@ describe("parseHistoryLines", () => {
         expect(lastSessionStats).toBeNull();
     });
 
+    it("resets lastSessionStats at a fresh session boundary (codex P2 on PR #2507)", () => {
+        // Window shape: [old result -> fresh boundary -> no new result].
+        // The old session's usage must NOT hydrate the fresh session's
+        // context-fill bar — the fresh model has none of those tokens.
+        const lines = [
+            line({ type: "text", content: "old turn" }),
+            line({ type: "session_end", stats: { input_tokens: 900, output_tokens: 90 } }),
+            JSON.stringify({
+                type: "system",
+                subtype: "agentmux_session_outcome",
+                outcome: "fresh",
+                attempted_sid: "sid-1",
+                actual_sid: null,
+                timestamp: "2026-08-10T08:00:00Z",
+            }),
+            line({ type: "text", content: "new turn" }),
+        ];
+        const { lastSessionStats } = parseHistoryLines(lines, "claude-stream-json");
+        expect(lastSessionStats).toBeNull();
+    });
+
+    it("post-boundary usage still hydrates after a fresh boundary", () => {
+        const lines = [
+            line({ type: "session_end", stats: { input_tokens: 900, output_tokens: 90 } }),
+            JSON.stringify({
+                type: "system",
+                subtype: "agentmux_session_outcome",
+                outcome: "fresh",
+                attempted_sid: "sid-1",
+                actual_sid: null,
+                timestamp: "2026-08-10T08:00:00Z",
+            }),
+            line({ type: "session_end", stats: { input_tokens: 40, output_tokens: 4 } }),
+        ];
+        const { lastSessionStats } = parseHistoryLines(lines, "claude-stream-json");
+        expect(lastSessionStats).toEqual({ input_tokens: 40, output_tokens: 4 });
+    });
+
     it("does not let a later empty-stats session_end clobber real historical stats", () => {
         // reagent P1 on PR #2059: Claude's persistent-mode controller emits a
         // session_end with stats: {} after EVERY plain-text turn (the per-turn

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -199,6 +199,16 @@ export function parseHistoryLines(
             // flushPending() above still runs — the accumulator split at
             // this line predates this change and keeps replay/live node
             // ids aligned.
+            if (data && data.outcome === "fresh") {
+                // codex P2 on PR #2507: a usage-bearing `session_end` seen
+                // BEFORE this boundary belongs to the old session — the
+                // fresh model has none of those tokens in context. Without
+                // this reset, a restore window shaped [old result → fresh
+                // boundary → no new result yet] hydrates the context-fill
+                // bar (`ReconcileContextFromHistory`) with the dead
+                // session's count. Only post-boundary usage may seed it.
+                lastSessionStats = null;
+            }
             if (data && data.outcome !== "resumed") {
                 const parsedTs = typeof rawEvent.timestamp === "string" ? Date.parse(rawEvent.timestamp) : NaN;
                 const node: SessionOutcomeNode = {


### PR DESCRIPTION
## Summary

Follow-up addressing the three codex P2 review comments that landed on #2507/#2508 after they merged (they were unanswered — the review-notification jekts only relay reagent reviews; codex comments need an explicit PR check, which is now part of my merge routine).

1. **Stats reset at a fresh boundary** ([#2507 comment](https://github.com/agentmuxai/agentmux/pull/2507#discussion_r-)): `parseHistoryLines` now nulls `lastSessionStats` when it materializes a `fresh` session outcome — a restore window shaped [old usage-bearing result → fresh boundary → no new result] was hydrating the context-fill bar with the dead session's token count. Post-boundary usage still hydrates.
2. **tsidx through the archive lifecycle** (#2508 comment 1): the sidecar now travels with `output` everywhere — `agent_session::archive_session` copies it into the archive zone (per-channel + global-source paths) and clears it from `:current` in all three clear paths; `session_archive` archives it to `<block>.tsidx.gz`, deletes it alongside `output`, and restores it on session restore. Without this, a stale sidecar under a fresh offset-0 `output` mis-times the next session's lines, and archived history loses its stamps.
3. **Exact stamp offsets** (#2508 comment 2): new `FileStore::append_data_at` performs the size read and part writes under one connection lock and returns the offset the batch actually landed at; all three tsidx stamp sites use it instead of the racy pre-append stat. `append_data` becomes a delegating wrapper — zero behavior change for existing callers. (The broadcast event's `offset` field keeps the pre-append stat — pre-existing contract, reconcile-only consumer, unchanged.)

## Verification

- New tests: fresh-boundary stats reset + post-boundary rehydration (frontend, 2), `archive_carries_and_clears_tsidx_sidecar`, `tsidx_offsets_match_actual_append_positions` (backend, 2).
- Full backend suite: 2103 passed. parseHistoryLines suite: 22 passed. `tsc --noEmit` clean.

<!-- agentmux:agent_id=agentx -->