### PR TITLE
fix(armory): rename ABF requirements.json provider key to credentialProvider

### DIFF
--- a/.changesets/1786405324-fix-armory-rename-abf-requirements-json-provider-key-to-cred-t7j1.md
+++ b/.changesets/1786405324-fix-armory-rename-abf-requirements-json-provider-key-to-cred-t7j1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): rename ABF requirements.json provider key to credentialProvider

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -497,7 +497,13 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
             }
             requirements.push(json!({
                 "id": format!("{slug}-{name}"),
-                "provider": slug,
+                // ABF v0.2 (SPEC_ABF_V0_2_PROVIDER_AWARE_COMPONENTS_AND_
+                // NATIVE_MEMORY_2026_08_10.md §2.1): renamed from "provider"
+                // to disambiguate from the harness/model-vendor "provider"
+                // concept components.instructions now uses (§2.2) — this one
+                // means "which credential/account service", matching
+                // db_accounts.provider, not a coding harness.
+                "credentialProvider": slug,
                 "kind": "api-key",
                 // "Where it lands" per the requirements.json schema
                 // (research report §5.3) -- an env var name, header name,
@@ -722,6 +728,28 @@ mod tests {
             .expect("expected accounts/requirements.json to be inferred");
         assert!(req_file.content.contains("GITHUB_TOKEN"));
         assert!(!req_file.content.to_lowercase().contains("ghp_"), "must never contain a real secret value");
+    }
+
+    #[test]
+    fn requirement_entries_use_credential_provider_not_provider() {
+        // ABF v0.2, §2.1: "provider" was ambiguous with the newer harness/
+        // model-vendor sense components.instructions now uses. Exported
+        // requirements must use the disambiguated key.
+        let mcp_servers = r#"[{"name":"github","type":"stdio","command":"gh-mcp","env":{"GITHUB_TOKEN":""}}]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+
+        let req_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "accounts/requirements.json")
+            .unwrap();
+        assert!(req_file.content.contains("\"credentialProvider\""));
+        assert!(
+            !req_file.content.contains("\"provider\""),
+            "must not emit the old, ambiguous key alongside the new one: {}",
+            req_file.content
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -228,6 +228,18 @@ pub struct ParsedMcpServer {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AccountRequirement {
     pub id: String,
+    /// ABF v0.2 (SPEC_ABF_V0_2_PROVIDER_AWARE_COMPONENTS_AND_NATIVE_MEMORY_
+    /// 2026_08_10.md §2.1): the wire key is `credentialProvider`, renamed
+    /// from the ambiguous v0.1 `provider` (which collided with the
+    /// unrelated harness/model-vendor "provider" concept components.
+    /// instructions now uses — §2.2). `alias` keeps a v0.1-produced bundle
+    /// (still carrying the old key) importing unchanged; new exports only
+    /// ever write `credentialProvider`. The Rust field itself keeps its
+    /// name — every internal caller (account-requirement resolution,
+    /// `db_accounts.provider` matching) already reads it as "which
+    /// credential service", which was always accurate; only the wire
+    /// format needed disambiguating from the newer, unrelated sense.
+    #[serde(rename = "credentialProvider", alias = "provider")]
     pub provider: String,
     #[serde(default)]
     pub kind: String,
@@ -1315,6 +1327,27 @@ mod tests {
 
     #[test]
     fn parses_account_requirements_read_only() {
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "accounts": "accounts/requirements.json",
+            }))),
+            file("accounts/requirements.json", r#"{"requirements":[{"id":"gh-main","credentialProvider":"github","kind":"api-key","env":"GITHUB_TOKEN","optional":false}]}"#),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+        assert_eq!(result.requirements, vec![AccountRequirement {
+            id: "gh-main".to_string(),
+            provider: "github".to_string(),
+            kind: "api-key".to_string(),
+            env: "GITHUB_TOKEN".to_string(),
+            optional: false,
+        }]);
+    }
+
+    #[test]
+    fn a_v01_bundle_still_carrying_the_old_provider_key_still_imports() {
+        // ABF v0.2, §2.1: "provider" was renamed to "credentialProvider" on
+        // export, but a bundle exported by a v0.1 build (or hand-authored
+        // against the old spec) still uses the old key — must not break.
         let files = vec![
             file("armory.json", &minimal_manifest(serde_json::json!({
                 "accounts": "accounts/requirements.json",


### PR DESCRIPTION
## Summary
- First of several PRs implementing `docs/specs/SPEC_ABF_V0_2_PROVIDER_AWARE_COMPONENTS_AND_NATIVE_MEMORY_2026_08_10.md` §2.1.
- Renames `accounts/requirements.json`'s per-requirement `"provider"` key to `"credentialProvider"`, disambiguating it from the harness/model-vendor "provider" concept the next PR (§2.2) introduces on `components.instructions`.
- Backward compatible: the Rust field keeps its name (every internal caller already reads it correctly as "credential service"), and `#[serde(alias = "provider")]` means a bundle exported by a v0.1 build still imports unchanged. New exports only ever write `credentialProvider`.
- Added a test confirming new exports emit `credentialProvider` and never the old key, plus a test confirming an old-style v0.1 bundle still imports correctly.

## Test plan
- [x] `cargo test -p agentmux-srv bundle_` — 101 passed, including 2 new tests.

<!-- agentmux:agent_id=camper -->