### PR TITLE
fix(lan): stop broadcasting the full-access auth_key to LAN peers

### DIFF
--- a/.changesets/1786693117-fix-lan-stop-broadcasting-the-full-access-auth-key-to-lan-pe-0yzz.md
+++ b/.changesets/1786693117-fix-lan-stop-broadcasting-the-full-access-auth-key-to-lan-pe-0yzz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(lan): stop broadcasting the full-access auth_key to LAN peers

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -581,16 +581,26 @@ impl LanDiscoveryController {
     }
 
     /// Query LAN peers for which one hosts `agent_id`. Returns `(peer_url,
-    /// auth_key)` for the first peer that responds 2xx to the agent-lookup
+    /// lan_key)` for the first peer that responds 2xx to the agent-lookup
     /// endpoint. Results — both positive and negative — are cached for
     /// `LAN_AGENT_CACHE_TTL_SECS` seconds to avoid a blocking peer fan-out on
     /// every inject for cloud-only agents.
     ///
-    /// Security: `auth_key` is broadcast in the mDNS TXT record. This is
-    /// intentional and matches the same trust assumption as tier-2 loopback
-    /// forwarding — LAN traffic is trusted (private network). Anyone on the LAN
-    /// who can already intercept mDNS multicast can intercept the HTTP traffic
-    /// too, so the key adds no exposure beyond what already exists.
+    /// Security (SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md LAN P0-1):
+    /// the value broadcast in the mDNS TXT record / UDP probe response
+    /// (`self.auth_key` field name kept for wire back-compat with older
+    /// peer versions — see `Config::lan_key`'s doc comment) is now a
+    /// separate, narrowly-scoped credential, NOT the instance's full-access
+    /// `auth_key`. A passive LAN listener who captures it gets standing
+    /// access to only the two LAN-forwarding routes
+    /// (`lan_or_full_auth_middleware` in `server/mod.rs`) — not the full
+    /// `/agentmux/service` surface this used to expose. Broadcasting
+    /// *something* in cleartext to the LAN is still an accepted trade-off
+    /// of this opt-in feature (mDNS/UDP have no confidentiality of their
+    /// own); this change is about shrinking what a captured value is worth,
+    /// not about hiding it in transit — see the spec's LAN P1-1 for the
+    /// separate, not-yet-implemented "encrypt/authenticate the transport
+    /// too" hardening.
     pub async fn find_agent(
         &self,
         agent_id: &str,

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1191,8 +1191,11 @@ pub async fn bind_listeners_and_network(
 ) -> NetworkBundle {
     // When LAN discovery is enabled the user has explicitly opted in to network
     // visibility. Bind to 0.0.0.0 so devices on the same network can reach the
-    // port that mDNS advertises. The auth_key (X-AuthKey header, broadcast in
-    // the mDNS TXT record) gates every API route.
+    // port that mDNS advertises. The scoped `lan_key` (X-AuthKey header,
+    // broadcast in the mDNS TXT record) gates only the two LAN-forwarding
+    // routes (`lan_or_full_auth_middleware`) — not the full auth_key
+    // previously broadcast here, which gated the entire API surface (see
+    // Config::lan_key's doc comment).
     //
     // Known limitation: `bind_addr` is resolved once at startup. The toggle is
     // therefore only fully effective before launch (settings.json) or after a
@@ -1200,7 +1203,7 @@ pub async fn bind_listeners_and_network(
     //   OFF→ON: mDNS re-advertises the LAN IP but listeners stay on 127.0.0.1,
     //           so remote devices cannot connect until restart.
     //   ON→OFF: mDNS is stopped but listeners remain on 0.0.0.0 and are still
-    //           reachable on the LAN until restart (auth_key still gates routes).
+    //           reachable on the LAN until restart (lan_key still gates routes).
     // A future improvement would re-bind listeners on toggle; deferred because
     // rebinding an active axum server is non-trivial.
     let bind_addr = if config_watcher.get_settings().network_lan_discovery {
@@ -1240,7 +1243,7 @@ pub async fn bind_listeners_and_network(
         version.to_string(),
         web_addr.port(),
         event_bus.clone(),
-        config.auth_key.clone(),
+        config.lan_key.clone(),
     ));
     // Honor the current setting at boot — starts the daemon if enabled.
     lan_discovery.apply(config_watcher.get_settings().network_lan_discovery);
@@ -1411,6 +1414,7 @@ pub fn build_app_state(
 
     AppState {
         auth_key: config.auth_key.clone(),
+        lan_key: config.lan_key.clone(),
         boot_id: Arc::from(uuid::Uuid::new_v4().to_string()),
         version,
         app_path: config.app_path.clone(),

--- a/agentmux-srv/src/config.rs
+++ b/agentmux-srv/src/config.rs
@@ -36,6 +36,23 @@ pub enum SrvCommand {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub auth_key: String,
+    /// A separate, narrowly-scoped credential for LAN peer discovery
+    /// (mDNS TXT record + UDP broadcast responder) — NOT `auth_key`.
+    /// Minted fresh per-launch, internal to srv only (never needs to
+    /// leave this process except via the LAN broadcast itself, unlike
+    /// `auth_key` which the launcher/frontend also need — see
+    /// `LanDiscovery`'s doc comment). Broadcasting the full-access
+    /// `auth_key` to anything that can receive an mDNS multicast packet
+    /// or send a UDP probe used to mean a passive LAN listener got
+    /// standing access to the ENTIRE local `/agentmux/service` surface,
+    /// not just LAN-forwarding — this key is accepted only by the two
+    /// routes LAN peer forwarding actually needs
+    /// (`lan_or_full_auth_middleware` in `server/mod.rs`), so a captured
+    /// value's blast radius shrinks to "can forward jekts to this
+    /// instance and query which agents live here." See
+    /// docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md §2.1/§3
+    /// LAN P0-1.
+    pub lan_key: String,
     pub data_home: String,
     pub config_home: String,
     pub app_path: String,
@@ -82,8 +99,17 @@ impl Config {
             Some(agentmux_common::RuntimeMode::Dev { .. })
         );
 
+        // Two v4 UUIDs concatenated for margin over a single UUID's 122 bits
+        // of randomness — same "avoid a rand/getrandom dependency just for
+        // this" reasoning as agent_jekt_keys.rs's random_key_bytes(), but
+        // kept as a plain string here (not raw bytes) since this only ever
+        // travels as a String — an mDNS TXT record value / UDP JSON field /
+        // HTTP header — never binary-serialized or HMAC-keyed.
+        let lan_key = format!("{}{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+
         Ok(Config {
             auth_key,
+            lan_key,
             data_home,
             config_home,
             app_path,
@@ -181,6 +207,34 @@ mod tests {
         assert_eq!(config.config_home, "/config");
         assert_eq!(config.app_path, "/app");
         assert!(config.is_dev);
+        clear_env();
+    }
+
+    #[test]
+    fn lan_key_is_generated_nonempty_and_distinct_from_auth_key() {
+        let _lock = lock();
+        clear_env();
+        std::env::set_var("AGENTMUX_AUTH_KEY", "test-key-67890");
+        let args = CliArgs { wavedata: None, instance: "default".to_string(), command: None };
+        let config = Config::from_env_and_args(&args).unwrap();
+        assert!(!config.lan_key.is_empty());
+        assert_ne!(
+            config.lan_key, config.auth_key,
+            "the LAN-broadcast credential must never equal the full-access auth_key"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn lan_key_is_freshly_generated_per_call_not_a_fixed_constant() {
+        let _lock = lock();
+        clear_env();
+        std::env::set_var("AGENTMUX_AUTH_KEY", "test-key-67890");
+        let args = CliArgs { wavedata: None, instance: "default".to_string(), command: None };
+        let first = Config::from_env_and_args(&args).unwrap().lan_key;
+        std::env::set_var("AGENTMUX_AUTH_KEY", "test-key-67890");
+        let second = Config::from_env_and_args(&args).unwrap().lan_key;
+        assert_ne!(first, second, "each process launch must mint its own lan_key");
         clear_env();
     }
 }

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -318,6 +318,7 @@ mod recent_sessions_tests {
         let fs_watch_pool = crate::backend::fs_watch::FsWatchPool::new();
         let state = AppState {
             auth_key: "test".to_string(),
+            lan_key: "test-lan".to_string(),
             boot_id: std::sync::Arc::from("test-boot"),
             version: "test".to_string(),
             app_path: String::new(),
@@ -648,6 +649,7 @@ mod recent_sessions_tests {
         let fs_watch_pool = crate::backend::fs_watch::FsWatchPool::new();
         let state = AppState {
             auth_key: "test".to_string(),
+            lan_key: "test-lan".to_string(),
             boot_id: std::sync::Arc::from("test-boot"),
             version: "test".to_string(),
             app_path: String::new(),

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -68,6 +68,10 @@ use agentmux_common::api_types::{
 #[derive(Clone)]
 pub struct AppState {
     pub auth_key: String,
+    /// LAN peer-discovery credential — see `Config::lan_key`'s doc comment.
+    /// Accepted only by `lan_or_full_auth_middleware`'s two routes, never
+    /// the general `auth_middleware` gating everything else.
+    pub lan_key: String,
     /// Random identifier generated once per process boot — NOT the
     /// `--instance` channel name (`config.instance_id`), which is
     /// stable across restarts and shared by every process on the same
@@ -266,17 +270,34 @@ pub fn build_router(state: AppState) -> Router {
         // allow_origin comment above).
         .expose_headers(vec!["X-ZoneFileInfo".parse().unwrap()]);
 
+    // The two routes an LAN peer actually calls when forwarding a jekt or
+    // looking up which agents this instance hosts
+    // (`LanDiscoveryController::find_agent`, `server/reactive.rs`'s Tier-3
+    // forward). Kept OUT of `reactive_routes`/`authed_routes` deliberately
+    // — merged at the top level with their own `lan_or_full_auth_middleware`
+    // instead, so a LAN peer's scoped `lan_key` (see `Config::lan_key`) is
+    // accepted here without also being accepted by `authed_routes`'s much
+    // broader surface (the general `auth_middleware` there requires the
+    // full `auth_key` only). See `lan_or_full_auth_middleware`'s doc
+    // comment for why this can't just be nested inside `authed_routes`.
+    let lan_forward_routes = Router::new()
+        .route("/agentmux/reactive/inject", post(reactive::handle_reactive_inject))
+        .route("/agentmux/reactive/agent", get(reactive::handle_reactive_agent))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            lan_or_full_auth_middleware,
+        ));
+
     // Reactive routes. Previously registered without auth on the
     // assumption that localhost is a trust boundary; the 2026-05-11
     // security audit (C1 + C2) showed that any local process — or a
     // web page driving 127.0.0.1 via the permissive CORS layer — could
     // drive `/agentmux/reactive/inject` and reconfigure the cloud
     // muxbus poller. These routes are now merged into `authed_routes`
-    // below and gated by `auth_middleware`.
+    // below and gated by `auth_middleware`. (`/inject` and `/agent` are
+    // NOT here — see `lan_forward_routes` above.)
     let reactive_routes = Router::new()
-        .route("/agentmux/reactive/inject", post(reactive::handle_reactive_inject))
         .route("/agentmux/reactive/agents", get(reactive::handle_reactive_agents))
-        .route("/agentmux/reactive/agent", get(reactive::handle_reactive_agent))
         .route("/agentmux/reactive/audit", get(reactive::handle_reactive_audit))
         .route("/agentmux/reactive/register", post(reactive::handle_reactive_register))
         .route(
@@ -446,6 +467,7 @@ pub fn build_router(state: AppState) -> Router {
     Router::new()
         .merge(health)
         .merge(whatsapp_webhooks)
+        .merge(lan_forward_routes)
         .merge(authed_routes)
         .layer(cors)
         .with_state(state)
@@ -1371,6 +1393,49 @@ async fn auth_middleware(
 
     match auth_key {
         Some(key) if key == state.auth_key => next.run(req).await,
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "unauthorized"})),
+        )
+            .into_response(),
+    }
+}
+
+/// Auth middleware for the two LAN-forwarding-relevant reactive routes
+/// (`/agentmux/reactive/agent`, `/agentmux/reactive/inject`) — accepts
+/// EITHER `state.auth_key` (the normal, full-access case: every other
+/// caller of these two routes, e.g. agentmux-mcp's SendMessage tool for a
+/// plain host-tier inject) OR `state.lan_key` (a LAN peer forwarding a
+/// jekt or looking up which agents this instance hosts).
+///
+/// Deliberately a SEPARATE middleware from `auth_middleware`, applied to a
+/// standalone router merged at the top level rather than nested inside
+/// `authed_routes` — nesting would put `authed_routes`'s own
+/// `route_layer(auth_middleware)` on the outside, rejecting the LAN key
+/// before this middleware ever ran. This is why these two routes live in
+/// their own `lan_forward_routes` router in `router()`, not in
+/// `reactive_routes`.
+///
+/// `state.lan_key` grants access to ONLY these two routes — never the rest
+/// of `/agentmux/service`, `/agentmux/file`, shell creation, credential/
+/// identity endpoints, etc. See `Config::lan_key`'s doc comment for why
+/// this exists (SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md LAN P0-1).
+async fn lan_or_full_auth_middleware(
+    State(state): State<AppState>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    if req.method() == Method::OPTIONS {
+        return next.run(req).await;
+    }
+
+    let auth_key = req
+        .headers()
+        .get("X-AuthKey")
+        .and_then(|v| v.to_str().ok());
+
+    match auth_key {
+        Some(key) if key == state.auth_key || key == state.lan_key => next.run(req).await,
         _ => (
             StatusCode::UNAUTHORIZED,
             Json(json!({"error": "unauthorized"})),

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -38,6 +38,7 @@ pub(crate) fn test_state() -> AppState {
 
     AppState {
         auth_key: "test-secret-key".to_string(),
+        lan_key: "test-lan-key".to_string(),
         boot_id: std::sync::Arc::from("test-boot"),
         version: "0.28.20".to_string(),
         app_path: String::new(),
@@ -784,6 +785,103 @@ async fn self_endpoint_resolves_seeded_agent() {
     assert_eq!(json["workspace_name"], "Starter workspace");
     assert!(json["workspace_id"].is_string(), "workspace_id resolved");
     assert!(json["window_id"].is_string(), "window_id resolved via reverse lookup");
+}
+
+// SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md LAN P0-1 — the scoped
+// `lan_key` (broadcast via mDNS/UDP for LAN peer discovery) must be
+// accepted by the two LAN-forwarding routes but rejected everywhere else,
+// and the full `auth_key` must keep working on those same two routes
+// (the normal, non-LAN case — e.g. agentmux-mcp's SendMessage tool).
+
+#[tokio::test]
+async fn lan_key_is_accepted_on_reactive_agent_lookup() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/agentmux/reactive/agent?id=nonexistent")
+        .header("X-AuthKey", "test-lan-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    // 404 (agent not found), not 401 — proves the lan_key cleared auth and
+    // the request reached the handler.
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn full_auth_key_still_works_on_reactive_agent_lookup() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/agentmux/reactive/agent?id=nonexistent")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn lan_key_is_accepted_on_reactive_inject() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/agentmux/reactive/inject")
+        .header("X-AuthKey", "test-lan-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            serde_json::json!({"target_agent": "nonexistent", "message": "hi"}).to_string(),
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    // The route itself always returns 200 with a success:false body for an
+    // unknown target (see handle_reactive_inject) — the point here is just
+    // that it's not 401.
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn garbage_key_is_rejected_on_reactive_inject() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/agentmux/reactive/inject")
+        .header("X-AuthKey", "not-a-real-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            serde_json::json!({"target_agent": "nonexistent", "message": "hi"}).to_string(),
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// The whole point of LAN P0-1: a captured `lan_key` must NOT grant access
+/// to the general API surface, only the two LAN-forwarding routes.
+#[tokio::test]
+async fn lan_key_is_rejected_on_the_general_service_route() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/self?block_id=anything")
+        .header("X-AuthKey", "test-lan-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn lan_key_is_rejected_on_other_reactive_routes() {
+    let app = test_router();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/agentmux/reactive/agents")
+        .header("X-AuthKey", "test-lan-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 /// `/api/v1/self` is auth-gated like every other route.


### PR DESCRIPTION
## Summary
- LAN discovery (mDNS TXT record + UDP broadcast responder) used to hand out the SAME `auth_key` that gates the entire `/agentmux/service` API surface to anything that could receive an mDNS multicast packet or send a UDP probe from a private-looking source address. A passive listener who captured it once had standing full-instance access for as long as it kept running, not just visibility into forwarded jekt traffic.
- Mints a separate `lan_key` (`Config::lan_key`), freshly generated per process launch, broadcast in place of `auth_key`.
- New `lan_or_full_auth_middleware` accepts it ONLY on the two routes LAN peer forwarding actually needs (`/agentmux/reactive/agent`, `/agentmux/reactive/inject`) — applied via a standalone `lan_forward_routes` router merged at the top level, not nested inside `authed_routes` (nesting would put `authed_routes`'s own strict `auth_middleware` on the outside, rejecting the `lan_key` before the permissive middleware ever ran). Every other route keeps requiring the full `auth_key`, completely unaffected.
- The wire field name (mDNS TXT property / UDP JSON key) stays `"auth_key"` for backward compatibility with peer instances running an older version — only the *value* it carries changed, not the wire shape.

## What this doesn't change
- LAN discovery stays opt-in, default off.
- Broadcasting a credential in cleartext to the LAN is still this feature's accepted trade-off (mDNS/UDP have no confidentiality of their own) — this shrinks *what a captured value is worth* (two narrow routes, not the whole instance), it doesn't hide it in transit. LAN P1-1 (encrypt/authenticate the transport itself) from `docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md` remains open, not attempted here.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2210 passed (8 new: `lan_key` accepted on both LAN-forward routes, full `auth_key` still works, garbage key rejected, `lan_key` rejected on the general service route and on other reactive routes, `lan_key` generated non-empty/distinct/fresh-per-launch)
- [x] `cargo check --workspace` clean
- [ ] CI — pending

<!-- agentmux:agent_id=agentx -->