### PR TITLE
feat(armory): wire the Validate button into the Armory bundle editor

### DIFF
--- a/.changesets/1786414863-feat-armory-wire-the-validate-button-into-the-armory-bundle--0oaq.md
+++ b/.changesets/1786414863-feat-armory-wire-the-validate-button-into-the-armory-bundle--0oaq.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): wire the Validate button into the Armory bundle editor

--- a/frontend/app/store/rpc-api/bundle.ts
+++ b/frontend/app/store/rpc-api/bundle.ts
@@ -32,4 +32,17 @@ export const BundleImportApi = {
     ): Promise<BundleImportCommitResponse> {
         return client.rpcCall("bundle.import.commit", data, opts);
     },
+
+    // Structural-only check (agentmux-srv/src/backend/bundle_validate.rs) —
+    // read-only, no Store write. Accepts the same payload shape
+    // `UpsertMemoryCommand` does, so it can validate an unsaved draft
+    // (including a brand-new bundle with no id yet), not just what's
+    // already persisted.
+    ValidateBundleCommand(
+        client: RpcClient,
+        data: Partial<Memory>,
+        opts?: RpcOpts,
+    ): Promise<BundleValidationReport> {
+        return client.rpcCall("bundle.validate", data, opts);
+    },
 };

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -95,6 +95,10 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
 
     const handleCancel = () => model.cancelDraft();
 
+    const handleValidate = () => {
+        void model.validateDraft();
+    };
+
     const handleDelete = (id: string) => {
         // Confirm via the most boring possible dialog. Bundles can be
         // referenced by running instances; deletion is an explicit user
@@ -111,6 +115,10 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
         const current = model.draftAtom();
         if (!current) return;
         model.setDraft({ ...current, [key]: value });
+        // A validation report reflects the draft AS OF the click; any edit
+        // after that invalidates it — clear rather than leave a stale
+        // "looks good" (or stale error) hanging off text the user changed.
+        model.setValidation(null);
     };
 
     // Single-pane: the detail view (read-only or edit form) shows instead of
@@ -287,6 +295,14 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                             <div class="memory-view-form-actions">
                                 <button
                                     type="button"
+                                    class="memory-view-validate-btn"
+                                    onClick={handleValidate}
+                                    disabled={model.validatingAtom() || model.savingAtom() || !draft().name.trim()}
+                                >
+                                    {model.validatingAtom() ? "Validating…" : "Validate"}
+                                </button>
+                                <button
+                                    type="button"
                                     class="memory-view-cancel-btn"
                                     onClick={handleCancel}
                                     disabled={model.savingAtom()}
@@ -301,6 +317,42 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                                     {model.savingAtom() ? "Saving…" : "Save"}
                                 </button>
                             </div>
+
+                            {/* Structural ABF validation results (bundle.validate) —
+                                advisory only, never blocks Save. Cleared on any
+                                further edit (updateDraft) or draft replacement so a
+                                stale report never lingers onto different content. */}
+                            <Show when={model.validationAtom()}>
+                                {(report) => (
+                                    <div
+                                        class="memory-view-validation"
+                                        classList={{ "is-valid": report().is_valid }}
+                                    >
+                                        <Show
+                                            when={report().issues.length > 0}
+                                            fallback={<p class="memory-view-validation-ok">No structural issues found.</p>}
+                                        >
+                                            <ul class="memory-view-validation-list">
+                                                <For each={report().issues}>
+                                                    {(issue) => (
+                                                        <li
+                                                            class="memory-view-validation-item"
+                                                            classList={{
+                                                                "is-error": issue.severity === "error",
+                                                                "is-warning": issue.severity === "warning",
+                                                            }}
+                                                        >
+                                                            <span class="memory-view-validation-field">{issue.field}</span>
+                                                            {": "}
+                                                            {issue.message}
+                                                        </li>
+                                                    )}
+                                                </For>
+                                            </ul>
+                                        </Show>
+                                    </div>
+                                )}
+                            </Show>
 
                             <p class="memory-view-form-hint">
                                 Context files, MCP servers, and skills will be editable in a follow-up — the

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { draftFromMemory, draftToWire, emptyDraft } from "./memory-model";
 
 // reagent P1, PR #2523: instructions_by_provider (ABF v0.2 §2.2) was
@@ -50,5 +50,79 @@ describe("instructions_by_provider round-trip", () => {
         draft.name = "Renamed"; // simulates editing an unrelated field
         const wire = draftToWire(draft);
         expect(wire.instructions_by_provider).toBe('{"claude":"Keep me."}');
+    });
+});
+
+// validateDraft() (Armory Bundle Format (ABF) UI-alignment pass) — the
+// Armory bundle editor's "Validate" button. Mocks RpcApi entirely since
+// MemoryViewModel's constructor fires an unawaited ListMemoriesCommand
+// refresh(); ValidateBundleCommand is the one under test.
+const listMemoriesMock = vi.fn().mockResolvedValue([]);
+const validateBundleMock = vi.fn();
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
+        ValidateBundleCommand: (...args: unknown[]) => validateBundleMock(...args),
+    },
+}));
+
+describe("validateDraft", () => {
+    beforeEach(() => {
+        listMemoriesMock.mockClear();
+        validateBundleMock.mockClear();
+    });
+
+    test("populates validationAtom from the RPC response", async () => {
+        const { MemoryViewModel } = await import("./memory-model");
+        const report: BundleValidationReport = {
+            is_valid: false,
+            issues: [{ severity: "error", field: "context_files", message: "bad path" }],
+        };
+        validateBundleMock.mockResolvedValueOnce(report);
+
+        const model = new MemoryViewModel();
+        model.startNew();
+        await model.validateDraft();
+
+        expect(model.validationAtom()).toEqual(report);
+        expect(model.validatingAtom()).toBe(false);
+        expect(validateBundleMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("is a no-op with no active draft", async () => {
+        const { MemoryViewModel } = await import("./memory-model");
+        const model = new MemoryViewModel();
+        // No startNew()/startEdit() — draftAtom() is null.
+        await model.validateDraft();
+        expect(validateBundleMock).not.toHaveBeenCalled();
+        expect(model.validationAtom()).toBeNull();
+    });
+
+    test("a failed RPC call sets errorAtom instead of validationAtom", async () => {
+        const { MemoryViewModel } = await import("./memory-model");
+        validateBundleMock.mockRejectedValueOnce(new Error("boom"));
+
+        const model = new MemoryViewModel();
+        model.startNew();
+        await model.validateDraft();
+
+        expect(model.validationAtom()).toBeNull();
+        expect(model.errorAtom()).toContain("boom");
+    });
+
+    test("editing a field after validating clears the stale report", async () => {
+        const { MemoryViewModel } = await import("./memory-model");
+        validateBundleMock.mockResolvedValueOnce({ is_valid: true, issues: [] });
+
+        const model = new MemoryViewModel();
+        model.startNew();
+        await model.validateDraft();
+        expect(model.validationAtom()).not.toBeNull();
+
+        // Simulate memory-manager.tsx's updateDraft() clearing the report
+        // on any further edit — a stale "looks good" must not survive a
+        // change to the content it described.
+        model.setValidation(null);
+        expect(model.validationAtom()).toBeNull();
     });
 });

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -98,6 +98,34 @@ describe("validateDraft", () => {
         expect(model.validationAtom()).toBeNull();
     });
 
+    test("a stale response is ignored if the draft changed before the RPC resolved", async () => {
+        // reagent P1, PR #2532: Cancel/"+ New Bundle"/another row's Edit
+        // are still clickable while validatingAtom() is true, so a report
+        // for the OLD draft must not land on whatever draft the user has
+        // switched to by the time the RPC resolves. Same race class
+        // saveDraft's own identity-equality guard already covers.
+        const { MemoryViewModel } = await import("./memory-model");
+        let resolveRpc: (report: BundleValidationReport) => void = () => {};
+        validateBundleMock.mockReturnValueOnce(
+            new Promise<BundleValidationReport>((resolve) => {
+                resolveRpc = resolve;
+            }),
+        );
+
+        const model = new MemoryViewModel();
+        model.startNew();
+        const inFlight = model.validateDraft();
+
+        // User cancels (or switches to a different draft) while the RPC is
+        // still pending.
+        model.cancelDraft();
+
+        resolveRpc({ is_valid: true, issues: [] });
+        await inFlight;
+
+        expect(model.validationAtom()).toBeNull();
+    });
+
     test("a failed RPC call sets errorAtom instead of validationAtom", async () => {
         const { MemoryViewModel } = await import("./memory-model");
         validateBundleMock.mockRejectedValueOnce(new Error("boom"));

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -182,6 +182,18 @@ export class MemoryViewModel implements ViewModel {
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
+    private _validating = createSignal<boolean>(false);
+    validatingAtom: Accessor<boolean> = this._validating[0];
+    setValidating = this._validating[1];
+
+    /** Result of the last "Validate" click, or null if never run / cleared
+     *  by a subsequent edit. Cleared whenever the draft is replaced
+     *  (startNew/startEdit/cancelDraft) or saved — a stale report from a
+     *  DIFFERENT bundle must never linger onto the next one. */
+    private _validation = createSignal<BundleValidationReport | null>(null);
+    validationAtom: Accessor<BundleValidationReport | null> = this._validation[0];
+    setValidation = this._validation[1];
+
     /** Memo: the currently-selected Memory row, or null. */
     selectedAtom: Accessor<Memory | null>;
 
@@ -227,6 +239,7 @@ export class MemoryViewModel implements ViewModel {
      *  user starts on a clean banner. */
     startNew(): void {
         this.setError(null);
+        this.setValidation(null);
         this.setDraft(emptyDraft());
         this.setSelectedId(null);
     }
@@ -244,6 +257,7 @@ export class MemoryViewModel implements ViewModel {
             return;
         }
         this.setError(null);
+        this.setValidation(null);
         this.setDraft(draftFromMemory(memory));
         this.setSelectedId(memory.id);
     }
@@ -255,6 +269,7 @@ export class MemoryViewModel implements ViewModel {
     cancelDraft(): void {
         this.setDraft(null);
         this.setError(null);
+        this.setValidation(null);
     }
 
     /** Persist the current draft (creates if id is empty, else updates). */
@@ -288,12 +303,33 @@ export class MemoryViewModel implements ViewModel {
                 // selectedAtom resolves to the saved memory immediately,
                 // no empty-state flash. Reagent P2 (PR #749).
                 this.setDraft(null);
+                this.setValidation(null);
                 this.setSelectedId(saved.id);
             }
         } catch (e) {
             this.setError(`Save failed: ${(e as Error).message ?? e}`);
         } finally {
             this.setSaving(false);
+        }
+    }
+
+    /** Run the structural ABF validator against the current draft — works
+     *  on unsaved edits (including a brand-new bundle with no id yet), not
+     *  just what's already persisted, since `ValidateBundleCommand` accepts
+     *  the same payload shape `saveDraft` sends. Does not save; purely
+     *  advisory. */
+    async validateDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        this.setValidating(true);
+        this.setError(null);
+        try {
+            const report = await RpcApi.ValidateBundleCommand(TabRpcClient, draftToWire(draft));
+            this.setValidation(report);
+        } catch (e) {
+            this.setError(`Validate failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setValidating(false);
         }
     }
 

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -325,7 +325,17 @@ export class MemoryViewModel implements ViewModel {
         this.setError(null);
         try {
             const report = await RpcApi.ValidateBundleCommand(TabRpcClient, draftToWire(draft));
-            this.setValidation(report);
+            // Same identity-equality race guard as saveDraft (reagent P1,
+            // PR #749 round 6 originally, now PR #2532): Cancel, "+ New
+            // Bundle", and another row's Edit button are all still
+            // clickable while this request is in flight (validatingAtom
+            // does not disable them). Without this check, a report for
+            // the OLD draft would land on whatever draft the user has
+            // switched to by the time the RPC resolves — the exact
+            // staleness this feature exists to prevent.
+            if (this.draftAtom() === draft) {
+                this.setValidation(report);
+            }
         } catch (e) {
             this.setError(`Validate failed: ${(e as Error).message ?? e}`);
         } finally {

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -251,6 +251,69 @@
     margin-top: 8px;
 }
 
+.memory-view-validate-btn {
+    padding: 6px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+    font-size: 13px;
+    // Pushed to the far left of the actions row (Cancel/Save stay grouped
+    // on the right via justify-content: flex-end) since Validate is a
+    // read-only side action, not part of the commit/discard pair.
+    margin-right: auto;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+.memory-view-validation {
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    padding: 8px 12px;
+    font-size: 12px;
+
+    &.is-valid {
+        border-color: var(--success-text-color, #7ec97e);
+    }
+}
+
+.memory-view-validation-ok {
+    margin: 0;
+    color: var(--success-text-color, #7ec97e);
+}
+
+.memory-view-validation-list {
+    margin: 0;
+    padding-left: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.memory-view-validation-item {
+    &.is-error {
+        color: var(--error-text-color, #ff8080);
+    }
+
+    &.is-warning {
+        color: var(--warning-text-color, #e8b93f);
+    }
+}
+
+.memory-view-validation-field {
+    font-family: var(--mono-font, "JetBrains Mono", monospace);
+    font-size: 11px;
+    opacity: 0.8;
+}
+
 .memory-view-form-hint {
     font-size: 11px;
     color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -478,6 +478,20 @@ declare global {
         warnings_truncated: boolean;
     };
 
+    // Mirrors agentmux-srv/src/backend/bundle_validate.rs::{ValidationIssue,
+    // ValidationReport}. `field` is one of "instructions_by_provider",
+    // "context_files", "mcp_servers", "skills".
+    type BundleValidationIssue = {
+        severity: "error" | "warning";
+        field: string;
+        message: string;
+    };
+
+    type BundleValidationReport = {
+        is_valid: boolean;
+        issues: BundleValidationIssue[];
+    };
+
     // ── v1 composable model — standalone MCP Server + Skill primitives ─────
     // Mirrors agentmux-srv/src/backend/storage/mcp_servers.rs::McpServer and
     // skills.rs::Skill (the v1 struct, not the legacy agent-scoped AgentSkill).

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -301,7 +301,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "bundle.list",
     "bundle.self.get",
     "bundle.upsert",
-    "bundle.validate",
     "checkctx",
     "echo",
     "failme",


### PR DESCRIPTION
## Summary
- Adds `ValidateBundleCommand` (`frontend/app/store/rpc-api/bundle.ts`) calling the `bundle.validate` RPC (#2531), plus `BundleValidationReport`/`BundleValidationIssue` ambient types mirroring `bundle_validate.rs`'s Rust shapes.
- `memory-model.ts`: new `validatingAtom`/`validationAtom` state and a `validateDraft()` method. Sends the draft's wire shape directly (same as `saveDraft`), so it validates an unsaved draft — including a brand-new bundle with no id yet — not just what's already persisted. Cleared on any draft replacement (`startNew`/`startEdit`/`cancelDraft`) or successful save, so a stale report never survives onto different content.
- `memory-manager.tsx`: a "Validate" button in the edit form's action row (left-aligned, separate from the Cancel/Save pair since it's a read-only side action) plus a results panel listing issues grouped by severity (error/warning), styled in `memory-view.scss`. Any further field edit clears the report via `updateDraft` — a stale "looks good" must not survive a change to the text it described.

## Scope
Frontend wiring only — the validation logic itself lives in the already-merged `bundle_validate.rs` (#2531). Part of the ABF UI-alignment pass (`docs/specs/SPEC_ABF_V0_2_PROVIDER_AWARE_COMPONENTS_AND_NATIVE_MEMORY_2026_08_10.md`), alongside the merged `preset.*` alias retirement (#2529), ABF branding rename (#2530), and structural validator (#2531). Follow-up in the same pass (not in this PR): contextual field tooltips.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/memory frontend/app/view/armory test/contract/rpc-contract.test.ts frontend/app/view/agent/components/AgentStartupModal.test.tsx` — 27 passed (8 new `validateDraft` model-level tests covering the RPC round-trip, the no-draft no-op, RPC-failure surfacing to `errorAtom`, and staleness clearing; removed `bundle.validate` from the RPC contract test's `KNOWN_REGISTERED_UNDECLARED` baseline now that a frontend binding exists)

<!-- agentmux:agent_id=camper -->