### PR TITLE
chore: release v0.55.9

### DIFF
--- a/.changesets/1786742533-feat-instance-panel-show-a-red-pill-when-this-instance-has-n-qfbe.md
+++ b/.changesets/1786742533-feat-instance-panel-show-a-red-pill-when-this-instance-has-n-qfbe.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(instance-panel): show a red pill when this instance has no valid muxbus session

--- a/.changesets/1786744950-stop-the-agent-pane-shell-drawer-s-windows-psreadline-resync-r9vw.md
+++ b/.changesets/1786744950-stop-the-agent-pane-shell-drawer-s-windows-psreadline-resync-r9vw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Stop the agent-pane shell drawer's Windows PSReadLine-resync thaw from visibly resizing the terminal canvas ~300ms after open

--- a/.changesets/1786766524-style-composer-strip-host-tag-yellow-instead-of-red-a208.md
+++ b/.changesets/1786766524-style-composer-strip-host-tag-yellow-instead-of-red-a208.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-style(composer-strip): HOST tag yellow instead of red

--- a/.changesets/1786769933-feat-statusbar-always-visible-red-muxbus-chip-when-session-i-ftmw.md
+++ b/.changesets/1786769933-feat-statusbar-always-visible-red-muxbus-chip-when-session-i-ftmw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(statusbar): always-visible red MuxBus chip when session is invalid

--- a/.changesets/1786770831-fix-muxbus-make-pkce-login-single-flight-a-new-attempt-super-gcod.md
+++ b/.changesets/1786770831-fix-muxbus-make-pkce-login-single-flight-a-new-attempt-super-gcod.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): make PKCE login single-flight — a new attempt supersedes the pending one

--- a/.changesets/1786771863-feat-muxbus-cloud-relayed-login-callback-desktop-no-longer-r-mknn.md
+++ b/.changesets/1786771863-feat-muxbus-cloud-relayed-login-callback-desktop-no-longer-r-mknn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxbus): cloud-relayed login callback — desktop no longer runs a loopback listener

--- a/.changesets/1786794961-fix-jekt-narrow-tier-sensitive-to-real-red-flags-only-f3ny.md
+++ b/.changesets/1786794961-fix-jekt-narrow-tier-sensitive-to-real-red-flags-only-f3ny.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(jekt): narrow TIER=sensitive to real red flags only

--- a/.changesets/1786816108-feat-armory-every-agent-gets-its-own-dedicated-portable-abf--0cfl.md
+++ b/.changesets/1786816108-feat-armory-every-agent-gets-its-own-dedicated-portable-abf--0cfl.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): every agent gets its own dedicated, portable ABF bundle (mandatory per-agent binding, readonly harness/model, backfill, export/import)

--- a/.changesets/1786816932-feat-jekt-per-agent-ed25519-signing-for-lan-tier-jekts-l8m7.md
+++ b/.changesets/1786816932-feat-jekt-per-agent-ed25519-signing-for-lan-tier-jekts-l8m7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): per-agent Ed25519 signing for LAN-tier jekts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.8"
+version = "0.55.9"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.8"
+version = "0.55.9"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.8"
+version = "0.55.9"
 dependencies = [
  "base64",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.8"
+version = "0.55.9"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.8"
+version = "0.55.9"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.8"
+version = "0.55.9"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.8"
+version = "0.55.9"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,18 @@
 # AgentMux Version History
 
+## 0.55.9 — 2026-08-15
+
+- feat(instance-panel): show a red pill when this instance has no valid muxbus session
+- Stop the agent-pane shell drawer's Windows PSReadLine-resync thaw from visibly resizing the terminal canvas ~300ms after open
+- style(composer-strip): HOST tag yellow instead of red
+- feat(statusbar): always-visible red MuxBus chip when session is invalid
+- fix(muxbus): make PKCE login single-flight — a new attempt supersedes the pending one
+- feat(muxbus): cloud-relayed login callback — desktop no longer runs a loopback listener
+- fix(jekt): narrow TIER=sensitive to real red flags only
+- feat(armory): every agent gets its own dedicated, portable ABF bundle (mandatory per-agent binding, readonly harness/model, backfill, export/import)
+- feat(jekt): per-agent Ed25519 signing for LAN-tier jekts
+
+
 ## 0.55.8 — 2026-08-14
 
 - feat(window): restore last session's tabs/panes on relaunch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.8",
+  "version": "0.55.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.8",
+      "version": "0.55.9",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.8",
+  "version": "0.55.9",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Forced patch release (`task release -- --as patch`) per direct instruction, consuming 9 pending changesets that would otherwise have computed to a minor bump (several `feat(...)` entries in the mix — deliberate override, not an oversight).

Consumed changesets (all from tonight's work):
- feat(instance-panel): show a red pill when this instance has no valid muxbus session
- Stop the agent-pane shell drawer's Windows PSReadLine-resync thaw from visibly resizing the terminal canvas
- style(composer-strip): HOST tag yellow instead of red
- feat(statusbar): always-visible red MuxBus chip when session is invalid
- fix(muxbus): make PKCE login single-flight — a new attempt supersedes the pending one
- feat(muxbus): cloud-relayed login callback — desktop no longer runs a loopback listener
- fix(jekt): narrow TIER=sensitive to real red flags only
- feat(armory): every agent gets its own dedicated, portable ABF bundle
- feat(jekt): per-agent Ed25519 signing for LAN-tier jekts

**Version consistency invariant** (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) verified to all agree at `0.55.9` — independently checked, not just trusting `scripts/release.sh`'s own report.

`0.55.8 → 0.55.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agentx -->