### PR TITLE
feat(browser-pane): wire Ctrl+L / Ctrl+R / Alt+Left / Alt+Right shortcuts

### DIFF
--- a/.changesets/1786506220-feat-browser-pane-wire-ctrl-l-ctrl-r-alt-left-alt-right-shor-uys7.md
+++ b/.changesets/1786506220-feat-browser-pane-wire-ctrl-l-ctrl-r-alt-left-alt-right-shor-uys7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(browser-pane): wire Ctrl+L / Ctrl+R / Alt+Left / Alt+Right shortcuts (#1190)

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -183,6 +183,8 @@ wrap_drag_handler! {
 // trigger the built-in action; the key still reaches JavaScript.
 // ---------------------------------------------------------------------------
 
+/// CEF event flag: Shift key is held (cef_types.h `EVENTFLAG_SHIFT_DOWN`).
+const EVENTFLAG_SHIFT_DOWN: u32 = 1 << 1;
 /// CEF event flag: Ctrl key is held.
 const EVENTFLAG_CONTROL_DOWN: u32 = 1 << 2;
 /// CEF event flag: Alt key is held (cef_types.h `EVENTFLAG_ALT_DOWN`).
@@ -221,7 +223,16 @@ enum BrowserPaneShortcut {
 /// they depend on browser-pane tabs, which don't exist yet (see the issue's
 /// own sequencing note). Ctrl+F (in-page find) is also deferred: it needs a
 /// find-bar UI (input + match-count display), not just an intercepted key.
-fn browser_pane_shortcut_for(ctrl: bool, alt: bool, vk: i32) -> Option<BrowserPaneShortcut> {
+///
+/// `shift` must be false to match: codex P2 on #2548 — without this,
+/// Ctrl+Shift+R (Chromium's hard-reload chord) was silently downgraded to a
+/// plain cached reload, and Ctrl+Shift+L was hijacked as focus-address too.
+/// Requiring shift-up leaves those shifted chords alone (falls through to
+/// CEF's normal handling) instead of guessing what they should do.
+fn browser_pane_shortcut_for(ctrl: bool, alt: bool, shift: bool, vk: i32) -> Option<BrowserPaneShortcut> {
+    if shift {
+        return None;
+    }
     if ctrl && !alt {
         match vk {
             VK_L => Some(BrowserPaneShortcut::FocusAddress),
@@ -265,11 +276,26 @@ fn run_browser_pane_shortcut(
 
     match shortcut {
         BrowserPaneShortcut::FocusAddress => {
-            crate::events::emit_event_from_state(
-                &state,
-                "browser-pane-shortcut",
-                &serde_json::json!({ "block_id": block_id, "action": "focus-address" }),
-            );
+            // codex P2 on #2548: emit_event_from_state always targets "main" —
+            // wrong when the pane was torn off into a floating window, since
+            // that window's own BrowserNavBar (not main's) owns the matching
+            // listener. Route to the pane's actual owning window instead.
+            match state.browser_pane_window_label(&block_id) {
+                Some(label) => {
+                    crate::events::emit_event_to_window(
+                        &state,
+                        &label,
+                        "browser-pane-shortcut",
+                        &serde_json::json!({ "block_id": block_id, "action": "focus-address" }),
+                    );
+                }
+                None => {
+                    tracing::warn!(
+                        "[browser-pane-shortcut] no owning window label for block_id={}",
+                        block_id
+                    );
+                }
+            }
         }
         BrowserPaneShortcut::Reload => state.browser_panes.reload(&block_id, &state),
         BrowserPaneShortcut::GoBack => state.browser_panes.go_back(&block_id, &state),
@@ -314,11 +340,12 @@ fn handle_pre_key_event(
     // KEYUP, which would otherwise double-fire (e.g. two reloads per press).
     if ev.type_ == KeyEventType::RAWKEYDOWN {
         let alt = (ev.modifiers & EVENTFLAG_ALT_DOWN) != 0;
+        let shift = (ev.modifiers & EVENTFLAG_SHIFT_DOWN) != 0;
         #[cfg(target_os = "macos")]
         let pane_primary_mod = (ev.modifiers & EVENTFLAG_COMMAND_DOWN) != 0;
         #[cfg(not(target_os = "macos"))]
         let pane_primary_mod = ctrl;
-        if let Some(shortcut) = browser_pane_shortcut_for(pane_primary_mod, alt, ev.windows_key_code) {
+        if let Some(shortcut) = browser_pane_shortcut_for(pane_primary_mod, alt, shift, ev.windows_key_code) {
             if run_browser_pane_shortcut(inner, browser, shortcut) {
                 return 1;
             }
@@ -630,7 +657,7 @@ mod browser_pane_shortcut_tests {
     #[test]
     fn ctrl_l_focuses_address_bar() {
         assert_eq!(
-            browser_pane_shortcut_for(true, false, VK_L),
+            browser_pane_shortcut_for(true, false, false, VK_L),
             Some(BrowserPaneShortcut::FocusAddress)
         );
     }
@@ -638,7 +665,7 @@ mod browser_pane_shortcut_tests {
     #[test]
     fn ctrl_r_reloads() {
         assert_eq!(
-            browser_pane_shortcut_for(true, false, VK_R),
+            browser_pane_shortcut_for(true, false, false, VK_R),
             Some(BrowserPaneShortcut::Reload)
         );
     }
@@ -646,7 +673,7 @@ mod browser_pane_shortcut_tests {
     #[test]
     fn alt_left_goes_back() {
         assert_eq!(
-            browser_pane_shortcut_for(false, true, VK_LEFT),
+            browser_pane_shortcut_for(false, true, false, VK_LEFT),
             Some(BrowserPaneShortcut::GoBack)
         );
     }
@@ -654,15 +681,15 @@ mod browser_pane_shortcut_tests {
     #[test]
     fn alt_right_goes_forward() {
         assert_eq!(
-            browser_pane_shortcut_for(false, true, VK_RIGHT),
+            browser_pane_shortcut_for(false, true, false, VK_RIGHT),
             Some(BrowserPaneShortcut::GoForward)
         );
     }
 
     #[test]
     fn plain_keypress_without_modifier_is_not_a_shortcut() {
-        assert_eq!(browser_pane_shortcut_for(false, false, VK_L), None);
-        assert_eq!(browser_pane_shortcut_for(false, false, VK_LEFT), None);
+        assert_eq!(browser_pane_shortcut_for(false, false, false, VK_L), None);
+        assert_eq!(browser_pane_shortcut_for(false, false, false, VK_LEFT), None);
     }
 
     #[test]
@@ -670,13 +697,13 @@ mod browser_pane_shortcut_tests {
         // Ctrl+Alt+L / Ctrl+Alt+Left are not reserved shortcuts — only plain
         // Ctrl+<key> and plain Alt+<key> are matched, so a page/site binding
         // Ctrl+Alt+<key> for its own purposes isn't hijacked.
-        assert_eq!(browser_pane_shortcut_for(true, true, VK_L), None);
-        assert_eq!(browser_pane_shortcut_for(true, true, VK_LEFT), None);
+        assert_eq!(browser_pane_shortcut_for(true, true, false, VK_L), None);
+        assert_eq!(browser_pane_shortcut_for(true, true, false, VK_LEFT), None);
     }
 
     #[test]
     fn unrelated_key_is_not_a_shortcut() {
-        assert_eq!(browser_pane_shortcut_for(true, false, VK_P), None);
+        assert_eq!(browser_pane_shortcut_for(true, false, false, VK_P), None);
     }
 
     #[test]
@@ -686,7 +713,18 @@ mod browser_pane_shortcut_tests {
         // deliberate, not an oversight, until that dependency lands.
         const VK_T: i32 = 0x54;
         const VK_W: i32 = 0x57;
-        assert_eq!(browser_pane_shortcut_for(true, false, VK_T), None);
-        assert_eq!(browser_pane_shortcut_for(true, false, VK_W), None);
+        assert_eq!(browser_pane_shortcut_for(true, false, false, VK_T), None);
+        assert_eq!(browser_pane_shortcut_for(true, false, false, VK_W), None);
+    }
+
+    #[test]
+    fn shift_held_excludes_plain_shortcuts() {
+        // codex P2 on #2548: Ctrl+Shift+R is Chromium's hard-reload chord and
+        // Ctrl+Shift+L isn't a shortcut at all — neither should be silently
+        // downgraded/hijacked into the plain Ctrl+R/Ctrl+L actions.
+        assert_eq!(browser_pane_shortcut_for(true, false, true, VK_R), None);
+        assert_eq!(browser_pane_shortcut_for(true, false, true, VK_L), None);
+        assert_eq!(browser_pane_shortcut_for(false, true, true, VK_LEFT), None);
+        assert_eq!(browser_pane_shortcut_for(false, true, true, VK_RIGHT), None);
     }
 }

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -27,7 +27,7 @@ wrap_client! {
         }
 
         fn keyboard_handler(&self) -> Option<KeyboardHandler> {
-            Some(AgentMuxKeyboardHandler::new())
+            Some(AgentMuxKeyboardHandler::new(self.inner.clone()))
         }
 
         fn life_span_handler(&self) -> Option<LifeSpanHandler> {
@@ -185,10 +185,98 @@ wrap_drag_handler! {
 
 /// CEF event flag: Ctrl key is held.
 const EVENTFLAG_CONTROL_DOWN: u32 = 1 << 2;
+/// CEF event flag: Alt key is held (cef_types.h `EVENTFLAG_ALT_DOWN`).
+const EVENTFLAG_ALT_DOWN: u32 = 1 << 3;
+/// CEF event flag: Cmd key is held (cef_types.h `EVENTFLAG_COMMAND_DOWN`) —
+/// macOS's Ctrl-equivalent modifier for the browser-pane shortcuts below
+/// (issue #1190's acceptance criteria: "same set with Cmd on macOS"). Not
+/// live-verified on macOS hardware — same caveat as issues #2188/#2189.
+#[cfg(target_os = "macos")]
+const EVENTFLAG_COMMAND_DOWN: u32 = 1 << 7;
 
 /// Windows virtual-key codes for shortcuts we want to forward to JS.
 const VK_P: i32 = 0x50; // Ctrl+P — command palette (not print)
 const VK_G: i32 = 0x47; // Ctrl+G — (reserve for app use)
+
+/// Windows virtual-key codes for browser-pane-only shortcuts (issue #1190).
+const VK_L: i32 = 0x4C; // Ctrl+L — focus address bar
+const VK_R: i32 = 0x52; // Ctrl+R — reload
+const VK_LEFT: i32 = 0x25; // Alt+Left — back
+const VK_RIGHT: i32 = 0x27; // Alt+Right — forward
+
+/// Reserved chrome-style shortcuts intercepted only when the focused CEF
+/// browser is a browser pane (see issue #1190 — browser panes are native
+/// CEF child windows, so normal app-level keydown handling never sees these
+/// keystrokes). Kept independent of any CEF/AppState types so the matching
+/// logic itself is unit-testable without a CEF runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BrowserPaneShortcut {
+    FocusAddress,
+    Reload,
+    GoBack,
+    GoForward,
+}
+
+/// Ctrl+T/Ctrl+W (new tab / close tab) are intentionally not matched here —
+/// they depend on browser-pane tabs, which don't exist yet (see the issue's
+/// own sequencing note). Ctrl+F (in-page find) is also deferred: it needs a
+/// find-bar UI (input + match-count display), not just an intercepted key.
+fn browser_pane_shortcut_for(ctrl: bool, alt: bool, vk: i32) -> Option<BrowserPaneShortcut> {
+    if ctrl && !alt {
+        match vk {
+            VK_L => Some(BrowserPaneShortcut::FocusAddress),
+            VK_R => Some(BrowserPaneShortcut::Reload),
+            _ => None,
+        }
+    } else if alt && !ctrl {
+        match vk {
+            VK_LEFT => Some(BrowserPaneShortcut::GoBack),
+            VK_RIGHT => Some(BrowserPaneShortcut::GoForward),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// Resolve the focused pane's `block_id` and run `shortcut` against it —
+/// either by emitting an event the frontend reacts to (`FocusAddress`, which
+/// needs to move DOM focus in the host webview) or by calling straight into
+/// `BrowserPaneManager` (`Reload`/`GoBack`/`GoForward`, the same methods the
+/// nav-bar buttons already use via IPC — see `ipc.rs`'s `browser_pane_go_back`
+/// etc.), so this stays consistent with the existing back/forward/reload path
+/// instead of poking CEF's `Browser` directly.
+fn run_browser_pane_shortcut(
+    inner: &Arc<Mutex<AgentMuxHandler>>,
+    browser: Option<&mut Browser>,
+    shortcut: BrowserPaneShortcut,
+) -> bool {
+    let handler = inner.lock();
+    if !handler.is_browser_pane {
+        return false;
+    }
+    let Some(b) = browser else { return false };
+    let Some(block_id) = crate::browser_pane::callbacks::resolve_pane_block_id(&handler.state, b)
+    else {
+        return false;
+    };
+    let state = handler.state.clone();
+    drop(handler);
+
+    match shortcut {
+        BrowserPaneShortcut::FocusAddress => {
+            crate::events::emit_event_from_state(
+                &state,
+                "browser-pane-shortcut",
+                &serde_json::json!({ "block_id": block_id, "action": "focus-address" }),
+            );
+        }
+        BrowserPaneShortcut::Reload => state.browser_panes.reload(&block_id, &state),
+        BrowserPaneShortcut::GoBack => state.browser_panes.go_back(&block_id, &state),
+        BrowserPaneShortcut::GoForward => state.browser_panes.go_forward(&block_id, &state),
+    }
+    true
+}
 
 // cef-rs declares `on_pre_key_event`'s `os_event` differently per platform:
 //   Windows → Option<&mut MSG>     (typed)
@@ -197,73 +285,102 @@ const VK_G: i32 = 0x47; // Ctrl+G — (reserve for app use)
 // A single signature can't satisfy all three, so we expand the macro per
 // target and forward to a shared body.
 fn handle_pre_key_event(
+    inner: &Arc<Mutex<AgentMuxHandler>>,
+    browser: Option<&mut Browser>,
     event: Option<&KeyEvent>,
     is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
 ) -> ::std::os::raw::c_int {
-    if let Some(ev) = event {
-        let ctrl = (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0;
-        if ctrl && matches!(ev.windows_key_code, VK_P | VK_G) {
-            // Tell CEF this is a keyboard shortcut so it dispatches
-            // the keydown event to JavaScript instead of handling it
-            // as a built-in browser action (print dialog, etc.).
-            if let Some(flag) = is_keyboard_shortcut {
-                *flag = 1;
+    let Some(ev) = event else { return 0 };
+    let ctrl = (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0;
+
+    if ctrl && matches!(ev.windows_key_code, VK_P | VK_G) {
+        // Tell CEF this is a keyboard shortcut so it dispatches
+        // the keydown event to JavaScript instead of handling it
+        // as a built-in browser action (print dialog, etc.).
+        if let Some(flag) = is_keyboard_shortcut {
+            *flag = 1;
+        }
+        // Return 0 = not consumed at pre-key stage; CEF will
+        // still call on_key_event where we return 0 again,
+        // letting JS handle it via the normal keydown path.
+        return 0;
+    }
+
+    // Browser-pane shortcuts (issue #1190) are handled entirely here — unlike
+    // Ctrl+P/Ctrl+G above, they must NOT reach the pane's own page JS (an
+    // arbitrary, possibly untrusted site), so we fully consume them (return 1)
+    // instead of forwarding. Gated on RAWKEYDOWN so the action fires once per
+    // physical key press — CEF also calls `on_pre_key_event` for the matching
+    // KEYUP, which would otherwise double-fire (e.g. two reloads per press).
+    if ev.type_ == KeyEventType::RAWKEYDOWN {
+        let alt = (ev.modifiers & EVENTFLAG_ALT_DOWN) != 0;
+        #[cfg(target_os = "macos")]
+        let pane_primary_mod = (ev.modifiers & EVENTFLAG_COMMAND_DOWN) != 0;
+        #[cfg(not(target_os = "macos"))]
+        let pane_primary_mod = ctrl;
+        if let Some(shortcut) = browser_pane_shortcut_for(pane_primary_mod, alt, ev.windows_key_code) {
+            if run_browser_pane_shortcut(inner, browser, shortcut) {
+                return 1;
             }
-            // Return 0 = not consumed at pre-key stage; CEF will
-            // still call on_key_event where we return 0 again,
-            // letting JS handle it via the normal keydown path.
         }
     }
+
     0 // not consumed
 }
 
 #[cfg(target_os = "windows")]
 wrap_keyboard_handler! {
-    struct AgentMuxKeyboardHandler;
+    struct AgentMuxKeyboardHandler {
+        inner: Arc<Mutex<AgentMuxHandler>>,
+    }
 
     impl KeyboardHandler {
         fn on_pre_key_event(
             &self,
-            _browser: Option<&mut Browser>,
+            browser: Option<&mut Browser>,
             event: Option<&KeyEvent>,
             _os_event: Option<&mut cef::sys::MSG>,
             is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
         ) -> ::std::os::raw::c_int {
-            handle_pre_key_event(event, is_keyboard_shortcut)
+            handle_pre_key_event(&self.inner, browser, event, is_keyboard_shortcut)
         }
     }
 }
 
 #[cfg(target_os = "linux")]
 wrap_keyboard_handler! {
-    struct AgentMuxKeyboardHandler;
+    struct AgentMuxKeyboardHandler {
+        inner: Arc<Mutex<AgentMuxHandler>>,
+    }
 
     impl KeyboardHandler {
         fn on_pre_key_event(
             &self,
-            _browser: Option<&mut Browser>,
+            browser: Option<&mut Browser>,
             event: Option<&KeyEvent>,
             _os_event: Option<&mut cef::sys::XEvent>,
             is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
         ) -> ::std::os::raw::c_int {
-            handle_pre_key_event(event, is_keyboard_shortcut)
+            handle_pre_key_event(&self.inner, browser, event, is_keyboard_shortcut)
         }
     }
 }
 
 #[cfg(target_os = "macos")]
 wrap_keyboard_handler! {
-    struct AgentMuxKeyboardHandler;
+    struct AgentMuxKeyboardHandler {
+        inner: Arc<Mutex<AgentMuxHandler>>,
+    }
 
     impl KeyboardHandler {
         fn on_pre_key_event(
             &self,
-            _browser: Option<&mut Browser>,
+            browser: Option<&mut Browser>,
             event: Option<&KeyEvent>,
             _os_event: *mut u8,
             is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
         ) -> ::std::os::raw::c_int {
-            handle_pre_key_event(event, is_keyboard_shortcut)
+            handle_pre_key_event(&self.inner, browser, event, is_keyboard_shortcut)
         }
     }
 }
@@ -503,5 +620,73 @@ wrap_permission_handler! {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod browser_pane_shortcut_tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_l_focuses_address_bar() {
+        assert_eq!(
+            browser_pane_shortcut_for(true, false, VK_L),
+            Some(BrowserPaneShortcut::FocusAddress)
+        );
+    }
+
+    #[test]
+    fn ctrl_r_reloads() {
+        assert_eq!(
+            browser_pane_shortcut_for(true, false, VK_R),
+            Some(BrowserPaneShortcut::Reload)
+        );
+    }
+
+    #[test]
+    fn alt_left_goes_back() {
+        assert_eq!(
+            browser_pane_shortcut_for(false, true, VK_LEFT),
+            Some(BrowserPaneShortcut::GoBack)
+        );
+    }
+
+    #[test]
+    fn alt_right_goes_forward() {
+        assert_eq!(
+            browser_pane_shortcut_for(false, true, VK_RIGHT),
+            Some(BrowserPaneShortcut::GoForward)
+        );
+    }
+
+    #[test]
+    fn plain_keypress_without_modifier_is_not_a_shortcut() {
+        assert_eq!(browser_pane_shortcut_for(false, false, VK_L), None);
+        assert_eq!(browser_pane_shortcut_for(false, false, VK_LEFT), None);
+    }
+
+    #[test]
+    fn ctrl_alt_combo_matches_neither_group() {
+        // Ctrl+Alt+L / Ctrl+Alt+Left are not reserved shortcuts — only plain
+        // Ctrl+<key> and plain Alt+<key> are matched, so a page/site binding
+        // Ctrl+Alt+<key> for its own purposes isn't hijacked.
+        assert_eq!(browser_pane_shortcut_for(true, true, VK_L), None);
+        assert_eq!(browser_pane_shortcut_for(true, true, VK_LEFT), None);
+    }
+
+    #[test]
+    fn unrelated_key_is_not_a_shortcut() {
+        assert_eq!(browser_pane_shortcut_for(true, false, VK_P), None);
+    }
+
+    #[test]
+    fn ctrl_t_and_ctrl_w_are_not_yet_matched() {
+        // Tabs (#1190's Ctrl+T/Ctrl+W) depend on browser-pane tabs, which
+        // don't exist yet — asserting the non-match documents that this is
+        // deliberate, not an oversight, until that dependency lands.
+        const VK_T: i32 = 0x54;
+        const VK_W: i32 = 0x57;
+        assert_eq!(browser_pane_shortcut_for(true, false, VK_T), None);
+        assert_eq!(browser_pane_shortcut_for(true, false, VK_W), None);
     }
 }

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -1,8 +1,8 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createEffect, createSignal, Show, type JSX } from "solid-js";
-import { invokeCommand } from "@/app/platform/ipc";
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import type { BrowserViewModel } from "./browser-model";
 
@@ -85,6 +85,34 @@ export function BrowserNavBar(props: {
             handleNavigate();
         }
     };
+
+    // Ctrl+L (Cmd+L on macOS) is dead by default in a browser pane — CEF
+    // intercepts it at the pre-key stage (agentmux-cef/src/client/handlers.rs)
+    // since a pane's keystrokes go to the CEF child browser, not this webview,
+    // and emits `browser-pane-shortcut` instead of forwarding to the (possibly
+    // untrusted) page. See issue #1190.
+    onMount(() => {
+        let unsub: (() => void) | undefined;
+        void listenEvent<{ block_id: string; action: string }>(
+            "browser-pane-shortcut",
+            (payload) => {
+                if (payload.block_id !== model.blockId) return;
+                if (payload.action !== "focus-address") return;
+                diag(`shortcut-focus-address`);
+                // Same OS-focus handoff the address bar's own onMouseDown
+                // needs (see its comment above): the pane HWND currently
+                // holds OS keyboard focus, so a bare DOM .focus() call
+                // wouldn't actually move keystrokes to this input without
+                // first reclaiming OS focus for this window.
+                invokeCommand("main_window_focus", { window_label: windowLabel }).catch(() => {});
+                addressInputRef?.focus();
+                addressInputRef?.select();
+            }
+        ).then((fn) => {
+            unsub = fn;
+        });
+        onCleanup(() => unsub?.());
+    });
 
     return (
         <Show when={model.showControlsAtom()}>


### PR DESCRIPTION
## Summary
- Browser panes are native CEF child windows, so their keystrokes never reach the app-level keydown dispatcher (`frontend/app/store/keymodel.ts`) — Ctrl+L, Ctrl+R, and Alt+Left/Right were completely dead in a focused pane.
- `agentmux-cef/src/client/handlers.rs`'s `OnPreKeyEvent` now intercepts these at the pre-key stage, resolves the focused pane's `block_id` via the existing `resolve_pane_block_id`, and either:
  - **Ctrl+L** — emits a new `browser-pane-shortcut` event (same delivery mechanism as `browser-pane-nav-state`), consumed in `browser-nav-bar.tsx` to focus + select the address input (wiring already existed, just nothing drove it).
  - **Ctrl+R / Alt+Left / Alt+Right** — call straight into `BrowserPaneManager::reload/go_back/go_forward` — the exact same methods the nav-bar buttons already use via IPC, so no new action logic, just a new way to trigger it.
- All four are fully consumed (return `1` from `OnPreKeyEvent`) so they never leak to the pane's own loaded page — unlike Ctrl+P/Ctrl+G, which intentionally forward to the app's own JS.
- macOS gets the Cmd-key equivalent per the issue's acceptance criteria, but this is **not live-verified on macOS hardware** (this session only has Windows available) — same caveat as #2188/#2189.

## Deliberately out of scope
- **Ctrl+T / Ctrl+W** — depend on browser-pane tabs, which don't exist yet (per the issue's own sequencing note).
- **Ctrl+F** (in-page find) — needs a find-bar UI (input + match-count display), not just an intercepted key; a `browser.host().find()` CEF API exists and is feasible for a follow-up.

## Test plan
- [x] 8 new unit tests for the pure shortcut-matching logic (`agentmux-cef/src/client/handlers.rs`'s `browser_pane_shortcut_for`) — modifier combos, non-matches, and an explicit assertion that Ctrl+T/W are not yet matched.
- [x] `cargo test -p agentmux-cef` and `npx tsc --noEmit` both clean.
- [x] Live-verified against a running `task dev` build via real OS-level keystrokes (not synthetic DOM events) into a real browser pane: Ctrl+L focuses+selects the address bar, Ctrl+R reloads, Alt+Left/Right navigate back/forward — confirmed via both frontend DOM state and the Rust-side diagnostic log.

This is a PARTIAL fix for issue #1190 (see agentmuxai/agentmux#1190) — Ctrl+L/R/Alt+Left/Right are done here; Ctrl+T/W/F are not, so #1190 should stay open. Deliberately not using a GitHub closing keyword so merging this PR does not auto-close it.

<!-- agentmux:agent_id=agenta -->