### PR TITLE
feat(muxspect): surface run_in_background on dock entries

### DIFF
--- a/.changesets/1786404839-feat-muxspect-surface-run-in-background-on-dock-entries-clos-i6o2.md
+++ b/.changesets/1786404839-feat-muxspect-surface-run-in-background-on-dock-entries-clos-i6o2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(muxspect): surface run_in_background on dock entries — closes the blind spot behind issue #2518

--- a/agentmux-srv/src/backend/dock_snapshot.rs
+++ b/agentmux-srv/src/backend/dock_snapshot.rs
@@ -31,6 +31,20 @@ pub struct DockNodeSnapshot {
     /// so a slow/backed-up push doesn't understate how stale the
     /// snapshot itself is.
     pub observed_at: i64,
+    /// Whether `params.run_in_background` was `true` on this call (Bash
+    /// only; `None` for every other tool). `status` above is the RAW
+    /// `ToolNode` status, which for an accepted background launch is
+    /// terminal ("success") within ~a second — it does NOT reflect
+    /// whether the dock is still showing this row as `running` while it
+    /// awaits a `<task-notification>` (that reclassification happens
+    /// entirely client-side in `tool-adapter.ts`'s `toolActivities`,
+    /// which the server has no visibility into). This flag exists so a
+    /// human reading `muxspect dock` output isn't misled by `status:
+    /// success` into assuming the dock row is finished too — see issue
+    /// #2518, where exactly that gap let 11 of 17 backgrounded calls in
+    /// one session get stuck `running` in the actual UI while this raw
+    /// snapshot showed them as long-since `success`.
+    pub run_in_background: Option<bool>,
 }
 
 /// One block's tracked nodes, keyed by node id so a later delta for the
@@ -125,6 +139,7 @@ mod tests {
             status: status.to_string(),
             timestamp: Some(1000),
             observed_at: 2000,
+            run_in_background: None,
         }
     }
 
@@ -142,6 +157,15 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].node_id, "n1");
         assert_eq!(got[0].status, "running");
+    }
+
+    #[test]
+    fn run_in_background_round_trips() {
+        let cache = DockSnapshotCache::new();
+        let mut n = node("n1", "success");
+        n.run_in_background = Some(true);
+        cache.push_delta("block-1", n);
+        assert_eq!(cache.get("block-1", 2000)[0].run_in_background, Some(true));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -150,6 +150,11 @@ pub struct CommandDockNodeStatusData {
     /// `ToolNode.timestamp` (ms), if the pushing client had one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<i64>,
+    /// `params.run_in_background === true` on the pushing client's own
+    /// `ToolNode`, if it's a Bash call. See
+    /// `DockNodeSnapshot::run_in_background`'s doc comment (issue #2518).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_in_background: Option<bool>,
 }
 
 /// Data for AgentAnswerCommand — an AskUserQuestion answer delivered back to

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -233,8 +233,9 @@ function renderDock(data) {
         status: n.status,
         age: msToAge(n.age_ms),
         stuck: n.stuck ? "STUCK?" : "",
+        bg: n.run_in_background ? "bg" : "",
     }));
-    const cols = ["node_id", "tool", "status", "age", "stuck"];
+    const cols = ["node_id", "tool", "status", "age", "stuck", "bg"];
     const widths = Object.fromEntries(
         cols.map((c) => [c, Math.max(c.length, ...rows.map((r) => String(r[c]).length))])
     );
@@ -244,6 +245,16 @@ function renderDock(data) {
     if (rows.some((r) => r.stuck)) {
         console.log(`\nSTUCK? nodes: 'running' past the promotion threshold with nothing srv-side backing this block.`);
         console.log(`Clear one with: muxspect dock clear ${data.block_id} <node_id>`);
+    }
+    // issue #2518: a 'bg' row's status is the RAW ToolNode status, terminal
+    // ("success") within ~a second — it can NEVER show STUCK? here even if
+    // the real dock row has been showing 'running' for hours, because the
+    // srv has no visibility into whether this node's <task-notification>
+    // ever arrived (that reclassification happens entirely client-side).
+    // A long-`age` 'bg' row with status=success is worth checking by hand
+    // in the actual UI even though this table reads clean.
+    if (rows.some((r) => r.bg)) {
+        console.log(`\nbg rows: backgrounded launches — STUCK? never applies to these (server can't see the dock's own <task-notification> tracking). Check the live UI by hand if one looks old.`);
     }
 }
 

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -244,7 +244,24 @@ pub struct DockNodeView {
     /// see spec §3.1's own framing of this as "the same signal a human
     /// would manually cross-reference today, automated," not a perfect
     /// per-node liveness oracle.
+    ///
+    /// Does NOT cover a backgrounded call stuck in the actual dock UI
+    /// (issue #2518): `status` here is the RAW `ToolNode` status, which is
+    /// terminal ("success") for an accepted background launch within ~a
+    /// second — this field can never go `true` for that case no matter how
+    /// long the real dock row has been showing `running`, because the
+    /// server has no visibility into whether a `<task-notification>` ever
+    /// arrived (that reclassification is entirely client-side, in
+    /// `tool-adapter.ts`). See `run_in_background` below: a `true` there
+    /// combined with a long `age_ms` is worth checking by hand even when
+    /// `stuck` reads `false`.
     pub stuck: bool,
+    /// `params.run_in_background === true` on the pushing client's own
+    /// `ToolNode`, if it's a Bash call and the renderer reported it.
+    /// `None` for every non-Bash tool and for older clients that predate
+    /// this field. See `stuck`'s doc comment above for why this exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_in_background: Option<bool>,
 }
 
 /// `GET /api/v1/muxspect/dock?block_id=X` — the cached `ToolNode` status
@@ -299,6 +316,7 @@ fn dock_node_views(
                 status: n.status,
                 age_ms,
                 stuck,
+                run_in_background: n.run_in_background,
             }
         })
         .collect()
@@ -475,6 +493,7 @@ mod tests {
             status: status.to_string(),
             timestamp: Some(observed_at),
             observed_at,
+            run_in_background: None,
         }
     }
 
@@ -524,6 +543,22 @@ mod tests {
         assert_eq!(views.len(), 2);
         assert_eq!(views[0].node_id, "n1");
         assert_eq!(views[1].node_id, "n2");
+    }
+
+    #[test]
+    fn dock_node_views_surfaces_run_in_background_even_though_status_is_terminal() {
+        // Issue #2518: an accepted background launch is terminal
+        // ("success") within ~a second server-side, so `stuck` can never
+        // catch it — this is the one signal that lets a human tell "this
+        // success might actually still be running in the real dock" apart
+        // from an ordinary finished call, without the server having to
+        // duplicate the client's <task-notification> cross-referencing.
+        let now_ms = 100_000;
+        let mut bg_node = dock_node("n1", "success", 0);
+        bg_node.run_in_background = Some(true);
+        let views = dock_node_views(vec![bg_node], now_ms, false);
+        assert_eq!(views[0].run_in_background, Some(true));
+        assert!(!views[0].stuck, "status is terminal — the raw heuristic correctly stays quiet");
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1035,6 +1035,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                         status: cmd.status,
                         timestamp: cmd.timestamp,
                         observed_at,
+                        run_in_background: cmd.run_in_background,
                     },
                 );
                 Ok(None)

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -51,13 +51,25 @@ before it ever ran) can stay stuck at `status: "running"` in the dock
 indefinitely, invisible to every other `muxspect` command.
 
 `dock <block_id>` reads a lightweight snapshot the renderer itself pushes
-on every `ToolNode` status change (id, tool name, status, age — no
-transcript content) and flags entries that look stuck (`running`, past
-the 30s promotion threshold, with nothing srv-side backing the block).
+on every `ToolNode` status change (id, tool name, status, age, whether it
+was a `run_in_background` launch — no transcript content) and flags
+entries that look stuck (`running`, past the 30s promotion threshold,
+with nothing srv-side backing the block).
 `dock clear <block_id> <node_id>` force-cancels one specific entry live,
 in whatever renderer currently has that block open — no pane reload
 needed. This is `muxspect`'s only mutating command; every other command
 is read-only diagnostics.
+
+The `STUCK?` heuristic has a blind spot for backgrounded launches (issue
+#2518): an accepted `run_in_background` launch's raw `ToolNode.status`
+goes terminal (`success`) within ~a second, so `STUCK?` — which only ever
+fires on `status: "running"` — structurally can never flag one, no matter
+how long the *actual* dock row has been showing `running` while it awaits
+a `<task-notification>` (that reclassification is entirely client-side,
+in `tool-adapter.ts`; the srv never sees it). The `bg` column is the one
+signal that survives the trip: a `bg` row with an old `age` and
+`status: success` is worth checking by hand in the live UI even though
+`STUCK?` reads clean for it.
 
 Full design: `docs/specs/SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md`.
 This targets one specific, narrow bug class — it is not a fix for the

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -49,6 +49,13 @@ function pushResolvedDockNodes(blockId: string, events: AgentDocumentEvent[]) {
                 node_id: n.id,
                 tool_name: n.toolName,
                 status: n.status,
+                // reagent P1 on PR #2520: DockSnapshotCache::push_delta fully
+                // overwrites a node's snapshot per push — omitting this would
+                // silently blank an earlier `run_in_background: true` push
+                // back to undefined right when a node resolves via scrub,
+                // erasing the signal for exactly the orphaned/stuck-launch
+                // class this field exists to flag.
+                run_in_background: n.run_in_background,
             }).catch(() => {});
         }
     }

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -944,7 +944,7 @@ describe("agent document reducer", () => {
             ]);
         });
 
-        it("reagent P1 on PR #2520: an orphaned background launch's resolvedToolNodes entry carries run_in_background, so muxspect dock's cache doesn't get its earlier true silently blanked back to undefined", () => {
+        it("codex P2 / reagent P1 on PR #2520: a node orphaned BEFORE any acceptance response ever arrived reports run_in_background as undefined, never a false 'bg' — isAcceptedBackgroundLaunch requires status success, which this branch's own guard (status running) makes impossible", () => {
             const bg = tool("bg1", { status: "running", params: { command: "task dev", run_in_background: true } });
             const r = update(seed([bg]), { type: "ScrubOrphanedInProgress", at: 1000 });
             expect(r.events).toEqual([
@@ -952,7 +952,7 @@ describe("agent document reducer", () => {
                     type: "orphans-scrubbed",
                     markdownCanceled: 0,
                     toolsCanceled: 1,
-                    resolvedToolNodes: [{ id: "bg1", status: "canceled", toolName: "Bash", run_in_background: true }],
+                    resolvedToolNodes: [{ id: "bg1", status: "canceled", toolName: "Bash" }],
                 },
             ]);
         });

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -944,6 +944,19 @@ describe("agent document reducer", () => {
             ]);
         });
 
+        it("reagent P1 on PR #2520: an orphaned background launch's resolvedToolNodes entry carries run_in_background, so muxspect dock's cache doesn't get its earlier true silently blanked back to undefined", () => {
+            const bg = tool("bg1", { status: "running", params: { command: "task dev", run_in_background: true } });
+            const r = update(seed([bg]), { type: "ScrubOrphanedInProgress", at: 1000 });
+            expect(r.events).toEqual([
+                {
+                    type: "orphans-scrubbed",
+                    markdownCanceled: 0,
+                    toolsCanceled: 1,
+                    resolvedToolNodes: [{ id: "bg1", status: "canceled", toolName: "Bash", run_in_background: true }],
+                },
+            ]);
+        });
+
         // AskUserQuestion answered before reload (conversation continued past
         // the question) — must resolve to `success` and clear `question` so the
         // question panel does NOT re-surface. SPEC_ASK_USER_QUESTION §13/Phase 3.

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -13,7 +13,8 @@
  * on every mount. Issue #728 gap 4.
  */
 
-import type { BashParams, DocumentNode, ShellNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
+import type { DocumentNode, ShellNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
+import { isAcceptedBackgroundLaunch } from "../../view/agent/activity/tool-adapter";
 import { lastFreshBoundaryIndex } from "../../view/agent/session-outcome";
 import {
     AgentDocumentCommand,
@@ -183,11 +184,20 @@ function scrubOrphanedInProgress(
             const closedLog = n.log != null ? { ...n.log, open: false } : n.log;
             next[i] = { ...n, status: "canceled", log: closedLog };
             toolsCanceled++;
+            // isAcceptedBackgroundLaunch (not the raw params flag — codex P2 /
+            // reagent P1 on PR #2520) requires status === "success", which
+            // this branch's own guard (n.status === "running") makes
+            // impossible here by construction: a node that WAS confirmed
+            // accepted is already "success" and never reaches this branch
+            // again. That's correct, not dead code — a node orphaned before
+            // any response ever arrived genuinely can't be confirmed as an
+            // accepted background launch, so reporting undefined here (never
+            // a false "bg") is the accurate answer, not a gap.
             resolvedToolNodes.push({
                 id: n.id,
                 status: "canceled",
                 toolName: n.toolName ?? n.tool,
-                run_in_background: (n.params as BashParams | undefined)?.run_in_background,
+                run_in_background: isAcceptedBackgroundLaunch(n) || undefined,
             });
             continue;
         }

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -13,7 +13,7 @@
  * on every mount. Issue #728 gap 4.
  */
 
-import type { DocumentNode, ShellNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
+import type { BashParams, DocumentNode, ShellNode, ToolLogChunk, ToolNode, ToolStreamingLog } from "../../view/agent/types";
 import { lastFreshBoundaryIndex } from "../../view/agent/session-outcome";
 import {
     AgentDocumentCommand,
@@ -120,13 +120,21 @@ function scrubOrphanedInProgress(
      * reporting an already-resolved node as STUCK? forever). Consumed
      * by `agent-document-store.ts`'s `dispatch()` — the pure reducer
      * itself does no I/O — to push a final status delta for each.
+     *
+     * Carries `run_in_background` too (reagent P1 on PR #2520): the cache's
+     * `push_delta` fully overwrites a node's snapshot per push, so if this
+     * omitted it, a background Bash node resolved via this exact scrub path
+     * would silently blank an earlier `run_in_background: true` push back
+     * to `undefined` — erasing the diagnostic signal for precisely the
+     * orphaned/stuck-launch class `muxspect dock`'s `bg` column exists to
+     * flag.
      */
-    resolvedToolNodes: Array<{ id: string; status: ToolNode["status"]; toolName: string }>;
+    resolvedToolNodes: Array<{ id: string; status: ToolNode["status"]; toolName: string; run_in_background?: boolean }>;
 } | null {
     let next: DocumentNode[] | null = null;
     let markdownCanceled = 0;
     let toolsCanceled = 0;
-    const resolvedToolNodes: Array<{ id: string; status: ToolNode["status"]; toolName: string }> = [];
+    const resolvedToolNodes: Array<{ id: string; status: ToolNode["status"]; toolName: string; run_in_background?: boolean }> = [];
 
     // Spec's "simple heuristic" (SPEC_ORPHAN_THINKING_NODES §Design):
     // a thinking markdown is orphaned only when it's the document's
@@ -175,7 +183,12 @@ function scrubOrphanedInProgress(
             const closedLog = n.log != null ? { ...n.log, open: false } : n.log;
             next[i] = { ...n, status: "canceled", log: closedLog };
             toolsCanceled++;
-            resolvedToolNodes.push({ id: n.id, status: "canceled", toolName: n.toolName ?? n.tool });
+            resolvedToolNodes.push({
+                id: n.id,
+                status: "canceled",
+                toolName: n.toolName ?? n.tool,
+                run_in_background: (n.params as BashParams | undefined)?.run_in_background,
+            });
             continue;
         }
         // AskUserQuestion that has content AFTER it was answered (the

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -231,7 +231,7 @@ export type AgentDocumentEvent =
            * cache learns about the resolution instead of reporting an
            * already-resolved node as stuck forever (reagentx P1, PR #2432).
            */
-          resolvedToolNodes: Array<{ id: string; status: string; toolName: string }>;
+          resolvedToolNodes: Array<{ id: string; status: string; toolName: string; run_in_background?: boolean }>;
       }
     | { type: "tool-force-canceled"; nodeId: string }
     | {

--- a/frontend/app/view/agent/activity/tool-adapter.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.ts
@@ -83,8 +83,15 @@ function resultText(result: ToolNode["result"]): string | undefined {
  * exactly the fast-finishing case. A failed launch (`status: "failed"` —
  * the harness refused the command) is also not a live background task and
  * falls through to the ordinary duration rules, same as before.
+ *
+ * Exported so `pushDockNodeStatus`/the orphan-scrub push (issue #2520)
+ * reuse this exact classification instead of the raw `params` flag —
+ * codex P2 / reagent P1 on PR #2520: forwarding the raw flag tagged the
+ * MAJORITY of backgrounded calls `bg` in `muxspect dock` (11 of the 17 in
+ * #2518's own motivating session were fast-finishing, i.e. NOT accepted),
+ * making the column noisy on the common case instead of a signal.
  */
-function isAcceptedBackgroundLaunch(n: ToolNode): boolean {
+export function isAcceptedBackgroundLaunch(n: ToolNode): boolean {
     if ((n.params as BashParams | undefined)?.run_in_background !== true || n.status !== "success") return false;
     const text = resultText(n.result);
     return typeof text === "string" && text.startsWith(BACKGROUND_LAUNCH_ACCEPTED_PREFIX);

--- a/frontend/app/view/agent/stream-flush-queue.test.ts
+++ b/frontend/app/view/agent/stream-flush-queue.test.ts
@@ -126,6 +126,10 @@ describe("StreamFlushQueue.flushNow", () => {
             tool: "Bash",
             status: "success",
             params: { command: "task dev", run_in_background: true },
+            // Must be the acceptance message, not just the params flag
+            // (codex P2 / reagent P1 on PR #2520) — isAcceptedBackgroundLaunch
+            // checks this, not the raw flag alone.
+            result: { stdout: "Command running in background with ID: b12345. Output is being written to: …", stderr: "", exitCode: 0 },
             collapsed: false,
             summary: "",
             timestamp: 1000,
@@ -143,5 +147,29 @@ describe("StreamFlushQueue.flushNow", () => {
         q.pushNewNode(fgBash);
         const fgCall = calls.find(([, data]) => data.node_id === "toolu_fg");
         expect(fgCall?.[1].run_in_background).toBeUndefined();
+    });
+
+    it("codex P2 / reagent P1 on PR #2520: a run_in_background: true call that finished synchronously (never actually detached) sends undefined, not true — the raw params flag alone is NOT the signal", () => {
+        const { model } = makeModel();
+        const q = createStreamFlushQueue(model);
+
+        const fastFinish: ToolNode = {
+            type: "tool",
+            id: "toolu_fast",
+            tool: "Bash",
+            status: "success",
+            params: { command: "du -sh .cargo", run_in_background: true },
+            // The harness's own real output, not the acceptance message —
+            // issue #2518's own majority case (11 of 17 in that session).
+            result: { stdout: "<exited 0 in 13.38s>\n707M    .cargo", stderr: "", exitCode: 0 },
+            collapsed: false,
+            summary: "",
+            timestamp: 1000,
+        };
+        q.pushNewNode(fastFinish);
+
+        const calls = vi.mocked(RpcApi.DockNodeStatusCommand).mock.calls;
+        const call = calls.find(([, data]) => data.node_id === "toolu_fast");
+        expect(call?.[1].run_in_background).toBeUndefined();
     });
 });

--- a/frontend/app/view/agent/stream-flush-queue.test.ts
+++ b/frontend/app/view/agent/stream-flush-queue.test.ts
@@ -11,8 +11,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RpcApi } from "@/app/store/rpc-api";
 import { createStreamFlushQueue } from "./stream-flush-queue";
-import type { DocumentNode } from "./types";
+import type { DocumentNode, ToolNode } from "./types";
 
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: { DockNodeStatusCommand: vi.fn().mockResolvedValue(undefined) },
@@ -113,5 +114,34 @@ describe("StreamFlushQueue.flushNow", () => {
         expect(dispatched.length).toBeGreaterThan(afterFirst);
         const flushes = dispatched.filter((d) => d.command.type === "StreamFlush");
         expect(flushes[1].command.newNodes.map((n: DocumentNode) => n.id)).toEqual(["n2"]);
+    });
+
+    it("issue #2518: pushDockNodeStatus forwards run_in_background so muxspect dock can tell a background launch's 'success' apart from an ordinary finished call's", () => {
+        const { model } = makeModel();
+        const q = createStreamFlushQueue(model);
+
+        const bgBash: ToolNode = {
+            type: "tool",
+            id: "toolu_bg",
+            tool: "Bash",
+            status: "success",
+            params: { command: "task dev", run_in_background: true },
+            collapsed: false,
+            summary: "",
+            timestamp: 1000,
+        };
+        q.pushNewNode(bgBash);
+
+        const calls = vi.mocked(RpcApi.DockNodeStatusCommand).mock.calls;
+        const call = calls.find(([, data]) => data.node_id === "toolu_bg");
+        expect(call?.[1].run_in_background).toBe(true);
+
+        // An ordinary Bash call (no run_in_background) sends undefined, not
+        // false — the server-side field stays absent (skip_serializing_if)
+        // rather than misleadingly asserting "definitely not background."
+        const fgBash: ToolNode = { ...bgBash, id: "toolu_fg", params: { command: "ls" } };
+        q.pushNewNode(fgBash);
+        const fgCall = calls.find(([, data]) => data.node_id === "toolu_fg");
+        expect(fgCall?.[1].run_in_background).toBeUndefined();
     });
 });

--- a/frontend/app/view/agent/stream-flush-queue.ts
+++ b/frontend/app/view/agent/stream-flush-queue.ts
@@ -30,7 +30,7 @@ import { batch } from "solid-js";
 import type { AgentPaneModel } from "@/app/store/agent-pane-model";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import type { DocumentNode, ShellNode, ToolLogChunk } from "./types";
+import type { BashParams, DocumentNode, ShellNode, ToolLogChunk } from "./types";
 
 /**
  * Fire-and-forget push of a `ToolNode`'s current status to srv, for
@@ -41,6 +41,13 @@ import type { DocumentNode, ShellNode, ToolLogChunk } from "./types";
  * non-tool nodes and RPC failures (best-effort telemetry, never blocks or
  * surfaces an error for the actual document write).
  * See docs/specs/SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md §3.1.
+ *
+ * Also sends `run_in_background` (issue #2518): `status` alone can't tell a
+ * human reading `muxspect dock` apart an accepted background launch (whose
+ * raw ToolNode status goes terminal within ~a second) from an ordinary
+ * finished call — the actual dock row's `running` classification for that
+ * case happens entirely client-side, in `tool-adapter.ts`, which the server
+ * never sees. This flag is the one bit that survives the trip.
  */
 function pushDockNodeStatus(model: AgentPaneModel, node: DocumentNode) {
     if (node.type !== "tool") return;
@@ -50,6 +57,7 @@ function pushDockNodeStatus(model: AgentPaneModel, node: DocumentNode) {
         tool_name: node.toolName ?? node.tool,
         status: node.status,
         timestamp: node.timestamp,
+        run_in_background: (node.params as BashParams | undefined)?.run_in_background,
     }).catch(() => {});
 }
 

--- a/frontend/app/view/agent/stream-flush-queue.ts
+++ b/frontend/app/view/agent/stream-flush-queue.ts
@@ -30,7 +30,8 @@ import { batch } from "solid-js";
 import type { AgentPaneModel } from "@/app/store/agent-pane-model";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import type { BashParams, DocumentNode, ShellNode, ToolLogChunk } from "./types";
+import { isAcceptedBackgroundLaunch } from "./activity/tool-adapter";
+import type { DocumentNode, ShellNode, ToolLogChunk } from "./types";
 
 /**
  * Fire-and-forget push of a `ToolNode`'s current status to srv, for
@@ -48,6 +49,13 @@ import type { BashParams, DocumentNode, ShellNode, ToolLogChunk } from "./types"
  * finished call — the actual dock row's `running` classification for that
  * case happens entirely client-side, in `tool-adapter.ts`, which the server
  * never sees. This flag is the one bit that survives the trip.
+ *
+ * Uses `isAcceptedBackgroundLaunch`, NOT the raw `params.run_in_background`
+ * flag (codex P2 / reagent P1 on PR #2520): the raw flag is true on every
+ * call that merely REQUESTED backgrounding, most of which the harness
+ * resolves synchronously (issue #2518's own motivating session: 11 of 17).
+ * Tagging all of those `bg` would make the column noisy on the common
+ * case instead of a signal.
  */
 function pushDockNodeStatus(model: AgentPaneModel, node: DocumentNode) {
     if (node.type !== "tool") return;
@@ -57,7 +65,7 @@ function pushDockNodeStatus(model: AgentPaneModel, node: DocumentNode) {
         tool_name: node.toolName ?? node.tool,
         status: node.status,
         timestamp: node.timestamp,
-        run_in_background: (node.params as BashParams | undefined)?.run_in_background,
+        run_in_background: isAcceptedBackgroundLaunch(node) || undefined,
     }).catch(() => {});
 }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -202,6 +202,7 @@ declare global {
         tool_name: string;
         status: string;
         timestamp?: number;
+        run_in_background?: boolean;
     };
 
     // CommandAgentAnswerData — AskUserQuestion answer, delivered to the running


### PR DESCRIPTION
Follow-up to #2519 — extends `muxspect dock`'s introspection to cover the blind spot that made #2518 hard to diagnose in the first place.

## Why

Diagnosing #2518 (17 backgrounded Bash calls in one session, 11 stuck showing `running` in the dock forever) required an ad-hoc node script cross-referencing the raw transcript against `<task-notification>` markers. `muxspect dock` (PR #2432), the existing tool for exactly this class of problem, couldn't see it at all — it only ever reads the RAW `ToolNode.status`, which for an accepted background launch goes terminal (`success`) within ~a second. The `stuck` heuristic (`status == "running" && ...`) can structurally never fire for this category, no matter how long the actual dock row has been showing `running`, because that reclassification (waiting on a `<task-notification>`) happens entirely client-side in `tool-adapter.ts`, invisible to the server.

## What this adds

Threads `params.run_in_background` through the existing `docknodestatus` push into `DockNodeSnapshot`/`DockNodeView`, rendered as a `bg` column in `muxspect dock`. This is deliberately the minimal signal, not a server-side reimplementation of the client's `<task-notification>` cross-referencing (disproportionate now that #2519 fixed the actual bug) — a `bg` row with an old `age` and `status: success` is worth checking by hand in the live UI even though `STUCK?` reads clean for it, next time a similar gap opens up.

## Testing

- `cargo test -p agentmux-srv` — 2121 + 4 + 7 passed, 0 failed (new: `run_in_background_round_trips`, `dock_node_views_surfaces_run_in_background_even_though_status_is_terminal`).
- `npx vitest run` — full suite green (2508 passed, 3 skipped — expected e2e skips). New: `pushDockNodeStatus forwards run_in_background...`.
- `npx tsc --noEmit` — clean.
- `docs/MUXSPECT.md` updated with the new column and its own limitation (still can't see whether a notification actually arrived).

<!-- agentmux:agent_id=agenta -->