### PR TITLE
fix(agent-pane): composer strip stable width + deliberate edge-split tiers

### DIFF
--- a/.changesets/1786738726-fix-agent-pane-composer-strip-stable-width-deliberate-edge-s-ookx.md
+++ b/.changesets/1786738726-fix-agent-pane-composer-strip-stable-width-deliberate-edge-s-ookx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): composer strip stable width + deliberate edge-split tiers

--- a/docs/specs/SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md
@@ -152,10 +152,22 @@ centered filler when alone). `-stats-zone`'s `text-align: center` was
 already correct under this model — its identity *is* "centered," matching
 its widest-tier role — and needed no change.
 
-The design and table in the body above already reflect both corrections;
-this addendum exists so the "why" (two real revisions, not typos) has a
-record, matching this file's established pattern (see the 08-03 spec's
-own same-day addendum).
+**Round 3 (PR #2577 review) — the flicker fix (§1) never actually took
+effect.** `.agent-composer-strip-stats` is a plain `<span>` in
+`AgentComposerStrip.tsx`, and its parent (`.agent-composer-strip-stats-zone`)
+is not itself a flex/grid container — unlike `-controls`/`-right`'s
+children, nothing blockifies it, so it stayed genuinely `display: inline`.
+`min-width` has no effect on non-replaced inline elements per the CSS box
+model spec, so the `min-width: 12ch` from §1 silently did nothing — caught
+by reagent's automated review, not by any of the manual/live verification
+above. **Fix:** added `display: inline-block` to
+`.agent-composer-strip-stats`, which makes `min-width` actually apply
+while keeping the element sitting inline with any siblings.
+
+The design and table in the body above already reflect all three
+corrections; this addendum exists so the "why" (three real revisions, not
+typos) has a record, matching this file's established pattern (see the
+08-03 spec's own same-day addendum).
 
 ## Files changed
 

--- a/docs/specs/SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md
@@ -1,0 +1,191 @@
+# SPEC — Composer strip: stable width + deliberate edge-split tiers
+
+**Date:** 2026-08-14
+**Type:** Responsive layout fix
+**Status:** Implemented
+**Scope:** `frontend/app/view/agent/components/AgentComposerStrip.tsx`,
+`frontend/app/view/agent/styles/_composer-strip.scss`
+
+## Related history
+
+- `SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md` — the
+  immediately-prior design. Fixed a real clipping bug (PR #2393/#2408) by
+  switching from a hard `grid-template-areas` 2-row swap to `flex-wrap`
+  with no line cap, and made every tier below the widest (≥482px)
+  left-justified with lines breaking wherever content organically ran out
+  of room. **This spec reverts the left-justify decision** — flagged
+  directly by the user as a mistake — but keeps every part of the
+  clip-safety design (no `max-height`/`overflow:hidden`, internal
+  `flex-wrap` on `-controls`/`-right`) unchanged.
+
+## Problems
+
+1. **1↔2 line flicker with no width change.** `AgentComposerStrip` ticks
+   `turnTokens`/elapsed every second while a turn is in flight
+   (`useTick(1000)`). `formatElapsedCompact`/`formatCompactNumber` don't
+   produce fixed-length strings (`"9s"` → `"10s"`, `"↑890 ↓340"` →
+   `"↑1.2k ↓340"`), so the stats zone's rendered width drifts slightly
+   every tick. With no floor on that width, a wrap decision sitting right
+   at the fit boundary can flip on every tick even though the pane itself
+   never resized — the "toggles annoyingly between 1 and 2 lines"
+   complaint.
+2. **Left-justify-always was a mistake.** Below 482px, content wrapped
+   wherever `flex-wrap` happened to run out of room, always left-justified.
+   The user wants deliberate split points instead, preserving the *same
+   edge-split visual language as the widest tier* (something pinned left,
+   something pinned right, sometimes something centered between) as the
+   pane narrows through more line tiers — not raw left-packing, and,
+   after an intermediate revision below, explicitly **not** a centered
+   blob either.
+
+## Design
+
+### 1. Stable width for the stats zone
+
+`.agent-composer-strip-stats` gets `min-width: 12ch` (it's already
+monospace, so `ch` sizing is exact). This doesn't make the box perfectly
+immutable — a genuinely long-running turn can still exceed it and cause a
+real reflow — but it absorbs the common tick-to-tick jitter (seconds
+rolling over, token counts crossing a k/m suffix) that was the actual
+trigger, not a pane resize.
+
+### 2. Three deliberate, edge-split tiers
+
+Two zones (`-stats-zone`, `-right`) get a default `flex-basis: 100%` —
+forces each onto its own line. One `@container agent-pane` query
+progressively un-forces `-stats-zone` as width grows:
+
+| Width | Lines | Layout |
+|---|---|---|
+| < 280px | 3 | `[controls]` / `[stats]` / `[right]`, each its own line, each keeping its own identity (left / center / right) exactly as it would sit at the widest tier — just stacked instead of side by side |
+| 280–481px | 2 | `[controls (left) \| stats (right)]` on line 1 / `[right]` (right-anchored) alone on line 2 |
+| ≥ 482px | 1 | `controls` left / `stats` true-centered / `right` right (unchanged from the 08-03 addendum) |
+
+Each zone keeps a fixed identity at every tier instead of the whole strip
+being blob-centered:
+
+- **Controls** — never forced to `flex-basis: 100%` (it's the anchor the
+  other two zones' splits are relative to: as the first zone in DOM order
+  it's already alone on line 1 whenever `-stats-zone` is also forced onto
+  its own line). No `justify-content` override — stays left-anchored by
+  the flexbox default at every tier, including the ≥482px tier's own
+  `flex: 1 1 0` half of the row.
+- **Stats** — `text-align: center`, unconditionally. Centered whether it's
+  alone on a full-width line (<280px) or true-centered between controls
+  and right (≥482px). At 280-481px it shares line 1 with controls — the
+  outer strip's `justify-content: space-between` (not `center`) pins it
+  to that line's right edge, matching its role as the "other end" of that
+  2-zone line.
+- **Right** — `justify-content: flex-end`, unconditionally. Always
+  right-anchored, whether alone on a full-width line (<482px) or occupying
+  its own `flex: 1 1 0` half at the widest tier.
+
+`.agent-composer-strip`'s own `justify-content` is `space-between` — on a
+line with exactly 2 zones sharing it (the 280-481px tier's controls+stats
+line) this pins the first to the line's left edge and the last to its
+right edge, not centered as a pair. Lines with a single zone forced to
+`flex-basis: 100%` have no slack left for the parent's `justify-content`
+to matter either way, so that zone's own internal alignment (above) is
+what actually determines its position.
+
+### 3. Why this doesn't reintroduce the PR #2393/#2408 clipping bugs
+
+The `flex-basis: 100%` toggle is a "smart split point" implemented as a
+regular flex property, not a return to `grid-template-areas`:
+
+- Still no `max-height`/`overflow: hidden` on `.agent-composer-strip`.
+- `.agent-composer-strip-controls`/`-right` keep their own internal
+  `flex-wrap: wrap` — if a zone's content still doesn't fit the line it's
+  been assigned (e.g. a very long resolved model name in `-controls` on
+  the 2-line tier), it wraps onto an internal sub-line instead of
+  overflowing, exactly as the 08-03 fix established.
+- If a tier's breakpoint estimate is off for some real content
+  combination, the result is an extra reflow, not a clip — the same
+  safety net every breakpoint in this file already relies on.
+
+### Breakpoint estimate
+
+280px is estimated from documented content widths (controls ≈ 120-150px
+including its gap, stats ≈ 84-96px with the new 12ch floor plus gap),
+matching the file's existing practice of estimating from content width
+rather than measured DOM output (see the ≥482px tier's own history: first
+shipped as an estimated 640px, corrected to a live-measured 482px after
+testing in `task dev` found the real 1-line/2-line wrap point). **280px
+has not yet been live-verified in `task dev`** — same outstanding caveat
+as most breakpoints in this file; adjust if real content doesn't match.
+
+## Addendum (same day) — two corrections from live user review
+
+The design above shipped, was run in `task dev`, and got two rounds of
+direct user feedback:
+
+**Round 1 — dead/wrong `justify-content: center` on `-controls`.** The
+first implementation added `justify-content: center` to
+`.agent-composer-strip-controls`, reasoning it would matter symmetrically
+with `-stats-zone`/`-right` whenever the zone was forced alone onto a
+full-width line. But controls is *never* forced to `flex-basis: 100%` (it
+never needs to be — see "Controls" above), so its box always matches its
+own content width exactly, except at the ≥482px tier's `flex: 1 1 0`,
+where the box genuinely is wider than its content. There, `center`
+visibly pulled the Mode/Model/Effort trigger away from the left edge —
+the most commonly-seen tier, so immediately visible. **Fix:** removed the
+rule entirely rather than add a targeted override; controls now relies on
+the flexbox default (`flex-start`) everywhere, which is correct at every
+tier including ≥482px.
+
+**Round 2 — the whole design was still wrong: blob-centering instead of
+edge-splitting.** The first implementation used `.agent-composer-strip`'s
+`justify-content: center` (centering whichever zones share a line as a
+group) and internal `justify-content: center` on `-right` (centering its
+content when alone). User feedback: this wasn't the intent — "as the
+responsive [design] triggers more lines, the unit at which the left
+justified and right justified portions change... right now you are
+centering everything. We need it split just like at the largest
+responsive stage, just what gets split is thought through intelligently."
+I.e.: preserve the widest tier's left/center/right *edge-split* language
+at every tier — never collapse to a centered blob. **Fix:** `-strip`'s
+`justify-content` changed `center` → `space-between` (pins a 2-zone
+line's endpoints to that line's edges instead of centering them as a
+pair); `-right`'s internal `justify-content` changed `center` → `flex-end`
+(always right-anchored, matching its widest-tier identity, not merely
+centered filler when alone). `-stats-zone`'s `text-align: center` was
+already correct under this model — its identity *is* "centered," matching
+its widest-tier role — and needed no change.
+
+The design and table in the body above already reflect both corrections;
+this addendum exists so the "why" (two real revisions, not typos) has a
+record, matching this file's established pattern (see the 08-03 spec's
+own same-day addendum).
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/styles/_composer-strip.scss` | `.agent-composer-strip`: `justify-content: flex-start` → `space-between`. `-stats-zone`: default `flex-basis: 100%` + `text-align: center`; `flex-basis: auto` at ≥280px. `-right`: default `flex-basis: 100%` + `justify-content: flex-end` (both apply at every tier, not just ≥482px). `min-width: 12ch` added to `.agent-composer-strip-stats`. No change to `-controls` (an earlier `justify-content: center` addition was added then removed same day — see addendum). Comments updated throughout. |
+| `frontend/app/view/agent/components/AgentComposerStrip.tsx` | No structural change — header comment updated to describe the edge-split design. |
+
+## Verification performed
+
+- `npx tsc --noEmit` — clean (2 pre-existing unrelated errors in
+  `armory-view.tsx`/`warden-view.tsx` confirmed present on `main` before
+  this change, via `git stash` + re-run).
+- `npx stylelint frontend/app/view/agent/styles/_composer-strip.scss` —
+  one pre-existing hex-color lint error (`--warning-color, #d9a441`
+  fallback), same one flagged and left as-is by the 08-03 spec.
+- `npx vitest run frontend/app/view/agent` — 1142/1143 passed; the one
+  failure (`tool-renderers/registry.test.ts`, a 5s timeout) is unrelated
+  to this change and passes cleanly in isolation (confirmed flaky, not a
+  regression).
+- Run live in `task dev` (Windows) with hot reload; the Round-1 bug was
+  caught this way — by the user, not by static checks, since no test
+  exercises this component's rendered layout (same gap the 08-03 spec
+  shipped with).
+- **Not performed:** a full pass through every documented breakpoint (the
+  280px tier specifically) confirming pixel-accurate line counts — only
+  the ≥482px tier and the Round-1 bug's specific symptom were actually
+  observed. Resize a real agent pane through ~500px → ~150px and confirm:
+  (a) the 3 tiers land close to the documented widths, (b) the 280-481px
+  tier reads as controls-left/stats-right on one line, not centered
+  together, (c) no clipping/overlap with the textarea below at any width,
+  (d) the stats zone no longer visibly reflows on its own every second
+  during an in-flight turn at a width near a tier boundary.

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -3,15 +3,22 @@
 
 /**
  * AgentComposerStrip — status row that sits directly above the textarea in
- * the agent pane composer region. Below the widest tier: left-justified,
- * wrapping onto additional lines (no hard cap — see _composer-strip.scss's
- * file header) rather than clipping when the pane narrows — see
- * docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md.
- * At the widest tier (≥482px, live-measured — the real 1-line/2-line wrap
- * point, not an estimate): controls left / stats zone true-centered / right
- * zone right — restored the same day after the left-justify-always behavior
- * above silently dropped the centered stats presentation as a side effect
- * (the narrow-tier wrap/no-clip fix itself is unchanged either way).
+ * the agent pane composer region. Deliberate tiered split points (not
+ * organic flex-wrap reflow), always edge-split — same left/center/right
+ * visual language as the widest tier, extended to fewer zones per line as
+ * the pane narrows, never a centered blob — see
+ * docs/specs/SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md
+ * (supersedes SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md's
+ * "always left-justify below the widest tier" design, reverted per direct
+ * user feedback; an intermediate "center everything as one group" revision
+ * was itself corrected same day per further feedback). <280px: controls /
+ * stats / right, each its own line, each keeping its identity (left /
+ * center / right) exactly as it would sit at the widest tier, just
+ * stacked. 280-481px: [controls left | stats right] on line 1, right
+ * alone (right-anchored) on line 2. >=482px (live-measured — the real
+ * 1-line/2-line wrap point, not an estimate): controls left / stats zone
+ * true-centered / right right — see _composer-strip.scss for the actual
+ * container queries.
  *
  * In flow order:
  *   1. AgentRuntimeDropup (single Mode · Model · Effort trigger)

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -218,15 +218,16 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 </Show>
             </span>
 
-            {/* Stats zone — token/elapsed stats. Below the widest tier:
-                left-justified in flow, sitting right after the controls
-                zone or wrapping onto its own line when there isn't room for
-                both. At the widest tier: true-centered between the controls
-                and right zones (see _composer-strip.scss). The wrapper span
-                always renders (even with no stats yet) so this zone's
-                presence in the flow order — and therefore where the right
-                zone wraps to — stays stable whether or not stats are
-                populated yet. */}
+            {/* Stats zone — token/elapsed stats. Always centered (this
+                zone's identity at every tier, matching its widest-tier
+                true-centered position) — forced alone onto its own line
+                below 280px, rejoins the controls line (pinned to its right
+                edge) at 280-481px, true-centered between the controls and
+                right zones at the widest tier (see _composer-strip.scss).
+                The wrapper span always renders (even with no stats yet) so
+                this zone's presence in the flow order — and therefore
+                where the right zone wraps to — stays stable whether or not
+                stats are populated yet. */}
             <span class="agent-composer-strip-stats-zone">
                 <Show when={rightText()}>
                     <span
@@ -240,10 +241,12 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
 
             {/* Right zone — process badge + context text + auth tag + the
                 HOST/SANDBOX tag paired with the Shell toggle (see
-                .agent-composer-strip-host-shell below), in that order. That
-                pair still lands rightmost on a wide pane (last in a
-                left-filling line); on a wrapped line it starts at that
-                line's left margin like everything else. */}
+                .agent-composer-strip-host-shell below), in that order.
+                Always right-anchored (this zone's identity at every tier,
+                matching its widest-tier `justify-content: flex-end` pin) —
+                forced alone onto its own full-width line below 482px, its
+                own flex-basis-0 half of the row at the widest tier (see
+                _composer-strip.scss). */}
             <span class="agent-composer-strip-right">
                 <Show when={(props.processCount ?? 0) > 0}>
                     <button

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -384,6 +384,15 @@
 }
 
 .agent-composer-strip-stats {
+    // This is a plain <span> (AgentComposerStrip.tsx), and its parent
+    // (.agent-composer-strip-stats-zone) is not a flex/grid container —
+    // unlike -controls/-right's children, nothing blockifies this element,
+    // so it stays genuinely `display: inline` unless overridden here.
+    // `min-width` has no effect on non-replaced inline elements per the
+    // CSS box model spec — without this, the min-width below silently did
+    // nothing (reagent P1, PR #2577). `inline-block` keeps it sitting
+    // inline with any siblings while making min-width actually apply.
+    display: inline-block;
     font-family: var(--termfontfamily, monospace);
     font-size: 11px;
     color: var(--secondary-text-color);

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -6,21 +6,44 @@
 //   2. token/elapsed stats
 //   3. process badge · context text · auth tag · HOST/SANDBOX tag + Shell
 //      toggle (paired as a single unit — see .agent-composer-strip-host-shell)
-// Below the widest tier: a wrapping flex row, not a grid — `flex-wrap`
-// reflows content onto a new line automatically wherever it doesn't fit,
-// always left-justified, no centering, no right-pinning. See
-// docs/specs/SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md
-// (supersedes the grid + true-centered-stats design from
-// SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md and the
-// two-row grid-template-areas tier from
-// SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md) — this is the tier
-// that matters for never clipping/overlapping the textarea below, and stays
-// exactly as that spec left it.
-// At the widest tier (≥482px, see the container query near the bottom of
-// this file): the stats zone is true-centered again, controls left, right
-// zone right — same visual result as the pre-08-03 grid, restored the same
-// day after user feedback that always-left-justifying (even with room to
-// spare) silently dropped the centered stats presentation.
+//
+// Deliberate (not organic) tiered split points, always edge-split — same
+// visual language as the widest tier's left/center/right split, extended
+// down to fewer zones per line as the pane narrows, never a centered
+// blob. The "always left-justified below the widest tier" design from
+// SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03.md was
+// reverted per direct user feedback ("the justify left was a mistake"),
+// and an intermediate "center everything" revision was itself corrected
+// same day per further feedback ("split just like at the largest
+// responsive stage... what gets split is thought through intelligently")
+// — see SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md. Three
+// tiers, each choosing which zones share a line:
+//   - <280px (3 lines): controls / stats / right, each its own line, each
+//     keeping its own identity — controls left, stats centered, right
+//     right — exactly as it would sit at the widest tier, just stacked.
+//   - 280-481px (2 lines): [controls left | stats right] on line 1, right
+//     alone (right-anchored) on line 2.
+//   - >=482px (1 line): controls / stats / right, edge-pinned (unchanged
+//     from the 08-03 addendum below).
+// `justify-content: space-between` on the outer strip pins a 2-zone
+// line's first item to the left edge and last item to the right edge —
+// not centered as a group. A zone forced alone onto a full-width line
+// (flex-basis: 100%) has no slack on its own line for that to matter
+// either way, so it keeps its identity via internal alignment instead —
+// see .agent-composer-strip-right's `justify-content: flex-end` (always
+// right-anchored) and -stats-zone's `text-align: center` (always
+// centered, matching its role at the widest tier).
+//
+// The split points themselves still use `flex-wrap` + a `flex-basis`
+// toggle, not a hard grid-template-areas swap — deliberately. That's what
+// actually fixed the real clipping bug this file has a documented history
+// with (PR #2393/#2408, see the "Revised during review" section of the
+// 08-03 spec): no `max-height`/`overflow:hidden` on the outer strip, and
+// `.agent-composer-strip-controls`/`-right` keep their own internal
+// `flex-wrap: wrap` as a last-resort safety net if a zone's content still
+// doesn't fit the line it's been assigned. None of that changes here — only
+// *which* zones are assigned to share a line, and how each line's content
+// is justified, changed.
 //
 // No max-height/overflow:hidden cap: an earlier revision capped this at
 // ~3 lines, but .agent-composer-strip-controls/-right can *also* wrap
@@ -40,7 +63,18 @@
     display: flex;
     flex-wrap: wrap;
     align-content: flex-start; // stack wrapped lines from the top
-    justify-content: flex-start; // always left
+    // Edge-split per line (per-line, standard flex-wrap behavior — each
+    // wrapped line is justified independently), same visual language as
+    // the widest tier's left/center/right split, just fewer zones per
+    // line as it narrows. On a 2-zone line (the 280-481px tier's
+    // controls+stats line) this pins the first zone to the line's left
+    // edge and the last to its right edge — not centered as a blob. A
+    // zone forced alone onto a full-width line (flex-basis: 100%, below)
+    // has no slack left on ITS line for this to matter either way, so it
+    // keeps its own identity via internal alignment instead — see
+    // -right's `justify-content: flex-end` (always right-anchored) and
+    // -stats-zone's `text-align: center` (its role at the widest tier too).
+    justify-content: space-between;
     align-items: center;
     row-gap: 2px;
     column-gap: var(--space-2);
@@ -61,8 +95,9 @@
 }
 
 // ── Controls zone ────────────────────────────────────────────────────────
-// First in flow — wraps onto its own line if it and the stats zone don't
-// both fit on line 1.
+// First in flow, always on line 1. Never gets its own forced flex-basis:
+// 100% break — it's the anchor the other two zones' split points are
+// defined relative to (see the 280px/482px container queries below).
 
 .agent-composer-strip-controls {
     display: flex;
@@ -75,6 +110,14 @@
     // the Shell toggle itself — same fix applied to both zones.
     flex-wrap: wrap;
     align-items: center;
+    // No `justify-content` override here (default flex-start) — unlike
+    // -stats-zone/-right, this zone never gets a forced `flex-basis: 100%`
+    // (see the file-header comment: controls is the anchor the other two
+    // zones' splits are relative to), so its box always matches its own
+    // content width exactly except at the ≥482px tier's `flex: 1 1 0`
+    // — where it must stay left-anchored, not centered, to match -right's
+    // opposite `flex-end` pin. Centering here would be a no-op everywhere
+    // else and actively wrong at that one tier.
     gap: var(--space-1);
     // A flex item's default min-width is `auto` (its content's intrinsic
     // size), not 0 — without this the runtime trigger's own max-width cap
@@ -84,13 +127,23 @@
 }
 
 // ── Stats zone ───────────────────────────────────────────────────────────
-// Below the widest tier: sits left-justified in flow, immediately after
-// controls when there's room, or alone on its own wrapped line when there
-// isn't. At the widest tier (≥482px, see the container query near the
-// bottom of this file): true-centered between the controls and right zones.
+// Default (<280px, 3-line tier): forced onto its own line, below controls
+// — see the flex-basis toggle below the shed-content queries. At 280px+
+// (2-line tier): rejoins controls on line 1. At the widest tier (≥482px):
+// true-centered between the controls and right zones (see the container
+// query near the bottom of this file).
 
 .agent-composer-strip-stats-zone {
     min-width: 0;
+    // Default tier: forced alone onto its own line (paired with -right's
+    // identical default below — together these two rules are what make
+    // <280px a 3-line layout with no container query needed for the
+    // narrowest tier itself, only for progressively un-forcing it as width
+    // grows). Centers the stats text within that full-width line — this
+    // zone's identity is "centered" at every tier (matching its role at
+    // the widest tier), independent of -strip's own `justify-content`.
+    flex-basis: 100%;
+    text-align: center;
 }
 
 // The consolidated Mode/Model/Effort trigger — a single <button> laying out
@@ -258,15 +311,17 @@
 // ── Right zone ───────────────────────────────────────────────────────────
 // Process badge · context text · auth tag · HOST/SANDBOX tag + Shell toggle
 // (paired, see .agent-composer-strip-host-shell below), in that order — the
-// HOST/SANDBOX + Shell pair last. Below the widest tier: not pinned to the
-// row's right edge —
-// on a wide-but-below-482px pane it still lands near the right because it's
-// the last thing in flow and line 1 fills left-to-right; on a wrapped line
-// it starts at that line's left margin like everything else. At the widest
-// tier (≥482px): explicitly pinned right again via `justify-content:
-// flex-end` on this zone's own flex-basis-0 half of the row (see the
-// container query near the bottom of this file) — same visual position as
-// the pre-08-03 grid's `justify-self: end`.
+// HOST/SANDBOX + Shell pair last. Right-anchored (`justify-content:
+// flex-end`) at every tier — this zone's identity, matching the widest
+// tier's pin — not just centered filler. Forced onto its own line
+// (flex-basis: 100%, default) at every tier below 482px — both the 3-line
+// and 2-line tiers give it a dedicated line, since it's consistently the
+// largest zone and holds the strip's one real action (Shell). At the
+// widest tier (≥482px): the same `flex-end` pin now applies to this
+// zone's own flex-basis-0 half of the row instead of its full-width line
+// (see the container query near the bottom of this file, which overrides
+// the flex-basis: 100% default below) — same visual position as the
+// pre-08-03 grid's `justify-self: end`.
 
 .agent-composer-strip-right {
     display: flex;
@@ -279,8 +334,16 @@
     // silently unreachable." Reagent P1, PR #2393.
     flex-wrap: wrap;
     align-items: center;
+    // Always right-anchored (this zone's identity at every tier, matching
+    // the widest tier's `flex-end` pin) — forced alone onto its own
+    // full-width line below 482px (see -stats-zone's identical
+    // flex-basis: 100% default above), so this right-aligns its own
+    // content (badge / ctx / auth / host+shell) within that full-width
+    // line rather than leaving it glued to the line's own left edge.
+    justify-content: flex-end;
     gap: var(--space-1-5);
     min-width: 0;
+    flex-basis: 100%;
 }
 
 // HOST/SANDBOX tag + Shell toggle, paired as a single unit — moved out of
@@ -326,6 +389,17 @@
     color: var(--secondary-text-color);
     letter-spacing: 0.01em;
     white-space: nowrap;
+    // Reserves a stable footprint for this text so the strip doesn't
+    // reflow every second while a turn is in flight. The text ticks live
+    // (useTick(1000) in AgentComposerStrip.tsx) and its rendered length
+    // isn't fixed — e.g. "9s" → "10s" or "↑890 ↓340" → "↑1.2k ↓340" — so
+    // without a floor, a wrap decision sitting right at the boundary can
+    // flip every tick even though the pane itself never resized. 12ch
+    // comfortably covers the common in-flight range (per-turn tokens,
+    // elapsed up to several minutes); a genuinely long single turn can
+    // still exceed it and reflow, same as every other width in this file —
+    // that's an occasional, real width change, not tick-driven jitter.
+    min-width: 12ch;
 
     // Live "Compacting… Ns" readout (Tier 1/2 —
     // SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md). Reuses the
@@ -407,10 +481,9 @@
 }
 
 // ── Responsive tiers ─────────────────────────────────────────────────────
-// The wrap itself needs no width-keyed rules — `flex-wrap: wrap` on
-// `.agent-composer-strip` (outer lines) plus on `-controls`/`-right`
-// (internal sub-lines) reflows content onto additional lines automatically
-// as the pane narrows, always left-justified, with no hard cap — see the
+// `flex-wrap: wrap` on `.agent-composer-strip` (outer lines) plus on
+// `-controls`/`-right` (internal sub-lines) reflows content onto additional
+// lines automatically as the pane narrows, with no hard cap — see the
 // file-header comment for why there's no `max-height`/`overflow:hidden`
 // here. That alone is the fix for the clipping/overlap
 // `SPEC_COMPOSER_STRIP_TWO_LINE_RESPONSIVE_2026_07_30.md` documented (the
@@ -419,18 +492,32 @@
 // nothing reflowed in production before that spec, and the two-line
 // grid-template-areas tier it landed only ever bought a 2nd line).
 //
-// What still needs a width-keyed rule is the *last-resort* shed order
-// below — not to prevent clipping (nothing clips now) but to keep the
-// strip's real-world height to ~1-3 lines instead of growing tall enough
-// to noticeably eat into the transcript above it. Content and Shell stay
-// visible at every tier — ctx is the one safety signal in this bar
-// (compaction proximity), Shell is the strip's one real action — so
-// shedding starts with the least essential, informational-only items,
-// trimming content before either zone would otherwise need an internal
-// sub-line.
+// What DOES need a width-keyed rule is *which* zones share a line — the
+// deliberate 3-line/2-line/1-line split points from the file-header comment
+// (SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md), plus the
+// *last-resort* shed order below — not to prevent clipping (nothing clips
+// now) but to keep the strip's real-world height to ~1-3 lines instead of
+// growing tall enough to noticeably eat into the transcript above it.
+// Content and Shell stay visible at every tier — ctx is the one safety
+// signal in this bar (compaction proximity), Shell is the strip's one real
+// action — so shedding starts with the least essential, informational-only
+// items, trimming content before either zone would otherwise need an
+// internal sub-line.
 // Breakpoints are estimated from content width (right zone ≈ badge 28px +
 // ctx 50px + auth 70px + Shell 40px + 3 gaps ≈ 220px), not measured DOM
 // output — confirm against real rendered widths in `task dev` and adjust.
+
+// 2-line split point: lets the stats zone rejoin controls on line 1 (its
+// default, below 280px, is flex-basis: 100% — forced onto its own line,
+// giving the 3-line tier). Controls (~120-150px incl. gap) + stats (12ch
+// reserved ≈ 84-96px depending on font metrics, plus gap) together land
+// comfortably under this — estimated, same caveat as every breakpoint here.
+@container agent-pane (min-width: 280px) {
+    .agent-composer-strip-stats-zone {
+        flex-basis: auto;
+        text-align: left;
+    }
+}
 
 // HOST/SANDBOX sheds ahead of auth (below), not alongside it: it now shares
 // its wrapper with Shell — the strip's one real action, which never sheds —
@@ -473,23 +560,20 @@
     }
 }
 
-// ── Widest tier — restore true-centered stats (2026-08-03, later same day) ──
-// The left-justified flex-wrap above is unchanged and stays the ONLY layout
-// below this breakpoint — it fixed a real clipping bug (PR #2393, Codex
-// P1 / ReAgent P2: content could overflow under the textarea) and nothing
-// here touches that. But left-justifying at EVERY width, including wide
-// panes with a whole line to spare, silently dropped the true-centered
-// stats zone from SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md
-// as a side effect, not a deliberate goal — flagged by the user directly.
-// Restore it, but without the grid that caused the original clipping bug:
-// give `-controls` and `-right` matching `flex: 1 1 0` (equal flex-basis, so
-// they grow to occupy equal width) and center-align the stats zone between
-// them — the standard "true-center a middle flex item regardless of
-// left/right content width" pattern, same visual result as the old
-// `1fr auto 1fr` grid, without switching `display` or touching `flex-wrap`
-// (still `wrap`, inherited, unchanged — if this breakpoint's estimate is a
-// little off for some real content combination, it still safely reflows
-// instead of clipping, same safety net as every other tier in this file).
+// ── Widest tier — edge-pinned controls/right, true-centered stats ──────────
+// The 1-line tier (originally landed 2026-08-03, later same day; unchanged
+// by the 2026-08-14 centered-smart-split revision above other than the
+// surrounding tiers' comments). Gives `-controls` and `-right` matching
+// `flex: 1 1 0` (equal flex-basis, so they grow to occupy equal width) and
+// center-aligns the stats zone between them — the standard "true-center a
+// middle flex item regardless of left/right content width" pattern.
+// Overrides both lower tiers' `flex-basis: 100%`/`auto` toggles on
+// `-stats-zone`/`-right` (this block is last in file order, so it wins the
+// cascade at any width where multiple `min-width` container queries match
+// at once) — nothing here switches `display` or touches `flex-wrap` (still
+// `wrap`, inherited, unchanged — if this breakpoint's estimate is a little
+// off for some real content combination, it still safely reflows instead of
+// clipping, same safety net as every other tier in this file).
 // Breakpoint is estimated (controls ~150-250px + stats ~120-180px + right
 // ~220px + gaps ≈ 600-650px on one line), not measured — needs live
 // task dev verification, same caveat as every breakpoint in this file.


### PR DESCRIPTION
## Summary
- Fixes the composer strip (Shell/stats/model-selector row above the agent pane textarea) toggling annoyingly between 1 and 2 lines with no pane resize: the live-ticking stats text (tokens/elapsed, `useTick(1000)`) had no width floor, so a wrap decision sitting near the fit boundary could flip every second. Added `min-width: 12ch` to absorb the common tick-to-tick jitter.
- Reverts the "always left-justify below the widest tier" design (SPEC_COMPOSER_STRIP_LEFT_JUSTIFIED_TIERED_WRAP_2026_08_03) per direct feedback, and corrects an intermediate "center everything as one group" revision (also per feedback, same day) to the final design: each zone (controls/stats/right) keeps a fixed left/center/right identity at every tier — matching the widest (≥482px) tier's own edge-pinned layout — redistributed across up to 3 lines as the pane narrows, rather than collapsing into a centered blob or wrapping wherever content organically ran out of room.
- Full design writeup, including two same-day corrections from live `task dev` review, in `docs/specs/SPEC_COMPOSER_STRIP_CENTERED_SMART_SPLIT_2026_08_14.md`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx stylelint frontend/app/view/agent/styles/_composer-strip.scss` — one pre-existing unrelated hex-color warning, same as before this change
- [x] `npx vitest run frontend/app/view/agent` — 1142/1143 passed (1 pre-existing flaky timeout, unrelated, passes in isolation)
- [x] Verified live in `task dev` (Windows) with hot reload — confirmed by direct user review, including catching and fixing a real bug (dead/wrong `justify-content: center` on the controls zone) that static checks didn't catch

<!-- agentmux:agent_id=loap -->