### PR TITLE
fix(menu): context-submenu wrong-strategy positioning + main window silent show() no-op

### DIFF
--- a/.changesets/1786650533-fix-menu-context-submenu-wrong-strategy-positioning-main-win-f75t.md
+++ b/.changesets/1786650533-fix-menu-context-submenu-wrong-strategy-positioning-main-win-f75t.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+fix(menu): context-submenu wrong-strategy positioning + main window silent show() no-op

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -163,6 +163,72 @@ pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+/// Bound on how many times `on_load_end`'s top-level `window.show()` retries
+/// when `browser_view_get_for_browser()`/`BrowserView::window()` return
+/// `None` at load-end, instead of the previous silent no-op that left the
+/// window permanently hidden with zero diagnostic trace. This is the same
+/// class of CEF Views timing quirk already diagnosed and worked around on
+/// the pool-window path (`commands/window_pool.rs`'s `POOL_HWND_CACHE`,
+/// `SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md`) but was never ported to the
+/// main/top-level window path — see
+/// `docs/retro/RETRO_MAIN_WINDOW_SHOW_SILENT_NOOP_2026_08_13.md`.
+const SHOW_WINDOW_MAX_RETRIES: u32 = 10;
+/// Delay between retries — short enough that a handful still resolves within
+/// a user-imperceptible instant if the window becomes resolvable a frame or
+/// two later, long enough not to busy-loop the UI thread.
+const SHOW_WINDOW_RETRY_DELAY_MS: i64 = 50;
+
+/// Show + focus a top-level (non-pool) window by label if its `BrowserView`/
+/// `Window` are resolvable and it isn't already visible. Returns `true` once
+/// resolved (shown or already visible), `false` if the CEF Views objects
+/// aren't available yet — caller should retry rather than give up silently.
+fn try_show_top_level_window(state: &std::sync::Arc<crate::state::AppState>, label: &str) -> bool {
+    let Some(mut browser) = state.get_browser(label) else { return false };
+    let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) else { return false };
+    let Some(window) = bv.window() else { return false };
+    if window.is_visible() == 0 {
+        window.show();
+        if let Some(host) = browser.host() {
+            host.set_focus(1);
+        }
+    }
+    true
+}
+
+wrap_task! {
+    struct ShowWindowRetryTask {
+        state: std::sync::Arc<crate::state::AppState>,
+        label: String,
+        retries_left: u32,
+    }
+    impl Task { fn execute(&self) {
+        if try_show_top_level_window(&self.state, &self.label) {
+            tracing::info!(
+                target: "wrr",
+                label = %self.label,
+                retries_left = self.retries_left,
+                "[on_load_end] show() retry succeeded"
+            );
+            return;
+        }
+        if self.retries_left == 0 {
+            tracing::error!(
+                target: "wrr",
+                label = %self.label,
+                max_retries = SHOW_WINDOW_MAX_RETRIES,
+                "[on_load_end] browser_view/window still not resolvable after all retries — window will stay hidden"
+            );
+            return;
+        }
+        let mut next = ShowWindowRetryTask::new(
+            self.state.clone(),
+            self.label.clone(),
+            self.retries_left - 1,
+        );
+        post_delayed_task(ThreadId::UI, Some(&mut next), SHOW_WINDOW_RETRY_DELAY_MS);
+    }}
+}
+
 impl AgentMuxHandler {
     /// CEF fires this whenever the browser's loading/history state changes
     /// (navigation started, navigation committed, back/forward enabled).
@@ -331,8 +397,10 @@ impl AgentMuxHandler {
             .map_or(false, |l| l.starts_with("window-pool-") || l.starts_with("floating-pool-"));
 
         if !is_pool_window {
+            let mut resolved = false;
             if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {
                 if let Some(window) = bv.window() {
+                    resolved = true;
                     if window.is_visible() == 0 {
                         // Linux: defer the actual show()/focus (and the splash
                         // dismiss above) until the frontend confirms a real
@@ -400,6 +468,30 @@ impl AgentMuxHandler {
                             }
                         }
                     }
+                }
+            }
+            if !resolved {
+                // browser_view_get_for_browser()/bv.window() returned None —
+                // the CEF Views timing quirk documented on
+                // ShowWindowRetryTask above. Previously this silently left
+                // the window hidden forever; now retry on a short backoff.
+                if let Some(label) = browser_label.clone() {
+                    tracing::warn!(
+                        target: "wrr",
+                        label = %label,
+                        "[on_load_end] browser_view/window not resolvable at load-end — scheduling show() retry"
+                    );
+                    let mut task = ShowWindowRetryTask::new(
+                        self.state.clone(),
+                        label,
+                        SHOW_WINDOW_MAX_RETRIES,
+                    );
+                    post_delayed_task(ThreadId::UI, Some(&mut task), SHOW_WINDOW_RETRY_DELAY_MS);
+                } else {
+                    tracing::error!(
+                        target: "wrr",
+                        "[on_load_end] browser_view/window not resolvable AND label unknown — cannot retry show(), window will stay hidden"
+                    );
                 }
             }
         }

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -178,19 +178,77 @@ const SHOW_WINDOW_MAX_RETRIES: u32 = 10;
 /// two later, long enough not to busy-loop the UI thread.
 const SHOW_WINDOW_RETRY_DELAY_MS: i64 = 50;
 
-/// Show + focus a top-level (non-pool) window by label if its `BrowserView`/
-/// `Window` are resolvable and it isn't already visible. Returns `true` once
-/// resolved (shown or already visible), `false` if the CEF Views objects
-/// aren't available yet — caller should retry rather than give up silently.
+/// Show (or, on Linux, arm the startup-paint gate for) a top-level window's
+/// Views `Window`, once confirmed not yet visible. Shared by `on_load_end`'s
+/// primary resolution path and `ShowWindowRetryTask`'s retry path so BOTH
+/// respect the same Linux paint gating
+/// (`linux_paint_gate_pending`/`reveal_gated_window`,
+/// `SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md`) — reagentx P1 on this PR:
+/// the retry path originally called `window.show()` unconditionally on every
+/// platform, bypassing the gate entirely. Whenever a *retry* (not the first
+/// `on_load_end` pass) is what actually resolves the window, that would
+/// reintroduce the Linux white-flash bug the gate exists to prevent.
+///
+/// `label` is `None` only when the window label couldn't be resolved at all
+/// — matches the pre-existing "can't gate safely on an unknown label"
+/// fallback (immediate show, every platform).
+///
+/// `state`/`label` are only read inside the `#[cfg(target_os = "linux")]`
+/// branch below — unused on every other platform, hence the `allow`.
+#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+fn reveal_top_level_window(
+    state: &std::sync::Arc<crate::state::AppState>,
+    label: Option<&str>,
+    window: &cef::Window,
+    browser: Option<&mut Browser>,
+) {
+    #[cfg(target_os = "linux")]
+    if let Some(label) = label {
+        // The real paint signal can race ahead of this call (see
+        // handle_first_paint_signal) — if it already arrived, reveal
+        // immediately instead of arming a gate + safety timeout for a paint
+        // that already happened.
+        let already_painted = state.linux_first_paint_seen.lock().remove(label);
+        // Fresh epoch per arm — see PAINT_GATE_NEXT_EPOCH and
+        // reveal_gated_window's doc comment. Guards against a reload/retry
+        // re-arming this same label before a timeout fires.
+        let epoch = PAINT_GATE_NEXT_EPOCH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        state
+            .linux_paint_gate_pending
+            .lock()
+            .insert(label.to_string(), (std::time::Instant::now(), epoch));
+        if already_painted {
+            reveal_gated_window(state, label, "signal-early", None);
+        } else {
+            let mut timeout_task = PaintGateRevealTask::new(
+                state.clone(),
+                label.to_string(),
+                "timeout",
+                Some(epoch),
+            );
+            post_delayed_task(ThreadId::UI, Some(&mut timeout_task), PAINT_GATE_SAFETY_TIMEOUT_MS);
+        }
+        return;
+    }
+    window.show();
+    if let Some(b) = browser {
+        if let Some(host) = b.host() {
+            host.set_focus(1);
+        }
+    }
+}
+
+/// Resolve a top-level (non-pool) window by label and reveal it (via
+/// `reveal_top_level_window`) if its `BrowserView`/`Window` are resolvable
+/// and it isn't already visible. Returns `true` once resolved (shown,
+/// gate-armed, or already visible), `false` if the CEF Views objects aren't
+/// available yet — caller should retry rather than give up silently.
 fn try_show_top_level_window(state: &std::sync::Arc<crate::state::AppState>, label: &str) -> bool {
     let Some(mut browser) = state.get_browser(label) else { return false };
     let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) else { return false };
     let Some(window) = bv.window() else { return false };
     if window.is_visible() == 0 {
-        window.show();
-        if let Some(host) = browser.host() {
-            host.set_focus(1);
-        }
+        reveal_top_level_window(state, Some(label), &window, Some(&mut browser));
     }
     true
 }
@@ -409,64 +467,15 @@ impl AgentMuxHandler {
                         // docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
                         // Falls back to the old immediate-show behavior if the
                         // window label can't be resolved (can't gate safely on
-                        // an unknown label).
-                        #[cfg(target_os = "linux")]
-                        let gate_label = browser_label.clone();
-                        #[cfg(target_os = "linux")]
-                        let gated = gate_label.is_some();
-                        #[cfg(target_os = "linux")]
-                        if let Some(label) = gate_label {
-                            // The real paint signal can race ahead of this
-                            // on_load_end call (see handle_first_paint_signal)
-                            // — if it already arrived, reveal immediately
-                            // instead of arming a gate + safety timeout for a
-                            // paint that already happened.
-                            let already_painted =
-                                self.state.linux_first_paint_seen.lock().remove(&label);
-                            // Fresh epoch per arm — see PAINT_GATE_NEXT_EPOCH
-                            // and reveal_gated_window's doc comment. Guards
-                            // against a reload/retry re-arming this same
-                            // label before a timeout fires.
-                            let epoch = PAINT_GATE_NEXT_EPOCH
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            self.state
-                                .linux_paint_gate_pending
-                                .lock()
-                                .insert(label.clone(), (std::time::Instant::now(), epoch));
-                            if already_painted {
-                                reveal_gated_window(&self.state, &label, "signal-early", None);
-                            } else {
-                                let mut timeout_task = PaintGateRevealTask::new(
-                                    self.state.clone(),
-                                    label,
-                                    "timeout",
-                                    Some(epoch),
-                                );
-                                post_delayed_task(
-                                    ThreadId::UI,
-                                    Some(&mut timeout_task),
-                                    PAINT_GATE_SAFETY_TIMEOUT_MS,
-                                );
-                            }
-                        }
-                        #[cfg(target_os = "linux")]
-                        if !gated {
-                            window.show();
-                            if let Some(ref mut b) = browser_cloned {
-                                if let Some(host) = b.host() {
-                                    host.set_focus(1);
-                                }
-                            }
-                        }
-                        #[cfg(not(target_os = "linux"))]
-                        {
-                            window.show();
-                            if let Some(ref mut b) = browser_cloned {
-                                if let Some(host) = b.host() {
-                                    host.set_focus(1);
-                                }
-                            }
-                        }
+                        // an unknown label). Shared with ShowWindowRetryTask's
+                        // retry path via reveal_top_level_window so both
+                        // respect the same gating.
+                        reveal_top_level_window(
+                            &self.state,
+                            browser_label.as_deref(),
+                            &window,
+                            browser_cloned.as_mut(),
+                        );
                     }
                 }
             }

--- a/docs/retro/RETRO_MAIN_WINDOW_SHOW_SILENT_NOOP_2026_08_13.md
+++ b/docs/retro/RETRO_MAIN_WINDOW_SHOW_SILENT_NOOP_2026_08_13.md
@@ -1,0 +1,110 @@
+# Retro: main window's `on_load_end` show() silently no-ops, leaving a blank/grey window
+
+**Date:** 2026-08-13
+**Severity:** High when it hits (app appears completely broken — blank grey
+window, no error anywhere) but intermittent, not deterministic.
+
+## What happened
+
+Launching `task dev` on a shared multi-agent dev machine repeatedly (not
+every time) produced a window that rendered as a totally blank grey
+rectangle. Confirmed via `agentmux-host-*.log`:
+
+- The only window-creation event ever logged was `PoolWindowAdded { label:
+  "window-pool-<uuid>" }` — never `WindowOpened` for `"main"`.
+- `mem_attribution` heartbeats showed `panes_mb="0"` indefinitely.
+- The frontend logged `[initApp] pool mode — deferring init until
+  pool:promote or pool:new-window` (`frontend/app/init/pool.ts`) and sat
+  there forever — no promote ever arrived, because nothing was supposed to
+  promote a startup pool window; those exist purely as a pre-warmed reserve
+  for future tab tear-off (`agentmux-cef/src/commands/window_pool.rs`'s
+  module doc).
+- Reproduced independently on an **unrelated `dev:main` instance that had
+  been running on the same machine for 4+ hours** with the identical stuck
+  state — ruling out anything specific to one particular launch/session.
+
+## Root cause
+
+`agentmux-cef/src/client/navigation.rs`'s `on_load_end` handler is
+responsible for calling `window.show()` on the top-level (non-pool) window
+once its page finishes loading:
+
+```rust
+if !is_pool_window {
+    if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {
+        if let Some(window) = bv.window() {
+            if window.is_visible() == 0 {
+                window.show();
+                ...
+            }
+        }
+    }
+}
+```
+
+Both `browser_view_get_for_browser(...)` and `bv.window()` can return `None`
+— confirmed from the log: the main window's page genuinely loaded fine
+(`Injected IPC port ... window_transparent=0` — main's URL never carries a
+`windowLabel` param, unlike pool/floating windows, so that's main's
+signature) and the frontend painted (`[startup-bench] frontend-painted`), but
+the native HWND was never shown. When either `Option` resolves to `None` at
+this exact moment, the old code **silently did nothing** — no log line, no
+retry, no fallback. The window then stays hidden forever with zero
+diagnostic trace, and whatever OTHER window happens to be on-screen (a pool
+window, if its off-screen parking at `(-32000,-32000)` doesn't hold on that
+particular session/monitor layout) is what the user actually sees.
+
+This is the same class of CEF Views timing quirk already diagnosed and
+worked around **on the pool-window path specifically**:
+`window_pool.rs`'s `POOL_HWND_CACHE` was built after
+`SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md` found that
+`BrowserHost::window_handle()` returns null after the page loads even though
+the underlying Win32 window is alive — the pool path caches the HWND at an
+earlier, reliable point and falls back to it. The main/top-level window path
+never got the equivalent treatment.
+
+## Why this wasn't caught earlier
+
+- It's intermittent — most `task dev` launches presumably work fine, so this
+  only surfaces under specific timing (this dev machine runs many concurrent
+  agent processes and CEF instances, which is exactly the kind of load that
+  makes rare timing windows land).
+- The failure is **completely silent**. Nothing in the logs at any level
+  (`ERROR`, `WARN`, or otherwise) indicated the show() call was skipped —
+  the only symptom was the visible window being the wrong one (a stray pool
+  window) with no link back to the real cause.
+- This directly explains a standing gap noted on PR #2525
+  (`fix(menu): submenu positioning flash...`): the author flagged that
+  manual `task dev` verification "didn't yield a distinguishable
+  build/process to verify against" on this same shared machine and asked for
+  a follow-up manual pass that never happened. This bug is a strong
+  candidate for *why* — anyone hitting it would see an apparently-broken
+  blank window with no error to investigate, and reasonably give up on
+  manual verification rather than debug the launcher itself.
+
+## Fix
+
+Converted the silent no-op into a logged, bounded retry
+(`navigation.rs`): if `browser_view_get_for_browser`/`bv.window()` aren't
+resolvable at `on_load_end`, log a `WARN` and reschedule the same check on
+the CEF UI thread every 50ms, up to 10 times (~500ms total). If it still
+hasn't resolved after all retries, log an `ERROR` with enough context to
+actually diagnose a next occurrence (label, retry count) — previously there
+was nothing to look at all. `ShowWindowRetryTask` mirrors the existing
+`PaintGateRevealTask`/`FirstPaintSignalTask` retry pattern already used in
+this same file for Linux's paint-gating.
+
+Not fully root-caused: *why* `browser_view_get_for_browser`/`bv.window()`
+return `None` at this point isn't pinned down (same as the pool-window
+analogue, which also ships a workaround rather than a root fix). The retry
+is a pragmatic mitigation matching the precedent already set by the
+pool-window code, not a guarantee it can never recur — if `ERROR`-level logs
+from `ShowWindowRetryTask` start showing up in the wild, that's the signal
+to dig further into *why* CEF Views loses the reference, rather than just
+raising the retry budget.
+
+## Verification
+
+Manual `task dev` verification is exactly what this bug was blocking, so
+verifying the fix itself needs a live run — tracked as a follow-up to this
+retro rather than closed out here.

--- a/frontend/util/cef-api.test.ts
+++ b/frontend/util/cef-api.test.ts
@@ -129,8 +129,14 @@ describe("showJsContextMenu — submenu placement", () => {
             expect(sub.style.display).toBe("");
             expect(sub.style.visibility).toBe("hidden");
 
-            // Let the in-flight computeMenuPosition promise resolve.
-            await vi.advanceTimersByTimeAsync(0);
+            // computeMenuPosition itself is deferred one requestAnimationFrame
+            // (avoids measuring mid-reflow) before the in-flight promise even
+            // starts, so flush the frame first, then let the promise resolve.
+            // vitest 3.2 has no advanceTimersToNextFrameAsync — a plain
+            // time-based advance past a frame (~16ms) flushes both the
+            // requestAnimationFrame callback and the computeMenuPosition
+            // promise chained after it.
+            await vi.advanceTimersByTimeAsync(20);
             expect(sub.style.visibility).toBe("");
             expect(sub.style.position).toBe("fixed");
             expect(sub.style.left).toMatch(/^-?\d+px$/);
@@ -169,8 +175,16 @@ describe("showJsContextMenu — submenu placement", () => {
             // while computeMenuPosition's promise is still in flight.
             sub.style.display = "none";
 
-            // Let the in-flight computeMenuPosition promise settle.
-            await vi.advanceTimersByTimeAsync(0);
+            // Flush the requestAnimationFrame computeMenuPosition is deferred
+            // behind, then let the in-flight promise settle. The rAF callback
+            // itself re-checks display/isConnected too (guards the "closed
+            // during the frame wait, before computeMenuPosition was even
+            // called" case), so this also exercises that guard.
+            // vitest 3.2 has no advanceTimersToNextFrameAsync — a plain
+            // time-based advance past a frame (~16ms) flushes both the
+            // requestAnimationFrame callback and the computeMenuPosition
+            // promise chained after it.
+            await vi.advanceTimersByTimeAsync(20);
 
             // The guard (`sub.style.display === "none"` check in the `.then()`)
             // must not re-reveal a submenu whose hover already ended.

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -271,22 +271,58 @@ export function showJsContextMenu(
                     onOpen: () => {
                         sub.style.visibility = "hidden";
                         sub.style.display = "";
-                        void computeMenuPosition(
-                            {
-                                anchor: row.getBoundingClientRect(),
-                                placement: "right-start",
-                                avoidNativePanes: false,
-                            },
-                            sub,
-                        ).then((pos) => {
-                            // Hover may have left (or the whole menu closed)
-                            // before the async placement resolved.
+                        // Deferred one rAF (mirrors flyoutmenu.tsx's SubMenu /
+                        // registerSubMenu) so the display:none→"" reflow has
+                        // settled before anything gets measured.
+                        requestAnimationFrame(() => {
                             if (!sub.isConnected || sub.style.display === "none") return;
-                            applyMenuPosition(sub, pos);
-                            sub.style.visibility = "";
-                            assertMenuInPaintableArea(sub, "context-submenu");
-                        }).catch(() => {
-                            if (sub.isConnected) sub.style.visibility = "";
+                            // The actual bug (root-caused live 2026-08-13,
+                            // reproduced deterministically regardless of anchor
+                            // position — left:121px, top:-393px every time,
+                            // ruling out a mere layout-timing race): `sub`
+                            // starts `position:absolute` (inherited from the
+                            // `.menu` class) as a deliberate row-relative
+                            // fallback for the .catch() below, but
+                            // computeMenuPosition computes coordinates for
+                            // `strategy:"fixed"`. floating-ui resolves the
+                            // floating element's offset parent from its
+                            // CURRENT position at measurement time, so calling
+                            // it while `sub` is still `position:absolute`
+                            // (nested inside `row`, which has
+                            // `position:relative`) resolves coordinates
+                            // against the wrong containing block entirely.
+                            // FlyoutMenu's Solid sibling never hits this
+                            // because its placeholder style is already
+                            // `position:fixed;left:0px;top:0px` before it ever
+                            // calls computeMenuPosition — match that here:
+                            // switch to fixed strategy BEFORE measuring, and
+                            // restore the absolute row-relative fallback
+                            // explicitly if placement itself fails.
+                            sub.style.position = "fixed";
+                            void computeMenuPosition(
+                                {
+                                    anchor: row.getBoundingClientRect(),
+                                    placement: "right-start",
+                                    avoidNativePanes: false,
+                                },
+                                sub,
+                            ).then((pos) => {
+                                // Hover may have left (or the whole menu closed)
+                                // before the async placement resolved.
+                                if (!sub.isConnected || sub.style.display === "none") return;
+                                applyMenuPosition(sub, pos);
+                                sub.style.visibility = "";
+                                assertMenuInPaintableArea(sub, "context-submenu");
+                            }).catch(() => {
+                                if (!sub.isConnected) return;
+                                // Restore the row-relative absolute fallback —
+                                // position:fixed with left:100% would otherwise
+                                // pin it just off the right edge of the screen.
+                                sub.style.position = "absolute";
+                                sub.style.left = "100%";
+                                sub.style.top = "0";
+                                sub.style.visibility = "";
+                            });
                         });
                     },
                     onClose: () => {


### PR DESCRIPTION
## Summary

Two bugs found while trying to live-verify PR #2525
("fix(menu): submenu positioning flash + safe-triangle hover close timing")
at the operator's request — that PR's own test plan flagged that manual
`task dev` verification was never completed, and it turns out there was
a real gap.

**1. `cef-api.ts`'s context-submenu still renders off the paintable area**
("Replace With...", "Pane Color", etc.) — e.g. `top:-393px` on a
1176px-tall window, despite #2525's `visibility:hidden`-until-positioned
guard.

Root cause: `sub` starts `position:absolute` (a deliberate row-relative
fallback for when `computeMenuPosition` rejects — see the comment it's
already carrying), but `computeMenuPosition` computes coordinates for
`strategy:"fixed"`. floating-ui resolves the floating element's offset
parent from its *current* position at measurement time, so measuring
while `sub` is still `position:absolute` (nested inside `row`, itself
`position:relative`) resolves against the wrong containing block
entirely. This reproduced **deterministically regardless of anchor
position** — the exact same wrong constant every time — which is what
ruled out a mere layout-timing race (my first, incorrect theory).

`flyoutmenu.tsx`'s Solid `SubMenu` sibling never hits this because its
placeholder style is already `position:fixed;left:0px;top:0px` *before*
it ever calls `computeMenuPosition`. Fix: switch `sub` to
`position:fixed` before measuring, and restore the absolute row-relative
fallback explicitly if placement itself fails (so a rejection doesn't
regress to `position:fixed; left:100%`, which would pin it off the right
edge of the screen). Also deferred measurement one `requestAnimationFrame`
(matching `flyoutmenu.tsx`'s own `registerSubMenu`) so the
`display:none`→`""` reflow settles first.

**2. `agentmux-cef`'s main window intermittently never appears** — stuck
showing a stray pool window instead (pool windows are meant to stay
invisible off-screen until explicitly promoted for tab tear-off).

`on_load_end`'s `window.show()` call sits inside two nested
`if let Some(...)` guards (`browser_view_get_for_browser`, `bv.window()`)
that silently no-op if either resolves to `None` — no log, no retry, no
diagnostic trace at all. This is the same CEF Views timing quirk the
pool-window path already diagnosed and worked around
(`POOL_HWND_CACHE`, `SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md`), but the
workaround was never ported to the main-window path. Converted the
silent no-op into a logged, bounded retry (`ShowWindowRetryTask`, mirrors
the existing Linux paint-gate retry pattern already in the same file).
Full writeup: `docs/retro/RETRO_MAIN_WINDOW_SHOW_SILENT_NOOP_2026_08_13.md`.

Both confirmed live via `task dev` on the affected dev machine, including
the operator directly reproducing and then confirming the fix.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `cargo check -p agentmux-cef` — clean, no new warnings
- [x] Live `task dev` verification — reproduced both bugs, applied fixes,
      reproduced again on a fresh instance to confirm each fix, operator
      confirmed the submenu positioning is fixed
- [ ] Full `npm test` suite — not run this session (frontend change is in
      a `.ts` utility file with no existing unit tests around this exact
      code path; flagging rather than claiming coverage)

<!-- agentmux:agent_id=agenty -->