### PR TITLE
chore: release v0.55.6

### DIFF
--- a/.changesets/1786407797-fix-agent-pane-progress-bar-renders-above-the-tab-strip-not--at71.md
+++ b/.changesets/1786407797-fix-agent-pane-progress-bar-renders-above-the-tab-strip-not--at71.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): progress bar renders above the tab strip, not overlapping the content region

--- a/.changesets/1786409116-fix-agent-pane-tab-strip-floats-over-the-conversation-instea-sdlr.md
+++ b/.changesets/1786409116-fix-agent-pane-tab-strip-floats-over-the-conversation-instea-sdlr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): tab strip floats over the conversation instead of reserving a row

--- a/.changesets/1786450498-fix-agent-failed-tool-calls-hold-open-stop-mass-collapsing-o-klhb.md
+++ b/.changesets/1786450498-fix-agent-failed-tool-calls-hold-open-stop-mass-collapsing-o-klhb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): failed tool calls hold open; stop mass-collapsing on hidden pane

--- a/.changesets/1786450536-feat-agent-pane-agent-history-as-a-pane-tab-composer-draft-p-k7pn.md
+++ b/.changesets/1786450536-feat-agent-pane-agent-history-as-a-pane-tab-composer-draft-p-k7pn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): Agent History as a pane tab; composer draft preservation; scrolling link row

--- a/.changesets/1786451028-fix-agent-require-true-position-0-end-before-composer-histor-msux.md
+++ b/.changesets/1786451028-fix-agent-require-true-position-0-end-before-composer-histor-msux.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): require true position 0/end before composer history recall, not just visual first/last line

--- a/.changesets/1786456804-fix-dev-stop-go-task-from-shadowing-task-dev-title-overrides-cb1t.md
+++ b/.changesets/1786456804-fix-dev-stop-go-task-from-shadowing-task-dev-title-overrides-cb1t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dev): stop go-task from shadowing task dev TITLE=... overrides

--- a/.changesets/1786459796-fix-agent-pane-agent-history-tab-crash-missing-styling-cqsz.md
+++ b/.changesets/1786459796-fix-agent-pane-agent-history-tab-crash-missing-styling-cqsz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): Agent History tab crash + missing styling

--- a/.changesets/1786473678-fix-clipboard-code-block-copy-silently-wrote-empty-text-to-c-h7r3.md
+++ b/.changesets/1786473678-fix-clipboard-code-block-copy-silently-wrote-empty-text-to-c-h7r3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(clipboard): code block copy silently wrote empty text to clipboard

--- a/.changesets/1786474630-fix-agent-pane-flicker-on-tab-switch-spinner-fades-before-co-io0t.md
+++ b/.changesets/1786474630-fix-agent-pane-flicker-on-tab-switch-spinner-fades-before-co-io0t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): flicker on tab switch — spinner fades before content paints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.5"
+version = "0.55.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.5"
+version = "0.55.6"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.5"
+version = "0.55.6"
 dependencies = [
  "dirs",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.5"
+version = "0.55.6"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.5"
+version = "0.55.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.5"
+version = "0.55.6"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.5"
+version = "0.55.6"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,18 @@
 # AgentMux Version History
 
+## 0.55.6 — 2026-08-11
+
+- fix(agent-pane): progress bar renders above the tab strip, not overlapping the content region
+- fix(agent-pane): tab strip floats over the conversation instead of reserving a row
+- fix(agent): failed tool calls hold open; stop mass-collapsing on hidden pane
+- feat(agent-pane): Agent History as a pane tab; composer draft preservation; scrolling link row
+- fix(agent): require true position 0/end before composer history recall, not just visual first/last line
+- fix(dev): stop go-task from shadowing task dev TITLE=... overrides
+- fix(agent-pane): Agent History tab crash + missing styling
+- fix(clipboard): code block copy silently wrote empty text to clipboard
+- fix(agent-pane): flicker on tab switch — spinner fades before content paints
+
+
 ## 0.55.5 — 2026-08-11
 
 - fix(agent): seed shell drawer's term:zoom before construct, eliminate open jerk

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.5",
+  "version": "0.55.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.5",
+      "version": "0.55.6",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.5",
+  "version": "0.55.6",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Release PR consuming 9 pending changesets: `0.55.5 -> 0.55.6`.
- Bump type forced to **patch** via `task release -- --as patch` (override, as requested) — the computed bump was `minor` (one `feat` changeset among the 9), so this ships that minor-level change under a patch version. The release script prints a loud warning for this case; noting it here too for visibility.
- All 5 version locations verified in agreement at 0.55.6 by the release script itself (`package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`, `VERSION_HISTORY.md`).

## Changes included
- fix(agent-pane): progress bar renders above the tab strip, not overlapping the content region
- fix(agent-pane): tab strip floats over the conversation instead of reserving a row
- fix(agent): failed tool calls hold open; stop mass-collapsing on hidden pane
- feat(agent-pane): Agent History as a pane tab; composer draft preservation; scrolling link row
- fix(agent): require true position 0/end before composer history recall, not just visual first/last line
- fix(dev): stop go-task from shadowing task dev TITLE=... overrides
- fix(agent-pane): Agent History tab crash + missing styling
- fix(clipboard): code block copy silently wrote empty text to clipboard
- fix(agent-pane): flicker on tab switch — spinner fades before content paints

## Test plan
- [x] Release script confirmed all 5 version locations agree at 0.55.6
- [x] `.changesets/` fully consumed (9 files deleted, folded into `VERSION_HISTORY.md`)

<!-- agentmux:agent_id=agent3 -->