### PR TITLE
fix(tabs): desaturate tab color picker, keep agent pane borders vivid

### DIFF
--- a/.changesets/1786665927-fix-tabs-desaturate-tab-color-picker-keep-agent-pane-borders-zjq2.md
+++ b/.changesets/1786665927-fix-tabs-desaturate-tab-color-picker-keep-agent-pane-borders-zjq2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): desaturate tab color picker, keep agent pane borders vivid

--- a/agentmux-srv/src/backend/agent_color.rs
+++ b/agentmux-srv/src/backend/agent_color.rs
@@ -11,10 +11,13 @@
 //! existing pane-frame rendering displays it with no frontend changes.
 //! See `docs/specs/SPEC_AGENT_COLOR_2026_08_08.md`.
 
-/// The 14-hue palette — hex values mirror the frontend's `TAB_COLORS`
-/// (`frontend/app/tab/tab.tsx`). Duplicated deliberately: assigned colors
-/// are STORED, not derived, so palette drift between the two lists cannot
-/// recolor existing agents.
+/// The 14-hue palette — hex values mirror the frontend's
+/// `AGENT_COLOR_PALETTE` (`frontend/app/view/agent/agent-color.ts`).
+/// Duplicated deliberately: assigned colors are STORED, not derived, so
+/// palette drift between the two lists cannot recolor existing agents.
+/// This is a distinct, deliberately-vivid array from the frontend's tab
+/// strip colors (`frontend/app/tab/tab.tsx`'s `TAB_COLORS`) — see
+/// docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md.
 pub const AGENT_COLOR_PALETTE: [&str; 14] = [
     "#ef4444", // Red
     "#f97316", // Orange

--- a/docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md
+++ b/docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md
@@ -1,8 +1,17 @@
 # Spec: Desaturate tab colors, keep agent pane border colors as-is
 
 **Date:** 2026-08-13
-**Status:** Proposed
-**Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tab.scss`
+**Status:** Implemented (see revision note below)
+**Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tabbar.tsx`, `frontend/app/view/agent/agent-color.ts`, `agentmux-srv/src/backend/agent_color.rs` (doc comment only)
+
+**Revision (same day):** the first implementation used a fully muted
+`S=45%/L=32%` palette (§3 table below). User feedback: "a little too
+desaturated" — go halfway between the original vivid hues and that muted
+set. The shipped values are the per-hue average of the original and muted
+HSL (S and L each averaged independently, hue unchanged), with lightness
+nudged down slightly on 7 of the 14 colors (Orange/Amber/Yellow/Lime/
+Green/Teal/Cyan) where the raw average dropped below WCAG AA. See the
+"Shipped (halfway)" column in §3.
 
 ## Problem
 
@@ -57,22 +66,22 @@ unchanged.
    desaturate-and-darken approach used for tab/label chips in tools like
    Linear and GitHub issue labels).
 
-   | Name    | Current (vivid) | Proposed (muted) | Contrast vs white text |
-   |---------|------------------|-------------------|------------------------|
-   | Red     | `#ef4444`        | `#762d2d`         | 9.61:1 |
-   | Orange  | `#f97316`        | `#764b2d`         | 7.45:1 |
-   | Amber   | `#f59e0b`        | `#765b2d`         | 6.35:1 |
-   | Yellow  | `#eab308`        | `#76642d`         | 5.75:1 |
-   | Lime    | `#84cc16`        | `#59762d`         | 5.16:1 |
-   | Green   | `#22c55e`        | `#2d7648`         | 5.51:1 |
-   | Teal    | `#14b8a6`        | `#2d766e`         | 5.32:1 |
-   | Cyan    | `#06b6d4`        | `#2d6c76`         | 5.99:1 |
-   | Blue    | `#3b82f6`        | `#2d4976`         | 9.05:1 |
-   | Indigo  | `#6366f1`        | `#2d2e76`         | 11.85:1 |
-   | Violet  | `#8b5cf6`        | `#432d76`         | 11.19:1 |
-   | Fuchsia | `#d946ef`        | `#6d2d76`         | 9.20:1 |
-   | Pink    | `#ec4899`        | `#762d51`         | 9.26:1 |
-   | Rose    | `#f43f5e`        | `#762d39`         | 9.51:1 |
+   | Name    | Current (vivid) | Muted (first pass, not shipped) | Shipped (halfway) | Contrast vs white text |
+   |---------|------------------|----------------------------------|---------------------|------------------------|
+   | Red     | `#ef4444`        | `#762d2d`                        | `#c22a2a`           | 5.77:1 |
+   | Orange  | `#f97316`        | `#764b2d`                        | `#b75e20`           | 4.51:1 |
+   | Amber   | `#f59e0b`        | `#765b2d`                        | `#9d6d1d`           | 4.51:1 |
+   | Yellow  | `#eab308`        | `#76642d`                        | `#90731a`           | 4.52:1 |
+   | Lime    | `#84cc16`        | `#59762d`                        | `#5a821e`           | 4.52:1 |
+   | Green   | `#22c55e`        | `#2d7648`                        | `#248749`           | 4.52:1 |
+   | Teal    | `#14b8a6`        | `#2d766e`                        | `#1e8479`           | 4.51:1 |
+   | Cyan    | `#06b6d4`        | `#2d6c76`                        | `#1a8294`           | 4.51:1 |
+   | Blue    | `#3b82f6`        | `#2d4976`                        | `#2562c5`           | 5.79:1 |
+   | Indigo  | `#6366f1`        | `#2d2e76`                        | `#2d30cf`           | 8.61:1 |
+   | Violet  | `#8b5cf6`        | `#432d76`                        | `#5c29d2`           | 7.77:1 |
+   | Fuchsia | `#d946ef`        | `#6d2d76`                        | `#ae2ac2`           | 5.36:1 |
+   | Pink    | `#ec4899`        | `#762d51`                        | `#c02b75`           | 5.45:1 |
+   | Rose    | `#f43f5e`        | `#762d39`                        | `#c42742`           | 5.64:1 |
 
    All 14 exceed WCAG AA (4.5:1) for normal text, so no change needed to
    the tab-label text color or the `!important` white override at

--- a/docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md
+++ b/docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md
@@ -46,10 +46,15 @@ unchanged.
 ## Proposed change
 
 1. Add a new `TAB_COLORS` replacement (muted) in `tab.tsx`, keeping the same
-   14 names/order so existing per-tab `--tab-color` values (stored as hex
-   strings, e.g. in saved layouts) still resolve to a color — old saved tab
-   colors will just render muted after this change, no migration needed
-   since the value itself is a plain hex string, not an index.
+   14 names/order for consistency with the picker UI. Note this does
+   **not** migrate existing tabs: `tab:color` stores the literal hex
+   string, not a name/index into `TAB_COLORS`, and there is no migration
+   logic anywhere in the codebase. A tab whose color was set before this
+   change keeps its old vivid hex indefinitely — it renders muted only if
+   the user re-picks a color from the (now-muted) swatch panel. Only newly
+   created tabs (`randomNewTabColor()` in `tab-actions.ts`) and the
+   startup-tab default (`tabbar.tsx`) pick up the new values immediately,
+   since those read `TAB_COLORS` at call time rather than a stored hex.
 
 2. Rename the current vivid array (don't delete it) to
    `AGENT_BORDER_COLORS` and move it to `frontend/app/view/agent/agent-color.ts`

--- a/docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md
+++ b/docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md
@@ -1,0 +1,108 @@
+# Spec: Desaturate tab colors, keep agent pane border colors as-is
+
+**Date:** 2026-08-13
+**Status:** Proposed
+**Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tab.scss`
+
+## Problem
+
+The tab color picker (right-click a tab → color) assigns colors from the
+`TAB_COLORS` array in `frontend/app/tab/tab.tsx:20-35` — 14 stock
+Tailwind-500 hues, ~26° apart on the hue wheel, applied as a solid
+`background: var(--tab-color)` fill on the tab (`tab.scss:141-159`). At
+full Tailwind-500 saturation (81-95%) these read as neon/fluorescent,
+which looks out of place in a tab strip meant to sit quietly in the
+periphery.
+
+The border colors around agent panes are **not** in scope — they should
+stay exactly as they are.
+
+## Why this isn't a one-line palette edit
+
+`TAB_COLORS` is not tab-exclusive. `frontend/app/view/agent/agent-color.ts:18-20`
+reuses the same array as `AGENT_COLOR_PALETTE`, which auto-assigns agent
+pane **border** colors (`frame:bordercolor` / `frame:activebordercolor` in
+`frontend/app/block/blockframe.tsx:704-750`, dimmed via `dimAgentColor` for
+unfocused panes). A separate 12-hue vivid palette
+(`hueToActiveBorder(hue) = hsl(hue, 65%, 52%)` in
+`frontend/app/block/pane-color-menu.ts`) also drives pane border color when
+a user picks a custom hue.
+
+Editing `TAB_COLORS` in place would silently desaturate agent pane borders
+too — the exact colors the user wants to keep vivid. So this spec **forks**
+the palette: a new muted array feeds the tab color picker; `agent-color.ts`
+and `pane-color-menu.ts` keep sourcing from the original vivid values,
+unchanged.
+
+## Proposed change
+
+1. Add a new `TAB_COLORS` replacement (muted) in `tab.tsx`, keeping the same
+   14 names/order so existing per-tab `--tab-color` values (stored as hex
+   strings, e.g. in saved layouts) still resolve to a color — old saved tab
+   colors will just render muted after this change, no migration needed
+   since the value itself is a plain hex string, not an index.
+
+2. Rename the current vivid array (don't delete it) to
+   `AGENT_BORDER_COLORS` and move it to `frontend/app/view/agent/agent-color.ts`
+   (or keep it in `tab.tsx` under a new name and re-export) so
+   `AGENT_COLOR_PALETTE` keeps pointing at the original vivid hexes with no
+   behavior change. `pane-color-menu.ts`'s `hueToActiveBorder` formula is
+   untouched — it doesn't reference `TAB_COLORS`.
+
+3. Muted palette values — same hue per color (so "Blue" still reads as
+   blue), normalized to HSL `S=45%, L=32%`. This keeps ≥4.5:1 contrast
+   against the existing white tab-label text (`rgba(255,255,255,0.95)` in
+   `tab.scss`) for every color — verified below — while reading as a calm,
+   professional "jewel tone" set instead of neon (this is the same
+   desaturate-and-darken approach used for tab/label chips in tools like
+   Linear and GitHub issue labels).
+
+   | Name    | Current (vivid) | Proposed (muted) | Contrast vs white text |
+   |---------|------------------|-------------------|------------------------|
+   | Red     | `#ef4444`        | `#762d2d`         | 9.61:1 |
+   | Orange  | `#f97316`        | `#764b2d`         | 7.45:1 |
+   | Amber   | `#f59e0b`        | `#765b2d`         | 6.35:1 |
+   | Yellow  | `#eab308`        | `#76642d`         | 5.75:1 |
+   | Lime    | `#84cc16`        | `#59762d`         | 5.16:1 |
+   | Green   | `#22c55e`        | `#2d7648`         | 5.51:1 |
+   | Teal    | `#14b8a6`        | `#2d766e`         | 5.32:1 |
+   | Cyan    | `#06b6d4`        | `#2d6c76`         | 5.99:1 |
+   | Blue    | `#3b82f6`        | `#2d4976`         | 9.05:1 |
+   | Indigo  | `#6366f1`        | `#2d2e76`         | 11.85:1 |
+   | Violet  | `#8b5cf6`        | `#432d76`         | 11.19:1 |
+   | Fuchsia | `#d946ef`        | `#6d2d76`         | 9.20:1 |
+   | Pink    | `#ec4899`        | `#762d51`         | 9.26:1 |
+   | Rose    | `#f43f5e`        | `#762d39`         | 9.51:1 |
+
+   All 14 exceed WCAG AA (4.5:1) for normal text, so no change needed to
+   the tab-label text color or the `!important` white override at
+   `tab.scss:145-150`.
+
+4. Hover/active brightening in `tab.scss:219-241` (`filter:
+   brightness(1.1-1.18)`) applies unchanged — verify visually that the
+   brightened state doesn't overshoot back toward neon; if it does, reduce
+   the hover brightness multiplier for `.tab-colored` specifically rather
+   than touching the base palette further.
+
+## Out of scope (explicitly unchanged)
+
+- `--accent-color` and all theme tokens in `theme.scss` / `themes/*.scss`
+  (active-tab top stripe, focus rings, buttons, etc.)
+- `--border-color` and the translucent per-theme hairline borders (tab
+  separators, modal borders, pane-tab-strip borders)
+- `AGENT_COLOR_PALETTE` (agent pane border auto-assignment) and
+  `hueToActiveBorder`/`hueToBorder` (custom pane border hue picker) —
+  these stay on the original vivid values
+
+## Open questions
+
+- Should the muted palette have separate light-theme values? `TAB_COLORS`
+  today is not theme-aware (same hex regardless of `data-theme`/polarity).
+  The proposed `L=32%` values are tuned for white label text and read fine
+  on both dark and light tab-strip backgrounds since they're solid fills,
+  not translucent — but this should get a quick visual check in the 4
+  light themes (`light`, `solarized-light`, `gruvbox-light`,
+  `catppuccin-latte`) before shipping.
+- The 12-hue custom picker in `pane-color-menu.ts` is out of scope here
+  since it drives pane borders, not tabs — confirm no UI lets a user apply
+  that same 12-hue vivid picker to a tab background elsewhere in the app.

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -17,26 +17,29 @@ import { measureTabWidth } from "./tab-measure";
 import "./tab.scss";
 
 // 14 colors — same hues as the agent-pane border palette
-// (agent-color.ts's AGENT_COLOR_PALETTE), desaturated to HSL S=45%/L=32%
-// for a muted, non-fluorescent tab strip. Deliberately a separate array,
-// not derived from the agent border palette — see
-// docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md for why the two
-// must not share one source (editing this must never affect pane borders).
+// (agent-color.ts's AGENT_COLOR_PALETTE), desaturated to roughly halfway
+// between the original Tailwind-500 vivid hues and a fully muted
+// (S=45%/L=32%) set — per-hue lightness nudged down slightly where needed
+// to keep WCAG AA (>=4.5:1) contrast against the existing white tab-label
+// text. Deliberately a separate array, not derived from the agent border
+// palette — see docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md for
+// why the two must not share one source (editing this must never affect
+// pane borders).
 export const TAB_COLORS: { name: string; hex: string }[] = [
-    { name: "Red",     hex: "#762d2d" },
-    { name: "Orange",  hex: "#764b2d" },
-    { name: "Amber",   hex: "#765b2d" },
-    { name: "Yellow",  hex: "#76642d" },
-    { name: "Lime",    hex: "#59762d" },
-    { name: "Green",   hex: "#2d7648" },
-    { name: "Teal",    hex: "#2d766e" },
-    { name: "Cyan",    hex: "#2d6c76" },
-    { name: "Blue",    hex: "#2d4976" },
-    { name: "Indigo",  hex: "#2d2e76" },
-    { name: "Violet",  hex: "#432d76" },
-    { name: "Fuchsia", hex: "#6d2d76" },
-    { name: "Pink",    hex: "#762d51" },
-    { name: "Rose",    hex: "#762d39" },
+    { name: "Red",     hex: "#c22a2a" },
+    { name: "Orange",  hex: "#b75e20" },
+    { name: "Amber",   hex: "#9d6d1d" },
+    { name: "Yellow",  hex: "#90731a" },
+    { name: "Lime",    hex: "#5a821e" },
+    { name: "Green",   hex: "#248749" },
+    { name: "Teal",    hex: "#1e8479" },
+    { name: "Cyan",    hex: "#1a8294" },
+    { name: "Blue",    hex: "#2562c5" },
+    { name: "Indigo",  hex: "#2d30cf" },
+    { name: "Violet",  hex: "#5c29d2" },
+    { name: "Fuchsia", hex: "#ae2ac2" },
+    { name: "Pink",    hex: "#c02b75" },
+    { name: "Rose",    hex: "#c42742" },
 ];
 
 interface TabContextPanelProps {

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -16,22 +16,27 @@ import { makeORef, useWaveObjectValue } from "../store/wos";
 import { measureTabWidth } from "./tab-measure";
 import "./tab.scss";
 
-// 14 colors — 10 original hues + 4 new fills at perceptual midpoints
+// 14 colors — same hues as the agent-pane border palette
+// (agent-color.ts's AGENT_COLOR_PALETTE), desaturated to HSL S=45%/L=32%
+// for a muted, non-fluorescent tab strip. Deliberately a separate array,
+// not derived from the agent border palette — see
+// docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md for why the two
+// must not share one source (editing this must never affect pane borders).
 export const TAB_COLORS: { name: string; hex: string }[] = [
-    { name: "Red",     hex: "#ef4444" },
-    { name: "Orange",  hex: "#f97316" },
-    { name: "Amber",   hex: "#f59e0b" },
-    { name: "Yellow",  hex: "#eab308" },
-    { name: "Lime",    hex: "#84cc16" },
-    { name: "Green",   hex: "#22c55e" },
-    { name: "Teal",    hex: "#14b8a6" },
-    { name: "Cyan",    hex: "#06b6d4" },
-    { name: "Blue",    hex: "#3b82f6" },
-    { name: "Indigo",  hex: "#6366f1" },
-    { name: "Violet",  hex: "#8b5cf6" },
-    { name: "Fuchsia", hex: "#d946ef" },
-    { name: "Pink",    hex: "#ec4899" },
-    { name: "Rose",    hex: "#f43f5e" },
+    { name: "Red",     hex: "#762d2d" },
+    { name: "Orange",  hex: "#764b2d" },
+    { name: "Amber",   hex: "#765b2d" },
+    { name: "Yellow",  hex: "#76642d" },
+    { name: "Lime",    hex: "#59762d" },
+    { name: "Green",   hex: "#2d7648" },
+    { name: "Teal",    hex: "#2d766e" },
+    { name: "Cyan",    hex: "#2d6c76" },
+    { name: "Blue",    hex: "#2d4976" },
+    { name: "Indigo",  hex: "#2d2e76" },
+    { name: "Violet",  hex: "#432d76" },
+    { name: "Fuchsia", hex: "#6d2d76" },
+    { name: "Pink",    hex: "#762d51" },
+    { name: "Rose",    hex: "#762d39" },
 ];
 
 interface TabContextPanelProps {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -113,13 +113,13 @@ function TabBar(props: TabBarProps): JSX.Element {
         // tab. Without this guard, a user who clears the color on a single-
         // tab workspace would have it silently restored on the next mount.
         if (tab.meta?.["tab:color-initialized"]) return;
-        // #3b82f6 is the "Blue" entry in TAB_COLORS — same as the color
+        // #2d4976 is the "Blue" entry in TAB_COLORS — same as the color
         // picker's blue swatch, so stays consistent with user-chosen blue.
         fireAndForget(async () => {
             try {
                 await ObjectService.UpdateObjectMeta(
                     makeORef("tab", firstId),
-                    { "tab:color": "#3b82f6", "tab:color-initialized": true } as MetaType,
+                    { "tab:color": "#2d4976", "tab:color-initialized": true } as MetaType,
                 );
             } catch (e) {
                 console.error("[tabbar] startup-tab color apply failed:", e);

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -113,13 +113,13 @@ function TabBar(props: TabBarProps): JSX.Element {
         // tab. Without this guard, a user who clears the color on a single-
         // tab workspace would have it silently restored on the next mount.
         if (tab.meta?.["tab:color-initialized"]) return;
-        // #2d4976 is the "Blue" entry in TAB_COLORS — same as the color
+        // #2562c5 is the "Blue" entry in TAB_COLORS — same as the color
         // picker's blue swatch, so stays consistent with user-chosen blue.
         fireAndForget(async () => {
             try {
                 await ObjectService.UpdateObjectMeta(
                     makeORef("tab", firstId),
-                    { "tab:color": "#2d4976", "tab:color-initialized": true } as MetaType,
+                    { "tab:color": "#2562c5", "tab:color-initialized": true } as MetaType,
                 );
             } catch (e) {
                 console.error("[tabbar] startup-tab color apply failed:", e);

--- a/frontend/app/view/agent/agent-color.test.ts
+++ b/frontend/app/view/agent/agent-color.test.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { TAB_COLORS } from "@/app/tab/tab";
-import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
+import { AGENT_COLOR_PALETTE, dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
 
 describe("pickAgentColor", () => {
     it("is deterministic", () => {
@@ -11,7 +10,7 @@ describe("pickAgentColor", () => {
     });
 
     it("returns a palette member", () => {
-        const palette = new Set(TAB_COLORS.map((c) => c.hex));
+        const palette = new Set(AGENT_COLOR_PALETTE);
         for (const id of ["a", "b", "c", "0d5b45f1-9b2c-4a7e-8f3d-1234567890ab", ""]) {
             expect(palette.has(pickAgentColor(id))).toBe(true);
         }
@@ -25,8 +24,8 @@ describe("pickAgentColor", () => {
 
 describe("isValidAgentColor", () => {
     it("accepts every palette color", () => {
-        for (const c of TAB_COLORS) {
-            expect(isValidAgentColor(c.hex)).toBe(true);
+        for (const hex of AGENT_COLOR_PALETTE) {
+            expect(isValidAgentColor(hex)).toBe(true);
         }
     });
 
@@ -45,10 +44,10 @@ describe("dimAgentColor", () => {
     it("scales channels down and stays valid", () => {
         expect(dimAgentColor("#ffffff")).toBe("#8c8c8c");
         expect(dimAgentColor("#000000")).toBe("#000000");
-        for (const c of TAB_COLORS) {
-            const dimmed = dimAgentColor(c.hex);
+        for (const hex of AGENT_COLOR_PALETTE) {
+            const dimmed = dimAgentColor(hex);
             expect(isValidAgentColor(dimmed)).toBe(true);
-            expect(dimmed).not.toBe(c.hex);
+            expect(dimmed).not.toBe(hex);
         }
     });
 

--- a/frontend/app/view/agent/agent-color.ts
+++ b/frontend/app/view/agent/agent-color.ts
@@ -15,9 +15,27 @@
 // (either path) just reads that stored value back. See
 // docs/specs/SPEC_AGENT_COLOR_2026_08_08.md.
 
-import { TAB_COLORS } from "@/app/tab/tab";
-
-const AGENT_COLOR_PALETTE: string[] = TAB_COLORS.map((c) => c.hex);
+// Deliberately NOT derived from tab.tsx's TAB_COLORS — that array was
+// desaturated for the tab strip (docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md)
+// and agent pane borders must keep the original vivid hues. Mirrors
+// agentmux-srv/src/backend/agent_color.rs::AGENT_COLOR_PALETTE (same 14
+// hexes, same order — keep both in sync if this list changes).
+export const AGENT_COLOR_PALETTE: string[] = [
+    "#ef4444", // Red
+    "#f97316", // Orange
+    "#f59e0b", // Amber
+    "#eab308", // Yellow
+    "#84cc16", // Lime
+    "#22c55e", // Green
+    "#14b8a6", // Teal
+    "#06b6d4", // Cyan
+    "#3b82f6", // Blue
+    "#6366f1", // Indigo
+    "#8b5cf6", // Violet
+    "#d946ef", // Fuchsia
+    "#ec4899", // Pink
+    "#f43f5e", // Rose
+];
 
 /** Deterministic FNV-1a hash of the agent id onto the palette — stable
  * across reloads/machines, no RNG needed. Mirrors


### PR DESCRIPTION
## Summary
- Tab color picker swatches were full-saturation Tailwind-500 hues (81-95% sat) — read as neon/fluorescent in the tab strip.
- New `TAB_COLORS` palette (`frontend/app/tab/tab.tsx`) sits halfway between the original vivid hues and a fully-muted set, per user feedback on the first pass — same hues, all still WCAG AA (>=4.5:1) against the existing white tab-label text.
- Agent pane border colors are explicitly **not** touched: `TAB_COLORS` was previously double-duty (also fed `AGENT_COLOR_PALETTE` for pane border auto-assignment), so this forks a separate hardcoded vivid array into `agent-color.ts`, matching the backend's independent `agent_color.rs` copy. Borders keep their original fluorescent colors.
- Startup-tab default blue (`tabbar.tsx`) updated to match the new Blue swatch.
- Spec: `docs/specs/SPEC_TAB_COLOR_DESATURATION_2026_08_13.md`.

## Test plan
- [x] `npx vitest run frontend/app/view/agent/agent-color.test.ts frontend/app/tab` — 46 passed
- [x] `npx tsc --noEmit` — clean
- [x] `cargo check -p agentmux-srv` — clean (doc-comment-only Rust change)
- [ ] Visual check in `task dev`: right-click a tab → color picker shows muted swatches; agent pane borders remain vivid

<!-- agentmux:agent_id=loap -->