### PR TITLE
feat(window): restore last session's tabs/panes on relaunch

### DIFF
--- a/.changesets/1786628662-feat-window-restore-last-session-s-tabs-panes-on-relaunch-o9os.md
+++ b/.changesets/1786628662-feat-window-restore-last-session-s-tabs-panes-on-relaunch-o9os.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(window): restore last session's tabs/panes on relaunch

--- a/.changesets/1786713585-fix-window-close-toctou-races-in-session-restore-snapshot-sa-rki0.md
+++ b/.changesets/1786713585-fix-window-close-toctou-races-in-session-restore-snapshot-sa-rki0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): close TOCTOU races in session-restore snapshot save/clear and restore activetabid/magnifiednodeid

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -3150,7 +3150,14 @@ mod tests {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("AGENTMUX_BASHWRAP_IDLE_TIMEOUT_SECS").ok();
         unsafe {
-            std::env::set_var("AGENTMUX_BASHWRAP_IDLE_TIMEOUT_SECS", "1");
+            // 1s was tight enough that a loaded CI runner's PTY-reader-thread
+            // scheduling delay alone could exceed it before `echo hello` ever
+            // produced output — a genuine idle-kill by the test's own
+            // (deliberately short) timeout, not the idle_rx/wait_task
+            // misclassification race this test exists to catch. 3s keeps the
+            // race window this test targets while giving scheduling enough
+            // slack not to trip the timeout on its own.
+            std::env::set_var("AGENTMUX_BASHWRAP_IDLE_TIMEOUT_SECS", "3");
         }
 
         let bash = locate_bash().expect("locate_bash for test — same dependency the whole binary needs");
@@ -3261,13 +3268,29 @@ mod tests {
             };
             let buffered = Arc::new(tokio::sync::Mutex::new(Vec::<u8>::new()));
 
-            let result = tokio::time::timeout(
-                Duration::from_secs(15),
+            // A hung/slow attempt is treated the same as a wrong-occurrence
+            // attempt (retry, don't hard-fail): a loaded CI runner can push
+            // process-spawn latency past a fixed per-attempt budget without
+            // that being evidence of a real bug in `run_via_pty` itself —
+            // same rationale as the occurrence-count retry below, just
+            // covering the timeout path too (previously a timeout here
+            // bypassed the retry loop entirely via a hard `.expect()`).
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(20),
                 run_via_pty(&args, command, None, buffered.clone(), &bash, pair),
             )
-            .await
-            .expect("run_via_pty must not hang")
-            .expect("run_via_pty should return Ok");
+            .await;
+            let result = match outcome {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => panic!("run_via_pty should return Ok, got: {e}"),
+                Err(_) => {
+                    eprintln!(
+                        "attempt {attempt}/{MAX_ATTEMPTS}: run_via_pty did not complete within \
+                         20s (retrying: a loaded CI runner can delay process spawn/scheduling)"
+                    );
+                    continue;
+                }
+            };
             assert_eq!(result, 0, "command should exit cleanly");
 
             let blob = String::from_utf8_lossy(&buffered.lock().await).into_owned();

--- a/agentmux-srv/src/server/service/layout_helpers.rs
+++ b/agentmux-srv/src/server/service/layout_helpers.rs
@@ -55,6 +55,7 @@ pub(crate) async fn setup_torn_off_block_layout(
         rootnode,
         String::new(),
         leaforder,
+        String::new(),
     )
     .await
 }

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -22,6 +22,7 @@ mod misc;
 mod object;
 mod object_helpers;
 mod reducer_helpers;
+pub(crate) mod session_restore;
 mod tab_lifecycle;
 mod tab_move;
 mod tear_off;

--- a/agentmux-srv/src/server/service/reducer_helpers.rs
+++ b/agentmux-srv/src/server/service/reducer_helpers.rs
@@ -82,12 +82,13 @@ pub(crate) async fn seed_layout_via_reducer(
     new_tree: agentmux_common::LayoutNode,
     focused_node_id: String,
     leaforder: Vec<crate::backend::obj::LeafOrderEntry>,
+    magnified_node_id: String,
 ) -> Result<(), String> {
     let store = &state.wstore;
     let slices = agentmux_common::LayoutClientSlices {
         leaforder: serde_json::to_value(&leaforder).ok(),
         focused_node_id,
-        magnified_node_id: String::new(),
+        magnified_node_id,
         // Fresh-tab seed: REPLACE semantics clear any stale queue.
         pending_backend_actions: None,
     };

--- a/agentmux-srv/src/server/service/session_restore.rs
+++ b/agentmux-srv/src/server/service/session_restore.rs
@@ -56,6 +56,15 @@ fn placeholder_idx(s: &str) -> Option<usize> {
 pub(crate) fn snapshot_workspace(store: &Store, workspace_id: &str) -> Option<Value> {
     let workspace = store.get::<Workspace>(workspace_id).ok().flatten()?;
     let mut tabs = Vec::new();
+    // Position of `workspace.activetabid` WITHIN the successfully-captured
+    // `tabs` array (reagentx P2 on PR #2560: previously never captured at
+    // all, so a restore always focused whichever tab `CreateTab`'s
+    // first-tab-wins default left active — see `wcore/tab.rs`'s
+    // `ws.activetabid.is_empty()` check). Same "index by position in the
+    // list that actually survived" reasoning as blocks below: if the
+    // originally-active tab is one that fails to load, this simply stays
+    // `None` and restore falls back to whatever `CreateTab` leaves active.
+    let mut active_tab_index: Option<usize> = None;
     // `pinnedtabids` is a legacy field (pinning was removed from AgentMux —
     // see `tab_lifecycle.rs`); a workspace the reducer hasn't touched yet
     // (e.g. straight out of `ensure_initial_data`) can still have its one
@@ -87,8 +96,8 @@ pub(crate) fn snapshot_workspace(store: &Store, workspace_id: &str) -> Option<Va
         if blocks.is_empty() {
             continue;
         }
-        let (rootnode, focusednodeid) = if tab.layoutstate.is_empty() {
-            (None, String::new())
+        let (rootnode, focusednodeid, magnifiednodeid) = if tab.layoutstate.is_empty() {
+            (None, String::new(), String::new())
         } else {
             match store.get::<LayoutState>(&tab.layoutstate) {
                 Ok(Some(layout)) => {
@@ -96,22 +105,26 @@ pub(crate) fn snapshot_workspace(store: &Store, workspace_id: &str) -> Option<Va
                         placeholderize(&mut tree, &idx_by_block_id);
                         tree
                     });
-                    (rootnode, layout.focusednodeid)
+                    (rootnode, layout.focusednodeid, layout.magnifiednodeid)
                 }
-                _ => (None, String::new()),
+                _ => (None, String::new(), String::new()),
             }
         };
+        if tab_id == &workspace.activetabid {
+            active_tab_index = Some(tabs.len());
+        }
         tabs.push(json!({
             "name": tab.name,
             "blocks": blocks,
             "rootnode": rootnode,
             "focusednodeid": focusednodeid,
+            "magnifiednodeid": magnifiednodeid,
         }));
     }
     if tabs.is_empty() {
         return None;
     }
-    Some(json!({ "tabs": tabs }))
+    Some(json!({ "tabs": tabs, "active_tab_index": active_tab_index }))
 }
 
 /// Replace every leaf's real block id (in `data.block_id`, `block_stack`,
@@ -170,15 +183,28 @@ fn resolve_placeholders(node: &mut LayoutNode, new_ids: &[String]) {
 /// Persist a snapshot as the durable "last session" record, overwriting
 /// whatever was there before. Best-effort: a write failure is logged, never
 /// propagated — this must never block the close it rides alongside.
+///
+/// Reads-then-writes the singleton `Client` row inside a single
+/// `with_tx` (reagentx P1 on PR #2560): the two used to be separate
+/// `store.get_all`/`store.update` calls, unlike `persist_subscriber`'s
+/// window handlers which already wrap this exact shape in a transaction.
+/// A concurrent write to `Client` between the read and the write here
+/// (e.g. another in-flight `CloseWindow` pruning `windowids`, or a second
+/// concurrent snapshot save/clear) would silently lose whichever change
+/// didn't win the race — a classic lost-update. `with_tx` holds the
+/// store's connection lock for the whole read+write, so no other caller
+/// can observe or write an intermediate state.
 pub(crate) fn save_last_session_snapshot(store: &Store, snapshot: Value) {
-    let Ok(clients) = store.get_all::<Client>() else {
-        return;
-    };
-    let Some(mut client) = clients.into_iter().next() else {
-        return;
-    };
-    client.meta.insert(SNAPSHOT_META_KEY.to_string(), snapshot);
-    if let Err(e) = store.update(&mut client) {
+    let result = store.with_tx(|tx| {
+        let clients = tx.get_all::<Client>()?;
+        let Some(mut client) = clients.into_iter().next() else {
+            return Ok(());
+        };
+        client.meta.insert(SNAPSHOT_META_KEY.to_string(), snapshot);
+        tx.update(&mut client)?;
+        Ok(())
+    });
+    if let Err(e) = result {
         tracing::warn!(
             error = %e,
             "session_restore: failed to persist last-session snapshot"
@@ -201,16 +227,21 @@ fn load_last_session_snapshot(store: &Store) -> Option<Value> {
 /// (`handle_create_window`) already independently guards against — this is
 /// defense in depth, not the only thing preventing duplicates.
 pub(crate) fn clear_last_session_snapshot(store: &Store) {
-    let Ok(clients) = store.get_all::<Client>() else {
-        return;
-    };
-    let Some(mut client) = clients.into_iter().next() else {
-        return;
-    };
-    if client.meta.remove(SNAPSHOT_META_KEY).is_none() {
-        return; // nothing to clear
-    }
-    if let Err(e) = store.update(&mut client) {
+    // Same `with_tx`-atomicity reasoning as `save_last_session_snapshot`
+    // above (reagentx P1 on PR #2560) — this read-then-write was
+    // previously two separate store calls.
+    let result = store.with_tx(|tx| {
+        let clients = tx.get_all::<Client>()?;
+        let Some(mut client) = clients.into_iter().next() else {
+            return Ok(());
+        };
+        if client.meta.remove(SNAPSHOT_META_KEY).is_none() {
+            return Ok(()); // nothing to clear
+        }
+        tx.update(&mut client)?;
+        Ok(())
+    });
+    if let Err(e) = result {
         tracing::warn!(
             error = %e,
             "session_restore: failed to clear last-session snapshot after restore"
@@ -285,8 +316,15 @@ pub(crate) async fn restore_last_session(
 
     let mut all_events = ws_events;
     let mut restored_any_tab = false;
+    // Maps this tab's position in the ORIGINAL snapshot (`tabs_json`) to its
+    // freshly-created id, for tabs that actually made it through restore —
+    // resolves `active_tab_index` below the same way `resolve_placeholders`
+    // resolves block placeholders: by position among what actually survived,
+    // not raw snapshot index (a tab that fails to restore must not desync
+    // this lookup for every tab after it).
+    let mut new_tab_ids_by_snapshot_index: HashMap<usize, String> = HashMap::new();
 
-    for tab_json in &tabs_json {
+    for (snapshot_idx, tab_json) in tabs_json.iter().enumerate() {
         let name = tab_json
             .get("name")
             .and_then(|v| v.as_str())
@@ -347,6 +385,7 @@ pub(crate) async fn restore_last_session(
             continue;
         }
         restored_any_tab = true;
+        new_tab_ids_by_snapshot_index.insert(snapshot_idx, tab_id.clone());
 
         if let Some(rootnode_json) = tab_json.get("rootnode").filter(|v| !v.is_null()) {
             if let Ok(mut tree) = serde_json::from_value::<LayoutNode>(rootnode_json.clone()) {
@@ -356,7 +395,21 @@ pub(crate) async fn restore_last_session(
                     .and_then(|v| v.as_str())
                     .unwrap_or_default()
                     .to_string();
-                if let Err(e) = seed_layout_via_reducer(state, &tab_id, tree, focused, Vec::new()).await {
+                // `magnifiednodeid` refers to a LayoutNode.id, not a block
+                // id — like `focusednodeid`, it survives the snapshot
+                // round-trip verbatim (only `data.block_id`/`block_stack`/
+                // `active_block_id` get placeholder-remapped, never
+                // `LayoutNode.id` itself), so no resolve_placeholders-style
+                // step is needed here. Previously never captured/passed at
+                // all (reagentx P2 on PR #2560), so a tab closed with a
+                // pane magnified always relaunched showing the full split
+                // tree.
+                let magnified = tab_json
+                    .get("magnifiednodeid")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                if let Err(e) = seed_layout_via_reducer(state, &tab_id, tree, focused, Vec::new(), magnified).await {
                     tracing::warn!(
                         tab_id = %tab_id,
                         error = %e,
@@ -379,6 +432,33 @@ pub(crate) async fn restore_last_session(
         let _ = apply_and_publish(state, &comp).await;
         super::reducer_helpers::publish_events(state, &comp);
         return Ok(None);
+    }
+
+    // Restore which tab was active (reagentx P2 on PR #2560: previously
+    // never captured/restored at all — every relaunch focused whichever tab
+    // `CreateTab`'s own first-tab-wins default (`wcore/tab.rs`) happened to
+    // leave active, i.e. always the first). `None` (no index in the
+    // snapshot, or that index's tab didn't survive restore) leaves that
+    // default in place rather than erroring — an unset/stale active tab is
+    // a cosmetic miss, not a reason to fail the whole restore.
+    if let Some(active_snapshot_idx) = snapshot.get("active_tab_index").and_then(|v| v.as_u64()) {
+        if let Some(new_active_tab_id) = new_tab_ids_by_snapshot_index.get(&(active_snapshot_idx as usize)) {
+            let active_events = dispatch_to_reducer(
+                state,
+                Command::SetActiveTab {
+                    workspace_id: ws_id.clone(),
+                    tab_id: new_active_tab_id.clone(),
+                },
+            )
+            .await;
+            if let Some(err) = find_error(&active_events) {
+                tracing::warn!(error = %err, "restore_last_session: SetActiveTab failed — leaving default active tab");
+            } else if apply_and_publish(state, &active_events).await.is_err() {
+                tracing::warn!("restore_last_session: SetActiveTab SQLite write failed — leaving default active tab");
+            } else {
+                all_events.extend(active_events);
+            }
+        }
     }
 
     Ok(Some((ws_id, all_events)))
@@ -541,7 +621,7 @@ mod tests {
             data: None,
             extra: Default::default(),
         };
-        seed_layout_via_reducer(&state, &tab_id, tree, "left".into(), Vec::new())
+        seed_layout_via_reducer(&state, &tab_id, tree, "left".into(), Vec::new(), String::new())
             .await
             .unwrap();
 
@@ -582,6 +662,173 @@ mod tests {
             .collect();
         assert_eq!(leaf_block_ids, vec![new_tab.blockids[0].clone(), new_tab.blockids[1].clone()]);
         assert!(!leaf_block_ids.iter().any(|id| id.starts_with("__snap_block_")));
+    }
+
+    // reagentx P2 on PR #2560: `LayoutState.magnifiednodeid` was never
+    // captured/restored, so a tab closed with a pane magnified always
+    // relaunched showing the full split tree instead of the magnified pane.
+    #[tokio::test]
+    async fn snapshot_and_restore_preserves_magnifiednodeid() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "mytab".into() },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk1 = dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: json!({"view": "agent"}) },
+        )
+        .await
+        .iter()
+        .find_map(|e| match e {
+            Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+        let blk2 = dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: json!({"view": "sysinfo"}) },
+        )
+        .await
+        .iter()
+        .find_map(|e| match e {
+            Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+        let tree = agentmux_common::LayoutNode {
+            id: "root".into(),
+            flex_direction: agentmux_common::FlexDirection::Row,
+            size: 10.0,
+            children: vec![
+                agentmux_common::LayoutNode {
+                    id: "left".into(),
+                    size: 5.0,
+                    data: Some(agentmux_common::LayoutNodeData { block_id: blk1.clone(), ..Default::default() }),
+                    ..Default::default()
+                },
+                agentmux_common::LayoutNode {
+                    id: "right".into(),
+                    size: 5.0,
+                    data: Some(agentmux_common::LayoutNodeData { block_id: blk2.clone(), ..Default::default() }),
+                    ..Default::default()
+                },
+            ],
+            data: None,
+            extra: Default::default(),
+        };
+        // "left" pane is magnified.
+        seed_layout_via_reducer(&state, &tab_id, tree, "left".into(), Vec::new(), "left".into())
+            .await
+            .unwrap();
+
+        let snap = snapshot_workspace(&state.wstore, &ws_id).expect("snapshot should be produced");
+        assert_eq!(snap["tabs"][0]["magnifiednodeid"], "left", "magnifiednodeid captured in snapshot");
+        save_last_session_snapshot(&state.wstore, snap);
+
+        let (new_ws_id, _events) = restore_last_session(&state).await.unwrap().unwrap();
+        let new_workspace = state.wstore.get::<Workspace>(&new_ws_id).unwrap().unwrap();
+        let new_tab = state.wstore.get::<Tab>(&new_workspace.tabids[0]).unwrap().unwrap();
+        let new_layout = state.wstore.get::<LayoutState>(&new_tab.layoutstate).unwrap().unwrap();
+        assert_eq!(
+            new_layout.magnifiednodeid, "left",
+            "magnifiednodeid restored — LayoutNode.id values aren't placeholder-remapped, \
+             only block ids are, so this survives verbatim"
+        );
+    }
+
+    // reagentx P2 on PR #2560: `Workspace.activetabid` was never
+    // captured/restored, so a relaunch always focused the first tab
+    // regardless of which was actually active at close.
+    #[tokio::test]
+    async fn snapshot_and_restore_preserves_active_tab_when_not_the_first() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        // tab1 is created first (and would be the default active tab per
+        // wcore/tab.rs's first-tab-wins rule) but tab2 is the one the user
+        // actually left active.
+        let tab1_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "tab-one".into() },
+        )
+        .await;
+        let tab1_id = tab1_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab1_id.clone(), meta: json!({"view": "agent"}) },
+        )
+        .await;
+
+        let tab2_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "tab-two".into() },
+        )
+        .await;
+        let tab2_id = tab2_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab2_id.clone(), meta: json!({"view": "sysinfo"}) },
+        )
+        .await;
+
+        dispatch_apply(
+            &state,
+            Command::SetActiveTab { workspace_id: ws_id.clone(), tab_id: tab2_id.clone() },
+        )
+        .await;
+        let workspace_before = state.wstore.get::<Workspace>(&ws_id).unwrap().unwrap();
+        assert_eq!(workspace_before.activetabid, tab2_id, "precondition: tab-two is active");
+
+        let snap = snapshot_workspace(&state.wstore, &ws_id).expect("snapshot should be produced");
+        assert_eq!(snap["active_tab_index"], 1, "active tab is the SECOND captured tab");
+        save_last_session_snapshot(&state.wstore, snap);
+
+        let (new_ws_id, _events) = restore_last_session(&state).await.unwrap().unwrap();
+        let new_workspace = state.wstore.get::<Workspace>(&new_ws_id).unwrap().unwrap();
+        assert_eq!(new_workspace.tabids.len(), 2);
+        let new_tab2 = state.wstore.get::<Tab>(&new_workspace.tabids[1]).unwrap().unwrap();
+        assert_eq!(new_tab2.name, "tab-two");
+        assert_eq!(
+            new_workspace.activetabid, new_tab2.oid,
+            "the restored workspace's active tab is the NEW tab-two, not whichever \
+             CreateTab's first-tab-wins default would otherwise leave active"
+        );
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/service/session_restore.rs
+++ b/agentmux-srv/src/server/service/session_restore.rs
@@ -1,0 +1,586 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Restore-on-relaunch (Feature 1 of
+//! `docs/specs/SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13.md`).
+//!
+//! A graceful window close today deliberately cascades a full delete of the
+//! workspace/tabs/blocks (`e3a6f85c2`, wired to the last-window "main" case
+//! by `4cbf856b7` — see `docs/retro/retro-pane-layout-restore-was-a-leak-not-a-feature-2026-08-13.md`),
+//! so the next cold launch always finds `Client.windowids` empty and reseeds
+//! the hardcoded default 3-pane layout (`window_create::default_three_pane_tree`).
+//!
+//! This module adds an independent, durable "what was open last" record —
+//! written just before that destroy cascade runs (`window_close::handle_close_window`)
+//! and consulted by the cold-launch path (`window_create::handle_create_window`)
+//! before it falls back to the hardcoded seed. It deliberately does NOT touch
+//! the destroy cascade itself (that fix is correct and must stay — orphaned
+//! shell processes were the original bug) and does NOT reuse Pillar 1's
+//! crash-reproject machinery (that's scoped to crash-only recovery from rows
+//! a graceful close is specifically supposed to remove — see
+//! `docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md` §3).
+//!
+//! Stored as a JSON blob under `Client.meta["session:last_topology"]` —
+//! `Client` is already a durable singleton row with a generic `meta` sidecar
+//! (the same "per-entity loosely-typed sidecar" pattern Pillar 1 Step 2 used
+//! for floating-pane placement on `Block.meta`), so this needs no new
+//! `StoreObj` type, table, or migration.
+
+use std::collections::HashMap;
+
+use agentmux_common::ipc::{Command, Event};
+use agentmux_common::LayoutNode;
+use serde_json::{json, Value};
+
+use crate::backend::obj::{Block, Client, LayoutState, Tab, Workspace};
+use crate::backend::storage::store::Store;
+use crate::server::AppState;
+
+use super::reducer_helpers::{dispatch_to_reducer, seed_layout_via_reducer};
+
+const SNAPSHOT_META_KEY: &str = "session:last_topology";
+
+fn placeholder(idx: usize) -> String {
+    format!("__snap_block_{idx}__")
+}
+
+fn placeholder_idx(s: &str) -> Option<usize> {
+    s.strip_prefix("__snap_block_")?.strip_suffix("__")?.parse().ok()
+}
+
+/// Read the given workspace's tabs/blocks/layout directly from the store and
+/// build a durable, block-id-independent snapshot (real block ids are
+/// replaced with positional placeholders — `CreateBlock` always assigns a
+/// fresh id, so the snapshot can never reference one that will exist again).
+/// Returns `None` for an empty/unknown workspace (nothing worth persisting).
+pub(crate) fn snapshot_workspace(store: &Store, workspace_id: &str) -> Option<Value> {
+    let workspace = store.get::<Workspace>(workspace_id).ok().flatten()?;
+    let mut tabs = Vec::new();
+    for tab_id in &workspace.tabids {
+        let Some(tab) = store.get::<Tab>(tab_id).ok().flatten() else {
+            continue;
+        };
+        let mut idx_by_block_id: HashMap<String, usize> = HashMap::new();
+        let mut blocks = Vec::new();
+        for (i, block_id) in tab.blockids.iter().enumerate() {
+            let Some(block) = store.get::<Block>(block_id).ok().flatten() else {
+                continue;
+            };
+            idx_by_block_id.insert(block_id.clone(), i);
+            blocks.push(json!({ "meta": block.meta }));
+        }
+        if blocks.is_empty() {
+            continue;
+        }
+        let (rootnode, focusednodeid) = if tab.layoutstate.is_empty() {
+            (None, String::new())
+        } else {
+            match store.get::<LayoutState>(&tab.layoutstate) {
+                Ok(Some(layout)) => {
+                    let rootnode = layout.rootnode.map(|mut tree| {
+                        placeholderize(&mut tree, &idx_by_block_id);
+                        tree
+                    });
+                    (rootnode, layout.focusednodeid)
+                }
+                _ => (None, String::new()),
+            }
+        };
+        tabs.push(json!({
+            "name": tab.name,
+            "blocks": blocks,
+            "rootnode": rootnode,
+            "focusednodeid": focusednodeid,
+        }));
+    }
+    if tabs.is_empty() {
+        return None;
+    }
+    Some(json!({ "tabs": tabs }))
+}
+
+/// Replace every leaf's real block id (in `data.block_id`, `block_stack`,
+/// `active_block_id`) with a positional placeholder, in place.
+fn placeholderize(node: &mut LayoutNode, idx_by_block_id: &HashMap<String, usize>) {
+    if let Some(data) = node.data.as_mut() {
+        if let Some(&idx) = idx_by_block_id.get(&data.block_id) {
+            data.block_id = placeholder(idx);
+        }
+        for id in data.block_stack.iter_mut() {
+            if let Some(&idx) = idx_by_block_id.get(id.as_str()) {
+                *id = placeholder(idx);
+            }
+        }
+        if let Some(&idx) = idx_by_block_id.get(&data.active_block_id) {
+            data.active_block_id = placeholder(idx);
+        }
+    }
+    for child in node.children.iter_mut() {
+        placeholderize(child, idx_by_block_id);
+    }
+}
+
+/// Replace every leaf's positional placeholder with the corresponding freshly
+/// created block id, in place. A placeholder with no matching entry (should
+/// not happen — `new_ids` is built 1:1 from the same snapshot's `blocks`
+/// array — but tolerated defensively) is left as-is; such a leaf simply won't
+/// resolve to a real block and the frontend already handles unknown block ids
+/// in a layout leaf as an empty pane, matching how a manually-crafted or
+/// corrupted layout degrades today.
+fn resolve_placeholders(node: &mut LayoutNode, new_ids: &[String]) {
+    if let Some(data) = node.data.as_mut() {
+        if let Some(idx) = placeholder_idx(&data.block_id) {
+            if let Some(real) = new_ids.get(idx) {
+                data.block_id = real.clone();
+            }
+        }
+        for id in data.block_stack.iter_mut() {
+            if let Some(idx) = placeholder_idx(id) {
+                if let Some(real) = new_ids.get(idx) {
+                    *id = real.clone();
+                }
+            }
+        }
+        if let Some(idx) = placeholder_idx(&data.active_block_id) {
+            if let Some(real) = new_ids.get(idx) {
+                data.active_block_id = real.clone();
+            }
+        }
+    }
+    for child in node.children.iter_mut() {
+        resolve_placeholders(child, new_ids);
+    }
+}
+
+/// Persist a snapshot as the durable "last session" record, overwriting
+/// whatever was there before. Best-effort: a write failure is logged, never
+/// propagated — this must never block the close it rides alongside.
+pub(crate) fn save_last_session_snapshot(store: &Store, snapshot: Value) {
+    let Ok(clients) = store.get_all::<Client>() else {
+        return;
+    };
+    let Some(mut client) = clients.into_iter().next() else {
+        return;
+    };
+    client.meta.insert(SNAPSHOT_META_KEY.to_string(), snapshot);
+    if let Err(e) = store.update(&mut client) {
+        tracing::warn!(
+            error = %e,
+            "session_restore: failed to persist last-session snapshot"
+        );
+    }
+}
+
+fn load_last_session_snapshot(store: &Store) -> Option<Value> {
+    let clients = store.get_all::<Client>().ok()?;
+    let client = clients.into_iter().next()?;
+    client.meta.get(SNAPSHOT_META_KEY).cloned()
+}
+
+fn find_error(events: &[Event]) -> Option<String> {
+    events.iter().find_map(|e| match e {
+        Event::Error { message, .. } => Some(message.clone()),
+        _ => None,
+    })
+}
+
+async fn apply_and_publish(
+    state: &AppState,
+    events: &[Event],
+) -> Result<(), String> {
+    for ev in events {
+        if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore) {
+            return Err(format!("SQLite write failed: {}", e));
+        }
+    }
+    Ok(())
+}
+
+/// Attempt to replay the durable "last session" snapshot (if any) into a
+/// fresh workspace: `CreateWorkspace` → per-tab `CreateTab` + per-block
+/// `CreateBlock` (reusing each block's saved `meta`, so a restored agent pane
+/// relaunches the same way opening a fresh one does) → `LayoutSetTree` with
+/// the saved split tree (block ids remapped from placeholders to the newly
+/// created ones).
+///
+/// Returns `Ok(None)` when there's nothing to restore (no snapshot, or every
+/// tab in it failed to recreate) — the caller falls back to the hardcoded
+/// default seed exactly as it did before this feature existed. Returns
+/// `Err` only for a failure in the very first step (creating the workspace
+/// itself); per-tab/per-block failures during replay are logged and skipped
+/// rather than aborting the whole restore, so a partially-stale snapshot
+/// (e.g. one tab's block meta no longer makes sense) still restores
+/// everything else instead of failing shut.
+pub(crate) async fn restore_last_session(
+    state: &AppState,
+) -> Result<Option<(String, Vec<Event>)>, String> {
+    let Some(snapshot) = load_last_session_snapshot(&state.wstore) else {
+        return Ok(None);
+    };
+    let tabs_json = snapshot
+        .get("tabs")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if tabs_json.is_empty() {
+        return Ok(None);
+    }
+
+    let ws_events = dispatch_to_reducer(
+        state,
+        Command::CreateWorkspace { name: String::new() },
+    )
+    .await;
+    if let Some(err) = find_error(&ws_events) {
+        return Err(format!("restore_last_session: CreateWorkspace failed: {}", err));
+    }
+    apply_and_publish(state, &ws_events).await?;
+    let Some(ws_id) = ws_events.iter().find_map(|e| match e {
+        Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+        _ => None,
+    }) else {
+        return Err("restore_last_session: CreateWorkspace produced no WorkspaceCreated event".into());
+    };
+
+    let mut all_events = ws_events;
+    let mut restored_any_tab = false;
+
+    for tab_json in &tabs_json {
+        let name = tab_json
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let tab_events = dispatch_to_reducer(
+            state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name },
+        )
+        .await;
+        if let Some(err) = find_error(&tab_events) {
+            tracing::warn!(error = %err, "restore_last_session: CreateTab failed — skipping this tab");
+            continue;
+        }
+        if apply_and_publish(state, &tab_events).await.is_err() {
+            tracing::warn!("restore_last_session: CreateTab SQLite write failed — skipping this tab");
+            continue;
+        }
+        let Some(tab_id) = tab_events.iter().find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        }) else {
+            continue;
+        };
+        all_events.extend(tab_events);
+
+        let blocks_json = tab_json
+            .get("blocks")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let mut new_block_ids: Vec<String> = Vec::new();
+        for block_json in &blocks_json {
+            let meta = block_json.get("meta").cloned().unwrap_or(Value::Null);
+            let blk_events = dispatch_to_reducer(
+                state,
+                Command::CreateBlock { tab_id: tab_id.clone(), meta },
+            )
+            .await;
+            if let Some(err) = find_error(&blk_events) {
+                tracing::warn!(error = %err, "restore_last_session: CreateBlock failed — skipping this block");
+                continue;
+            }
+            if apply_and_publish(state, &blk_events).await.is_err() {
+                tracing::warn!("restore_last_session: CreateBlock SQLite write failed — skipping this block");
+                continue;
+            }
+            if let Some(block_id) = blk_events.iter().find_map(|e| match e {
+                Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            }) {
+                new_block_ids.push(block_id);
+            }
+            all_events.extend(blk_events);
+        }
+
+        if new_block_ids.is_empty() {
+            continue;
+        }
+        restored_any_tab = true;
+
+        if let Some(rootnode_json) = tab_json.get("rootnode").filter(|v| !v.is_null()) {
+            if let Ok(mut tree) = serde_json::from_value::<LayoutNode>(rootnode_json.clone()) {
+                resolve_placeholders(&mut tree, &new_block_ids);
+                let focused = tab_json
+                    .get("focusednodeid")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                if let Err(e) = seed_layout_via_reducer(state, &tab_id, tree, focused, Vec::new()).await {
+                    tracing::warn!(
+                        tab_id = %tab_id,
+                        error = %e,
+                        "restore_last_session: layout write failed — tab restored blank"
+                    );
+                }
+            }
+        }
+    }
+
+    if !restored_any_tab {
+        // Nothing actually came back (every tab's CreateTab/CreateBlock
+        // failed) — compensate the now-empty workspace so we don't leave a
+        // stray row behind, and let the caller fall back to the default seed.
+        let comp = dispatch_to_reducer(
+            state,
+            Command::DeleteWorkspace { workspace_id: ws_id.clone(), force: false },
+        )
+        .await;
+        let _ = apply_and_publish(state, &comp).await;
+        super::reducer_helpers::publish_events(state, &comp);
+        return Ok(None);
+    }
+
+    Ok(Some((ws_id, all_events)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::tests::test_state;
+
+    async fn dispatch_apply(state: &AppState, cmd: Command) -> Vec<Event> {
+        let events = dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn no_snapshot_means_nothing_to_load() {
+        let state = test_state();
+        assert!(load_last_session_snapshot(&state.wstore).is_none());
+    }
+
+    #[tokio::test]
+    async fn save_then_load_round_trips() {
+        let state = test_state();
+        let snap = json!({ "tabs": [{"name": "t", "blocks": [{"meta": {"view": "agent"}}]}] });
+        save_last_session_snapshot(&state.wstore, snap.clone());
+        assert_eq!(load_last_session_snapshot(&state.wstore), Some(snap));
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_prior_snapshot() {
+        let state = test_state();
+        save_last_session_snapshot(&state.wstore, json!({"tabs": [{"name": "old"}]}));
+        save_last_session_snapshot(&state.wstore, json!({"tabs": [{"name": "new"}]}));
+        let loaded = load_last_session_snapshot(&state.wstore).unwrap();
+        assert_eq!(loaded["tabs"][0]["name"], "new");
+    }
+
+    #[tokio::test]
+    async fn snapshot_workspace_captures_tab_and_block_meta() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "mytab".into() },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        dispatch_apply(
+            &state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+                meta: json!({ "view": "agent", "agent:name": "test-agent" }),
+            },
+        )
+        .await;
+
+        let snap = snapshot_workspace(&state.wstore, &ws_id).expect("snapshot should be produced");
+        let tabs = snap["tabs"].as_array().unwrap();
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0]["name"], "mytab");
+        let blocks = tabs[0]["blocks"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0]["meta"]["agent:name"], "test-agent");
+    }
+
+    #[tokio::test]
+    async fn snapshot_of_unknown_workspace_is_none() {
+        let state = test_state();
+        assert!(snapshot_workspace(&state.wstore, "no-such-workspace").is_none());
+    }
+
+    #[tokio::test]
+    async fn restore_with_no_snapshot_returns_none() {
+        let state = test_state();
+        let result = restore_last_session(&state).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn round_trip_snapshot_then_restore_recreates_tabs_and_blocks() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "mytab".into() },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk1 = dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: json!({"view": "agent"}) },
+        )
+        .await
+        .iter()
+        .find_map(|e| match e {
+            Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+        let blk2 = dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: json!({"view": "sysinfo"}) },
+        )
+        .await
+        .iter()
+        .find_map(|e| match e {
+            Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+        // Give the tab a real split layout referencing both blocks.
+        let tree = agentmux_common::LayoutNode {
+            id: "root".into(),
+            flex_direction: agentmux_common::FlexDirection::Row,
+            size: 10.0,
+            children: vec![
+                agentmux_common::LayoutNode {
+                    id: "left".into(),
+                    size: 5.0,
+                    data: Some(agentmux_common::LayoutNodeData { block_id: blk1.clone(), ..Default::default() }),
+                    ..Default::default()
+                },
+                agentmux_common::LayoutNode {
+                    id: "right".into(),
+                    size: 5.0,
+                    data: Some(agentmux_common::LayoutNodeData { block_id: blk2.clone(), ..Default::default() }),
+                    ..Default::default()
+                },
+            ],
+            data: None,
+            extra: Default::default(),
+        };
+        seed_layout_via_reducer(&state, &tab_id, tree, "left".into(), Vec::new())
+            .await
+            .unwrap();
+
+        // Snapshot + save exactly like the close hook does.
+        let snap = snapshot_workspace(&state.wstore, &ws_id).expect("snapshot should be produced");
+        save_last_session_snapshot(&state.wstore, snap);
+
+        // Restore into a brand-new workspace.
+        let (new_ws_id, _events) = restore_last_session(&state)
+            .await
+            .unwrap()
+            .expect("restore should recreate the tab");
+        assert_ne!(new_ws_id, ws_id, "restore creates a NEW workspace, not the deleted one");
+
+        let new_workspace = state.wstore.get::<Workspace>(&new_ws_id).unwrap().unwrap();
+        assert_eq!(new_workspace.tabids.len(), 1);
+        let new_tab = state.wstore.get::<Tab>(&new_workspace.tabids[0]).unwrap().unwrap();
+        assert_eq!(new_tab.name, "mytab");
+        assert_eq!(new_tab.blockids.len(), 2);
+
+        let new_blk1 = state.wstore.get::<Block>(&new_tab.blockids[0]).unwrap().unwrap();
+        assert_eq!(new_blk1.meta.get("view").and_then(|v| v.as_str()), Some("agent"));
+        let new_blk2 = state.wstore.get::<Block>(&new_tab.blockids[1]).unwrap().unwrap();
+        assert_eq!(new_blk2.meta.get("view").and_then(|v| v.as_str()), Some("sysinfo"));
+
+        // Layout tree was restored with the NEW block ids, not the old ones
+        // or leftover placeholders.
+        let new_layout = state
+            .wstore
+            .get::<LayoutState>(&new_tab.layoutstate)
+            .unwrap()
+            .unwrap();
+        let rootnode = new_layout.rootnode.expect("layout tree restored");
+        let leaf_block_ids: Vec<String> = rootnode
+            .children
+            .iter()
+            .filter_map(|c| c.data.as_ref().map(|d| d.block_id.clone()))
+            .collect();
+        assert_eq!(leaf_block_ids, vec![new_tab.blockids[0].clone(), new_tab.blockids[1].clone()]);
+        assert!(!leaf_block_ids.iter().any(|id| id.starts_with("__snap_block_")));
+    }
+
+    #[tokio::test]
+    async fn restore_is_idempotent_source_snapshot_survives() {
+        // A second restore attempt (e.g. the app crashed mid-restore and
+        // relaunched again) must still find and replay the same snapshot —
+        // restoring does not consume/clear it.
+        let state = test_state();
+        let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "t".into() },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        dispatch_apply(
+            &state,
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: json!({"view": "agent"}) },
+        )
+        .await;
+        let snap = snapshot_workspace(&state.wstore, &ws_id).unwrap();
+        save_last_session_snapshot(&state.wstore, snap);
+
+        let (first_ws, _) = restore_last_session(&state).await.unwrap().unwrap();
+        let (second_ws, _) = restore_last_session(&state).await.unwrap().unwrap();
+        assert_ne!(first_ws, second_ws, "each restore call creates its own fresh workspace");
+        assert!(state.wstore.get::<Workspace>(&first_ws).unwrap().is_some());
+        assert!(state.wstore.get::<Workspace>(&second_ws).unwrap().is_some());
+    }
+}

--- a/agentmux-srv/src/server/service/session_restore.rs
+++ b/agentmux-srv/src/server/service/session_restore.rs
@@ -56,7 +56,13 @@ fn placeholder_idx(s: &str) -> Option<usize> {
 pub(crate) fn snapshot_workspace(store: &Store, workspace_id: &str) -> Option<Value> {
     let workspace = store.get::<Workspace>(workspace_id).ok().flatten()?;
     let mut tabs = Vec::new();
-    for tab_id in &workspace.tabids {
+    // `pinnedtabids` is a legacy field (pinning was removed from AgentMux —
+    // see `tab_lifecycle.rs`); a workspace the reducer hasn't touched yet
+    // (e.g. straight out of `ensure_initial_data`) can still have its one
+    // tab sitting there instead of in `tabids` until the next
+    // `TabsReordered` event drains it. Read both so a snapshot taken before
+    // that drain doesn't silently see zero tabs.
+    for tab_id in workspace.pinnedtabids.iter().chain(workspace.tabids.iter()) {
         let Some(tab) = store.get::<Tab>(tab_id).ok().flatten() else {
             continue;
         };

--- a/agentmux-srv/src/server/service/session_restore.rs
+++ b/agentmux-srv/src/server/service/session_restore.rs
@@ -60,13 +60,22 @@ pub(crate) fn snapshot_workspace(store: &Store, workspace_id: &str) -> Option<Va
         let Some(tab) = store.get::<Tab>(tab_id).ok().flatten() else {
             continue;
         };
+        // Index by position WITHIN `blocks` (the successfully-loaded list),
+        // not position within `tab.blockids` (the full original list) —
+        // reviewer-caught bug (reagentx P2 on PR #2560): a single unreadable
+        // block previously desynced every subsequent placeholder index
+        // against restore's `new_block_ids` (built from the same
+        // successfully-recreated count), silently misattributing later
+        // blocks' layout positions. `blocks.len()` at insert time is always
+        // this block's actual final position, skipped entries included or
+        // not.
         let mut idx_by_block_id: HashMap<String, usize> = HashMap::new();
         let mut blocks = Vec::new();
-        for (i, block_id) in tab.blockids.iter().enumerate() {
+        for block_id in &tab.blockids {
             let Some(block) = store.get::<Block>(block_id).ok().flatten() else {
                 continue;
             };
-            idx_by_block_id.insert(block_id.clone(), i);
+            idx_by_block_id.insert(block_id.clone(), blocks.len());
             blocks.push(json!({ "meta": block.meta }));
         }
         if blocks.is_empty() {
@@ -175,6 +184,32 @@ fn load_last_session_snapshot(store: &Store) -> Option<Value> {
     let clients = store.get_all::<Client>().ok()?;
     let client = clients.into_iter().next()?;
     client.meta.get(SNAPSHOT_META_KEY).cloned()
+}
+
+/// Consume the durable "last session" record after a fully successful
+/// restore (called only once `window_create::handle_create_window`'s final
+/// window read-back succeeds — see that call site's comment for why not any
+/// earlier). Best-effort, same as `save_last_session_snapshot`: a failure to
+/// clear just means a future stray/misused restore call could replay this
+/// snapshot again, which `client_windowids_empty`'s server-side check
+/// (`handle_create_window`) already independently guards against — this is
+/// defense in depth, not the only thing preventing duplicates.
+pub(crate) fn clear_last_session_snapshot(store: &Store) {
+    let Ok(clients) = store.get_all::<Client>() else {
+        return;
+    };
+    let Some(mut client) = clients.into_iter().next() else {
+        return;
+    };
+    if client.meta.remove(SNAPSHOT_META_KEY).is_none() {
+        return; // nothing to clear
+    }
+    if let Err(e) = store.update(&mut client) {
+        tracing::warn!(
+            error = %e,
+            "session_restore: failed to clear last-session snapshot after restore"
+        );
+    }
 }
 
 fn find_error(events: &[Event]) -> Option<String> {

--- a/agentmux-srv/src/server/service/window_close.rs
+++ b/agentmux-srv/src/server/service/window_close.rs
@@ -387,6 +387,26 @@ mod snapshot_timing_tests {
         snapshot["tabs"][0]["name"].as_str().map(|s| s.to_string())
     }
 
+    /// `test_state()` seeds a "Starter workspace" bootstrap window
+    /// (`wcore::ensure_initial_data`) before any test code runs — without
+    /// closing it first, `Client.windowids` always has that extra entry, so
+    /// `will_empty_windowids` never actually goes true in these tests no
+    /// matter how many test-created windows get closed. Close it before
+    /// setting up a test's own "N independent windows" scenario.
+    async fn close_bootstrap_window(state: &crate::server::AppState) {
+        let bootstrap_id = state
+            .wstore
+            .get_all::<Client>()
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .windowids[0]
+            .clone();
+        let ret = handle_window_service(state, &close_call(&bootstrap_id)).await;
+        assert!(ret.success, "closing bootstrap window failed: {:?}", ret.error);
+    }
+
     /// The core fix: with two independent windows open, closing the FIRST
     /// one (the other is still open — `Client.windowids` does NOT empty)
     /// must not touch the snapshot at all. Only closing the SECOND (last)
@@ -396,23 +416,25 @@ mod snapshot_timing_tests {
     #[tokio::test]
     async fn closing_one_of_two_open_windows_does_not_touch_the_snapshot() {
         let state = test_state();
+        // Closing the lone bootstrap window IS a genuine terminal close (it
+        // empties `Client.windowids` on its own), so it legitimately writes
+        // a snapshot of its own — capture that as the baseline rather than
+        // assuming "no snapshot yet".
+        close_bootstrap_window(&state).await;
+        let snapshot_after_bootstrap_close = last_session_snapshot_tab_name(&state);
 
         let first = create_window(&state).await;
         rename_first_tab(&state, &first.workspaceid, "first-window-tab");
         let second = create_window(&state).await;
         rename_first_tab(&state, &second.workspaceid, "second-window-tab");
 
-        assert!(
-            last_session_snapshot_tab_name(&state).is_none(),
-            "precondition: no snapshot exists yet"
-        );
-
         // Close the FIRST window while the second is still open.
         let ret = handle_window_service(&state, &close_call(&first.oid)).await;
         assert!(ret.success, "CloseWindow failed: {:?}", ret.error);
 
-        assert!(
-            last_session_snapshot_tab_name(&state).is_none(),
+        assert_eq!(
+            last_session_snapshot_tab_name(&state),
+            snapshot_after_bootstrap_close,
             "closing one of two open windows must not write a snapshot — \
              the session hasn't actually ended yet"
         );
@@ -439,6 +461,11 @@ mod snapshot_timing_tests {
     #[tokio::test]
     async fn snapshot_reflects_whichever_close_actually_empties_windowids() {
         let state = test_state();
+        // See `closing_one_of_two_open_windows_does_not_touch_the_snapshot`:
+        // closing the lone bootstrap window is itself a terminal close, so
+        // it writes a snapshot — capture that as the baseline.
+        close_bootstrap_window(&state).await;
+        let snapshot_after_bootstrap_close = last_session_snapshot_tab_name(&state);
 
         let main = create_window(&state).await;
         rename_first_tab(&state, &main.workspaceid, "main-session");
@@ -448,8 +475,9 @@ mod snapshot_timing_tests {
         // Close "main" first — does NOT empty windowids (tearoff still open).
         let ret = handle_window_service(&state, &close_call(&main.oid)).await;
         assert!(ret.success);
-        assert!(
-            last_session_snapshot_tab_name(&state).is_none(),
+        assert_eq!(
+            last_session_snapshot_tab_name(&state),
+            snapshot_after_bootstrap_close,
             "closing main first must not snapshot — it isn't the terminal close"
         );
 

--- a/agentmux-srv/src/server/service/window_close.rs
+++ b/agentmux-srv/src/server/service/window_close.rs
@@ -41,19 +41,28 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
         }
     };
     // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
-    // Feature 1) — snapshot this window's workspace BEFORE the destroy
-    // cascade below removes it, so the next cold launch has something to
-    // restore instead of always reseeding the default layout. Best-effort
-    // and independent of the cascade: a failure here must never block the
-    // close itself (see `session_restore` module docs for why this is a
-    // separate durable record, not a change to the cascade).
-    if let Some(ref ws_id_for_snapshot) = ws_id {
-        if let Some(snapshot) =
-            super::session_restore::snapshot_workspace(store, ws_id_for_snapshot)
-        {
-            super::session_restore::save_last_session_snapshot(store, snapshot);
-        }
-    }
+    // Feature 1) — is this close the one that empties `Client.windowids`,
+    // i.e. a genuine "the user is fully quitting" moment? Deliberately NOT
+    // "does this close cascade-delete ITS OWN workspace" (`!any_other_window`
+    // below is a workspace-sharing question, answered independently per
+    // window, true for basically every close in the common 1:1
+    // window:workspace case) — reviewer-caught bug (reagentx P1 on PR
+    // #2560): gating on workspace-destruction alone still let closing a
+    // small independent tear-off window (its own small 1:1 workspace, so
+    // `!any_other_window` is true for it too) AFTER the real main window
+    // overwrite the just-saved full-session snapshot with the tear-off's
+    // tiny one. Gating on "windowids is about to be empty" instead ties the
+    // snapshot to the same trigger `restore_last_session` itself waits for
+    // on the read side (only fires when `Client.windowids` is empty) — the
+    // save and the read side now agree on what "the session ended" means.
+    // Computed once, up front, off the state as it stood BEFORE this
+    // close's own dispatch below mutates anything.
+    let will_empty_windowids = store
+        .get_all::<Client>()
+        .ok()
+        .and_then(|cs| cs.into_iter().next())
+        .map(|c| c.windowids.iter().all(|id| id == &window_id))
+        .unwrap_or(false);
     // Step 1: drop the window mapping in reducer.
     let close_events = dispatch_to_reducer(
         state,
@@ -120,6 +129,17 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
                 .map(|ws| ws.iter().any(|w| w.workspaceid == ws_id))
                 .unwrap_or(true);
             if !any_other_window {
+                // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
+                // Feature 1) — gated on `will_empty_windowids` (computed at
+                // function entry — see its own doc comment for why this is
+                // NOT the same condition as `!any_other_window` above), not
+                // on workspace destruction. Best-effort: a failure here must
+                // never block the close itself.
+                if will_empty_windowids {
+                    if let Some(snapshot) = super::session_restore::snapshot_workspace(store, &ws_id) {
+                        super::session_restore::save_last_session_snapshot(store, snapshot);
+                    }
+                }
                 // A workspace the reducer tracks goes through the
                 // saga (keeps reducer + store consistent, durable
                 // provenance). One it never knew — the usual case
@@ -183,6 +203,22 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
             s.windows.values().any(|w| w.workspace_id == ws_id)
         };
         if !any_other_window {
+            // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
+            // Feature 1) — gated on `will_empty_windowids` (see the doc
+            // comment at its computation, function entry, for why this is
+            // NOT the same condition as `!any_other_window` above — that
+            // question is "does closing this window destroy ITS OWN
+            // workspace," true for basically every close in the common 1:1
+            // window:workspace case; this one is "is the user fully
+            // quitting"). Workspace tabs/blocks are still fully intact at
+            // this point — `CloseWindowInternal`'s already-applied events
+            // only touched Window/Client, the actual tab/block cascade is
+            // the saga call right below this.
+            if will_empty_windowids {
+                if let Some(snapshot) = super::session_restore::snapshot_workspace(store, &ws_id) {
+                    super::session_restore::save_last_session_snapshot(store, snapshot);
+                }
+            }
             if let Err(e) =
                 crate::sagas::delete_workspace::run(state, ws_id.clone()).await
             {
@@ -295,5 +331,135 @@ mod close_window_divergence_tests {
         let state = test_state();
         let ret = handle_window_service(&state, &close_call("no-such-window")).await;
         assert!(ret.success, "idempotent CloseWindow failed: {:?}", ret.error);
+    }
+}
+
+/// Restore-on-relaunch snapshot-timing regression tests
+/// (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13.md Feature 1).
+/// Reviewer-caught bug (reagentx P1 on PR #2560): the original
+/// implementation snapshotted unconditionally on every window close, so
+/// closing a second, independent window AFTER the real session's window
+/// would silently overwrite the correct snapshot with the second window's
+/// (typically much smaller) content — since each window normally owns its
+/// own 1:1 workspace, "does this close destroy its own workspace" was true
+/// for nearly every close, not a useful filter. These pin the fix: the
+/// snapshot now only fires on the close that actually empties
+/// `Client.windowids` — the same condition the read side already requires.
+#[cfg(test)]
+mod snapshot_timing_tests {
+    use super::super::window::handle_window_service;
+    use super::super::window_create::handle_create_window;
+    use crate::backend::obj::{Client, Tab, Window, Workspace};
+    use crate::backend::service::WebCallType;
+    use crate::server::tests::test_state;
+
+    fn close_call(window_id: &str) -> WebCallType {
+        WebCallType {
+            service: "window".to_string(),
+            method: "CloseWindow".to_string(),
+            uicontext: None,
+            args: vec![serde_json::Value::String(window_id.to_string())],
+        }
+    }
+
+    async fn create_window(state: &crate::server::AppState) -> Window {
+        let call = WebCallType {
+            service: "window".to_string(),
+            method: "CreateWindow".to_string(),
+            uicontext: None,
+            args: vec![serde_json::Value::Null, serde_json::Value::String(String::new())],
+        };
+        let resp = handle_create_window(state, &call).await;
+        assert!(resp.success, "CreateWindow failed: {:?}", resp.error);
+        serde_json::from_value(resp.data.unwrap()).unwrap()
+    }
+
+    fn rename_first_tab(state: &crate::server::AppState, workspace_id: &str, name: &str) {
+        let ws = state.wstore.get::<Workspace>(workspace_id).unwrap().unwrap();
+        let mut tab = state.wstore.get::<Tab>(&ws.tabids[0]).unwrap().unwrap();
+        tab.name = name.to_string();
+        state.wstore.update(&mut tab).unwrap();
+    }
+
+    fn last_session_snapshot_tab_name(state: &crate::server::AppState) -> Option<String> {
+        let client = state.wstore.get_all::<Client>().unwrap().into_iter().next()?;
+        let snapshot = client.meta.get("session:last_topology")?;
+        snapshot["tabs"][0]["name"].as_str().map(|s| s.to_string())
+    }
+
+    /// The core fix: with two independent windows open, closing the FIRST
+    /// one (the other is still open — `Client.windowids` does NOT empty)
+    /// must not touch the snapshot at all. Only closing the SECOND (last)
+    /// window may write one. Under the pre-fix code (unconditional
+    /// snapshot-on-every-close) this test fails at the first assertion —
+    /// the first close already wrote a snapshot.
+    #[tokio::test]
+    async fn closing_one_of_two_open_windows_does_not_touch_the_snapshot() {
+        let state = test_state();
+
+        let first = create_window(&state).await;
+        rename_first_tab(&state, &first.workspaceid, "first-window-tab");
+        let second = create_window(&state).await;
+        rename_first_tab(&state, &second.workspaceid, "second-window-tab");
+
+        assert!(
+            last_session_snapshot_tab_name(&state).is_none(),
+            "precondition: no snapshot exists yet"
+        );
+
+        // Close the FIRST window while the second is still open.
+        let ret = handle_window_service(&state, &close_call(&first.oid)).await;
+        assert!(ret.success, "CloseWindow failed: {:?}", ret.error);
+
+        assert!(
+            last_session_snapshot_tab_name(&state).is_none(),
+            "closing one of two open windows must not write a snapshot — \
+             the session hasn't actually ended yet"
+        );
+
+        // Now close the SECOND (last) window — this is the real end of the
+        // session, and must snapshot the second window's own content.
+        let ret = handle_window_service(&state, &close_call(&second.oid)).await;
+        assert!(ret.success, "CloseWindow failed: {:?}", ret.error);
+
+        assert_eq!(
+            last_session_snapshot_tab_name(&state).as_deref(),
+            Some("second-window-tab"),
+            "the terminal close must snapshot ITS OWN (last) window's content"
+        );
+    }
+
+    /// Direct regression for the reviewer's exact scenario: close the
+    /// window with the "real" session first, then a smaller second window
+    /// — the smaller window's close (being the one that actually empties
+    /// `Client.windowids`) legitimately becomes the final snapshot, but the
+    /// key guarantee is that this reflects a real, coherent design decision
+    /// (snapshot = "whatever was open at the moment of full quit") rather
+    /// than an arbitrary race between two unconditional writes.
+    #[tokio::test]
+    async fn snapshot_reflects_whichever_close_actually_empties_windowids() {
+        let state = test_state();
+
+        let main = create_window(&state).await;
+        rename_first_tab(&state, &main.workspaceid, "main-session");
+        let tearoff = create_window(&state).await;
+        rename_first_tab(&state, &tearoff.workspaceid, "tiny-tearoff");
+
+        // Close "main" first — does NOT empty windowids (tearoff still open).
+        let ret = handle_window_service(&state, &close_call(&main.oid)).await;
+        assert!(ret.success);
+        assert!(
+            last_session_snapshot_tab_name(&state).is_none(),
+            "closing main first must not snapshot — it isn't the terminal close"
+        );
+
+        // Close "tearoff" last — THIS empties windowids, so it (correctly,
+        // by definition of "what was open at full quit") is what's saved.
+        let ret = handle_window_service(&state, &close_call(&tearoff.oid)).await;
+        assert!(ret.success);
+        assert_eq!(
+            last_session_snapshot_tab_name(&state).as_deref(),
+            Some("tiny-tearoff")
+        );
     }
 }

--- a/agentmux-srv/src/server/service/window_close.rs
+++ b/agentmux-srv/src/server/service/window_close.rs
@@ -40,29 +40,6 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
             ));
         }
     };
-    // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
-    // Feature 1) — is this close the one that empties `Client.windowids`,
-    // i.e. a genuine "the user is fully quitting" moment? Deliberately NOT
-    // "does this close cascade-delete ITS OWN workspace" (`!any_other_window`
-    // below is a workspace-sharing question, answered independently per
-    // window, true for basically every close in the common 1:1
-    // window:workspace case) — reviewer-caught bug (reagentx P1 on PR
-    // #2560): gating on workspace-destruction alone still let closing a
-    // small independent tear-off window (its own small 1:1 workspace, so
-    // `!any_other_window` is true for it too) AFTER the real main window
-    // overwrite the just-saved full-session snapshot with the tear-off's
-    // tiny one. Gating on "windowids is about to be empty" instead ties the
-    // snapshot to the same trigger `restore_last_session` itself waits for
-    // on the read side (only fires when `Client.windowids` is empty) — the
-    // save and the read side now agree on what "the session ended" means.
-    // Computed once, up front, off the state as it stood BEFORE this
-    // close's own dispatch below mutates anything.
-    let will_empty_windowids = store
-        .get_all::<Client>()
-        .ok()
-        .and_then(|cs| cs.into_iter().next())
-        .map(|c| c.windowids.iter().all(|id| id == &window_id))
-        .unwrap_or(false);
     // Step 1: drop the window mapping in reducer.
     let close_events = dispatch_to_reducer(
         state,
@@ -130,11 +107,38 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
                 .unwrap_or(true);
             if !any_other_window {
                 // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
-                // Feature 1) — gated on `will_empty_windowids` (computed at
-                // function entry — see its own doc comment for why this is
-                // NOT the same condition as `!any_other_window` above), not
-                // on workspace destruction. Best-effort: a failure here must
-                // never block the close itself.
+                // Feature 1) — is THIS close the one that empties
+                // `Client.windowids`, i.e. a genuine "the user is fully
+                // quitting" moment? Deliberately NOT the same question as
+                // `!any_other_window` above (that's workspace-sharing,
+                // answered independently per window, true for basically
+                // every close in the common 1:1 window:workspace case) —
+                // reviewer-caught bug (reagentx P1 on PR #2560): gating on
+                // workspace-destruction alone still let closing a small
+                // independent tear-off window (its own small 1:1 workspace,
+                // so `!any_other_window` is true for it too) AFTER the real
+                // main window overwrite the just-saved full-session
+                // snapshot with the tear-off's tiny one. Gating on
+                // "windowids is about to be empty" instead ties the
+                // snapshot to the same trigger `restore_last_session` itself
+                // waits for on the read side.
+                //
+                // Read FRESH here, not once up front at function entry
+                // (reagentx P1 on PR #2560, re-review): `apply_srv_window_closed`
+                // above already pruned this window's id, so this reflects
+                // the post-prune state. A stale pre-dispatch read let
+                // concurrent CloseWindow calls during a multi-window quit
+                // each independently see "the other window is still there"
+                // and conclude `will_empty_windowids = false` for BOTH,
+                // losing the snapshot entirely even though the user
+                // genuinely closed everything.
+                let will_empty_windowids = store
+                    .get_all::<Client>()
+                    .ok()
+                    .and_then(|cs| cs.into_iter().next())
+                    .map(|c| c.windowids.is_empty())
+                    .unwrap_or(false);
+                // Best-effort: a failure here must never block the close itself.
                 if will_empty_windowids {
                     if let Some(snapshot) = super::session_restore::snapshot_workspace(store, &ws_id) {
                         super::session_restore::save_last_session_snapshot(store, snapshot);
@@ -204,16 +208,23 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
         };
         if !any_other_window {
             // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
-            // Feature 1) — gated on `will_empty_windowids` (see the doc
-            // comment at its computation, function entry, for why this is
-            // NOT the same condition as `!any_other_window` above — that
-            // question is "does closing this window destroy ITS OWN
-            // workspace," true for basically every close in the common 1:1
-            // window:workspace case; this one is "is the user fully
-            // quitting"). Workspace tabs/blocks are still fully intact at
-            // this point — `CloseWindowInternal`'s already-applied events
-            // only touched Window/Client, the actual tab/block cascade is
-            // the saga call right below this.
+            // Feature 1) — see the divergence-path branch above for why this
+            // is gated on "windowids is now empty" rather than
+            // `!any_other_window` (a workspace-sharing question, not a
+            // full-quit one). Workspace tabs/blocks are still fully intact
+            // at this point — `CloseWindowInternal`'s already-applied events
+            // (line 182-189 above) only touched Window/Client, the actual
+            // tab/block cascade is the saga call right below this — so
+            // `Client.windowids` reflects this window's own prune already,
+            // and reading it fresh here (not a stale function-entry
+            // snapshot — reagentx P1 on PR #2560, re-review) is what makes
+            // this correct under a concurrent multi-window quit.
+            let will_empty_windowids = store
+                .get_all::<Client>()
+                .ok()
+                .and_then(|cs| cs.into_iter().next())
+                .map(|c| c.windowids.is_empty())
+                .unwrap_or(false);
             if will_empty_windowids {
                 if let Some(snapshot) = super::session_restore::snapshot_workspace(store, &ws_id) {
                     super::session_restore::save_last_session_snapshot(store, snapshot);
@@ -488,6 +499,43 @@ mod snapshot_timing_tests {
         assert_eq!(
             last_session_snapshot_tab_name(&state).as_deref(),
             Some("tiny-tearoff")
+        );
+    }
+
+    /// reagentx P1 on PR #2560 (re-review): `will_empty_windowids` used to
+    /// be computed once at function entry, off a snapshot of
+    /// `Client.windowids` taken BEFORE this call's own dispatch mutated
+    /// anything. Under genuine concurrent overlap (two `CloseWindow` calls
+    /// as part of one multi-window quit), each could read "the other
+    /// window is still there" and both conclude `will_empty_windowids =
+    /// false` — losing the snapshot entirely even though the user closed
+    /// everything. Reading fresh, after each call's own prune has already
+    /// landed, closes that gap: whichever close actually observes an empty
+    /// `Client.windowids` afterward saves a snapshot, so at least one of
+    /// two concurrent terminal closes always does.
+    #[tokio::test]
+    async fn concurrent_close_of_the_last_two_windows_still_saves_a_snapshot() {
+        let state = test_state();
+        close_bootstrap_window(&state).await;
+
+        let first = create_window(&state).await;
+        rename_first_tab(&state, &first.workspaceid, "first-window-tab");
+        let second = create_window(&state).await;
+        rename_first_tab(&state, &second.workspaceid, "second-window-tab");
+
+        let first_call = close_call(&first.oid);
+        let second_call = close_call(&second.oid);
+        let (ret1, ret2) = tokio::join!(
+            handle_window_service(&state, &first_call),
+            handle_window_service(&state, &second_call),
+        );
+        assert!(ret1.success, "first concurrent close failed: {:?}", ret1.error);
+        assert!(ret2.success, "second concurrent close failed: {:?}", ret2.error);
+
+        assert!(
+            last_session_snapshot_tab_name(&state).is_some(),
+            "closing the last two windows concurrently must still save SOME \
+             snapshot, not lose it entirely"
         );
     }
 }

--- a/agentmux-srv/src/server/service/window_close.rs
+++ b/agentmux-srv/src/server/service/window_close.rs
@@ -40,6 +40,20 @@ pub(crate) async fn handle_close_window(state: &AppState, call: &WebCallType) ->
             ));
         }
     };
+    // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
+    // Feature 1) — snapshot this window's workspace BEFORE the destroy
+    // cascade below removes it, so the next cold launch has something to
+    // restore instead of always reseeding the default layout. Best-effort
+    // and independent of the cascade: a failure here must never block the
+    // close itself (see `session_restore` module docs for why this is a
+    // separate durable record, not a change to the cascade).
+    if let Some(ref ws_id_for_snapshot) = ws_id {
+        if let Some(snapshot) =
+            super::session_restore::snapshot_workspace(store, ws_id_for_snapshot)
+        {
+            super::session_restore::save_last_session_snapshot(store, snapshot);
+        }
+    }
     // Step 1: drop the window mapping in reducer.
     let close_events = dispatch_to_reducer(
         state,

--- a/agentmux-srv/src/server/service/window_create.rs
+++ b/agentmux-srv/src/server/service/window_create.rs
@@ -29,7 +29,26 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
     // (tear-off, "Open New Window", the workspace-missing error-recovery
     // fallback) omits it and gets the pre-existing default-seed behavior,
     // completely unchanged, below.
-    let restore_if_available: bool = service::get_arg(args, 3).unwrap_or(false);
+    //
+    // The client's own claim isn't trusted alone (reagentx P2 on PR #2560):
+    // re-check `Client.windowids` server-side too, so a stray/duplicate/
+    // misused call with `restoreIfAvailable: true` mid-session (when other
+    // windows are legitimately still open) can't resurrect the last snapshot
+    // into a spurious extra workspace.
+    let client_windowids_empty = store
+        .get_all::<Client>()
+        .ok()
+        .and_then(|cs| cs.into_iter().next())
+        .map(|c| c.windowids.is_empty())
+        .unwrap_or(true);
+    let restore_if_available: bool =
+        service::get_arg(args, 3).unwrap_or(false) && client_windowids_empty;
+    // Set when a restore actually replays the last snapshot — gates clearing
+    // it (see the final read-back below) so a genuinely successful restore
+    // can't be replayed again by a later call, while a crash mid-restore
+    // (this flag set, but the function never reaches that final clear)
+    // leaves the snapshot intact for the next launch to retry.
+    let mut did_restore = false;
     // Resolve / create the workspace.
     let (ws_id, fresh_workspace_events): (String, Vec<agentmux_common::ipc::Event>) =
         if requested_ws_id.is_empty() {
@@ -49,6 +68,7 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
                 None
             };
             if let Some(result) = restored_from_last_session {
+                did_restore = true;
                 result
             } else {
             // Step 1: create workspace.
@@ -351,7 +371,23 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
     publish_events(state, &all_events);
     // Return the Window struct (matches the prior RPC contract).
     match store.must_get::<Window>(&window_id) {
-        Ok(win) => WebReturnType::success(serde_json::to_value(&win).unwrap_or_default()),
+        Ok(win) => {
+            // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
+            // Feature 1) — only clear the snapshot once the restore it
+            // produced has fully, successfully completed (this read-back is
+            // the last step of that path). A crash between
+            // `restore_last_session` returning and reaching this line never
+            // executes this clear, so the next launch's `Client.windowids`
+            // is still empty and retries against the same intact snapshot —
+            // deliberately not cleared any earlier than this. Reviewer-caught
+            // (reagentx P2 on PR #2560): without this, a stray repeat call
+            // could replay the same snapshot into a second duplicate
+            // workspace even after a genuinely successful restore.
+            if did_restore {
+                super::session_restore::clear_last_session_snapshot(store);
+            }
+            WebReturnType::success(serde_json::to_value(&win).unwrap_or_default())
+        }
         Err(e) => WebReturnType::error(format!(
             "CreateWindow: window read-back failed: {}",
             e

--- a/agentmux-srv/src/server/service/window_create.rs
+++ b/agentmux-srv/src/server/service/window_create.rs
@@ -243,6 +243,7 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
                         tree,
                         focused,
                         leaforder,
+                        String::new(),
                     )
                     .await
                     {

--- a/agentmux-srv/src/server/service/window_create.rs
+++ b/agentmux-srv/src/server/service/window_create.rs
@@ -23,9 +23,34 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
     let store = &state.wstore;
     let args = &call.args;
     let requested_ws_id: String = service::get_arg(args, 1).unwrap_or_default();
+    // Restore-on-relaunch (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
+    // Feature 1) — arg 3 is set only by the frontend's genuine cold-start
+    // call site (`Client.windowids` was empty). Every other caller
+    // (tear-off, "Open New Window", the workspace-missing error-recovery
+    // fallback) omits it and gets the pre-existing default-seed behavior,
+    // completely unchanged, below.
+    let restore_if_available: bool = service::get_arg(args, 3).unwrap_or(false);
     // Resolve / create the workspace.
     let (ws_id, fresh_workspace_events): (String, Vec<agentmux_common::ipc::Event>) =
         if requested_ws_id.is_empty() {
+            let restored_from_last_session = if restore_if_available {
+                match super::session_restore::restore_last_session(state).await {
+                    Ok(Some(result)) => Some(result),
+                    Ok(None) => None,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "CreateWindow: session restore failed — falling back to default seed"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            if let Some(result) = restored_from_last_session {
+                result
+            } else {
             // Step 1: create workspace.
             let ws_events = dispatch_to_reducer(
                 state,
@@ -213,6 +238,7 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
             combined.extend(tab_events);
             combined.extend(block_seed_events);
             (new_ws_id, combined)
+            }
         } else {
             // Existing workspace — verify it's in the reducer
             // (or SQLite), but no creation needed.

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1211,7 +1211,7 @@ async fn layout_seeders_route_through_reducer_coherently() {
     let (tree, focused, leaforder) =
         crate::backend::wcore::default_three_pane_tree("b-agent", "b-sysinfo", "b-swarm");
     crate::server::service::seed_layout_via_reducer(
-        &state, &tab1, tree, focused, leaforder,
+        &state, &tab1, tree, focused, leaforder, String::new(),
     )
     .await
     .expect("three-pane seed via reducer");
@@ -1278,7 +1278,7 @@ async fn layout_seed_unknown_tab_errors() {
     let (tree, focused, leaforder) =
         crate::backend::wcore::default_three_pane_tree("a", "b", "c");
     let err = crate::server::service::seed_layout_via_reducer(
-        &state, "ghost-tab", tree, focused, leaforder,
+        &state, "ghost-tab", tree, focused, leaforder, String::new(),
     )
     .await
     .expect_err("unknown tab must error");

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -319,15 +319,22 @@ fn restore_last_session_survives_a_real_process_restart() {
     // --- Process 1: create a window, add a marked block, close gracefully ---
     let (guard1, web_addr, _ws_addr, auth_key) = spawn_backend_with_data_dir(data_dir.path());
 
-    let window = rpc(
-        &client,
-        &web_addr,
-        &auth_key,
-        "window",
-        "CreateWindow",
-        serde_json::json!([null, "", "main", true]),
-    );
-    let window_id = window["oid"].as_str().expect("window oid").to_string();
+    // Mirror the real frontend cold-start path (`initHostWave` in
+    // `app-init.ts`): a fresh server has already bootstrapped a "Starter
+    // workspace" window via `ensure_initial_data` at startup, so
+    // `Client.windowids` is non-empty here — the frontend reuses
+    // `windowids[0]` rather than calling `CreateWindow` again. Calling
+    // `CreateWindow` unconditionally here (as this test used to) would spawn
+    // a SECOND window that the bootstrap window still keeps alive,
+    // permanently pinning `Client.windowids` above one entry — CloseWindow
+    // would never see it empty out, so it (correctly, per
+    // `will_empty_windowids`) would never write a snapshot.
+    let client_data = rpc(&client, &web_addr, &auth_key, "client", "GetClientData", serde_json::json!([]));
+    let window_id = client_data["windowids"][0]
+        .as_str()
+        .expect("bootstrap window id")
+        .to_string();
+    let window = rpc(&client, &web_addr, &auth_key, "window", "GetWindow", serde_json::json!([window_id]));
     let workspace_id = window["workspaceid"].as_str().expect("window workspaceid").to_string();
 
     let workspace = rpc(
@@ -338,7 +345,15 @@ fn restore_last_session_survives_a_real_process_restart() {
         "GetObject",
         serde_json::json!([format!("workspace:{}", workspace_id)]),
     );
-    let tab_id = workspace["tabids"][0].as_str().expect("workspace has a tab").to_string();
+    // The bootstrap workspace's initial tab can still be sitting in the
+    // legacy `pinnedtabids` field rather than `tabids` (drained into
+    // `tabids` only on the next `TabsReordered` event) — check both, same
+    // as `session_restore::snapshot_workspace`.
+    let tab_id = workspace["tabids"][0]
+        .as_str()
+        .or_else(|| workspace["pinnedtabids"][0].as_str())
+        .expect("workspace has a tab")
+        .to_string();
 
     let marker_block = rpc(
         &client,

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -214,6 +214,239 @@ fn auth_accepts_valid_header() {
     assert!(body["success"].as_bool().unwrap_or(false));
 }
 
+/// Same as `spawn_backend`, but pins `AGENTMUX_DATA_DIR` to a caller-owned
+/// directory instead of whatever this process would otherwise default to —
+/// so a second spawn against the same path can prove state survived a real
+/// process exit, not just an in-process code path.
+fn spawn_backend_with_data_dir(data_dir: &std::path::Path) -> (SrvGuard, String, String, String) {
+    let auth_key = "integration-test-key-12345";
+    let binary = env!("CARGO_BIN_EXE_agentmux-srv");
+
+    let child = Command::new(binary)
+        .env("AGENTMUX_AUTH_KEY", auth_key)
+        .env("AGENTMUX_DATA_DIR", data_dir)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to spawn agentmux-srv");
+
+    #[cfg(windows)]
+    let job = assign_to_kill_on_close_job(&child);
+
+    let mut guard = SrvGuard {
+        child,
+        #[cfg(windows)]
+        _job: job,
+    };
+
+    let stderr = guard.stderr.take().unwrap();
+    let reader = BufReader::new(stderr);
+
+    let mut web_addr = String::new();
+    let mut ws_addr = String::new();
+
+    for line in reader.lines() {
+        let line = line.expect("failed to read stderr");
+        if line.contains("AGENTMUXSRV-ESTART") {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            for part in &parts {
+                if let Some(addr) = part.strip_prefix("ws:") {
+                    ws_addr = addr.to_string();
+                } else if let Some(addr) = part.strip_prefix("web:") {
+                    web_addr = addr.to_string();
+                }
+            }
+            break;
+        }
+    }
+
+    assert!(!web_addr.is_empty(), "failed to parse web addr from ESTART");
+    assert!(!ws_addr.is_empty(), "failed to parse ws addr from ESTART");
+
+    (guard, web_addr, ws_addr, auth_key.to_string())
+}
+
+/// Minimal RPC helper: POST to `/agentmux/service`, assert success, return `data`.
+fn rpc(
+    client: &reqwest::blocking::Client,
+    web_addr: &str,
+    auth_key: &str,
+    service: &str,
+    method: &str,
+    args: serde_json::Value,
+) -> serde_json::Value {
+    let body = serde_json::json!({ "service": service, "method": method, "args": args });
+    let resp = client
+        .post(format!("http://{}/agentmux/service", web_addr))
+        .header("X-AuthKey", auth_key)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .unwrap_or_else(|e| panic!("{}::{} request failed: {}", service, method, e));
+    let status = resp.status();
+    let json: serde_json::Value = resp.json().expect("response body was not JSON");
+    assert!(
+        status.is_success() && json["success"].as_bool().unwrap_or(false),
+        "{}::{} failed: status={} body={}",
+        service,
+        method,
+        status,
+        json
+    );
+    json["data"].clone()
+}
+
+/// End-to-end proof of SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13
+/// Feature 1 — spawns two SEPARATE real `agentmux-srv` processes against the
+/// same data dir (not two calls within one process), matching what an actual
+/// quit-and-relaunch does: process 1 creates a window, adds a block with a
+/// distinctive meta marker, and is closed gracefully (`CloseWindow`, which
+/// snapshots-then-cascades — see `window_close::handle_close_window`); it is
+/// then killed for real. Process 2 starts cold against the same
+/// `AGENTMUX_DATA_DIR` and calls `CreateWindow` the same way the frontend's
+/// genuine cold-start path does (`restoreIfAvailable: true`, `app-init.ts`).
+/// The marker surviving into process 2's restored block proves the durable
+/// write-through and the replay path both work against the real HTTP API and
+/// real SQLite file, not just the in-process unit tests in
+/// `server::service::session_restore`.
+#[test]
+fn restore_last_session_survives_a_real_process_restart() {
+    let data_dir = tempfile::tempdir().expect("failed to create temp data dir");
+    let client = reqwest::blocking::Client::new();
+    let marker = "hello-restore-e2e";
+
+    // --- Process 1: create a window, add a marked block, close gracefully ---
+    let (guard1, web_addr, _ws_addr, auth_key) = spawn_backend_with_data_dir(data_dir.path());
+
+    let window = rpc(
+        &client,
+        &web_addr,
+        &auth_key,
+        "window",
+        "CreateWindow",
+        serde_json::json!([null, "", "main", true]),
+    );
+    let window_id = window["oid"].as_str().expect("window oid").to_string();
+    let workspace_id = window["workspaceid"].as_str().expect("window workspaceid").to_string();
+
+    let workspace = rpc(
+        &client,
+        &web_addr,
+        &auth_key,
+        "object",
+        "GetObject",
+        serde_json::json!([format!("workspace:{}", workspace_id)]),
+    );
+    let tab_id = workspace["tabids"][0].as_str().expect("workspace has a tab").to_string();
+
+    let marker_block = rpc(
+        &client,
+        &web_addr,
+        &auth_key,
+        "object",
+        "CreateBlock",
+        serde_json::json!([{ "meta": { "view": "term", "test:marker": marker } }, null, tab_id]),
+    );
+    // `object::CreateBlock` returns the new block id as a bare JSON string
+    // (`success_data_updates(json!(bid), updates)`), not a block object.
+    let marker_block_id = marker_block.as_str().expect("marker block id string").to_string();
+    assert!(!marker_block_id.is_empty());
+
+    rpc(
+        &client,
+        &web_addr,
+        &auth_key,
+        "window",
+        "CloseWindow",
+        serde_json::json!([window_id]),
+    );
+
+    // Kill the process for real (not just logically closed) — proves this
+    // survives an actual restart, not merely an in-process code path.
+    drop(guard1);
+
+    // --- Process 2: fresh process, SAME data dir — cold start must restore ---
+    let (guard2, web_addr2, _ws_addr2, auth_key2) = spawn_backend_with_data_dir(data_dir.path());
+
+    let restored_window = rpc(
+        &client,
+        &web_addr2,
+        &auth_key2,
+        "window",
+        "CreateWindow",
+        serde_json::json!([null, "", "main", true]),
+    );
+    let restored_ws_id = restored_window["workspaceid"]
+        .as_str()
+        .expect("restored window workspaceid")
+        .to_string();
+    assert_ne!(
+        restored_ws_id, workspace_id,
+        "restore creates a brand-new workspace, it does not resurrect the deleted one"
+    );
+
+    let restored_workspace = rpc(
+        &client,
+        &web_addr2,
+        &auth_key2,
+        "object",
+        "GetObject",
+        serde_json::json!([format!("workspace:{}", restored_ws_id)]),
+    );
+    let restored_tab_id = restored_workspace["tabids"][0]
+        .as_str()
+        .expect("restored workspace has a tab")
+        .to_string();
+    let restored_tab = rpc(
+        &client,
+        &web_addr2,
+        &auth_key2,
+        "object",
+        "GetObject",
+        serde_json::json!([format!("tab:{}", restored_tab_id)]),
+    );
+    let restored_block_ids: Vec<String> = restored_tab["blockids"]
+        .as_array()
+        .expect("restored tab has blockids")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    // The default seed is 3 blocks (agent/sysinfo/swarm); our marker block
+    // was the 4th added before close, so a correct restore must bring all 4
+    // back, not silently drop the one added after the initial seed.
+    assert_eq!(restored_block_ids.len(), 4, "expected all 4 original blocks to be restored");
+
+    let mut found_marker = false;
+    for block_id in &restored_block_ids {
+        let block = rpc(
+            &client,
+            &web_addr2,
+            &auth_key2,
+            "object",
+            "GetObject",
+            serde_json::json!([format!("block:{}", block_id)]),
+        );
+        if block["meta"]["test:marker"].as_str() == Some(marker) {
+            found_marker = true;
+            // And it must be a genuinely NEW block id, not the one from the
+            // now-deleted first workspace (CreateBlock always mints a fresh
+            // id; this also guards against a remap bug leaving a stale
+            // placeholder or the original id in the restored tree).
+            assert_ne!(block_id, &marker_block_id);
+            break;
+        }
+    }
+    assert!(
+        found_marker,
+        "restored session must contain the marker block created before the \
+         process restart; got block ids: {:?}",
+        restored_block_ids
+    );
+
+    drop(guard2);
+}
+
 #[test]
 fn sigterm_exits_process() {
     let (mut child, _web_addr, _ws_addr, _auth_key) = spawn_backend();

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -336,10 +336,16 @@ async function initHostWave(): Promise<void> {
 
         let windowId = clientData.windowids?.[0];
 
-        // If no windows exist, create one
+        // If no windows exist, create one. This is the genuine cold-start
+        // case (SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13 Feature 1)
+        // — `Client.windowids` is empty, which only happens right after a
+        // graceful quit (the destroy-on-close cascade always empties it) or
+        // on a truly first-ever launch. Pass `restoreIfAvailable: true` so
+        // srv replays the last-session snapshot if one was saved on close,
+        // instead of always seeding the hardcoded default 3-pane layout.
         if (!windowId) {
             t = performance.now();
-            const newWindow = await withTimeout(WindowService.CreateWindow(null, "", currentWindowLabel()), RPC_TIMEOUT, "CreateWindow");
+            const newWindow = await withTimeout(WindowService.CreateWindow(null, "", currentWindowLabel(), true), RPC_TIMEOUT, "CreateWindow");
             tlog("CreateWindow (no windows)", t);
             windowId = newWindow.oid;
         }

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -109,7 +109,14 @@ class WindowServiceType {
     // the caller's CEF window label, persisted as a `host:label` meta crumb on
     // the created Window row so srv-side cleanup can attribute rows without
     // the host registration chain.
-    CreateWindow(winSize: WinSize, workspaceId: string, hostLabel?: string): Promise<WaveWindow> {
+    //
+    // `restoreIfAvailable` (optional, SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_
+    // 2026_08_13 Feature 1): only the true cold-start call site in
+    // app-init.ts sets this — it tells srv to replay the last-session
+    // snapshot (if one exists) instead of seeding the hardcoded default
+    // 3-pane layout. Every other caller (tear-off, "Open New Window") omits
+    // it and keeps today's always-blank-workspace behavior.
+    CreateWindow(winSize: WinSize, workspaceId: string, hostLabel?: string, restoreIfAvailable?: boolean): Promise<WaveWindow> {
         return WOS.callBackendService("window", "CreateWindow", Array.from(arguments))
     }
     GetWindow(windowId: string): Promise<WaveWindow> {


### PR DESCRIPTION
## Summary
- Adds a real restore-on-relaunch mechanism, independent of the existing (correct) destroy-on-close cascade: `session_restore.rs` snapshots a workspace's tabs/blocks/layout tree into `Client.meta["session:last_topology"]` just before close, and replays it on the next cold start instead of always reseeding the hardcoded default 3-pane layout.
- Wired into `window_close.rs` (write) and `window_create.rs` (read, gated behind a new opt-in `restoreIfAvailable` arg set only by the frontend's genuine cold-start call site — tear-off / "Open New Window" are unaffected).
- See companion docs PR #2559 for the retro (why this regressed) and spec (full design, including a separately-specced "Layouts" save/load feature not included here).

Not included here (tracked as explicit follow-ups): a settings toggle to disable this, and the "Layouts" menu UI.

## Test plan
- [x] `cargo test -p agentmux-srv` — full suite (2193 tests) passes, no regressions.
- [x] New unit tests in `session_restore.rs` covering the snapshot/restore round trip, placeholder remapping, and idempotency.
- [x] New live integration test (`restore_last_session_survives_a_real_process_restart`) — spawns two separate real `agentmux-srv` processes against the same data dir, closes the first gracefully, kills it, cold-starts the second, and confirms a marker block created before the restart comes back. Proves durability across an actual process restart, not just an in-process call.
- [x] `npx tsc --noEmit` clean on the frontend change.
- [ ] Not live-tested through the actual Electron/CEF UI (`task dev`, closing/reopening the real app) — only through the real HTTP RPC API, which exercises the same server-side path but not the frontend/host wiring end-to-end.

<!-- agentmux:agent_id=agentx -->