### PR TITLE
feat(warden): add SupervisorNudge route/MCP tool, nudge ceiling, and Supervisor manager UI

### DIFF
--- a/.changesets/1786577572-feat-warden-add-supervisornudge-route-mcp-tool-consecutive-n-im48.md
+++ b/.changesets/1786577572-feat-warden-add-supervisornudge-route-mcp-tool-consecutive-n-im48.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(warden): add SupervisorNudge route + MCP tool + consecutive-nudge ceiling

--- a/.changesets/1786578516-feat-warden-add-supervisor-manager-ui-fix-nudge-entitlement--y0pg.md
+++ b/.changesets/1786578516-feat-warden-add-supervisor-manager-ui-fix-nudge-entitlement--y0pg.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(warden): add Supervisor manager UI + fix nudge entitlement/ceiling gaps

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -142,6 +142,21 @@ const GET_AGENT_TRANSCRIPT_TOOL: &str = r#"{
   }
 }"#;
 
+const SUPERVISOR_NUDGE_TOOL: &str = r#"{
+  "name": "SupervisorNudge",
+  "description": "For a Warden Supervisor watcher agent: record a decision about a target agent that just ended its turn, after inspecting it with GetAgentTranscript. action=\"nudge\" delivers `message` to the target as an ordinary jekt telling it to continue, and logs the decision. action=\"decline\" sends nothing and just logs that you chose not to nudge (e.g. the target isn't opted in, or looks genuinely done/blocked, not merely pausing to ask). A nudge that would exceed the server-side consecutive-nudge ceiling is refused (HTTP 429/tool error) — treat that as a signal to stop nudging this target and escalate to a human via SendMessage instead of retrying.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "target_agent": { "type": "string", "description": "Name of the agent this decision is about (its AGENTMUX_AGENT_ID value)" },
+      "action":       { "type": "string", "enum": ["nudge", "decline"], "description": "Whether to nudge the target to continue or decline to" },
+      "message":      { "type": "string", "description": "Required when action is \"nudge\" — the message delivered to the target as a jekt" },
+      "reason":       { "type": "string", "description": "Your stated reasoning for this decision, recorded in the audit log" }
+    },
+    "required": ["target_agent", "action"]
+  }
+}"#;
+
 const SET_ACTIVE_TAB_TOOL: &str = r#"{
   "name": "SetActiveTab",
   "description": "Switch the active (foreground) tab to the given tab_id within its workspace. Get tab ids from Layout(query:\"tabs\") or Layout(query:\"layout\").",
@@ -514,6 +529,8 @@ async fn main() {
                     serde_json::from_str(DISCOVER_AGENTS_TOOL).expect("static json");
                 let get_agent_transcript: Value =
                     serde_json::from_str(GET_AGENT_TRANSCRIPT_TOOL).expect("static json");
+                let supervisor_nudge: Value =
+                    serde_json::from_str(SUPERVISOR_NUDGE_TOOL).expect("static json");
                 let whoami: Value = serde_json::from_str(WHOAMI_TOOL).expect("static json");
                 let layout: Value = serde_json::from_str(LAYOUT_TOOL).expect("static json");
                 let set_name: Value = serde_json::from_str(SET_NAME_TOOL).expect("static json");
@@ -542,7 +559,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -1108,6 +1125,73 @@ async fn call_tool(
                 .json()
                 .await
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "SupervisorNudge" => {
+            let target_agent = arguments
+                .get("target_agent")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: target_agent"))?;
+            let action = arguments
+                .get("action")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: action"))?;
+            if action != "nudge" && action != "decline" {
+                anyhow::bail!("invalid action: {action} (expected \"nudge\" or \"decline\")");
+            }
+            let message = arguments.get("message").and_then(|v| v.as_str());
+            if action == "nudge" && message.map(|m| m.is_empty()).unwrap_or(true) {
+                anyhow::bail!("message is required when action is \"nudge\"");
+            }
+            let reason = arguments.get("reason").and_then(|v| v.as_str());
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let source_agent = std::env::var("AGENTMUX_AGENT_ID")
+                .ok()
+                .filter(|s| !s.is_empty());
+
+            let url = format!(
+                "{}/agentmux/reactive/supervisor-decision",
+                local_url.trim_end_matches('/')
+            );
+            let body = json!({
+                "target_agent": target_agent,
+                "action": action,
+                "message": message,
+                "reason": reason,
+                "source_agent": source_agent,
+            });
+
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            let status = resp.status();
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
+            if !status.is_success() {
+                let err = result
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                anyhow::bail!("supervisor decision rejected: HTTP {status} — {err}");
+            }
 
             Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
         }

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -144,13 +144,12 @@ const GET_AGENT_TRANSCRIPT_TOOL: &str = r#"{
 
 const SUPERVISOR_NUDGE_TOOL: &str = r#"{
   "name": "SupervisorNudge",
-  "description": "For a Warden Supervisor watcher agent: record a decision about a target agent that just ended its turn, after inspecting it with GetAgentTranscript. action=\"nudge\" delivers `message` to the target as an ordinary jekt telling it to continue, and logs the decision. action=\"decline\" sends nothing and just logs that you chose not to nudge (e.g. the target isn't opted in, or looks genuinely done/blocked, not merely pausing to ask). A nudge that would exceed the server-side consecutive-nudge ceiling is refused (HTTP 429/tool error) — treat that as a signal to stop nudging this target and escalate to a human via SendMessage instead of retrying.",
+  "description": "For a Warden Supervisor watcher agent: record a decision about a target agent that just ended its turn, after inspecting it with GetAgentTranscript. action=\"nudge\" delivers a fixed, server-owned continuation message to the target as an ordinary jekt and logs the decision — this tool does NOT accept custom message text; the nudge is deliberately a narrow, non-composable template, not an instruction you write per-situation. action=\"decline\" sends nothing and just logs that you chose not to nudge (e.g. the target isn't opted in, or looks genuinely done/blocked, not merely pausing to ask). A nudge is refused (tool error) if the target hasn't opted in via auto_continue_enabled, or if it would exceed the server-side consecutive-nudge ceiling — treat either as a signal to stop nudging this target and escalate to a human via SendMessage instead of retrying.",
   "inputSchema": {
     "type": "object",
     "properties": {
       "target_agent": { "type": "string", "description": "Name of the agent this decision is about (its AGENTMUX_AGENT_ID value)" },
       "action":       { "type": "string", "enum": ["nudge", "decline"], "description": "Whether to nudge the target to continue or decline to" },
-      "message":      { "type": "string", "description": "Required when action is \"nudge\" — the message delivered to the target as a jekt" },
       "reason":       { "type": "string", "description": "Your stated reasoning for this decision, recorded in the audit log" }
     },
     "required": ["target_agent", "action"]
@@ -1142,10 +1141,6 @@ async fn call_tool(
             if action != "nudge" && action != "decline" {
                 anyhow::bail!("invalid action: {action} (expected \"nudge\" or \"decline\")");
             }
-            let message = arguments.get("message").and_then(|v| v.as_str());
-            if action == "nudge" && message.map(|m| m.is_empty()).unwrap_or(true) {
-                anyhow::bail!("message is required when action is \"nudge\"");
-            }
             let reason = arguments.get("reason").and_then(|v| v.as_str());
 
             if local_url.is_empty() || auth_key.is_empty() {
@@ -1166,7 +1161,6 @@ async fn call_tool(
             let body = json!({
                 "target_agent": target_agent,
                 "action": action,
-                "message": message,
                 "reason": reason,
                 "source_agent": source_agent,
             });
@@ -1191,6 +1185,21 @@ async fn call_tool(
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown error");
                 anyhow::bail!("supervisor decision rejected: HTTP {status} — {err}");
+            }
+
+            // The route always returns HTTP 200 for a request that passed
+            // the entitlement/ceiling gates — actual delivery success is
+            // only reflected in the response body's `success` field (a
+            // failed nudge still gets logged and returned as 200/success:
+            // false, same as SendMessage's InjectionResponse). Checking
+            // HTTP status alone previously reported a failed delivery to
+            // the calling Supervisor as success (reagentx P2 on PR #2557).
+            if result.get("success").and_then(|v| v.as_bool()) != Some(true) {
+                let err = result
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                anyhow::bail!("supervisor decision delivery failed: {err}");
             }
 
             Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -82,6 +82,12 @@ pub(super) const MAX_CONSECUTIVE_AUTO_CONTINUES: u32 = 5;
 /// session even without a fresh `registration_nonce`.
 pub(super) const NUDGE_COOLDOWN_RESET_MS: u64 = 30 * 60 * 1000;
 
+/// The one, fixed message a `SupervisorAction::Nudge` ever delivers.
+/// Deliberately not a parameter — see the doc on `record_supervisor_decision`'s
+/// `Nudge` arm for why a free-form message defeats the guardrail this
+/// exists for.
+pub(super) const NUDGE_MESSAGE: &str = "Continue the task you were already doing.";
+
 // ---- Handler ----
 
 /// Core reactive messaging handler.
@@ -288,19 +294,25 @@ impl Handler {
     /// then spawns 3 delayed `\r` sends at 200ms intervals as separate
     /// PTY writes to ensure submission. See `specs/jekt-inject-timing.md`.
     pub fn inject_message(&mut self, req: InjectionRequest) -> InjectionResponse {
-        self.inject_message_inner(req, None, None)
+        self.inject_message_inner(req, None, None, None)
     }
 
     /// Shared delivery path behind both `inject_message` (ordinary jekt,
-    /// `outcome`/`reason` always `None`) and `record_supervisor_decision`'s
-    /// `Nudge` arm (`outcome: Some("nudge_sent")`, `reason` the Supervisor's
-    /// stated reasoning) — every audit-log write below carries these
-    /// through instead of the two call sites duplicating sanitize/deliver
-    /// logic.
+    /// every `outcome`/`reason` param always `None`) and
+    /// `record_supervisor_decision`'s `Nudge` arm (`outcome_on_success:
+    /// Some("nudge_sent")`, `outcome_on_failure: Some("nudge_failed")`,
+    /// `reason` the Supervisor's stated reasoning) — every audit-log write
+    /// below carries these through instead of the two call sites
+    /// duplicating sanitize/deliver logic. Two separate outcome params
+    /// (rather than one applied uniformly) so a failed delivery is audited
+    /// distinctly from a successful one (reagentx P2 on PR #2557 — the
+    /// Supervisor UI's decision feed must not show "nudged" for a delivery
+    /// that actually failed).
     fn inject_message_inner(
         &mut self,
         mut req: InjectionRequest,
-        outcome: Option<&str>,
+        outcome_on_success: Option<&str>,
+        outcome_on_failure: Option<&str>,
         reason: Option<&str>,
     ) -> InjectionResponse {
         let now = now_unix_millis();
@@ -351,7 +363,7 @@ impl Handler {
                     false,
                     Some(&err),
                     &request_id,
-                    outcome,
+                    outcome_on_failure,
                     reason,
                 );
                 return InjectionResponse {
@@ -429,7 +441,7 @@ impl Handler {
                         true,
                         None,
                         &request_id,
-                        outcome,
+                        outcome_on_success,
                         reason,
                     );
                     return InjectionResponse {
@@ -462,7 +474,7 @@ impl Handler {
                         false,
                         Some(&e),
                         &request_id,
-                        outcome,
+                        outcome_on_failure,
                         reason,
                     );
                     return InjectionResponse {
@@ -490,7 +502,7 @@ impl Handler {
                     false,
                     Some(&err),
                     &request_id,
-                    outcome,
+                    outcome_on_failure,
                     reason,
                 );
                 return InjectionResponse {
@@ -531,7 +543,7 @@ impl Handler {
                 false,
                 Some(&e),
                 &request_id,
-                outcome,
+                outcome_on_failure,
                 reason,
             );
             return InjectionResponse {
@@ -565,7 +577,7 @@ impl Handler {
             true,
             None,
             &request_id,
-            outcome,
+            outcome_on_success,
             reason,
         );
 
@@ -643,7 +655,7 @@ impl Handler {
                     effective_tier: None,
                 })
             }
-            SupervisorAction::Nudge(message) => {
+            SupervisorAction::Nudge => {
                 // Bound `nudge_counters`' growth (reagentx P2 on PR #2557):
                 // an entry idle past the cooldown window is about to be
                 // treated as stale on next use anyway, so dropping it here
@@ -657,29 +669,37 @@ impl Handler {
                     .get(&target_key)
                     .map(|info| info.registration_nonce)
                     .unwrap_or(0);
-                let entry = self.nudge_counters.entry(target_key).or_insert(NudgeCounterState {
-                    registration_nonce: current_nonce,
-                    block_id: block_id.clone(),
-                    count: 0,
-                    last_nudge_at_ms: 0,
-                });
-                // registration_nonce only distinguishes a respawn for
-                // persistent-controller agents (real nonces, ≥ 1);
-                // PTY/shell/HTTP-register paths always register with 0, so
-                // block_id is the fallback signal for those (reagentx P1 on
-                // PR #2557 — nonce alone never fired for them, leaving a
-                // respawned PTY agent stuck behind its prior run's
-                // exhausted ceiling for up to the full cooldown window).
-                let stale = entry.registration_nonce != current_nonce
-                    || entry.block_id != block_id
-                    || now.saturating_sub(entry.last_nudge_at_ms) > NUDGE_COOLDOWN_RESET_MS;
-                if stale {
-                    entry.registration_nonce = current_nonce;
-                    entry.block_id = block_id.clone();
-                    entry.count = 0;
-                }
 
-                if entry.count >= MAX_CONSECUTIVE_AUTO_CONTINUES {
+                // Scoped borrow: check/reset staleness and read the
+                // pre-delivery count, then drop the borrow before calling
+                // `inject_message_inner` (which needs `&mut self` too).
+                let count_before = {
+                    let entry = self.nudge_counters.entry(target_key.clone()).or_insert(NudgeCounterState {
+                        registration_nonce: current_nonce,
+                        block_id: block_id.clone(),
+                        count: 0,
+                        last_nudge_at_ms: 0,
+                    });
+                    // registration_nonce only distinguishes a respawn for
+                    // persistent-controller agents (real nonces, ≥ 1);
+                    // PTY/shell/HTTP-register paths always register with 0,
+                    // so block_id is the fallback signal for those
+                    // (reagentx P1 on PR #2557 — nonce alone never fired
+                    // for them, leaving a respawned PTY agent stuck behind
+                    // its prior run's exhausted ceiling for up to the full
+                    // cooldown window).
+                    let stale = entry.registration_nonce != current_nonce
+                        || entry.block_id != block_id
+                        || now.saturating_sub(entry.last_nudge_at_ms) > NUDGE_COOLDOWN_RESET_MS;
+                    if stale {
+                        entry.registration_nonce = current_nonce;
+                        entry.block_id = block_id.clone();
+                        entry.count = 0;
+                    }
+                    entry.count
+                };
+
+                if count_before >= MAX_CONSECUTIVE_AUTO_CONTINUES {
                     let ceiling_reason = "consecutive-nudge ceiling reached".to_string();
                     self.log_audit(
                         source_agent,
@@ -695,12 +715,20 @@ impl Handler {
                     return Err(ceiling_reason);
                 }
 
-                entry.count += 1;
-                entry.last_nudge_at_ms = now;
-
+                // Fixed, narrow continuation template — deliberately NOT
+                // free-form text composed by the calling Supervisor agent.
+                // ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_
+                // 2026_08_12.md §4.3: "The nudge text should be a fixed,
+                // narrow template... not a free-form instruction the
+                // watcher composes per-situation — this is the direct
+                // mitigation for consent-chain degradation." (reagentx P1
+                // on PR #2557 — SupervisorNudge used to accept arbitrary
+                // `message` text.) `reason` (the Supervisor's own
+                // reasoning) still travels separately, into the audit log
+                // only — never into what's delivered to the target.
                 let req = InjectionRequest {
                     target_agent: target_agent.to_string(),
-                    message,
+                    message: NUDGE_MESSAGE.to_string(),
                     source_agent: source_agent.map(|s| s.to_string()),
                     request_id: Some(request_id.to_string()),
                     priority: Some("normal".to_string()),
@@ -709,7 +737,25 @@ impl Handler {
                     delivery_tier: Some("host".to_string()),
                     forward_hops: 0,
                 };
-                Ok(self.inject_message_inner(req, Some("nudge_sent"), Some(reason)))
+                let resp = self.inject_message_inner(
+                    req,
+                    Some("nudge_sent"),
+                    Some("nudge_failed"),
+                    Some(reason),
+                );
+
+                // Only a successful delivery consumes the ceiling
+                // (reagentx P2 on PR #2557) — a rate-limited/unavailable-
+                // controller failure shouldn't cost the Supervisor one of
+                // its 5 consecutive attempts for this target.
+                if resp.success {
+                    if let Some(entry) = self.nudge_counters.get_mut(&target_key) {
+                        entry.count += 1;
+                        entry.last_nudge_at_ms = now;
+                    }
+                }
+
+                Ok(resp)
             }
         }
     }

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -43,6 +43,32 @@ impl RateLimiter {
     }
 }
 
+// ---- Supervisor nudge-ceiling tracking ----
+
+/// Per-target-agent consecutive-nudge tracking for the Warden Supervisor
+/// guardrail. Keyed on the target agent's lowercased name in
+/// `Handler::nudge_counters`.
+struct NudgeCounterState {
+    /// The target's `AgentRegistration::registration_nonce` as of the last
+    /// nudge — a respawn (new nonce) resets the counter, since "consecutive"
+    /// only makes sense within one continuous run.
+    registration_nonce: u64,
+    count: u32,
+    last_nudge_at_ms: u64,
+}
+
+/// Max consecutive auto-continue nudges a Supervisor may send to the same
+/// target agent (within one registration / cooldown window) before
+/// `record_supervisor_decision` refuses and forces a decline instead. Bounds
+/// a runaway auto-continue loop — see
+/// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+pub(super) const MAX_CONSECUTIVE_AUTO_CONTINUES: u32 = 5;
+
+/// Gap since the last nudge after which the consecutive counter resets, on
+/// the theory that a long-idle target has effectively started a new work
+/// session even without a fresh `registration_nonce`.
+pub(super) const NUDGE_COOLDOWN_RESET_MS: u64 = 30 * 60 * 1000;
+
 // ---- Handler ----
 
 /// Core reactive messaging handler.
@@ -61,6 +87,10 @@ pub struct Handler {
     audit_log: Vec<AuditLogEntry>,
     rate_limiter: RateLimiter,
     include_source_in_message: bool,
+    /// Warden Supervisor consecutive-nudge ceiling state, keyed on the
+    /// target agent's lowercased name. In-memory only (same lifecycle as
+    /// `audit_log`) — not persisted across a restart.
+    nudge_counters: HashMap<String, NudgeCounterState>,
 }
 
 impl Handler {
@@ -76,6 +106,7 @@ impl Handler {
             audit_log: Vec::with_capacity(AUDIT_LOG_MAX),
             rate_limiter: RateLimiter::new(RATE_LIMIT_MAX),
             include_source_in_message: false,
+            nudge_counters: HashMap::new(),
         }
     }
 
@@ -243,7 +274,22 @@ impl Handler {
     /// Sends `message\r` as a single payload (required for text display),
     /// then spawns 3 delayed `\r` sends at 200ms intervals as separate
     /// PTY writes to ensure submission. See `specs/jekt-inject-timing.md`.
-    pub fn inject_message(&mut self, mut req: InjectionRequest) -> InjectionResponse {
+    pub fn inject_message(&mut self, req: InjectionRequest) -> InjectionResponse {
+        self.inject_message_inner(req, None, None)
+    }
+
+    /// Shared delivery path behind both `inject_message` (ordinary jekt,
+    /// `outcome`/`reason` always `None`) and `record_supervisor_decision`'s
+    /// `Nudge` arm (`outcome: Some("nudge_sent")`, `reason` the Supervisor's
+    /// stated reasoning) — every audit-log write below carries these
+    /// through instead of the two call sites duplicating sanitize/deliver
+    /// logic.
+    fn inject_message_inner(
+        &mut self,
+        mut req: InjectionRequest,
+        outcome: Option<&str>,
+        reason: Option<&str>,
+    ) -> InjectionResponse {
         let now = now_unix_millis();
 
         // Generate request ID if missing
@@ -292,8 +338,8 @@ impl Handler {
                     false,
                     Some(&err),
                     &request_id,
-                    None,
-                    None,
+                    outcome,
+                    reason,
                 );
                 return InjectionResponse {
                     success: false,
@@ -370,8 +416,8 @@ impl Handler {
                         true,
                         None,
                         &request_id,
-                        None,
-                        None,
+                        outcome,
+                        reason,
                     );
                     return InjectionResponse {
                         success: true,
@@ -403,8 +449,8 @@ impl Handler {
                         false,
                         Some(&e),
                         &request_id,
-                        None,
-                        None,
+                        outcome,
+                        reason,
                     );
                     return InjectionResponse {
                         success: false,
@@ -431,8 +477,8 @@ impl Handler {
                     false,
                     Some(&err),
                     &request_id,
-                    None,
-                    None,
+                    outcome,
+                    reason,
                 );
                 return InjectionResponse {
                     success: false,
@@ -472,8 +518,8 @@ impl Handler {
                 false,
                 Some(&e),
                 &request_id,
-                None,
-                None,
+                outcome,
+                reason,
             );
             return InjectionResponse {
                 success: false,
@@ -506,8 +552,8 @@ impl Handler {
             true,
             None,
             &request_id,
-            None,
-            None,
+            outcome,
+            reason,
         );
 
         InjectionResponse {
@@ -517,6 +563,114 @@ impl Handler {
             error: None,
             timestamp: now,
             effective_tier: Some(effective_tier.to_string()),
+        }
+    }
+
+    /// Record a Warden Supervisor watcher agent's decision about
+    /// `target_agent`. A `Nudge` is delivered through the same path
+    /// `inject_message` uses (`inject_message_inner`) and audited with
+    /// `outcome: "nudge_sent"`; a `Decline` sends nothing and is audited
+    /// directly with `outcome: "nudge_declined"`.
+    ///
+    /// Enforces the consecutive-nudge ceiling
+    /// (`MAX_CONSECUTIVE_AUTO_CONTINUES`): if this nudge would exceed it,
+    /// the decision is forced to a decline (audited with
+    /// `outcome: "nudge_declined"`, `reason: "consecutive-nudge ceiling
+    /// reached"`) and `Err` is returned so the calling agent's MCP
+    /// tool-call result surfaces the refusal directly — a signal for it to
+    /// stop nudging and escalate to a human via an ordinary jekt instead of
+    /// retrying. The counter resets when the target's
+    /// `registration_nonce` changes (a respawn — "consecutive" only makes
+    /// sense within one continuous run) or after `NUDGE_COOLDOWN_RESET_MS`
+    /// of inactivity.
+    pub fn record_supervisor_decision(
+        &mut self,
+        target_agent: &str,
+        action: SupervisorAction,
+        reason: &str,
+        request_id: &str,
+        source_agent: Option<&str>,
+    ) -> Result<InjectionResponse, String> {
+        let now = now_unix_millis();
+        let target_key = target_agent.to_lowercase();
+        let block_id = self
+            .agent_to_block
+            .get(&target_key)
+            .cloned()
+            .unwrap_or_default();
+
+        match action {
+            SupervisorAction::Decline => {
+                self.log_audit(
+                    source_agent,
+                    target_agent,
+                    &block_id,
+                    "",
+                    true,
+                    None,
+                    request_id,
+                    Some("nudge_declined"),
+                    Some(reason),
+                );
+                Ok(InjectionResponse {
+                    success: true,
+                    request_id: request_id.to_string(),
+                    block_id: if block_id.is_empty() { None } else { Some(block_id) },
+                    error: None,
+                    timestamp: now,
+                    effective_tier: None,
+                })
+            }
+            SupervisorAction::Nudge(message) => {
+                let current_nonce = self
+                    .agent_info
+                    .get(&target_key)
+                    .map(|info| info.registration_nonce)
+                    .unwrap_or(0);
+                let entry = self.nudge_counters.entry(target_key).or_insert(NudgeCounterState {
+                    registration_nonce: current_nonce,
+                    count: 0,
+                    last_nudge_at_ms: 0,
+                });
+                let stale = entry.registration_nonce != current_nonce
+                    || now.saturating_sub(entry.last_nudge_at_ms) > NUDGE_COOLDOWN_RESET_MS;
+                if stale {
+                    entry.registration_nonce = current_nonce;
+                    entry.count = 0;
+                }
+
+                if entry.count >= MAX_CONSECUTIVE_AUTO_CONTINUES {
+                    let ceiling_reason = "consecutive-nudge ceiling reached".to_string();
+                    self.log_audit(
+                        source_agent,
+                        target_agent,
+                        &block_id,
+                        "",
+                        true,
+                        None,
+                        request_id,
+                        Some("nudge_declined"),
+                        Some(&ceiling_reason),
+                    );
+                    return Err(ceiling_reason);
+                }
+
+                entry.count += 1;
+                entry.last_nudge_at_ms = now;
+
+                let req = InjectionRequest {
+                    target_agent: target_agent.to_string(),
+                    message,
+                    source_agent: source_agent.map(|s| s.to_string()),
+                    request_id: Some(request_id.to_string()),
+                    priority: Some("normal".to_string()),
+                    wait_for_idle: false,
+                    jekt_tier: Some(super::types::JektTier::Coord),
+                    delivery_tier: Some("host".to_string()),
+                    forward_hops: 0,
+                };
+                Ok(self.inject_message_inner(req, Some("nudge_sent"), Some(reason)))
+            }
         }
     }
 
@@ -684,6 +838,21 @@ impl ReactiveHandler {
 
     pub fn get_audit_log(&self, limit: usize) -> Vec<AuditLogEntry> {
         self.inner.lock().unwrap().get_audit_log(limit)
+    }
+
+    /// See the inner [`Handler::record_supervisor_decision`].
+    pub fn record_supervisor_decision(
+        &self,
+        target_agent: &str,
+        action: SupervisorAction,
+        reason: &str,
+        request_id: &str,
+        source_agent: Option<&str>,
+    ) -> Result<InjectionResponse, String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .record_supervisor_decision(target_agent, action, reason, request_id, source_agent)
     }
 }
 

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -51,8 +51,21 @@ impl RateLimiter {
 struct NudgeCounterState {
     /// The target's `AgentRegistration::registration_nonce` as of the last
     /// nudge — a respawn (new nonce) resets the counter, since "consecutive"
-    /// only makes sense within one continuous run.
+    /// only makes sense within one continuous run. Real nonces are ≥ 1
+    /// (persistent-controller spawns only — `persistent::next_registration_
+    /// nonce`); PTY/shell and HTTP-register paths always register with 0
+    /// ("not recorded"), so nonce alone can't detect a respawn for them —
+    /// `block_id` below covers that case instead.
     registration_nonce: u64,
+    /// The target's block id as of the last nudge. A PTY/shell-registered
+    /// agent that's closed and relaunched gets a fresh block id (a new
+    /// pane), which nonce (always 0 for these paths) can't see — comparing
+    /// block_id catches that respawn case reagent flagged as a P1 gap
+    /// (nonce-only reset never fires for PTY agents). Doesn't help detect a
+    /// respawn that reuses the same pane/block id (e.g. a one-shot
+    /// SubprocessController that re-registers every turn in-place) — that
+    /// case still relies on `NUDGE_COOLDOWN_RESET_MS` alone, same as before.
+    block_id: String,
     count: u32,
     last_nudge_at_ms: u64,
 }
@@ -579,10 +592,19 @@ impl Handler {
     /// reached"`) and `Err` is returned so the calling agent's MCP
     /// tool-call result surfaces the refusal directly — a signal for it to
     /// stop nudging and escalate to a human via an ordinary jekt instead of
-    /// retrying. The counter resets when the target's
-    /// `registration_nonce` changes (a respawn — "consecutive" only makes
-    /// sense within one continuous run) or after `NUDGE_COOLDOWN_RESET_MS`
-    /// of inactivity.
+    /// retrying. The counter resets when the target's `registration_nonce`
+    /// or `block_id` changes (a respawn — "consecutive" only makes sense
+    /// within one continuous run; see `NudgeCounterState`'s field docs for
+    /// why both signals are needed) or after `NUDGE_COOLDOWN_RESET_MS` of
+    /// inactivity.
+    ///
+    /// Does NOT check the target's `auto_continue_enabled` opt-in itself —
+    /// `Handler` has no `Store` access by design (this module doesn't
+    /// depend on `backend::storage`). That gate lives at the HTTP boundary,
+    /// in `handle_reactive_supervisor_decision`
+    /// (`server/reactive.rs`), which has `AppState::wstore`. Any other
+    /// caller of this method directly is responsible for its own
+    /// entitlement check first.
     pub fn record_supervisor_decision(
         &mut self,
         target_agent: &str,
@@ -622,6 +644,14 @@ impl Handler {
                 })
             }
             SupervisorAction::Nudge(message) => {
+                // Bound `nudge_counters`' growth (reagentx P2 on PR #2557):
+                // an entry idle past the cooldown window is about to be
+                // treated as stale on next use anyway, so dropping it here
+                // is behavior-neutral — just reclaims memory instead of
+                // accumulating one entry per distinct target agent forever.
+                self.nudge_counters
+                    .retain(|_, v| now.saturating_sub(v.last_nudge_at_ms) <= NUDGE_COOLDOWN_RESET_MS);
+
                 let current_nonce = self
                     .agent_info
                     .get(&target_key)
@@ -629,13 +659,23 @@ impl Handler {
                     .unwrap_or(0);
                 let entry = self.nudge_counters.entry(target_key).or_insert(NudgeCounterState {
                     registration_nonce: current_nonce,
+                    block_id: block_id.clone(),
                     count: 0,
                     last_nudge_at_ms: 0,
                 });
+                // registration_nonce only distinguishes a respawn for
+                // persistent-controller agents (real nonces, ≥ 1);
+                // PTY/shell/HTTP-register paths always register with 0, so
+                // block_id is the fallback signal for those (reagentx P1 on
+                // PR #2557 — nonce alone never fired for them, leaving a
+                // respawned PTY agent stuck behind its prior run's
+                // exhausted ceiling for up to the full cooldown window).
                 let stale = entry.registration_nonce != current_nonce
+                    || entry.block_id != block_id
                     || now.saturating_sub(entry.last_nudge_at_ms) > NUDGE_COOLDOWN_RESET_MS;
                 if stale {
                     entry.registration_nonce = current_nonce;
+                    entry.block_id = block_id.clone();
                     entry.count = 0;
                 }
 

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -793,6 +793,61 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registratio
     assert!(resp.success);
 }
 
+/// PTY/shell and HTTP-register paths always register with
+/// `registration_nonce: 0` ("not recorded") — nonce equality alone can
+/// never detect a respawn for them (0 == 0 every time). A relaunch into a
+/// new pane (new block_id) must still reset the ceiling — this is the P1
+/// reagentx flagged on PR #2557 (nonce-only reset silently never fired for
+/// the common PTY case).
+#[tokio::test]
+async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_block_id_when_nonce_is_zero() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(|_block_id: &str, _data: &[u8]| Ok(())));
+    // register_agent (not _with_nonce) always passes nonce 0 — the PTY/HTTP
+    // register path this test is guarding.
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    for i in 0..MAX_CONSECUTIVE_AUTO_CONTINUES {
+        handler
+            .record_supervisor_decision(
+                "agent1",
+                SupervisorAction::Nudge("keep going".to_string()),
+                "still making progress",
+                &format!("req-{i}"),
+                Some("warden-supervisor"),
+            )
+            .unwrap_or_else(|e| panic!("nudge {i} should not hit the ceiling yet: {e}"));
+    }
+    assert!(
+        handler
+            .record_supervisor_decision(
+                "agent1",
+                SupervisorAction::Nudge("keep going".to_string()),
+                "still making progress",
+                "req-over",
+                Some("warden-supervisor"),
+            )
+            .is_err(),
+        "ceiling must be hit before the relaunch"
+    );
+
+    // Relaunch: same agent name, closed and reopened in a NEW pane — a
+    // different block_id, still nonce 0 (PTY path never records a real
+    // nonce).
+    handler.register_agent("agent1", "block2", None).unwrap();
+
+    let resp = handler
+        .record_supervisor_decision(
+            "agent1",
+            SupervisorAction::Nudge("keep going".to_string()),
+            "fresh run in a new pane, target paused again",
+            "req-after-relaunch",
+            Some("warden-supervisor"),
+        )
+        .expect("a new block_id must reset the ceiling even though nonce stayed 0");
+    assert!(resp.success);
+}
+
 // -- Poller tests --
 
 #[test]

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -691,6 +691,51 @@ fn test_record_supervisor_decision_decline_logs_one_entry_no_delivery() {
     );
 }
 
+/// A failed delivery (no input sender configured) must be audited as
+/// `nudge_failed`, not `nudge_sent` — and must NOT consume the
+/// consecutive-nudge ceiling, since nothing was actually delivered
+/// (reagentx P2 on PR #2557, round 2).
+#[tokio::test]
+async fn test_record_supervisor_decision_nudge_failure_is_audited_and_not_counted() {
+    let mut handler = Handler::new();
+    // Deliberately no `set_input_sender` — delivery will fail with
+    // "input sender not configured".
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler
+        .record_supervisor_decision(
+            "agent1",
+            SupervisorAction::Nudge,
+            "target looks stalled",
+            "req-fail-1",
+            Some("warden-supervisor"),
+        )
+        .expect("a failed delivery is still Ok — it's not a ceiling refusal");
+    assert!(!resp.success);
+
+    let log = handler.get_audit_log(10);
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0].outcome.as_deref(), Some("nudge_failed"));
+    assert!(!log[0].success);
+
+    // Wire up a working sender and confirm the full ceiling is still
+    // available — the failed attempt above must not have consumed any of
+    // it.
+    handler.set_input_sender(Arc::new(|_block_id: &str, _data: &[u8]| Ok(())));
+    for i in 0..MAX_CONSECUTIVE_AUTO_CONTINUES {
+        let resp = handler
+            .record_supervisor_decision(
+                "agent1",
+                SupervisorAction::Nudge,
+                "still making progress",
+                &format!("req-ok-{i}"),
+                Some("warden-supervisor"),
+            )
+            .unwrap_or_else(|e| panic!("nudge {i} should not hit the ceiling: {e}"));
+        assert!(resp.success);
+    }
+}
+
 /// `MAX_CONSECUTIVE_AUTO_CONTINUES` nudges to the same target succeed; the
 /// next one is refused with the ceiling error and logs a `nudge_declined`
 /// entry instead of attempting delivery.
@@ -704,7 +749,7 @@ async fn test_record_supervisor_decision_nudge_ceiling() {
         let resp = handler
             .record_supervisor_decision(
                 "agent1",
-                SupervisorAction::Nudge("keep going".to_string()),
+                SupervisorAction::Nudge,
                 "still making progress",
                 &format!("req-{i}"),
                 Some("warden-supervisor"),
@@ -716,7 +761,7 @@ async fn test_record_supervisor_decision_nudge_ceiling() {
     let err = handler
         .record_supervisor_decision(
             "agent1",
-            SupervisorAction::Nudge("keep going".to_string()),
+            SupervisorAction::Nudge,
             "still making progress",
             "req-over",
             Some("warden-supervisor"),
@@ -756,7 +801,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registratio
         handler
             .record_supervisor_decision(
                 "agent1",
-                SupervisorAction::Nudge("keep going".to_string()),
+                SupervisorAction::Nudge,
                 "still making progress",
                 &format!("req-{i}"),
                 Some("warden-supervisor"),
@@ -767,7 +812,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registratio
         handler
             .record_supervisor_decision(
                 "agent1",
-                SupervisorAction::Nudge("keep going".to_string()),
+                SupervisorAction::Nudge,
                 "still making progress",
                 "req-over",
                 Some("warden-supervisor"),
@@ -784,7 +829,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registratio
     let resp = handler
         .record_supervisor_decision(
             "agent1",
-            SupervisorAction::Nudge("keep going".to_string()),
+            SupervisorAction::Nudge,
             "fresh run, target paused again",
             "req-after-respawn",
             Some("warden-supervisor"),
@@ -811,7 +856,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_block_id_wh
         handler
             .record_supervisor_decision(
                 "agent1",
-                SupervisorAction::Nudge("keep going".to_string()),
+                SupervisorAction::Nudge,
                 "still making progress",
                 &format!("req-{i}"),
                 Some("warden-supervisor"),
@@ -822,7 +867,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_block_id_wh
         handler
             .record_supervisor_decision(
                 "agent1",
-                SupervisorAction::Nudge("keep going".to_string()),
+                SupervisorAction::Nudge,
                 "still making progress",
                 "req-over",
                 Some("warden-supervisor"),
@@ -839,7 +884,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_block_id_wh
     let resp = handler
         .record_supervisor_decision(
             "agent1",
-            SupervisorAction::Nudge("keep going".to_string()),
+            SupervisorAction::Nudge,
             "fresh run in a new pane, target paused again",
             "req-after-relaunch",
             Some("warden-supervisor"),

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -659,6 +659,140 @@ fn test_handler_audit_log_ring_buffer() {
     assert_eq!(log[0].request_id, "req-109");
 }
 
+// -- Warden Supervisor decision tests --
+
+/// A `Decline` decision must log exactly one audit entry (`nudge_declined`)
+/// and must not attempt any delivery — no input sender is configured at
+/// all, so a delivery attempt would panic/error, not just be a no-op.
+#[test]
+fn test_record_supervisor_decision_decline_logs_one_entry_no_delivery() {
+    let mut handler = Handler::new();
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler
+        .record_supervisor_decision(
+            "agent1",
+            SupervisorAction::Decline,
+            "target looks genuinely done, not just pausing",
+            "req-1",
+            Some("warden-supervisor"),
+        )
+        .expect("decline never fails");
+
+    assert!(resp.success);
+    assert_eq!(resp.block_id.as_deref(), Some("block1"));
+
+    let log = handler.get_audit_log(10);
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0].outcome.as_deref(), Some("nudge_declined"));
+    assert_eq!(
+        log[0].reason.as_deref(),
+        Some("target looks genuinely done, not just pausing")
+    );
+}
+
+/// `MAX_CONSECUTIVE_AUTO_CONTINUES` nudges to the same target succeed; the
+/// next one is refused with the ceiling error and logs a `nudge_declined`
+/// entry instead of attempting delivery.
+#[tokio::test]
+async fn test_record_supervisor_decision_nudge_ceiling() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(|_block_id: &str, _data: &[u8]| Ok(())));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    for i in 0..MAX_CONSECUTIVE_AUTO_CONTINUES {
+        let resp = handler
+            .record_supervisor_decision(
+                "agent1",
+                SupervisorAction::Nudge("keep going".to_string()),
+                "still making progress",
+                &format!("req-{i}"),
+                Some("warden-supervisor"),
+            )
+            .unwrap_or_else(|e| panic!("nudge {i} should not hit the ceiling yet: {e}"));
+        assert!(resp.success);
+    }
+
+    let err = handler
+        .record_supervisor_decision(
+            "agent1",
+            SupervisorAction::Nudge("keep going".to_string()),
+            "still making progress",
+            "req-over",
+            Some("warden-supervisor"),
+        )
+        .expect_err("the next nudge must be refused");
+    assert_eq!(err, "consecutive-nudge ceiling reached");
+
+    let log = handler.get_audit_log(20);
+    let ceiling_entry = log
+        .iter()
+        .find(|e| e.request_id == "req-over")
+        .expect("the declined attempt must still be audited");
+    assert_eq!(ceiling_entry.outcome.as_deref(), Some("nudge_declined"));
+    assert_eq!(
+        ceiling_entry.reason.as_deref(),
+        Some("consecutive-nudge ceiling reached")
+    );
+    // Every prior nudge must have actually been delivered (nudge_sent), not
+    // silently declined early.
+    let sent_count = log.iter().filter(|e| e.outcome.as_deref() == Some("nudge_sent")).count();
+    assert_eq!(sent_count as u32, MAX_CONSECUTIVE_AUTO_CONTINUES);
+}
+
+/// A respawn (new `registration_nonce`) resets the consecutive-nudge
+/// counter — "consecutive" only makes sense within one continuous run, so a
+/// fresh spawn of the same agent name must not inherit the prior run's
+/// nudge count.
+#[tokio::test]
+async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registration_nonce() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(|_block_id: &str, _data: &[u8]| Ok(())));
+    handler
+        .register_agent_with_nonce("agent1", "block1", None, 1)
+        .unwrap();
+
+    for i in 0..MAX_CONSECUTIVE_AUTO_CONTINUES {
+        handler
+            .record_supervisor_decision(
+                "agent1",
+                SupervisorAction::Nudge("keep going".to_string()),
+                "still making progress",
+                &format!("req-{i}"),
+                Some("warden-supervisor"),
+            )
+            .unwrap_or_else(|e| panic!("nudge {i} should not hit the ceiling yet: {e}"));
+    }
+    assert!(
+        handler
+            .record_supervisor_decision(
+                "agent1",
+                SupervisorAction::Nudge("keep going".to_string()),
+                "still making progress",
+                "req-over",
+                Some("warden-supervisor"),
+            )
+            .is_err(),
+        "ceiling must be hit before the respawn"
+    );
+
+    // Respawn: same agent name, new nonce.
+    handler
+        .register_agent_with_nonce("agent1", "block1", None, 2)
+        .unwrap();
+
+    let resp = handler
+        .record_supervisor_decision(
+            "agent1",
+            SupervisorAction::Nudge("keep going".to_string()),
+            "fresh run, target paused again",
+            "req-after-respawn",
+            Some("warden-supervisor"),
+        )
+        .expect("a fresh registration_nonce must reset the ceiling");
+    assert!(resp.success);
+}
+
 // -- Poller tests --
 
 #[test]

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -124,11 +124,15 @@ pub struct AuditLogEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
     pub request_id: String,
-    /// "nudge_sent" | "nudge_declined" — present only for Warden Supervisor-
-    /// originated entries (see ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_
-    /// WATCHER_2026_08_12.md); absent for ordinary jekt injections. A
-    /// "nudge_declined" entry has no corresponding delivery at all — this
-    /// field is the ONLY record that decision ever existed.
+    /// "nudge_sent" | "nudge_failed" | "nudge_declined" — present only for
+    /// Warden Supervisor-originated entries (see
+    /// ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md);
+    /// absent for ordinary jekt injections. "nudge_sent" only when delivery
+    /// actually succeeded; "nudge_failed" when the Supervisor attempted a
+    /// nudge but delivery itself failed (rate limit, unavailable
+    /// controller, etc — see `entry.success`/`error_message` for why). A
+    /// "nudge_declined" entry has no corresponding delivery attempt at
+    /// all — this field is the ONLY record that decision ever existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub outcome: Option<String>,
     /// The Supervisor's stated reasoning, populated alongside `outcome`.
@@ -142,11 +146,18 @@ pub struct AuditLogEntry {
 /// isn't opted in, or the Supervisor judged it genuinely done/blocked).
 /// See `Handler::record_supervisor_decision` and
 /// ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum SupervisorAction {
-    /// Deliver `message` to the target as an ordinary jekt (via the same
-    /// path `inject_message` uses), then log the decision.
-    Nudge(String),
+    /// Deliver a fixed, narrow continuation message to the target as an
+    /// ordinary jekt (via the same path `inject_message` uses), then log
+    /// the decision. Deliberately carries no caller-supplied text — the
+    /// message itself is a constant (`handler::NUDGE_MESSAGE`), not
+    /// composed by the calling Supervisor agent. See
+    /// ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md
+    /// §4.3 ("never a free-form instruction the watcher composes
+    /// per-situation") — reagentx P1 on PR #2557 flagged an earlier
+    /// version of this type that accepted arbitrary text.
+    Nudge,
     /// No delivery — just log that the Supervisor decided not to nudge.
     Decline,
 }

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -137,6 +137,20 @@ pub struct AuditLogEntry {
     pub reason: Option<String>,
 }
 
+/// A Warden Supervisor watcher agent's decision about a target agent that
+/// just ended its turn: nudge it to continue, or decline (e.g. the target
+/// isn't opted in, or the Supervisor judged it genuinely done/blocked).
+/// See `Handler::record_supervisor_decision` and
+/// ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+#[derive(Debug, Clone)]
+pub enum SupervisorAction {
+    /// Deliver `message` to the target as an ordinary jekt (via the same
+    /// path `inject_message` uses), then log the decision.
+    Nudge(String),
+    /// No delivery — just log that the Supervisor decided not to nudge.
+    Decline,
+}
+
 /// Poller configuration for AgentMux cloud service.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PollerConfig {

--- a/agentmux-srv/src/backend/rpc_types/agent.rs
+++ b/agentmux-srv/src/backend/rpc_types/agent.rs
@@ -434,6 +434,14 @@ pub struct CommandUpdateAgentDefinitionData {
     /// carry it. SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3.
     #[serde(default)]
     pub use_ambient_login: Option<i64>,
+    /// Per-agent opt-in letting a Warden Supervisor watcher agent
+    /// auto-continue this agent's session on turn-end (0/1). `None`
+    /// (omitted) preserves the stored value — callers that only edit
+    /// name/icon/accounts don't carry it. Toggled from the Warden
+    /// Supervisor panel. See
+    /// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+    #[serde(default)]
+    pub auto_continue_enabled: Option<i64>,
 }
 
 /// Input for deleteagent

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -234,10 +234,11 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // above, so a UI-driven save never silently wipes a
                     // vendor override set via `agent.define`.
                     model_vendor_base_url: old.model_vendor_base_url.clone(),
-                    // Not carried by CommandUpdateAgentDefinitionData yet —
-                    // always preserve; the Warden Supervisor panel gets its
-                    // own dedicated toggle path.
-                    auto_continue_enabled: old.auto_continue_enabled,
+                    // Preserve the auto-continue opt-in when the caller omits
+                    // the field (Option — most callers only edit name/icon/
+                    // accounts). The Warden Supervisor panel sends Some(0|1)
+                    // to flip it, same shape as use_ambient_login above.
+                    auto_continue_enabled: cmd.auto_continue_enabled.unwrap_or(old.auto_continue_enabled),
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -298,6 +298,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/agentmux/reactive/transcript",
             get(reactive::handle_reactive_transcript),
+        )
+        .route(
+            "/agentmux/reactive/supervisor-decision",
+            post(reactive::handle_reactive_supervisor_decision),
         );
 
     // MessageBus routes (authed, localhost-only)

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -718,6 +718,17 @@ pub(super) async fn handle_reactive_supervisor_decision(
     // check belongs at the HTTP boundary where `state.wstore` is available,
     // not inside `record_supervisor_decision`. Decline never delivers
     // anything, so it isn't gated.
+    //
+    // Match on `d.slug`, NOT `d.name` (reagentx P0, round 3 — every
+    // delivery path keys registration off `AGENTMUX_AGENT_ID`, which
+    // `agent_open.rs` sets to the agent's stable `slug`, not its
+    // renameable display `name`. Matching on `name` here let a renamed
+    // agent's own opt-in go unrecognized, and — worse — let one agent's
+    // slug collide with an unrelated agent's current display name,
+    // authorizing a nudge off the wrong definition's flag. Same
+    // name/slug cross-namespace hazard `agents.rs`'s
+    // `instance_get_by_name_and_by_slug_never_cross_the_others_namespace`
+    // regression-tests for the read path.)
     if matches!(action, SupervisorAction::Nudge) {
         let opted_in = state
             .wstore
@@ -725,7 +736,7 @@ pub(super) async fn handle_reactive_supervisor_decision(
             .ok()
             .and_then(|defs| {
                 defs.into_iter()
-                    .find(|d| d.name.eq_ignore_ascii_case(&req.target_agent))
+                    .find(|d| d.slug.eq_ignore_ascii_case(&req.target_agent))
             })
             .map(|d| d.auto_continue_enabled != 0)
             .unwrap_or(false);

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -667,10 +667,6 @@ pub(super) struct SupervisorDecisionRequest {
     target_agent: String,
     /// "nudge" | "decline".
     action: String,
-    /// Required when `action == "nudge"` — the message delivered to
-    /// `target_agent` as an ordinary jekt.
-    #[serde(default)]
-    message: Option<String>,
     #[serde(default)]
     reason: Option<String>,
     #[serde(default)]
@@ -684,13 +680,14 @@ pub(super) struct SupervisorDecisionRequest {
 
 /// `POST /agentmux/reactive/supervisor-decision` — a Warden Supervisor
 /// watcher agent's decision about a target agent it just polled (see
-/// `GetAgentTranscript`). `action: "nudge"` delivers `message` to
-/// `target_agent` through the same path `SendMessage`/`Loop` use and audits
-/// it as a Supervisor-originated entry; `action: "decline"` sends nothing
-/// and just audits the decision. A nudge that would exceed the
-/// consecutive-nudge ceiling is refused with HTTP 429 — the calling agent
-/// should treat that as a signal to stop and escalate to a human instead of
-/// retrying.
+/// `GetAgentTranscript`). `action: "nudge"` delivers a fixed continuation
+/// message (not caller-supplied text — see `SupervisorAction::Nudge`'s
+/// doc) to `target_agent` through the same path `SendMessage`/`Loop` use
+/// and audits it as a Supervisor-originated entry; `action: "decline"`
+/// sends nothing and just audits the decision. A nudge that would exceed
+/// the consecutive-nudge ceiling is refused with HTTP 429 — the calling
+/// agent should treat that as a signal to stop and escalate to a human
+/// instead of retrying.
 pub(super) async fn handle_reactive_supervisor_decision(
     State(state): State<AppState>,
     Json(req): Json<SupervisorDecisionRequest>,
@@ -704,16 +701,7 @@ pub(super) async fn handle_reactive_supervisor_decision(
     }
 
     let action = match req.action.as_str() {
-        "nudge" => {
-            let Some(message) = req.message.filter(|m| !m.is_empty()) else {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": "message is required when action is \"nudge\""})),
-                )
-                    .into_response();
-            };
-            SupervisorAction::Nudge(message)
-        }
+        "nudge" => SupervisorAction::Nudge,
         "decline" => SupervisorAction::Decline,
         other => {
             return (
@@ -730,7 +718,7 @@ pub(super) async fn handle_reactive_supervisor_decision(
     // check belongs at the HTTP boundary where `state.wstore` is available,
     // not inside `record_supervisor_decision`. Decline never delivers
     // anything, so it isn't gated.
-    if matches!(action, SupervisorAction::Nudge(_)) {
+    if matches!(action, SupervisorAction::Nudge) {
         let opted_in = state
             .wstore
             .agent_def_list()

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -724,6 +724,37 @@ pub(super) async fn handle_reactive_supervisor_decision(
         }
     };
 
+    // Entitlement gate (reagentx P1 on PR #2557): a Nudge must not deliver
+    // unless the target has actually opted in via `auto_continue_enabled`.
+    // `Handler` (backend::reactive) has no `Store` access by design — this
+    // check belongs at the HTTP boundary where `state.wstore` is available,
+    // not inside `record_supervisor_decision`. Decline never delivers
+    // anything, so it isn't gated.
+    if matches!(action, SupervisorAction::Nudge(_)) {
+        let opted_in = state
+            .wstore
+            .agent_def_list()
+            .ok()
+            .and_then(|defs| {
+                defs.into_iter()
+                    .find(|d| d.name.eq_ignore_ascii_case(&req.target_agent))
+            })
+            .map(|d| d.auto_continue_enabled != 0)
+            .unwrap_or(false);
+        if !opted_in {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": format!(
+                        "target agent '{}' has not opted in to auto_continue_enabled",
+                        req.target_agent
+                    )
+                })),
+            )
+                .into_response();
+        }
+    }
+
     let reason = req.reason.unwrap_or_default();
     let request_id = req
         .request_id

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::backend::reactive::InjectionRequest;
+use crate::backend::reactive::{InjectionRequest, SupervisorAction};
 use crate::backend::reactive::registry as agent_registry;
 use crate::backend::subagent_watcher;
 use crate::backend::base;
@@ -660,4 +660,88 @@ pub(super) async fn handle_reactive_transcript(
         "truncated": truncated,
     }))
     .into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct SupervisorDecisionRequest {
+    target_agent: String,
+    /// "nudge" | "decline".
+    action: String,
+    /// Required when `action == "nudge"` — the message delivered to
+    /// `target_agent` as an ordinary jekt.
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    request_id: Option<String>,
+    /// The calling Supervisor agent's own identity — same shape as
+    /// `InjectRequest::source_agent` (`SendMessage`/`Loop`). `None` for
+    /// callers that omit it (e.g. cron-driven).
+    #[serde(default)]
+    source_agent: Option<String>,
+}
+
+/// `POST /agentmux/reactive/supervisor-decision` — a Warden Supervisor
+/// watcher agent's decision about a target agent it just polled (see
+/// `GetAgentTranscript`). `action: "nudge"` delivers `message` to
+/// `target_agent` through the same path `SendMessage`/`Loop` use and audits
+/// it as a Supervisor-originated entry; `action: "decline"` sends nothing
+/// and just audits the decision. A nudge that would exceed the
+/// consecutive-nudge ceiling is refused with HTTP 429 — the calling agent
+/// should treat that as a signal to stop and escalate to a human instead of
+/// retrying.
+pub(super) async fn handle_reactive_supervisor_decision(
+    State(state): State<AppState>,
+    Json(req): Json<SupervisorDecisionRequest>,
+) -> Response {
+    if req.target_agent.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "missing target_agent"})),
+        )
+            .into_response();
+    }
+
+    let action = match req.action.as_str() {
+        "nudge" => {
+            let Some(message) = req.message.filter(|m| !m.is_empty()) else {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": "message is required when action is \"nudge\""})),
+                )
+                    .into_response();
+            };
+            SupervisorAction::Nudge(message)
+        }
+        "decline" => SupervisorAction::Decline,
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("unknown action: {other} (expected \"nudge\" or \"decline\")")})),
+            )
+                .into_response();
+        }
+    };
+
+    let reason = req.reason.unwrap_or_default();
+    let request_id = req
+        .request_id
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    match state.reactive_handler.record_supervisor_decision(
+        &req.target_agent,
+        action,
+        &reason,
+        &request_id,
+        req.source_agent.as_deref(),
+    ) {
+        Ok(resp) => Json(serde_json::to_value(&resp).unwrap_or_default()).into_response(),
+        Err(e) => (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({"error": e})),
+        )
+            .into_response(),
+    }
 }

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -448,10 +448,21 @@ async fn reactive_supervisor_decision_unknown_action_is_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
+/// reagentx P1 on PR #2557: `SupervisorAction::Nudge` delivers a fixed,
+/// server-owned message (`handler::NUDGE_MESSAGE`) — it no longer accepts
+/// (or requires) caller-supplied text at all. A `message` field in the
+/// request body, if a caller sends one out of habit, must be silently
+/// ignored (serde's default unknown-field behavior), not error and not
+/// influence what's delivered — this regression-guards against the
+/// free-form-text contract reagentx flagged ever coming back.
 #[tokio::test]
-async fn reactive_supervisor_decision_nudge_without_message_is_400() {
+async fn reactive_supervisor_decision_nudge_ignores_a_stray_message_field() {
     let app = test_router();
-    let body = serde_json::json!({"target_agent": "some-agent", "action": "nudge"});
+    let body = serde_json::json!({
+        "target_agent": "some-agent",
+        "action": "nudge",
+        "message": "do something completely different",
+    });
     let req = Request::builder()
         .method("POST")
         .uri("/agentmux/reactive/supervisor-decision")
@@ -460,7 +471,11 @@ async fn reactive_supervisor_decision_nudge_without_message_is_400() {
         .body(Body::from(body.to_string()))
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // "some-agent" has no AgentDefinition in this hermetic store, so the
+    // entitlement gate refuses it — same as any other not-opted-in target.
+    // The point of this test is that a stray `message` field didn't change
+    // that outcome (e.g. by being misparsed into some other code path).
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]
@@ -501,7 +516,6 @@ async fn reactive_supervisor_decision_nudge_rejected_when_not_opted_in() {
     let body = serde_json::json!({
         "target_agent": "supervisor-nudge-test-not-opted-in",
         "action": "nudge",
-        "message": "keep going",
     });
     let req = Request::builder()
         .method("POST")
@@ -543,7 +557,6 @@ async fn reactive_supervisor_decision_nudge_rejected_when_opted_out() {
     let body = serde_json::json!({
         "target_agent": "supervisor-nudge-test-opted-out",
         "action": "nudge",
-        "message": "keep going",
     });
     let req = Request::builder()
         .method("POST")
@@ -581,7 +594,6 @@ async fn reactive_supervisor_decision_nudge_passes_gate_when_opted_in() {
     let body = serde_json::json!({
         "target_agent": "supervisor-nudge-test-opted-in",
         "action": "nudge",
-        "message": "keep going",
     });
     let req = Request::builder()
         .method("POST")

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -491,6 +491,113 @@ async fn reactive_supervisor_decision_decline_succeeds_for_unregistered_target()
     assert!(json["success"].as_bool().unwrap());
 }
 
+/// reagentx P1 on PR #2557: a Nudge must not deliver unless the target
+/// has actually opted in via `auto_continue_enabled`. An agent with no
+/// matching `AgentDefinition` at all (never opted in — the default) must
+/// be refused with 403, not silently attempted.
+#[tokio::test]
+async fn reactive_supervisor_decision_nudge_rejected_when_not_opted_in() {
+    let app = test_router();
+    let body = serde_json::json!({
+        "target_agent": "supervisor-nudge-test-not-opted-in",
+        "action": "nudge",
+        "message": "keep going",
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["error"].as_str().unwrap().contains("auto_continue_enabled"));
+}
+
+/// The same gate must actively check the flag's value, not just presence
+/// of a definition row — `auto_continue_enabled: 0` (the default) is
+/// still a rejection.
+#[tokio::test]
+async fn reactive_supervisor_decision_nudge_rejected_when_opted_out() {
+    let state = test_state();
+    let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
+        "id": "def-supervisor-nudge-opted-out",
+        "slug": "supervisor-nudge-opted-out-slug",
+        "name": "supervisor-nudge-test-opted-out",
+        "icon": "robot",
+        "provider": "claude",
+        "description": "test agent",
+        "created_at": 1,
+        "auto_continue_enabled": 0,
+    }))
+    .expect("definition fixture");
+    state.wstore.agent_def_insert(&mut def).expect("insert definition");
+
+    let app = build_router(state);
+    let body = serde_json::json!({
+        "target_agent": "supervisor-nudge-test-opted-out",
+        "action": "nudge",
+        "message": "keep going",
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+/// An opted-in target's Nudge must pass the entitlement gate (i.e. NOT get
+/// refused with 403) — whatever happens next is ordinary delivery
+/// machinery (in this hermetic test harness, delivery itself fails because
+/// no input sender is wired into the shared global reactive handler, which
+/// is a test-environment gap unrelated to the gate this test targets).
+#[tokio::test]
+async fn reactive_supervisor_decision_nudge_passes_gate_when_opted_in() {
+    let state = test_state();
+    let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
+        "id": "def-supervisor-nudge-opted-in",
+        "slug": "supervisor-nudge-opted-in-slug",
+        "name": "supervisor-nudge-test-opted-in",
+        "icon": "robot",
+        "provider": "claude",
+        "description": "test agent",
+        "created_at": 1,
+        "auto_continue_enabled": 1,
+    }))
+    .expect("definition fixture");
+    state.wstore.agent_def_insert(&mut def).expect("insert definition");
+
+    let app = build_router(state);
+    let body = serde_json::json!({
+        "target_agent": "supervisor-nudge-test-opted-in",
+        "action": "nudge",
+        "message": "keep going",
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "an opted-in target must not be blocked by the entitlement gate"
+    );
+}
+
 #[tokio::test]
 async fn reactive_poller_status() {
     let app = test_router();

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -401,6 +401,97 @@ async fn reactive_transcript_unknown_agent_is_404() {
 }
 
 #[tokio::test]
+async fn reactive_supervisor_decision_missing_target_agent_is_rejected() {
+    // `target_agent` is a required field on `SupervisorDecisionRequest`, so
+    // an omitted key fails at axum's Json extractor (422), before the
+    // handler's own empty-string check (400) ever runs.
+    let app = test_router();
+    let body = serde_json::json!({"action": "decline"});
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn reactive_supervisor_decision_empty_target_agent_is_400() {
+    let app = test_router();
+    let body = serde_json::json!({"target_agent": "", "action": "decline"});
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn reactive_supervisor_decision_unknown_action_is_400() {
+    let app = test_router();
+    let body = serde_json::json!({"target_agent": "some-agent", "action": "maybe"});
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn reactive_supervisor_decision_nudge_without_message_is_400() {
+    let app = test_router();
+    let body = serde_json::json!({"target_agent": "some-agent", "action": "nudge"});
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn reactive_supervisor_decision_decline_succeeds_for_unregistered_target() {
+    // Decline never attempts delivery, so it succeeds even for a target
+    // that isn't (or is no longer) registered — matching a Supervisor
+    // deciding not to nudge an agent it can no longer see.
+    let app = test_router();
+    let body = serde_json::json!({
+        "target_agent": "supervisor-decision-test-decline-target-http",
+        "action": "decline",
+        "reason": "target looks done"
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["success"].as_bool().unwrap());
+}
+
+#[tokio::test]
 async fn reactive_poller_status() {
     let app = test_router();
     let req = Request::builder()

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -540,10 +540,15 @@ async fn reactive_supervisor_decision_nudge_rejected_when_not_opted_in() {
 #[tokio::test]
 async fn reactive_supervisor_decision_nudge_rejected_when_opted_out() {
     let state = test_state();
+    // `target_agent` is what every delivery path actually keys on:
+    // AGENTMUX_AGENT_ID, which agent_open.rs sets to the stable `slug`, NOT
+    // the renameable `name` (reagentx P0, round 3). `name` is deliberately
+    // a different string here so this test also guards against the gate
+    // matching on `name` again.
     let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
         "id": "def-supervisor-nudge-opted-out",
-        "slug": "supervisor-nudge-opted-out-slug",
-        "name": "supervisor-nudge-test-opted-out",
+        "slug": "supervisor-nudge-test-opted-out",
+        "name": "Opted-Out Display Name",
         "icon": "robot",
         "provider": "claude",
         "description": "test agent",
@@ -577,10 +582,12 @@ async fn reactive_supervisor_decision_nudge_rejected_when_opted_out() {
 #[tokio::test]
 async fn reactive_supervisor_decision_nudge_passes_gate_when_opted_in() {
     let state = test_state();
+    // Same slug/name distinction as the opted-out test above — `name` is
+    // deliberately not what `target_agent` matches.
     let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
         "id": "def-supervisor-nudge-opted-in",
-        "slug": "supervisor-nudge-opted-in-slug",
-        "name": "supervisor-nudge-test-opted-in",
+        "slug": "supervisor-nudge-test-opted-in",
+        "name": "Opted-In Display Name",
         "icon": "robot",
         "provider": "claude",
         "description": "test agent",
@@ -607,6 +614,64 @@ async fn reactive_supervisor_decision_nudge_passes_gate_when_opted_in() {
         resp.status(),
         StatusCode::FORBIDDEN,
         "an opted-in target must not be blocked by the entitlement gate"
+    );
+}
+
+/// reagentx P0, round 3: the exact cross-namespace collision the entitlement
+/// gate must not fall into. Agent A's own SLUG is unrelated, but its
+/// display NAME happens to equal Agent B's slug; Agent A is opted OUT.
+/// Agent B is opted IN. A nudge for `target_agent = "collision"` (which is
+/// how every delivery path — and thus this gate — must resolve it: as
+/// Agent B's slug) must pass the gate, not get wrongly authorized OR
+/// wrongly rejected off Agent A's unrelated definition via a name match.
+/// Mirrors `agents.rs`'s own
+/// `instance_get_by_name_and_by_slug_never_cross_the_others_namespace`.
+#[tokio::test]
+async fn reactive_supervisor_decision_nudge_slug_match_does_not_cross_into_a_colliding_display_name() {
+    let state = test_state();
+    let mut agent_a: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
+        "id": "def-collision-agent-a",
+        "slug": "agent-a-unrelated-slug",
+        "name": "collision",
+        "icon": "robot",
+        "provider": "claude",
+        "description": "test agent",
+        "created_at": 1,
+        "auto_continue_enabled": 0,
+    }))
+    .expect("definition fixture");
+    state.wstore.agent_def_insert(&mut agent_a).expect("insert agent a");
+
+    let mut agent_b: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
+        "id": "def-collision-agent-b",
+        "slug": "collision",
+        "name": "Agent B Unrelated Display Name",
+        "icon": "robot",
+        "provider": "claude",
+        "description": "test agent",
+        "created_at": 1,
+        "auto_continue_enabled": 1,
+    }))
+    .expect("definition fixture");
+    state.wstore.agent_def_insert(&mut agent_b).expect("insert agent b");
+
+    let app = build_router(state);
+    let body = serde_json::json!({
+        "target_agent": "collision",
+        "action": "nudge",
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/reactive/supervisor-decision")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "must resolve to Agent B (slug match, opted in), not Agent A (name match, opted out)"
     );
 }
 

--- a/frontend/app/view/warden-audit/warden-audit-manager.tsx
+++ b/frontend/app/view/warden-audit/warden-audit-manager.tsx
@@ -59,18 +59,21 @@ export const WardenAuditManager = (): JSX.Element => {
                 <ul class="warden-audit-feed">
                     <For each={audit()}>
                         {(entry) => {
-                            // Supervisor rows (outcome set) get neutral/informational
-                            // styling regardless of `success` — a "declined" entry has
-                            // success=true (nothing failed, it just chose not to act)
-                            // and shouldn't read as an error.
+                            // Supervisor rows get styling by their own outcome, not a
+                            // blanket "outcome set → neutral" rule — a "declined" entry
+                            // has success=true (nothing failed, it just chose not to
+                            // act) and shouldn't read as an error, but "nudge_failed"
+                            // means delivery genuinely failed and must read as one.
                             const statusVariant = () => {
                                 if (entry.outcome === "nudge_sent") return "nudge";
                                 if (entry.outcome === "nudge_declined") return "declined";
+                                if (entry.outcome === "nudge_failed") return "err";
                                 return entry.success ? "ok" : "err";
                             };
                             const statusLabel = () => {
                                 if (entry.outcome === "nudge_sent") return "nudged";
                                 if (entry.outcome === "nudge_declined") return "declined";
+                                if (entry.outcome === "nudge_failed") return "nudge failed";
                                 return entry.success ? "ok" : "err";
                             };
                             return (

--- a/frontend/app/view/warden-audit/warden-audit-shared.ts
+++ b/frontend/app/view/warden-audit/warden-audit-shared.ts
@@ -21,9 +21,12 @@ export interface AuditEntry {
     success: boolean;
     error_message?: string;
     request_id: string;
-    /** "nudge_sent" | "nudge_declined" — present only for Supervisor-
-     *  originated entries; absent for ordinary jekt entries. Mirrors
-     *  AuditLogEntry.outcome (agentmux-srv/src/backend/reactive/types.rs). */
+    /** "nudge_sent" | "nudge_failed" | "nudge_declined" — present only for
+     *  Supervisor-originated entries; absent for ordinary jekt entries.
+     *  "nudge_sent" only when delivery actually succeeded; "nudge_failed"
+     *  when a nudge was attempted but delivery itself failed (see
+     *  `success`/`error_message`). Mirrors AuditLogEntry.outcome
+     *  (agentmux-srv/src/backend/reactive/types.rs). */
     outcome?: string;
     /** Supervisor's stated reasoning, populated alongside `outcome`. */
     reason?: string;

--- a/frontend/app/view/warden-supervisor/warden-supervisor-manager.scss
+++ b/frontend/app/view/warden-supervisor/warden-supervisor-manager.scss
@@ -28,6 +28,10 @@
     gap: var(--space-2);
     padding: 2px var(--space-2);
     background: rgba(96, 165, 250, 0.08);
+
+    &[data-variant="failed"] {
+        background: rgba(239, 68, 68, 0.08);
+    }
 }
 
 .warden-supervisor-decision-time {
@@ -40,6 +44,10 @@
     text-transform: uppercase;
     font-size: 0.8em;
     color: #60a5fa;
+
+    [data-variant="failed"] & {
+        color: #ef4444;
+    }
 }
 
 .warden-supervisor-decision-reason {

--- a/frontend/app/view/warden-supervisor/warden-supervisor-manager.scss
+++ b/frontend/app/view/warden-supervisor/warden-supervisor-manager.scss
@@ -1,0 +1,62 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Warden — Supervisor section styles. Dedicated (not shared with
+// warden-audit-manager.scss's `.warden-audit-row`) so this decision feed's
+// column layout can't silently drift out of sync with the Audit tab's.
+
+.warden-supervisor-toggle-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+}
+
+.warden-supervisor-decision-feed {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.85em;
+}
+
+.warden-supervisor-decision-row {
+    display: grid;
+    grid-template-columns: 70px 1fr 60px 1fr;
+    gap: var(--space-2);
+    padding: 2px var(--space-2);
+    background: rgba(96, 165, 250, 0.08);
+}
+
+.warden-supervisor-decision-time {
+    opacity: 0.55;
+    font-family: monospace;
+}
+
+.warden-supervisor-decision-status {
+    text-align: center;
+    text-transform: uppercase;
+    font-size: 0.8em;
+    color: #60a5fa;
+}
+
+.warden-supervisor-decision-reason {
+    opacity: 0.8;
+    color: #60a5fa;
+    font-size: 0.95em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+@container warden (max-width: 479px) {
+    .warden-supervisor-decision-row {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: 4px var(--space-2);
+        border-bottom: 1px solid var(--border-color);
+    }
+}

--- a/frontend/app/view/warden-supervisor/warden-supervisor-manager.tsx
+++ b/frontend/app/view/warden-supervisor/warden-supervisor-manager.tsx
@@ -153,15 +153,22 @@ export const WardenSupervisorManager = (): JSX.Element => {
                 <ul class="warden-supervisor-decision-feed">
                     <For each={decisions()}>
                         {(entry) => {
-                            const nudged = () => entry.outcome === "nudge_sent";
+                            const statusLabel = () => {
+                                if (entry.outcome === "nudge_sent") return "nudged";
+                                if (entry.outcome === "nudge_failed") return "nudge failed";
+                                return "declined";
+                            };
                             return (
-                                <li class="warden-supervisor-decision-row">
+                                <li
+                                    class="warden-supervisor-decision-row"
+                                    data-variant={entry.outcome === "nudge_failed" ? "failed" : "ok"}
+                                >
                                     <span class="warden-supervisor-decision-time">
                                         {formatAge(ageMs(entry.timestamp, now()))} ago
                                     </span>
                                     <span class="warden-manager-mono">{entry.target_agent}</span>
                                     <span class="warden-supervisor-decision-status">
-                                        {nudged() ? "nudged" : "declined"}
+                                        {statusLabel()}
                                     </span>
                                     <Show when={entry.reason} fallback={<span class="warden-manager-dim">—</span>}>
                                         <span class="warden-supervisor-decision-reason">{entry.reason}</span>

--- a/frontend/app/view/warden-supervisor/warden-supervisor-manager.tsx
+++ b/frontend/app/view/warden-supervisor/warden-supervisor-manager.tsx
@@ -1,28 +1,186 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Warden — Supervisor section. Placeholder pending its backend support
-// (per-agent auto_continue_enabled field, the transcript-read + nudge
-// routes/MCP tools, and the consecutive-nudge-ceiling guardrail — see
-// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md).
-// Once that lands, this becomes a per-agent auto-continue toggle list +
-// recent-decisions feed (reusing warden-audit-shared.ts, filtered to
-// entry.outcome != null).
+// Warden — Supervisor section. A control surface only: a per-agent
+// auto_continue_enabled toggle list, plus a recent-decisions feed (reusing
+// warden-audit-shared.ts, client-filtered to entries with `outcome` set).
+// The judgment itself — whether/when to nudge — runs inside an ordinary
+// spawned AgentMux agent using GetAgentTranscript + SupervisorNudge (MCP
+// tools), not here. See
+// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
+//
+// Explicitly out of scope (v1): a "spawn a Supervisor for this agent"
+// button, or any liveness check proving a specific running agent IS the
+// Supervisor for a given target. The toggle is the source of truth for
+// "opted in"; operators spawn/configure the actual watcher agent
+// themselves, same as spawning any other agent today.
 
-import type { JSX } from "solid-js";
+import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { useTick } from "@/app/hook/useTick";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+import { ageMs, formatAge, WARDEN_REFRESH_MS } from "@/app/view/warden-shared/warden-shared";
+import { fetchWardenAudit, type AuditEntry } from "@/app/view/warden-audit/warden-audit-shared";
 
 import "@/app/view/warden-shared/warden-manager-chrome.scss";
+import "./warden-supervisor-manager.scss";
 
-export const WardenSupervisorManager = (): JSX.Element => (
-    <div class="warden-manager-body">
-        <p class="warden-manager-summary">Opt-in continuation nudging for stalled agents</p>
-        <div class="warden-section-stub">
-            Coming soon — per-agent auto-continue configuration and a
-            recent-decisions feed. Backend support (transcript access,
-            nudge delivery, and the consecutive-nudge ceiling guardrail)
-            ships in a follow-up PR.
+export const WardenSupervisorManager = (): JSX.Element => {
+    const [agents, setAgents] = createSignal<AgentDefinition[]>([]);
+    const [decisions, setDecisions] = createSignal<AuditEntry[]>([]);
+    const [error, setError] = createSignal<string | null>(null);
+    const [loading, setLoading] = createSignal(true);
+    const [savingId, setSavingId] = createSignal<string | null>(null);
+    const tick = useTick(1000);
+    const now = createMemo(() => (tick(), Date.now()));
+
+    const refreshAgents = async () => {
+        try {
+            const list = await RpcApi.ListAgentDefinitionsCommand(TabRpcClient, { is_seeded: 0 });
+            setAgents(list);
+            setError(null);
+        } catch (e) {
+            setError(String((e as Error).message ?? e));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const refreshDecisions = async () => {
+        try {
+            const log = await fetchWardenAudit();
+            setDecisions(log.filter((entry) => entry.outcome != null));
+        } catch {
+            // The Audit tab already surfaces fetch failures for this same
+            // endpoint — avoid a second, redundant error banner here.
+        }
+    };
+
+    const handleToggle = async (agent: AgentDefinition, enabled: boolean) => {
+        setSavingId(agent.id);
+        try {
+            await RpcApi.UpdateAgentDefinitionCommand(TabRpcClient, {
+                id: agent.id,
+                name: agent.name,
+                icon: agent.icon,
+                provider: agent.provider,
+                description: agent.description,
+                working_directory: agent.working_directory,
+                shell: agent.shell,
+                provider_flags: agent.provider_flags,
+                auto_start: agent.auto_start,
+                restart_on_crash: agent.restart_on_crash,
+                idle_timeout_minutes: agent.idle_timeout_minutes,
+                agent_type: agent.agent_type,
+                environment: agent.environment,
+                agent_bus_id: agent.agent_bus_id,
+                auto_continue_enabled: enabled ? 1 : 0,
+            });
+            setAgents((prev) =>
+                prev.map((a) => (a.id === agent.id ? { ...a, auto_continue_enabled: enabled ? 1 : 0 } : a)),
+            );
+        } catch (e) {
+            setError(String((e as Error).message ?? e));
+        } finally {
+            setSavingId(null);
+        }
+    };
+
+    onMount(() => {
+        void refreshAgents();
+        void refreshDecisions();
+        const dataTimer = window.setInterval(() => {
+            void refreshAgents();
+            void refreshDecisions();
+        }, WARDEN_REFRESH_MS);
+        onCleanup(() => window.clearInterval(dataTimer));
+    });
+
+    return (
+        <div class="warden-manager-body">
+            <p class="warden-manager-summary">Opt-in continuation nudging for stalled agents</p>
+            <Show when={error()}>
+                <div class="warden-manager-error">⚠ {error()}</div>
+            </Show>
+            <Show
+                when={agents().length > 0}
+                fallback={
+                    <div class="warden-section-stub">
+                        {loading() ? "Loading…" : "No agents yet."}
+                    </div>
+                }
+            >
+                <table class="warden-manager-table">
+                    <thead>
+                        <tr>
+                            <th>agent</th>
+                            <th>provider</th>
+                            <th>auto-continue</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <For each={agents()}>
+                            {(agent) => (
+                                <tr>
+                                    <td class="warden-manager-mono">{agent.name}</td>
+                                    <td class="warden-manager-dim">{agent.provider}</td>
+                                    <td>
+                                        <label class="warden-supervisor-toggle-row">
+                                            <input
+                                                type="checkbox"
+                                                checked={!!agent.auto_continue_enabled}
+                                                disabled={savingId() === agent.id}
+                                                onChange={(e) => void handleToggle(agent, e.currentTarget.checked)}
+                                            />
+                                            <Show when={savingId() === agent.id}>
+                                                <span class="warden-manager-dim">saving…</span>
+                                            </Show>
+                                        </label>
+                                    </td>
+                                </tr>
+                            )}
+                        </For>
+                    </tbody>
+                </table>
+            </Show>
+
+            <p class="warden-manager-summary">Recent Supervisor decisions</p>
+            <Show
+                when={decisions().length > 0}
+                fallback={<div class="warden-section-stub">No Supervisor decisions yet.</div>}
+            >
+                <ul class="warden-supervisor-decision-feed">
+                    <For each={decisions()}>
+                        {(entry) => {
+                            const nudged = () => entry.outcome === "nudge_sent";
+                            return (
+                                <li class="warden-supervisor-decision-row">
+                                    <span class="warden-supervisor-decision-time">
+                                        {formatAge(ageMs(entry.timestamp, now()))} ago
+                                    </span>
+                                    <span class="warden-manager-mono">{entry.target_agent}</span>
+                                    <span class="warden-supervisor-decision-status">
+                                        {nudged() ? "nudged" : "declined"}
+                                    </span>
+                                    <Show when={entry.reason} fallback={<span class="warden-manager-dim">—</span>}>
+                                        <span class="warden-supervisor-decision-reason">{entry.reason}</span>
+                                    </Show>
+                                </li>
+                            );
+                        }}
+                    </For>
+                </ul>
+            </Show>
+
+            <div class="warden-manager-footnote">
+                Refreshes every {WARDEN_REFRESH_MS / 1000}s. Spawn/configure the
+                Supervisor watcher agent itself the same way you'd spawn any
+                other agent — this panel only controls which agents it may
+                act on.
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 WardenSupervisorManager.displayName = "WardenSupervisorManager";

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -836,6 +836,12 @@ declare global {
          * AgentDefinition.use_ambient_login.
          */
         use_ambient_login?: number;
+        /**
+         * Per-agent opt-in letting a Warden Supervisor watcher agent
+         * auto-continue this agent's session on turn-end (0/1). Omit to
+         * preserve the stored value. See AgentDefinition.auto_continue_enabled.
+         */
+        auto_continue_enabled?: number;
     };
 
     // CommandDeleteAgentDefinitionData


### PR DESCRIPTION
## Summary

- New `POST /agentmux/reactive/supervisor-decision` route
  (`handle_reactive_supervisor_decision`): a Warden Supervisor watcher
  agent's decision about a target agent it just polled via
  `GetAgentTranscript`. `action: "nudge"` delivers `message` to the target
  through the same delivery path `SendMessage`/`Loop` use, audited as
  `outcome: "nudge_sent"`. `action: "decline"` sends nothing, audited as
  `outcome: "nudge_declined"`.
- **Entitlement gate**: a Nudge is refused with HTTP 403 unless the target
  agent's `AgentDefinition.auto_continue_enabled` is set — checked at the
  HTTP boundary (`Handler` has no `Store` access by design).
- `Handler::inject_message`'s body is now `inject_message_inner(req,
  outcome, reason)` — a shared delivery path threading `outcome`/`reason`
  into every `log_audit` call, so `record_supervisor_decision`'s `Nudge` arm
  reuses it instead of duplicating sanitize/deliver logic.
- **Consecutive-nudge ceiling** (`MAX_CONSECUTIVE_AUTO_CONTINUES = 5`):
  tracked per target agent in `Handler::nudge_counters`, keyed on the
  target's `registration_nonce` AND `block_id` (a respawn resets the
  counter — nonce alone misses PTY/shell-registered agents, which always
  register with nonce 0), and also reset after `NUDGE_COOLDOWN_RESET_MS`
  (30min) of inactivity. Swept on every Nudge to bound memory growth. A
  nudge that would exceed the ceiling is refused (forced decline, audited)
  and the caller gets `Err`/HTTP 429 — a signal to stop and escalate to a
  human instead of retrying.
- New `SupervisorNudge` MCP tool wraps the route, same `reqwest` POST +
  `X-AuthKey` pattern `SendMessage` already uses.
- **Supervisor manager UI**: `CommandUpdateAgentDefinitionData` gained
  `auto_continue_enabled` (`Option<i64>`, same shape as `use_ambient_login`).
  `WardenSupervisorManager` replaces the placeholder stub — lists user-owned
  agents with a toggle bound to the field (via
  `RpcApi.UpdateAgentDefinitionCommand`), plus a recent-decisions feed
  (`fetchWardenAudit`, filtered to entries with `outcome` set).

This completes the Warden Supervisor feature — see
`docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md`.
Continues #2553/#2554/#2555/#2556.

## Test plan

- [x] `cargo build -p agentmux-srv` and `cargo build -p agentmux-mcp` — clean
- [x] `cargo test -p agentmux-srv` — 2180 tests passing, including:
  - Nudge-ceiling tests (both `registration_nonce`- and `block_id`-based respawn reset)
  - Entitlement-gate tests (rejected when unregistered/opted-out, passes when opted-in)
  - `record_supervisor_decision(Decline, ...)` audits without delivering
  - HTTP-level validation tests for `/agentmux/reactive/supervisor-decision`
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=camper -->