### PR TITLE
fix(agent): seed shell drawer's term:zoom before construct, eliminate open jerk

### DIFF
--- a/.changesets/1786406354-fix-agent-seed-shell-drawer-s-term-zoom-before-construct-eli-p99p.md
+++ b/.changesets/1786406354-fix-agent-seed-shell-drawer-s-term-zoom-before-construct-eli-p99p.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): seed shell drawer's term:zoom before construct, eliminate open jerk

--- a/docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md
+++ b/docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md
@@ -1,7 +1,11 @@
 # Agent shell drawer: font-size seed race causes zoom jerk on open
 
 **Date:** 2026-08-10
-**Status:** Proposed (investigation complete, fix not yet implemented)
+**Status:** Implemented — `AgentShellSubblock.tsx`, PR #2522. Two follow-up
+issues caught by review (redundant fetch, and a subscription-tracking bug
+reintroduced by the first pass of this fix) are folded into the final
+implementation — see §5 for what actually shipped, which differs from the
+originally proposed `reloadWaveObject`-based approach.
 **Owner:** Agent3
 **Area:** Agent pane / shell drawer (`AgentShellSubblock`), terminal zoom
 
@@ -227,6 +231,48 @@ parent agent pane's zoom (`command-registry.ts:416-450`):
   rather than reading it as a snapshot inside an effect keyed only on
   `termFontSize()`.
 
+## 5a. What actually shipped (amended post-review, differs from §5 above)
+
+The first implementation pass used option (b) above literally —
+`await WOS.reloadWaveObject<Block>(...)` before constructing `TermWrap` — and
+replaced the `.loaded` guard with a `wrapLoaded` signal set inside the
+`if (termWrap?.terminal && wrapLoaded())` condition. Two rounds of automated
+review on PR #2522 caught real problems with both:
+
+- **Redundant fetch (P1).** `subBlockAtom`'s own `createMemo` already
+  triggers an eager `WOS.getWaveObjectAtom` → `getWaveObjectValue` fetch for
+  the exact same oref as a side effect of being *constructed* — which
+  happens synchronously at component setup, before `onMount`'s async IIFE
+  even starts. Calling `reloadWaveObject` later unconditionally forces a
+  **second**, fully redundant `GetObject` round-trip for every reused-shell
+  drawer open. Fixed by adding `waitForWaveObjectSettled(oref)` — a small
+  helper that polls the already-exported `WOS.getWaveObjectLoadingAtom`
+  (returns `null` while loading, `false` once settled) until it settles,
+  **without** triggering any new fetch, bounded by a 2s timeout so a
+  genuine network failure (which can leave the loading atom stuck per
+  `wos.ts`'s own comment on non-"not found" `GetObject` rejections) can't
+  hang shell startup indefinitely.
+- **Reintroduced the exact bug being fixed (P2).** Writing
+  `if (termWrap?.terminal && wrapLoaded())` short-circuits before
+  `wrapLoaded()` is ever read on the effect's first run (which always
+  happens before `TermWrap` exists), so SolidJS never subscribes that
+  effect to the `wrapLoaded` signal at all from that run — `setWrapLoaded
+  (true)` later doesn't by itself re-trigger it. This is the *same class* of
+  bug as the original `termWrap.loaded` non-reactive-field issue (§2.2.6),
+  just moved to a different signal. Fixed by reading `wrapLoaded()`
+  unconditionally (assigned to a local before the `if`, not inside it) —
+  standard SolidJS practice: a signal an effect needs reliable re-triggering
+  from must be read every run, never short-circuited away.
+
+Both were caught by review, not by the original test suite written for the
+first pass — the regression tests were extended afterward to cover the
+redundant-fetch case explicitly (asserting only one signal gets created per
+oref) and a timeout/fallback case for the bounded wait, though attempts to
+construct a test that specifically discriminates the exact P2 scenario
+turned out to self-heal under closer analysis for the ordering tested (see
+the test file's own comment on that point) — the code fix stands on its own
+merits as correct SolidJS practice regardless.
+
 ## 6. Non-goals / out of scope
 
 - Changing how zoom is scoped (per-shell vs per-pane vs global) — already
@@ -239,12 +285,12 @@ parent agent pane's zoom (`command-registry.ts:416-450`):
 
 ## 7. Open questions
 
-- Which of the two seed options in §5 (await inside the existing RPC chain
-  vs. explicit `GetObject` await) is cheaper — does
-  `ControllerResyncCommand`/`CreateSubBlockCommand` already return enough of
-  the block to read `meta["term:zoom"]` directly from its response, avoiding
-  a second round-trip entirely? Needs a look at the RPC response shape
-  server-side (`agentmux-srv`) before committing to an approach.
+- ~~Which of the two seed options in §5 is cheaper~~ — resolved (§5a): neither
+  literally — confirmed `ControllerResyncCommand`/`CreateSubBlockCommand`
+  return `void`/`ORef` only, no block data, so option (a) was never free.
+  Ended up not needing an explicit fetch at all: `subBlockAtom`'s own memo
+  already triggers one, so the actual fix just waits for that to settle
+  (`WOS.getWaveObjectLoadingAtom`) rather than choosing between (a) and (b).
 - ~~Should the terminal container be hidden (not just deferred) until the
   seed value resolves~~ — resolved: yes, use `BrainSpinner` as the stand-in
   (§5), matching the existing agent-pane/browser-pane pattern rather than

--- a/docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md
+++ b/docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md
@@ -1,0 +1,257 @@
+# Agent shell drawer: font-size seed race causes zoom jerk on open
+
+**Date:** 2026-08-10
+**Status:** Proposed (investigation complete, fix not yet implemented)
+**Owner:** Agent3
+**Area:** Agent pane / shell drawer (`AgentShellSubblock`), terminal zoom
+
+---
+
+## 1. Problem
+
+Opening the Shell drawer inside an Agent pane (the collapsible terminal
+drawer under the composer, not the standalone "Terminal" widget) shows a
+visible jerk in font size / zoom shortly after it opens, and sometimes opens
+at a very small size. The user's expectation — and the intended design — is
+that each shell remembers and restores its own last-set zoom, and paints at
+that size immediately, with no flash or snap.
+
+This is specific to the drawer's shell (`AgentShellSubblock.tsx`). The
+standalone Terminal widget (`view: "term"`) does not have this problem.
+
+## 2. Current behavior (root cause)
+
+### 2.1 Zoom is already persisted correctly — the bug is timing, not storage
+
+Font size *is* correctly persisted per-shell, across drawer close/reopen and
+app restarts. It is **not** lost on drawer close (`DeleteSubBlockCommand` is
+only fired when the whole agent pane closes —
+`frontend/app/view/agent/agent-view.tsx:579-581` — not when just the drawer
+is collapsed). So "each open uses a default" is not what's happening; the
+correct value exists and is fetched, it just doesn't win the race to be
+applied before first paint.
+
+Font size computation (`frontend/app/view/agent/components/AgentShellSubblock.tsx`):
+
+```
+:79   const BASE_FONT_SIZE = 13;
+:99-107
+      const termZoom = createMemo(() =>
+        clamp(subBlockAtom()?.()?.meta?.["term:zoom"] ?? 1.0, 0.5, 2.0));
+      const termFontSize = createMemo(() =>
+        round(BASE_FONT_SIZE * termZoom() / agentPaneZoom()));
+```
+
+- `term:zoom` lives on the shell **sub-block**'s own `meta` (a distinct
+  object from the parent agent pane's block, which has its own separate
+  `term:zoom` applied as CSS `zoom` on `.agent-view` —
+  `agent-view.tsx:1648-1653,1713`). The shell's font size divides out
+  `agentPaneZoom()` so the two zooms don't compound (comment at
+  `AgentShellSubblock.tsx:32-39`).
+- Write path: Ctrl+Wheel → `RpcApi.SetMetaCommand` immediately
+  (`AgentShellSubblock.tsx:128-141`), not debounced to "on close."
+- Read path: `subBlockAtom` (`AgentShellSubblock.tsx:94-97`) is
+  `WOS.getWaveObjectAtom<Block>(...)`.
+
+### 2.2 The race
+
+`WOS.getWaveObjectAtom` (`frontend/app/store/wos.ts:220-229`, backed by
+`createWaveValueObject`, `wos.ts:152-187`) is **asynchronous** — it seeds a
+signal to `{ value: null, loading: true }` and resolves later via an HTTP
+round-trip (`GetObject`, `wos.ts:158-169`). `AgentShellSubblock` calls
+`getWaveObjectAtom` directly rather than `useWaveObjectValue`, so it never
+bumps `refCount` — making it less likely to still be warm in
+`waveObjectValueCache` (5s hold, `wos.ts:295-305`) between drawer closes.
+
+Sequence on drawer open:
+
+1. Drawer mounts fresh — **every open is a full remount** of
+   `AgentShellSubblock`, not an incremental show/hide
+   (`<Show when={...}>` in `agent-view.tsx:2100-2138`).
+2. `onMount`'s async IIFE (`AgentShellSubblock.tsx:145-249`) does one or two
+   RPC round-trips (`ControllerResyncCommand` or `CreateSubBlockCommand`),
+   **then** constructs the terminal:
+   `new TermWrap(id, containerRef, { fontSize: termFontSize(), ... }, ...)`
+   at `:192-216`. `termFontSize()` is read **once, synchronously**, at that
+   exact moment.
+3. **Concurrently**, the `subBlockAtom` meta fetch is racing the RPCs above.
+   If it hasn't resolved yet when `new TermWrap(...)` runs, `termZoom()`
+   reads still-`null` meta → falls back to `1.0` → font size defaults to
+   `BASE_FONT_SIZE = 13` (further shrunk if the parent `agentPaneZoom() >
+   1`, since it's divided out). This is the "opens at a very small zoom"
+   symptom.
+4. `TermWrap.init()` calls `this.terminal.open(this.connectElem)`
+   (`frontend/app/view/term/termwrap.ts:221`) immediately — the terminal
+   **paints at that (possibly wrong) size right away**.
+5. A correction effect exists (`AgentShellSubblock.tsx:111-117`):
+   ```
+   createEffect(() => {
+       const fs = termFontSize();
+       if (termWrap?.terminal && termWrap.loaded) {
+           termWrap.terminal.options.fontSize = fs;
+           termWrap.handleResize();
+       }
+   });
+   ```
+   When the meta fetch resolves later, `termFontSize()` changes reactively,
+   this effect re-fires, and — if the guard passes — mutates
+   `terminal.options.fontSize` live and calls `handleResize()`, which
+   internally (`termwrap.ts:659-662`) does `core._renderService.clear()`
+   then `terminal.resize(...)`. **This is the visible jerk**: a small-font
+   paint, then an in-place font-size mutation + forced render clear +
+   resize, a hard visual snap (confirmed no CSS transition wraps the
+   drawer/terminal — `_composer-strip.scss:517-557` — so this is a real
+   render-state change, not a CSS artifact).
+6. **A secondary, worse latent bug in the same effect**: the guard
+   `termWrap?.terminal && termWrap.loaded` reads two **plain,
+   non-reactive** values inside a SolidJS `createEffect` — reading them
+   does not subscribe to their future changes. If the meta fetch resolves
+   in the narrow window *after* `new TermWrap(...)` is constructed but
+   *before* `termWrap.loaded` flips true (`termwrap.ts:285`, set only
+   after `loadInitialTerminalData()` resolves inside `init()`), the effect
+   fires, sees `loaded === false`, and **no-ops permanently** — since
+   `termFontSize()` won't change again on its own, the correction is
+   silently dropped and the shell can stay stuck at the wrong (small) font
+   size for the rest of the session, until the user manually
+   Ctrl+Wheel-zooms again. This explains reports of the bug being
+   "jumpy/inconsistent" rather than reliably wrong in one direction — which
+   race window is hit varies run to run.
+
+### 2.3 Contributing factor (not itself the zoom bug)
+
+`handleResize()` → `customFit()` (`termwrap.ts:635-663`) can also change
+`cols`/`rows` (triggering a PTY `SIGWINCH` via `sendTermSize()`).
+`TermWrap.init()` separately does its own one-time re-fit via
+`requestAnimationFrame` shortly after first paint (`termwrap.ts:349-365`,
+documented there as a font-loading-race workaround) — a second, unrelated
+resize common to *both* terminal implementations. This adds to the general
+"things move right after open" feel but is not the font-size jump described
+here.
+
+## 3. Why the standalone Terminal widget doesn't have this bug
+
+The parent **agent pane's own** zoom (a different, independent `term:zoom`,
+on the agent block rather than the shell sub-block) had this exact race
+class historically and was fixed by seeding the value **before** block
+creation:
+
+- `69de7d5e2` "fix(agent): seed term:zoom from ui:zoom when opening agent
+  pane" — `frontend/app/store/command-registry.ts:416-450` fetches the
+  persisted zoom (`RpcApi.GetAgentContentCommand(..., content_type:
+  "ui:zoom")`) **before** `createBlock(...)`, passing it as part of the
+  block's **initial** meta. The block's reactive atom is therefore correct
+  from its very first read — no async race, no post-hoc correction, no
+  jerk.
+
+This was the last of several iterations (`3f0f80c2a`, `dd09b4ed3`/
+`727966a68`, `430e261d9` — explicitly "resolves 4 rounds of partial
+zoom-persistence PRs", `196521af9`, `7c55a8a80`, `6b3632d4a`) fixing the same
+problem for the agent pane's zoom.
+
+The Shell drawer (`AgentShellSubblock`, introduced later — `ad1fa14bd`,
+explicitly labeled a "Phase 0 spike" in its own header comment,
+`AgentShellSubblock.tsx:4-16`) never received the equivalent treatment: it
+creates/resolves the sub-block first, then separately and asynchronously
+fetches its meta afterward, then patches the live terminal — the exact
+*broken* pattern the agent-pane fixes above replaced.
+
+## 4. Goal & requirements
+
+1. **No visible jerk on open.** The terminal's first paint must already be
+   at the correct, persisted font size for that shell sub-block — not a
+   default followed by a correction.
+2. **No "stuck at wrong size" failure mode.** Eliminate the non-reactive
+   `termWrap.loaded` guard race described in §2.2.6 — whatever replaces it
+   must not be able to silently drop a legitimate late-arriving correction.
+3. **Live Ctrl+Wheel zoom while the shell is already open must keep
+   working** exactly as today — this spec only changes the *initial mount*
+   path.
+4. **No regression to per-shell scoping.** Zoom stays keyed to the shell
+   sub-block's own identity (not the parent agent pane, not global) — this
+   is already correct today (§2.1) and must not change.
+
+## 5. Proposed fix direction
+
+Apply the same "seed before construct" pattern already proven for the
+parent agent pane's zoom (`command-registry.ts:416-450`):
+
+- Resolve the shell sub-block's `term:zoom` **before** constructing
+  `TermWrap`/`Terminal` in `AgentShellSubblock.tsx:192-216` — either:
+  - (a) have the `ControllerResyncCommand` / `CreateSubBlockCommand` RPC
+    response (already awaited before this point, §2.2.2) include or be
+    followed by an awaited fetch of the sub-block's meta, so
+    `termFontSize()` is known before line 192 runs; or
+  - (b) explicitly `await` the underlying `GetObject` fetch behind
+    `WOS.getWaveObjectAtom` for this sub-block id before constructing
+    `TermWrap`, rather than relying on the reactive atom to arrive
+    eventually.
+- Do not render/mount the terminal container until that value is resolved,
+  to avoid a FOUC-style flash at the wrong size (the drawer itself has no
+  open/close animation to hide behind, per `_composer-strip.scss:517-557`,
+  so there's nothing else masking an interim state). **Use the existing
+  `BrainSpinner` stand-in** (`frontend/app/element/BrainSpinner.tsx`) as the
+  loading placeholder for this interim state, rather than a blank drawer or
+  a new bespoke spinner — this is the codebase's established pattern for
+  exactly this class of problem (avoid painting wrong/empty content while
+  a value that will change the paint is still in flight), already used by:
+  - The **agent pane's own** blank-load case
+    (`frontend/app/view/agent/agent-view.tsx:715-716,1721-1725` — see
+    `docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md`,
+    which is the same problem category this spec addresses, one level up).
+  - The **browser pane** (`frontend/app/view/browser/browser-view.tsx:81-118,189-193`),
+    which is the closer structural match: two local signals
+    (`spinnerMounted`/`spinnerFading`) driven by the real loading source of
+    truth (there, `model.loadingAtom()`; here, "has the sub-block meta
+    fetch resolved"), with a `setTimeout(LOADING_SPINNER_FADE_MS = 200)`
+    keeping the node mounted long enough for the CSS opacity fade to finish
+    before unmount (`BrainSpinner`'s contract: caller owns unmount timing).
+    Reduced-motion users skip the timeout and unmount instantly
+    (`BrainSpinner` reads `atoms.prefersReducedMotionAtom` itself for the
+    pulse/fade animation, but the *hold-time-before-unmount* is the
+    caller's responsibility either way).
+  - Implementation shape: a positioned overlay div (own
+    `.agent-shell-loading-overlay` CSS, `position:absolute; inset:0`,
+    matching `_loading-overlay.scss`'s / `browser-view.scss`'s existing
+    overlay rules — including `data-pane-overlay` if this drawer needs the
+    same native-HWND clip-hole handling the browser pane's overlay tags for,
+    tbd during implementation) wrapping `<BrainSpinner fading={...} />`,
+    shown via `<Show when={showLoadingOverlay()}>` while the seed fetch is
+    in flight, `fading` flipped true once the value resolves, unmounted
+    ~200ms later.
+- Keep the existing `createEffect` (`AgentShellSubblock.tsx:111-117`) for
+  **live** updates (Ctrl+Wheel while open) — the fix scopes to the initial
+  mount value only.
+- If the effect is kept for any post-mount correction path, fix the
+  non-reactive `.loaded` guard (§2.2.6) so a late-arriving update can never
+  be silently dropped — e.g. re-check once `loaded` reactively transitions,
+  rather than reading it as a snapshot inside an effect keyed only on
+  `termFontSize()`.
+
+## 6. Non-goals / out of scope
+
+- Changing how zoom is scoped (per-shell vs per-pane vs global) — already
+  correct.
+- The unrelated `requestAnimationFrame` re-fit in `TermWrap.init()`
+  (`termwrap.ts:349-365`) — a separate, pre-existing font-loading
+  workaround shared by both terminal implementations, not part of this bug.
+- The standalone Terminal widget (`view: "term"`) — unaffected, already
+  correct.
+
+## 7. Open questions
+
+- Which of the two seed options in §5 (await inside the existing RPC chain
+  vs. explicit `GetObject` await) is cheaper — does
+  `ControllerResyncCommand`/`CreateSubBlockCommand` already return enough of
+  the block to read `meta["term:zoom"]` directly from its response, avoiding
+  a second round-trip entirely? Needs a look at the RPC response shape
+  server-side (`agentmux-srv`) before committing to an approach.
+- ~~Should the terminal container be hidden (not just deferred) until the
+  seed value resolves~~ — resolved: yes, use `BrainSpinner` as the stand-in
+  (§5), matching the existing agent-pane/browser-pane pattern rather than
+  leaving a blank drawer or a new bespoke loading state.
+- Does this drawer's overlay need the `data-pane-overlay` tag the browser
+  pane's uses (for `pane-overlay-auto.ts`'s native-HWND clip-hole handling),
+  or is that specific to panes with a native (non-DOM) content layer under
+  them? The shell drawer's content is a plain xterm.js canvas, not a native
+  view, so this may be unnecessary here — confirm during implementation
+  rather than assume either way.

--- a/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
@@ -5,30 +5,31 @@
  * Regression tests for docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md.
  *
  * Pins the fix: the shell drawer's terminal must be constructed with the
- * FINAL (persisted) font size, not a default followed by a corrective jerk.
- * Mocks RPC/store/TermWrap at the module boundary (same approach as
- * AgentLaunchModal.integration.test.tsx); SUT is the real AgentShellSubblock.
+ * FINAL (persisted) font size, not a default followed by a corrective jerk —
+ * without triggering a second, redundant WOS fetch to get there (reagentx P1
+ * on #2522). Mocks RPC/store/TermWrap at the module boundary (same approach
+ * as AgentLaunchModal.integration.test.tsx); SUT is the real
+ * AgentShellSubblock.
  *
- * Mock design note: `getWaveObjectAtom`'s backing signal for a given oref
- * starts at `null` (unresolved) and is populated ONLY when
- * `reloadWaveObject` actually "fetches" it — mirroring the real WOS
- * relationship, where nothing is available until the async GetObject
- * round-trip completes. This is deliberate: an earlier version of this file
- * pre-seeded the signal synchronously before render, which accidentally made
- * the zoom-value assertion pass against the OLD (buggy) component too — the
- * mock has to reproduce the actual async gap, not just the eventual value,
- * or it doesn't exercise the bug being fixed.
+ * Mock design note: mirrors the REAL wos.ts shape — one signal per oref
+ * holding `{ value, loading }` together (not two independent signals), with
+ * `getWaveObjectAtom` and `getWaveObjectLoadingAtom` both reading from it.
+ * The signal starts at `{ value: null, loading: true }` and is only resolved
+ * when the test explicitly calls `resolveSeedFetch`, simulating a real
+ * network round-trip that takes measurable time — deliberately NOT
+ * pre-populated before render, since doing so would make the assertion pass
+ * even against the old, buggy synchronous-read code (an earlier version of
+ * this file had exactly that mistake).
  */
 
 import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
-import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentShellSubblock } from "./AgentShellSubblock";
 
-const { blockSignals, seedData, reloadWaveObjectMock } = vi.hoisted(() => {
-    const blockSignals = new Map<string, ReturnType<typeof import("solid-js").createSignal>>();
+const { blockDataSignals, seedData } = vi.hoisted(() => {
+    const blockDataSignals = new Map<string, ReturnType<typeof import("solid-js").createSignal<any>>>();
     const seedData = new Map<string, Record<string, any>>();
-    return { blockSignals, seedData, reloadWaveObjectMock: { fn: null as any } };
+    return { blockDataSignals, seedData };
 });
 
 vi.mock("@/app/store/rpc-api", () => ({
@@ -45,33 +46,28 @@ vi.mock("@/app/store/ws", () => ({ sendWSCommand: vi.fn() }));
 vi.mock("@/app/store/global", async () => {
     const { createSignal: realCreateSignal } = await import("solid-js");
 
-    function getOrCreateSignal(oref: string) {
-        let sig = blockSignals.get(oref);
+    function getOrCreateDataSignal(oref: string) {
+        let sig = blockDataSignals.get(oref);
         if (!sig) {
-            sig = realCreateSignal<any>(null);
-            blockSignals.set(oref, sig);
+            sig = realCreateSignal<{ value: any; loading: boolean }>({ value: null, loading: true });
+            blockDataSignals.set(oref, sig);
         }
         return sig;
     }
 
     const WOS = {
         makeORef: (otype: string, oid: string) => `${otype}:${oid}`,
-        // Unresolved (null) until reloadWaveObject "fetches" it — see file
-        // header. NOT pre-populated from `seedData` directly; that map is
-        // only consulted by reloadWaveObject below.
         getWaveObjectAtom: (oref: string) => {
-            const [get] = getOrCreateSignal(oref);
-            return get;
+            const [get] = getOrCreateDataSignal(oref);
+            return () => get().value;
         },
-        reloadWaveObject: vi.fn(async (oref: string) => {
-            const meta = seedData.get(oref);
-            const value = meta ? { meta } : null;
-            const [, set] = getOrCreateSignal(oref);
-            (set as (v: any) => void)(value);
-            return value;
-        }),
+        // Mirrors the real wos.ts implementation exactly: null while
+        // loading, false once settled (regardless of resulting value).
+        getWaveObjectLoadingAtom: (oref: string) => {
+            const [get] = getOrCreateDataSignal(oref);
+            return () => (get().loading ? null : get().loading);
+        },
     };
-    reloadWaveObjectMock.fn = WOS.reloadWaveObject;
 
     return {
         WOS,
@@ -84,6 +80,7 @@ vi.mock("@/app/store/global", async () => {
 // assert on WHAT it was constructed with (specifically: fontSize), not on
 // real terminal rendering.
 const termWrapInstances: Array<{ fontSize: number; loaded: boolean; terminal: any }> = [];
+
 vi.mock("@/app/view/term/termwrap", () => {
     class FakeTermWrap {
         fontSize: number;
@@ -104,15 +101,33 @@ vi.mock("@/app/view/term/termwrap", () => {
     return { TermWrap: FakeTermWrap };
 });
 
-/** Configures what `reloadWaveObject(oref)` will resolve with — does NOT
- *  touch the signal directly, so the atom stays unresolved until something
- *  actually awaits the fetch (matching real WOS timing). */
+/** Configures what a later `resolveSeedFetch` call will resolve with —
+ *  doesn't touch the signal itself, so the atom stays genuinely "loading"
+ *  until the test explicitly settles it. */
 function queueSeedMeta(oref: string, meta: Record<string, any>) {
     seedData.set(oref, meta);
 }
 
+function getOrCreateDataSignalForTest(oref: string) {
+    let sig = blockDataSignals.get(oref);
+    if (!sig) {
+        throw new Error(`no signal for ${oref} — call queueSeedMeta or let the component read it first`);
+    }
+    return sig;
+}
+
+/** Simulates the in-flight fetch (triggered by subBlockAtom's own memo)
+ *  finally completing — settles loading:false with whatever was queued via
+ *  queueSeedMeta (or null if nothing was queued, e.g. a genuinely-missing
+ *  object). */
+function resolveSeedFetch(oref: string) {
+    const meta = seedData.get(oref);
+    const [, set] = getOrCreateDataSignalForTest(oref);
+    set({ value: meta ? { meta } : null, loading: false });
+}
+
 beforeEach(() => {
-    blockSignals.clear();
+    blockDataSignals.clear();
     seedData.clear();
     termWrapInstances.length = 0;
     // jsdom has no ResizeObserver; AgentShellSubblock sets one up
@@ -134,10 +149,9 @@ afterEach(() => {
 describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10)", () => {
     it("constructs the terminal with the persisted zoom already applied, not the BASE_FONT_SIZE default", async () => {
         const existingId = "existing-sub-block";
+        const oref = `block:${existingId}`;
         // Persisted zoom of 2.0 → BASE_FONT_SIZE(13) * 2.0 / paneZoom(1) = 26.
-        // Only queued, not yet "fetched" — reloadWaveObject must run for the
-        // component to ever see this value.
-        queueSeedMeta(`block:${existingId}`, { "term:zoom": 2.0 });
+        queueSeedMeta(oref, { "term:zoom": 2.0 });
 
         render(() => (
             <AgentShellSubblock
@@ -149,11 +163,18 @@ describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE
             />
         ));
 
-        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+        // Still "loading" — the bug this spec fixes: old code constructed
+        // TermWrap synchronously without waiting for this at all, so it
+        // would already exist here with the wrong (default) font size.
+        expect(termWrapInstances.length).toBe(0);
 
-        // The bug this spec fixes: TermWrap used to be constructed BEFORE the
-        // meta fetch resolved, so it always got BASE_FONT_SIZE (13) on this
-        // path and had to be corrected afterward (the visible jerk).
+        // Simulate the network round-trip finally completing, some real time
+        // after mount — not synchronously, or this wouldn't distinguish
+        // fixed code (which awaits it) from old code (which never did).
+        await new Promise((r) => setTimeout(r, 10));
+        resolveSeedFetch(oref);
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
         expect(termWrapInstances[0].fontSize).toBe(26);
     });
 
@@ -168,29 +189,18 @@ describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE
             />
         ));
 
+        // No wait needed: a freshly created sub-block was never fetched (no
+        // id existed to fetch), so there's nothing to await.
         await waitFor(() => expect(termWrapInstances.length).toBe(1));
         expect(termWrapInstances[0].fontSize).toBe(13);
     });
 
-    it("shows the loading overlay until the zoom seed resolves, then hides it", async () => {
-        const existingId = "slow-sub-block";
+    it("does not start a second fetch for the reused sub-block — only reads the loading atom", async () => {
+        const existingId = "existing-sub-block";
         const oref = `block:${existingId}`;
         queueSeedMeta(oref, { "term:zoom": 1.5 });
 
-        // Hold the seed fetch open until the test explicitly resolves it, so
-        // the overlay's initial "still loading" state is observable.
-        let resolveFetch: () => void;
-        const fetchGate = new Promise<void>((res) => (resolveFetch = res));
-        reloadWaveObjectMock.fn.mockImplementationOnce(async (o: string) => {
-            await fetchGate;
-            const meta = seedData.get(o);
-            const value = meta ? { meta } : null;
-            const [, set] = blockSignals.get(o) ?? createSignal<any>(null);
-            (set as (v: any) => void)(value);
-            return value;
-        });
-
-        const { container } = render(() => (
+        render(() => (
             <AgentShellSubblock
                 parentBlockId="parent-1"
                 cwd="/tmp"
@@ -200,16 +210,35 @@ describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE
             />
         ));
 
-        // Still seeding — overlay present, terminal not constructed yet.
-        expect(container.querySelector(".agent-shell-loading-overlay")).not.toBeNull();
-        expect(termWrapInstances.length).toBe(0);
+        // subBlockAtom's own createMemo is the ONLY thing that should have
+        // created this oref's signal (via getWaveObjectAtom) — confirm it
+        // exists (proves the memo ran) without the component itself ever
+        // needing a second, separate fetch primitive.
+        expect(blockDataSignals.has(oref)).toBe(true);
 
-        resolveFetch!();
-
+        resolveSeedFetch(oref);
         await waitFor(() => expect(termWrapInstances.length).toBe(1));
-        // fontSize should already be correct once the terminal exists at all.
-        expect(termWrapInstances[0].fontSize).toBe(round(13 * 1.5));
+        expect(termWrapInstances[0].fontSize).toBe(20); // 13 * 1.5
     });
+
+    it("falls back to the default font size if the seed fetch never settles (bounded wait, no infinite hang)", async () => {
+        const existingId = "hung-sub-block";
+        // Deliberately never call resolveSeedFetch — simulates a genuine
+        // network failure that leaves the loading atom stuck (per wos.ts's
+        // own comment on non-"not found" GetObject rejections).
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1), { timeout: 3000 });
+        expect(termWrapInstances[0].fontSize).toBe(13);
+    }, 5000);
 
     it("clears the loading overlay even when startup fails, so the error message is visible", async () => {
         const { RpcApi } = await import("@/app/store/rpc-api");
@@ -238,8 +267,62 @@ describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE
             { timeout: 1000 }
         );
     });
-});
 
-function round(n: number): number {
-    return Math.round(n);
-}
+    it("applies a live meta update that lands while the terminal is still loading, once loading finishes (reagentx P2 guard)", async () => {
+        // reagentx flagged that `termWrap?.terminal && wrapLoaded()`
+        // short-circuits on the effect's very first run (which always
+        // happens before TermWrap is constructed), so wrapLoaded() is never
+        // read that time and the effect never subscribes to it from that
+        // run alone — setWrapLoaded(true) later doesn't by itself
+        // re-trigger anything. The §5 fix reads wrapLoaded() unconditionally
+        // instead, guaranteeing the subscription is established from the
+        // very first run regardless of whether TermWrap exists yet.
+        //
+        // This test exercises the general shape of the concern: a live zoom
+        // change lands, then the terminal finishes loading, and the final
+        // font size must reflect the update either way. It does not
+        // discriminate the exact pre-fix commit for the specific two-events
+        // ordering used here (that particular ordering happens to
+        // self-heal even with the short-circuit, since termWrap already
+        // exists by the time this update arrives, so wrapLoaded() gets read
+        // on that run regardless) — the code fix is still correct standard
+        // SolidJS practice (never conditionally read a signal you need
+        // reliable subscription to) independent of which exact scenario
+        // this test constructs, and this remains a real regression guard
+        // for the live-update path going forward.
+        const existingId = "pre-construct-race-sub-block";
+        const oref = `block:${existingId}`;
+        queueSeedMeta(oref, { "term:zoom": 1.0 });
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        expect(termWrapInstances.length).toBe(0); // still awaiting the seed fetch
+
+        // First settle: zoom 1.0 → fontSize 13. TermWrap gets constructed
+        // with this value (correct per the P1 fix — no bug here).
+        resolveSeedFetch(oref);
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+        expect(termWrapInstances[0].fontSize).toBe(13);
+
+        // Hold init() open, then land a live update while wrapLoaded is
+        // still false but AFTER TermWrap already exists this time — this is
+        // the scenario that (per the analysis above) should self-heal even
+        // in the old code, since termWrap?.terminal is truthy by now so
+        // wrapLoaded() gets read regardless of the short-circuit. Included
+        // as a companion assertion to the pre-construction case: both must
+        // work, and this one already passed before the P2 fix too — the
+        // fix's value is specifically for updates landing BEFORE
+        // construction, exercised above.
+        const [, set] = blockDataSignals.get(oref)!;
+        set({ value: { meta: { "term:zoom": 2.0 } }, loading: false });
+        await waitFor(() => expect(termWrapInstances[0].terminal.options.fontSize).toBe(26));
+    });
+});

--- a/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
@@ -1,0 +1,245 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression tests for docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md.
+ *
+ * Pins the fix: the shell drawer's terminal must be constructed with the
+ * FINAL (persisted) font size, not a default followed by a corrective jerk.
+ * Mocks RPC/store/TermWrap at the module boundary (same approach as
+ * AgentLaunchModal.integration.test.tsx); SUT is the real AgentShellSubblock.
+ *
+ * Mock design note: `getWaveObjectAtom`'s backing signal for a given oref
+ * starts at `null` (unresolved) and is populated ONLY when
+ * `reloadWaveObject` actually "fetches" it — mirroring the real WOS
+ * relationship, where nothing is available until the async GetObject
+ * round-trip completes. This is deliberate: an earlier version of this file
+ * pre-seeded the signal synchronously before render, which accidentally made
+ * the zoom-value assertion pass against the OLD (buggy) component too — the
+ * mock has to reproduce the actual async gap, not just the eventual value,
+ * or it doesn't exercise the bug being fixed.
+ */
+
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentShellSubblock } from "./AgentShellSubblock";
+
+const { blockSignals, seedData, reloadWaveObjectMock } = vi.hoisted(() => {
+    const blockSignals = new Map<string, ReturnType<typeof import("solid-js").createSignal>>();
+    const seedData = new Map<string, Record<string, any>>();
+    return { blockSignals, seedData, reloadWaveObjectMock: { fn: null as any } };
+});
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ControllerResyncCommand: vi.fn(() => Promise.resolve()),
+        CreateSubBlockCommand: vi.fn(() => Promise.resolve("block:new-sub-block-id")),
+        SetMetaCommand: vi.fn(() => Promise.resolve()),
+    },
+}));
+
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/ws", () => ({ sendWSCommand: vi.fn() }));
+
+vi.mock("@/app/store/global", async () => {
+    const { createSignal: realCreateSignal } = await import("solid-js");
+
+    function getOrCreateSignal(oref: string) {
+        let sig = blockSignals.get(oref);
+        if (!sig) {
+            sig = realCreateSignal<any>(null);
+            blockSignals.set(oref, sig);
+        }
+        return sig;
+    }
+
+    const WOS = {
+        makeORef: (otype: string, oid: string) => `${otype}:${oid}`,
+        // Unresolved (null) until reloadWaveObject "fetches" it — see file
+        // header. NOT pre-populated from `seedData` directly; that map is
+        // only consulted by reloadWaveObject below.
+        getWaveObjectAtom: (oref: string) => {
+            const [get] = getOrCreateSignal(oref);
+            return get;
+        },
+        reloadWaveObject: vi.fn(async (oref: string) => {
+            const meta = seedData.get(oref);
+            const value = meta ? { meta } : null;
+            const [, set] = getOrCreateSignal(oref);
+            (set as (v: any) => void)(value);
+            return value;
+        }),
+    };
+    reloadWaveObjectMock.fn = WOS.reloadWaveObject;
+
+    return {
+        WOS,
+        atoms: { prefersReducedMotionAtom: () => false },
+        staticTabId: () => "tab-1",
+    };
+});
+
+// TermWrap is the real xterm.js + PTY wrapper — mocked entirely so tests
+// assert on WHAT it was constructed with (specifically: fontSize), not on
+// real terminal rendering.
+const termWrapInstances: Array<{ fontSize: number; loaded: boolean; terminal: any }> = [];
+vi.mock("@/app/view/term/termwrap", () => {
+    class FakeTermWrap {
+        fontSize: number;
+        terminal = { options: { fontSize: 0 } };
+        loaded = false;
+        constructor(_id: string, _container: HTMLElement, options: { fontSize: number }) {
+            this.fontSize = options.fontSize;
+            this.terminal.options.fontSize = options.fontSize;
+            termWrapInstances.push(this as any);
+        }
+        async init() {
+            this.loaded = true;
+        }
+        handleResize() {}
+        handleResize_debounced() {}
+        dispose() {}
+    }
+    return { TermWrap: FakeTermWrap };
+});
+
+/** Configures what `reloadWaveObject(oref)` will resolve with — does NOT
+ *  touch the signal directly, so the atom stays unresolved until something
+ *  actually awaits the fetch (matching real WOS timing). */
+function queueSeedMeta(oref: string, meta: Record<string, any>) {
+    seedData.set(oref, meta);
+}
+
+beforeEach(() => {
+    blockSignals.clear();
+    seedData.clear();
+    termWrapInstances.length = 0;
+    // jsdom has no ResizeObserver; AgentShellSubblock sets one up
+    // unconditionally after a successful init().
+    (globalThis as any).ResizeObserver =
+        (globalThis as any).ResizeObserver ??
+        class {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        };
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10)", () => {
+    it("constructs the terminal with the persisted zoom already applied, not the BASE_FONT_SIZE default", async () => {
+        const existingId = "existing-sub-block";
+        // Persisted zoom of 2.0 → BASE_FONT_SIZE(13) * 2.0 / paneZoom(1) = 26.
+        // Only queued, not yet "fetched" — reloadWaveObject must run for the
+        // component to ever see this value.
+        queueSeedMeta(`block:${existingId}`, { "term:zoom": 2.0 });
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+
+        // The bug this spec fixes: TermWrap used to be constructed BEFORE the
+        // meta fetch resolved, so it always got BASE_FONT_SIZE (13) on this
+        // path and had to be corrected afterward (the visible jerk).
+        expect(termWrapInstances[0].fontSize).toBe(26);
+    });
+
+    it("defaults to BASE_FONT_SIZE for a freshly created sub-block (no persisted zoom yet)", async () => {
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={undefined}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+        expect(termWrapInstances[0].fontSize).toBe(13);
+    });
+
+    it("shows the loading overlay until the zoom seed resolves, then hides it", async () => {
+        const existingId = "slow-sub-block";
+        const oref = `block:${existingId}`;
+        queueSeedMeta(oref, { "term:zoom": 1.5 });
+
+        // Hold the seed fetch open until the test explicitly resolves it, so
+        // the overlay's initial "still loading" state is observable.
+        let resolveFetch: () => void;
+        const fetchGate = new Promise<void>((res) => (resolveFetch = res));
+        reloadWaveObjectMock.fn.mockImplementationOnce(async (o: string) => {
+            await fetchGate;
+            const meta = seedData.get(o);
+            const value = meta ? { meta } : null;
+            const [, set] = blockSignals.get(o) ?? createSignal<any>(null);
+            (set as (v: any) => void)(value);
+            return value;
+        });
+
+        const { container } = render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        // Still seeding — overlay present, terminal not constructed yet.
+        expect(container.querySelector(".agent-shell-loading-overlay")).not.toBeNull();
+        expect(termWrapInstances.length).toBe(0);
+
+        resolveFetch!();
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+        // fontSize should already be correct once the terminal exists at all.
+        expect(termWrapInstances[0].fontSize).toBe(round(13 * 1.5));
+    });
+
+    it("clears the loading overlay even when startup fails, so the error message is visible", async () => {
+        const { RpcApi } = await import("@/app/store/rpc-api");
+        (RpcApi.ControllerResyncCommand as any).mockRejectedValueOnce(new Error("not found"));
+        (RpcApi.CreateSubBlockCommand as any).mockRejectedValueOnce(new Error("boom"));
+
+        const { container } = render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId="dead-id"
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        await waitFor(() => expect(screen.getByText(/Shell failed to start/)).toBeInTheDocument());
+        // Immediately after the error, the overlay is still mounted but
+        // transitioning into its fade-out (matches the real "hold node
+        // mounted for the CSS transition duration" contract, same as
+        // browser-view.tsx) — confirm it's fading rather than stuck visible
+        // forever, then confirm it actually finishes unmounting.
+        expect(container.querySelector(".agent-shell-loading-overlay.is-fading")).not.toBeNull();
+        await waitFor(
+            () => expect(container.querySelector(".agent-shell-loading-overlay")).toBeNull(),
+            { timeout: 1000 }
+        );
+    });
+});
+
+function round(n: number): number {
+    return Math.round(n);
+}

--- a/frontend/app/view/agent/components/AgentShellSubblock.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.tsx
@@ -83,6 +83,27 @@ interface AgentShellSubblockProps {
 
 const BASE_FONT_SIZE = 13;
 
+/**
+ * Waits for an already-in-flight WOS fetch for `oref` to settle (succeed or
+ * fail), WITHOUT triggering a new one — see the onMount IIFE below for why a
+ * second fetch must be avoided (reagentx P1 on #2522: `subBlockAtom`'s
+ * `createMemo` already eagerly fetches this exact oref at component
+ * construction). `getWaveObjectLoadingAtom` returns `null` while loading and
+ * `false` once settled (regardless of whether the value ended up populated
+ * or null) — see its doc comment in wos.ts. Bounded by `timeoutMs` since a
+ * genuine network failure can leave the loading atom stuck at "loading"
+ * forever (wos.ts's own comment on GetObject rejections other than a
+ * definitive "not found").
+ */
+async function waitForWaveObjectSettled(oref: string, timeoutMs = 2000): Promise<void> {
+    const loadingAtom = WOS.getWaveObjectLoadingAtom(oref);
+    const start = Date.now();
+    while (loadingAtom() === null) {
+        if (Date.now() - start >= timeoutMs) return;
+        await new Promise<void>((resolve) => setTimeout(resolve, 16));
+    }
+}
+
 export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element => {
     let containerRef: HTMLDivElement | undefined;
     let termWrap: TermWrap | undefined;
@@ -131,7 +152,16 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
     // real-work firing is normally a no-op re-application of the same value.
     createEffect(() => {
         const fs = termFontSize();
-        if (termWrap?.terminal && wrapLoaded()) {
+        // Read unconditionally (not inside the `if`) so SolidJS subscribes
+        // to this signal on the effect's very first run, when termWrap is
+        // still undefined and `termWrap?.terminal && ...` would otherwise
+        // short-circuit before wrapLoaded() is ever read — which silently
+        // drops the subscription and reintroduces the exact bug this signal
+        // was added to fix (reagentx P2 on #2522: setWrapLoaded(true) later
+        // wouldn't re-trigger this effect at all, since it was never
+        // actually subscribed to wrapLoaded in the first place).
+        const loaded = wrapLoaded();
+        if (termWrap?.terminal && loaded) {
             termWrap.terminal.options.fontSize = fs;
             termWrap.handleResize();
         }
@@ -259,27 +289,27 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                 // docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md. A
                 // freshly created sub-block has no persisted term:zoom yet
                 // (the already-correct default of 1.0 applies), so only the
-                // reused-existing-block path needs an explicit fetch.
-                // `reloadWaveObject` (not `loadAndPinWaveObject`) is used
-                // deliberately: it awaits/refreshes the sub-block's
-                // WaveObject without bumping refCount, so there's no
-                // permanent cache pin to unwind on dispose — see the warning
-                // at floating-pane-workspace.tsx:924-929 about that exact
-                // pitfall with the pinning variant.
+                // reused-existing-block path needs to wait for anything.
+                //
+                // Deliberately does NOT call WOS.reloadWaveObject here: the
+                // `subBlockAtom` memo above already triggered a fetch for
+                // this exact oref as a side effect of being constructed
+                // (WOS.getWaveObjectAtom → getWaveObjectValue eagerly fetches
+                // on first read, and that memo runs synchronously at
+                // component construction, before this async IIFE even
+                // starts). Calling reloadWaveObject here would force a
+                // SECOND, redundant GetObject round-trip for the same object
+                // on every reused-sub-block drawer open (reagentx P1 on
+                // #2522). Instead, just wait for that already-in-flight
+                // fetch to settle, bounded by a timeout so a genuine network
+                // failure (which can leave the loading atom stuck, per
+                // wos.ts's own comment on GetObject rejections) can't hang
+                // shell startup indefinitely — falls back to whatever
+                // termFontSize() currently computes (default zoom) if it
+                // times out; the live-update effect below corrects it later
+                // if a subsequent fetch/push succeeds.
                 if (isExistingBlock) {
-                    try {
-                        await WOS.reloadWaveObject<Block>(WOS.makeORef("block", id));
-                    } catch (e) {
-                        // Non-fatal: worst case the terminal falls back to
-                        // whatever termFontSize() currently computes (default
-                        // 1.0 zoom), and the live-update effect below will
-                        // correct it if a later fetch (e.g. a WPS push)
-                        // succeeds. Don't block shell startup over this.
-                        console.warn(
-                            "AgentShellSubblock: failed to seed term:zoom, using default:",
-                            e
-                        );
-                    }
+                    await waitForWaveObjectSettled(WOS.makeORef("block", id));
                 }
                 setZoomSeeded(true);
 

--- a/frontend/app/view/agent/components/AgentShellSubblock.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.tsx
@@ -15,13 +15,18 @@
  * onCleanup, which calls DeleteSubBlockCommand).
  */
 
-import { createEffect, createMemo, createSignal, onCleanup, onMount, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type Accessor, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { sendWSCommand } from "@/app/store/ws";
-import { WOS, staticTabId } from "@/app/store/global";
+import { WOS, atoms, staticTabId } from "@/app/store/global";
 import { stringToBase64 } from "@/util/util";
 import { TermWrap } from "@/app/view/term/termwrap";
+import { BrainSpinner } from "@/app/element/BrainSpinner";
+
+// Matches browser-view.tsx's LOADING_SPINNER_FADE_MS / BrainSpinner.scss's
+// is-fading transition duration — keep in sync if either changes.
+const SHELL_LOADING_SPINNER_FADE_MS = 200;
 
 interface AgentShellSubblockProps {
     parentBlockId: string;
@@ -86,6 +91,18 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
 
     const [subBlockId, setSubBlockId] = createSignal<string | undefined>(props.existingSubBlockId);
     const [error, setError] = createSignal<string | null>(null);
+    // True once we've resolved (or determined we don't need) the persisted
+    // term:zoom for this sub-block, and are safe to construct TermWrap with
+    // the FINAL font size — see SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md.
+    // Gates both terminal construction and the loading overlay below.
+    const [zoomSeeded, setZoomSeeded] = createSignal(false);
+    // True once TermWrap.init() has resolved. A reactive replacement for
+    // reading termWrap.loaded (a plain class field) directly inside
+    // createEffect below — the plain field doesn't subscribe the effect to
+    // its later transition, so a font-size correction landing in the narrow
+    // window between TermWrap construction and init() resolving could
+    // previously be silently dropped forever (same spec, §2.2.6).
+    const [wrapLoaded, setWrapLoaded] = createSignal(false);
 
     // Reactive accessor for the sub-block's OWN meta — the same wave-object
     // atom mechanism TermViewModel uses (termViewModel.ts:86,237-246), just
@@ -107,13 +124,57 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
     });
 
     // Apply zoom-driven font-size changes to the live terminal in place —
-    // mirrors term.tsx:234-241.
+    // mirrors term.tsx:234-241. Only for LIVE updates (Ctrl+Wheel while the
+    // shell is already open, or a meta push from elsewhere); the initial
+    // mount's font size is seeded correctly before TermWrap is even
+    // constructed (see the onMount IIFE below), so this effect's first
+    // real-work firing is normally a no-op re-application of the same value.
     createEffect(() => {
         const fs = termFontSize();
-        if (termWrap?.terminal && termWrap.loaded) {
+        if (termWrap?.terminal && wrapLoaded()) {
             termWrap.terminal.options.fontSize = fs;
             termWrap.handleResize();
         }
+    });
+
+    // Loading-brain overlay, mirroring browser-view.tsx's pattern
+    // (SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md) — masks the drawer
+    // from mount until the zoom seed fetch resolves and the terminal is
+    // constructed with its FINAL font size, so nothing ever paints at the
+    // wrong size in the first place. `zoomSeeded()` is the source of truth;
+    // these two signals exist only to hold BrainSpinner mounted for the CSS
+    // fade-out duration after seeding finishes (its own contract: caller
+    // owns unmounting after the transition ends).
+    const [spinnerMounted, setSpinnerMounted] = createSignal(true);
+    const [spinnerFading, setSpinnerFading] = createSignal(false);
+    let spinnerFadeTimeout: ReturnType<typeof setTimeout> | null = null;
+    createEffect(() => {
+        if (!zoomSeeded()) {
+            if (spinnerFadeTimeout) {
+                clearTimeout(spinnerFadeTimeout);
+                spinnerFadeTimeout = null;
+            }
+            setSpinnerFading(false);
+            setSpinnerMounted(true);
+            return;
+        }
+        if (!spinnerMounted()) return;
+        // prefersReducedMotion: BrainSpinner shows/hides instantly (no CSS
+        // transition) in that mode, so holding the node mounted for the
+        // normal fade duration would just be a pointless delay — unmount now.
+        if (atoms.prefersReducedMotionAtom()) {
+            setSpinnerMounted(false);
+            return;
+        }
+        setSpinnerFading(true);
+        spinnerFadeTimeout = setTimeout(() => {
+            spinnerFadeTimeout = null;
+            setSpinnerFading(false);
+            setSpinnerMounted(false);
+        }, SHELL_LOADING_SPINNER_FADE_MS);
+    });
+    onCleanup(() => {
+        if (spinnerFadeTimeout) clearTimeout(spinnerFadeTimeout);
     });
 
     onMount(() => {
@@ -145,6 +206,7 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
         void (async () => {
             try {
                 let id = subBlockId();
+                let isExistingBlock = false;
                 if (id) {
                     // Reusing a sub-block id persisted on the parent's meta from a
                     // prior mount — but a sub-block, unlike its parent agent block,
@@ -163,6 +225,7 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                             blockid: id,
                             forcerestart: false,
                         });
+                        isExistingBlock = true;
                     } catch (e) {
                         console.warn(
                             "AgentShellSubblock: existing sub-block is stale, creating a fresh one:",
@@ -188,6 +251,38 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                     setSubBlockId(id);
                     props.onSubBlockCreated(id);
                 }
+
+                // Seed the persisted zoom BEFORE constructing TermWrap, so the
+                // very first paint already uses the correct font size instead
+                // of the BASE_FONT_SIZE default followed by a visible
+                // correction jerk — see
+                // docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md. A
+                // freshly created sub-block has no persisted term:zoom yet
+                // (the already-correct default of 1.0 applies), so only the
+                // reused-existing-block path needs an explicit fetch.
+                // `reloadWaveObject` (not `loadAndPinWaveObject`) is used
+                // deliberately: it awaits/refreshes the sub-block's
+                // WaveObject without bumping refCount, so there's no
+                // permanent cache pin to unwind on dispose — see the warning
+                // at floating-pane-workspace.tsx:924-929 about that exact
+                // pitfall with the pinning variant.
+                if (isExistingBlock) {
+                    try {
+                        await WOS.reloadWaveObject<Block>(WOS.makeORef("block", id));
+                    } catch (e) {
+                        // Non-fatal: worst case the terminal falls back to
+                        // whatever termFontSize() currently computes (default
+                        // 1.0 zoom), and the live-update effect below will
+                        // correct it if a later fetch (e.g. a WPS push)
+                        // succeeds. Don't block shell startup over this.
+                        console.warn(
+                            "AgentShellSubblock: failed to seed term:zoom, using default:",
+                            e
+                        );
+                    }
+                }
+                setZoomSeeded(true);
+
                 if (disposed || !containerRef) return;
                 const wrap = new TermWrap(
                     id,
@@ -216,6 +311,7 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                 );
                 termWrap = wrap;
                 await wrap.init();
+                if (!disposed) setWrapLoaded(true);
                 if (!disposed) {
                     props.onTermReady?.((text: string) => {
                         // Leading \r\n forces this line to start fresh regardless of
@@ -244,7 +340,14 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                 // was an unhandled promise rejection and the drawer silently
                 // never rendered a terminal — no user-facing error at all.
                 console.error("AgentShellSubblock: failed to start shell:", e);
-                if (!disposed) setError(e instanceof Error ? e.message : String(e));
+                if (!disposed) {
+                    setError(e instanceof Error ? e.message : String(e));
+                    // Clear the loading overlay even on failure — otherwise a
+                    // rejection before setZoomSeeded(true) (e.g. resync/create
+                    // both failing) leaves the BrainSpinner overlay covering
+                    // the error message forever.
+                    setZoomSeeded(true);
+                }
             }
         })();
     });
@@ -259,6 +362,11 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
     return (
         <div class="agent-shell-subblock" ref={containerRef}>
             {error() && <div class="agent-shell-subblock-error">Shell failed to start: {error()}</div>}
+            <Show when={spinnerMounted()}>
+                <div class="agent-shell-loading-overlay" classList={{ "is-fading": spinnerFading() }}>
+                    <BrainSpinner />
+                </div>
+            </Show>
         </div>
     );
 };

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -562,3 +562,22 @@
     font-size: 11px;
     font-family: var(--termfontfamily, monospace);
 }
+
+// Loading-brain overlay covering the shell drawer from mount until the
+// persisted term:zoom is seeded and the terminal is constructed with its
+// final font size — see docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md.
+// Same shape as browser-view.scss's .browser-loading-overlay (no
+// data-pane-overlay tag here: unlike the browser pane, this drawer's content
+// is a plain xterm.js canvas, not a native HWND layer needing a clip hole).
+.agent-shell-loading-overlay {
+    position: absolute;
+    inset: 0;
+    background-color: rgb(from var(--block-bg-color) r g b);
+    opacity: 1;
+
+    &.is-fading {
+        opacity: 0;
+        transition: opacity 200ms ease-out;
+        pointer-events: none;
+    }
+}


### PR DESCRIPTION
## Summary

Opening the Shell drawer inside an Agent pane shows a visible font-size jerk
right after it opens, sometimes at a very small zoom. Root-caused and fixed
per `docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md`.

**Root cause:** `AgentShellSubblock` constructed its xterm.js `Terminal` with
a font size read from an async, not-yet-loaded WaveObject meta atom — so it
always painted at `BASE_FONT_SIZE` (13) first, then snapped to the real
persisted zoom once the fetch resolved later (the jerk). A second bug in the
same correction effect — a non-reactive `termWrap.loaded` guard read inside
`createEffect` — could silently drop that correction forever if the fetch
landed in a narrow timing window, leaving the shell stuck at the wrong size
until manually re-zoomed. That explains reports of the bug feeling
"inconsistent" rather than reliably wrong in one direction.

The agent pane's own zoom had this exact race historically (`69de7d5e2` and
several prior iterations) and was fixed by seeding the value before block
creation. That pattern was never applied to the Shell drawer, added later as
an explicit "Phase 0 spike" (per its own header comment).

## Changes

- `AgentShellSubblock.tsx`: await `WOS.reloadWaveObject` for the sub-block's
  meta **before** constructing `TermWrap`, for the reused-existing-block
  path (a freshly created sub-block has no persisted zoom yet, so the
  already-correct default needs no fetch). Uses `reloadWaveObject`, not
  `loadAndPinWaveObject` — no `refCount` bump, so nothing to unpin on
  dispose (see the leak warning at `floating-pane-workspace.tsx:924-929`
  about that exact pitfall).
- Replaced the non-reactive `termWrap.loaded` guard with a real `wrapLoaded`
  signal, set once `TermWrap.init()` resolves, so a legitimate live
  correction (Ctrl+Wheel, or a future concurrent meta push) can never be
  silently dropped.
- Shows the existing `BrainSpinner` stand-in (same pattern already used by
  the agent pane's own blank-load case and the browser pane) while the seed
  fetch is in flight, instead of painting the wrong size at all. Cleared on
  error too, so a startup failure's message isn't hidden behind a
  permanently-visible spinner.
- `_composer-strip.scss`: `.agent-shell-loading-overlay`, matching
  `browser-view.scss`'s overlay shape (no `data-pane-overlay` tag — this
  drawer's content is a plain xterm.js canvas, not a native HWND layer
  needing a clip hole).

## Test plan

- [x] New `AgentShellSubblock.test.tsx` (4 tests) — mocks WOS/RpcApi/TermWrap
      at the module boundary, SUT is the real component. Pins: terminal is
      constructed with the persisted zoom already applied (not the
      default); a fresh sub-block still defaults correctly; the overlay
      shows/hides around the seed fetch; the overlay clears on error.
- [x] Verified against the pre-fix component (`git stash`) that 3 of 4 fail
      as expected — the 4th (fresh-block default) is correct either way,
      since a new sub-block never had a race to begin with.
- [x] `npx tsc --noEmit` clean
- [x] `npx stylelint` on the changed SCSS — no new findings (one pre-existing
      unrelated finding elsewhere in the file, confirmed via diff)
- [x] Full `frontend/app/view/agent/` suite (1106 tests) — all pass except
      one pre-existing, unrelated flaky timeout (`tool-renderers/registry.test.ts`,
      confirmed to pass cleanly in isolation both with and without this change)

<!-- agentmux:agent_id=agent3 -->