### PR TITLE
feat(warden): add auto_continue_enabled per-agent opt-in field

### DIFF
--- a/.changesets/1786576024-feat-warden-add-auto-continue-enabled-per-agent-opt-in-field-a0xc.md
+++ b/.changesets/1786576024-feat-warden-add-auto-continue-enabled-per-agent-opt-in-field-a0xc.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(warden): add auto_continue_enabled per-agent opt-in field for Supervisor

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -197,6 +197,7 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
             container_name: String::new(),
             use_ambient_login: 0,
             model_vendor_base_url: String::new(), // manifest doesn't declare this yet
+            auto_continue_enabled: 0,
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -445,6 +446,7 @@ fn reseed_if_needed(
             container_name: String::new(),
             use_ambient_login: 0,
             model_vendor_base_url: String::new(), // manifest doesn't declare this yet
+            auto_continue_enabled: 0,
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {
@@ -553,6 +555,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut def).unwrap();

--- a/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
+++ b/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
@@ -285,6 +285,7 @@ pub fn migrate_promote_template_sessions_v1(
                 container_name: String::new(),
                 use_ambient_login: 0,
                 model_vendor_base_url: template.model_vendor_base_url.clone(),
+                auto_continue_enabled: 0,
             };
             if let Err(e) = wstore.agent_def_insert(&mut new_def) {
                 tracing::warn!(

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -491,6 +491,7 @@ fn insert_template(
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut def).unwrap();
@@ -725,6 +726,7 @@ fn template_promote_does_not_reuse_clone_with_active_zone() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut user_clone).unwrap();
@@ -833,6 +835,7 @@ fn template_promote_preserves_user_continuation_on_clone() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
@@ -933,6 +936,7 @@ fn template_promote_recovers_partial_copy_at_zone() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
@@ -1035,6 +1039,7 @@ fn template_promote_promotes_newer_source_over_stale_destination() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
@@ -1156,6 +1161,7 @@ fn template_promote_idempotent_under_partial_failure_at_archive_move() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
@@ -1294,6 +1300,7 @@ fn template_promote_skips_already_user_owned_definitions() {
         container_volumes: "[]".to_string(),
         container_name: String::new(),
         use_ambient_login: 0,
+        auto_continue_enabled: 0,
         model_vendor_base_url: String::new(),
     };
     wstore.agent_def_insert(&mut user_def).unwrap();

--- a/agentmux-srv/src/backend/blockcontroller/core.rs
+++ b/agentmux-srv/src/backend/blockcontroller/core.rs
@@ -336,6 +336,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -128,6 +128,15 @@ pub struct AgentDefinition {
     /// (known limitation, not wired into the registry mirror).
     #[serde(default)]
     pub model_vendor_base_url: String,
+    /// Per-agent opt-in: when non-zero, a running Warden Supervisor watcher
+    /// agent is permitted to auto-continue this agent's session on
+    /// turn-end (subject to a server-side consecutive-nudge ceiling).
+    /// Default 0 = opt-in required, same fail-by-default posture as
+    /// `use_ambient_login`. Schema v17. Toggled from the Warden Supervisor
+    /// panel. See
+    /// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+    #[serde(default)]
+    pub auto_continue_enabled: i64,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -310,7 +319,7 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login, model_vendor_base_url
+                    use_ambient_login, model_vendor_base_url, auto_continue_enabled
              FROM db_agent_definitions
              WHERE is_seeded = 0 AND parent_id = ?1
              ORDER BY updated_at DESC, created_at DESC",
@@ -371,7 +380,7 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login, model_vendor_base_url
+                    use_ambient_login, model_vendor_base_url, auto_continue_enabled
              FROM db_agent_definitions
              WHERE id = ?1",
         )?;
@@ -393,7 +402,7 @@ impl Store {
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_template_id, branch_label, updated_at,
                         user_hidden, container_image, container_volumes, container_name,
-                        use_ambient_login, model_vendor_base_url
+                        use_ambient_login, model_vendor_base_url, auto_continue_enabled
                  FROM db_agents
                  ORDER BY updated_at DESC, created_at ASC",
             )?;
@@ -573,9 +582,9 @@ impl Store {
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
              is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
              container_image, container_volumes, container_name, use_ambient_login,
-             model_vendor_base_url)
+             model_vendor_base_url, auto_continue_enabled)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
+                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)",
             params![
                 agent.id,
                 agent.slug,
@@ -613,6 +622,7 @@ impl Store {
                 agent.container_name,
                 agent.use_ambient_login,
                 agent.model_vendor_base_url,
+                agent.auto_continue_enabled,
             ],
         )?;
         // Persist the stamped updated_at before we leave the lock so the
@@ -738,7 +748,7 @@ impl Store {
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_id, branch_label, updated_at,
                         user_hidden, container_image, container_volumes, container_name,
-                        use_ambient_login, model_vendor_base_url
+                        use_ambient_login, model_vendor_base_url, auto_continue_enabled
                  FROM db_agent_definitions
                  WHERE (lower(trim(name)) = ?1 OR slug = ?2)
                    AND is_seeded = 0
@@ -788,10 +798,10 @@ impl Store {
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
                     is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
                     container_image, container_volumes, container_name, use_ambient_login,
-                    model_vendor_base_url)
+                    model_vendor_base_url, auto_continue_enabled)
                  VALUES
                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
+                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)",
                 params![
                     agent.id, agent.slug, agent.name, agent.icon, agent.provider,
                     agent.description, agent.working_directory, agent.shell,
@@ -804,6 +814,7 @@ impl Store {
                     agent.container_image, agent.container_volumes, agent.container_name,
                     agent.use_ambient_login,
                     agent.model_vendor_base_url,
+                    agent.auto_continue_enabled,
                 ],
             )?;
             agent.created_at
@@ -911,7 +922,8 @@ impl Store {
                  restart_on_crash=?9, idle_timeout_minutes=?10,
                  agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15,
                  container_image=?17, container_volumes=?18, container_name=?19,
-                 use_ambient_login=?20, branch_label=?21, model_vendor_base_url=?22
+                 use_ambient_login=?20, branch_label=?21, model_vendor_base_url=?22,
+                 auto_continue_enabled=?23
                  WHERE id=?16",
                 params![
                     agent.name,
@@ -936,6 +948,7 @@ impl Store {
                     agent.use_ambient_login,
                     agent.branch_label,
                     agent.model_vendor_base_url,
+                    agent.auto_continue_enabled,
                 ],
             )?
         };
@@ -2132,6 +2145,7 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
         container_name: row.get(24)?,
         use_ambient_login: row.get(25)?,
         model_vendor_base_url: row.get(26)?,
+        auto_continue_enabled: row.get(27)?,
     })
 }
 

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -59,6 +59,7 @@ pub(super) fn agent_definition_to_record(
         container_volumes: def.container_volumes.clone(),
         container_name: def.container_name.clone(),
         use_ambient_login: def.use_ambient_login,
+        auto_continue_enabled: def.auto_continue_enabled,
         content: content
             .iter()
             .map(|c| DefContentBlob {
@@ -123,6 +124,7 @@ pub(super) fn record_to_agent_definition(rec: &DefinitionRecord) -> AgentDefinit
         // a cross-channel agent reopened from the global registry starts
         // with the harness's default vendor. Known limitation, not a bug.
         model_vendor_base_url: String::new(),
+        auto_continue_enabled: d.auto_continue_enabled,
     }
 }
 
@@ -377,6 +379,7 @@ mod tests {
             container_name: String::new(),
             use_ambient_login: 0,
             model_vendor_base_url: String::new(),
+            auto_continue_enabled: 0,
         }
     }
 

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -67,7 +67,7 @@ impl Store {
                 slug, branch_label, working_directory,
                 created_at, updated_at, is_seeded, user_hidden,
                 container_image, container_volumes, container_name,
-                use_ambient_login, model_vendor_base_url
+                use_ambient_login, model_vendor_base_url, auto_continue_enabled
              ) VALUES (
                 ?1, ?2, ?3, ?4,
                 ?5, ?6,
@@ -77,7 +77,7 @@ impl Store {
                 ?17, ?18, ?19,
                 ?20, ?21, ?22, ?23,
                 ?24, ?25, ?26,
-                ?27, ?28
+                ?27, ?28, ?29
              )
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
@@ -104,7 +104,8 @@ impl Store {
                 container_volumes = excluded.container_volumes,
                 container_name = excluded.container_name,
                 use_ambient_login = excluded.use_ambient_login,
-                model_vendor_base_url = excluded.model_vendor_base_url",
+                model_vendor_base_url = excluded.model_vendor_base_url,
+                auto_continue_enabled = excluded.auto_continue_enabled",
             params![
                 def.id,
                 def.name,
@@ -134,6 +135,7 @@ impl Store {
                 def.container_name,
                 def.use_ambient_login,
                 def.model_vendor_base_url,
+                def.auto_continue_enabled,
             ],
         )?;
         Ok(())
@@ -631,7 +633,7 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login, model_vendor_base_url
+                    use_ambient_login, model_vendor_base_url, auto_continue_enabled
              FROM db_agent_definitions WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], |row| {
@@ -663,6 +665,7 @@ impl Store {
                 container_name: row.get(24)?,
                 use_ambient_login: row.get(25)?,
                 model_vendor_base_url: row.get(26)?,
+                auto_continue_enabled: row.get(27)?,
             })
         });
         match result {

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -713,6 +713,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -110,7 +110,13 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 7;
 ///        variant into a running agent is explicitly out of scope for this
 ///        version (per that spec's non-goals) — this column only makes the
 ///        data storable/exportable/importable.
-pub const OBJECT_SCHEMA_VERSION: i64 = 16;
+///   v17 — auto_continue_enabled on both db_agent_definitions and db_agents:
+///        per-agent opt-in letting a Warden Supervisor watcher agent
+///        auto-continue this agent's session on turn-end (subject to a
+///        server-side consecutive-nudge ceiling). Defaults to 0 (opt-in
+///        required — fail-by-default, same posture as use_ambient_login).
+///        See docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+pub const OBJECT_SCHEMA_VERSION: i64 = 17;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -247,7 +253,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             container_volumes    TEXT NOT NULL DEFAULT '[]',
             container_name       TEXT NOT NULL DEFAULT '',
             use_ambient_login    INTEGER NOT NULL DEFAULT 0,
-            model_vendor_base_url TEXT NOT NULL DEFAULT ''
+            model_vendor_base_url TEXT NOT NULL DEFAULT '',
+            auto_continue_enabled INTEGER NOT NULL DEFAULT 0
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_slug
             ON db_agent_definitions(slug);
@@ -432,7 +439,11 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
 
             -- Redirects this agent's harness at a non-default model vendor
             -- backend (schema v15) — see db_agent_definitions' column doc.
-            model_vendor_base_url TEXT NOT NULL DEFAULT ''
+            model_vendor_base_url TEXT NOT NULL DEFAULT '',
+
+            -- Warden Supervisor auto-continue opt-in (schema v17) — see
+            -- db_agent_definitions' column doc.
+            auto_continue_enabled INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_agents_is_template
             ON db_agents(is_template);
@@ -625,6 +636,11 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         // object of {provider_id: content} variants, additive to the
         // existing flat `instructions` column.
         "ALTER TABLE db_bundles ADD COLUMN instructions_by_provider TEXT NOT NULL DEFAULT '{}'",
+        // v17: Warden Supervisor auto-continue opt-in (fail-by-default,
+        // same posture as use_ambient_login) — see
+        // ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+        "ALTER TABLE db_agent_definitions ADD COLUMN auto_continue_enabled INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE db_agents ADD COLUMN auto_continue_enabled INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();
@@ -1165,6 +1181,20 @@ mod tests {
 
         assert!(column_exists(&conn, "db_agent_definitions", "model_vendor_base_url"));
         assert!(column_exists(&conn, "db_agents", "model_vendor_base_url"));
+    }
+
+    #[test]
+    fn test_object_schema_has_auto_continue_enabled_on_both_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        run_object_schema(&conn).unwrap();
+        // Second pass: the ALTER TABLE array's duplicate-column guard must
+        // not error when the column already exists (fresh installs get it
+        // via CREATE TABLE; the ALTER is for upgrading pre-v17 databases).
+        run_object_schema(&conn).unwrap();
+
+        assert!(column_exists(&conn, "db_agent_definitions", "auto_continue_enabled"));
+        assert!(column_exists(&conn, "db_agents", "auto_continue_enabled"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -633,6 +633,7 @@ mod effective_skills_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -318,6 +318,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut a1).unwrap();
@@ -386,6 +387,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut a1).unwrap();
@@ -449,6 +451,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }
@@ -2344,6 +2347,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -2385,6 +2389,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
@@ -2432,6 +2437,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -2480,6 +2486,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -2525,6 +2532,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -2564,6 +2572,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
@@ -2651,6 +2660,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
@@ -2747,6 +2757,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
@@ -2805,6 +2816,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
@@ -2861,6 +2873,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl_a).unwrap();
@@ -2929,6 +2942,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
             };
             store.agent_def_insert(&mut d).unwrap();
@@ -2972,6 +2986,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();
@@ -3047,6 +3062,7 @@
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut tpl).unwrap();

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -675,6 +675,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -749,6 +750,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -824,6 +826,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -888,6 +891,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }
@@ -1131,6 +1135,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1215,6 +1220,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1281,6 +1287,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1345,6 +1352,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1419,6 +1427,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1497,6 +1506,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1587,6 +1597,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1671,6 +1682,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();
@@ -1747,6 +1759,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         store.agent_def_insert(&mut def).unwrap();

--- a/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
+++ b/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
@@ -135,6 +135,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }

--- a/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
+++ b/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
@@ -174,6 +174,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut def).unwrap();
@@ -272,6 +273,7 @@ mod tests {
                     container_volumes: "[]".to_string(),
                     container_name: String::new(),
                     use_ambient_login: 0,
+                    auto_continue_enabled: 0,
                     content: Vec::new(),
                     skills: Vec::new(),
                 },

--- a/agentmux-srv/src/registry/def_migrate.rs
+++ b/agentmux-srv/src/registry/def_migrate.rs
@@ -86,6 +86,7 @@ const DEF_COLUMNS: &[(&str, &str)] = &[
     ("container_volumes", "'[]'"),
     ("container_name", "''"),
     ("use_ambient_login", "0"),
+    ("auto_continue_enabled", "0"),
 ];
 
 /// Outcome stats — surfaced in the srv log.
@@ -295,6 +296,7 @@ fn read_user_definitions(db: &Path) -> Result<Vec<(DefinitionRecord, i64)>, rusq
                 container_volumes: row.get(23)?,
                 container_name: row.get(24)?,
                 use_ambient_login: row.get(25)?,
+                auto_continue_enabled: row.get(26)?,
                 content: Vec::new(),
                 skills: Vec::new(),
             })

--- a/agentmux-srv/src/registry/def_schema.rs
+++ b/agentmux-srv/src/registry/def_schema.rs
@@ -129,6 +129,14 @@ pub struct DefinitionRecordV1 {
     /// the container_* fields — no envelope bump.
     #[serde(default)]
     pub use_ambient_login: i64,
+    /// Per-agent opt-in letting a Warden Supervisor watcher agent
+    /// auto-continue this agent's session on turn-end (mirrors the SQLite
+    /// v17 column —
+    /// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md).
+    /// Additive under `#[serde(default)]`, same as `use_ambient_login` —
+    /// no envelope bump.
+    #[serde(default)]
+    pub auto_continue_enabled: i64,
     /// System-prompt / mcp / env / soul / startup blobs (db_agent_content),
     /// embedded so a cross-channel agent launches with its instructions.
     #[serde(default)]
@@ -214,6 +222,7 @@ mod tests {
                 container_volumes: "[]".to_string(),
                 container_name: String::new(),
                 use_ambient_login: 0,
+                auto_continue_enabled: 0,
                 content: Vec::new(),
                 skills: Vec::new(),
             },

--- a/agentmux-srv/src/registry/def_store.rs
+++ b/agentmux-srv/src/registry/def_store.rs
@@ -305,6 +305,7 @@ mod tests {
                 container_volumes: "[]".to_string(),
                 container_name: String::new(),
                 use_ambient_login: 0,
+                auto_continue_enabled: 0,
                 content: Vec::new(),
                 skills: Vec::new(),
             },

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -130,6 +130,10 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Not settable via this RPC yet — only `agent.define`
                     // (the App-API/MCP path) can set a model vendor override.
                     model_vendor_base_url: String::new(),
+                    // Opt-in required, same fail-by-default posture as
+                    // use_ambient_login above. Toggled from the Warden
+                    // Supervisor panel (not this RPC) once that ships.
+                    auto_continue_enabled: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 // Assign the agent its display color at creation
@@ -230,6 +234,10 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // above, so a UI-driven save never silently wipes a
                     // vendor override set via `agent.define`.
                     model_vendor_base_url: old.model_vendor_base_url.clone(),
+                    // Not carried by CommandUpdateAgentDefinitionData yet —
+                    // always preserve; the Warden Supervisor panel gets its
+                    // own dedicated toggle path.
+                    auto_continue_enabled: old.auto_continue_enabled,
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -427,6 +435,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_name: String::new(),
                     use_ambient_login: 0,
                     model_vendor_base_url: String::new(),
+                    auto_continue_enabled: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
 
@@ -564,6 +573,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         container_name: String::new(),
                         use_ambient_login: 0,
                         model_vendor_base_url: String::new(),
+                        auto_continue_enabled: 0,
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -414,6 +414,7 @@ mod recent_sessions_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         let mut def_mut = def.clone();
@@ -731,6 +732,7 @@ mod recent_sessions_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut tpl).unwrap();
@@ -762,6 +764,7 @@ mod recent_sessions_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         };
         wstore.agent_def_insert(&mut user_a).unwrap();

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -145,6 +145,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_name: String::new(),
                     use_ambient_login: 0,
                     model_vendor_base_url: template.model_vendor_base_url.clone(),
+                    auto_continue_enabled: 0,
                 };
                 wstore
                     .agent_def_insert(&mut new_def)
@@ -354,6 +355,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_name: String::new(),
                     use_ambient_login: 0,
                     model_vendor_base_url: source.model_vendor_base_url.clone(),
+                    auto_continue_enabled: 0,
                 };
                 wstore
                     .agent_def_insert(&mut fork)

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -86,6 +86,7 @@ mod resolve_vendor_env_override_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: model_vendor_base_url.to_string(),
         }
     }
@@ -845,6 +846,7 @@ mod write_agent_config_files_tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -446,6 +446,7 @@ pub(crate) async fn agent_define_core(
         container_name: String::new(), // assigned by ContainerManager on first spawn
         use_ambient_login: 0,
         model_vendor_base_url: cmd_model_vendor_base_url.clone(),
+        auto_continue_enabled: 0,
     };
 
     // Atomic check-then-insert.
@@ -1974,6 +1975,7 @@ mod identity_self_accounts_tests {
             container_name: String::new(),
             use_ambient_login: 0,
             model_vendor_base_url: String::new(),
+            auto_continue_enabled: 0,
         };
         state.wstore.agent_def_insert(&mut def).unwrap();
 
@@ -2046,6 +2048,7 @@ mod identity_self_accounts_tests {
             container_name: String::new(),
             use_ambient_login: 0,
             model_vendor_base_url: String::new(),
+            auto_continue_enabled: 0,
         };
         state.wstore.agent_def_insert(&mut def).unwrap();
         state.wstore.identity_upsert(&sample_account("acct-good", "claude")).unwrap();

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -981,6 +981,7 @@ mod tests {
             container_volumes: "[]".to_string(),
             container_name: String::new(),
             use_ambient_login: 0,
+            auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
         }
     }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -336,6 +336,15 @@ declare global {
          * yet — see `agent_define_core`'s `validate_vendor_base_url`.
          */
         model_vendor_base_url?: string;
+        /**
+         * Per-agent opt-in: when non-zero, a running Warden Supervisor
+         * watcher agent is permitted to auto-continue this agent's session
+         * on turn-end (subject to a server-side consecutive-nudge ceiling).
+         * 0 (default) = opt-in required, same fail-by-default posture as
+         * use_ambient_login. Schema v17. Toggled from the Warden Supervisor
+         * panel.
+         */
+        auto_continue_enabled?: number;
     };
 
     // ── v6: identity, instance, junction ────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `auto_continue_enabled: i64` to `AgentDefinition` — a per-agent opt-in
letting a Warden Supervisor watcher agent auto-continue the agent's session
on turn-end, subject to a server-side consecutive-nudge ceiling (that
guardrail ships in a follow-up PR alongside the transcript-read/
SupervisorNudge routes).

Continues the Warden Supervisor build-out from #2553/#2554 — see
`docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md`.

## Design notes

- **Default `0` = opt-in required**, matching `use_ambient_login`'s
  fail-by-default posture, per explicit decision to follow that field's
  precedent rather than `model_vendor_base_url`'s.
- **Syncs normally across the global cross-channel registry** (added to
  `DefinitionRecordV1` in `registry/def_schema.rs`, wired through
  `def_registry_mirror.rs`) — unlike `model_vendor_base_url`, which has a
  deliberate channel-local-only carve-out. `auto_continue_enabled` gets no
  such carve-out; it's meant to travel with the agent.
- **Schema v17**: new `auto_continue_enabled INTEGER NOT NULL DEFAULT 0`
  column on both `db_agent_definitions` and `db_agents`, plus a schema test
  mirroring the existing `model_vendor_base_url` one.
- **Not yet settable via `createagent`/`updateagent` RPCs.** Those handlers
  always preserve the existing value (or default to `0` on create) — the
  Warden Supervisor panel UI gets its own dedicated toggle path in a
  follow-up PR (mirroring how `AgentIdentityModal.tsx` toggles
  `use_ambient_login` today).
- Every other `AgentDefinition { ... }` construction site in the crate
  (createagent, template clone, fork, import, seed, and ~50 test fixtures)
  was updated mechanically to set `auto_continue_enabled: 0` — clones/forks
  don't inherit the source's opt-in, matching `use_ambient_login`'s existing
  behavior at each of those same sites.

## Test plan

- [x] `cargo build -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv` — 2166 lib tests + integration + subprocess_io tests, all passing
- [x] `npx tsc --noEmit` — clean (added `auto_continue_enabled?: number` to `AgentDefinition` in `gotypes.d.ts`)
- [x] New schema test confirms the column exists on both tables

<!-- agentmux:agent_id=camper -->