### PR TITLE
feat(warden): add transcript-read route + GetAgentTranscript MCP tool

### DIFF
--- a/.changesets/1786576660-feat-warden-add-transcript-read-route-getagenttranscript-mcp-0wd5.md
+++ b/.changesets/1786576660-feat-warden-add-transcript-read-route-getagenttranscript-mcp-0wd5.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(warden): add transcript-read route + GetAgentTranscript MCP tool

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -129,6 +129,19 @@ const DISCOVER_AGENTS_TOOL: &str = r#"{
   }
 }"#;
 
+const GET_AGENT_TRANSCRIPT_TOOL: &str = r#"{
+  "name": "GetAgentTranscript",
+  "description": "Read the tail of a registered agent's session transcript by name, plus whether it currently has a turn in flight (turn_active). For a Warden Supervisor watcher agent polling other agents on its own interval to decide whether to nudge a stalled one to continue. Returns JSON: {agent, block_id, turn_active, lines: [...], truncated}. Read-only, best-effort — does not deliver anything to the target.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "agent":     { "type": "string", "description": "Name of the target agent (its AGENTMUX_AGENT_ID value)" },
+      "max_lines": { "type": "integer", "description": "Max number of recent transcript lines to return (default 100, server-capped at 500)" }
+    },
+    "required": ["agent"]
+  }
+}"#;
+
 const SET_ACTIVE_TAB_TOOL: &str = r#"{
   "name": "SetActiveTab",
   "description": "Switch the active (foreground) tab to the given tab_id within its workspace. Get tab ids from Layout(query:\"tabs\") or Layout(query:\"layout\").",
@@ -499,6 +512,8 @@ async fn main() {
                 let send_message: Value = serde_json::from_str(SEND_MESSAGE_TOOL).expect("static json");
                 let discover_agents: Value =
                     serde_json::from_str(DISCOVER_AGENTS_TOOL).expect("static json");
+                let get_agent_transcript: Value =
+                    serde_json::from_str(GET_AGENT_TRANSCRIPT_TOOL).expect("static json");
                 let whoami: Value = serde_json::from_str(WHOAMI_TOOL).expect("static json");
                 let layout: Value = serde_json::from_str(LAYOUT_TOOL).expect("static json");
                 let set_name: Value = serde_json::from_str(SET_NAME_TOOL).expect("static json");
@@ -527,7 +542,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -1042,6 +1057,51 @@ async fn call_tool(
                 let status = resp.status();
                 let text = resp.text().await.unwrap_or_default();
                 anyhow::bail!("discovery failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "GetAgentTranscript" => {
+            let agent = arguments
+                .get("agent")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: agent"))?;
+            let max_lines = arguments.get("max_lines").and_then(|v| v.as_u64());
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!(
+                "{}/agentmux/reactive/transcript",
+                local_url.trim_end_matches('/')
+            );
+            let mut query: Vec<(&str, String)> = vec![("agent", agent.to_string())];
+            if let Some(n) = max_lines {
+                query.push(("max_lines", n.to_string()));
+            }
+
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .query(&query)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("transcript fetch failed: HTTP {status} — {text}");
             }
 
             let result: Value = resp

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -294,6 +294,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/agentmux/reactive/poller/status",
             get(reactive::handle_reactive_poller_status),
+        )
+        .route(
+            "/agentmux/reactive/transcript",
+            get(reactive::handle_reactive_transcript),
         );
 
     // MessageBus routes (authed, localhost-only)

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -579,3 +579,85 @@ pub(super) async fn handle_reactive_poller_status(
     let status = state.poller.status();
     Json(serde_json::to_value(&status).unwrap_or(json!({})))
 }
+
+/// Server-side ceiling on `max_lines` — protects a Supervisor's transcript
+/// pull (and this route in general) from an unbounded read of a huge
+/// session file. Callers wanting more must paginate some other way; this
+/// route is a "recent tail" primitive, not a full-history export.
+const TRANSCRIPT_MAX_LINES_CAP: usize = 500;
+
+#[derive(serde::Deserialize)]
+pub(super) struct TranscriptQuery {
+    agent: String,
+    #[serde(default = "default_transcript_max_lines")]
+    max_lines: usize,
+}
+fn default_transcript_max_lines() -> usize {
+    100
+}
+
+/// `GET /agentmux/reactive/transcript?agent=<name>&max_lines=<n>` — read the
+/// tail of a registered agent's session output, for a Warden Supervisor
+/// watcher agent to inspect on its own poll interval (v1 is pull/poll, not
+/// push — see
+/// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md).
+pub(super) async fn handle_reactive_transcript(
+    State(state): State<AppState>,
+    Query(params): Query<TranscriptQuery>,
+) -> Response {
+    if params.agent.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "missing agent param"})),
+        )
+            .into_response();
+    }
+    let Some(reg) = state.reactive_handler.get_agent(&params.agent) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "agent not found"})),
+        )
+            .into_response();
+    };
+    let block_id = reg.block_id.clone();
+
+    let (raw_bytes, _total_line_count) = match crate::backend::session_archive::read_session_output(
+        &state.wstore,
+        &state.filestore,
+        &block_id,
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("read_session_output: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let text = String::from_utf8_lossy(&raw_bytes);
+    let all_lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    let requested = params.max_lines.min(TRANSCRIPT_MAX_LINES_CAP).max(1);
+    let truncated = all_lines.len() > requested;
+    let lines: Vec<String> = all_lines
+        .iter()
+        .rev()
+        .take(requested)
+        .rev()
+        .map(|l| l.to_string())
+        .collect();
+
+    let turn_active = crate::backend::blockcontroller::get_block_controller_status(&block_id)
+        .map(|s| s.turn_active)
+        .unwrap_or(false);
+
+    Json(json!({
+        "agent": reg.agent_id,
+        "block_id": block_id,
+        "turn_active": turn_active,
+        "lines": lines,
+        "truncated": truncated,
+    }))
+    .into_response()
+}

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -377,6 +377,30 @@ async fn reactive_agents_returns_empty_list() {
 }
 
 #[tokio::test]
+async fn reactive_transcript_missing_agent_param_is_400() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/reactive/transcript")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn reactive_transcript_unknown_agent_is_404() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/reactive/transcript?agent=nonexistent-agent")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn reactive_poller_status() {
     let app = test_router();
     let req = Request::builder()


### PR DESCRIPTION
## Summary

- New `GET /agentmux/reactive/transcript?agent=<name>&max_lines=<n>` route
  (`handle_reactive_transcript` in `agentmux-srv/src/server/reactive.rs`):
  resolves an agent name to its block via the existing reactive registry
  (`state.reactive_handler.get_agent`), reads the tail of its session
  output via `session_archive::read_session_output`, and reports
  `turn_active` via `blockcontroller::get_block_controller_status`.
  Response: `{agent, block_id, turn_active, lines: [...], truncated}`.
- Server-caps `max_lines` at 500 (`TRANSCRIPT_MAX_LINES_CAP`) — this is a
  "recent tail" primitive, not a full-history export.
- New `GetAgentTranscript` MCP tool (`agentmux-mcp/src/main.rs`), mirroring
  `DiscoverAgents`'s implementation shape — same `reqwest` GET +
  `X-AuthKey` pattern.

This lets a Warden Supervisor watcher agent poll a target agent's recent
output + turn-active status on its own interval — a **pull/poll design**,
not push. A real push mechanism to a spawned MCP-side agent doesn't exist
anywhere in this codebase today and would be a materially bigger, separate
feature (v2, not this pass).

Continues the Warden Supervisor build-out from #2553/#2554/#2555 — see
`docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md`.

## Test plan

- [x] `cargo build -p agentmux-srv` and `cargo build -p agentmux-mcp` — clean
- [x] `cargo test -p agentmux-srv` — 2168 tests passing (2 new: missing-agent-param → 400, unknown-agent → 404)
- [x] Manual review of `GetAgentTranscript`'s tool schema against MCP client expectations (mirrors `DiscoverAgents`)

<!-- agentmux:agent_id=camper -->