### PR TITLE
feat(agent): expose model vendor / custom endpoint UI + add Antigravity harness

### DIFF
--- a/.changesets/1786604409-feat-agent-expose-model-vendor-custom-endpoint-ui-add-antigr-81md.md
+++ b/.changesets/1786604409-feat-agent-expose-model-vendor-custom-endpoint-ui-add-antigr-81md.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): expose model vendor / custom endpoint UI + add Antigravity harness

--- a/agentmux-srv/agent-seed.json
+++ b/agentmux-srv/agent-seed.json
@@ -75,6 +75,30 @@
       ]
     },
     {
+      "id": "antigravity",
+      "name": "Antigravity",
+      "icon": "\u269b",
+      "provider": "antigravity",
+      "agent_type": "host",
+      "description": "Google's agentic coding CLI harness (AGY)",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "antigravity",
+      "content": {
+        "env": "AGENT_NAME=antigravity\nAGENTMUX_AGENT_ID=Antigravity",
+        "startup": "__SKIP__"
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages \u2014 install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
       "id": "kimi",
       "name": "Kimi",
       "icon": "\u25c8",

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -83,6 +83,16 @@ pub struct ProviderConfig {
     /// declared capability side of that split. Set only where independently
     /// verified, not guessed. See docs/specs for the harness/vendor concept.
     pub base_url_env_var: Option<&'static str>,
+    /// Intelligence model vendors this harness talks to, most-default-first
+    /// (e.g. claude → `&["anthropic"]`, openclaw → `&["openai", "anthropic",
+    /// "google"]` since it's model-agnostic). Purely descriptive/display
+    /// data — drives the dual-icon vendor badge and the picker's default
+    /// vendor inference (`resolveEffectiveVendor` on the frontend); does not
+    /// gate anything at spawn time. The one thing that DOES gate spawn-time
+    /// behavior is `base_url_env_var` above — a provider can be redirected
+    /// to a custom endpoint independent of whether that endpoint's vendor
+    /// is even listed here.
+    pub supported_vendors: &'static [&'static str],
 }
 
 impl ProviderConfig {
@@ -180,6 +190,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     // Documented Claude Code behavior: redirects the CLI at a non-Anthropic
     // (or proxied) backend — Bedrock, Vertex, OpenRouter, a custom proxy.
     base_url_env_var: Some("ANTHROPIC_BASE_URL"),
+    supported_vendors: &["anthropic"],
 };
 
 static CODEX: ProviderConfig = ProviderConfig {
@@ -206,6 +217,7 @@ static CODEX: ProviderConfig = ProviderConfig {
     npm_package: "@openai/codex",
     pinned_version: "0.116.0",
     base_url_env_var: None,
+    supported_vendors: &["openai"],
 };
 
 static GEMINI: ProviderConfig = ProviderConfig {
@@ -226,6 +238,7 @@ static GEMINI: ProviderConfig = ProviderConfig {
     npm_package: "@google/gemini-cli",
     pinned_version: "0.32.1",
     base_url_env_var: None,
+    supported_vendors: &["google"],
 };
 
 // Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
@@ -259,6 +272,7 @@ static QWEN: ProviderConfig = ProviderConfig {
     // that's baked-in default routing, not a confirmed user-configurable
     // override mechanism, so this stays unset rather than guessed.
     base_url_env_var: None,
+    supported_vendors: &["openrouter"],
 };
 
 static KIMI: ProviderConfig = ProviderConfig {
@@ -284,6 +298,7 @@ static KIMI: ProviderConfig = ProviderConfig {
     npm_package: "",
     pinned_version: "",
     base_url_env_var: None,
+    supported_vendors: &["moonshot"],
 };
 
 static OPENCLAW: ProviderConfig = ProviderConfig {
@@ -314,6 +329,7 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     npm_package: "openclaw",
     pinned_version: "2026.6.10",
     base_url_env_var: None,
+    supported_vendors: &["openai", "anthropic", "google"],
 };
 
 static PI: ProviderConfig = ProviderConfig {
@@ -332,6 +348,7 @@ static PI: ProviderConfig = ProviderConfig {
     npm_package: "@mariozechner/pi-coding-agent",
     pinned_version: "0.73.1",
     base_url_env_var: None,
+    supported_vendors: &["pi"],
 };
 
 // Mux Code — AgentMux's first-party agentic coding CLI.
@@ -360,6 +377,7 @@ static MUX_CODE: ProviderConfig = ProviderConfig {
     npm_package: "@agentmuxai/muxcode",
     pinned_version: "0.1.0",
     base_url_env_var: None,
+    supported_vendors: &["ollama", "anthropic", "openai"],
 };
 
 // GitHub Copilot CLI — Microsoft's coding agent. Runs in ACP mode via
@@ -382,6 +400,32 @@ static COPILOT: ProviderConfig = ProviderConfig {
     npm_package: "@github/copilot",
     pinned_version: "1.0.65",
     base_url_env_var: None,
+    supported_vendors: &["github"],
+};
+
+// Antigravity (AGY) — Google's agentic coding CLI harness. Emits the same
+// stream-json NDJSON envelope as Gemini CLI (its sibling harness), so it
+// reuses the gemini translator (styled_output_format "gemini-json") rather
+// than a new one. No base_url_env_var — not independently verified to
+// support a custom-endpoint override (same "unset unless confirmed"
+// discipline as every other non-claude provider above).
+static ANTIGRAVITY: ProviderConfig = ProviderConfig {
+    id: "antigravity",
+    cli_command: "agy",
+    controller_type: ControllerType::Subprocess,
+    launch_args: &["--output-format", "stream-json", "--yolo", "-p", ""],
+    persistent_launch_args: None,
+    resume_flag: Some("-r"),
+    session_id_field: "session_id",
+    styled_output_format: "gemini-json",
+    auth_config_dir_env_var: "ANTIGRAVITY_CONFIG_DIR",
+    auth_dir_name: "antigravity",
+    auth_extra_env: &[("ANTIGRAVITY_FORCE_FILE_STORAGE", "true")],
+    unset_env: &[],
+    npm_package: "@google/antigravity-cli",
+    pinned_version: "1.0.0",
+    base_url_env_var: None,
+    supported_vendors: &["google"],
 };
 
 // ─── Static registry ─────────────────────────────────────────────────────────
@@ -397,6 +441,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = Lazy
     m.insert(PI.id, &PI);
     m.insert(COPILOT.id, &COPILOT);
     m.insert(MUX_CODE.id, &MUX_CODE);
+    m.insert(ANTIGRAVITY.id, &ANTIGRAVITY);
     m
 });
 
@@ -418,6 +463,9 @@ static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(||
     m.insert("copilot_cli", "copilot");
     m.insert("mux-code", "muxcode");
     m.insert("mux_code", "muxcode");
+    m.insert("agy", "antigravity");
+    m.insert("antigravity-cli", "antigravity");
+    m.insert("antigravity_cli", "antigravity");
     m
 });
 
@@ -467,6 +515,21 @@ mod tests {
         assert!(get_provider("openclaw").is_some());
         assert!(get_provider("qwen").is_some());
         assert!(get_provider("muxcode").is_some());
+        assert!(get_provider("antigravity").is_some());
+    }
+
+    #[test]
+    fn antigravity_is_subprocess_with_gemini_stream_json() {
+        let p = get_provider("antigravity").unwrap();
+        assert_eq!(p.controller_type, ControllerType::Subprocess);
+        assert_eq!(p.controller_type_str(), "subprocess");
+        assert_eq!(p.styled_output_format, "gemini-json");
+        assert_eq!(p.cli_command, "agy");
+        assert_eq!(p.session_id_field, "session_id");
+        assert_eq!(p.resume_flag, Some("-r"));
+        assert_eq!(p.npm_package, "@google/antigravity-cli");
+        assert_eq!(p.supported_vendors, &["google"]);
+        assert!(p.base_url_env_var.is_none());
     }
 
     #[test]
@@ -484,6 +547,22 @@ mod tests {
     }
 
     #[test]
+    fn every_provider_declares_at_least_one_supported_vendor() {
+        for id in ["claude", "codex", "gemini", "qwen", "kimi", "openclaw", "pi", "muxcode", "copilot", "antigravity"] {
+            let p = get_provider(id).unwrap_or_else(|| panic!("provider '{id}' not registered"));
+            assert!(
+                !p.supported_vendors.is_empty(),
+                "provider '{id}' declares no supported_vendors"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_default_vendor_is_anthropic() {
+        assert_eq!(get_provider("claude").unwrap().supported_vendors, &["anthropic"]);
+    }
+
+    #[test]
     fn aliases_resolve() {
         assert_eq!(get_provider("claude-code").unwrap().id, "claude");
         assert_eq!(get_provider("claude_code").unwrap().id, "claude");
@@ -493,6 +572,9 @@ mod tests {
         assert_eq!(get_provider("qwen3-coder").unwrap().id, "qwen");
         assert_eq!(get_provider("kimi-cli").unwrap().id, "kimi");
         assert_eq!(get_provider("openclaw-cli").unwrap().id, "openclaw");
+        assert_eq!(get_provider("agy").unwrap().id, "antigravity");
+        assert_eq!(get_provider("antigravity-cli").unwrap().id, "antigravity");
+        assert_eq!(get_provider("antigravity_cli").unwrap().id, "antigravity");
     }
 
     #[test]
@@ -568,7 +650,7 @@ mod tests {
 
     #[test]
     fn non_claude_providers_have_no_base_url_env_var() {
-        for id in ["codex", "gemini", "qwen", "kimi", "openclaw", "pi", "copilot", "muxcode"] {
+        for id in ["codex", "gemini", "qwen", "kimi", "openclaw", "pi", "copilot", "muxcode", "antigravity"] {
             let p = get_provider(id).unwrap();
             assert!(
                 p.base_url_env_var.is_none(),

--- a/agentmux-srv/src/backend/rpc_types/agent.rs
+++ b/agentmux-srv/src/backend/rpc_types/agent.rs
@@ -318,6 +318,15 @@ pub struct CommandAgentDefCreateFromTemplateData {
     /// inheriting the (now container-defaulted) template value.
     #[serde(default)]
     pub agent_type: String,
+    /// Custom model vendor base URL override for the cloned agent.
+    /// `None` (omitted) → inherit the template's own value (the prior,
+    /// only behavior). `Some(url)` → use `url` instead, including
+    /// `Some("")` to explicitly clear a template-inherited override.
+    /// Validated the same way `agent.define` validates it — rejected
+    /// unless the template's provider declares `base_url_env_var`. See
+    /// `agent_define::validate_vendor_base_url`.
+    #[serde(default)]
+    pub model_vendor_base_url: Option<String>,
 }
 
 /// Response for `agentdefcreatefromtemplate`. The frontend uses
@@ -442,6 +451,15 @@ pub struct CommandUpdateAgentDefinitionData {
     /// docs/analysis/ANALYSIS_WARDEN_AUTO_CONTROLLER_CONTINUATION_WATCHER_2026_08_12.md.
     #[serde(default)]
     pub auto_continue_enabled: Option<i64>,
+    /// Custom model vendor base URL override — see
+    /// `AgentDefinition.model_vendor_base_url`. `None` (omitted) preserves
+    /// the stored value, same "None = don't touch" idiom as
+    /// `use_ambient_login`/`auto_continue_enabled` above. `Some("")`
+    /// explicitly clears an existing override back to the harness's
+    /// default vendor endpoint. Validated the same way `agent.define`
+    /// does — see `agent_define::validate_vendor_base_url`.
+    #[serde(default)]
+    pub model_vendor_base_url: Option<String>,
 }
 
 /// Input for deleteagent

--- a/agentmux-srv/src/backend/rpc_types/instance.rs
+++ b/agentmux-srv/src/backend/rpc_types/instance.rs
@@ -133,6 +133,13 @@ pub struct RecentSessionRow {
     pub definition_id: String,
     pub definition_name: String,
     pub provider: String,
+    /// Custom model vendor base URL override, mirrored from
+    /// `AgentDefinition.model_vendor_base_url` — empty means the harness
+    /// talks to its own default vendor. Lets `MyAgentsList` compute the
+    /// dual-icon vendor badge (`resolveEffectiveVendor`) without a second
+    /// round trip per row.
+    #[serde(default)]
+    pub model_vendor_base_url: String,
     pub working_directory: String,
     pub identity_id: String,
     pub identity_name: String,

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -173,6 +173,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let existing = wstore.agent_def_list().map_err(|e| format!("updateagent: {e}"))?;
                 let old = existing.iter().find(|a| a.id == cmd.id)
                     .ok_or_else(|| format!("updateagent: agent {} not found", cmd.id))?;
+                // Model vendor base URL: `None` (omitted) preserves the
+                // stored value; `Some(url)` overrides it (including
+                // `Some("")` to explicitly clear). Validated against the
+                // (possibly also-updated) `cmd.provider` — same check
+                // `agent.define` applies.
+                let chosen_model_vendor_base_url = match &cmd.model_vendor_base_url {
+                    Some(url) => {
+                        crate::server::app_api::validate_vendor_base_url(&cmd.provider, url)
+                            .map_err(|e| format!("updateagent: {e}"))?;
+                        url.clone()
+                    }
+                    None => old.model_vendor_base_url.clone(),
+                };
                 // slug is preserved from the existing row — it's
                 // immutable after creation. The update path never
                 // accepts a new slug from the client.
@@ -229,11 +242,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // accounts). The Agent setup modal's Accounts tab sends
                     // Some(0|1) to flip it. Spec §2.3.
                     use_ambient_login: cmd.use_ambient_login.unwrap_or(old.use_ambient_login),
-                    // Not carried by CommandUpdateAgentDefinitionData yet —
-                    // always preserve, same as container_name/parent_id
-                    // above, so a UI-driven save never silently wipes a
-                    // vendor override set via `agent.define`.
-                    model_vendor_base_url: old.model_vendor_base_url.clone(),
+                    model_vendor_base_url: chosen_model_vendor_base_url,
                     // Preserve the auto-continue opt-in when the caller omits
                     // the field (Option — most callers only edit name/icon/
                     // accounts). The Warden Supervisor panel sends Some(0|1)

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -384,6 +384,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             .map(|d| d.name.clone())
                             .unwrap_or_else(|| "(missing definition)".to_string()),
                         provider: def.map(|d| d.provider.clone()).unwrap_or_default(),
+                        model_vendor_base_url: def.map(|d| d.model_vendor_base_url.clone()).unwrap_or_default(),
                         working_directory: inst.working_directory,
                         identity_id: inst.identity_id,
                         identity_name,

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -105,6 +105,21 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 } else {
                     "local".to_string()
                 };
+                // Model vendor base URL: `None` (omitted) inherits the
+                // template's own value (the only behavior before this
+                // field existed on this RPC); `Some(url)` overrides it,
+                // including `Some("")` to explicitly clear a
+                // template-inherited override. Same validation `agent.define`
+                // already applies — rejected unless the template's provider
+                // declares `base_url_env_var`.
+                let chosen_model_vendor_base_url = match &cmd.model_vendor_base_url {
+                    Some(url) => {
+                        crate::server::app_api::validate_vendor_base_url(&template.provider, url)
+                            .map_err(|e| format!("agentdefcreatefromtemplate: {e}"))?;
+                        url.clone()
+                    }
+                    None => template.model_vendor_base_url.clone(),
+                };
                 let mut new_def = AgentDefinition {
                     id: uuid::Uuid::new_v4().to_string(),
                     // agent_def_insert derives a unique slug from the
@@ -144,7 +159,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_volumes: template.container_volumes.clone(),
                     container_name: String::new(),
                     use_ambient_login: 0,
-                    model_vendor_base_url: template.model_vendor_base_url.clone(),
+                    model_vendor_base_url: chosen_model_vendor_base_url,
                     auto_continue_enabled: 0,
                 };
                 wstore

--- a/agentmux-srv/src/server/app_api/agent_define.rs
+++ b/agentmux-srv/src/server/app_api/agent_define.rs
@@ -10,7 +10,12 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// without the async `Store`/`Broker` harness `agent_define_core` needs.
 /// An empty `base_url` is always fine — that's "use the harness's default
 /// vendor endpoint," never rejected regardless of provider.
-pub(super) fn validate_vendor_base_url(provider_id: &str, base_url: &str) -> Result<(), String> {
+///
+/// `pub(crate)` (not `pub(super)`) so `server::agent_handlers::template`'s
+/// `agentdefcreatefromtemplate` and `server::agent_handlers::core`'s
+/// `updateagent` handlers can reuse it too, instead of duplicating this
+/// check for the human-facing creation/edit paths.
+pub(crate) fn validate_vendor_base_url(provider_id: &str, base_url: &str) -> Result<(), String> {
     if base_url.is_empty() {
         return Ok(());
     }

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -28,6 +28,11 @@ use crate::server::cli_handlers::resolve_cli_on_path;
 mod agent_open;
 mod agent_io;
 mod agent_define;
+/// Re-exported so the human-facing creation/edit RPC handlers
+/// (`server::agent_handlers::template`/`core`) can reuse the same
+/// vendor-base-url validation `agent.define` already uses, instead of
+/// duplicating it.
+pub(crate) use agent_define::validate_vendor_base_url;
 mod pane;
 mod blockfile;
 pub(crate) mod session;

--- a/frontend/app/element/DualProviderLogo.test.tsx
+++ b/frontend/app/element/DualProviderLogo.test.tsx
@@ -1,0 +1,35 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+import { DualProviderLogo } from "./DualProviderLogo";
+
+afterEach(() => cleanup());
+
+describe("DualProviderLogo", () => {
+    it("omits the vendor badge when vendor matches the harness (single-vendor provider, no override)", () => {
+        const { container } = render(() => <DualProviderLogo harness="claude" vendor="claude" />);
+        expect(container.querySelector(".dual-provider-logo-badge")).toBeNull();
+    });
+
+    it("shows the vendor badge when vendor differs from the harness", () => {
+        const { container } = render(() => <DualProviderLogo harness="claude" vendor="anthropic" />);
+        expect(container.querySelector(".dual-provider-logo-badge")).not.toBeNull();
+    });
+
+    it("shows a \"custom\" badge for an agent with a vendor base URL override", () => {
+        const { container } = render(() => <DualProviderLogo harness="claude" vendor="custom" />);
+        const badge = container.querySelector(".dual-provider-logo-badge");
+        expect(badge).not.toBeNull();
+        const el = container.querySelector(".dual-provider-logo") as HTMLElement;
+        expect(el.title).toContain("custom endpoint");
+    });
+
+    it("omits the badge entirely when no vendor is passed", () => {
+        const { container } = render(() => <DualProviderLogo harness="claude" />);
+        expect(container.querySelector(".dual-provider-logo-badge")).toBeNull();
+        const el = container.querySelector(".dual-provider-logo") as HTMLElement;
+        expect(el.title).toBe("Claude Code harness");
+    });
+});

--- a/frontend/app/element/DualProviderLogo.tsx
+++ b/frontend/app/element/DualProviderLogo.tsx
@@ -1,0 +1,114 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DualProviderLogo — renders a primary Agent Harness icon with a small
+ * overlaid Model Vendor badge, realizing the harness-vs-vendor decoupling
+ * (`docs/specs/` — the `model_vendor_base_url`/`supportedVendors` work)
+ * everywhere an agent is shown: primary icon = the execution harness
+ * (e.g. Claude Code, Antigravity, Codex, OpenClaw); overlay badge = the
+ * upstream intelligence vendor actually serving responses (e.g. Anthropic,
+ * Google, OpenAI, or "custom" when the agent has a
+ * `model_vendor_base_url` override — see
+ * `providers/catalog.ts`'s `resolveEffectiveVendor`).
+ *
+ * The badge is omitted when vendor === harness (the common case for a
+ * single-vendor provider like claude/codex/gemini with no override) — it
+ * would be redundant, and every existing single-icon call site keeps
+ * looking exactly the same.
+ */
+
+import { ProviderLogo } from "@/element/ProviderLogo";
+import type { JSX } from "solid-js";
+
+export interface DualProviderLogoProps {
+    /** Harness/provider id (e.g. "claude", "antigravity", "codex", "openclaw"). */
+    harness: string;
+    /** Model vendor id (e.g. "anthropic", "google", "openai", "custom"). */
+    vendor?: string;
+    /** Base pixel size of the primary harness logo (default: 24). */
+    size?: number;
+    /** Additional CSS class names. */
+    class?: string;
+}
+
+const HARNESS_NAMES: Record<string, string> = {
+    claude: "Claude Code",
+    codex: "Codex CLI",
+    gemini: "Gemini CLI",
+    qwen: "Qwen Code",
+    kimi: "Kimi Code CLI",
+    openclaw: "OpenClaw",
+    pi: "Pi",
+    muxcode: "Mux Code",
+    copilot: "GitHub Copilot CLI",
+    antigravity: "Antigravity (AGY)",
+};
+
+const VENDOR_NAMES: Record<string, string> = {
+    anthropic: "Anthropic",
+    google: "Google",
+    openai: "OpenAI",
+    openrouter: "OpenRouter",
+    moonshot: "Moonshot AI",
+    github: "GitHub",
+    ollama: "Ollama (local)",
+    pi: "Pi",
+    custom: "a custom endpoint",
+};
+
+export const DualProviderLogo = (props: DualProviderLogoProps): JSX.Element => {
+    const size = () => props.size ?? 24;
+    const vendorSize = () => Math.max(10, Math.round(size() * 0.45));
+
+    const harnessName = () => HARNESS_NAMES[(props.harness ?? "").toLowerCase()] ?? props.harness;
+    const vendorName = () => (props.vendor ? VENDOR_NAMES[props.vendor.toLowerCase()] ?? props.vendor : "");
+
+    const showBadge = () =>
+        !!props.vendor && props.vendor.toLowerCase() !== (props.harness ?? "").toLowerCase();
+
+    const tooltip = () => {
+        const h = harnessName();
+        return showBadge() ? `${h} harness running on ${vendorName()}` : `${h} harness`;
+    };
+
+    return (
+        <span
+            class={`dual-provider-logo${props.class ? ` ${props.class}` : ""}`}
+            style={{
+                position: "relative",
+                display: "inline-flex",
+                "align-items": "center",
+                "justify-content": "center",
+                width: `${size()}px`,
+                height: `${size()}px`,
+            }}
+            title={tooltip()}
+            aria-label={tooltip()}
+        >
+            <ProviderLogo provider={props.harness} size={size()} />
+            {showBadge() && (
+                <span
+                    class="dual-provider-logo-badge"
+                    style={{
+                        position: "absolute",
+                        bottom: "-2px",
+                        right: "-2px",
+                        display: "inline-flex",
+                        "align-items": "center",
+                        "justify-content": "center",
+                        "background-color": "var(--main-bg-color)",
+                        "border-radius": "50%",
+                        padding: "1px",
+                        border: "1px solid var(--border-color)",
+                        "box-shadow": "0 1px 3px rgba(0, 0, 0, 0.3)",
+                    }}
+                >
+                    <ProviderLogo provider={props.vendor!} size={vendorSize()} />
+                </span>
+            )}
+        </span>
+    );
+};
+
+DualProviderLogo.displayName = "DualProviderLogo";

--- a/frontend/app/element/ProviderLogo.tsx
+++ b/frontend/app/element/ProviderLogo.tsx
@@ -82,7 +82,7 @@ export const ProviderLogo = (props: ProviderLogoProps): JSX.Element => {
         if (p === "anthropic" || p === "claude") return { html: claudeColorSvg };
         if (p === "codex") return { html: codexColorSvg };
         if (p === "openai") return { html: openaiSvg };
-        if (p === "gemini") return { html: geminiColorSvg };
+        if (p === "gemini" || p === "antigravity" || p === "agy") return { html: geminiColorSvg };
         if (p === "github") return { html: githubSvg };
         if (p === "copilot" || p === "githubcopilot" || p === "github-copilot") return { html: copilotColorSvg };
         if (p === "kimi") return { html: kimiSvg };

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -213,7 +213,7 @@ export function renderRequest(
                         // (spec note on CreateFromTemplateRequest) so
                         // `submitting()` covers both RPC steps and ESC
                         // / backdrop dismiss stay blocked end-to-end.
-                        onSubmit={async ({ name, accountId, memoryId, agentType }) => {
+                        onSubmit={async ({ name, accountId, memoryId, agentType, modelVendorBaseUrl }) => {
                             setSubmitting(true);
                             try {
                                 const resp = await RpcApi.AgentDefCreateFromTemplateCommand(
@@ -227,6 +227,13 @@ export function renderRequest(
                                         // new user-owned definition so later
                                         // reattach/auto-continue uses it too.
                                         agent_type: agentType,
+                                        // Always sent explicitly (never
+                                        // omitted) — the form always has a
+                                        // concrete value in scope (defaults
+                                        // to the template's own), so there's
+                                        // no "leave untouched" case to
+                                        // distinguish here.
+                                        model_vendor_base_url: modelVendorBaseUrl,
                                     },
                                 );
                                 await req.onCreatedAndLaunch(

--- a/frontend/app/store/rpc-api/agent.ts
+++ b/frontend/app/store/rpc-api/agent.ts
@@ -77,6 +77,10 @@ export const AgentApi = {
             /** Runtime to persist on the cloned definition ("host" |
              *  "container"). Omitted → backend keeps the template's. */
             agent_type?: string;
+            /** Custom model vendor base URL override for the cloned
+             *  agent. Omitted → backend keeps the template's own value.
+             *  `""` explicitly clears a template-inherited override. */
+            model_vendor_base_url?: string;
         },
         opts?: RpcOpts,
     ): Promise<{ definition_id: string; identity_id: string; memory_id: string }> {

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -20,8 +20,9 @@
  */
 
 import { createMemo, onMount, Show, type JSX } from "solid-js";
-import { ProviderLogo } from "@/element/ProviderLogo";
+import { DualProviderLogo } from "@/element/DualProviderLogo";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
+import { resolveEffectiveVendor } from "../providers/catalog";
 
 interface AgentCardProps {
     agent: AgentDefinition;
@@ -118,7 +119,12 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
             aria-disabled={props.disabled}
             aria-label={`Launch ${caption()}`}
         >
-            <ProviderLogo provider={props.agent.provider} size={28} class="agent-card-icon" />
+            <DualProviderLogo
+                harness={props.agent.provider}
+                vendor={resolveEffectiveVendor(props.agent.provider, props.agent.model_vendor_base_url)}
+                size={28}
+                class="agent-card-icon"
+            />
             <span class="agent-card-info">
                 <span class="agent-card-title">{title()}</span>
                 <span class="agent-card-caption">{caption()}</span>

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -212,4 +212,52 @@ describe("AgentCreateFromTemplateModalPanel", () => {
         await flush();
         expect(onSubmit).not.toHaveBeenCalled();
     });
+
+    it("shows the Model Vendor / Custom Endpoint field for a provider that declares baseUrlEnvVar (claude) and includes it in the submit payload", async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        await flush();
+        await flush();
+        await flush();
+        const input = screen.getByTestId(
+            "create-from-template-vendor-base-url-input",
+        ) as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "https://my-proxy.example.com" } });
+
+        const submit = screen.getByTestId("create-from-template-submit");
+        fireEvent.click(submit);
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+        expect(onSubmit.mock.calls[0][0].modelVendorBaseUrl).toBe(
+            "https://my-proxy.example.com",
+        );
+    });
+
+    it("hides the Model Vendor / Custom Endpoint field for a provider that doesn't declare baseUrlEnvVar, and submits an empty override", async () => {
+        const codexTemplate = { ...template, provider: "codex" } as AgentDefinition;
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={codexTemplate}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        await flush();
+        await flush();
+        await flush();
+        expect(screen.queryByTestId("create-from-template-vendor-base-url-input")).toBeNull();
+
+        const submit = screen.getByTestId("create-from-template-submit");
+        fireEvent.click(submit);
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+        expect(onSubmit.mock.calls[0][0].modelVendorBaseUrl).toBe("");
+    });
 });

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -28,6 +28,7 @@ import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
+import { PROVIDERS } from "../providers/catalog";
 import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 import { refreshAccountCache, type Account } from "@/app/view/identity/identity-model";
 
@@ -39,6 +40,11 @@ interface CreateFromTemplateFormData {
      *  it is NOT a property of the template (a template is runtime-
      *  agnostic). "container" requires a reachable Docker runtime. */
     agentType: "host" | "container";
+    /** Custom model vendor base URL override (e.g. a proxy in front of
+     *  Anthropic's API). Empty string = use the harness's default vendor
+     *  endpoint. Only meaningful — and only shown in the form — when the
+     *  template's provider declares `baseUrlEnvVar` in the catalog. */
+    modelVendorBaseUrl: string;
 }
 
 interface AgentCreateFromTemplateModalPanelProps {
@@ -62,6 +68,17 @@ export const AgentCreateFromTemplateModalPanel = (
     const [memories, setMemories] = createSignal<Memory[]>([]);
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
+    const [modelVendorBaseUrl, setModelVendorBaseUrl] = createSignal(
+        props.template.model_vendor_base_url ?? "",
+    );
+
+    // Only providers that declare `baseUrlEnvVar` (currently just claude)
+    // can actually be redirected to a custom endpoint — see
+    // agent_define::validate_vendor_base_url on the backend, which rejects
+    // a non-empty override for any other provider.
+    const supportsCustomEndpoint = createMemo(
+        () => !!PROVIDERS[props.template.provider]?.baseUrlEnvVar,
+    );
 
     // ── Runtime (host vs container) ────────────────────────────────
     // Runtime is decided HERE, when instantiating the template — it's
@@ -163,6 +180,7 @@ export const AgentCreateFromTemplateModalPanel = (
                 accountId: accountId(),
                 memoryId: memoryId(),
                 agentType: runtime(),
+                modelVendorBaseUrl: supportsCustomEndpoint() ? modelVendorBaseUrl().trim() : "",
             });
             // Layer unmounts via close-on-success. Reset is defensive.
             setSubmitting(false);
@@ -237,6 +255,26 @@ export const AgentCreateFromTemplateModalPanel = (
                         </span>
                     </Show>
                 </label>
+                <Show when={supportsCustomEndpoint()}>
+                    <label class="agent-new-bundle-modal-field">
+                        <span class="agent-new-bundle-modal-label">Model Vendor / Custom Endpoint</span>
+                        <input
+                            type="text"
+                            class="agent-new-bundle-modal-input"
+                            placeholder={`Default (${PROVIDERS[props.template.provider]?.baseUrlEnvVar})`}
+                            value={modelVendorBaseUrl()}
+                            onInput={(e) => setModelVendorBaseUrl(e.currentTarget.value)}
+                            onKeyDown={onKeyDown}
+                            disabled={submitting()}
+                            data-testid="create-from-template-vendor-base-url-input"
+                        />
+                        <span class="agent-new-bundle-modal-hint">
+                            Redirect this agent's harness at a custom API endpoint
+                            (e.g. a proxy or alternate model backend) instead of the
+                            default vendor. Leave blank to use the default.
+                        </span>
+                    </label>
+                </Show>
                 <label class="agent-new-bundle-modal-field">
                     <span class="agent-new-bundle-modal-label">Identity</span>
                     <select

--- a/frontend/app/view/agent/components/AgentIdentityModal.scss
+++ b/frontend/app/view/agent/components/AgentIdentityModal.scss
@@ -18,6 +18,63 @@
 // spawn gate no longer honors use_ambient_login at all, so the toggle was
 // dead UI promising a fallback that no longer existed.
 
+.agent-identity-vendor-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+    padding: var(--space-3) var(--space-5);
+    border-top: 1px solid var(--border-color);
+}
+
+.agent-identity-vendor-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    opacity: 0.75;
+}
+
+.agent-identity-vendor-row {
+    display: flex;
+    gap: var(--space-2);
+}
+
+.agent-identity-vendor-input {
+    flex: 1;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+}
+
+.agent-identity-vendor-save-btn {
+    padding: var(--space-1-5) var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--button-text-color);
+    background: var(--accent-color);
+    border: none;
+    border-radius: 0;
+    cursor: default;
+
+    &:disabled {
+        opacity: 0.5;
+    }
+
+    &:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--accent-color) 85%, var(--main-text-color));
+    }
+}
+
+.agent-identity-vendor-hint {
+    font-size: 0.8em;
+    opacity: 0.6;
+}
+
+.agent-identity-vendor-error {
+    font-size: 0.85em;
+    color: var(--warning-color, #d97706);
+}
+
 .agent-modal-footer {
     display: flex;
     justify-content: flex-end;

--- a/frontend/app/view/agent/components/AgentIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityModal.tsx
@@ -31,7 +31,7 @@
  * Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md §4.
  */
 
-import { createSignal, onCleanup, type JSX } from "solid-js";
+import { createMemo, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import {
@@ -40,6 +40,7 @@ import {
     type AgentAccounts,
 } from "@/app/view/identity/identity-model";
 import { AgentIdentityPanel } from "./AgentIdentityPanel";
+import { PROVIDERS } from "../providers/catalog";
 
 interface AgentIdentityModalPanelProps {
     agent: AgentDefinition;
@@ -87,6 +88,39 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
         setLiveAgent({ ...a, accounts: serialized });
     };
 
+    // ── Model vendor / custom endpoint ─────────────────────────────
+    // Only providers that declare `baseUrlEnvVar` (currently just claude)
+    // can actually be redirected — see agent_define::validate_vendor_base_url
+    // on the backend, which rejects a non-empty override for any other
+    // provider.
+    const supportsCustomEndpoint = createMemo(
+        () => !!PROVIDERS[liveAgent().provider]?.baseUrlEnvVar,
+    );
+    const [modelVendorBaseUrl, setModelVendorBaseUrl] = createSignal(
+        props.agent.model_vendor_base_url ?? "",
+    );
+    const [vendorSaving, setVendorSaving] = createSignal(false);
+    const [vendorError, setVendorError] = createSignal<string | null>(null);
+
+    const handleVendorSave = async (): Promise<void> => {
+        const a = liveAgent();
+        const url = modelVendorBaseUrl().trim();
+        setVendorSaving(true);
+        setVendorError(null);
+        try {
+            await RpcApi.UpdateAgentDefinitionCommand(TabRpcClient, {
+                ...basePayload(a),
+                accounts: a.accounts,
+                model_vendor_base_url: url,
+            });
+            setLiveAgent({ ...a, model_vendor_base_url: url });
+        } catch (e) {
+            setVendorError((e as Error)?.message ?? String(e));
+        } finally {
+            setVendorSaving(false);
+        }
+    };
+
     return (
         <div class="agent-identity-modal-body">
             <AgentIdentityPanel
@@ -94,6 +128,37 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
                 model={model}
                 onUpdate={handleUpdate}
             />
+            <Show when={supportsCustomEndpoint()}>
+                <div class="agent-identity-vendor-section">
+                    <span class="agent-identity-vendor-label">Model Vendor / Custom Endpoint</span>
+                    <div class="agent-identity-vendor-row">
+                        <input
+                            type="text"
+                            class="agent-identity-vendor-input"
+                            placeholder={`Default (${PROVIDERS[liveAgent().provider]?.baseUrlEnvVar})`}
+                            value={modelVendorBaseUrl()}
+                            onInput={(e) => setModelVendorBaseUrl(e.currentTarget.value)}
+                            disabled={vendorSaving()}
+                            data-testid="agent-identity-vendor-base-url-input"
+                        />
+                        <button
+                            class="agent-identity-vendor-save-btn"
+                            disabled={vendorSaving() || modelVendorBaseUrl().trim() === (liveAgent().model_vendor_base_url ?? "")}
+                            onClick={() => void handleVendorSave()}
+                            data-testid="agent-identity-vendor-base-url-save"
+                        >
+                            {vendorSaving() ? "Saving…" : "Save"}
+                        </button>
+                    </div>
+                    <span class="agent-identity-vendor-hint">
+                        Redirect this agent's harness at a custom API endpoint instead
+                        of the default vendor. Leave blank to use the default.
+                    </span>
+                    <Show when={vendorError()}>
+                        <div class="agent-identity-vendor-error">{vendorError()}</div>
+                    </Show>
+                </div>
+            </Show>
             <div class="agent-modal-footer">
                 <button
                     class="agent-modal-done-btn"

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -52,7 +52,8 @@ import { useTick } from "@/app/hook/useTick";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
-import { ProviderLogo } from "@/element/ProviderLogo";
+import { DualProviderLogo } from "@/element/DualProviderLogo";
+import { resolveEffectiveVendor } from "../providers/catalog";
 import { Logger } from "@/util/logger";
 import { formatTimeAgo } from "@/util/format-time";
 import { RuntimeBadge } from "./RuntimeBadge";
@@ -372,8 +373,9 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                         aria-label={`Continue ${row.instance_name}`}
                                         data-testid="agent-my-agents-entry"
                                     >
-                                        <ProviderLogo
-                                            provider={row.provider}
+                                        <DualProviderLogo
+                                            harness={row.provider}
+                                            vendor={resolveEffectiveVendor(row.provider, row.model_vendor_base_url)}
                                             size={24}
                                             class="agent-recent-sessions-icon"
                                         />

--- a/frontend/app/view/agent/defaults/cli-catalog.ts
+++ b/frontend/app/view/agent/defaults/cli-catalog.ts
@@ -87,6 +87,19 @@ const CLI_CATALOG: CliCatalogEntry[] = [
         containerSupported: false,
     },
     {
+        provider: "antigravity",
+        displayName: "Antigravity (AGY)",
+        icon: "⚛",
+        blurb: "Google's agentic coding CLI harness",
+        primaryContextFile: "AGENTS.md",
+        mcpSupport: "stdio+http",
+        popoverMarkdown:
+            "Google's agentic coding CLI harness — a sibling to Gemini CLI, sharing its stream-json output. Emphasizes high-throughput agentic task execution with native skill discovery and subagent support. Uses your Google account.",
+        hostSupported: true,
+        // No container image built yet — host-only until agentmux/antigravity ships.
+        containerSupported: false,
+    },
+    {
         provider: "qwen",
         displayName: "Qwen Code",
         icon: "❖",

--- a/frontend/app/view/agent/providers/catalog.ts
+++ b/frontend/app/view/agent/providers/catalog.ts
@@ -84,6 +84,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // (or proxied) backend — Bedrock, Vertex, OpenRouter, a custom proxy.
         // Mirrors agentmux-srv/src/backend/providers.rs `base_url_env_var`.
         baseUrlEnvVar: "ANTHROPIC_BASE_URL",
+        supportedVendors: ["anthropic"],
         launchArgs: ["-p", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
         resumeFlag: "--resume",
         sessionIdField: "session_id",
@@ -147,6 +148,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "robot",
         authConfigDirEnvVar: "CODEX_HOME",
         authDirName: "codex",
+        supportedVendors: ["openai"],
         launchArgs: ["exec", "--json", "--dangerously-bypass-approvals-and-sandbox", "-"],
         // Codex resume requires a subcommand change (exec resume <id>), not a simple flag.
         resumeFlag: null,
@@ -190,6 +192,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "brain",
         authConfigDirEnvVar: "MUXCODE_CONFIG_DIR",
         authDirName: "muxcode",
+        supportedVendors: ["ollama", "anthropic", "openai"],
         launchArgs: ["run", "-p"],
         resumeFlag: "--resume",
         sessionIdField: "session_id",
@@ -217,6 +220,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "diamond",
         authConfigDirEnvVar: "GEMINI_CLI_HOME",
         authDirName: "gemini",
+        supportedVendors: ["google"],
         authExtraEnv: { GEMINI_FORCE_FILE_STORAGE: "true" },
         launchArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
         resumeFlag: "-r",
@@ -256,6 +260,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "feather",
         authConfigDirEnvVar: "QWEN_HOME",
         authDirName: "qwen",
+        supportedVendors: ["openrouter"],
         launchArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
         resumeFlag: null,
         sessionIdField: "session_id",
@@ -309,6 +314,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "lobster",
         authConfigDirEnvVar: "OPENCLAW_HOME",
         authDirName: "openclaw",
+        supportedVendors: ["openai", "anthropic", "google"],
         launchArgs: ["acp"],
         resumeFlag: null,
         sessionIdField: "sessionId",
@@ -341,6 +347,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         unsetEnv: [],
         authConfigDirEnvVar: "KIMI_SHARE_DIR",
         authDirName: "kimi",
+        supportedVendors: ["moonshot"],
         launchArgs: ["--print", "--output-format", "stream-json", "--yolo", "-p", ""],
         resumeFlag: null,
         sessionIdField: "session_id",
@@ -374,6 +381,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "github",
         authConfigDirEnvVar: "COPILOT_HOME",
         authDirName: "copilot",
+        supportedVendors: ["github"],
         launchArgs: ["--acp"],
         resumeFlag: null,
         sessionIdField: "sessionId",
@@ -402,10 +410,49 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         icon: "terminal",
         authConfigDirEnvVar: "PI_HOME",
         authDirName: "pi",
+        supportedVendors: ["pi"],
         launchArgs: ["--json"],
         resumeFlag: null,
         sessionIdField: "sessionId",
         controllerType: "acp",
+    },
+    // Antigravity (AGY) — Google's agentic coding CLI harness. Emits the
+    // same stream-json NDJSON envelope as Gemini CLI (its sibling
+    // harness), so it reuses the gemini translator (styledOutputFormat
+    // "gemini-json"). Mirrors agentmux-srv/src/backend/providers.rs
+    // `static ANTIGRAVITY`.
+    antigravity: {
+        id: "antigravity",
+        displayName: "Antigravity (AGY)",
+        cliCommand: "agy",
+        defaultArgs: [],
+        styledArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
+        outputFormat: "raw",
+        styledOutputFormat: "gemini-json",
+        authType: "oauth",
+        authCheckCommand: ["auth", "status"],
+        authLoginCommand: ["auth", "login"],
+        npmPackage: "@google/antigravity-cli",
+        pinnedVersion: "1.0.0",
+        docsUrl: "https://ai.google.dev/antigravity",
+        windowsInstallCommand: "npm install -g @google/antigravity-cli",
+        unixInstallCommand: "npm install -g @google/antigravity-cli",
+        icon: "zap",
+        authConfigDirEnvVar: "ANTIGRAVITY_CONFIG_DIR",
+        authDirName: "antigravity",
+        authExtraEnv: { ANTIGRAVITY_FORCE_FILE_STORAGE: "true" },
+        supportedVendors: ["google"],
+        launchArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
+        resumeFlag: "-r",
+        sessionIdField: "session_id",
+        controllerType: "subprocess",
+        contextWindow: 1_000_000,
+        models: [
+            { value: "gemini-3.6-flash", label: "Gemini 3.6 Flash", default: true, description: "Fast, highly capable frontier model with 1M context" },
+            { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro", description: "Deep reasoning and complex coding" },
+            { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash", description: "Balanced performance and speed" },
+            { value: "gemini-2.0-flash-thinking", label: "Gemini 2.0 Flash Thinking", description: "Chain-of-thought agentic reasoning" },
+        ],
     },
 };
 
@@ -426,8 +473,31 @@ export const PROVIDER_ALIASES: Record<string, string> = {
     "copilot_cli": "copilot",
     "mux-code": "muxcode",
     "mux_code": "muxcode",
+    "agy": "antigravity",
+    "antigravity-cli": "antigravity",
+    "antigravity_cli": "antigravity",
 };
 
 export function resolveProviderAlias(id: string): string {
     return PROVIDER_ALIASES[id] ?? id;
+}
+
+/**
+ * The vendor concept is computed, not stored: a non-empty
+ * `modelVendorBaseUrl` means the harness has been redirected off its
+ * default backend, so the effective vendor is "custom" regardless of what
+ * `provider` declares as its default. An empty/absent override means the
+ * harness is talking to its own default vendor — the first entry in that
+ * provider's `supportedVendors` (falls back to the harness id itself for a
+ * provider with no `supportedVendors` declared, e.g. a not-yet-cataloged
+ * one from an older DB row).
+ */
+export function resolveEffectiveVendor(
+    provider: string,
+    modelVendorBaseUrl: string | undefined | null,
+): string {
+    if (modelVendorBaseUrl && modelVendorBaseUrl.trim().length > 0) {
+        return "custom";
+    }
+    return PROVIDERS[provider]?.supportedVendors?.[0] ?? provider;
 }

--- a/frontend/app/view/agent/providers/provider-id-aliases.ts
+++ b/frontend/app/view/agent/providers/provider-id-aliases.ts
@@ -32,6 +32,9 @@ const PROVIDER_ID_ALIASES: Record<string, string> = {
     copilot_cli: "copilot",
     "mux-code": "muxcode",
     mux_code: "muxcode",
+    agy: "antigravity",
+    "antigravity-cli": "antigravity",
+    antigravity_cli: "antigravity",
 };
 
 /** Resolve a possibly-legacy provider ID to its canonical form. Returns the

--- a/frontend/app/view/agent/providers/resolve-effective-vendor.test.ts
+++ b/frontend/app/view/agent/providers/resolve-effective-vendor.test.ts
@@ -1,0 +1,29 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveVendor } from "./catalog";
+
+describe("resolveEffectiveVendor", () => {
+    it("returns the provider's default vendor when there's no base URL override", () => {
+        expect(resolveEffectiveVendor("claude", undefined)).toBe("anthropic");
+        expect(resolveEffectiveVendor("claude", "")).toBe("anthropic");
+        expect(resolveEffectiveVendor("claude", null)).toBe("anthropic");
+        expect(resolveEffectiveVendor("codex", undefined)).toBe("openai");
+        expect(resolveEffectiveVendor("gemini", undefined)).toBe("google");
+    });
+
+    it("returns the FIRST supportedVendors entry for a multi-vendor harness", () => {
+        expect(resolveEffectiveVendor("openclaw", undefined)).toBe("openai");
+        expect(resolveEffectiveVendor("muxcode", undefined)).toBe("ollama");
+    });
+
+    it("returns \"custom\" whenever a base URL override is set, regardless of provider", () => {
+        expect(resolveEffectiveVendor("claude", "https://my-proxy.example.com")).toBe("custom");
+        expect(resolveEffectiveVendor("claude", "  https://my-proxy.example.com  ")).toBe("custom");
+    });
+
+    it("falls back to the provider id itself for an unknown provider", () => {
+        expect(resolveEffectiveVendor("not-a-real-provider", undefined)).toBe("not-a-real-provider");
+    });
+});

--- a/frontend/app/view/agent/providers/types.ts
+++ b/frontend/app/view/agent/providers/types.ts
@@ -131,4 +131,13 @@ export interface ProviderDefinition {
      * verified, not guessed.
      */
     baseUrlEnvVar?: string;
+    /**
+     * Intelligence model vendors this harness talks to, most-default-first
+     * (e.g. claude → `["anthropic"]`, openclaw → `["openai", "anthropic",
+     * "google"]` since it's model-agnostic). Purely descriptive/display
+     * data — drives the dual-icon vendor badge and `resolveEffectiveVendor`'s
+     * default-vendor inference; does not gate anything at launch. Mirrors
+     * Rust's `ProviderConfig::supported_vendors`.
+     */
+    supportedVendors?: string[];
 }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -761,6 +761,11 @@ declare global {
         definition_id: string;
         definition_name: string;
         provider: string;
+        /** Custom model vendor base URL override, mirrored from
+         *  AgentDefinition.model_vendor_base_url. Empty means the harness
+         *  talks to its own default vendor. See providers/catalog.ts's
+         *  resolveEffectiveVendor. */
+        model_vendor_base_url?: string;
         working_directory: string;
         identity_id: string;
         identity_name: string;
@@ -842,6 +847,12 @@ declare global {
          * preserve the stored value. See AgentDefinition.auto_continue_enabled.
          */
         auto_continue_enabled?: number;
+        /**
+         * Custom model vendor base URL override. Omit to preserve the
+         * stored value; "" explicitly clears it back to the harness's
+         * default vendor endpoint. See AgentDefinition.model_vendor_base_url.
+         */
+        model_vendor_base_url?: string;
     };
 
     // CommandDeleteAgentDefinitionData


### PR DESCRIPTION
## Summary

Finishes the harness-vs-model-vendor decoupling work from #2505, which shipped the backend plumbing (`AgentDefinition.model_vendor_base_url`, `ProviderConfig.base_url_env_var`) but explicitly scoped out UI: *"settable via `agent.define` only; the human 'New Agent'/edit UI doesn't surface it yet."* Also completes the Antigravity (AGY) harness integration originally prototyped on the unmerged `feat/harness-model-decoupling-antigravity` branch (single commit, never opened as a PR, 73 commits stale) — rebuilt fresh against current `main` rather than cherry-picked.

**No new `AgentDefinition`/database fields.** The vendor concept is computed, not stored: `resolveEffectiveVendor(provider, model_vendor_base_url)` returns `"custom"` when an override is set, else the provider's own default vendor (a new static `supportedVendors` catalog field, mirrored Rust `ProviderConfig` ↔ TS `ProviderDefinition`).

### Vendor/endpoint UI
- `CommandAgentDefCreateFromTemplateData` and `CommandUpdateAgentDefinitionData` both gained an `Option<String> model_vendor_base_url` field (`None` = inherit/preserve, `Some("")` = explicit clear), wired through `template.rs`'s and `core.rs`'s handlers with the same `validate_vendor_base_url` check `agent.define` already uses (widened to `pub(crate)` and re-exported instead of duplicated).
- `AgentCreateFromTemplateModal` gained a "Model Vendor / Custom Endpoint" field, shown only when the template's provider declares `baseUrlEnvVar` (currently just claude).
- `AgentIdentityModal` gained the same field for editing an existing agent, reusing its `basePayload()`/`handleUpdate` round-trip pattern.

### Dual-icon display
- New `DualProviderLogo` component (primary harness icon + overlaid vendor badge, omitted when vendor === harness) wired into `AgentCard` and `MyAgentsList`. `RecentSessionRow` gained `model_vendor_base_url` so `MyAgentsList` can compute the badge without a second round trip.

### Antigravity (AGY) harness
- Added as a full provider entry (Rust `ProviderConfig` + registry/aliases, TS catalog + provider-id-aliases, `ProviderLogo` icon mapping reusing Gemini's, seed template) so it's actually pickable as a "New Agent" template — the harness has no route into the UI otherwise, since creation is template-driven.

## Deliberately out of scope (explicit decision during planning)

- A from-scratch 3-step creation wizard — investigation found agent creation has no from-scratch flow today (every agent clones a template, which already fixes the provider/harness), so the wizard proposal doesn't map onto the current UX.
- New SVG icons for `openrouter`/`ollama`/`alibaba` vendors — letter-circle fallback is fine for v1.
- `AgentPaneIcon.tsx`'s pane-tab icon — resolves provider from block meta, not an `AgentDefinition`; no vendor-base-url meta key exists, and plumbing one through the launch flow for a 16px icon wasn't judged worth it this pass.

## Test plan

- [x] `cargo build -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv` — 2185 tests passing (new: antigravity provider tests, alias tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2588 tests passing (175 files), including new `DualProviderLogo.test.tsx`, `resolve-effective-vendor.test.ts`, and 2 new `AgentCreateFromTemplateModal` tests (field shown/hidden by provider, submit payload)
- [ ] Manual smoke test (`task dev`, launching the real desktop app) — **not performed**, consistent with how the rest of this session's UI work was verified (typecheck + component tests only, no live GUI launch attempted in this environment)

<!-- agentmux:agent_id=camper -->