### PR TITLE
test(persistent): close #2368 — held error line drops on successful stale-resume retry

### DIFF
--- a/.changesets/1786384589-test-persistent-add-missing-2368-regression-held-error-line--byt2.md
+++ b/.changesets/1786384589-test-persistent-add-missing-2368-regression-held-error-line--byt2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+test(persistent): add missing #2368 regression — held error line dropped on successful stale-resume retry

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -5075,6 +5075,63 @@ mod send_input_tests {
         );
     }
 
+    /// Closes issue #2368 (the visible-error-flash residue of #2360/#2373's
+    /// stale-`--resume` retry): unlike the two tests above (retry itself
+    /// fails to launch → flush; `DeliverDirect` fallback needed → don't
+    /// flush yet), this covers the actual `BecomeSpawner` HAPPY path — the
+    /// fresh, no-`--resume` respawn launches successfully. `held_error_line`
+    /// must be silently dropped here, never reaching the blockfile: the
+    /// doomed first attempt's error was never the user's problem to see
+    /// once the transparent retry it triggered actually worked. This is
+    /// the regression test
+    /// `docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md`
+    /// §5's verification list asked for before #2368 could be closed with
+    /// evidence.
+    #[tokio::test]
+    async fn retry_after_resume_failure_drops_the_held_error_line_when_the_respawn_succeeds() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "block-drop-on-successful-retry".to_string();
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            block_id.clone(),
+            Some(broker),
+            None,
+            None,
+            Some(filestore.clone()),
+        );
+
+        // "echo" (used elsewhere in this codebase's tests, e.g.
+        // subprocess/tests.rs) — a real, trivially-successful spawn target,
+        // so `spawn_process` returns `Ok(())` exactly as it would for a
+        // genuine fresh CLI respawn.
+        let config = PersistentSpawnConfig {
+            cli_command: "echo".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: String::new(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], Some("boom\n".to_string()));
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let flushed = filestore
+            .read_file(&block_id, PERSISTENT_OUTPUT_SUBJECT)
+            .unwrap()
+            .map(|bytes| String::from_utf8_lossy(&bytes).contains("boom"))
+            .unwrap_or(false);
+        assert!(
+            !flushed,
+            "a held error line from the doomed first attempt must be silently dropped — never \
+             flushed to the blockfile — when the stale-`--resume` retry's fresh respawn actually \
+             succeeds (issue #2368): the user should see only the real response, not a stale \
+             error bubble followed by it"
+        );
+    }
+
     /// codex P1 on PR #2360 (sixth review pass, round 5): the drain must
     /// track every message it successfully delivers beyond the first
     /// (which `spawn_process` already stashed synchronously — see

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -5101,13 +5101,17 @@ mod send_input_tests {
             Some(filestore.clone()),
         );
 
-        // "echo" (used elsewhere in this codebase's tests, e.g.
-        // subprocess/tests.rs) — a real, trivially-successful spawn target,
-        // so `spawn_process` returns `Ok(())` exactly as it would for a
-        // genuine fresh CLI respawn.
+        // codex P1 on this PR: "echo" is a cmd.exe BUILT-IN on Windows, not
+        // a standalone executable — `Command::new("echo")` fails to spawn
+        // on the required Windows CI leg, flipping this test's assertion
+        // (spawn `Err` routes through the FAILURE branch, which flushes
+        // "boom", the opposite of what's being proven here). "git" is a
+        // real, standalone executable guaranteed present on every
+        // supported CI platform (Windows/macOS/Linux all need it to check
+        // the repo out in the first place) and exits 0 near-instantly.
         let config = PersistentSpawnConfig {
-            cli_command: "echo".to_string(),
-            cli_args: vec![],
+            cli_command: "git".to_string(),
+            cli_args: vec!["--version".to_string()],
             working_dir: String::new(),
             env_vars: HashMap::new(),
             session_id_field: "session_id".to_string(),


### PR DESCRIPTION
Closes #2368.

## What this verifies

`docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md` §5 flagged #2368 as "likely fixed" by `held_error_line` (the mechanism introduced across PR #2371/#2373 that holds a doomed attempt's terminal error line until the retry decision resolves), but its own verification list required a live repro or regression test before closing.

Tracing `retry_after_resume_failure`'s `BecomeSpawner` arm confirms the fix is already correct:
- retry's own respawn fails → `held_error_line` is flushed (existing test: `retry_after_resume_failure_flushes_the_held_error_line_when_the_respawn_itself_fails`)
- `DeliverDirect`'s fallback drain is needed → not flushed yet, drain's own stalled branch handles it (existing test: `retry_after_resume_failure_does_not_flush_the_held_error_line_when_the_deliver_direct_fallback_is_needed`)
- **respawn actually succeeds** (the exact #2368 scenario) → `held_error_line` falls out of scope untouched, silently dropped — **this path had no test**

## What's new

`retry_after_resume_failure_drops_the_held_error_line_when_the_respawn_succeeds`: spawns a real (trivially-successful, `echo` — same convention as `subprocess/tests.rs`) process so the `BecomeSpawner` arm actually takes `spawn_result.is_ok()`, then asserts the blockfile never receives the doomed first attempt's held error line.

Ran green together with the full `blockcontroller` suite (206 passed).

<!-- agentmux:agent_id=agenta -->