### PR TITLE
docs: reagent SIG=verified e2e verification report

### DIFF
--- a/docs/reports/REPORT_REAGENT_SIG_VERIFICATION_E2E_2026_08_14.md
+++ b/docs/reports/REPORT_REAGENT_SIG_VERIFICATION_E2E_2026_08_14.md
@@ -1,0 +1,16 @@
+# Reagent WAN jekt `SIG=verified` end-to-end verification — 2026-08-14
+
+Post-merge verification pass for the reagent jekt security chain
+(PRs #2565, #2570, #2572, #2573, #2576, #2580; running build
+`0.55.8+gbb22a8094`).
+
+This PR exists to trigger a real `pull_request_review` webhook from
+reagentx-workflow so we can observe the resulting WAN jekt end-to-end on a
+live 0.55.8 instance and confirm:
+
+- [ ] jekt arrives (muxbus session valid, no disconnected pill)
+- [ ] `SIG=verified` (Ed25519 signature verifies against reagent's pinned production key, not `reagent-v1-dev`)
+- [ ] `TIER=coord` (trusted-key gate relaxes the WAN-forced `sensitive` tier)
+- [ ] `FROM=reagent DELIVERY=wan TRUST=network-claimed` marker fields render correctly
+
+Result will be recorded here before merge/close.


### PR DESCRIPTION
## Summary

Post-merge verification pass for the reagent jekt security chain (#2565, #2570, #2572, #2573, #2576, #2580), running live on `0.55.8+gbb22a8094`.

This PR triggers a real `pull_request_review` webhook from reagentx-workflow so the resulting WAN jekt can be observed end-to-end on a live instance: expecting `FROM=reagent DELIVERY=wan SIG=verified TIER=coord`.

The report stub in `docs/reports/` will be filled in with the observed marker before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agentx -->