### PR TITLE
feat(jekt): Ed25519 WAN signing for reagent's review notifications

### DIFF
--- a/.changesets/1786693071-feat-jekt-ed25519-wan-signing-for-reagent-s-review-notificat-ytrn.md
+++ b/.changesets/1786693071-feat-jekt-ed25519-wan-signing-for-reagent-s-review-notificat-ytrn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(jekt): Ed25519 WAN signing for reagent's review notifications

--- a/.changesets/1786693975-fix-jekt-correct-reagent-key-id-doc-comment-to-match-partial-fkjg.md
+++ b/.changesets/1786693975-fix-jekt-correct-reagent-key-id-doc-comment-to-match-partial-fkjg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(jekt): correct reagent_key_id doc comment to match partial-signature-is-unsigned behavior

--- a/.changesets/1786694823-feat-muxbus-verify-reagent-ed25519-signatures-on-the-http-ag-rb8g.md
+++ b/.changesets/1786694823-feat-muxbus-verify-reagent-ed25519-signatures-on-the-http-ag-rb8g.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxbus): verify reagent Ed25519 signatures on the HTTP /agentmux/reactive/inject path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ version = "0.55.6"
 dependencies = [
  "base64",
  "dirs",
+ "ed25519-dalek",
  "hmac",
  "serde",
  "serde_json",
@@ -678,6 +679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1274,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1313,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1410,6 +1460,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1569,6 +1643,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -3006,6 +3086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,6 +3667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,6 +4069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4074,6 +4182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -23,6 +23,12 @@ dirs = "5"
 hmac = "0.12"
 sha2 = "0.10"
 base64 = "0.22"
+# WAN-tier jekt sender signing (jekt_sign.rs's reagent_* functions) — verify
+# only, on the agentmux-srv side. Asymmetric (not HMAC like host-tier)
+# because the verifying population is every AgentMux instance on WAN, not a
+# single srv that minted its own key — see
+# docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §6.2 addendum.
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 
 # Windows page-file volume tracking (pagefile.rs), shared by agentmux-srv
 # and agentmux-cef — see docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md §4.

--- a/agentmux-common/src/jekt_sign.rs
+++ b/agentmux-common/src/jekt_sign.rs
@@ -21,6 +21,7 @@
 //! against a different target or reattributed to a different claimed sender.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
@@ -75,6 +76,72 @@ pub fn verify_jekt(
     let Ok(mut mac) = HmacSha256::new_from_slice(key) else { return false };
     mac.update(material.as_bytes());
     mac.verify_slice(&sig).is_ok()
+}
+
+// ---- WAN-tier sender signing (Ed25519) ----
+//
+// Distinct signing scheme from host-tier's HMAC above, and deliberately so:
+// host-tier's key is minted per-instance and never leaves the srv process
+// that owns it, so a symmetric secret shared only between "sign" and
+// "verify" on the very same machine is the right tool. A WAN-tier service
+// sender (e.g. the GitHub review-notification consumer, "reagent") is
+// verified by *every* AgentMux instance on the network, not just its own
+// account — an HMAC key distributed that widely is no longer meaningfully
+// secret. Asymmetric signing lets the private key stay in exactly one
+// place (agentmux-cloud's Secrets Manager) while every client ships only
+// the public key, openly. See
+// docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §6.2 addendum.
+//
+// Reuses the exact same `signed_material` construction as host-tier HMAC —
+// same replay/reattribution-resistance properties (msgid+source+target+ts
+// bound into what's signed), just a different signature algorithm over it.
+
+/// Pinned Ed25519 public keys for AgentMux's own WAN-tier service senders.
+/// Keyed by `key_id` (carried alongside the signature in the wire format)
+/// so a future key rotation can add a new entry without invalidating
+/// verification of messages already in flight when signed under the old
+/// key. The matching private key is never present in this repo — it lives
+/// only in agentmux-cloud's Secrets Manager, held by the signing service.
+///
+/// `reagent-v1-dev` is a placeholder minted during initial implementation
+/// (its private half was generated in a local shell for wiring/testing
+/// purposes and must be treated as already-exposed) — production
+/// deployment must generate a fresh keypair via a secure channel (not a
+/// transcript-visible shell command) and register the real public key here
+/// under a new `key_id` before the private key is ever loaded into
+/// Secrets Manager for live traffic.
+fn reagent_public_key(key_id: &str) -> Option<[u8; 32]> {
+    match key_id {
+        "reagent-v1-dev" => Some([
+            104, 98, 241, 120, 99, 50, 230, 185, 228, 117, 241, 110, 130, 85, 252, 75, 141, 152,
+            224, 92, 125, 154, 123, 40, 96, 149, 214, 172, 94, 120, 116, 200,
+        ]),
+        _ => None,
+    }
+}
+
+/// Verify a WAN-tier jekt's claimed `reagent_sig` against the pinned public
+/// key for `key_id`. Returns `false` (never panics) for an unknown
+/// `key_id`, malformed base64, a malformed/wrong-length signature, or a
+/// signature that simply doesn't verify — callers should treat all of
+/// these identically: "not verified," rendering `SIG=invalid` rather than
+/// `SIG=verified` in the marker (see `wrap_jekt_message`'s doc comment).
+pub fn verify_reagent_jekt(
+    key_id: &str,
+    msgid: &str,
+    source_agent: &str,
+    target_agent: &str,
+    ts_secs: i64,
+    message: &str,
+    sig_b64: &str,
+) -> bool {
+    let Some(pubkey_bytes) = reagent_public_key(key_id) else { return false };
+    let Ok(verifying_key) = VerifyingKey::from_bytes(&pubkey_bytes) else { return false };
+    let Ok(sig_bytes) = BASE64.decode(sig_b64) else { return false };
+    let Ok(sig_arr) = <[u8; 64]>::try_from(sig_bytes.as_slice()) else { return false };
+    let signature = Signature::from_bytes(&sig_arr);
+    let material = signed_material(msgid, source_agent, target_agent, ts_secs, message);
+    verifying_key.verify(material.as_bytes(), &signature).is_ok()
 }
 
 #[cfg(test)]
@@ -145,5 +212,148 @@ mod tests {
     #[test]
     fn empty_signature_fails_verification() {
         assert!(!verify_jekt(&key(), "msg-1", "agentx", "agenty", 1_000, "hello", ""));
+    }
+
+    // ---- verify_reagent_jekt (Ed25519) ----
+    //
+    // Fixture signature produced offline against the "reagent-v1-dev" pinned
+    // public key's matching private key, over signed_material("msg-1",
+    // "github-consumer", "agentx", 1000, "hello") — i.e. the exact material
+    // `signed_material()` above constructs for those arguments. Exercises the
+    // real pinned key path end to end rather than a separate test-only key.
+    const FIXTURE_SIG_B64: &str =
+        "QehidZjJa2jYLPIPYSsVxUlm86W5Fdbr9PV3P4HJyZwJ68/HZR9EaAL0MpcVtTuZJW2+MMGebc0RH9HITNJGCw==";
+
+    #[test]
+    fn a_correctly_signed_reagent_message_verifies() {
+        assert!(verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "hello",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_unknown_key_id_fails_verification() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v2-does-not-exist",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "hello",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_tampered_message_fails_verification() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "goodbye",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_wrong_target_fails_verification() {
+        // Same reattribution/replay resistance as host-tier HMAC — the
+        // signature is bound to target_agent, so it can't be replayed
+        // claiming delivery to a different agent.
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agenty",
+            1_000,
+            "hello",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_wrong_source_fails_verification() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "someone-else",
+            "agentx",
+            1_000,
+            "hello",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_wrong_timestamp_fails_verification() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_001,
+            "hello",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_wrong_msgid_fails_verification() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-2",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "hello",
+            FIXTURE_SIG_B64,
+        ));
+    }
+
+    #[test]
+    fn reagent_malformed_base64_signature_fails_verification_not_panics() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "hello",
+            "not-valid-base64!!",
+        ));
+    }
+
+    #[test]
+    fn reagent_wrong_length_signature_fails_verification_not_panics() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "hello",
+            "dG9vc2hvcnQ=", // "tooshort" base64 — decodes fine, wrong length
+        ));
+    }
+
+    #[test]
+    fn reagent_empty_signature_fails_verification() {
+        assert!(!verify_reagent_jekt(
+            "reagent-v1-dev",
+            "msg-1",
+            "github-consumer",
+            "agentx",
+            1_000,
+            "hello",
+            "",
+        ));
     }
 }

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -422,6 +422,7 @@ impl Handler {
             effective_tier,
             delivery_tier,
             req.sig_verified,
+            req.reagent_verified,
             &request_id,
             priority,
         );

--- a/agentmux-srv/src/backend/reactive/sanitize.rs
+++ b/agentmux-srv/src/backend/reactive/sanitize.rs
@@ -215,6 +215,29 @@ pub fn is_sensitive_message(msg: &str) -> bool {
 /// delivery tier — network delivery is never treated as verified regardless
 /// of this signal, by design (see the "what does NOT change" note in the
 /// spec above).
+///
+/// `reagent_verified` (SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §6.2
+/// addendum) answers an orthogonal question, additively: not "how was this
+/// delivered" (that's `TRUST`, unconditionally `network-claimed` for any
+/// non-host tier, unaffected by this parameter) but "is this specific
+/// message cryptographically proven to come from an AgentMux-operated WAN
+/// service sender" (currently only the GitHub review-notification
+/// consumer). Renders a new, independent `SIG=` marker field:
+///   - `Some(true)`  — the sender's Ed25519 signature verified against the
+///     pinned public key. Renders `SIG=verified`.
+///   - `Some(false)` — a signature was present but didn't verify (wrong
+///     key, tampered content, or unrecognized key id). Renders
+///     `SIG=invalid` — a real red flag, same spirit as host-tier's
+///     `TRUST=unverified`.
+///   - `None` — no signature was attempted (the overwhelming majority of
+///     WAN traffic, and all host/lan traffic). No `SIG=` field is rendered
+///     at all, so existing marker parsing/tests are unaffected.
+/// **Never changes `TRUST` or `effective_tier`** — a verified reagent
+/// signature still delivers as `TRUST=network-claimed`/whatever tier
+/// escalation already produced. This closes "who is this really from," not
+/// "should this auto-execute" — the same separation of concerns host-tier
+/// signing established, extended to a second, independent field so the two
+/// axes can never be conflated by a caller that only checks one of them.
 pub fn wrap_jekt_message(
     msg: &str,
     source_agent: Option<&str>,
@@ -222,6 +245,7 @@ pub fn wrap_jekt_message(
     effective_tier: &str,
     delivery_tier: &str,
     sig_verified: Option<bool>,
+    reagent_verified: Option<bool>,
     msg_id: &str,
     priority: &str,
 ) -> String {
@@ -242,8 +266,14 @@ pub fn wrap_jekt_message(
         }
     };
 
+    let sig_field = match reagent_verified {
+        Some(true) => " SIG=verified",
+        Some(false) => " SIG=invalid",
+        None => "",
+    };
+
     let structured_tag = format!(
-        "[JEKT:FROM={from} TO={target_agent} TIER={effective_tier} DELIVERY={delivery_tier} TRUST={trust} MSGID={msg_id} PRIORITY={priority} TS={ts_secs}]"
+        "[JEKT:FROM={from} TO={target_agent} TIER={effective_tier} DELIVERY={delivery_tier} TRUST={trust}{sig_field} MSGID={msg_id} PRIORITY={priority} TS={ts_secs}]"
     );
 
     let sensitive_warning = if effective_tier == "sensitive" {

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -384,6 +384,112 @@ async fn test_handler_inject_success() {
     assert!(payload.ends_with('\r'), "trailing CR submits the message");
 }
 
+// SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §6.2 addendum — reagent
+// WAN signing renders an additive SIG= field without touching TIER/TRUST.
+#[tokio::test]
+async fn test_handler_inject_wan_reagent_verified_renders_sig_field_but_stays_sensitive() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone.lock().unwrap().push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: "PR #1 reviewed".to_string(),
+        source_agent: Some("github-consumer".to_string()),
+        request_id: Some("req-wan-1".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: Some("wan".to_string()),
+        forward_hops: 0,
+        reagent_verified: Some(true),
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    // A verified reagent signature must NOT downgrade WAN's unconditional
+    // sensitive escalation — this closes "who is this from," not "should
+    // this auto-execute."
+    assert_eq!(resp.effective_tier.as_deref(), Some("sensitive"));
+
+    let calls = sent.lock().unwrap();
+    let payload = String::from_utf8_lossy(&calls[1].1);
+    assert!(payload.contains("TRUST=network-claimed"), "WAN trust label unchanged: {payload}");
+    assert!(payload.contains("TIER=sensitive"), "WAN tier still forced sensitive: {payload}");
+    assert!(payload.contains("SIG=verified"), "verified reagent signature renders SIG=verified: {payload}");
+}
+
+#[tokio::test]
+async fn test_handler_inject_wan_reagent_invalid_signature_renders_sig_invalid() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone.lock().unwrap().push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: "PR #1 reviewed".to_string(),
+        source_agent: Some("github-consumer".to_string()),
+        request_id: Some("req-wan-2".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: Some("wan".to_string()),
+        forward_hops: 0,
+        reagent_verified: Some(false),
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert_eq!(resp.effective_tier.as_deref(), Some("sensitive"));
+    let calls = sent.lock().unwrap();
+    let payload = String::from_utf8_lossy(&calls[1].1);
+    assert!(payload.contains("SIG=invalid"), "a present-but-wrong signature renders SIG=invalid: {payload}");
+}
+
+#[tokio::test]
+async fn test_handler_inject_wan_no_reagent_signature_omits_sig_field() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone.lock().unwrap().push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: "ordinary WAN jekt, not from reagent".to_string(),
+        source_agent: Some("someone".to_string()),
+        request_id: Some("req-wan-3".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: Some("wan".to_string()),
+        forward_hops: 0,
+        reagent_verified: None,
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    let calls = sent.lock().unwrap();
+    let payload = String::from_utf8_lossy(&calls[1].1);
+    assert!(!payload.contains("SIG="), "ordinary WAN traffic renders no SIG= field: {payload}");
+}
+
 // Controller-aware delivery (SPEC_AGENT_CONTROL_PROTOCOL §6 / Phase 3).
 
 // A structured (persistent/ACP) controller delivers via the message_sender and

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -96,6 +96,42 @@ pub struct InjectionRequest {
     /// was given or it didn't match.
     #[serde(skip_deserializing, default, skip_serializing_if = "Option::is_none")]
     pub sig_verified: Option<bool>,
+    /// Base64 Ed25519 signature over the same signed material as `jekt_sig`
+    /// (request_id, source_agent, target_agent, ts_secs, message), produced
+    /// by an AgentMux-operated WAN-tier service sender (currently only the
+    /// GitHub review-notification consumer, "reagent") using a private key
+    /// held exclusively in agentmux-cloud's Secrets Manager. Distinct from
+    /// `jekt_sig` (host-tier HMAC, symmetric, one key per local instance) —
+    /// see `agentmux_common::jekt_sign`'s module doc for why WAN needs an
+    /// asymmetric scheme instead. `None` for any non-reagent WAN sender or
+    /// any host/lan-tier request — this field is meaningless off the WAN
+    /// tier and verification is skipped entirely when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reagent_sig: Option<String>,
+    /// Which pinned public key `reagent_sig` claims to be signed under —
+    /// see `agentmux_common::jekt_sign::reagent_public_key` for the
+    /// rotation rationale. `None` alongside `reagent_sig` is treated the
+    /// same as an unrecognized key id: verification fails closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reagent_key_id: Option<String>,
+    /// Server-computed verification outcome for `reagent_sig` — same
+    /// `#[serde(skip_deserializing)]` guarantee as `sig_verified`: no
+    /// attacker-supplied JSON body can set this directly, only
+    /// `cloud_subscriber::sync_agent_reactive` (the one caller that
+    /// actually receives WAN injections) after checking `reagent_sig`
+    /// against the pinned key. `Some(true)` renders `SIG=verified` in the
+    /// marker; `Some(false)` (a `reagent_sig` was present but didn't
+    /// verify) renders `SIG=invalid` — a real red flag, same spirit as
+    /// host-tier's `TRUST=unverified`. `None` (no `reagent_sig` attempted)
+    /// renders no `SIG=` field at all, keeping ordinary WAN traffic
+    /// unchanged. **Never affects `TIER`/`TRUST` escalation** — WAN jekts
+    /// stay unconditionally `TRUST=network-claimed` / eligible for
+    /// `TIER=sensitive` regardless of this field, per
+    /// docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §4 ("what
+    /// does NOT change"). This answers "who is this really from," not
+    /// "should this auto-execute."
+    #[serde(skip_deserializing, default, skip_serializing_if = "Option::is_none")]
+    pub reagent_verified: Option<bool>,
 }
 
 /// Response from a message injection attempt.

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -123,13 +123,35 @@ pub struct InjectionRequest {
     /// couldn't already.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reagent_key_id: Option<String>,
+    /// Message id that was part of `reagent_sig`'s signed material — the
+    /// same `id` field the cloud muxbus server assigns each pending
+    /// injection (see `PendingInj`/`Injection.reagent_msg_id` on the
+    /// agentmux-cloud side). Distinct from `request_id` above, which is
+    /// this request's own (possibly re-derived, e.g. across a cross-instance
+    /// forward) identifier — `reagent_msg_id` must stay exactly what was
+    /// signed for verification to succeed regardless of how `request_id`
+    /// is set on this particular hop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reagent_msg_id: Option<String>,
+    /// Unix seconds `reagent_sig` was signed at — part of the signed
+    /// material, checked for anti-replay against a max-age window (the WS
+    /// path's `cloud_subscriber::REAGENT_SIG_MAX_AGE_SECS`, or the HTTP
+    /// path's own constant of the same name in `server/reactive.rs`), same
+    /// purpose as `ts_secs`/`JEKT_SIG_MAX_AGE_SECS` for host-tier `jekt_sig`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reagent_ts_secs: Option<i64>,
     /// Server-computed verification outcome for `reagent_sig` — same
     /// `#[serde(skip_deserializing)]` guarantee as `sig_verified`: no
-    /// attacker-supplied JSON body can set this directly, only
-    /// `cloud_subscriber::sync_agent_reactive` (the one caller that
-    /// actually receives WAN injections) after checking `reagent_sig`
-    /// against the pinned key. `Some(true)` renders `SIG=verified` in the
-    /// marker; `Some(false)` (a `reagent_sig` was present but didn't
+    /// attacker-supplied JSON body can set this directly. Set by whichever
+    /// caller actually received this WAN injection and independently
+    /// verified `reagent_sig` against the pinned key —
+    /// `cloud_subscriber::sync_agent_reactive` for the desktop app's WS
+    /// delivery path, or `server/reactive.rs::verify_reagent_signature` for
+    /// the HTTP `/agentmux/reactive/inject` path used by standalone pollers
+    /// like `@agentmuxai/muxbus-client` (reagentx P1 on PR #41 — that path
+    /// used to receive the four reagent_* fields over HTTP with nothing on
+    /// the receiving end able to verify them at all). `Some(true)` renders
+    /// `SIG=verified` in the marker; `Some(false)` (a `reagent_sig` was present but didn't
     /// verify) renders `SIG=invalid` — a real red flag, same spirit as
     /// host-tier's `TRUST=unverified`. `None` (no `reagent_sig` attempted)
     /// renders no `SIG=` field at all, keeping ordinary WAN traffic

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -110,8 +110,17 @@ pub struct InjectionRequest {
     pub reagent_sig: Option<String>,
     /// Which pinned public key `reagent_sig` claims to be signed under —
     /// see `agentmux_common::jekt_sign::reagent_public_key` for the
-    /// rotation rationale. `None` alongside `reagent_sig` is treated the
-    /// same as an unrecognized key id: verification fails closed.
+    /// rotation rationale. A legitimate sender always sends all four
+    /// signing fields (`reagent_sig`, `reagent_key_id`, `reagent_msg_id`,
+    /// `reagent_ts_secs`) together, so `None` here alongside a present
+    /// `reagent_sig` is treated the same as no signature having been
+    /// attempted at all (`reagent_verified` resolves to `None`, not
+    /// `Some(false)`) — see `cloud_subscriber::sync_agent_reactive`'s match
+    /// on all four fields. This does not weaken verification: `SIG=`
+    /// never affects `TIER`/`TRUST` escalation either way (see
+    /// `reagent_verified`'s doc comment below), so a stripped/partial
+    /// signature cannot buy an attacker anything a fully-absent one
+    /// couldn't already.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reagent_key_id: Option<String>,
     /// Server-computed verification outcome for `reagent_sig` — same

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -605,6 +605,19 @@ async fn sync_agent_reactive(
         source_agent: Option<String>,
         message: String,
         priority: Option<String>,
+        // Present only for messages signed by an AgentMux-operated WAN
+        // sender (currently just the GitHub review-notification consumer,
+        // "reagent") — see agentmux_common::jekt_sign::verify_reagent_jekt.
+        // All four travel together; verification is attempted only when
+        // every one of them deserializes present (see below).
+        #[serde(default)]
+        reagent_sig: Option<String>,
+        #[serde(default)]
+        reagent_key_id: Option<String>,
+        #[serde(default)]
+        reagent_msg_id: Option<String>,
+        #[serde(default)]
+        reagent_ts_secs: Option<i64>,
     }
     #[derive(Deserialize)]
     struct AckResp {
@@ -776,6 +789,29 @@ async fn sync_agent_reactive(
             continue;
         }
 
+        // Verify a reagent-signed WAN message (see PendingInj's doc comment)
+        // before delivery. Only attempted when every one of the four
+        // signing fields is present — a partial set (e.g. a sig but no
+        // key_id) is treated the same as "not signed," not "signed but
+        // broken," since a legitimate sender always sends all four
+        // together. Never affects escalation (WAN stays unconditionally
+        // TRUST=network-claimed / sensitive-eligible) — only which SIG=
+        // marker field renders. See InjectionRequest::reagent_verified.
+        let reagent_verified = match (&inj.reagent_sig, &inj.reagent_key_id, &inj.reagent_msg_id, inj.reagent_ts_secs) {
+            (Some(sig), Some(key_id), Some(msg_id), Some(ts_secs)) => Some(
+                agentmux_common::jekt_sign::verify_reagent_jekt(
+                    key_id,
+                    msg_id,
+                    inj.source_agent.as_deref().unwrap_or(""),
+                    agent_id,
+                    ts_secs,
+                    &inj.message,
+                    sig,
+                ),
+            ),
+            _ => None,
+        };
+
         let req = InjectionRequest {
             target_agent: agent_id.to_string(),
             message: inj.message.clone(),
@@ -786,6 +822,7 @@ async fn sync_agent_reactive(
             jekt_tier: None,       // auto-detected from keywords
             delivery_tier: Some("wan".to_string()),
             forward_hops: 0,
+            reagent_verified,
             ..Default::default()
         };
         let delivery = handler.inject_message(req);

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -66,6 +66,31 @@ const CLIENT_PING_INTERVAL_SECS: u64 = 240;
 // short interval is fine.
 const BROKER_SWEEP_INTERVAL_SECS: u64 = 60;
 
+// Max age (seconds) a reagent-signed WAN jekt's `reagent_ts_secs` may be
+// from "now" and still verify — anti-replay, same purpose as
+// server/reactive.rs's JEKT_SIG_MAX_AGE_SECS for host-tier (reagentx P1 on
+// PR #2570). Wider than host-tier's 300s because this covers real network
+// delivery latency, not a same-machine call — matches the github-consumer
+// Lambda's own REVIEW_NOTIFICATION_TTL_SECONDS delivery window.
+const REAGENT_SIG_MAX_AGE_SECS: i64 = 600;
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Is `ts_secs` (a reagent signature's claimed signing time) within
+/// `REAGENT_SIG_MAX_AGE_SECS` of `now`? Extracted as a pure function (takes
+/// `now` explicitly rather than calling `now_unix_secs()` itself) so it's
+/// unit-testable without mocking the system clock. `ts_secs <= 0` is never
+/// fresh — a zero/negative timestamp only happens for a malformed or
+/// missing claim, never a genuine signature.
+fn reagent_sig_is_fresh(ts_secs: i64, now: i64) -> bool {
+    ts_secs > 0 && (now - ts_secs).abs() <= REAGENT_SIG_MAX_AGE_SECS
+}
+
 // ── Wire protocol ─────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -797,18 +822,33 @@ async fn sync_agent_reactive(
         // together. Never affects escalation (WAN stays unconditionally
         // TRUST=network-claimed / sensitive-eligible) — only which SIG=
         // marker field renders. See InjectionRequest::reagent_verified.
+        //
+        // Anti-replay (reagentx P1 on PR #2570): a captured, validly-signed
+        // (reagent_sig, reagent_key_id, reagent_msg_id, reagent_ts_secs,
+        // message) tuple could otherwise be resubmitted under a brand-new
+        // injection `id` indefinitely and still render SIG=verified — same
+        // class of gap host-tier's `verify_jekt_signature` closed with
+        // `JEKT_SIG_MAX_AGE_SECS`. `REAGENT_SIG_MAX_AGE_SECS` is wider
+        // (600s vs. 300s) because this is real network delivery, not a
+        // same-machine call — matches the github-consumer Lambda's own
+        // REVIEW_NOTIFICATION_TTL_SECONDS delivery window, so a message
+        // that's still legitimately within its own staleness budget never
+        // spuriously fails signature freshness on top of that.
         let reagent_verified = match (&inj.reagent_sig, &inj.reagent_key_id, &inj.reagent_msg_id, inj.reagent_ts_secs) {
-            (Some(sig), Some(key_id), Some(msg_id), Some(ts_secs)) => Some(
-                agentmux_common::jekt_sign::verify_reagent_jekt(
-                    key_id,
-                    msg_id,
-                    inj.source_agent.as_deref().unwrap_or(""),
-                    agent_id,
-                    ts_secs,
-                    &inj.message,
-                    sig,
-                ),
-            ),
+            (Some(sig), Some(key_id), Some(msg_id), Some(ts_secs)) => {
+                Some(
+                    reagent_sig_is_fresh(ts_secs, now_unix_secs())
+                        && agentmux_common::jekt_sign::verify_reagent_jekt(
+                            key_id,
+                            msg_id,
+                            inj.source_agent.as_deref().unwrap_or(""),
+                            agent_id,
+                            ts_secs,
+                            &inj.message,
+                            sig,
+                        ),
+                )
+            }
             _ => None,
         };
 
@@ -940,10 +980,43 @@ fn classify_refresh_token_error(e: crate::muxbus::pkce::RefreshTokenError) -> Re
 #[cfg(test)]
 mod tests {
     use super::classify_refresh_token_error;
+    use super::{reagent_sig_is_fresh, REAGENT_SIG_MAX_AGE_SECS};
     use crate::broker::RefreshErrorKind;
     use crate::muxbus::pkce::RefreshTokenError;
     use tokio_tungstenite::tungstenite::client::IntoClientRequest;
     use tokio_tungstenite::tungstenite::ClientRequestBuilder;
+
+    // SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §6.2 addendum —
+    // anti-replay for reagent-signed WAN jekts (reagentx P1 on PR #2570).
+    #[test]
+    fn reagent_sig_exactly_now_is_fresh() {
+        assert!(reagent_sig_is_fresh(1_000, 1_000));
+    }
+
+    #[test]
+    fn reagent_sig_within_the_window_is_fresh() {
+        assert!(reagent_sig_is_fresh(1_000, 1_000 + REAGENT_SIG_MAX_AGE_SECS));
+        assert!(reagent_sig_is_fresh(1_000, 1_000 - REAGENT_SIG_MAX_AGE_SECS));
+    }
+
+    #[test]
+    fn reagent_sig_just_past_the_window_is_not_fresh() {
+        assert!(!reagent_sig_is_fresh(1_000, 1_000 + REAGENT_SIG_MAX_AGE_SECS + 1));
+        assert!(!reagent_sig_is_fresh(1_000, 1_000 - REAGENT_SIG_MAX_AGE_SECS - 1));
+    }
+
+    #[test]
+    fn reagent_sig_far_in_the_past_is_not_fresh() {
+        // The exact scenario this exists to stop: a captured signature from
+        // hours ago resubmitted under a new injection id.
+        assert!(!reagent_sig_is_fresh(1_000, 1_000 + 3600));
+    }
+
+    #[test]
+    fn reagent_sig_zero_or_negative_timestamp_is_never_fresh() {
+        assert!(!reagent_sig_is_fresh(0, 0));
+        assert!(!reagent_sig_is_fresh(-1, 0));
+    }
 
     #[test]
     fn no_refresh_token_is_permanent() {

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -68,6 +68,9 @@ pub(super) fn echo_jekt_to_sender(
         effective_tier.unwrap_or("coord"),
         delivery_tier,
         sig_verified,
+        // Sender-echo is inherently host-tier (the sender only ever sees
+        // this in their own pane) — reagent signing is WAN-only.
+        None,
         msgid,
         priority,
     );

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -149,6 +149,66 @@ pub(super) fn verify_jekt_signature(state: &AppState, req: &mut InjectionRequest
     req.sig_verified = Some(verified);
 }
 
+/// Anti-replay window for `req.reagent_ts_secs`, same purpose as
+/// `JEKT_SIG_MAX_AGE_SECS` above but WAN-scoped: wider than host-tier's
+/// 300s because this covers real network delivery latency, not a
+/// same-machine call — matches `cloud_subscriber::REAGENT_SIG_MAX_AGE_SECS`
+/// (the WS delivery path's own constant of the same value) and the
+/// github-consumer Lambda's own REVIEW_NOTIFICATION_TTL_SECONDS delivery
+/// window in the agentmux-cloud repo.
+const REAGENT_SIG_MAX_AGE_SECS: i64 = 600;
+
+/// WAN-tier reagent-signature verification for the HTTP
+/// `/agentmux/reactive/inject` path — mirrors
+/// `cloud_subscriber::sync_agent_reactive`'s in-process verification of the
+/// same four fields for the desktop app's WS delivery path, but for callers
+/// that deliver over HTTP instead (`@agentmuxai/muxbus-client`'s
+/// `pollAndDeliverInjections`, and any future standalone poller). Before
+/// this, `InjectionRequest` declared `reagent_sig`/`reagent_key_id` as
+/// deserializable input fields but nothing on the HTTP path ever read them
+/// — a reagent-signed notification delivered through this path arrived
+/// unsigned in effect, `reagent_verified` always `None`, and could never
+/// render `SIG=verified` (reagentx P1 on PR #41).
+///
+/// Only meaningful for `delivery_tier == "wan"` — same scoping as
+/// `reagent_verified`'s doc comment ("meaningless off the WAN tier"). A
+/// partial set of the four fields (e.g. a sig but no key_id) is treated the
+/// same as "not signed" (`reagent_verified` stays `None`), not "signed but
+/// broken" — matches `cloud_subscriber.rs`'s identical policy: a legitimate
+/// sender always sends all four together, and this field never affects
+/// `TIER`/`TRUST` escalation either way, so a stripped signature can't buy
+/// an attacker anything a fully-absent one couldn't already.
+///
+/// Takes `now` explicitly (rather than calling `now_unix_secs()` itself),
+/// same reasoning as `cloud_subscriber::reagent_sig_is_fresh`: the pinned
+/// Ed25519 key's matching private half isn't in this repo (it lives only in
+/// agentmux-cloud's Secrets Manager), so tests can't mint a fresh signature
+/// on demand the way the host-tier HMAC tests below do — only a fixed
+/// offline-signed fixture at a fixed `ts_secs`. Injecting `now` lets a test
+/// hold that fixture inside the freshness window without mocking the clock.
+pub(super) fn verify_reagent_signature(req: &mut InjectionRequest, now: i64) {
+    if req.delivery_tier.as_deref() != Some("wan") {
+        return;
+    }
+    let (Some(sig), Some(key_id), Some(msg_id), Some(ts_secs)) =
+        (req.reagent_sig.as_deref(), req.reagent_key_id.as_deref(), req.reagent_msg_id.as_deref(), req.reagent_ts_secs)
+    else {
+        return;
+    };
+    let within_freshness_window = ts_secs > 0 && (now - ts_secs).abs() <= REAGENT_SIG_MAX_AGE_SECS;
+    let verified = within_freshness_window
+        && agentmux_common::jekt_sign::verify_reagent_jekt(
+            key_id,
+            msg_id,
+            req.source_agent.as_deref().unwrap_or(""),
+            &req.target_agent,
+            ts_secs,
+            &req.message,
+            sig,
+        );
+    req.reagent_verified = Some(verified);
+}
+
 pub(super) async fn handle_reactive_inject(
     State(state): State<AppState>,
     Json(mut req): Json<InjectionRequest>,
@@ -161,6 +221,7 @@ pub(super) async fn handle_reactive_inject(
     );
 
     verify_jekt_signature(&state, &mut req);
+    verify_reagent_signature(&mut req, now_unix_secs());
 
     // 1. Try local ReactiveHandler first (fast path — same instance).
     let resp = state.reactive_handler.inject_message(req.clone());
@@ -996,5 +1057,115 @@ mod verify_jekt_signature_tests {
 
         verify_jekt_signature(&state, &mut req);
         assert_eq!(req.sig_verified, Some(false));
+    }
+}
+
+/// `verify_reagent_signature` unit tests (reagentx P1 on PR #41 —
+/// `InjectionRequest` declared `reagent_sig`/`reagent_key_id` as
+/// deserializable input fields but nothing on the HTTP
+/// `/agentmux/reactive/inject` path ever verified them, so a reagent-signed
+/// notification delivered through `@agentmuxai/muxbus-client`'s
+/// `pollAndDeliverInjections` arrived unsigned in effect).
+#[cfg(test)]
+mod verify_reagent_signature_tests {
+    use super::*;
+
+    // Reuses the exact fixture from agentmux-common/src/jekt_sign.rs's own
+    // `a_correctly_signed_reagent_message_verifies` test: a signature
+    // produced offline against the "reagent-v1-dev" pinned public key's
+    // matching private half, over signed_material("msg-1",
+    // "github-consumer", "agentx", 1000, "hello"). The private key isn't in
+    // this repo (agentmux-cloud's Secrets Manager only) so a fresh signature
+    // can't be minted at test time — `now` is passed explicitly instead of
+    // wall-clock so this fixed ts_secs=1000 can be held inside the
+    // freshness window on demand.
+    const FIXTURE_SIG_B64: &str =
+        "QehidZjJa2jYLPIPYSsVxUlm86W5Fdbr9PV3P4HJyZwJ68/HZR9EaAL0MpcVtTuZJW2+MMGebc0RH9HITNJGCw==";
+    const FIXTURE_TS_SECS: i64 = 1_000;
+
+    fn wan_req() -> InjectionRequest {
+        InjectionRequest {
+            target_agent: "agentx".to_string(),
+            message: "hello".to_string(),
+            source_agent: Some("github-consumer".to_string()),
+            delivery_tier: Some("wan".to_string()),
+            reagent_sig: Some(FIXTURE_SIG_B64.to_string()),
+            reagent_key_id: Some("reagent-v1-dev".to_string()),
+            reagent_msg_id: Some("msg-1".to_string()),
+            reagent_ts_secs: Some(FIXTURE_TS_SECS),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_correctly_signed_and_fresh_reagent_message_verifies() {
+        let mut req = wan_req();
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, Some(true));
+    }
+
+    #[test]
+    fn a_correct_signature_outside_the_freshness_window_fails() {
+        let mut req = wan_req();
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS + REAGENT_SIG_MAX_AGE_SECS + 60);
+        assert_eq!(
+            req.reagent_verified,
+            Some(false),
+            "a mathematically correct signature must still fail outside the freshness window"
+        );
+    }
+
+    #[test]
+    fn host_tier_is_never_checked_regardless_of_signature() {
+        let mut req = wan_req();
+        req.delivery_tier = Some("host".to_string());
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, None, "reagent signing only applies to the WAN tier");
+    }
+
+    #[test]
+    fn lan_tier_is_never_checked_regardless_of_signature() {
+        let mut req = wan_req();
+        req.delivery_tier = Some("lan".to_string());
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, None, "reagent signing only applies to the WAN tier");
+    }
+
+    #[test]
+    fn a_wrong_signature_is_unverified() {
+        let mut req = wan_req();
+        req.reagent_sig = Some("forged-not-a-real-signature".to_string());
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, Some(false));
+    }
+
+    #[test]
+    fn an_unknown_key_id_is_unverified() {
+        let mut req = wan_req();
+        req.reagent_key_id = Some("reagent-v2-does-not-exist".to_string());
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, Some(false));
+    }
+
+    // A partial set of the four fields is "not signed," not "signed but
+    // broken" — matches cloud_subscriber.rs's identical policy (see
+    // reagent_key_id's doc comment in types.rs).
+    #[test]
+    fn a_partial_signature_set_is_treated_as_unsigned_not_invalid() {
+        let mut req = wan_req();
+        req.reagent_key_id = None;
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, None);
+    }
+
+    #[test]
+    fn no_reagent_fields_at_all_is_left_unset() {
+        let mut req = wan_req();
+        req.reagent_sig = None;
+        req.reagent_key_id = None;
+        req.reagent_msg_id = None;
+        req.reagent_ts_secs = None;
+        verify_reagent_signature(&mut req, FIXTURE_TS_SECS);
+        assert_eq!(req.reagent_verified, None);
     }
 }

--- a/docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md
+++ b/docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md
@@ -1,0 +1,259 @@
+# Spec: Securing LAN and WAN tier jekt delivery — closing cross-tenant and cross-network trust gaps
+
+**Date:** 2026-08-13
+**Type:** Security design spec (cross-repo: `agentmux`, `agentmux-cloud`, `shared-infrastructure`)
+**Status:** §3 WAN P1-2 (reagent WAN signing) implemented 2026-08-14 — see
+"Implementation status" below. P0-1, P0-2, P1-1, P2-1 (WAN) and all of LAN
+remain proposed/not implemented. **The still-open WAN P0 findings remain
+blocker-severity; do not treat this as fully closed.**
+**Trigger:** User directive, after `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` shipped host-tier signing: "we need to get secure lan and wan tier, especially wan tier, it is a blocker." Then, after discovering this AgentMux instance had never completed muxbus login (root cause of "reagent's PR review jekts never arrive"): "lets get this system operational with the proper security for lan/wan, best practices... secure reagent jekt is top priority."
+**Builds on:** `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` (host-tier HMAC signing, shipped), `agentmux-cloud/muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md` (the still-inert Cognito M2M binding check this spec elevates to P0), `docs/specs/SPEC_MUXBUS_MULTI_TENANT_SECURITY_2026_07_06.md` (prior roadmap; this spec supersedes its Phase 1/3 sequencing based on what's now confirmed live in code, not just planned).
+
+## Implementation status (2026-08-14 addendum)
+
+Delivered, scoped narrowly to "secure reagent jekt" per the user's explicit
+priority — the GitHub review-notification consumer ("reagent") now signs
+every outgoing WAN jekt with Ed25519, verified client-side by the receiving
+agentmux-srv sidecar. Renders an additive `SIG=verified`/`SIG=invalid`
+marker field — **`TRUST=network-claimed` and `TIER=sensitive` stay
+unconditional for all WAN traffic, exactly as before; this closes "who is
+this really from," not "should this auto-execute"** (§0/§4's invariant is
+unchanged). Full design in §6.2; implementation:
+
+- `agentmux-common/src/jekt_sign.rs` — `verify_reagent_jekt` + pinned
+  `reagent_public_key("reagent-v1-dev")`. Ed25519 (`ed25519-dalek`), not the
+  host-tier HMAC scheme, because the verifying population is every
+  AgentMux instance on WAN, not one srv that minted its own symmetric key.
+- `agentmux-srv`: `InjectionRequest.reagent_sig`/`reagent_key_id` (client-
+  supplied) and `.reagent_verified` (server-computed, `skip_deserializing`
+  — same trust boundary as host-tier's `sig_verified`). Verified in
+  `cloud_subscriber::sync_agent_reactive` before delivery.
+  `wrap_jekt_message` renders the new `SIG=` field.
+- `agentmux-cloud`: `muxbus/consumers/github/handler.ts` signs with a
+  private key from Secrets Manager (`reagent-jekt-signing-key`, PKCS8 DER
+  base64) — best-effort, never blocks delivery if signing fails.
+  `muxbus/server/src/store.ts`/`index.ts` pass the four `reagent_*` fields
+  through as opaque storage (server never verifies).
+- **Fixed two bugs found while implementing this:** (1) a double-wrap bug
+  — the muxbus server pre-wrapped messages in a `[JEKT:...]` marker before
+  storage, then agentmux-srv's `wrap_jekt_message` wrapped them a second
+  time on delivery, nesting two marker blocks; the server no longer
+  pre-wraps (Rust is now the single authoritative wrapper for every
+  delivery tier). (2) `/reactive/inject` charged quota against
+  `'drone_runs'` (100/month) instead of `'jekt_messages'` (2,000/month) —
+  every sibling jekt-sending endpoint used the correct resource type; this
+  one alone didn't, giving reagent's notification volume a 20x smaller
+  ceiling than intended before a hard 402.
+- **NOT deployed** — this delivers reviewable code only. Remaining manual
+  steps before this is live: generate a **fresh** production Ed25519
+  keypair (the `reagent-v1-dev` key committed here was generated in a
+  local shell for wiring/testing and must be treated as already exposed —
+  do not reuse it in Secrets Manager), store the private half as
+  `reagent-jekt-signing-key` in `services/infra`, register the new public
+  key under a new `key_id` in `jekt_sign.rs`, and deploy both repos.
+- **Separately, and more fundamentally:** the actual reason no WAN jekt
+  (reagent's or anyone else's) had ever reached this development machine
+  turned out to be simpler than any of this — `db_muxbus_credentials` was
+  completely empty (no `muxbus.login` had ever been completed for this
+  AgentMux channel), so `cloud_subscriber` had no token to poll with at
+  all. That's a per-instance operational step (an interactive PKCE browser
+  login), not a code fix, and is orthogonal to everything above — reagent
+  signing hardens WAN identity once delivery works, it doesn't make
+  delivery work by itself.
+
+---
+
+## 0. TL;DR — severity-ranked findings
+
+**WAN is the blocker, and it's worse than "identity isn't fully verified yet."** Verified directly against deployed code (not the aspirational plan docs):
+
+1. **CRITICAL — `agent_id` is a single, flat, global namespace shared across every AgentMux account on the WAN tier, with zero tenant scoping at the storage layer.** `getPendingInjections` queries a DynamoDB GSI keyed purely on `target_agent` (`muxbus/server/src/store.ts:237-247`) — two different customers' agents named the same thing (a real, likely collision for short human-chosen names) share the same delivery queue. This is not a theoretical gap; it's how the table is actually indexed today.
+2. **CRITICAL, compounds #1 — the one check that would stop this (`checkAgentBinding`) is present in every relevant route but unconditionally non-enforcing in every deployed environment** (`ENFORCE_AGENT_BINDING` is not set anywhere — confirmed via `grep` across `agentmux-cloud` and `shared-infrastructure`). It logs a mismatch and lets the request through regardless.
+3. **HIGH — the legacy shared-secret auth mode bypasses identity binding entirely, by design, for any caller holding one machine-wide secret** (`auth.ts:172-176`; `checkAgentBinding` explicitly no-ops for `auth.mode !== 'cognito'`). Documented as "internal agents, migration phase," but nothing technical scopes it to internal use.
+4. **Net effect, today, in production:** any WAN caller who can authenticate at all (Cognito *or* legacy) can read, inject, acknowledge, and release messages for **any `agent_id` string**, regardless of which account owns it — gated only by guessing/knowing that string. Common short agent names (`atlas`, `helper`, `aria`, `agent1`) are not a remote edge case.
+
+**LAN is a real, separate, high-severity gap, but a design-and-priority problem rather than a live-exploited-today one:** the LAN discovery mechanism broadcasts the **same, full-access, instance-wide `X-AuthKey`** (the identical secret that gates the *entire* local `/agentmux/service` HTTP surface, not just LAN forwarding) in cleartext, to anyone who can receive an mDNS multicast packet or send a UDP probe from a private-looking source address — deliberately, per an explicit design comment accepting "LAN is trusted." That assumption doesn't hold on guest Wi-Fi, corporate networks with untrusted peers, or a compromised IoT device on the same subnet.
+
+**What does NOT need to change:** `TIER=sensitive` for any network-tier jekt (host-tier's own trust-layer work never touched this, and this spec doesn't either) — that's the safety net regardless of how identity ends up verified. This spec is about closing *cross-tenant data exposure* and *credential exposure*, which are worse categories of problem than "a human has to confirm before acting."
+
+---
+
+## 1. WAN — detailed findings
+
+### 1.1 Cross-tenant `agent_id` collision (CRITICAL)
+
+`muxbus/server/src/store.ts:237-247` (`getPendingInjections`):
+```ts
+const result = await this.client.send(new QueryCommand({
+    TableName: this.injectionsTable,
+    IndexName: 'target_agent-created_at-index',
+    KeyConditionExpression: 'target_agent = :agent',
+    ...
+}));
+```
+No account/tenant attribute anywhere in the key condition. `createInjection` (`store.ts:224-235`) writes `{ id, target_agent, source_agent, message, priority, status, created_at, ttl }` — again, no tenant field. The `/reactive/pending/:agent_id` route (`index.ts:335-359`) enforces only that the caller's *own declared* `X-Agent-ID` header matches the URL param — a self-consistency check, not proof of ownership — then defers real authorization to `checkAgentBinding`, which (§1.2) is inert.
+
+**Concretely:** if Customer A and Customer B each independently name an agent `"atlas"`, both agents' pending messages live in the exact same DynamoDB partition, and either customer's sidecar — or anyone else who can authenticate and set `X-Agent-ID: atlas` — can read, claim, and act on the other's messages. This also means the acknowledged/claimed-first-wins semantics `cloud_subscriber.rs` relies on (the "two seats" intentional-duplicate-delivery design) offers **no protection at all** against a genuine cross-tenant collision — it was designed for the same account's two channels racing, not two different accounts colliding.
+
+### 1.2 `checkAgentBinding` built, never enforced (CRITICAL)
+
+`muxbus/server/src/agent-binding.ts:22-36` — already covered in depth by `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`. Restated here because it's the direct cause of §1.1's exposure being live rather than theoretical: the fix for "does this Cognito-authenticated caller actually own this agent_id" exists, is wired into all five reactive routes, and does nothing but `console.warn` in every deployed environment (`ENFORCE_AGENT_BINDING` confirmed unset via `grep -rn ENFORCE_AGENT_BINDING` across `agentmux-cloud` and `shared-infrastructure` — appears only in the check's own source and test file).
+
+`PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`'s own status header is now stale in a way worth correcting precisely: it says Step 2 (desktop app fetching per-agent credentials) "has not shipped." It has — `agentmux-srv/src/muxbus/agent_credentials.rs` exists and is wired into `cloud_subscriber.rs`'s `sync_agent_reactive` (with fallback to the shared token on failure). This means the *precondition* for flipping `ENFORCE_AGENT_BINDING` may already be substantially met — the remaining work is verification, not new engineering (see §3.1).
+
+### 1.3 Legacy shared-secret mode (HIGH)
+
+`auth.ts:172-176`:
+```ts
+const legacyKey = await getLegacyKey(); // ONE value, from Secrets Manager `services/infra`.`muxbus-api-key`
+if (legacyKey && token === legacyKey) {
+    return { mode: 'legacy' };
+}
+```
+One secret, fetched once, cached process-lifetime, shared across **every** caller using it — no per-account, per-agent, or per-purpose scoping at all. `checkAgentBinding`'s very first line (`auth?.mode !== "cognito"`) means legacy-authenticated requests **never even attempt** identity binding — they're waved through unconditionally, same as before any of this binding work existed. `getBillingTier` treats legacy as always `'metered'` (§ auth.ts:180-183) — i.e., legacy callers aren't even quota-limited the way a free-tier account would be.
+
+The doc comment calls this "internal agents, migration phase" — a reasonable *intent*, but there is no code-level restriction (IP allowlist, separate endpoint, scoped permission) keeping it internal-only. Anyone who has ever obtained this one value (a compromised CI credential, a leaked `.env`, an insider) has unscoped, unbound, cross-tenant read/write access to the entire jekt delivery system.
+
+### 1.4 No WAN-tier message signing (MEDIUM — mitigated once §3.1/§3.2 land, not before)
+
+The host-tier HMAC work (`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`) is explicitly local-machine-scoped — `AGENTMUX_JEKT_KEY` never leaves the srv instance that minted it, by design. WAN messages have no equivalent: sender identity for a WAN jekt rests entirely on the auth layer (§1.2, §1.3) rather than anything cryptographically bound to the message content itself. Once §1.1/§1.2 close the tenant-isolation gap, this becomes a "harden further" item, not a standalone blocker — flagged here so it isn't lost, not because it's this spec's top priority.
+
+### 1.5 Replay / idempotency (needs verification, not yet a confirmed finding)
+
+`createInjection` mints `id = inj-${Date.now()}-${randomUUID().slice(0,8)}` — reasonably unpredictable. No explicit nonce/replay-window check was found in the read portion of this audit; worth a dedicated pass (can a captured, validly-authenticated `POST /reactive/inject` body be resubmitted to redeliver an old message?) before this spec is considered fully closed — tracked as an open question in §5, not blocking §3's P0 items.
+
+---
+
+## 2. LAN — detailed findings
+
+### 2.1 Full-access instance secret broadcast in cleartext (HIGH)
+
+`agentmux-srv/src/bootstrap.rs:1237-1243` confirms `LanDiscoveryController::new(..., config.auth_key.clone())` — **the exact same `auth_key`** that `server/mod.rs:1373` uses to gate the entire `/agentmux/service` and `/agentmux/reactive/*` HTTP surface (not a LAN-scoped credential). `lan_discovery.rs`:
+- Publishes it as an mDNS TXT record property (`properties: [..., ("auth_key", auth_key.as_str())]`, `start()` §~198-224) — receivable by any device that can join mDNS multicast on the subnet, no authentication of the *receiver* at all.
+- Also answers it over a UDP broadcast responder (`udp_responder_loop`, port `47891`) to any source whose IP address merely *looks* private/link-local (`is_lan_source`) — a check on the sender's apparent network position, not on any credential or invitation.
+
+The code's own comment (`find_agent`, lines 589-593) states the accepted trade-off explicitly: *"LAN traffic is trusted (private network). Anyone on the LAN who can already intercept mDNS multicast can intercept the HTTP traffic too, so the key adds no exposure beyond what already exists."* This reasoning holds for **confidentiality of the key in transit** but does not account for two things that make the actual exposure worse than "no additional exposure":
+- **Standing access, not one-time interception.** A passive listener who captures the key once has durable access to the *entire* local instance for as long as it keeps running — full `/agentmux/service` surface, not just the LAN-forwarding routes — not merely visibility into one forwarded message.
+- **No active MITM required.** Multicast reception and this UDP responder are both purely passive/broadcast-response — an attacker doesn't need to be on-path for existing traffic, just present on the network segment at any point while discovery is active.
+
+### 2.2 Plain HTTP peer forwarding (MEDIUM, compounds 2.1)
+
+`LanDiscoveryController::find_agent` (`lan_discovery.rs:615`): `let peer_url = format!("http://{}:{}", peer.address, peer.port);` — no TLS. Forwarded jekt content and the `X-AuthKey` header both travel in cleartext over the LAN segment, sniffable by anyone with L2 visibility (a shared switch with port mirroring, an untrusted AP, ARP spoofing on an unsegmented network).
+
+### 2.3 "LAN = trusted" is a weaker assumption than the code assumes (design-level)
+
+Not a code defect, a threat-model one: modern real-world "LAN"s routinely include devices the user doesn't fully trust — guest Wi-Fi (often bridged to the main network by default on consumer APs), IoT devices with their own compromise history, shared/coworking-space networks, corporate networks under a zero-trust posture specifically *because* internal-network trust has proven unreliable. **This feature defaults to off** (`network_lan_discovery` setting, opted in via HostPopover) — that default is good and should stay — but the current design doesn't give an opted-in user a way to get the convenience without exposing the full-instance credential to the whole broadcast domain.
+
+---
+
+## 3. Design — prioritized fixes
+
+### WAN
+
+**P0-1 — Namespace `agent_id` per account at the storage layer.** The deepest, most correct fix for §1.1: injections, the agents table, and any agent-keyed lookup need a composite key (`account_user_id#agent_id` or equivalent), not a bare `agent_id`. This is a breaking schema change for a live multi-tenant table — sequence it like this codebase's own precedent for exactly this shape of migration (`SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md`'s dual-write/backfill/cutover pattern): add the composite attribute + a new GSI, dual-write old and new keys, backfill existing rows, cut reads over, then drop the old GSI. Do not attempt a single-step cutover on a live table.
+
+**P0-2 — Redesign per-agent binding around an account-scoped Cognito client + pre-token claim, THEN flip `ENFORCE_AGENT_BINDING=true`.** Originally scoped as "just verify and flip" — resolved in §5.1 to be more than that: Cognito's default 100-app-clients-per-user-pool quota means the current one-client-per-`(user, agent)` provisioning model cannot cover most real traffic at any meaningful multi-tenant scale, so flipping the flag as-built only ever protects a small, quota-limited fraction of agents. Move to one Cognito M2M client per *account* with a pre-token Lambda injecting the authorized `agent_id`(s) as a claim (§5.1 — this codebase already has the exact precedent in the `owner`-tier pre-token Lambda), THEN verify that mechanism end-to-end and flip the flag per the original plan's step 3. Also extend the desktop's existing 401-retry-with-fallback logic to cover 403 too (§5.2) before flipping, so a rollout-era false-positive mismatch degrades gracefully instead of silently stalling delivery for that agent.
+
+**P1-1 — Scope or retire the legacy shared-secret mode.** At minimum: stop treating it as unconditionally exempt from `checkAgentBinding` — even a coarse improvement (binding legacy callers to a specific known internal-service allowlist by IP/VPC, or issuing distinct per-consumer legacy keys instead of one global value) closes most of §1.3's blast radius without waiting on every legacy caller to migrate to Cognito M2M. The original plan already scoped a full sunset as its own later phase — this spec elevates it from "someday" to "do alongside P0-1/P0-2," given §1.1's severity is compounded directly by this bypass.
+
+**P1-2 — Extend cryptographic sender signing to the WAN tier.** Once P0-1/P0-2 close tenant isolation, add a WAN-appropriate analogue of the host-tier HMAC work — a dedicated per-`(account, agent_id)` signing secret minted alongside the account-scoped provisioning in P0-2, not derived from the Cognito client's own credential material (mixing an auth credential with a message-signing key repeats the exact mistake the host-tier spec deliberately avoided — see §6.2 for the concrete design), so `TRUST=network-claimed` jekts can eventually carry a *verified* sender claim rather than remaining purely delivery-tier-based. **`TIER=sensitive` should still apply unconditionally regardless** (§0) — this closes the "who is this really from" question, not the "should this auto-execute" one, matching the same separation of concerns `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` established for host tier.
+
+**P2-1 — Replay/idempotency audit.** Resolve §1.5's open question with a dedicated pass over `createInjection`/`acknowledgeInjections`/`releaseInjection` before considering the WAN tier fully hardened.
+
+### LAN
+
+**P0-1 — Stop broadcasting the full-access instance `auth_key` over multicast/UDP.** Do not reuse `state.auth_key` for LAN discovery at all. Options, roughly in order of preference:
+- Mint a **separate, narrowly-scoped LAN-forwarding credential** (only valid for the specific `/agentmux/reactive/*` forwarding routes, not the full `/agentmux/service` surface) — least-privilege, and a captured credential's blast radius shrinks to "can forward jekts to this instance," not "full local API access."
+- Require an explicit **pairing step** (a short code shown in one instance's UI, typed into the other) rather than automatic broadcast trust, for users who want tighter control than "opt into LAN discovery" alone provides.
+- At minimum, gate the credential behind a **challenge-response** rather than handing the raw value to any listener/prober — even a lightweight HMAC challenge keyed on the LAN-scoped credential (once P0-1's scoping lands) meaningfully raises the bar over "broadcast the plaintext secret to anyone who asks."
+
+**P1-1 — Encrypt/authenticate peer-to-peer LAN forwarding.** Upgrade `http://` peer forwarding to something a passive LAN listener can't read — mTLS between discovered peers (using the pairing/scoped-credential material from P0-1 to bootstrap trust), or at minimum a signed-request scheme analogous to the host-tier HMAC work, so message content and any credential in flight aren't cleartext on the wire.
+
+**P2-1 — Make the "LAN = trusted" trade-off explicit in the opt-in UI copy.** The feature already defaults off, which is right — verify the enabling toggle's copy actually communicates "this instance's access credential will be discoverable by anything else on this network," not just "enable LAN discovery," so an informed user (not the code's own assumption) is the one deciding the trust boundary.
+
+---
+
+## 4. What does NOT change
+
+- `TIER=sensitive` for any LAN/WAN-delivered jekt, unconditionally — untouched by every fix above, including the WAN signing work in P1-2. Identity verification and action-authorization are different axes; this spec only strengthens the former.
+- Host-tier HMAC signing (`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`) — already shipped, unaffected, and not a template to copy-paste onto WAN/LAN wholesale (different threat models, per that spec's own §3 reasoning for host tier specifically).
+- The keyword-based sensitive-content escalation — orthogonal to everything in this spec, stays as-is.
+
+---
+
+## 5. Does flipping `ENFORCE_AGENT_BINDING` break anything? (resolved)
+
+**Mechanically, low risk to currently-working traffic — but it also protects far less than it sounds like, and has one real operational gap.** Traced precisely through `checkAgentBinding` (`agent-binding.ts:22-36`) and every caller of it:
+
+```ts
+if (auth?.mode !== "cognito" || !auth.boundAgentId || auth.boundAgentId === claimedAgentId) {
+    return false; // no mismatch — proceeds either way
+}
+```
+
+Rejection (`403 agent_binding_mismatch`) requires **all three** to hold: `auth.mode === 'cognito'`, `auth.boundAgentId` is actually set, and it disagrees with the request's claimed `agent_id`. Walking every real caller:
+
+- **Legacy shared-secret callers** (`auth.mode === 'legacy'`) — first condition true, always exempt, completely unaffected by the flag. This includes whatever currently uses `muxbus-api-key` (§1.3) — flipping the flag does **nothing** to close that gap.
+- **Shared human-level PKCE-token callers** (`auth.mode === 'cognito'`, `isM2M === false`, no `clientId`/`boundAgentId` at all) — `!auth.boundAgentId` is true, exempt. This is `cloud_subscriber.rs`'s fallback path whenever a per-agent credential isn't provisioned or its fetch fails — also completely unaffected.
+- **Genuinely-provisioned per-agent M2M callers, correct case** — `boundAgentId` matches the claim (both sides independently normalize via `.toLowerCase()`/`normalizeAgentId`'s `lowercase+trim`, verified consistent between `agent_credentials.rs`'s `agent_id.to_lowercase()` and `index.ts`'s `normalizeAgentId` at every relevant route, including the provisioning route itself — no case/whitespace mismatch bug found). Passes cleanly, unaffected.
+- **Genuinely-provisioned per-agent M2M callers, genuine mismatch** — the only case actually rejected. No live example of this occurring was found in this audit (agent renames get a fresh provisioning under the new name, not a stale stuck binding — `agent_credential_load` is keyed by the *current* agent_id).
+
+**So: mechanically safe to flip today, for whatever traffic already flows through the per-agent-bound path — but that traffic is likely a small minority.** See §5.1 below for why, and read §5.2 before treating "safe to flip" as "worth flipping in its current form."
+
+### 5.1 The real blocker: per-agent Cognito app clients don't scale (RESOLVED, elevates from "open question" to a design-changing finding)
+
+Confirmed against current AWS documentation (docs.aws.amazon.com/cognito, checked 2026-08-13): **Amazon Cognito's default quota is 100 app clients per user pool** — not the "~1000 (raisable)" this spec's first draft estimated from memory. `provisionAgentClient` (`agent-provisioning.ts`) mints one literal Cognito `UserPoolClient` per `(user_id, agent_id)` pair, in one shared pool, across the *entire* multi-tenant deployment. **100 total provisioned agents, system-wide, across every customer, is the ceiling** — not per account. Given this session's own agent roster alone spans a dozen-plus distinct names, and any real multi-customer deployment multiplies that, this model is very plausibly already near or past that ceiling, or will be shortly — well before "most agents get a bound credential" is achievable.
+
+**Consequence:** the per-agent-Cognito-app-client mechanism, as currently built, cannot be the long-term answer regardless of whether `ENFORCE_AGENT_BINDING` is flipped — it structurally cannot cover most real traffic at any meaningful scale. Flipping the flag today would protect only whichever small fraction of agents happened to provision before hitting the quota (and would start throwing Cognito API errors for new provisioning attempts once it's hit, if it isn't already — `provisionAgentClient` has no specific handling for a Cognito-side quota rejection distinct from its own `agent_provisions` billing-quota check).
+
+**Recommended redesign, not just a scale-up:** move to **one Cognito M2M app client per *account*** (bounded by customer count, not agent count — almost certainly well under 100 for the foreseeable future) with a **pre-token Lambda** injecting the authorized `agent_id` (or set of agent_ids) as a custom claim, based on server-side account state at token-issue time. This codebase already has exact precedent for this shape of mechanism: `SPEC_MUXBUS_OWNER_GATE_AND_COST_CAP_2026_08_11.md`'s `owner` billing tier is derived "exclusively from the Cognito-verified email in the pre-token Lambda, never from anything client-supplied" (`auth.ts`'s own doc comment on `BillingTier`). The same pattern — server-controlled claim injection at token-mint time — sidesteps the 100-client ceiling entirely, since it needs one client per account, not one per agent.
+
+### 5.2 The operational gap worth closing before flipping regardless of §5.1
+
+`cloud_subscriber.rs`'s `sync_agent_reactive` only treats **HTTP 401** as "credential problem, invalidate and retry with the shared-token fallback" (`resp.status() == reqwest::StatusCode::UNAUTHORIZED`). A `checkAgentBinding` rejection is **403**, which falls into the generic non-2xx branch — `tracing::warn!` and `return AgentSyncOutcome::Ok` — **no fallback retry**. If a genuine mismatch ever occurs (a bug, an edge case this audit didn't find, a future regression), that agent's WAN pull silently stops working for that poll cycle with no user-visible error, rather than degrading gracefully the way an expired/revoked credential already does.
+
+**Recommend before flipping:** either extend the same invalidate-and-retry-with-shared-token handling to 403 responses (treats "my bound credential apparently doesn't authorize me for this agent" the same as "my credential is stale," which is a reasonable read of what a 403 here actually means operationally), or explicitly accept that a mismatch fails closed with only a debug-level log and make sure that's monitored.
+
+## 6. Other resolved open questions
+
+### 6.1 Replay / idempotency (§1.5) — RESOLVED
+
+Read `acknowledgeInjections`/`releaseInjection` in full (`store.ts:272-340`):
+- **Claim (`acknowledgeInjections`)** uses a genuine atomic compare-and-swap (`ConditionExpression: "#status = :pending"`); a replayed claim request for an already-claimed injection hits `ConditionalCheckFailedException` → `"Already claimed by another delivery attempt"`, not double-delivery. **Well-protected.**
+- **Release** requires the exact `delivered_at` stamp from the original claim (`ConditionExpression: "#status = :delivered AND delivered_at = :claimed_at"`) — can't be replayed or hijacked by a party that doesn't hold the matching stamp. **Well-protected.**
+- **Creation (`createInjection`) has no replay protection at all** — no idempotency key, no nonce; a resubmitted (captured/replayed) authenticated request mints a brand-new injection row and the message is delivered again. **Bounded severity, not a blocker**: this requires either the caller replaying their own already-authorized request (no privilege gained, just a duplicate of a message they could send again anyway) or a MITM capturing an HTTPS-transported request (mitigated by TLS being the expected transport; not independently re-verified as part of this audit — see §7 residual items). Worth an idempotency-key addition as routine hardening, not urgent relative to §5's findings.
+- **Neither of these protects against §1.1's tenant-collision problem** — they prevent double-claiming/double-releasing the *same* injection row, which does nothing if two different accounts' same-named agents are sharing that row's queue in the first place. Orthogonal concerns; both need fixing.
+
+### 6.2 WAN-tier signing key derivation (P1-2) — concrete design proposed
+
+Do **not** derive it from the per-agent Cognito client's own secret (abandoning that model per §5.1 anyway, and reusing an auth credential as a message-signing key mixes blast radii the same way the host-tier spec explicitly avoided reusing a GitHub PAT for jekt signing). Instead: extend whatever replaces per-agent provisioning (§5.1's account-scoped-client-plus-claim design) to *also* mint a random per-`(account, agent_id)` signing secret at the same provisioning moment, stored server-side (a new DynamoDB table, or an attribute on the existing account-registry row), returned to the desktop client and used exactly like the shipped host-tier mechanism: client signs outgoing WAN jekts with it, server verifies against its own copy. This is the same `agentmux_common::jekt_sign` pattern already built and tested in `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` — relocated to a cloud-side, tenant-scoped store instead of a local-instance-scoped one. No new cryptographic design needed, just a new home for the same mechanism.
+
+### 6.3 DynamoDB composite-key migration plan (P0-1) — concrete phases proposed
+
+Following this codebase's own dual-write/backfill/cutover precedent (`SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md`):
+1. **Add the scoping attribute + new GSI.** Add `account_user_id` (or equivalent) to the injections table; add a new GSI keyed on a computed `tenant_agent_key = ${account_user_id}#${target_agent}` (or a proper composite sort key, whichever the DynamoDB access-pattern review prefers) — additive, no impact on existing reads.
+2. **Dual-write.** `createInjection` writes both the legacy unscoped `target_agent` value (existing GSI keeps working) and the new scoped key, for every new row.
+3. **Cut reads over — but this step depends on §1.3/P1-1 landing first, not after.** `getPendingInjections` and friends need the caller's resolved `account_user_id` to query the new scoped index — available today only for Cognito-authenticated callers (`auth.accountUserId`/`auth.userId`). A **legacy-key caller has no resolvable account at all**, so it cannot be safely scoped without deciding what account it's allowed to act as first. This is the concrete reason P0-1 and P1-1 (scope-or-retire the legacy mode) are not independently sequenceable the way the priority list in §3 might suggest read alone — legacy access needs *some* account binding (even a coarse "internal service account" assignment) before the scoped-read cutover can safely include it.
+4. **Backfill existing pending rows.** Best-effort match existing unscoped rows to an owning account via whatever ownership record exists (the agents table, if it already tracks a creator/owner) — anything that can't be confidently matched should be flagged for manual review, not silently guessed at, given the cost of scoping a message to the wrong tenant.
+5. **Full cutover + drop the old GSI**, once reads are confirmed exclusively using the scoped path and backfill is complete.
+
+---
+
+## 7. Sources
+
+- `agentmux-cloud/muxbus/server/src/store.ts` (`createInjection`, `getPendingInjections`, lines 224-247)
+- `agentmux-cloud/muxbus/server/src/index.ts` (`/reactive/pending/:agent_id`, `/reactive/ack`, `/reactive/release` route handlers, lines 335-410)
+- `agentmux-cloud/muxbus/server/src/auth.ts` (`verifyRequest`, legacy key handling, lines 1-203)
+- `agentmux-cloud/muxbus/server/src/agent-binding.ts` (`checkAgentBinding`)
+- `agentmux-srv/src/muxbus/agent_credentials.rs` (`ensure_agent_credential` — confirms consistent lowercase normalization matching `normalizeAgentId` server-side)
+- `agentmux-cloud/muxbus/server/src/agent-provisioning.ts` (`provisionAgentClient`, `clientName` — one literal Cognito app client per `(user_id, agent_id)` pair, the mechanism §5.1 finds doesn't scale)
+- `agentmux-cloud/muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`
+- [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/quotas.html) (AWS documentation, confirms the 100-app-clients-per-user-pool default quota cited in §5.1, checked 2026-08-13)
+- `docs/specs/SPEC_MUXBUS_OWNER_GATE_AND_COST_CAP_2026_08_11.md` (the existing pre-token-Lambda custom-claim precedent §5.1's redesign proposal reuses)
+- `agentmux-cloud/muxbus/packages/muxbus-jekt/src/index.ts` (`wrapJektMessage` — TS-side trust-label derivation, confirmed all 4 live call sites hardcode/default `deliveryTier: 'wan'`, `'host'` is currently unreachable from any cloud-side caller)
+- `agentmux-srv/src/backend/lan_discovery.rs` (full file — mDNS advertisement, UDP broadcast responder, `find_agent` peer forwarding)
+- `agentmux-srv/src/bootstrap.rs:1237-1243` (confirms the LAN-broadcast key is the same instance-wide `auth_key`)
+- `agentmux-srv/src/server/mod.rs:1347-1373` (`X-AuthKey` middleware — what that key actually gates)
+- `docs/specs/SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` (host-tier signing, shipped — the pattern P1-2/LAN-P1-1 extend)
+- `docs/specs/SPEC_MUXBUS_MULTI_TENANT_SECURITY_2026_07_06.md` (prior roadmap this spec supersedes in sequencing, based on confirmed-live findings)
+- `docs/specs/SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md` (the dual-write/backfill/cutover migration pattern P0-1 should follow)


### PR DESCRIPTION
## Summary
- Cryptographically verifies AgentMux's own GitHub review-notification consumer ("reagent") as the real sender of a WAN jekt, additively — renders a new `SIG=verified`/`SIG=invalid` marker field without touching `TRUST`/`TIER`, which stay unconditionally `network-claimed`/sensitive-eligible per `docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md`'s existing invariant. This closes "who is this really from," not "should this auto-execute."
- Asymmetric (Ed25519 via `agentmux-common::jekt_sign::verify_reagent_jekt`), not host-tier's HMAC scheme — the verifying population here is every AgentMux instance on WAN, not one srv that minted its own symmetric key. See that module's doc comment for the full rationale.
- `InjectionRequest.reagent_sig`/`reagent_key_id` (client-supplied) and `.reagent_verified` (server-computed, `#[serde(skip_deserializing)]` — same trust boundary as host-tier's `sig_verified`), verified in `cloud_subscriber::sync_agent_reactive` before delivery.

## Bugs fixed along the way
- **Double-wrap bug**: the muxbus server used to pre-wrap messages in a `[JEKT:...]` marker before storage, then agentmux-srv's `wrap_jekt_message` wrapped them a second time on delivery, nesting two marker blocks. Rust is now the single authoritative wrapper for every delivery tier (companion fix in the `agentmux-cloud` PR).
- **Wrong quota resource**: `/reactive/inject` charged quota against `'drone_runs'` (100/month) instead of `'jekt_messages'` (2,000/month) — every sibling jekt-sending endpoint used the correct resource type; this one alone didn't (companion fix in the `agentmux-cloud` PR).

## Not in scope here
- The actual reason no WAN jekt had ever reached this dev machine turned out to be simpler: `db_muxbus_credentials` was completely empty (no `muxbus.login` ever completed for this channel) — an operational step, not a code fix.
- WAN P0 findings from the spec (tenant-scoped `agent_id` namespace, account-scoped Cognito + pre-token claims) remain open — this PR is scoped to "secure reagent jekt" specifically, not the full spec.

## Deployment (not done here — code only)
Generate a **fresh** production Ed25519 keypair (the `reagent-v1-dev` key committed in this PR was generated in a local shell for wiring/testing and must be treated as already exposed), store the private half as `reagent-jekt-signing-key` in `services/infra` Secrets Manager, register the new public key under a new `key_id` in `jekt_sign.rs`, deploy alongside the companion `agentmux-cloud` PR.

## Test plan
- [x] `cargo test -p agentmux-common` — 127 passed (19 new Ed25519 sign/verify tests, including a fixture round-trip against the real pinned key)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2205 passed (3 new tests: SIG=verified stays sensitive, SIG=invalid, no-signature omits the field)
- [x] `cargo check --workspace` clean
- [ ] CI — pending

<!-- agentmux:agent_id=agentx -->