### PR TITLE
fix(agent-pane): flicker on tab switch — spinner fades before content paints

### DIFF
--- a/.changesets/1786474630-fix-agent-pane-flicker-on-tab-switch-spinner-fades-before-co-io0t.md
+++ b/.changesets/1786474630-fix-agent-pane-flicker-on-tab-switch-spinner-fades-before-co-io0t.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): flicker on tab switch — spinner fades before content paints

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -780,9 +780,19 @@ const AgentPresentationView = ({
     const [showLoadingOverlay, setShowLoadingOverlay] = createSignal(true);
     let cancelSettleWait: (() => void) | undefined;
     let loadingOverlayFadeTimeout: ReturnType<typeof setTimeout> | undefined;
+    // Two extra rAFs between "settle detected" and actually starting the
+    // fade — see the doc comment on scheduleOnSettle's call site below for
+    // why: Long-Task quiet alone can be reached before the browser has
+    // actually PAINTED this pane's content (live-reported flicker,
+    // 2026-08-11). Tracked so a pane close mid-transition doesn't write to
+    // disposed signals.
+    let settlePaintRaf1: number | undefined;
+    let settlePaintRaf2: number | undefined;
     onCleanup(() => {
         cancelSettleWait?.();
         clearTimeout(loadingOverlayFadeTimeout);
+        if (settlePaintRaf1 !== undefined) cancelAnimationFrame(settlePaintRaf1);
+        if (settlePaintRaf2 !== undefined) cancelAnimationFrame(settlePaintRaf2);
     });
     const history = useHistoryPagination({
         blockId: model.blockId,
@@ -795,8 +805,30 @@ const AgentPresentationView = ({
         onHistoryReady: () => {
             historyReadyFn?.();
             cancelSettleWait = scheduleOnSettle(() => {
-                setHistoryLoaded(true);
-                loadingOverlayFadeTimeout = setTimeout(() => setShowLoadingOverlay(false), 220);
+                // `scheduleOnSettle` only watches for Long-Task quiet
+                // (no synchronous block >50ms) — but this pane's actual
+                // reveal work (AgentDocumentVirtualList's measure
+                // ResizeObserver, scroll-pin/anchor-restore effects) is
+                // spread across several async/RAF-scheduled steps that
+                // never register as one long task each. "No long tasks
+                // observed" can therefore be reached before the browser has
+                // actually PAINTED the resulting rows — starting the fade
+                // there let the spinner finish disappearing while the pane
+                // was still genuinely blank underneath, then the real
+                // content popped in abruptly once that async chain finally
+                // caught up (live-reported flicker, 2026-08-11, repro:
+                // switch tabs, screenshot-burst the transition — spinner
+                // fully faded by ~400ms, content not visible until ~500ms).
+                // A double requestAnimationFrame is the standard "wait for
+                // an actual paint to have happened" technique: the second
+                // callback is guaranteed to run only after whatever was
+                // queued as of the first one's frame has been painted.
+                settlePaintRaf1 = requestAnimationFrame(() => {
+                    settlePaintRaf2 = requestAnimationFrame(() => {
+                        setHistoryLoaded(true);
+                        loadingOverlayFadeTimeout = setTimeout(() => setShowLoadingOverlay(false), 220);
+                    });
+                });
             });
         },
         // Schema v2: apply DocumentState + pane overlay after NDJSON replay.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -90,7 +90,7 @@ import { SlashCommandPicker } from "./components/SlashCommandPicker";
 import { SlashHelpPanel } from "./components/SlashHelpPanel";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { createBlock, getApi, openOrFocusPaneByView, pushNotification, refocusNode, WOS } from "@/app/store/global";
+import { atoms, createBlock, getApi, openOrFocusPaneByView, pushNotification, refocusNode, WOS } from "@/app/store/global";
 import { ObjectService } from "@/app/store/services";
 import { ConfirmModal } from "@/element/modal";
 import { ModalLayer } from "@/element/ModalLayer";
@@ -1843,7 +1843,10 @@ const AgentPresentationView = ({
                 blank while it replays. See
                 docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md. */}
             <Show when={showLoadingOverlay()}>
-                <div class="agent-pane-loading-overlay">
+                <div
+                    class="agent-pane-loading-overlay"
+                    classList={{ "is-fading": historyLoaded(), "is-reduced-motion": atoms.prefersReducedMotionAtom() }}
+                >
                     <BrainSpinner fading={historyLoaded()} />
                 </div>
             </Show>

--- a/frontend/app/view/agent/styles/_loading-overlay.scss
+++ b/frontend/app/view/agent/styles/_loading-overlay.scss
@@ -30,5 +30,30 @@
         // outside .agent-view's box entirely, since
         // SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md.)
         z-index: 1;
+
+        // codex P1 on #2543: only the child `<BrainSpinner>` had its own
+        // fade (`.brain-spinner.is-fading`, 200ms) — this div's own opaque
+        // `background` had none, so it stayed a fully solid cover for the
+        // entire `loadingOverlayFadeTimeout` window (220ms in
+        // agent-view.tsx) regardless of the spinner icon underneath having
+        // already faded to invisible, then vanished INSTANTLY (a `<Show>`
+        // unmount, no transition) when that timer fired — an extra,
+        // separate pop distinct from the spinner's own fade. Mirrors the
+        // spinner's exact easing/duration so both fade as one visual unit;
+        // agent-view.tsx now applies this class from the same
+        // `historyLoaded()` signal that drives the spinner's `fading` prop,
+        // and keeps the overlay mounted for the fade's own duration before
+        // unmounting (so removal itself is invisible, not a pop).
+        &.is-fading {
+            opacity: 0;
+            transition: opacity 200ms ease-out;
+            pointer-events: none;
+        }
+
+        // Same reduced-motion override as .brain-spinner.is-reduced-motion
+        // (BrainSpinner.scss) — instant show/hide, no animated fade.
+        &.is-reduced-motion.is-fading {
+            transition: none;
+        }
     }
 }


### PR DESCRIPTION
Live-reported after #2542: switching between in-pane tabs (forks, Agent History, "+" new-tab picker) shows a brief but real flicker — the loading brain-spinner fades out and fully disappears, the pane sits genuinely blank for another ~100-150ms, then the real content pops in abruptly.

## Root cause

The loading overlay's fade-out is gated by `scheduleOnSettle` (`docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md`), which watches for "no Long Tasks (>50ms) for 80ms" as its settle signal. But this pane's actual reveal work — `AgentDocumentVirtualList`'s measure `ResizeObserver`, scroll-pin/anchor-restore effects — is spread across several async/RAF-scheduled steps that individually never register as a single long task. "No long tasks observed" can be reached before the browser has actually **painted** the resulting rows, so the fade started (and finished) before there was anything real underneath it to reveal.

## Fix

A double `requestAnimationFrame` between "settle detected" and actually starting the fade — the standard technique for "wait until an actual paint has happened" (the second rAF callback only runs after whatever was queued as of the first one's frame has painted). Both handles are tracked and cancelled on unmount.

## Verification

Live-verified via CDP screenshot-burst captures (20-50ms intervals) against a running `task dev` instance, before and after:
- **Before:** spinner fully faded by ~400-450ms; content didn't appear until ~500-550ms — a real blank gap.
- **After:** across multiple clean repro runs, the spinner stays fully visible until content is actually ready — no gap between "spinner gone" and "content appears."

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite green: 2569 tests / 172 files (unaffected by this change — it's timing/paint-order behavior, not practically unit-testable without a real browser paint pipeline; jsdom has none)
- [x] Live-verified in a running dev build across repeated tab-switch cycles

<!-- agentmux:agent_id=agenta -->