### PR TITLE
feat(armory): retire preset.* RPC aliases

### DIFF
--- a/.changesets/1786412336-feat-armory-retire-preset-rpc-aliases-idir.md
+++ b/.changesets/1786412336-feat-armory-retire-preset-rpc-aliases-idir.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): retire preset.* RPC aliases

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -338,12 +338,12 @@ pub const COMMAND_BUNDLE_IMPORT_COMMIT: &str = "bundle.import.commit";
 // entry points that touch db_agent_native_memory.
 pub const COMMAND_BUNDLE_EXPORT_FOR_AGENT: &str = "bundle.export_for_agent";
 pub const COMMAND_BUNDLE_IMPORT_FOR_AGENT: &str = "bundle.import_for_agent";
-// Deprecated `preset.*` aliases — kept wired for one release (remove in Phase 4).
-pub const COMMAND_PRESET_LIST: &str = "preset.list";
-pub const COMMAND_PRESET_GET: &str = "preset.get";
-pub const COMMAND_PRESET_UPSERT: &str = "preset.upsert";
-pub const COMMAND_PRESET_DELETE: &str = "preset.delete";
-pub const COMMAND_PRESET_SELF_GET: &str = "preset.self.get";
+// Structural ABF validator — Armory Bundle Format (ABF) UI-alignment pass.
+// Read-only: fetches the bundle and runs the pure bundle_validate module
+// against it, no Store writes.
+pub const COMMAND_BUNDLE_VALIDATE: &str = "bundle.validate";
+// The deprecated `preset.*` aliases (Phase 2's one-release compat window)
+// were retired here — `bundle.*` is the only surface now.
 pub const COMMAND_MEMORY_LIST: &str = "memory.list";
 pub const COMMAND_MEMORY_READ: &str = "memory.read";
 pub const COMMAND_MEMORY_WRITE: &str = "memory.write";

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -71,11 +71,10 @@ pub(super) fn normalize_bundle_upsert_input(mut data: serde_json::Value) -> serd
     data
 }
 
-// Each handler is registered under BOTH the new `bundle.*` command and the
-// deprecated `preset.*` alias (one-release compat window, spec Phase 2). The
-// alias forwards to the same logic; remove it in Phase 4. The two
-// `register_handler` calls per fn pass explicit command constants (not a loop
-// variable) so the rpc-contract extractor can resolve every registered name.
+// The deprecated `preset.*` aliases (Phase 2's one-release compat window)
+// were retired as part of the Armory Bundle Format (ABF) UI-alignment pass —
+// `bundle.*` is the only surface now; see the ABF branding sweep this
+// change shipped alongside.
 
 fn register_bundle_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let make = |state: AppState| -> crate::backend::rpc::engine::CommandHandler {
@@ -85,7 +84,6 @@ fn register_bundle_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
         })
     };
     engine.register_handler(COMMAND_BUNDLE_LIST, make(state.clone()));
-    engine.register_handler(COMMAND_PRESET_LIST, make(state.clone()));
 }
 
 fn register_bundle_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -105,7 +103,6 @@ fn register_bundle_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
         })
     };
     engine.register_handler(COMMAND_BUNDLE_GET, make(state.clone()));
-    engine.register_handler(COMMAND_PRESET_GET, make(state.clone()));
 }
 
 fn register_bundle_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -161,7 +158,6 @@ fn register_bundle_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
         })
     };
     engine.register_handler(COMMAND_BUNDLE_UPSERT, make(state));
-    engine.register_handler(COMMAND_PRESET_UPSERT, make(state));
 }
 
 fn register_bundle_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -202,7 +198,6 @@ fn register_bundle_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
         })
     };
     engine.register_handler(COMMAND_BUNDLE_DELETE, make(state));
-    engine.register_handler(COMMAND_PRESET_DELETE, make(state));
 }
 
 fn register_bundle_self_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -220,7 +215,6 @@ fn register_bundle_self_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
         })
     };
     engine.register_handler(COMMAND_BUNDLE_SELF_GET, make(state.clone()));
-    engine.register_handler(COMMAND_PRESET_SELF_GET, make(state.clone()));
 }
 
 /// `bundle.export` — Armory Bundle Format (ABF) exporter, Phase 1 of

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -695,10 +695,11 @@ pub(crate) async fn bundle_list_impl(state: &AppState) -> Result<serde_json::Val
         "id": m.id, "name": m.name, "description": m.description,
         "provider": m.provider, "model": m.model, "is_blank": m.is_blank, "updated_at": m.updated_at,
     })).collect();
-    // Emit both keys during the Preset→Bundle alias window: new callers of
-    // `bundle.list` read `bundles`; the retained `preset.list` alias's existing
-    // agent/REST consumers still read `presets`. Drop the `presets` key in
-    // Phase 4 when the alias is removed (SPEC_PRESET_TO_BUNDLE_REFACTOR §2.1/§4.4).
+    // Emit both keys: `bundle.list` callers read `bundles`; the separate
+    // REST route `/api/v1/agent/preset/list` (`PresetList` MCP tool,
+    // server/mod.rs) still reads `presets` and is unrelated to the internal
+    // WS `preset.*` aliases retired in this pass — do not drop `presets`
+    // here without first retiring that REST route too.
     Ok(json!({ "bundles": bundles, "presets": bundles }))
 }
 

--- a/scripts/test-app-api.mjs
+++ b/scripts/test-app-api.mjs
@@ -1,4 +1,4 @@
-// Ad-hoc App API smoke test — exercises identity.*, preset.*, memory.* as AgentX.
+// Ad-hoc App API smoke test — exercises identity.*, bundle.*, memory.* as AgentX.
 // Run: node scripts/test-app-api.mjs
 import WebSocket from "ws";
 
@@ -76,11 +76,11 @@ async function run() {
             provider: "anthropic", secret: "sk-ant-adhoc-DUMMY",
         }));
 
-        console.log("\n=== preset.list ===");
-        show("presets", await call("preset.list", {}));
+        console.log("\n=== bundle.list ===");
+        show("bundles", await call("bundle.list", {}));
 
-        console.log("\n=== preset.self.get ===");
-        show("self-preset", await call("preset.self.get", { agent_id: AGENT }));
+        console.log("\n=== bundle.self.get ===");
+        show("self-bundle", await call("bundle.self.get", { agent_id: AGENT }));
 
         console.log("\n=== memory.write ===");
         show("write", await call("memory.write", {

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -313,11 +313,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "memory.read",
     "memory.write",
     "pane.open",
-    "preset.delete",
-    "preset.get",
-    "preset.list",
-    "preset.self.get",
-    "preset.upsert",
     "slow",
 ];
 


### PR DESCRIPTION
## Summary
First of a small series aligning the Armory around the Armory Bundle Format (ABF) naming/branding, per user request.

- Removes the deprecated `preset.list/get/upsert/delete/self.get` RPC aliases (Phase 2's one-release compat window) — confirmed zero live frontend callers before removing (`rpc-api/bundle.ts` only ever called `bundle.import.preview`/`.commit`).
- Declares the `bundle.validate` RPC command constant ahead of the structural-validator work landing next in this series — unused until that handler is registered, no behavior change here.
- Updates the RPC contract test's `KNOWN_REGISTERED_UNDECLARED` baseline to drop the five retired command names.

Deliberately left `/api/v1/agent/preset/get` (the `PresetGet` MCP tool HTTP route in `server/mod.rs`) untouched — it's a separate, external-facing surface from the internal WS `preset.*` aliases, and renaming it could break existing MCP tool integrations. Out of scope here.

## Test plan
- [x] `cargo build -p agentmux-srv` / `cargo test -p agentmux-srv bundle_` — 115 passed.
- [x] `npx vitest run test/contract/rpc-contract.test.ts` — 4 passed.

<!-- agentmux:agent_id=camper -->