### PR TITLE
fix(agent-pane): dock row for a fast-finishing backgrounded call no longer sticks running forever

### DIFF
--- a/.changesets/1786403020-fix-agent-pane-dock-row-for-a-fast-finishing-backgrounded-ba-fxr9.md
+++ b/.changesets/1786403020-fix-agent-pane-dock-row-for-a-fast-finishing-backgrounded-ba-fxr9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): dock row for a fast-finishing backgrounded Bash call no longer sticks running forever

--- a/frontend/app/view/agent/activity/attached-task.test.ts
+++ b/frontend/app/view/agent/activity/attached-task.test.ts
@@ -110,6 +110,7 @@ describe("backgrounded Bash calls (issue #2490)", () => {
             params: { command: "task dev", run_in_background: true },
             timestamp: 1000,
             duration: 0.4,
+            result: { stdout: "Command running in background with ID: b12345. Output is being written to: …", stderr: "", exitCode: 0 },
         });
         // Sub-second and terminal — invisible to the duration heuristic,
         // but a declared background task must still light the axis.
@@ -124,6 +125,7 @@ describe("backgrounded Bash calls (issue #2490)", () => {
             params: { command: "task dev", run_in_background: true },
             timestamp: 1000,
             duration: 0.4,
+            result: { stdout: "Command running in background with ID: b12345. Output is being written to: …", stderr: "", exitCode: 0 },
         });
         const notification: DocumentNode = {
             type: "user_message",

--- a/frontend/app/view/agent/activity/tool-adapter.test.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.test.ts
@@ -157,6 +157,7 @@ function mkBgBash(overrides: Partial<ToolNode> = {}): ToolNode {
         params: { command: "task dev", run_in_background: true },
         timestamp: 1000,
         duration: 0.4,
+        result: { stdout: "Command running in background with ID: b12345. Output is being written to: …", stderr: "", exitCode: 0 },
         ...overrides,
     });
 }
@@ -221,6 +222,26 @@ describe("toolActivities — backgrounded calls", () => {
         // the threshold gate drops it entirely.
         const nodes: DocumentNode[] = [mkBgBash({ status: "failed" })];
         expect(toolActivities(nodes, 2000)).toEqual([]);
+    });
+
+    it("issue #2518: a call that asked for run_in_background but finished too fast to actually detach is NOT treated as a live background task", () => {
+        // The harness itself decides per-call whether a command actually gets
+        // detached — a command that finishes fast enough is returned
+        // synchronously with the command's real output (the same
+        // `<exited N in Ts>` shape an ordinary call gets), not the "Command
+        // running in background with ID: …" acceptance message, even though
+        // run_in_background: true was passed. Without the result-content
+        // check, this was misclassified as "launch accepted, wait for a
+        // <task-notification> that will never come" — a dock row stuck
+        // `running` forever. Confirmed live: 11 of 17 backgrounded calls in
+        // a single session got stuck exactly this way.
+        const fastFinish = mkBgBash({
+            duration: 13.38,
+            result: { stdout: "<exited 0 in 13.38s>\n707M    /c/Users/area54/.cargo", stderr: "", exitCode: 0 },
+        });
+        // Long after it finished — must resolve via the ordinary
+        // duration/threshold rules, not the "wait for notification" path.
+        expect(toolActivities([fastFinish], 1000 + 13_380 + 60_000)).toEqual([]);
     });
 
     it("a foreground call is untouched by an unrelated notification in the document", () => {

--- a/frontend/app/view/agent/activity/tool-adapter.test.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.test.ts
@@ -244,6 +244,25 @@ describe("toolActivities — backgrounded calls", () => {
         expect(toolActivities([fastFinish], 1000 + 13_380 + 60_000)).toEqual([]);
     });
 
+    it("codex P1 on PR #2519: a genuine background acceptance arriving via the result.content fallback shape (not stdout) is still recognized", () => {
+        // claude-translator.ts's buildToolResults falls back to a plain
+        // `{ content: string }` shape (instead of the structured
+        // `{ stdout, stderr, interrupted }` sibling) when Claude omits a
+        // terminal-shaped tool_use_result or returns multiple tool_result
+        // blocks. A stdout-only check would reject this as "not accepted"
+        // and drop a still-running background launch from the dock
+        // entirely — worse than the original bug, since a stuck-forever
+        // entry is at least visible.
+        const nodes: DocumentNode[] = [
+            mkBgBash({
+                result: { content: "Command running in background with ID: b12345. Output is being written to: …" } as any,
+            }),
+        ];
+        const acts = toolActivities(nodes, 2000);
+        expect(acts).toHaveLength(1);
+        expect(acts[0].status).toBe("running");
+    });
+
     it("a foreground call is untouched by an unrelated notification in the document", () => {
         const nodes: DocumentNode[] = [
             mkBash({ id: "fg", timestamp: 1000 }),

--- a/frontend/app/view/agent/activity/tool-adapter.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.ts
@@ -35,13 +35,31 @@ import type { ActivityStatus, PinnedActivity } from "./types";
 export const TOOL_PROMOTION_MS = 30_000;
 
 /** The harness's literal acceptance-message prefix for a genuinely detached
- *  launch (see BashParams.run_in_background's doc comment). Exported so
- *  muxspect/introspection tooling can recognize the same signal — see
- *  docs/retro/retro-stuck-background-dock-timer-2026-08-10.md. */
+ *  launch (see BashParams.run_in_background's doc comment). Exported so any
+ *  other code that needs to recognize the same signal doesn't redefine it. */
 export const BACKGROUND_LAUNCH_ACCEPTED_PREFIX = "Command running in background with ID:";
 
 function isBashToolNode(n: DocumentNode): n is ToolNode {
     return n.type === "tool" && n.tool === "Bash" && n.timestamp != null;
+}
+
+/**
+ * The result's raw text, whichever field it landed in. claude-translator.ts's
+ * `buildToolResults` normally puts it in `stdout` (the structured
+ * `{ stdout, stderr, interrupted }` sibling), but falls back to a plain
+ * `{ content: string }` shape when Claude omits a terminal-shaped
+ * `tool_use_result` or returns multiple tool_result blocks (the structured
+ * sibling is then unattributable to any one block) — codex P1 on this PR:
+ * checking `stdout` alone missed that fallback shape, so a genuinely
+ * detached launch whose acceptance text arrived via `content` was rejected
+ * outright and vanished from the dock entirely instead of just being
+ * misclassified.
+ */
+function resultText(result: ToolNode["result"]): string | undefined {
+    const r = result as (BashResult & { content?: unknown }) | undefined;
+    if (typeof r?.stdout === "string") return r.stdout;
+    if (typeof r?.content === "string") return r.content;
+    return undefined;
 }
 
 /**
@@ -68,8 +86,8 @@ function isBashToolNode(n: DocumentNode): n is ToolNode {
  */
 function isAcceptedBackgroundLaunch(n: ToolNode): boolean {
     if ((n.params as BashParams | undefined)?.run_in_background !== true || n.status !== "success") return false;
-    const stdout = (n.result as BashResult | undefined)?.stdout;
-    return typeof stdout === "string" && stdout.startsWith(BACKGROUND_LAUNCH_ACCEPTED_PREFIX);
+    const text = resultText(n.result);
+    return typeof text === "string" && text.startsWith(BACKGROUND_LAUNCH_ACCEPTED_PREFIX);
 }
 
 /**

--- a/frontend/app/view/agent/activity/tool-adapter.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.ts
@@ -29,10 +29,16 @@
  */
 
 import { extractToolDetail } from "../stream-parser";
-import type { BashParams, DocumentNode, ToolNode } from "../types";
+import type { BashParams, BashResult, DocumentNode, ToolNode } from "../types";
 import type { ActivityStatus, PinnedActivity } from "./types";
 
 export const TOOL_PROMOTION_MS = 30_000;
+
+/** The harness's literal acceptance-message prefix for a genuinely detached
+ *  launch (see BashParams.run_in_background's doc comment). Exported so
+ *  muxspect/introspection tooling can recognize the same signal — see
+ *  docs/retro/retro-stuck-background-dock-timer-2026-08-10.md. */
+export const BACKGROUND_LAUNCH_ACCEPTED_PREFIX = "Command running in background with ID:";
 
 function isBashToolNode(n: DocumentNode): n is ToolNode {
     return n.type === "tool" && n.tool === "Bash" && n.timestamp != null;
@@ -40,16 +46,30 @@ function isBashToolNode(n: DocumentNode): n is ToolNode {
 
 /**
  * True for a Bash call the harness ran detached (issue #2490): its
- * `tool_use.input` carried `run_in_background: true` and the tool_result
- * came back accepted ("Command running in background with ID: …"). The
- * ToolNode is terminal within ~a second, but the real process tree keeps
- * running until a `<task-notification>` lands — so, unlike an ordinary
- * call, terminal-with-success here means STARTED, not finished. A failed
- * launch (`status: "failed"` — the harness refused the command) is not a
- * live background task and falls through to the ordinary duration rules.
+ * `tool_use.input` carried `run_in_background: true` AND the tool_result's
+ * own text actually is the acceptance message ("Command running in
+ * background with ID: …"), not the command's real output. The ToolNode is
+ * terminal within ~a second, but the real process tree keeps running until
+ * a `<task-notification>` lands — so, unlike an ordinary call,
+ * terminal-with-success here means STARTED, not finished.
+ *
+ * The `params.run_in_background === true` flag alone is NOT sufficient —
+ * issue #2518: the harness decides per-call whether a command actually
+ * gets detached; a command that finishes fast enough is returned
+ * synchronously (result text `<exited N in Ts>\n<real output>`, the SAME
+ * shape an ordinary call gets) even though the caller asked for
+ * `run_in_background: true`. Treating that case as "launch accepted, wait
+ * for a `<task-notification>` that will never come" left the dock row
+ * `running` forever with a growing timer — confirmed live: a single
+ * session with 17 backgrounded calls left 11 stuck this way, each one
+ * exactly the fast-finishing case. A failed launch (`status: "failed"` —
+ * the harness refused the command) is also not a live background task and
+ * falls through to the ordinary duration rules, same as before.
  */
 function isAcceptedBackgroundLaunch(n: ToolNode): boolean {
-    return (n.params as BashParams | undefined)?.run_in_background === true && n.status === "success";
+    if ((n.params as BashParams | undefined)?.run_in_background !== true || n.status !== "success") return false;
+    const stdout = (n.result as BashResult | undefined)?.stdout;
+    return typeof stdout === "string" && stdout.startsWith(BACKGROUND_LAUNCH_ACCEPTED_PREFIX);
 }
 
 /**


### PR DESCRIPTION
Closes #2518.

## Root cause

`isAcceptedBackgroundLaunch` (`frontend/app/view/agent/activity/tool-adapter.ts`) classified any Bash `ToolNode` with `params.run_in_background === true && status === "success"` as a genuine detached launch, awaiting a `<task-notification>` for its real completion. That assumption breaks when the harness decides a command finished fast enough to return it **synchronously** instead of actually detaching it — the tool_result carries the command's real output (`<exited N in Ts>\n...`, the same shape an ordinary call gets) rather than the acceptance message (`Command running in background with ID: …`), and no `<task-notification>` for that `tool_use_id` will ever arrive. The dock row was stuck `running` forever, timer climbing.

Live-confirmed via direct transcript inspection (not speculative): a single session made 17 `run_in_background: true` Bash calls. 11 resolved synchronously and got stuck exactly this way; only 6 got a real `<task-notification>`.

## Fix

`isAcceptedBackgroundLaunch` now also checks that `result.stdout` actually starts with the acceptance-message prefix, not just the params flag and status. A synchronously-resolved call falls through to the ordinary duration/threshold rules like any other finished Bash call.

## Testing

- New regression test (`tool-adapter.test.ts`): a call with `run_in_background: true` whose result is the real output, not the acceptance message, resolves via ordinary rules instead of sticking `running`.
- Existing background-launch fixtures (`tool-adapter.test.ts`, `attached-task.test.ts`) updated to include the acceptance-message result shape they were implicitly relying on.
- `npx tsc --noEmit`: clean.
- `npx vitest run`: full suite green (2493 passed, 3 skipped — expected e2e skips).

<!-- agentmux:agent_id=agenta -->