### PR TITLE
fix(dev): stop go-task from shadowing task dev TITLE=... overrides

### DIFF
--- a/.changesets/1786456804-fix-dev-stop-go-task-from-shadowing-task-dev-title-overrides-cb1t.md
+++ b/.changesets/1786456804-fix-dev-stop-go-task-from-shadowing-task-dev-title-overrides-cb1t.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dev): stop go-task from shadowing task dev TITLE=... overrides

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,8 +54,15 @@ tasks:
 
     dev:
         desc: 'Run AgentMux in development mode (Vite hot reload). Optional: task dev TITLE="agentx: PR #1780" sets the OS window title so you can tell parallel dev sessions apart.'
-        vars:
-            TITLE: ''
+        # Deliberately NOT declaring `vars: TITLE: ''` here — go-task 3.48.0
+        # shadows a CLI-supplied `task dev TITLE=...` override with a task's
+        # own `vars:` default for that same name (confirmed via isolated
+        # repro; a declared default always wins over the CLI value, silently
+        # discarding it), leaving {{.TITLE}} empty regardless of what was
+        # passed. Omitting the declaration lets the CLI value flow through
+        # normally (still renders empty when nothing is passed — Go
+        # templates render an unset var as ""). See
+        # docs/retro/retro-task-dev-title-var-shadowing-2026-08-11.md.
         cmds:
             - task: dev:serve
               vars:
@@ -829,8 +836,10 @@ tasks:
     dev:serve:
         internal: true
         desc: Start Vite dev server and the app concurrently, via the launcher (launcher → srv + host on all platforms; Windows uses the runtime/ layout, macOS/Linux a flat layout).
-        vars:
-            TITLE: ''
+        # No `vars: TITLE: ''` here either — see the `dev` task's comment
+        # above (same go-task CLI/caller-var shadowing gotcha applies to a
+        # parent task's `task: dev:serve / vars: TITLE: ...` call just as
+        # much as to a CLI-supplied var).
         env:
             VITE_DEV_TITLE: '{{.TITLE}}'
         cmds:

--- a/docs/retro/retro-task-dev-title-var-shadowing-2026-08-11.md
+++ b/docs/retro/retro-task-dev-title-var-shadowing-2026-08-11.md
@@ -1,0 +1,104 @@
+# Retro: `task dev TITLE=...` silently ignored (go-task var-shadowing)
+
+**Date:** 2026-08-11
+**Owner:** Agent3
+**Area:** `Taskfile.yml` (`dev`, `dev:serve` tasks) / dev window titling
+
+---
+
+## 1. Symptom
+
+Asked to set a `task dev` window's OS title to the agent's own name via
+`scripts\dev-agent.cmd TITLE="Agent3"` (per this repo's documented pattern for
+telling parallel dev sessions apart). The resulting window instead showed the
+generic positional fallback, `Window 1 - tab1 - AgentMux`, indistinguishable
+from another agent's simultaneously-running dev instance — which is what
+triggered the user's initial "your instance isn't running" read: two windows
+with the same generic title look like one window, not two.
+
+## 2. Root cause
+
+`Taskfile.yml`'s `dev` and `dev:serve` tasks each declared:
+
+```yaml
+vars:
+    TITLE: ''
+```
+
+In go-task 3.48.0, a task's own `vars:` block is not a *default* in the usual
+sense (only-fill-if-unset) — it **unconditionally overwrites** any value
+supplied by the caller for that same variable name, whether the caller is a
+CLI invocation (`task dev TITLE=Agent3`) or a parent task's own `vars:` pass-through
+(`task: dev:serve` with `vars: TITLE: '{{.TITLE}}'`). Confirmed via a
+from-scratch isolated repro (`/tmp/tasktest/Taskfile.yml`, deleted after
+confirming) with both quoted and unquoted CLI values — identical result
+either way, so quoting was never the variable at play.
+
+This meant `{{.TITLE}}` inside `dev:serve` always rendered `''` regardless of
+what was passed at any call site, so `VITE_DEV_TITLE` was always baked in
+empty. `frontend/app-init.ts:400-408` reads `import.meta.env.VITE_DEV_TITLE`
+at startup and calls `ObjectService.UpdateObjectMeta` with it — with an empty
+string, the window's `window:displayname` meta is never set, so
+`resolveWindowName()` (`frontend/util/window-title.ts`) falls through to its
+third tier, `Window ${index + 1}`.
+
+Confirmed live (not just by code reading) via CDP against the actual running
+dev instance: `import.meta.env` showed `DEV: true` but `VITE_DEV_TITLE: ""`,
+matching the theory exactly before any fix was applied.
+
+## 3. Fix
+
+Removed the `vars: TITLE: ''` declaration from both `dev` and `dev:serve`.
+Go templates render an unset variable as `""` by default, so the "no TITLE
+passed" case behaves identically to before; the only change is that a
+CLI-supplied or parent-task-supplied value is no longer shadowed. Verified
+against an isolated repro Taskfile matching `dev:serve`'s exact `env:`-block
+structure for both the empty-TITLE and `TITLE=Agent3` cases before applying
+to the real file.
+
+## 4. Why this wasn't caught earlier
+
+The wrapper script `scripts/dev-agent.cmd` already auto-defaults `TITLE=` to
+`$AGENTMUX_AGENT_ID` when the caller doesn't pass one explicitly — most
+day-to-day usage never exercises an *explicit* `TITLE=...` override at all,
+since the common case (a single agent, one dev session) never needs to tell
+sessions apart. The bug only surfaces when two dev instances are running
+side by side and someone deliberately passes a distinguishing title — an
+infrequent path, and the failure mode (falls back to a plausible-looking
+default, "Window 1") doesn't look like an error, so it wasn't obviously
+broken until directly compared against a second instance.
+
+## 5. Fixing the already-running instance
+
+The Taskfile fix only affects *future* `task dev` launches — an
+already-running dev instance had already baked in the empty
+`VITE_DEV_TITLE` at Vite startup (env values are replaced at build/serve
+time, not re-read at runtime). Relaunching was avoidable: the same
+`window:displayname` meta the app itself writes is settable directly via the
+app's own RPC (`RpcApi.SetMetaCommand(TabRpcClient, { oref: WOS.makeORef("window",
+windowId), meta: { "window:displayname": "Agent3" } })`), reached over CDP
+(`Runtime.evaluate` against the instance's remote-debugging port — see
+[[cdp-live-verify-technique]] in agent memory) since `mcp__agentmux__SetName`
+only reaches the invoking agent's own hosting window, not a separately
+launched `task dev` process. After the RPC call, the frontend's local
+reactive cache for the window object needed an explicit `WOS.reloadWaveObject(oref)`
+to pick up the change — `SetMetaCommand` updates the backend but doesn't by
+itself push a refreshed value into the already-subscribed local atom.
+Confirmed both `document.title` and the native OS title bar
+(`Get-Process | Select MainWindowTitle`) updated to `Agent3 - tab1 - AgentMux`
+after the reload.
+
+## 6. What went well
+
+- Root-caused with an isolated, from-scratch repro before touching the real
+  Taskfile, so the fix was verified in isolation first.
+- Live-verified against the actual running instance (CDP) rather than
+  trusting code-reading alone, both for diagnosing the empty env var and for
+  confirming the eventual live title patch took effect.
+
+## 7. Follow-up
+
+None identified — the fix is a straight deletion of a shadowing declaration
+with no behavioral change to the unset-TITLE case, and the live-patch
+technique for an already-running instance is documented here for reuse
+rather than needing a dedicated tool.


### PR DESCRIPTION
## Summary
- `task dev`/`task dev:serve` each declared `vars: TITLE: ''`, which go-task 3.48.0 uses to unconditionally overwrite any CLI- or parent-task-supplied `TITLE` value — so `task dev TITLE="..."` silently produced an empty OS window title, falling back to the generic "Window N" instead.
- Removing the `vars:` declaration lets the caller's value flow through normally; the no-`TITLE`-passed case is unchanged (Go templates render an unset var as `""`).
- Root-caused via an isolated from-scratch repro, confirmed live against a running dev instance (CDP: `import.meta.env.VITE_DEV_TITLE` was `""` despite `TITLE=` being passed), and re-verified against a copy of the exact real Taskfile snippet for three cases: no TITLE, `TITLE=Agent3Test`, and a quoted multi-word TITLE.
- Full writeup in `docs/retro/retro-task-dev-title-var-shadowing-2026-08-11.md`, including how the already-running (pre-fix) dev instance's title was live-patched via the app's own `RpcApi.SetMetaCommand` RPC over CDP, without needing a relaunch.

## Test plan
- [x] Isolated repro Taskfile confirming the shadowing bug and the fix, for both no-TITLE and `TITLE=...` cases
- [x] Re-verified against a copy of the actual `dev`/`dev:serve` snippet (verbatim structure) for no-TITLE, simple TITLE, and quoted-with-spaces TITLE
- [x] Live-confirmed on the already-running dev instance via CDP that `window:displayname` meta + OS title bar reflect the intended name once set

<!-- agentmux:agent_id=agent3 -->