### PR TITLE
fix(agent-pane): stop truncating AskUserQuestion answers in tool summary row

### DIFF
--- a/.changesets/1786714074-fix-agent-pane-stop-truncating-askuserquestion-answers-in-to-67jz.md
+++ b/.changesets/1786714074-fix-agent-pane-stop-truncating-askuserquestion-answers-in-to-67jz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): stop truncating AskUserQuestion answers in tool summary row

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -366,6 +366,12 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 denied: props.node.status === "denied",
             })}
             data-tool={props.node.tool.toLowerCase()}
+            // Raw provider tool name, distinct from `data-tool` above: `tool` is normalized to
+            // a coarse closed set (unrecognized names, e.g. "AskUserQuestion", collapse to
+            // "other" — see normalizeToolName in stream-parser.ts), which loses exactly the
+            // names CSS needs to target one specific open-ended tool without touching the
+            // shared "other" styling every other unrecognized tool also falls back to.
+            data-tool-name={props.node.toolName?.toLowerCase()}
             onMouseEnter={() => { if (props.pinned || autoExpanded()) setUserHolding(true); }}
             onMouseLeave={() => setUserHolding(false)}
         >

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -468,6 +468,29 @@
         }
     }
 
+    // AskUserQuestion's answer should read like a normal typed message once answered —
+    // wrap and stay visible, not clip to one line + ellipsis like every other tool's
+    // collapsed summary (the default above, meant for command names and file paths).
+    // A free-text "Other" response can be a full sentence, unreadable if truncated —
+    // the only way to see it was previously the hover-peek tooltip.
+    .agent-tool-block[data-tool="askuserquestion"] {
+        .agent-tool-summary {
+            white-space: normal;
+            align-items: flex-start;
+        }
+
+        .agent-tool-name-peek-anchor {
+            overflow: visible;
+        }
+
+        .agent-tool-name {
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+            overflow: visible;
+            text-overflow: unset;
+        }
+    }
+
     // Per-tool-type color on the collapsed summary name.
     // Requires data-tool attribute on .agent-tool-block (ToolBlock.tsx).
     .agent-tool-block[data-tool="bash"]   .agent-tool-name { color: var(--term-bright-green); }

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -473,7 +473,10 @@
     // collapsed summary (the default above, meant for command names and file paths).
     // A free-text "Other" response can be a full sentence, unreadable if truncated —
     // the only way to see it was previously the hover-peek tooltip.
-    .agent-tool-block[data-tool="askuserquestion"] {
+    // Must target data-tool-name (raw provider name), not data-tool: AskUserQuestion isn't
+    // in normalizeToolName's knownTools list, so data-tool collapses it to "other" — matching
+    // on that would also affect every other unrecognized tool's summary row (codex review).
+    .agent-tool-block[data-tool-name="askuserquestion"] {
         .agent-tool-summary {
             white-space: normal;
             align-items: flex-start;


### PR DESCRIPTION
## Summary

- The collapsed tool row's default styling (`white-space: nowrap` +
  `text-overflow: ellipsis` on `.agent-tool-name`) is right for command
  names and file paths, but it was also silently clipping the printed
  answer after an `AskUserQuestion` prompt to one line — a longer selected
  answer, or a free-text "Other" response, became unreadable without
  hovering for the peek tooltip.
- Scoped via the `data-tool="askuserquestion"` attribute already set on
  `.agent-tool-block` (same pattern already used for per-tool colors right
  below it in `_document-nodes.scss`): switches to `white-space: pre-wrap`
  + `overflow-wrap: anywhere`, matching how normal typed user messages
  already wrap in `UserMessageBlock.tsx`. Font-size/line-height untouched
  — both inherit the same `var(--termfontsize)`/`1.35` from `.agent-view`.
- Applies to both the live pane and the read-only history tab, since both
  render tool rows through the same `ToolBlock.tsx`.

## Test plan

- [x] `npx stylelint frontend/app/view/agent/styles/_document-nodes.scss`
      — 31 pre-existing errors, confirmed identical count on `main` before
      this change (none introduced)
- [ ] Visual check: ask a question with a long answer, confirm it now wraps
      and stays visible in both the live pane and the history tab

<!-- agentmux:agent_id=agent1 -->