### PR TITLE
fix(agent): failed tool calls hold open; stop mass-collapsing on hidden pane

### DIFF
--- a/.changesets/1786450498-fix-agent-failed-tool-calls-hold-open-stop-mass-collapsing-o-klhb.md
+++ b/.changesets/1786450498-fix-agent-failed-tool-calls-hold-open-stop-mass-collapsing-o-klhb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): failed tool calls hold open; stop mass-collapsing on hidden pane

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -86,6 +86,35 @@ describe("ToolBlock — panel mode", () => {
         expect(panel!.classList.contains("agent-tool-panel--hidden")).toBe(false);
     });
 
+    it("heldOpen + failed → panel is in-flow, same as a held-open success", () => {
+        // A `failed` tool is an agent-caused error, not a user dismissal — it
+        // should hold open exactly like `success` until scrolled off, per
+        // ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md's own
+        // recommendation. Previously this rendered `--hidden` immediately.
+        const failed: ToolNode = { ...baseTool, status: "failed" };
+        const { container } = render(() => (
+            <ToolBlock node={failed} pinned={false} heldOpen={true} onTogglePin={() => {}} />
+        ));
+        const panel = container.querySelector(".agent-tool-panel");
+        expect(panel).not.toBeNull();
+        expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(true);
+        expect(panel!.classList.contains("agent-tool-panel--hidden")).toBe(false);
+    });
+
+    it.each(["denied", "canceled"] as const)(
+        "heldOpen + %s → panel stays hidden (user-dismissed, collapses immediately)",
+        (status) => {
+            const node: ToolNode = { ...baseTool, status };
+            const { container } = render(() => (
+                <ToolBlock node={node} pinned={false} heldOpen={true} onTogglePin={() => {}} />
+            ));
+            const panel = container.querySelector(".agent-tool-panel");
+            expect(panel).not.toBeNull();
+            expect(panel!.classList.contains("agent-tool-panel--hidden")).toBe(true);
+            expect(panel!.classList.contains("agent-tool-panel--flow")).toBe(false);
+        },
+    );
+
     it("calls onHoldOpen once when a running tool completes (active→inactive)", () => {
         const onHoldOpen = vi.fn();
         const [node, setNode] = createSignal<ToolNode>({ ...baseTool, status: "running" });

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -189,15 +189,20 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // Auto-expand while the tool is actively running (or awaiting approval), and
     // keep a completed tool expanded while it's held open (props.heldOpen — set
     // on completion, cleared when the row scrolls off the top). Pin still wins as
-    // an explicit override. Fail-terminal statuses (failed/denied/canceled) skip
-    // the heldOpen hold and collapse immediately; success holds normally.
+    // an explicit override. `denied`/`canceled` are user-dismissed terminations
+    // (the user already acted on them) and skip the heldOpen hold, collapsing
+    // immediately. `failed` is an agent-caused error, not a dismissal — it holds
+    // open exactly like `success` per the original design doc's own
+    // recommendation (ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md,
+    // "failed: same as success"); the earlier implementation had lumped it in
+    // with denied/canceled, diverging from that call.
     //
     // Per SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md §4.2 and
     // docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md — the 3 s
     // post-completion timer was replaced by scroll-position-driven collapse.
     const isFailTerminal = (): boolean => {
         const s = props.node.status;
-        return s === "failed" || s === "denied" || s === "canceled";
+        return s === "denied" || s === "canceled";
     };
     const autoExpanded = (): boolean => {
         const s = props.node.status;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.collapse.test.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.collapse.test.tsx
@@ -1,0 +1,141 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression coverage for the hidden-pane scroll-off-collapse bug: switching
+ * to another browser tab (inactive tab: `display:none`) or minimizing the
+ * window makes `getBoundingClientRect()` report an all-zero rect for every
+ * element — jsdom's own default `getBoundingClientRect()` already returns
+ * all-zero for everything, which is exactly the hidden-pane signature, so
+ * these tests exercise it directly without any extra stubbing. Before the
+ * fix, `collapseScrolledOffTools()` treated every held-open tool as
+ * "scrolled off" the instant it ran against a zero-size container, even
+ * though nothing had actually scrolled.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentDocumentVirtualList } from "./AgentDocumentVirtualList";
+import { createAgentViewState } from "./state";
+import type { DocumentNode, DocumentState, ToolNode } from "../types";
+
+afterEach(() => cleanup());
+
+// ── Fake ResizeObserver — AgentDocumentVirtualList registers two of these
+// on mount; jsdom has no real one. ─────────────────────────────────────
+class FakeResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+}
+
+// ── Fake requestAnimationFrame — scroll handling is rAF-coalesced
+// (scrollRafId), so a dispatched "scroll" event needs a manual flush to
+// actually reach handleScrollNow. ──────────────────────────────────────
+let rafQueue: FrameRequestCallback[] = [];
+function flushRaf(): void {
+    const pending = rafQueue;
+    rafQueue = [];
+    for (const cb of pending) cb(0);
+}
+
+function makeScrollable(el: HTMLElement, geo: { scrollTop: number; scrollHeight: number; clientHeight: number }): void {
+    let { scrollTop, scrollHeight, clientHeight } = geo;
+    Object.defineProperty(el, "scrollTop", {
+        configurable: true,
+        get: () => scrollTop,
+        set: (v: number) => { scrollTop = v; },
+    });
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(el, "clientHeight", { configurable: true, get: () => clientHeight });
+    el.scrollTo = (() => {}) as typeof el.scrollTo;
+}
+
+const toolNode: ToolNode = {
+    type: "tool",
+    id: "tc-1",
+    tool: "Bash",
+    params: { command: "ls" },
+    status: "success",
+    collapsed: true,
+    summary: "Bash ls",
+};
+
+const documentState = (expandedTools: Set<string>): DocumentState => ({
+    collapsedNodes: new Set(),
+    pinnedNodes: new Set(),
+    expandedTools,
+    scrollPosition: 0,
+    selectedNode: null,
+    filter: { showThinking: true } as DocumentState["filter"],
+});
+
+function setup(expandedTools: Set<string>) {
+    const documentAtom = createSignal<DocumentNode[]>([toolNode]);
+    const viewState = createAgentViewState(documentAtom);
+    const [docState] = createSignal(documentState(expandedTools));
+    const onReleaseToolOpen = vi.fn();
+
+    const utils = render(() => (
+        <AgentDocumentVirtualList
+            viewState={viewState}
+            documentState={docState}
+            onToggleCollapse={() => {}}
+            onTogglePin={() => {}}
+            onReleaseToolOpen={onReleaseToolOpen}
+        />
+    ));
+
+    const scrollRef = utils.container.querySelector(".agent-document") as HTMLElement;
+    makeScrollable(scrollRef, { scrollTop: 0, scrollHeight: 500, clientHeight: 200 });
+    return { scrollRef, onReleaseToolOpen };
+}
+
+describe("AgentDocumentVirtualList — hidden-pane scroll-off collapse guard", () => {
+    beforeEach(() => {
+        rafQueue = [];
+        vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+            rafQueue.push(cb);
+            return rafQueue.length;
+        });
+        vi.stubGlobal("cancelAnimationFrame", () => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("does NOT release a held-open tool when the container reports a zero-size rect (hidden pane)", () => {
+        const { scrollRef, onReleaseToolOpen } = setup(new Set(["tc-1"]));
+
+        // jsdom's default getBoundingClientRect() is already all-zero for
+        // every element — exactly the display:none / minimized-window
+        // signature — so no extra stubbing is needed to reproduce it.
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        expect(onReleaseToolOpen).not.toHaveBeenCalled();
+    });
+
+    it("still releases a held-open tool once it has genuinely scrolled off the top", () => {
+        const { scrollRef, onReleaseToolOpen } = setup(new Set(["tc-1"]));
+
+        // Give the container real, non-zero geometry...
+        scrollRef.getBoundingClientRect = () =>
+            ({ top: 0, bottom: 200, left: 0, right: 800, width: 800, height: 200, x: 0, y: 0, toJSON() {} }) as DOMRect;
+        // ...and the row a rect that has scrolled fully above the top
+        // (bottom <= containerTop).
+        const row = scrollRef.querySelector('[data-node-id="tc-1"]') as HTMLElement;
+        expect(row).not.toBeNull();
+        row.getBoundingClientRect = () =>
+            ({ top: -50, bottom: -10, left: 0, right: 800, width: 800, height: 40, x: 0, y: -50, toJSON() {} }) as DOMRect;
+
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        expect(onReleaseToolOpen).toHaveBeenCalledWith("tc-1");
+    });
+});

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -597,7 +597,17 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         if (!release || !scrollRef) return;
         const ds = props.documentState();
         if (ds.expandedTools.size === 0) return;
-        const containerTop = scrollRef.getBoundingClientRect().top;
+        const containerRect = scrollRef.getBoundingClientRect();
+        // A hidden pane (inactive tab: display:none, same "0×0" signature the
+        // ResizeObserver comment above already relies on) or a minimized window
+        // reports a zero-size rect for every element, not just this container's
+        // children — a real "scrolled off the top" collapse can never be
+        // determined when nothing has size, so skip the scan rather than
+        // mass-releasing every held-open tool the instant hidden-but-still-
+        // streaming content arrives (user-reported: tool blocks were
+        // collapsing on tab-switch/window-minimize with no actual scroll).
+        if (containerRect.width === 0 && containerRect.height === 0) return;
+        const containerTop = containerRect.top;
         for (const id of ds.expandedTools) {
             if (ds.pinnedNodes.has(id)) continue;
             const el = scrollRef.querySelector(


### PR DESCRIPTION
## Summary
Two bugs in the Agent pane's scroll-driven tool-call collapse behavior (`docs/analysis/ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`):

1. **Failed tool calls collapsed immediately** instead of holding open like a successful one. `ToolBlock.tsx`'s `isFailTerminal()` lumped `failed` in with `denied`/`canceled`, skipping the `heldOpen` hold. This contradicted the original design doc's own recommendation ("failed: same as success: stays open while visible, collapses on scroll-off") — the implementation had diverged from that call. Narrowed `isFailTerminal()` to only `denied`/`canceled` (genuine user-dismissals — the user already acted on those, nothing to hold open for); `failed` now falls through to the same `heldOpen` path `success` uses.

2. **Tool calls mass-collapsed when the pane's tab went inactive or the window was minimized**, staying collapsed on return even though nothing scrolled. Root cause: `AgentDocumentVirtualList.tsx`'s `collapseScrolledOffTools()` measures rows with `getBoundingClientRect()`, which returns an all-zero rect for every element once the container is `display:none` (inactive tab) or the window is minimized. The off-screen test (`el.bottom <= containerTop`) read `0 <= 0 → true` for every held-open tool in that state, so any streamed content arriving while hidden mass-released everything — a measurement artifact, not an intentional visibility hook (no `visibilitychange`/focus listener is involved anywhere in this path). Added an early-return guard: skip the scan when the container's rect is 0×0.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent/` — 87 files / 1117 tests passed, no regressions
- [x] 3 new `ToolBlock.test.tsx` cases: `failed` + `heldOpen` renders in-flow (was `--hidden` before the fix); `denied`/`canceled` + `heldOpen` still collapse immediately (regression guard against overcorrecting)
- [x] New `AgentDocumentVirtualList.collapse.test.tsx`: `collapseScrolledOffTools()` does not release a held-open tool when the container reports a 0×0 rect (jsdom's own default `getBoundingClientRect()` — same signature as a hidden pane); still releases normally once the rect is genuinely non-zero and the row has scrolled off
- [x] Both new test files confirmed **red-before / green-after**: reverted the fix locally, re-ran, watched the exact regression assertion fail, then restored the fix

<!-- agentmux:agent_id=camper -->