### PR TITLE
fix(agent): require true position 0/end before composer history recall, not just visual first/last line

### DIFF
--- a/.changesets/1786451028-fix-agent-require-true-position-0-end-before-composer-histor-msux.md
+++ b/.changesets/1786451028-fix-agent-require-true-position-0-end-before-composer-histor-msux.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): require true position 0/end before composer history recall, not just visual first/last line

--- a/docs/specs/SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md
+++ b/docs/specs/SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md
@@ -1,0 +1,237 @@
+# Composer: Shift+ArrowUp triggers history recall before the top line is fully selected
+
+**Date:** 2026-08-11
+**Status:** Implemented — `AgentFooter.tsx`. The implementation simplified
+further than §4 proposed: once the requirement is "true absolute position,"
+the mirror-div visual-row measurement becomes unnecessary entirely (position
+0 is always visual row 0 regardless of wrapping) — the whole `caretVisualEdge`
+function was replaced with a two-line pure position check,
+`caretAtSelectionEdge`, rather than layering a position check on top of the
+existing measurement. See the function's own doc comment for the reasoning.
+**Owner:** Agent3
+**Area:** Agent pane composer (`AgentFooter.tsx`) — sent-message history
+recall vs. text selection
+
+---
+
+## 1. Problem
+
+In the Agent pane composer, selecting multi-line text and repeatedly pressing
+Shift+ArrowUp to extend the selection upward behaves correctly line-by-line
+until it reaches the topmost line, where only part of that line ends up
+selected (expected — the browser lands the selection focus at whatever
+column the shift+up sequence started from, which may fall mid-way through a
+shorter top line). Pressing Shift+ArrowUp **again** at that point should
+extend the selection to cover the rest of the top line (snap to column 0),
+matching standard textarea behavior when there's no line above to move to.
+Instead, it immediately triggers **sent-message history recall** — the
+composer's content is replaced with the previously sent message, destroying
+the in-progress selection.
+
+**Desired behavior:** history recall should only trigger once the selection
+already covers the true start of the content (column 0 of line 0) — one
+keystroke later than it currently does.
+
+## 2. Current behavior (root cause)
+
+### 2.1 The handler
+
+`AgentFooter.tsx:860-895` — the combined ArrowUp/ArrowDown handler for
+queued-message un-queue + sent-message history recall:
+
+```js
+860  if (textareaRef && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+861      const empty = textareaRef.value.length === 0;
+862      const navigating = histPos < sentHistory.length;
+863      const { first: caretOnFirstLine, last: caretOnLastLine } = caretVisualEdge(textareaRef);
+...
+879      if (e.key === "ArrowUp" && histPos > 0 && caretOnFirstLine) {
+880          if (!navigating) histDraft = textareaRef.value;
+881          histPos--;
+882          e.preventDefault();
+883          setComposerValue(sentHistory[histPos]);
+884          return;
+885      }
+```
+
+`caretOnFirstLine` is the sole gate deciding "the user can't go up any
+further in the textarea, so treat this ArrowUp as history navigation
+instead." No `e.shiftKey` branch exists anywhere in this block (confirmed —
+`grep shiftKey AgentFooter.tsx` only matches Enter and Ctrl/Cmd+Z elsewhere
+in the file) — plain ArrowUp and Shift+ArrowUp share the exact same gate.
+
+### 2.2 `caretOnFirstLine` checks the wrong thing: line, not column
+
+`caretVisualEdge()` (`AgentFooter.tsx:376-409`):
+
+```js
+376  function caretVisualEdge(ta: HTMLTextAreaElement): { first: boolean; last: boolean } {
+377      const pos = ta.selectionStart;
+378      const val = ta.value;
+379      const needsFirst = !val.slice(0, pos).includes("\n");
+...
+404      const caretY = measureY(val.slice(0, pos));
+405      return {
+406          first: needsFirst && caretY <= measureY(""),   // matches baseline (first visual row)
+```
+
+This answers "is the active position on visual row 0" — it does **not**
+check "is the active position at absolute offset 0 (the true start of
+content)." The moment the selection's moving end lands *anywhere* on the top
+visual line — including mid-line, which per §1 is the normal, expected
+result of the shift+up sequence's own line-by-line extension — `first`
+already evaluates `true`. The very next ArrowUp then satisfies line 879's
+`caretOnFirstLine` and fires history recall a keystroke early, before the
+browser ever gets to extend the selection the rest of the way to column 0.
+
+This is a distinct bug from the one the 2026-06-23 retro
+(`docs/retro/RETRO_COMPOSER_ARROWKEY_HISTORY_SOFT_WRAP_2026_06_23.md`) fixed
+in this exact function: that retro corrected line-vs-line detection (soft-wrapped
+visual rows vs. physical `\n`), not line-vs-column. Its own "What Went Well"
+section notes "the existing guard structure... was correct in intent — the
+bug was only in the implementation of those booleans," which is why this
+deeper column-level gap was never surfaced at the time — that statement was
+true for the soft-wrap bug, but the boolean itself (`caretOnFirstLine`
+meaning "on line 0") is the wrong question for the selection-extension case;
+it needs to mean "at column 0 of line 0."
+
+### 2.3 A second, independent bug in the same line: `selectionDirection` is never checked
+
+`caretVisualEdge` always reads `ta.selectionStart` (line 377), regardless of
+`ta.selectionDirection`. `grep -r selectionDirection frontend/` returns no
+matches anywhere in the frontend — it's never referenced.
+
+For a selection where the **anchor is before the focus** (`selectionDirection
+=== "forward"` — e.g. the user shift-clicked or drag-selected downward from
+an earlier point, then switched to Shift+ArrowUp to extend further), the end
+that Shift+ArrowUp actually moves is `selectionEnd`, not `selectionStart`.
+`caretVisualEdge` would measure the **fixed anchor** (`selectionStart`)
+instead of the caret that's actually moving, making `caretOnFirstLine`
+answer a question about the wrong end of the selection entirely.
+
+The common repro path in §1 (extending a collapsed cursor upward via
+Shift+ArrowUp from the start) happens to work correctly *by accident*: a
+collapsed cursor has `selectionStart === selectionEnd`, so there's no
+anchor/focus ambiguity until the first Shift+ArrowUp actually creates a
+selection — and because that first extension is upward, the resulting
+selection's moving end (backward direction) does correspond to
+`selectionStart`. A selection that starts in the forward direction hits the
+second bug independently of the first.
+
+### 2.4 Non-shift ArrowUp shares the same over-eager gate
+
+Since there's no `e.shiftKey` branch, a plain (non-shift) ArrowUp landing
+mid-line on the top visual line *also* triggers history recall one keystroke
+early, before the browser's native "ArrowUp on the top line moves the caret
+to absolute position 0" behavior gets to run. This case doesn't have the
+selection-extension nuance (a collapsed cursor's `selectionStart ===
+selectionEnd` always), so the correct condition here is simpler: gate on
+`textareaRef.selectionStart === 0` directly, no visual-row measurement
+needed at all for this specific case.
+
+### 2.5 User-visible impact of firing early
+
+`setComposerValue()` (`AgentFooter.tsx:562-575`) fully replaces the textarea
+content and collapses the selection to the end
+(`textareaRef.setSelectionRange(text.length, text.length)`, line 571). So
+when history recall fires prematurely, the user doesn't just fail to extend
+their selection — their in-progress selection is destroyed outright and
+replaced with a different message's text, cursor at the end of it. This is
+what makes the bug disruptive rather than merely inconvenient.
+
+## 3. Goal & requirements
+
+1. **Shift+ArrowUp must fully select the top line before history recall can
+   trigger.** History recall should only fire on the ArrowUp press *after*
+   the selection's moving end is already at absolute offset 0.
+2. **Plain ArrowUp must reach true column 0 before history recall can
+   trigger**, not just "visual row 0" — same underlying fix, simpler
+   condition (no selection direction to resolve, per §2.4).
+3. **Correct for both selection directions.** A forward-direction selection
+   (anchor before focus) extended upward via Shift+ArrowUp must gate on
+   `selectionEnd`, not `selectionStart` — see §2.3.
+4. **No regression to the existing soft-wrap fix** (2026-06-23 retro) — the
+   mirror-div visual-row measurement for genuinely ambiguous soft-wrapped
+   text must still work; this fix adds a column check on top of it, not a
+   replacement for the visual-row logic itself where it's still needed.
+5. **ArrowDown/last-line symmetry**: `caretOnLastLine` (`AgentFooter.tsx:889`)
+   has the mirror-image version of this bug for Shift+ArrowDown extending a
+   selection toward the end of a multi-line composer, gated on `navigating`
+   rather than being able to spontaneously enter history mode — lower
+   severity (only reachable while already navigating history) but should be
+   fixed the same way for consistency, in the same change.
+
+## 4. Proposed fix
+
+### 4.1 Resolve the "moving end" once, correctly, for both keys
+
+Add a small helper (or inline at the call site) that resolves which offset
+is the one Shift+ArrowUp/Down actually moves, given `selectionDirection`:
+
+```js
+function activeSelectionEdge(ta: HTMLTextAreaElement): number {
+    // "backward": anchor is selectionEnd, focus (the moving end) is
+    // selectionStart. "forward" or "none" (collapsed, or same-direction
+    // ambiguous): focus is selectionEnd. A collapsed cursor has
+    // selectionStart === selectionEnd, so this is a no-op for the
+    // non-shift case either way.
+    return ta.selectionDirection === "backward" ? ta.selectionStart : ta.selectionEnd;
+}
+```
+
+### 4.2 Require true column 0, not just visual row 0
+
+`caretVisualEdge` (or its call site) needs the resolved edge from §4.1
+instead of the raw `ta.selectionStart` at line 377, AND needs an additional
+`=== 0` check layered on top of the existing visual-row check — the
+visual-row check alone (needed for soft-wrap correctness per the June retro)
+answers "is this row 0," not "is this absolute position 0":
+
+```js
+const edge = activeSelectionEdge(ta);
+const onFirstVisualRow = /* existing caretVisualEdge "first" logic, using `edge` instead of ta.selectionStart */;
+const first = onFirstVisualRow && edge === 0;
+```
+
+Symmetric change for `last`, using the requirement "at the true end of
+content" (`edge === val.length`) instead of just "last visual row," per
+requirement 5.
+
+### 4.3 Keep the non-shift case simple
+
+Per §2.4, non-shift ArrowUp doesn't need the visual-row measurement path at
+all for the *history-trigger decision* — `selectionStart === 0` (equivalently
+`activeSelectionEdge(ta) === 0` for a collapsed cursor, since anchor==focus)
+is sufficient and cheaper. Whether it's worth special-casing this to skip
+the mirror-div measurement, or just always going through the same
+`first`/`last` computation from §4.2 uniformly for both shift and non-shift
+(simpler code, negligible extra cost per the June retro's own note that the
+mirror-div path is "negligible... at human typing rates"), is an
+implementation choice — recommend the latter for less branching, unless
+profiling shows otherwise.
+
+## 5. Non-goals / out of scope
+
+- The queued-message un-queue gesture (`AgentFooter.tsx:866-873`, only
+  reachable on an empty composer) — unaffected, `empty` already implies
+  `selectionStart === selectionEnd === 0`.
+- Any change to the history state machine itself (`histPos`, `sentHistory`,
+  `histDraft`) — this is purely about when the existing transitions are
+  allowed to fire.
+- Migrating the composer off `<textarea>` to `contenteditable` — floated as
+  a "prefer contenteditable" best practice in the June retro for unrelated
+  reasons (rich editing features), not needed to fix this.
+
+## 6. Testing gap
+
+No existing test covers Shift+ArrowUp / selection-extension behavior —
+`AgentFooter.test.tsx` has no `shiftKey`-related ArrowUp/ArrowDown cases
+(confirmed via grep). The June 2026 retro's own best-practices list
+explicitly calls for testing `empty`, `single-line`, `multi-physical-line`,
+and `single-long-paragraph-that-soft-wraps` cases "at the time of initial
+implementation, not after a bug is reported" — this bug is a direct instance
+of that gap recurring for a case (selection extension) the original tests
+never covered either. The fix should add coverage for: collapsed-cursor
+Shift+ArrowUp reaching column 0 before recall fires; a forward-direction
+selection (§2.3) extended upward; plain ArrowUp on a mid-line top-row
+position; and the symmetric ArrowDown/last-line cases.

--- a/frontend/app/view/agent/components/AgentFooter.test.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.test.tsx
@@ -92,6 +92,157 @@ describe("AgentFooter Esc-clear Undo", () => {
     });
 });
 
+/**
+ * Regression tests for
+ * docs/specs/SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md.
+ *
+ * jsdom has no layout engine, so `offsetTop` (what the old mirror-div
+ * `caretVisualEdge` measured) always reads 0 regardless of actual cursor
+ * position — meaning the pre-fix code's "on visual row 0" check would have
+ * been unconditionally true for any position with no `\n` before it in this
+ * test environment, unable to meaningfully exercise the bug at all. The fix
+ * (require the true start/end of content via `selectionStart`/`selectionEnd`,
+ * no layout measurement) is fully testable here precisely because it no
+ * longer depends on layout.
+ */
+describe("AgentFooter composer history vs. selection (SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md)", () => {
+    async function sendMessages(ta: HTMLTextAreaElement, user: ReturnType<typeof userEvent.setup>, ...messages: string[]) {
+        for (const msg of messages) {
+            await user.type(ta, msg);
+            keyOn(ta, "Enter");
+        }
+    }
+
+    it("does not trigger history recall while a Shift+ArrowUp selection has only partially reached the top line", async () => {
+        const onSendMessage = vi.fn();
+        render(() => <AgentFooter agentName="Test" onSendMessage={onSendMessage} />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+        await sendMessages(ta, user, "first message", "second message");
+
+        const draft = "hello world\nsecond line";
+        await user.type(ta, draft);
+        expect(ta.value).toBe(draft);
+
+        // Selection extended backward (upward) from position 18 (on line 2)
+        // to position 5 (mid-way through "hello world" on line 1) — the
+        // normal, expected result of a Shift+ArrowUp sequence reaching the
+        // top line without yet covering it fully.
+        ta.setSelectionRange(5, 18, "backward");
+        keyOn(ta, "ArrowUp", { shiftKey: true });
+
+        // Bug: the old "on visual row 0" check would have fired history
+        // recall here, replacing the draft. Fixed: the active selection edge
+        // (selectionStart=5, backward direction) isn't at true position 0
+        // yet, so the draft and selection must be left alone.
+        expect(ta.value).toBe(draft);
+        expect(ta.selectionStart).toBe(5);
+        expect(ta.selectionEnd).toBe(18);
+    });
+
+    it("triggers history recall on Shift+ArrowUp once the selection reaches true position 0", async () => {
+        const onSendMessage = vi.fn();
+        render(() => <AgentFooter agentName="Test" onSendMessage={onSendMessage} />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+        await sendMessages(ta, user, "first message", "second message");
+
+        const draft = "hello world\nsecond line";
+        await user.type(ta, draft);
+
+        // Now the selection covers the ENTIRE top line (the state one more
+        // Shift+ArrowUp should have produced from the partial-selection case
+        // above).
+        ta.setSelectionRange(0, 18, "backward");
+        keyOn(ta, "ArrowUp", { shiftKey: true });
+
+        expect(ta.value).toBe("second message"); // most recently sent
+    });
+
+    it("does not trigger history recall on plain ArrowUp mid-line, only once the caret reaches true position 0", async () => {
+        const onSendMessage = vi.fn();
+        render(() => <AgentFooter agentName="Test" onSendMessage={onSendMessage} />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+        await sendMessages(ta, user, "only message");
+
+        const draft = "hello world";
+        await user.type(ta, draft);
+
+        ta.setSelectionRange(5, 5); // collapsed cursor mid-line, not at start
+        keyOn(ta, "ArrowUp");
+        expect(ta.value).toBe(draft); // untouched — jsdom doesn't move the caret itself
+
+        ta.setSelectionRange(0, 0); // now truly at the start
+        keyOn(ta, "ArrowUp");
+        expect(ta.value).toBe("only message");
+    });
+
+    it("uses the active (moving) selection edge, not always selectionStart, for a forward-direction selection", async () => {
+        // reagentx P2 on #2522's sibling finding, §2.3 of the spec: a
+        // forward-direction selection's moving end for Shift+ArrowUp is
+        // selectionEnd, not selectionStart. The old code always read
+        // selectionStart regardless of direction — here selectionStart is 0
+        // but the ACTUAL moving end (selectionEnd=5) is not, so history must
+        // NOT fire even though selectionStart alone would suggest it should.
+        const onSendMessage = vi.fn();
+        render(() => <AgentFooter agentName="Test" onSendMessage={onSendMessage} />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+        await sendMessages(ta, user, "only message");
+
+        const draft = "hello world";
+        await user.type(ta, draft);
+
+        ta.setSelectionRange(0, 5, "forward");
+        keyOn(ta, "ArrowUp", { shiftKey: true });
+
+        expect(ta.value).toBe(draft); // must not have been replaced
+    });
+
+    it("symmetric ArrowDown/last-line case: requires true end of content, not just the last visual line", async () => {
+        const onSendMessage = vi.fn();
+        render(() => <AgentFooter agentName="Test" onSendMessage={onSendMessage} />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+        await sendMessages(ta, user, "first message", "second message");
+
+        // Walk back to the oldest entry (two ArrowUps at true start). Note:
+        // editing the recalled text would reset histPos via handleInput
+        // (AgentFooter.tsx:580, exiting history mode on any edit) — this
+        // test stays purely within keyboard navigation to avoid that, since
+        // it's testing the ArrowDown boundary condition itself, not editing.
+        ta.setSelectionRange(0, 0);
+        keyOn(ta, "ArrowUp");
+        expect(ta.value).toBe("second message");
+        ta.setSelectionRange(0, 0);
+        keyOn(ta, "ArrowUp");
+        expect(ta.value).toBe("first message");
+
+        // Collapsed cursor mid-word, not yet at the true end of "first message".
+        ta.setSelectionRange(2, 2);
+        keyOn(ta, "ArrowDown", { shiftKey: true });
+        expect(ta.value).toBe("first message"); // untouched — not at true end yet
+
+        // Now truly at the end: advances forward to the next entry.
+        ta.setSelectionRange("first message".length, "first message".length);
+        keyOn(ta, "ArrowDown");
+        expect(ta.value).toBe("second message");
+
+        // Past the newest entry: falls back to the stashed live draft (empty,
+        // since the composer was empty before entering history mode here —
+        // stashed once, on the very first ArrowUp above).
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+        keyOn(ta, "ArrowDown");
+        expect(ta.value).toBe("");
+    });
+});
+
 // Minimal AgentViewModel double — only the fields AgentFooter actually reads:
 // blockId (voice-target wiring), blockAtom (ghost-text suggestion meta), and
 // voiceTargetRef (onMount registers a PaneVoiceHandle onto it unconditionally

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -360,52 +360,47 @@ interface AgentFooterProps {
 }
 
 /**
- * Returns whether the textarea caret is on the first and/or last *visual* line.
- *
- * `<textarea>` wraps text both at explicit `\n` characters and at soft-wrap
- * word-boundaries determined by CSS layout. The simple `includes("\n")` test
- * cannot detect soft-wrap line boundaries — a long single-paragraph message
- * with no `\n` can span many visual rows but always looks like "one line" to a
- * character scan. This function uses a mirror div that replicates the textarea's
- * CSS so the browser word-wraps identically, then reads the zero-width-space
- * marker's `offsetTop` to get the actual visual row Y.
- *
- * Fast-path: when a physical `\n` exists before (or after) the cursor, the
- * answer is known from character data alone — no DOM measurement needed.
+ * Resolves the offset of the selection's "moving" end — the one that
+ * ArrowUp/ArrowDown (with or without Shift) actually relocates. For a
+ * backward-direction selection (anchor after focus — e.g. a collapsed
+ * cursor extended upward via Shift+ArrowUp), that's `selectionStart`; for
+ * "forward" or "none" (anchor before/equal to focus — includes every
+ * collapsed-cursor case, where start===end so direction is moot), that's
+ * `selectionEnd`. Getting this wrong measures the *fixed* anchor instead of
+ * the caret that's actually moving for a forward-direction selection (e.g.
+ * shift-click below the original cursor, then Shift+ArrowUp to extend
+ * further) — see docs/specs/SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md §2.3.
  */
-function caretVisualEdge(ta: HTMLTextAreaElement): { first: boolean; last: boolean } {
-    const pos = ta.selectionStart;
-    const val = ta.value;
-    const needsFirst = !val.slice(0, pos).includes("\n");
-    const needsLast  = !val.slice(pos).includes("\n");
-    if (!needsFirst && !needsLast) return { first: false, last: false };
+function activeSelectionEdge(ta: HTMLTextAreaElement): number {
+    return ta.selectionDirection === "backward" ? ta.selectionStart : ta.selectionEnd;
+}
 
-    const cs = window.getComputedStyle(ta); // perf:allow-layout-read — mirror-div caret detection; runs only on ArrowUp/Down when no physical \n exists, not on every keystroke
-    const baseCss =
-        "position:absolute;visibility:hidden;overflow:hidden;top:-9999px;left:-9999px;" +
-        `width:${ta.clientWidth}px;white-space:pre-wrap;word-wrap:break-word;` + // perf:allow-layout-read — same as above; synchronous read required for mirror-div width match
-        `font:${cs.font};` +
-        `padding:${cs.paddingTop} ${cs.paddingRight} ${cs.paddingBottom} ${cs.paddingLeft};` +
-        `box-sizing:${cs.boxSizing};`;
-
-    const measureY = (text: string): number => {
-        const div = document.createElement("div");
-        div.style.cssText = baseCss;
-        div.textContent = text;
-        const span = document.createElement("span");
-        span.textContent = "​"; // zero-width space — marks the caret position
-        div.appendChild(span);
-        document.body.appendChild(div);
-        const y = span.offsetTop; // perf:allow-layout-read — reads detached mirror div; synchronous result needed to decide ArrowUp/Down behavior
-        document.body.removeChild(div);
-        return y;
-    };
-
-    const caretY = measureY(val.slice(0, pos));
-    return {
-        first: needsFirst && caretY <= measureY(""),   // matches baseline (first visual row)
-        last:  needsLast  && caretY >= measureY(val),  // matches Y at end of text
-    };
+/**
+ * Returns whether the textarea's active selection edge (see
+ * `activeSelectionEdge`) is at the true start/end of the content — i.e.
+ * ArrowUp/ArrowDown has nowhere left to move, so it's safe to intercept for
+ * history navigation instead.
+ *
+ * This used to be a "first/last *visual* line" check (a mirror-div
+ * measurement replicating the textarea's CSS to detect soft-wrapped row
+ * boundaries — see the 2026-06-23 retro,
+ * docs/retro/RETRO_COMPOSER_ARROWKEY_HISTORY_SOFT_WRAP_2026_06_23.md). That
+ * was solving a real problem (character-scanning `\n` alone can't detect
+ * soft-wrap boundaries) but in service of an insufficiently strict
+ * condition: being on visual row 0 doesn't mean there's nowhere left to
+ * move within the line (ArrowUp can still legitimately move the caret to
+ * column 0 of that same row) — only true absolute position 0 means that.
+ * Once the condition is tightened to require the true start/end of content,
+ * the visual-row measurement becomes unnecessary entirely: position 0 is
+ * always the very first character of the very first visual row regardless
+ * of wrapping, and a plain string-length comparison answers the question
+ * more simply, more cheaply (no DOM mutation per keystroke), and more
+ * correctly (also fixes the it-should-take-one-more-keystroke bug — see the
+ * spec cited above) than the mirror-div approach ever could.
+ */
+function caretAtSelectionEdge(ta: HTMLTextAreaElement): { first: boolean; last: boolean } {
+    const pos = activeSelectionEdge(ta);
+    return { first: pos === 0, last: pos === ta.value.length };
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -854,13 +849,16 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // ("send now") held message — the Claude-Code-CLI gesture (unsent, so a
         // true un-send). When nothing is queued, ArrowUp walks back through
         // previously SENT messages (shell-style history) and ArrowDown walks
-        // forward toward the live draft. The caret-on-first/last-line guards let
-        // multiline editing of a recalled message still move line-by-line, and
-        // only cross into history at the top/bottom edge.
+        // forward toward the live draft. The caret-at-start/end guards let
+        // multiline editing of a recalled message (or extending/shrinking a
+        // selection with Shift held) still move within the text normally, and
+        // only cross into history once there's truly nowhere left to move —
+        // i.e. the active selection edge is already at absolute position 0 (or
+        // the end of the content), not merely "on the first/last visual line."
         if (textareaRef && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
             const empty = textareaRef.value.length === 0;
             const navigating = histPos < sentHistory.length;
-            const { first: caretOnFirstLine, last: caretOnLastLine } = caretVisualEdge(textareaRef);
+            const { first: caretAtStart, last: caretAtEnd } = caretAtSelectionEdge(textareaRef);
 
             // Empty composer: ArrowUp un-queues a held message before history.
             if (e.key === "ArrowUp" && empty) {
@@ -872,11 +870,13 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 }
             }
 
-            // Older: whenever the caret is on the first line (so we don't fight
-            // multiline cursor movement). Covers an empty composer, a partially
-            // typed draft (stashed into histDraft, restorable with ArrowDown),
-            // and continuing further back while already navigating.
-            if (e.key === "ArrowUp" && histPos > 0 && caretOnFirstLine) {
+            // Older: whenever the active selection edge is at true position 0
+            // (so we don't fight multiline cursor movement OR an in-progress
+            // Shift+ArrowUp selection that hasn't reached the start yet).
+            // Covers an empty composer, a partially typed draft (stashed into
+            // histDraft, restorable with ArrowDown), and continuing further
+            // back while already navigating.
+            if (e.key === "ArrowUp" && histPos > 0 && caretAtStart) {
                 if (!navigating) histDraft = textareaRef.value; // stash the live draft
                 histPos--;
                 e.preventDefault();
@@ -884,9 +884,9 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 return;
             }
 
-            // Newer: only while navigating, caret on the last line. Past the
-            // newest entry, restore the stashed draft.
-            if (e.key === "ArrowDown" && navigating && caretOnLastLine) {
+            // Newer: only while navigating, active selection edge at the true
+            // end of content. Past the newest entry, restore the stashed draft.
+            if (e.key === "ArrowDown" && navigating && caretAtEnd) {
                 histPos++;
                 e.preventDefault();
                 setComposerValue(histPos >= sentHistory.length ? histDraft : sentHistory[histPos]);


### PR DESCRIPTION
## Summary

Shift+ArrowUp extending a selection line-by-line up to the top of the
composer, then pressing Shift+ArrowUp again to cover the rest of a
partially-selected top line, instead triggered sent-message history recall
one keystroke early — wiping the in-progress selection and replacing the
composer with a previous message. Same for plain ArrowUp mid-line on the top
row. Root-caused and fixed per
`docs/specs/SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md`.

**Root cause:** the gate deciding "nothing left to move to, safe to
intercept for history nav" answered "is the caret on visual row 0," not "is
the caret at absolute position 0." Reaching row 0 mid-line — the normal,
expected state partway through a Shift+ArrowUp selection sequence — already
satisfied it.

**Also found and fixed, same code:** `selectionDirection` was never checked
anywhere in the frontend, so for a forward-direction selection (anchor
before focus — e.g. shift-click below the cursor, then Shift+ArrowUp), the
code measured the fixed anchor (`selectionStart`) instead of the caret
that's actually moving (`selectionEnd`). The common repro (extending a
collapsed cursor upward) avoided this by luck, since that specific case
always ends up backward-directed.

## Changes

- `activeSelectionEdge()`: resolves the correct moving selection end from
  `selectionDirection`.
- `caretAtSelectionEdge()`: requires that edge to equal the true start/end
  of content — replaces the entire prior `caretVisualEdge()` mirror-div
  visual-row measurement (added by the 2026-06-23 retro for soft-wrap
  correctness). Turns out unnecessary once the requirement is tightened:
  true absolute position 0 is always visual row 0 regardless of wrapping,
  so a plain string-length comparison answers the question — simpler,
  cheaper (no per-keystroke DOM mutation), and correctly strict in a way
  "on row 0" alone never was once a selection is involved.
- Renamed `caretOnFirstLine`/`caretOnLastLine` → `caretAtStart`/`caretAtEnd`
  at the call site to match the corrected semantics.
- Symmetric fix applied to the ArrowDown/last-line case.

## Test plan

- [x] 5 new tests in `AgentFooter.test.tsx` covering: partial top-line
      selection doesn't fire early; full top-line selection does fire;
      plain ArrowUp mid-line doesn't fire early; forward-direction
      selection uses the correct (moving) edge; symmetric ArrowDown/last-line
      case.
- [x] Verified via `git stash` that 4 of the 5 new tests fail against the
      pre-fix code (the 5th, the already-working positive case, correctly
      passes either way).
- [x] Full `frontend/app/view/agent/` suite (1117 tests, 86 files) passes.
- [x] `npx tsc --noEmit` clean.
- [x] `npx stylelint` — no changes to SCSS in this PR.

<!-- agentmux:agent_id=agent3 -->