### PR TITLE
chore: release v0.55.8

### DIFF
--- a/.changesets/1786628662-feat-window-restore-last-session-s-tabs-panes-on-relaunch-o9os.md
+++ b/.changesets/1786628662-feat-window-restore-last-session-s-tabs-panes-on-relaunch-o9os.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(window): restore last session's tabs/panes on relaunch

--- a/.changesets/1786648800-fix-ci-retry-create-no-window-flag-set-exclude-windows-defen-2nf1.md
+++ b/.changesets/1786648800-fix-ci-retry-create-no-window-flag-set-exclude-windows-defen-2nf1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): retry create_no_window_flag_set + exclude Windows Defender scanning on CI

--- a/.changesets/1786665908-fix-agent-view-stop-transcript-divider-rules-from-crossing-p-wuve.md
+++ b/.changesets/1786665908-fix-agent-view-stop-transcript-divider-rules-from-crossing-p-wuve.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-view): stop transcript divider rules from crossing pill text

--- a/.changesets/1786693071-feat-jekt-ed25519-wan-signing-for-reagent-s-review-notificat-ytrn.md
+++ b/.changesets/1786693071-feat-jekt-ed25519-wan-signing-for-reagent-s-review-notificat-ytrn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(jekt): Ed25519 WAN signing for reagent's review notifications

--- a/.changesets/1786693117-fix-lan-stop-broadcasting-the-full-access-auth-key-to-lan-pe-0yzz.md
+++ b/.changesets/1786693117-fix-lan-stop-broadcasting-the-full-access-auth-key-to-lan-pe-0yzz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan): stop broadcasting the full-access auth_key to LAN peers

--- a/.changesets/1786693223-fix-muxbus-treat-a-403-agent-binding-rejection-the-same-as-4-9qky.md
+++ b/.changesets/1786693223-fix-muxbus-treat-a-403-agent-binding-rejection-the-same-as-4-9qky.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): treat a 403 (agent-binding rejection) the same as 401 in cloud_subscriber

--- a/.changesets/1786693975-fix-jekt-correct-reagent-key-id-doc-comment-to-match-partial-fkjg.md
+++ b/.changesets/1786693975-fix-jekt-correct-reagent-key-id-doc-comment-to-match-partial-fkjg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(jekt): correct reagent_key_id doc comment to match partial-signature-is-unsigned behavior

--- a/.changesets/1786694205-fix-muxbus-don-t-reconnect-the-shared-wan-session-on-a-403-b-xem0.md
+++ b/.changesets/1786694205-fix-muxbus-don-t-reconnect-the-shared-wan-session-on-a-403-b-xem0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): don't reconnect the shared WAN session on a 403 binding-mismatch rejection

--- a/.changesets/1786694823-feat-muxbus-verify-reagent-ed25519-signatures-on-the-http-ag-rb8g.md
+++ b/.changesets/1786694823-feat-muxbus-verify-reagent-ed25519-signatures-on-the-http-ag-rb8g.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxbus): verify reagent Ed25519 signatures on the HTTP /agentmux/reactive/inject path

--- a/.changesets/1786696309-fix-muxbus-cool-down-a-per-agent-credential-after-a-binding--2gxa.md
+++ b/.changesets/1786696309-fix-muxbus-cool-down-a-per-agent-credential-after-a-binding--2gxa.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): cool down a per-agent credential after a binding-mismatch 403, not just clear its token

--- a/.changesets/1786712782-fix-bashwrap-stop-leaking-orphaned-bash-pty-processes-on-a1--618o.md
+++ b/.changesets/1786712782-fix-bashwrap-stop-leaking-orphaned-bash-pty-processes-on-a1--618o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bashwrap): stop leaking orphaned bash/PTY processes on a1 test retry timeout

--- a/.changesets/1786713585-fix-window-close-toctou-races-in-session-restore-snapshot-sa-rki0.md
+++ b/.changesets/1786713585-fix-window-close-toctou-races-in-session-restore-snapshot-sa-rki0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): close TOCTOU races in session-restore snapshot save/clear and restore activetabid/magnifiednodeid

--- a/.changesets/1786714074-fix-agent-pane-stop-truncating-askuserquestion-answers-in-to-67jz.md
+++ b/.changesets/1786714074-fix-agent-pane-stop-truncating-askuserquestion-answers-in-to-67jz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): stop truncating AskUserQuestion answers in tool summary row

--- a/.changesets/1786724172-feat-jekt-relax-tier-sensitive-for-wan-jekts-verified-agains-x4ue.md
+++ b/.changesets/1786724172-feat-jekt-relax-tier-sensitive-for-wan-jekts-verified-agains-x4ue.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): relax TIER=sensitive for WAN jekts verified against reagent's Ed25519 signature

--- a/.changesets/1786724311-fix-agent-pane-wire-up-submittimeoutelapsed-dispatch-visibil-yt1z.md
+++ b/.changesets/1786724311-fix-agent-pane-wire-up-submittimeoutelapsed-dispatch-visibil-yt1z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): wire up SubmitTimeoutElapsed dispatch + visibility catch-up watchdog tick

--- a/.changesets/1786738726-fix-agent-pane-composer-strip-stable-width-deliberate-edge-s-ookx.md
+++ b/.changesets/1786738726-fix-agent-pane-composer-strip-stable-width-deliberate-edge-s-ookx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): composer strip stable width + deliberate edge-split tiers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.7"
+version = "0.55.8"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.7"
+version = "0.55.8"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.7"
+version = "0.55.8"
 dependencies = [
  "base64",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.7"
+version = "0.55.8"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.7"
+version = "0.55.8"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.7"
+version = "0.55.8"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.7"
+version = "0.55.8"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -19,7 +19,6 @@
 - fix(agent-pane): wire up SubmitTimeoutElapsed dispatch + visibility catch-up watchdog tick
 - fix(agent-pane): composer strip stable width + deliberate edge-split tiers
 
-
 ## 0.55.7 — 2026-08-13
 
 - fix(browser-pane): OAuth/GIS sign-in works in-pane again — no instance-exit, real child popup completes the login, external-protocol guard

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,25 @@
 # AgentMux Version History
 
+## 0.55.8 — 2026-08-14
+
+- feat(window): restore last session's tabs/panes on relaunch
+- fix(ci): retry create_no_window_flag_set + exclude Windows Defender scanning on CI
+- fix(agent-view): stop transcript divider rules from crossing pill text
+- feat(jekt): Ed25519 WAN signing for reagent's review notifications
+- fix(lan): stop broadcasting the full-access auth_key to LAN peers
+- fix(muxbus): treat a 403 (agent-binding rejection) the same as 401 in cloud_subscriber
+- fix(jekt): correct reagent_key_id doc comment to match partial-signature-is-unsigned behavior
+- fix(muxbus): don't reconnect the shared WAN session on a 403 binding-mismatch rejection
+- feat(muxbus): verify reagent Ed25519 signatures on the HTTP /agentmux/reactive/inject path
+- fix(muxbus): cool down a per-agent credential after a binding-mismatch 403, not just clear its token
+- fix(bashwrap): stop leaking orphaned bash/PTY processes on a1 test retry timeout
+- fix(window): close TOCTOU races in session-restore snapshot save/clear and restore activetabid/magnifiednodeid
+- fix(agent-pane): stop truncating AskUserQuestion answers in tool summary row
+- feat(jekt): relax TIER=sensitive for WAN jekts verified against reagent's Ed25519 signature
+- fix(agent-pane): wire up SubmitTimeoutElapsed dispatch + visibility catch-up watchdog tick
+- fix(agent-pane): composer strip stable width + deliberate edge-split tiers
+
+
 ## 0.55.7 — 2026-08-13
 
 - fix(browser-pane): OAuth/GIS sign-in works in-pane again — no instance-exit, real child popup completes the login, external-protocol guard

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.7",
+  "version": "0.55.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.7",
+      "version": "0.55.8",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.7",
+  "version": "0.55.8",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 16 pending changesets. **Forced to `patch` via `--as patch`** per explicit request — the computed bump from the pending changesets was `minor` (several `feat(...)` entries queued), so this ships those minor-level changes under a patch version. `scripts/release.sh` printed its standard loud warning for this override; noting it here per the reagent gate on version-bump PRs.

0.55.7 → 0.55.8

Consumed changesets (16):
- feat(window): restore last session's tabs/panes on relaunch
- fix(ci): retry create_no_window_flag_set + exclude Windows Defender scanning on CI
- fix(agent-view): stop transcript divider rules from crossing pill text
- feat(jekt): Ed25519 WAN signing for reagent's review notifications
- fix(lan): stop broadcasting the full-access auth_key to LAN peers
- fix(muxbus): treat a 403 (agent-binding rejection) the same as 401 in cloud_subscriber
- fix(jekt): correct reagent_key_id doc comment to match partial-signature-is-unsigned behavior
- fix(muxbus): don't reconnect the shared WAN session on a 403 binding-mismatch rejection
- feat(muxbus): verify reagent Ed25519 signatures on the HTTP /agentmux/reactive/inject path
- fix(muxbus): cool down a per-agent credential after a binding-mismatch 403, not just clear its token
- fix(bashwrap): stop leaking orphaned bash/PTY processes on a1 test retry timeout
- fix(window): close TOCTOU races in session-restore snapshot save/clear and restore activetabid/magnifiednodeid
- fix(agent-pane): stop truncating AskUserQuestion answers in tool summary row
- feat(jekt): relax TIER=sensitive for WAN jekts verified against reagent's Ed25519 signature
- fix(agent-pane): wire up SubmitTimeoutElapsed dispatch + visibility catch-up watchdog tick
- fix(agent-pane): composer strip stable width + deliberate edge-split tiers

## Release consistency invariant

Verified all 5 locations agree at `0.55.8` (`scripts/release.sh`'s own post-bump check, re-verified manually):
- `VERSION_HISTORY.md` top section
- `package.json.version`
- `Cargo.toml [workspace.package].version`
- `Cargo.lock` workspace-member versions
- `package-lock.json` root version

## Test plan

- [x] `scripts/release.sh --as patch` completed cleanly, all 5 version locations agree
- [x] All 16 changesets consumed and deleted, `VERSION_HISTORY.md` updated
- Underlying changes were already reviewed/tested/merged individually in their own PRs — this is a version-bump-only PR, no source changes

<!-- agentmux:agent_id=manoz -->