### PR TITLE
chore: release v0.55.5

### DIFF
--- a/.changesets/1786406354-fix-agent-seed-shell-drawer-s-term-zoom-before-construct-eli-p99p.md
+++ b/.changesets/1786406354-fix-agent-seed-shell-drawer-s-term-zoom-before-construct-eli-p99p.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): seed shell drawer's term:zoom before construct, eliminate open jerk

--- a/.changesets/1786406857-fix-menu-submenu-positioning-flash-safe-triangle-hover-close-ncuy.md
+++ b/.changesets/1786406857-fix-menu-submenu-positioning-flash-safe-triangle-hover-close-ncuy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(menu): submenu positioning flash + safe-triangle hover close timing

--- a/.changesets/1786408777-feat-armory-agent-scoped-bundle-export-import-carrying-nativ-v63e.md
+++ b/.changesets/1786408777-feat-armory-agent-scoped-bundle-export-import-carrying-nativ-v63e.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): agent-scoped bundle export/import carrying native memory

--- a/.changesets/1786412336-feat-armory-retire-preset-rpc-aliases-idir.md
+++ b/.changesets/1786412336-feat-armory-retire-preset-rpc-aliases-idir.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): retire preset.* RPC aliases

--- a/.changesets/1786413296-feat-armory-rebrand-bundles-preset-wording-to-armory-bundle--62x2.md
+++ b/.changesets/1786413296-feat-armory-rebrand-bundles-preset-wording-to-armory-bundle--62x2.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): rebrand Bundles/Preset wording to Armory Bundle Format (ABF)

--- a/.changesets/1786414166-feat-armory-add-structural-abf-bundle-validator-bundle-valid-vh7e.md
+++ b/.changesets/1786414166-feat-armory-add-structural-abf-bundle-validator-bundle-valid-vh7e.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): add structural ABF bundle validator + bundle.validate RPC

--- a/.changesets/1786414863-feat-armory-wire-the-validate-button-into-the-armory-bundle--0oaq.md
+++ b/.changesets/1786414863-feat-armory-wire-the-validate-button-into-the-armory-bundle--0oaq.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): wire the Validate button into the Armory bundle editor

--- a/.changesets/1786415229-feat-armory-add-contextual-abf-tooltips-to-the-bundle-editor-m1wf.md
+++ b/.changesets/1786415229-feat-armory-add-contextual-abf-tooltips-to-the-bundle-editor-m1wf.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): add contextual ABF tooltips to the bundle editor fields

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.4"
+version = "0.55.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.4"
+version = "0.55.5"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.4"
+version = "0.55.5"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.4"
+version = "0.55.5"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.4"
+version = "0.55.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.4"
+version = "0.55.5"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.4"
+version = "0.55.5"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,17 @@
 # AgentMux Version History
 
+## 0.55.5 — 2026-08-11
+
+- fix(agent): seed shell drawer's term:zoom before construct, eliminate open jerk
+- fix(menu): submenu positioning flash + safe-triangle hover close timing
+- feat(armory): agent-scoped bundle export/import carrying native memory
+- feat(armory): retire preset.* RPC aliases
+- feat(armory): rebrand Bundles/Preset wording to Armory Bundle Format (ABF)
+- feat(armory): add structural ABF bundle validator + bundle.validate RPC
+- feat(armory): wire the Validate button into the Armory bundle editor
+- feat(armory): add contextual ABF tooltips to the bundle editor fields
+
+
 ## 0.55.4 — 2026-08-10
 
 - feat(agent-pane): AskUserQuestion countdown hides on hover, resumes after 15s

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.4",
+  "version": "0.55.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.4",
+      "version": "0.55.5",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.4",
+  "version": "0.55.5",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR consuming all 8 pending changesets, forced to a **patch** bump (`--as patch`) per explicit request even though most changesets were queued as `minor` — 0.55.4 → 0.55.5.

## Changes shipping
- fix(agent): seed shell drawer's term:zoom before construct, eliminate open jerk
- fix(menu): submenu positioning flash + safe-triangle hover close timing
- feat(armory): agent-scoped bundle export/import carrying native memory
- feat(armory): retire preset.* RPC aliases
- feat(armory): rebrand Bundles/Preset wording to Armory Bundle Format (ABF)
- feat(armory): add structural ABF bundle validator + bundle.validate RPC
- feat(armory): wire the Validate button into the Armory bundle editor
- feat(armory): add contextual ABF tooltips to the bundle editor fields

## Verification
- [x] `task release -- --as patch` — all 5 version-location invariant checks agree at 0.55.5 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md)
- [x] All 8 changesets consumed and deleted

<!-- agentmux:agent_id=camper -->