### PR TITLE
feat(instance-panel): show a red pill when this instance has no valid muxbus session

### DIFF
--- a/.changesets/1786742533-feat-instance-panel-show-a-red-pill-when-this-instance-has-n-qfbe.md
+++ b/.changesets/1786742533-feat-instance-panel-show-a-red-pill-when-this-instance-has-n-qfbe.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(instance-panel): show a red pill when this instance has no valid muxbus session

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import { atoms, getApi, isDev, openFloatingPaneEntriesAtom, openWindowEntriesAtom, type FloatingPaneEntry, type WindowEntry } from "@/store/global";
+import { useMuxBusStatus } from "@/app/view/accounts/AgentMuxConnectPanel";
 import { MaintenanceSection } from "./MaintenanceSection";
 import { reconcileKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
 import { launcherEventsActive } from "@/util/launcher-events";
@@ -79,6 +80,18 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     const floatingEntries = openFloatingPaneEntriesAtom;
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
+
+    // MuxBus connection status — refreshed on open (mirrors HostPopover's
+    // own `void muxbus.refresh()` on-open pattern). A missing/expired
+    // session fails WAN jekt delivery completely silently otherwise (no
+    // error, nothing — see this row's CSS comment for the incident that
+    // motivated surfacing it here).
+    const muxbus = useMuxBusStatus();
+    void muxbus.refresh();
+    const muxbusOk = () => {
+        const s = muxbus.status();
+        return !!s && s.connected && s.valid;
+    };
 
     // Refresh window-instance state ONLY when the launcher is silent
     // (`task dev` mode — no launcher process, no typed events). In
@@ -466,6 +479,20 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                         <span class="instance-panel-label">Runtime</span>
                         <span class="instance-panel-value instance-panel-mono">
                             {[about().platform, about().arch].filter(Boolean).join(" · ")}
+                        </span>
+                    </div>
+                </Show>
+                <Show when={muxbus.status() !== null && !muxbusOk()}>
+                    <div class="instance-panel-row instance-panel-row-meta">
+                        <span class="instance-panel-label">MuxBus</span>
+                        <span class="instance-panel-value">
+                            <span class="instance-panel-muxbus-icon">◈</span>
+                            <span
+                                class="instance-panel-muxbus-pill"
+                                title="This instance has no valid MuxBus session — cloud/WAN jekt delivery will not work until you sign in again."
+                            >
+                                Not connected
+                            </span>
                         </span>
                     </div>
                 </Show>

--- a/frontend/app/statusbar/_instance-panel.scss
+++ b/frontend/app/statusbar/_instance-panel.scss
@@ -48,6 +48,31 @@
     font-size: 11px;
 }
 
+// MuxBus connection status row (header). The diamond is decorative — same
+// glyph as .instance-panel-pane-icon — the pill next to it is the actual
+// signal: it only renders when this instance has no valid muxbus session,
+// which otherwise fails completely silently (no WAN jekt delivery, no
+// error anywhere) — see SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md's
+// verification writeup for the incident that motivated this.
+.instance-panel-muxbus-icon {
+    flex: 0 0 auto;
+    color: var(--accent-color, var(--secondary-text-color));
+    font-size: 11px;
+    margin-right: var(--space-1);
+}
+
+.instance-panel-muxbus-pill {
+    display: inline-flex;
+    align-items: center;
+    font-size: 10px;
+    font-weight: 500;
+    padding: 1px 8px;
+    border-radius: 999px;
+    color: var(--error-color);
+    background: color-mix(in srgb, var(--error-color) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 40%, transparent);
+}
+
 .instance-panel-copy {
     flex: 0 0 auto;
     background: transparent;


### PR DESCRIPTION
## Summary
- A missing or expired muxbus login fails WAN jekt delivery completely silently. Confirmed today the hard way while verifying reagent jekt signing end-to-end (agentmux-cloud PR #44-46): this instance had zero outbound cloud connections and a full day's backlog of undelivered WAN messages, with no indication anywhere.
- Adds a "MuxBus" row to the Instance Panel header (same diamond glyph style already used for floating-pane rows) that only renders when the session is missing or expired — a red "Not connected" pill.
- Reuses the existing `useMuxBusStatus()` controller (same one `HostPopover`/`AccountsManager` already share), refreshed on open, matching `HostPopover`'s own on-open refresh pattern.

## Test plan
- [x] `npx tsc --noEmit` — zero new errors (2 pre-existing, unrelated errors in armory-view.tsx/warden-view.tsx)
- [ ] Manual: open Instance Panel while disconnected from muxbus, confirm the pill renders; sign in, confirm it disappears

<!-- agentmux:agent_id=agentx -->