### PR TITLE
fix(agent): seed parent pane's zoom before shell drawer construct

### DIFF
--- a/.changesets/1786740499-fix-agent-seed-parent-pane-s-zoom-before-shell-drawer-constr-jdpx.md
+++ b/.changesets/1786740499-fix-agent-seed-parent-pane-s-zoom-before-shell-drawer-constr-jdpx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): seed parent pane's zoom before shell drawer construct, close remaining twitch

--- a/docs/specs/SPEC_AGENT_SHELL_PARENT_PANE_ZOOM_SEED_RACE_2026-08-14.md
+++ b/docs/specs/SPEC_AGENT_SHELL_PARENT_PANE_ZOOM_SEED_RACE_2026-08-14.md
@@ -1,0 +1,210 @@
+# Agent shell drawer: zoom twitches ~500ms after every open (parent pane's zoom, not the shell's own)
+
+**Date:** 2026-08-14
+**Status:** Draft — root-cause analysis, no code written yet.
+**Owner:** Agent1
+**Area:** Agent pane / shell drawer (`AgentShellSubblock`), terminal zoom
+
+---
+
+## 1. Problem
+
+Reported: "in the agent pane, when opening the shell, the zoom level
+twitches one level every time it opens, after about 500ms or so, happens
+every time." Reproducible, not flaky — happens on every open, at a
+consistent delay.
+
+This is the **same bug class**, in the **same component**, as
+`docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md` (PR #2522,
+shipped `1d15a77cb`) — but that fix closed the race for the shell's *own*
+persisted zoom (`term:zoom` on the shell sub-block). This is a second,
+structurally identical, still-open race one level up: the shell's font-size
+formula also depends on the **parent agent pane's** zoom, which was never
+given the same seed-before-use treatment.
+
+## 2. Current behavior (root cause)
+
+### 2.1 The formula has two independent zoom inputs, only one of which was fixed
+
+`AgentShellSubblock.tsx:142-145`:
+
+```ts
+const termFontSize = createMemo(() => {
+    const paneZoom = props.agentPaneZoom() || 1;
+    return Math.max(4, Math.min(64, Math.round((BASE_FONT_SIZE * termZoom()) / paneZoom)));
+});
+```
+
+`termZoom()` (the shell's own `term:zoom`) is now correctly seeded before
+`TermWrap` construction — that's what the 08-10 spec fixed. `paneZoom` —
+`props.agentPaneZoom`, passed as `agentPaneZoom={zoomFactor}` at the call
+site (`agent-view.tsx:2262`) — is **not** seeded by `AgentShellSubblock` at
+all. It's read live, straight from the parent's own memo.
+
+### 2.2 The parent's zoom memo has the exact same async-atom shape the 08-10 fix was built to avoid
+
+`agent-view.tsx:1791-1796`:
+
+```ts
+const zoomFactor = createMemo(() => {
+    const meta = block()?.meta;
+    const z = meta?.["term:zoom"];
+    if (z == null || typeof z !== "number" || isNaN(z)) return 1.0;
+    return Math.max(0.5, Math.min(2.0, z));
+});
+```
+
+`block` here is `model.blockAtom` (`agent-model.ts:67`):
+`WOS.getWaveObjectAtom<Block>(\`block:${blockId}\`)` — the identical async
+WOS-atom mechanism the shell's own `subBlockAtom` uses, and identical to
+what `SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md` §2.2 already
+documented in detail for that case: seeds to `null`/loading, resolves later
+via a `GetObject` round-trip. Before it resolves, `block()` is falsy →
+`zoomFactor()` returns the default `1.0`, regardless of what the pane's
+actual persisted zoom is.
+
+### 2.3 Why the parent pane's own rendering doesn't show this (misleadingly, since it made this look "already fixed")
+
+The 08-10 spec's own §3 notes the agent pane's zoom *did* have this race
+historically, and was fixed by seeding the value into the block's *initial*
+meta before creation (`command-registry.ts:416-450`, commit `69de7d5e2`).
+That fix guarantees that **whenever** `block()` first resolves, the value it
+carries is already correct — it does not, and structurally cannot, make
+`block()` resolve synchronously. The `undefined → default → real value` gap
+still exists on every pane mount; it's just that the *pane's own* content
+(CSS `zoom` on `.agent-view`) transitioning through that gap is a single
+instant snap on a whole pane, with no forced re-render/re-layout of
+character cells — far less perceptible than what happens downstream in the
+shell (§2.4). That's why this wasn't caught as a bug for the pane itself:
+the race is real there too, just invisible.
+
+### 2.4 Why it's visible and jarring specifically in the shell
+
+Same correction-effect mechanism the 08-10 spec documented for the shell's
+own zoom, still present by design for live Ctrl+Wheel updates
+(`AgentShellSubblock.tsx:153-168`):
+
+```ts
+createEffect(() => {
+    const fs = termFontSize();
+    const loaded = wrapLoaded();
+    if (termWrap?.terminal && loaded) {
+        termWrap.terminal.options.fontSize = fs;
+        termWrap.handleResize();
+    }
+});
+```
+
+When `block()` (parent pane) resolves shortly after the shell has already
+mounted and painted at the default-`paneZoom` font size, `termFontSize()`
+recomputes, this effect fires, and — same as the original bug —
+`handleResize()` internally forces `core._renderService.clear()` then
+`terminal.resize(...)`: a real render-state mutation, not a CSS artifact,
+with no transition to soften it (`_composer-strip.scss` has none for this
+drawer, per the 08-10 spec's own confirmation). One firing, one visible
+"twitch," exactly the reported shape.
+
+### 2.5 Why it's consistently ~500ms, not flaky
+
+The shell drawer is typically opened shortly after the agent pane itself,
+which means the pane's own `blockAtom` `GetObject` round-trip is often
+still in flight when the shell mounts. Unlike the original bug (§2.2.6 of
+the 08-10 spec — a genuinely flaky race window), this one resolves at
+whatever this environment's consistent WOS/RPC latency is for that fetch —
+observed here as a steady ~500ms, not "sometimes wrong, sometimes not."
+
+## 3. Relationship to the 08-10 fix — why this wasn't caught by it
+
+The 08-10 spec's own §4 requirement 4 ("no regression to per-shell scoping
+— zoom stays keyed to the shell sub-block's own identity") and its fix
+scope were both specific to `termZoom()`/the shell's *own* meta. `paneZoom`
+was correctly identified as a separate, independent input (comment at
+`AgentShellSubblock.tsx:257-261`: "the pane's zoom... and the shell's own
+zoom... are independent controls, and neither should visually leak into the
+other") — but "independent" only covered *value* leakage (not compounding
+the two zooms together), not *timing* leakage. The parent's async-resolve
+gap leaks into the shell's paint timing regardless of the two zooms being
+otherwise correctly decoupled in the formula.
+
+## 4. Goal & requirements
+
+1. **No visible twitch on open**, matching the 08-10 fix's own bar — the
+   terminal's first paint (and its first live-effect firing, if any) must
+   already reflect the FINAL `agentPaneZoom()`, not a default that gets
+   corrected after the fact.
+2. **No new redundant fetch.** `AgentShellSubblock` must not trigger a
+   second `GetObject` for the parent block — `agent-view.tsx` (or whatever
+   owns `model.blockAtom`) is presumably already fetching it, same
+   reasoning as the 08-10 spec's §5a P1 finding for the shell's own oref.
+3. **Don't touch the pane's own zoom-seeding path** (`command-registry.ts:416-450`)
+   — out of scope, already correct for its own purpose (§2.3).
+4. **Live Ctrl+Wheel zoom** (both the pane's and the shell's own, while the
+   shell is open) must keep working exactly as today.
+
+## 5. Proposed fix direction
+
+Extend the *already-proven* pattern from the 08-10 fix — `AgentShellSubblock`
+already has `waitForWaveObjectSettled(oref)` (`AgentShellSubblock.tsx:98-105`),
+a helper built exactly for "wait for an in-flight WOS fetch to settle
+without triggering a new one." It's currently only called for the shell's
+own sub-block oref (`AgentShellSubblock.tsx:311-313`, gated on
+`isExistingBlock`). Call it a second time for the **parent** block's oref
+before flipping `zoomSeeded(true)`:
+
+```ts
+await waitForWaveObjectSettled(WOS.makeORef("block", props.parentBlockId));
+```
+
+`AgentShellSubblock` already receives `parentBlockId` as a prop
+(`agent-view.tsx:2254`), so no new prop plumbing is needed. Unlike the
+shell's own oref wait, this one should run **unconditionally** (not gated
+on `isExistingBlock`) — the parent pane's zoom fetch is in flight or not
+independent of whether this particular shell sub-block is new or reused.
+This is cheap in the already-settled case: `waitForWaveObjectSettled`
+returns immediately if the loading atom isn't `null` (i.e., most opens,
+where the pane finished loading before the user ever reached for the
+shell) — the added wait only has teeth in the specific window this bug
+report describes.
+
+Run both waits concurrently (`Promise.all`) rather than sequentially, so a
+reused shell with its own pending fetch doesn't pay both round-trips
+back-to-back.
+
+Everything else from the 08-10 fix (the `BrainSpinner` loading overlay
+masking the drawer until `zoomSeeded()`, the `wrapLoaded`-gated live-update
+effect) already generalizes for free — the overlay just stays up slightly
+longer on the specific opens where the parent fetch is still in flight,
+which is exactly the masking behavior wanted here.
+
+## 6. Non-goals / out of scope
+
+- Re-litigating how the pane's own zoom is seeded/persisted
+  (`command-registry.ts:416-450`) — correct already, per §2.3.
+- The unrelated Windows-only PSReadLine "thaw" resize
+  (`termwrap.ts:396-430`, fires ~250-300ms after `TermWrap.init()` on every
+  terminal on Windows) and the font-load re-fit
+  (`termwrap.ts:349-365`) — both real, both pre-existing, both column/grid
+  reflows rather than font-size changes. Considered and ruled out as the
+  primary cause: the report specifically says "zoom level," and the timing/
+  consistency (steady ~500ms, not flaky, "every time") matches the
+  parent-block WOS fetch far better than either of these, which don't
+  depend on network/RPC latency. Worth a sanity check during implementation
+  (watch `termWrap.terminal.options.fontSize` vs `.cols` at the moment of
+  the twitch) but not expected to require its own fix.
+- The standalone Terminal widget (`view: "term"`) — reads the pane's own
+  zoom directly (it *is* the pane), not a nested child depending on a
+  parent's separately-resolving zoom, so this specific race shape doesn't
+  apply to it.
+
+## 7. Open questions
+
+- Should `waitForWaveObjectSettled` be renamed/generalized now that it's
+  called for two different orefs in the same component (e.g. inline both
+  calls under one `Promise.all` with a short comment, vs. extracting a
+  `waitForBothSettled(...)` helper)? Minor, decide during implementation —
+  doesn't change the fix's correctness either way.
+- Is there a third dependency on `props.agentPaneZoom()` anywhere else in
+  `AgentShellSubblock.tsx` (e.g. `handleWheel`/live Ctrl+Wheel math) that
+  should double-check its own value is post-seed, or was it already
+  correctly gated by the existing `wrapLoaded`-based effect? Worth a quick
+  audit pass during implementation, not expected to change the fix shape.

--- a/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
@@ -23,6 +23,7 @@
  */
 
 import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentShellSubblock } from "./AgentShellSubblock";
 
@@ -126,10 +127,23 @@ function resolveSeedFetch(oref: string) {
     set({ value: meta ? { meta } : null, loading: false });
 }
 
+/** All tests use parentBlockId="parent-1" — pre-settle its oref as "already
+ *  resolved, empty" by default (the realistic common case: the pane's own
+ *  zoom fetch finished before the shell was ever opened), so the new
+ *  parent-oref wait (SPEC_AGENT_SHELL_PARENT_PANE_ZOOM_SEED_RACE_2026-08-14.md)
+ *  doesn't add latency/timeout delay to every other test in this file. Tests
+ *  that specifically exercise that race overwrite this back to loading
+ *  before render. */
+const PARENT_OREF = "block:parent-1";
+function preSettleOref(oref: string) {
+    blockDataSignals.set(oref, createSignal<{ value: any; loading: boolean }>({ value: null, loading: false }));
+}
+
 beforeEach(() => {
     blockDataSignals.clear();
     seedData.clear();
     termWrapInstances.length = 0;
+    preSettleOref(PARENT_OREF);
     // jsdom has no ResizeObserver; AgentShellSubblock sets one up
     // unconditionally after a successful init().
     (globalThis as any).ResizeObserver =
@@ -325,4 +339,87 @@ describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE
         set({ value: { meta: { "term:zoom": 2.0 } }, loading: false });
         await waitFor(() => expect(termWrapInstances[0].terminal.options.fontSize).toBe(26));
     });
+});
+
+describe("AgentShellSubblock — parent pane zoom seed race (SPEC_AGENT_SHELL_PARENT_PANE_ZOOM_SEED_RACE_2026-08-14)", () => {
+    it("waits for the parent pane's zoom fetch to settle before constructing the terminal, even for a freshly created sub-block", async () => {
+        // Freshly created sub-block — no wait needed on its OWN oref (matches the
+        // existing "defaults to BASE_FONT_SIZE" test) — but the parent's oref is
+        // still loading here (overwriting beforeEach's default settled state),
+        // which alone must be enough to block construction. This is exactly the
+        // gap the 08-10 fix didn't close: that fix only ever waited on the
+        // shell's own oref.
+        blockDataSignals.set(PARENT_OREF, createSignal<{ value: any; loading: boolean }>({ value: null, loading: true }));
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={undefined}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        // Still waiting on the parent — old code (pre-fix) would have
+        // constructed TermWrap here already, since a fresh sub-block never
+        // waited on anything at all.
+        await new Promise((r) => setTimeout(r, 10));
+        expect(termWrapInstances.length).toBe(0);
+
+        const [, setParent] = blockDataSignals.get(PARENT_OREF)!;
+        setParent({ value: null, loading: false });
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+    });
+
+    it("waits for the parent's fetch even when the shell's own (reused) oref already resolved", async () => {
+        const existingId = "existing-sub-block";
+        const oref = `block:${existingId}`;
+        queueSeedMeta(oref, { "term:zoom": 1.0 });
+        blockDataSignals.set(PARENT_OREF, createSignal<{ value: any; loading: boolean }>({ value: null, loading: true }));
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        // Settle the shell's own oref immediately — construction must still
+        // block on the parent's, since the two waits are independent inputs
+        // to the same gate (Promise.all), not "either one is enough."
+        resolveSeedFetch(oref);
+        await new Promise((r) => setTimeout(r, 10));
+        expect(termWrapInstances.length).toBe(0);
+
+        const [, setParent] = blockDataSignals.get(PARENT_OREF)!;
+        setParent({ value: null, loading: false });
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+        expect(termWrapInstances[0].fontSize).toBe(13);
+    });
+
+    it("falls back to constructing the terminal after the bounded wait if only the parent's fetch hangs", async () => {
+        // Deliberately never resolve the parent's oref — simulates the same
+        // class of genuine-failure scenario the existing shell-oref hang test
+        // covers, mirrored for the new wait.
+        blockDataSignals.set(PARENT_OREF, createSignal<{ value: any; loading: boolean }>({ value: null, loading: true }));
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={undefined}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+
+        await waitFor(() => expect(termWrapInstances.length).toBe(1), { timeout: 3000 });
+        expect(termWrapInstances[0].fontSize).toBe(13);
+    }, 5000);
 });

--- a/frontend/app/view/agent/components/AgentShellSubblock.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.tsx
@@ -282,35 +282,43 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                     props.onSubBlockCreated(id);
                 }
 
-                // Seed the persisted zoom BEFORE constructing TermWrap, so the
-                // very first paint already uses the correct font size instead
-                // of the BASE_FONT_SIZE default followed by a visible
-                // correction jerk — see
-                // docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md. A
-                // freshly created sub-block has no persisted term:zoom yet
-                // (the already-correct default of 1.0 applies), so only the
-                // reused-existing-block path needs to wait for anything.
+                // Seed BOTH persisted zoom inputs BEFORE constructing TermWrap, so the
+                // very first paint (and termFontSize()'s very first computation) already
+                // uses the correct final font size instead of a default followed by a
+                // visible correction jerk. termFontSize = BASE_FONT_SIZE * termZoom() /
+                // agentPaneZoom() has two independent async-resolved inputs — see
+                // docs/specs/SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md (fixed the
+                // first) and docs/specs/SPEC_AGENT_SHELL_PARENT_PANE_ZOOM_SEED_RACE_2026-08-14.md
+                // (fixed the second, this block).
                 //
-                // Deliberately does NOT call WOS.reloadWaveObject here: the
-                // `subBlockAtom` memo above already triggered a fetch for
-                // this exact oref as a side effect of being constructed
-                // (WOS.getWaveObjectAtom → getWaveObjectValue eagerly fetches
-                // on first read, and that memo runs synchronously at
-                // component construction, before this async IIFE even
-                // starts). Calling reloadWaveObject here would force a
-                // SECOND, redundant GetObject round-trip for the same object
-                // on every reused-sub-block drawer open (reagentx P1 on
-                // #2522). Instead, just wait for that already-in-flight
-                // fetch to settle, bounded by a timeout so a genuine network
-                // failure (which can leave the loading atom stuck, per
-                // wos.ts's own comment on GetObject rejections) can't hang
-                // shell startup indefinitely — falls back to whatever
-                // termFontSize() currently computes (default zoom) if it
-                // times out; the live-update effect below corrects it later
-                // if a subsequent fetch/push succeeds.
-                if (isExistingBlock) {
-                    await waitForWaveObjectSettled(WOS.makeORef("block", id));
-                }
+                // Deliberately does NOT call WOS.reloadWaveObject for either oref: both
+                // atoms already have an eager fetch in flight as a side effect of being
+                // constructed/read (this component's own `subBlockAtom` memo for the shell's
+                // oref; agent-view.tsx's `model.blockAtom` for the parent's, read live via
+                // props.agentPaneZoom — its owning memo triggers the same eager
+                // getWaveObjectAtom → getWaveObjectValue fetch on first read, well before
+                // this drawer ever mounts). Calling reloadWaveObject here would force a
+                // SECOND, redundant GetObject round-trip on every open (reagentx P1 on
+                // #2522, for the shell's own oref — same reasoning applies to the parent's).
+                // Instead, just wait for whichever fetches are still in flight to settle,
+                // bounded by a timeout so a genuine network failure (which can leave a
+                // loading atom stuck, per wos.ts's own comment on GetObject rejections)
+                // can't hang shell startup indefinitely — falls back to whatever
+                // termFontSize() currently computes if either times out; the live-update
+                // effect below corrects it later if a subsequent fetch/push succeeds.
+                //
+                // The shell's own oref only needs waiting for on the reused-existing-block
+                // path (a freshly created sub-block has no persisted term:zoom yet — the
+                // already-correct default of 1.0 applies immediately). The PARENT's oref
+                // wait is unconditional: whether the pane's own zoom fetch is still in
+                // flight when this drawer opens is independent of whether this particular
+                // shell sub-block is new or reused. Run both concurrently rather than
+                // sequentially so a reused shell with its own pending fetch doesn't pay
+                // both round-trips back-to-back.
+                await Promise.all([
+                    isExistingBlock ? waitForWaveObjectSettled(WOS.makeORef("block", id)) : Promise.resolve(),
+                    waitForWaveObjectSettled(WOS.makeORef("block", props.parentBlockId)),
+                ]);
                 setZoomSeeded(true);
 
                 if (disposed || !containerRef) return;


### PR DESCRIPTION
## Summary

Fixes a reliable ~500ms zoom twitch on every shell drawer open ("the zoom
level twitches one level, after about 500ms, every time").

Same bug class as `SPEC_AGENT_SHELL_ZOOM_SEED_RACE_2026-08-10.md` (PR
#2522), one input further: `termFontSize() = BASE_FONT_SIZE * termZoom() /
agentPaneZoom()` has two independently-async-resolved zoom sources. The
08-10 fix seeded `termZoom()` (the shell's own persisted zoom) before
constructing `TermWrap`. `agentPaneZoom()` — read live from the parent
agent pane's own `zoomFactor` memo, itself backed by an async
`WOS.getWaveObjectAtom` — was never given the same treatment, so a shell
opened before the parent pane's own zoom fetch resolves still paints at the
wrong font size, then visibly corrects once that fetch lands.

- Extends the existing `waitForWaveObjectSettled(oref)` helper (already
  proven for the shell's own oref) to also wait on the parent block's
  oref, unconditionally (independent of whether this shell sub-block is
  new or reused), run concurrently via `Promise.all` so a reused shell
  with its own pending fetch doesn't pay both round-trips back-to-back.
- No new fetch triggered — same reasoning as the 08-10 fix's own P1
  finding, just for a second oref.
- Full root-cause analysis: `docs/specs/SPEC_AGENT_SHELL_PARENT_PANE_ZOOM_SEED_RACE_2026-08-14.md`

## Test plan

- [x] 3 new regression tests in `AgentShellSubblock.test.tsx`: waits for
      the parent's fetch before constructing (even for a freshly-created
      sub-block), waits for the parent's fetch even when the shell's own
      already resolved, and a bounded-timeout fallback if only the
      parent's fetch hangs
- [x] `npx vitest run frontend/app/view/agent/` — 90 files / 1146 tests
      passing (one `tool-renderers/registry.test.ts` timeout seen on one
      run, confirmed to be pre-existing system-load flakiness — reproduces
      identically on `main` with no diff, passed cleanly on rerun both with
      and without this change)
- [ ] Visual check: open a shell drawer, confirm no font-size twitch ~500ms
      after open

<!-- agentmux:agent_id=agent1 -->