### PR TITLE
chore: release v0.55.7

### DIFF
--- a/.changesets/1786504803-fix-browser-pane-oauth-popup-in-pane.md
+++ b/.changesets/1786504803-fix-browser-pane-oauth-popup-in-pane.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-fix(browser-pane): OAuth/GIS sign-in works in-pane again — no instance-exit, real child popup completes the login, external-protocol guard

--- a/.changesets/1786506220-feat-browser-pane-wire-ctrl-l-ctrl-r-alt-left-alt-right-shor-uys7.md
+++ b/.changesets/1786506220-feat-browser-pane-wire-ctrl-l-ctrl-r-alt-left-alt-right-shor-uys7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(browser-pane): wire Ctrl+L / Ctrl+R / Alt+Left / Alt+Right shortcuts (#1190)

--- a/.changesets/1786508406-fix-cef-stop-mdns-0-0-0-0-5353-bind-that-triggers-the-window-tdpj.md
+++ b/.changesets/1786508406-fix-cef-stop-mdns-0-0-0-0-5353-bind-that-triggers-the-window-tdpj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): stop mDNS 0.0.0.0:5353 bind that triggers the Windows Firewall prompt on launch

--- a/.changesets/1786538021-test-lan-discovery-mark-mdns-wire-discovery-test-ignored-env-11kr.md
+++ b/.changesets/1786538021-test-lan-discovery-mark-mdns-wire-discovery-test-ignored-env-11kr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(lan-discovery): mark mDNS wire-discovery test ignored — environment-fragile, not flaky

--- a/.changesets/1786573639-feat-warden-rebuild-as-a-5-section-rail-matching-armory-s-ui-veck.md
+++ b/.changesets/1786573639-feat-warden-rebuild-as-a-5-section-rail-matching-armory-s-ui-veck.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(warden): rebuild as a 5-section rail matching Armory's UI pattern

--- a/.changesets/1786574599-feat-warden-extend-auditlogentry-with-outcome-reason-for-sup-krmt.md
+++ b/.changesets/1786574599-feat-warden-extend-auditlogentry-with-outcome-reason-for-sup-krmt.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(warden): extend AuditLogEntry with outcome/reason for Supervisor decisions

--- a/.changesets/1786576024-feat-warden-add-auto-continue-enabled-per-agent-opt-in-field-a0xc.md
+++ b/.changesets/1786576024-feat-warden-add-auto-continue-enabled-per-agent-opt-in-field-a0xc.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(warden): add auto_continue_enabled per-agent opt-in field for Supervisor

--- a/.changesets/1786576660-feat-warden-add-transcript-read-route-getagenttranscript-mcp-0wd5.md
+++ b/.changesets/1786576660-feat-warden-add-transcript-read-route-getagenttranscript-mcp-0wd5.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(warden): add transcript-read route + GetAgentTranscript MCP tool

--- a/.changesets/1786577572-feat-warden-add-supervisornudge-route-mcp-tool-consecutive-n-im48.md
+++ b/.changesets/1786577572-feat-warden-add-supervisornudge-route-mcp-tool-consecutive-n-im48.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(warden): add SupervisorNudge route + MCP tool + consecutive-nudge ceiling

--- a/.changesets/1786578516-feat-warden-add-supervisor-manager-ui-fix-nudge-entitlement--y0pg.md
+++ b/.changesets/1786578516-feat-warden-add-supervisor-manager-ui-fix-nudge-entitlement--y0pg.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(warden): add Supervisor manager UI + fix nudge entitlement/ceiling gaps

--- a/.changesets/1786604409-feat-agent-expose-model-vendor-custom-endpoint-ui-add-antigr-81md.md
+++ b/.changesets/1786604409-feat-agent-expose-model-vendor-custom-endpoint-ui-add-antigr-81md.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): expose model vendor / custom endpoint UI + add Antigravity harness

--- a/.changesets/1786629295-feat-armory-dynamic-pane-title-reflects-selected-rail-sectio-7se4.md
+++ b/.changesets/1786629295-feat-armory-dynamic-pane-title-reflects-selected-rail-sectio-7se4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): dynamic pane title reflects selected rail section (also warden, settings)

--- a/.changesets/1786649949-feat-jekt-add-host-tier-per-agent-hmac-signing-for-sender-ve-422w.md
+++ b/.changesets/1786649949-feat-jekt-add-host-tier-per-agent-hmac-signing-for-sender-ve-422w.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): add host-tier per-agent HMAC signing for sender verification

--- a/.changesets/1786650533-fix-menu-context-submenu-wrong-strategy-positioning-main-win-f75t.md
+++ b/.changesets/1786650533-fix-menu-context-submenu-wrong-strategy-positioning-main-win-f75t.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-fix(menu): context-submenu wrong-strategy positioning + main window silent show() no-op

--- a/.changesets/1786665927-fix-tabs-desaturate-tab-color-picker-keep-agent-pane-borders-zjq2.md
+++ b/.changesets/1786665927-fix-tabs-desaturate-tab-color-picker-keep-agent-pane-borders-zjq2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): desaturate tab color picker, keep agent pane borders vivid

--- a/.changesets/1786666690-feat-pane-tab-strip-frosted-glass-trailing-space-per-pane-zo-6jlz.md
+++ b/.changesets/1786666690-feat-pane-tab-strip-frosted-glass-trailing-space-per-pane-zo-6jlz.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(pane-tab-strip): frosted-glass trailing space, per-pane zoom binding, top scroll-clearance for short agent conversations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.6"
+version = "0.55.7"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.6"
+version = "0.55.7"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.6"
+version = "0.55.7"
 dependencies = [
  "base64",
  "dirs",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.6"
+version = "0.55.7"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.6"
+version = "0.55.7"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.6"
+version = "0.55.7"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.6"
+version = "0.55.7"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -19,7 +19,6 @@
 - fix(tabs): desaturate tab color picker, keep agent pane borders vivid
 - feat(pane-tab-strip): frosted-glass trailing space, per-pane zoom binding, top scroll-clearance for short agent conversations
 
-
 ## 0.55.6 — 2026-08-11
 
 - fix(agent-pane): progress bar renders above the tab strip, not overlapping the content region

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,25 @@
 # AgentMux Version History
 
+## 0.55.7 — 2026-08-13
+
+- fix(browser-pane): OAuth/GIS sign-in works in-pane again — no instance-exit, real child popup completes the login, external-protocol guard
+- feat(browser-pane): wire Ctrl+L / Ctrl+R / Alt+Left / Alt+Right shortcuts (#1190)
+- fix(cef): stop mDNS 0.0.0.0:5353 bind that triggers the Windows Firewall prompt on launch
+- test(lan-discovery): mark mDNS wire-discovery test ignored — environment-fragile, not flaky
+- feat(warden): rebuild as a 5-section rail matching Armory's UI pattern
+- feat(warden): extend AuditLogEntry with outcome/reason for Supervisor decisions
+- feat(warden): add auto_continue_enabled per-agent opt-in field for Supervisor
+- feat(warden): add transcript-read route + GetAgentTranscript MCP tool
+- feat(warden): add SupervisorNudge route + MCP tool + consecutive-nudge ceiling
+- feat(warden): add Supervisor manager UI + fix nudge entitlement/ceiling gaps
+- feat(agent): expose model vendor / custom endpoint UI + add Antigravity harness
+- feat(armory): dynamic pane title reflects selected rail section (also warden, settings)
+- feat(jekt): add host-tier per-agent HMAC signing for sender verification
+- fix(menu): context-submenu wrong-strategy positioning + main window silent show() no-op
+- fix(tabs): desaturate tab color picker, keep agent pane borders vivid
+- feat(pane-tab-strip): frosted-glass trailing space, per-pane zoom binding, top scroll-clearance for short agent conversations
+
+
 ## 0.55.6 — 2026-08-11
 
 - fix(agent-pane): progress bar renders above the tab strip, not overlapping the content region

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.6",
+  "version": "0.55.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.6",
+      "version": "0.55.7",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.6",
+  "version": "0.55.7",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release consuming 16 pending changesets, **forced to patch via `--as patch`** despite the computed bump being `minor` (most of the pending changesets are `feat`-level) — per explicit request to override.

`0.55.6` → `0.55.7`

### Changes shipping in this release

- fix(browser-pane): OAuth/GIS sign-in works in-pane again — no instance-exit, real child popup completes the login, external-protocol guard
- feat(browser-pane): wire Ctrl+L / Ctrl+R / Alt+Left / Alt+Right shortcuts
- fix(cef): stop mDNS 0.0.0.0:5353 bind that triggers the Windows Firewall prompt on launch
- test(lan-discovery): mark mDNS wire-discovery test ignored — environment-fragile, not flaky
- feat(warden): rebuild as a 5-section rail matching Armory's UI pattern
- feat(warden): extend AuditLogEntry with outcome/reason for Supervisor decisions
- feat(warden): add auto_continue_enabled per-agent opt-in field for Supervisor
- feat(warden): add transcript-read route + GetAgentTranscript MCP tool
- feat(warden): add SupervisorNudge route + MCP tool + consecutive-nudge ceiling
- feat(warden): add Supervisor manager UI + fix nudge entitlement/ceiling gaps
- feat(agent): expose model vendor / custom endpoint UI + add Antigravity harness
- feat(armory): dynamic pane title reflects selected rail section (also warden, settings)
- feat(jekt): add host-tier per-agent HMAC signing for sender verification
- fix(menu): context-submenu wrong-strategy positioning + main window silent show() no-op
- fix(tabs): desaturate tab color picker, keep agent pane borders vivid
- feat(pane-tab-strip): frosted-glass trailing space, per-pane zoom binding, top scroll-clearance for short agent conversations (#2566)

## Test plan

- [x] `scripts/release.sh --as patch` — all 5 version locations agree at `0.55.7` (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`)
- [x] Reviewed `git diff --staged` before committing — 16 changesets consumed/deleted, no unexpected file changes
- [ ] CI

<!-- agentmux:agent_id=agenta -->