### PR TITLE
fix(cef): stop mDNS 0.0.0.0:5353 bind that triggers the Windows Firewall prompt on launch

### DIFF
--- a/.changesets/1786508406-fix-cef-stop-mdns-0-0-0-0-5353-bind-that-triggers-the-window-tdpj.md
+++ b/.changesets/1786508406-fix-cef-stop-mdns-0-0-0-0-5353-bind-that-triggers-the-window-tdpj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): stop mDNS 0.0.0.0:5353 bind that triggers the Windows Firewall prompt on launch

--- a/agentmux-cef/src/app/mod.rs
+++ b/agentmux-cef/src/app/mod.rs
@@ -578,10 +578,32 @@ wrap_app! {
                 // kNoValidation) — the policy is read before FeatureList init so
                 // this runtime flag cannot apply in time and is NOT the load-bearing
                 // mechanism. Do not remove the patch thinking these flags cover it.
+                //   WebRtcHideLocalIpsWithMdns — Chromium's network service
+                //     binds an mDNS (multicast DNS) listener on UDP
+                //     0.0.0.0:5353 to mint `.local` hostnames that hide local
+                //     IPs from WebRTC peers. It binds this proactively at
+                //     startup even with no active WebRTC (confirmed via
+                //     `netstat -ano`: a Chromium network subprocess holds
+                //     `UDP 0.0.0.0:5353`). That all-interfaces bind is what
+                //     raises the Windows Defender Firewall "Windows Security
+                //     Alert" on first run — labelled "CEF Bootstrap
+                //     Application" because agentmux-cef.exe is CEF's bootstrap
+                //     stub, whose PE version-info carries CEF's default
+                //     description (build.rs stamps the AgentMux metadata onto
+                //     the .dll, not the stub). MediaRouter (the other mDNS
+                //     source) is already disabled above; disabling this one
+                //     removes the last proactive 5353 bind, so no firewall
+                //     prompt. Tradeoff: a browser-pane page using
+                //     RTCPeerConnection would expose local IPs instead of
+                //     `.local` names (pre-2019 Chrome default) — acceptable for
+                //     a local single-user workbench; AgentMux's own UI uses no
+                //     WebRTC, and voice input (getUserMedia audio) is
+                //     unaffected. See feedback_no_os_notices_at_launch.
                 let val = CefString::from(
                     "CalculateNativeWinOcclusion,MediaRouter,PreconnectToSearch,\
                      AutofillServerCommunication,MachPortRendezvousValidatePeerRequirements,\
-                     MachPortRendezvousEnforcePeerRequirements,MacAppCodeSignClone",
+                     MachPortRendezvousEnforcePeerRequirements,MacAppCodeSignClone,\
+                     WebRtcHideLocalIpsWithMdns",
                 );
                 cmd.append_switch_with_value(Some(&key), Some(&val));
 


### PR DESCRIPTION
## Summary

On first launch — and on every fresh `task dev` build (new exe path) — Windows Defender Firewall raised a **"Windows Security Alert"** for AgentMux, shown as **"CEF Bootstrap Application"**. Surfaced while testing a browser-pane login; the user originally described it as "a UAC."

**Root cause (confirmed via `netstat -ano`):** Chromium's network service binds an **mDNS listener on UDP `0.0.0.0:5353`** — proactively at startup, even with no active WebRTC or Cast. That all-interfaces bind is the *only* non-loopback listener the app opens (the DevTools remote-debugging and IPC ports are both `127.0.0.1`), so it's what makes Windows prompt.

The dialog says "CEF Bootstrap Application" because `agentmux-cef.exe` is CEF's **bootstrap stub** (the real code is in `agentmux-cef.dll`); the stub carries CEF's default PE version-info, while `build.rs`'s "AgentMux" metadata lands on the DLL.

## Fix

`MediaRouter` (Cast/DIAL mDNS) was already in the app's `--disable-features` list (added for the analogous macOS local-network prompt). The remaining 5353 binder is WebRTC's local-IP-hiding responder — **`WebRtcHideLocalIpsWithMdns`**. Added it to that **same** existing `--disable-features` value (not a second switch — Chromium honors only one). With both mDNS sources off, the responder is never created, the socket is never bound, and the firewall never prompts.

## Verification (live)

Built and launched a fresh instance with the fix, alongside a pre-fix instance:
- **Fixed instance:** none of its CEF processes bind `UDP 0.0.0.0:5353` (its network subprocess is absent from the 5353-binder set).
- **Pre-fix instance:** its network subprocess (a `--type=utility`) still binds `0.0.0.0:5353`.

So the offending bind is gone. Because Windows Firewall prompts per-exe-path on first non-loopback bind, a fresh build with no 5353 bind produces no prompt. (Owner is confirming the prompt is gone on their machine.)

## Tradeoff

With `WebRtcHideLocalIpsWithMdns` off, a page in a **browser pane** that uses `RTCPeerConnection` would expose local IPs instead of `.local` mDNS names — the pre-2019 Chrome default. Acceptable for a local single-user workbench: AgentMux's own UI uses no WebRTC, and voice input (`getUserMedia` audio) is unaffected (no peer connection / mDNS).

## Not in this PR (separate, cosmetic)

The bootstrap stub exe's version-info still reads "CEF Bootstrap Application" rather than "AgentMux". Fixing that is a packaging-time PE-resource re-stamp of CEF's prebuilt bootstrap exe — orthogonal to removing the prompt (which this PR does), so left as a follow-up.

<!-- agentmux:agent_id=lark -->