### PR TITLE
chore: release v0.55.3

### DIFF
--- a/.changesets/1786370383-feat-agent-pane-session-scoped-scrollback-clamp-at-fresh-ses-4ubt.md
+++ b/.changesets/1786370383-feat-agent-pane-session-scoped-scrollback-clamp-at-fresh-ses-4ubt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): session-scoped scrollback — clamp at fresh session boundary, demote 'Session continued' divider

--- a/.changesets/1786370573-feat-agent-introduce-model-vendor-as-a-concept-distinct-from-6686.md
+++ b/.changesets/1786370573-feat-agent-introduce-model-vendor-as-a-concept-distinct-from-6686.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): introduce model vendor as a concept distinct from harness

--- a/.changesets/1786371477-feat-agent-pane-output-tsidx-receive-time-sidecar-replayed-t-wkfs.md
+++ b/.changesets/1786371477-feat-agent-pane-output-tsidx-receive-time-sidecar-replayed-t-wkfs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): output.tsidx receive-time sidecar — replayed transcript nodes get real timestamps (hover peek works after restore)

--- a/.changesets/1786372533-feat-agent-pane-agent-history-view-read-only-full-history-re-74vs.md
+++ b/.changesets/1786372533-feat-agent-pane-agent-history-view-read-only-full-history-re-74vs.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): Agent History view — read-only full-history reader with day separators; 'Earlier conversations' link row

--- a/.changesets/1786373216-fix-agent-pane-address-codex-review-on-2507-2508-stats-reset-vgfo.md
+++ b/.changesets/1786373216-fix-agent-pane-address-codex-review-on-2507-2508-stats-reset-vgfo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): address codex review on #2507/#2508 — stats reset at fresh boundary, tsidx archive lifecycle, exact stamp offsets

--- a/.changesets/1786384589-test-persistent-add-missing-2368-regression-held-error-line--byt2.md
+++ b/.changesets/1786384589-test-persistent-add-missing-2368-regression-held-error-line--byt2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(persistent): add missing #2368 regression — held error line dropped on successful stale-resume retry

--- a/.changesets/1786396855-fix-lan-discovery-registered-instances-were-never-actually-a-j0u7.md
+++ b/.changesets/1786396855-fix-lan-discovery-registered-instances-were-never-actually-a-j0u7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan-discovery): registered instances were never actually announced on the wire

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.2"
+version = "0.55.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.2"
+version = "0.55.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.2"
+version = "0.55.3"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.2"
+version = "0.55.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.2"
+version = "0.55.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.2"
+version = "0.55.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.2"
+version = "0.55.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,16 @@
 # AgentMux Version History
 
+## 0.55.3 — 2026-08-10
+
+- feat(agent-pane): session-scoped scrollback — clamp at fresh session boundary, demote 'Session continued' divider
+- feat(agent): introduce model vendor as a concept distinct from harness
+- feat(agent-pane): output.tsidx receive-time sidecar — replayed transcript nodes get real timestamps (hover peek works after restore)
+- feat(agent-pane): Agent History view — read-only full-history reader with day separators; 'Earlier conversations' link row
+- fix(agent-pane): address codex review on #2507/#2508 — stats reset at fresh boundary, tsidx archive lifecycle, exact stamp offsets
+- test(persistent): add missing #2368 regression — held error line dropped on successful stale-resume retry
+- fix(lan-discovery): registered instances were never actually announced on the wire
+
+
 ## 0.55.2 — 2026-08-10
 
 - feat(agent): add Codex JSONL and resume support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.2",
+  "version": "0.55.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.2",
+      "version": "0.55.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.2",
+  "version": "0.55.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 7 pending changesets, forced to a **patch** bump (`--as patch`) per the repo's changesets workflow (RFC #857 Phase 2), even though the computed bump from the queued changesets would have been `minor`.

`0.55.2 -> 0.55.3`

## Changes shipping

- feat(agent-pane): session-scoped scrollback — clamp at fresh session boundary, demote 'Session continued' divider
- feat(agent): introduce model vendor as a concept distinct from harness
- feat(agent-pane): output.tsidx receive-time sidecar — replayed transcript nodes get real timestamps (hover peek works after restore)
- feat(agent-pane): Agent History view — read-only full-history reader with day separators; 'Earlier conversations' link row
- fix(agent-pane): address codex review on #2507/#2508 — stats reset at fresh boundary, tsidx archive lifecycle, exact stamp offsets
- test(persistent): add missing #2368 regression — held error line dropped on successful stale-resume retry
- fix(lan-discovery): registered instances were never actually announced on the wire

## Verification

- [x] `scripts/release.sh --as patch` — all 5 version locations agree at `0.55.3` (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) — this is the exact invariant reagent's release-consistency gate checks.
- [x] `cargo check -p agentmux-srv` — clean after the bump.
- [x] Diff is minimal and mechanical: 7 changeset files deleted, 5 version files updated, no source changes.

<!-- agentmux:agent_id=camper -->