### PR TITLE
feat(warden): extend AuditLogEntry with outcome/reason for Supervisor decisions

### DIFF
--- a/.changesets/1786574599-feat-warden-extend-auditlogentry-with-outcome-reason-for-sup-krmt.md
+++ b/.changesets/1786574599-feat-warden-extend-auditlogentry-with-outcome-reason-for-sup-krmt.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(warden): extend AuditLogEntry with outcome/reason for Supervisor decisions

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -292,6 +292,8 @@ impl Handler {
                     false,
                     Some(&err),
                     &request_id,
+                    None,
+                    None,
                 );
                 return InjectionResponse {
                     success: false,
@@ -368,6 +370,8 @@ impl Handler {
                         true,
                         None,
                         &request_id,
+                        None,
+                        None,
                     );
                     return InjectionResponse {
                         success: true,
@@ -399,6 +403,8 @@ impl Handler {
                         false,
                         Some(&e),
                         &request_id,
+                        None,
+                        None,
                     );
                     return InjectionResponse {
                         success: false,
@@ -425,6 +431,8 @@ impl Handler {
                     false,
                     Some(&err),
                     &request_id,
+                    None,
+                    None,
                 );
                 return InjectionResponse {
                     success: false,
@@ -464,6 +472,8 @@ impl Handler {
                 false,
                 Some(&e),
                 &request_id,
+                None,
+                None,
             );
             return InjectionResponse {
                 success: false,
@@ -496,6 +506,8 @@ impl Handler {
             true,
             None,
             &request_id,
+            None,
+            None,
         );
 
         InjectionResponse {
@@ -520,7 +532,10 @@ impl Handler {
         entries
     }
 
-    /// Add an entry to the audit ring buffer.
+    /// Add an entry to the audit ring buffer. `outcome`/`reason` are `None`
+    /// for every ordinary jekt injection (all current call sites) — only
+    /// Warden Supervisor decisions (see `record_supervisor_decision`) ever
+    /// set them.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn log_audit(
         &mut self,
@@ -531,6 +546,8 @@ impl Handler {
         success: bool,
         error_message: Option<&str>,
         request_id: &str,
+        outcome: Option<&str>,
+        reason: Option<&str>,
     ) {
         let entry = AuditLogEntry {
             timestamp: now_unix_millis(),
@@ -542,6 +559,8 @@ impl Handler {
             success,
             error_message: error_message.map(|s| s.to_string()),
             request_id: request_id.to_string(),
+            outcome: outcome.map(|s| s.to_string()),
+            reason: reason.map(|s| s.to_string()),
         };
 
         if self.audit_log.len() >= AUDIT_LOG_MAX {

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -548,6 +548,93 @@ fn test_handler_audit_log() {
     assert!(!log[0].success);
 }
 
+/// Ordinary jekt injections (the only path that runs today) always leave
+/// `outcome`/`reason` unset — those fields exist only for Warden Supervisor
+/// entries, added via `log_audit`'s two new trailing params.
+#[test]
+fn test_handler_audit_log_ordinary_jekt_has_no_outcome() {
+    let mut handler = Handler::new();
+    handler.register_agent("agent1", "block1", None).unwrap();
+    handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: "test".to_string(),
+        source_agent: Some("src".to_string()),
+        request_id: Some("req-1".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+    });
+
+    let log = handler.get_audit_log(10);
+    assert_eq!(log.len(), 1);
+    assert!(log[0].outcome.is_none());
+    assert!(log[0].reason.is_none());
+}
+
+/// `log_audit`'s new outcome/reason params, when set, land in the
+/// resulting entry — this is the path `record_supervisor_decision` (a
+/// follow-up PR) will call.
+#[test]
+fn test_log_audit_stores_outcome_and_reason_when_provided() {
+    let mut handler = Handler::new();
+    handler.log_audit(
+        None,
+        "agent1",
+        "block1",
+        "continue",
+        true,
+        None,
+        "req-1",
+        Some("nudge_sent"),
+        Some("agent paused asking for permission to continue"),
+    );
+
+    let log = handler.get_audit_log(10);
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0].outcome.as_deref(), Some("nudge_sent"));
+    assert_eq!(
+        log[0].reason.as_deref(),
+        Some("agent paused asking for permission to continue"),
+    );
+}
+
+/// `AuditLogEntry`'s new fields must round-trip through serde and, per the
+/// struct's `skip_serializing_if` convention (matching `source_agent`/
+/// `error_message`), be OMITTED from the JSON entirely when `None` — a
+/// back-compat guard for any existing consumer of the audit JSON shape.
+#[test]
+fn test_audit_log_entry_outcome_field_serde_roundtrip() {
+    let with_outcome = AuditLogEntry {
+        timestamp: 1,
+        source_agent: None,
+        target_agent: "agent1".to_string(),
+        block_id: "block1".to_string(),
+        message_hash: "hash".to_string(),
+        message_length: 0,
+        success: true,
+        error_message: None,
+        request_id: "req-1".to_string(),
+        outcome: Some("nudge_declined".to_string()),
+        reason: Some("consecutive-nudge ceiling reached".to_string()),
+    };
+    let json = serde_json::to_value(&with_outcome).unwrap();
+    assert_eq!(json["outcome"], "nudge_declined");
+    assert_eq!(json["reason"], "consecutive-nudge ceiling reached");
+    let round_tripped: AuditLogEntry = serde_json::from_value(json).unwrap();
+    assert_eq!(round_tripped.outcome.as_deref(), Some("nudge_declined"));
+
+    let without_outcome = AuditLogEntry {
+        outcome: None,
+        reason: None,
+        ..with_outcome
+    };
+    let json = serde_json::to_value(&without_outcome).unwrap();
+    assert!(json.get("outcome").is_none(), "outcome must be omitted, not null, when None");
+    assert!(json.get("reason").is_none(), "reason must be omitted, not null, when None");
+}
+
 #[test]
 fn test_handler_audit_log_ring_buffer() {
     let mut handler = Handler::new();
@@ -561,6 +648,8 @@ fn test_handler_audit_log_ring_buffer() {
             true,
             None,
             &format!("req-{}", i),
+            None,
+            None,
         );
     }
 

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -124,6 +124,17 @@ pub struct AuditLogEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
     pub request_id: String,
+    /// "nudge_sent" | "nudge_declined" — present only for Warden Supervisor-
+    /// originated entries (see ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_
+    /// WATCHER_2026_08_12.md); absent for ordinary jekt injections. A
+    /// "nudge_declined" entry has no corresponding delivery at all — this
+    /// field is the ONLY record that decision ever existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    /// The Supervisor's stated reasoning, populated alongside `outcome`.
+    /// Not used by ordinary (non-Supervisor) jekt entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Poller configuration for AgentMux cloud service.


### PR DESCRIPTION
## Summary
Adds two new optional fields to `AuditLogEntry` — `outcome` (`"nudge_sent"` | `"nudge_declined"`) and `reason` (free-text justification) — populated only by the Warden Supervisor feature (a follow-up PR), absent for every existing ordinary jekt injection entry. Both use the same `#[serde(default, skip_serializing_if = "Option::is_none")]` convention `source_agent`/`error_message` already use on this struct, so the JSON shape is unchanged for anything not setting them.

Widens `log_audit`'s signature with the two new trailing params; all 6 existing call sites in `inject_message` (plus the one test call site) pass `None, None` — mechanical, zero behavior change for the ordinary jekt path.

## Scope
Backend schema only — no route/RPC changes in this PR. Part of the Warden Auto-Controller design (`docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md`), alongside the already-merged rail restructure (#2553), which already renders these fields when present. Follow-ups in the same design (not in this PR): per-agent `auto_continue_enabled` config field, transcript-read + nudge REST routes/MCP tools, and the consecutive-nudge ceiling guardrail.

## Test plan
- [x] `cargo build -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv reactive::` — 72 passed (3 new: ordinary-jekt-has-no-outcome, log_audit-stores-outcome-when-provided, serde-roundtrip-omits-when-none)

<!-- agentmux:agent_id=camper -->