### PR TITLE
Fix layer-3 credential gate reading agent.provider instead of the bound bundle

### DIFF
--- a/.changesets/1786839907-fix-identity-layer-3-credential-gate-resolves-provider-throu-k984.md
+++ b/.changesets/1786839907-fix-identity-layer-3-credential-gate-resolves-provider-throu-k984.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): layer-3 credential gate resolves provider through the bound bundle, not the driftable agent column

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -2941,6 +2941,39 @@ mod bundle_provisioning_store_separation_tests {
         assert_eq!(store.resolve_effective_provider_id(&agent), "claude");
     }
 
+    // ReAgent review on PR #2592 round 3: dropped during the consolidation
+    // from agent_open.rs's former resolve_effective_provider_id_tests
+    // module despite the commit claiming a one-for-one move — restoring
+    // it here. The shared "blank" singleton and pre-§7 bundles have an
+    // empty `provider` column; must not shadow a real value with "".
+    #[test]
+    fn resolve_effective_provider_id_falls_back_when_bundle_provider_is_empty() {
+        let store = Store::open_in_memory().unwrap();
+        let mut agent = base_agent("a1", "Agent One", "claude", "");
+        // provider left empty ("") deliberately, unlike the other tests'
+        // bundle_provision_for_new_agent-built bundles.
+        let bundle = super::super::memory_bundles::Memory {
+            id: "bundle-empty-provider".to_string(),
+            name: "Empty Provider Bundle".to_string(),
+            description: String::new(),
+            is_blank: false,
+            is_global: false,
+            provider: String::new(),
+            model: String::new(),
+            instructions: String::new(),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: 0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_memory_upsert(&bundle).unwrap();
+        agent.memory_id = "bundle-empty-provider".to_string();
+        assert_eq!(store.resolve_effective_provider_id(&agent), "claude");
+    }
+
     // The core store-separation regression case: the bundle exists in ONE
     // store but the method is called on a DIFFERENT one — proves the
     // lookup only succeeds via the store it's actually called on, so a

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1001,6 +1001,44 @@ impl Store {
             .to_string()
     }
 
+    /// Resolve the effective harness/provider id for `agent`, preferring
+    /// its bound ABF bundle's copy over the agent's own `provider`
+    /// column. The bundle is the readonly-once-set source of truth
+    /// (`ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §7.4.1):
+    /// `AgentDefinition.provider` can still drift after creation via
+    /// `agent.define`'s `if_exists=update` path, while the bundle's own
+    /// copy cannot (backend-enforced in `bundle.upsert`, see
+    /// `check_provider_model_immutable`). Falls back to `agent.provider`
+    /// when there's no bundle to consult (unbound legacy agent, missing
+    /// row, or an empty `provider` on the bundle itself) — a caller
+    /// never hard-fails on this alone.
+    ///
+    /// **Call this on the EFFECTIVE identity/memory store
+    /// (`AppState.id_store`), never on the per-channel `wstore` directly**
+    /// — the bundle lives in the shared store when one is configured (the
+    /// normal case), so a `wstore` lookup silently returns the fallback
+    /// every time in that configuration. See
+    /// `bundle_provision_for_new_agent`'s own doc comment for the write-
+    /// side half of this same rule.
+    ///
+    /// Consolidated here (2026-08-15) after the identical resolution
+    /// logic was independently duplicated in `agent_open.rs`'s spawn path
+    /// and found to have the exact same wstore-vs-id_store mistake twice
+    /// in review (rounds 3 and, for a second call site,
+    /// `identity/resolver/inject.rs`'s layer-3 credential gate, found in
+    /// a later scoping pass — not by an automated review this time). One
+    /// shared implementation both consumers call means they can't drift
+    /// on this resolution independently again.
+    pub fn resolve_effective_provider_id(&self, agent: &AgentDefinition) -> String {
+        if agent.memory_id.is_empty() {
+            return agent.provider.clone();
+        }
+        match self.bundle_memory_get(&agent.memory_id) {
+            Ok(Some(b)) if !b.provider.is_empty() => b.provider,
+            _ => agent.provider.clone(),
+        }
+    }
+
     /// Provision a fresh, dedicated ABF bundle for a NEW agent definition —
     /// the definition-time half of
     /// `docs/specs/ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §3.2
@@ -2860,5 +2898,63 @@ mod bundle_provisioning_store_separation_tests {
         assert!(!agent_a.memory_id.is_empty(), "first same-named agent must still get bound");
         assert!(!agent_b.memory_id.is_empty(), "second same-named agent must NOT be silently left unbound");
         assert_ne!(agent_a.memory_id, agent_b.memory_id, "each agent still gets its own distinct bundle");
+    }
+
+    // resolve_effective_provider_id — consolidated shared implementation
+    // (was previously duplicated between agent_open.rs's spawn path and
+    // identity/resolver/inject.rs's layer-3 credential gate; the latter
+    // was found reading agent.provider directly during a follow-up
+    // scoping pass, the same class of bug agent_open.rs already had
+    // fixed for itself). These mirror agent_open.rs's own former
+    // `resolve_effective_provider_id_tests` module one-for-one, plus the
+    // store-separation case matching this file's other bundle-resolution
+    // tests.
+
+    #[test]
+    fn resolve_effective_provider_id_prefers_the_bundles_provider_over_a_drifted_agent_column() {
+        let store = Store::open_in_memory().unwrap();
+        let mut agent = base_agent("a1", "Agent One", "codex", "");
+        store.agent_def_insert(&mut agent).unwrap();
+        let bundle_id = store.bundle_provision_for_new_agent(&base_agent("a1", "Agent One", "claude", ""), 0).unwrap();
+        store.agent_def_set_memory_id_if_empty(&agent.id, &bundle_id).unwrap();
+        agent.memory_id = bundle_id;
+
+        // Simulates the exact drift this exists to correct: agent.define's
+        // if_exists=update path changed agent.provider (still "codex" on
+        // this in-memory struct) after creation, but the bundle's own
+        // copy ("claude") is backend-enforced immutable.
+        assert_eq!(store.resolve_effective_provider_id(&agent), "claude");
+    }
+
+    #[test]
+    fn resolve_effective_provider_id_falls_back_to_agent_provider_when_unbound() {
+        let store = Store::open_in_memory().unwrap();
+        let agent = base_agent("a1", "Agent One", "claude", "");
+        assert_eq!(store.resolve_effective_provider_id(&agent), "claude");
+    }
+
+    #[test]
+    fn resolve_effective_provider_id_falls_back_when_bundle_row_is_missing() {
+        let store = Store::open_in_memory().unwrap();
+        let mut agent = base_agent("a1", "Agent One", "claude", "");
+        agent.memory_id = "no-such-bundle".to_string();
+        assert_eq!(store.resolve_effective_provider_id(&agent), "claude");
+    }
+
+    // The core store-separation regression case: the bundle exists in ONE
+    // store but the method is called on a DIFFERENT one — proves the
+    // lookup only succeeds via the store it's actually called on, so a
+    // caller that mistakenly passes wstore instead of id_store gets the
+    // safe fallback rather than a silent, unexplained "wrong" answer.
+    #[test]
+    fn resolve_effective_provider_id_falls_back_when_called_on_the_wrong_store() {
+        let id_store = Store::open_in_memory().unwrap();
+        let wstore = Store::open_in_memory().unwrap();
+        let mut agent = base_agent("a1", "Agent One", "claude", "");
+        let bundle_id = id_store.bundle_provision_for_new_agent(&base_agent("a1", "Agent One", "codex", ""), 0).unwrap();
+        agent.memory_id = bundle_id;
+
+        assert_eq!(id_store.resolve_effective_provider_id(&agent), "codex", "must find it via the store it was actually provisioned into");
+        assert_eq!(wstore.resolve_effective_provider_id(&agent), "claude", "an unrelated store must fall back to agent.provider, not silently succeed");
     }
 }

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -282,14 +282,32 @@ pub fn inject_identity_env_with_broker(
     // definition row reads as flag=false / no expected provider — the
     // per-binding gate still applies to whatever links exist.
     //
+    // Provider is resolved via `id_store.resolve_effective_provider_id`
+    // (`backend/storage/agents.rs`), NOT `d.provider` directly — the
+    // definition's own column can drift post-creation (`agent.define`'s
+    // `if_exists=update` path) while the agent's bound ABF bundle's copy
+    // is backend-enforced immutable, so the bundle is the one to trust
+    // for a security-relevant decision like this gate. Found during a
+    // follow-up scoping pass after `agent_open.rs`'s spawn path was fixed
+    // for the identical bug (ReAgent review, PR #2587 round 3) — the same
+    // resolution logic is now shared between both call sites specifically
+    // so they can't drift on it independently again.
+    //
     // Canonicalized via `resolve_provider_alias` (codex P1 on PR #2377): a
     // definition's own `provider` field predates this alias table in rare
     // cases, and this value is compared below against `injected_oauth` /
     // `bindings`' raw (possibly aliased) provider strings — comparing
     // uncanonicalized would let a genuinely-injected alias-only binding
-    // still trip the "no account bound" gate.
+    // still trip the "no account bound" gate. Applied to the bundle-
+    // resolved value, not the raw column, so an aliased definition whose
+    // bundle already carries the canonical id doesn't get re-aliased
+    // incorrectly (resolve_provider_alias is idempotent on an
+    // already-canonical id, so this is safe either way).
     let (use_ambient, def_provider) = match wstore.agent_def_get(&instance.definition_id) {
-        Ok(Some(d)) => (d.use_ambient_login != 0, Some(resolve_provider_alias(&d.provider).to_string())),
+        Ok(Some(d)) => {
+            let effective_provider = id_store.resolve_effective_provider_id(&d);
+            (d.use_ambient_login != 0, Some(resolve_provider_alias(&effective_provider).to_string()))
+        }
         Ok(None) => (false, None),
         Err(e) => {
             tracing::warn!(
@@ -573,7 +591,7 @@ mod tests {
     use super::*;
     use super::super::oauth_probe::oauth_status;
     use crate::backend::storage::store::{
-        AgentInstance, IdentityAccount, InstanceStatus, SecretRef,
+        AgentInstance, IdentityAccount, InstanceStatus, Memory, SecretRef,
     };
 
     fn make_store() -> Arc<Store> {
@@ -1815,5 +1833,122 @@ mod tests {
         // updated_at unchanged — the resolver only upserts when the
         // probed status differs from the stored value.
         assert_eq!(after.updated_at, 0);
+    }
+
+    // P0 regression test (found in a follow-up scoping pass after
+    // agent_open.rs's identical bug was fixed in PR #2587 round 3):
+    // the layer-3 gate must resolve the definition's provider through
+    // its bound ABF bundle (`id_store.resolve_effective_provider_id`),
+    // not `d.provider` directly. Uses two genuinely separate stores —
+    // wstore (definition, block, instance) and id_store (bundle,
+    // account, link) — so the test can't pass by accident the way it
+    // would if both roles were backed by the same `Arc<Store>`, which
+    // every OTHER test in this module does (matching production's
+    // AppState.wstore/id_store split, but meaning none of them could
+    // have caught this class of bug).
+    //
+    // Scenario: the definition's own `provider` column has drifted to
+    // "codex" (e.g. via a since-superseded agent.define update), but
+    // its bound bundle's copy — the backend-enforced-immutable one —
+    // still correctly says "claude", and the agent has a perfectly
+    // valid Claude OAuth account bound. Before the fix, the gate read
+    // `d.provider` directly, saw "codex", found no binding for codex
+    // (only claude), and WRONGLY BLOCKED a correctly-configured agent's
+    // spawn with "no account bound for the agent's provider" — even
+    // though a valid claude credential was right there. After the fix,
+    // it resolves "claude" via the bundle, the claude binding injects
+    // successfully, and the spawn proceeds.
+    #[test]
+    fn spawn_gate_resolves_provider_through_the_bound_bundle_not_the_drifted_definition_column() {
+        let wstore = make_store();
+        // Real shared-store schema, not open_in_memory's channel schema —
+        // db_agent_identity_links only has a `db_agent_definitions` FK in
+        // the channel schema (migrations.rs:334); the shared-store schema
+        // (migrations.rs:829) deliberately omits it, since agent
+        // definitions never live in the shared store. Using two
+        // open_in_memory() stores here would incorrectly enforce an FK
+        // that doesn't exist in production's real id_store.
+        let id_store_tmp = tempfile::NamedTempFile::new().unwrap();
+        let id_store = Arc::new(Store::open_shared(id_store_tmp.path()).unwrap());
+
+        let mut def = crate::backend::storage::store::AgentDefinition {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            // Drifted: the definition's own column says codex...
+            provider: "codex".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            // ...but its bound bundle (below, in id_store) says claude.
+            memory_id: "bundle-1".to_string(),
+        };
+        wstore.agent_def_insert(&mut def).unwrap();
+
+        let bundle = Memory {
+            id: "bundle-1".to_string(),
+            name: "Drift Test Bundle".to_string(),
+            description: String::new(),
+            is_blank: false,
+            is_global: false,
+            provider: "claude".to_string(),
+            model: "anthropic".to_string(),
+            instructions: String::new(),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: 0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        id_store.bundle_memory_upsert(&bundle).unwrap();
+
+        let claude = make_account(
+            "acct-drift",
+            "claude",
+            SecretRef::OAuthConfigDir {
+                dir: "/var/agentmux/identities/id-drift/claude".to_string(),
+            },
+        );
+        id_store.identity_upsert(&claude).unwrap();
+        id_store
+            .agent_identity_link("def-1", "acct-drift", "claude")
+            .unwrap();
+
+        insert_block_for_agent(&wstore, "block-drift", "def-1");
+        let inst = make_instance("block-drift", "id-drift");
+        wstore.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        let res = inject_identity_env(wstore, id_store, "block-drift", &mut env);
+
+        assert!(res.is_ok(), "a valid claude account must not be blocked by a stale codex column: {res:?}");
+        assert_eq!(
+            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
+            Some("/var/agentmux/identities/id-drift/claude"),
+            "the claude binding must actually inject, proving the gate expected claude (from the bundle), not codex (from the drifted column)"
+        );
     }
 }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -54,220 +54,16 @@ fn resolve_vendor_env_override(
         .map(|var| (var, agent.model_vendor_base_url.clone()))
 }
 
-/// Resolve the effective harness/provider id for a spawn. The agent's
-/// bound ABF bundle is the readonly-once-set source of truth
-/// (`ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §7.4.1):
-/// `AgentDefinition.provider` can still drift after creation via
-/// `agent.define`'s `if_exists=update` path, while the bundle's own copy
-/// cannot (backend-enforced in `bundle.upsert`, see
-/// `check_provider_model_immutable` in `bundle.rs`). Falls back to
-/// `agent.provider` when there's no bundle to consult — an unbound
-/// legacy agent predating `m0021`, or a bundle row that's gone missing —
-/// so a spawn never hard-fails on this alone. Pure, so it's unit-testable
-/// without the full async spawn-time harness, same as
-/// `resolve_vendor_env_override` above.
-fn resolve_effective_provider_id(agent: &AgentDefinition, bundle: Option<&Memory>) -> String {
-    match bundle {
-        Some(b) if !b.provider.is_empty() => b.provider.clone(),
-        _ => agent.provider.clone(),
-    }
-}
-
-/// Look up an agent's bound ABF bundle for spawn-time provider resolution.
-/// `None` when unbound (`memory_id` empty) or the lookup fails/returns
-/// nothing.
-///
-/// Takes the store to look it up in as an EXPLICIT parameter rather than
-/// resolving it internally — `resolve_effective_provider_id` above only
-/// exists because `AgentDefinition.provider` can drift while the bundle's
-/// copy can't, but that guarantee only holds if this lookup actually
-/// finds the bundle. It has to run against `AppState.id_store` (the
-/// EFFECTIVE identity/memory store — shared store when configured, else
-/// `wstore`; same store every bundle-provisioning site now writes to),
-/// never `wstore` directly — a `wstore` lookup silently returns `None`
-/// whenever a shared store is configured, defeating the whole guarantee
-/// without erroring (ReAgent review on PR #2587, round 3: this exact
-/// mistake was made at this exact call site, in the same PR that fixed
-/// the analogous write-side bug everywhere else). Making the store an
-/// explicit parameter here, rather than an inline `app_state.id_store...`
-/// at the call site, makes that choice testable instead of a detail an
-/// inline expression can silently get wrong again later.
-fn resolve_bound_bundle(id_store: &Store, agent: &AgentDefinition) -> Option<Memory> {
-    if agent.memory_id.is_empty() {
-        return None;
-    }
-    id_store.bundle_memory_get(&agent.memory_id).ok().flatten()
-}
-
-#[cfg(test)]
-mod resolve_bound_bundle_tests {
-    use super::*;
-
-    fn agent_with_memory_id(memory_id: &str) -> AgentDefinition {
-        AgentDefinition {
-            id: "a1".to_string(),
-            slug: "a1".to_string(),
-            name: "T".to_string(),
-            icon: String::new(),
-            provider: "claude".to_string(),
-            description: String::new(),
-            working_directory: String::new(),
-            shell: String::new(),
-            provider_flags: String::new(),
-            auto_start: 0,
-            restart_on_crash: 0,
-            idle_timeout_minutes: 0,
-            created_at: 0,
-            agent_type: "host".to_string(),
-            environment: String::new(),
-            agent_bus_id: String::new(),
-            is_seeded: 0,
-            accounts: String::new(),
-            parent_id: String::new(),
-            branch_label: String::new(),
-            updated_at: 0,
-            user_hidden: 0,
-            container_image: String::new(),
-            container_volumes: "[]".to_string(),
-            container_name: String::new(),
-            use_ambient_login: 0,
-            model_vendor_base_url: String::new(),
-            auto_continue_enabled: 0,
-            memory_id: memory_id.to_string(),
-        }
-    }
-
-    #[test]
-    fn returns_none_when_unbound() {
-        let store = Store::open_in_memory().unwrap();
-        let agent = agent_with_memory_id("");
-        assert!(resolve_bound_bundle(&store, &agent).is_none());
-    }
-
-    // The core regression case: the bundle exists in ONE store but not
-    // the other — proves the lookup only finds it via the store it was
-    // actually passed, not via some other store the caller might have
-    // reached for instead (the exact mistake this function replaces).
-    #[test]
-    fn only_finds_the_bundle_via_the_store_it_was_actually_provisioned_into() {
-        let id_store = Store::open_in_memory().unwrap();
-        let wstore = Store::open_in_memory().unwrap();
-        let bundle = Memory {
-            id: "mem1".to_string(),
-            name: "Bundle".to_string(),
-            description: String::new(),
-            is_blank: false,
-            is_global: false,
-            provider: "claude".to_string(),
-            model: "anthropic".to_string(),
-            instructions: String::new(),
-            instructions_by_provider: "{}".to_string(),
-            context_files: "[]".to_string(),
-            mcp_servers: "[]".to_string(),
-            skills: "[]".to_string(),
-            sort_order: 0,
-            created_at: 0,
-            updated_at: 0,
-        };
-        id_store.bundle_memory_upsert(&bundle).unwrap();
-        let agent = agent_with_memory_id("mem1");
-
-        assert!(resolve_bound_bundle(&id_store, &agent).is_some(), "must find the bundle via id_store");
-        assert!(resolve_bound_bundle(&wstore, &agent).is_none(), "must NOT find it via an unrelated store");
-    }
-}
-
-#[cfg(test)]
-mod resolve_effective_provider_id_tests {
-    use super::*;
-
-    fn base_agent(provider: &str, memory_id: &str) -> AgentDefinition {
-        AgentDefinition {
-            id: "a1".to_string(),
-            slug: "a1".to_string(),
-            name: "T".to_string(),
-            icon: String::new(),
-            provider: provider.to_string(),
-            description: String::new(),
-            working_directory: String::new(),
-            shell: String::new(),
-            provider_flags: String::new(),
-            auto_start: 0,
-            restart_on_crash: 0,
-            idle_timeout_minutes: 0,
-            created_at: 0,
-            agent_type: "host".to_string(),
-            environment: String::new(),
-            agent_bus_id: String::new(),
-            is_seeded: 0,
-            accounts: String::new(),
-            parent_id: String::new(),
-            branch_label: String::new(),
-            updated_at: 0,
-            user_hidden: 0,
-            container_image: String::new(),
-            container_volumes: "[]".to_string(),
-            container_name: String::new(),
-            use_ambient_login: 0,
-            model_vendor_base_url: String::new(),
-            auto_continue_enabled: 0,
-            memory_id: memory_id.to_string(),
-        }
-    }
-
-    fn bundle_with_provider(provider: &str) -> Memory {
-        Memory {
-            id: "mem1".to_string(),
-            name: "Bundle".to_string(),
-            description: String::new(),
-            is_blank: false,
-            is_global: false,
-            provider: provider.to_string(),
-            model: "anthropic".to_string(),
-            instructions: String::new(),
-            instructions_by_provider: "{}".to_string(),
-            context_files: "[]".to_string(),
-            mcp_servers: "[]".to_string(),
-            skills: "[]".to_string(),
-            sort_order: 0,
-            created_at: 0,
-            updated_at: 0,
-        }
-    }
-
-    #[test]
-    fn prefers_the_bundles_provider_over_a_drifted_agent_column() {
-        // Simulates the exact drift this exists to correct: agent.define's
-        // if_exists=update path changed agent.provider after creation, but
-        // the bundle's own copy is backend-enforced immutable.
-        let agent = base_agent("codex", "mem1");
-        let bundle = bundle_with_provider("claude");
-        assert_eq!(resolve_effective_provider_id(&agent, Some(&bundle)), "claude");
-    }
-
-    #[test]
-    fn falls_back_to_agent_provider_when_unbound() {
-        let agent = base_agent("claude", "");
-        assert_eq!(resolve_effective_provider_id(&agent, None), "claude");
-    }
-
-    #[test]
-    fn falls_back_to_agent_provider_when_bundle_missing() {
-        // memory_id points somewhere, but the caller couldn't load a row
-        // for it (deleted, or a lookup error swallowed upstream).
-        let agent = base_agent("claude", "mem1");
-        assert_eq!(resolve_effective_provider_id(&agent, None), "claude");
-    }
-
-    #[test]
-    fn falls_back_to_agent_provider_when_bundle_provider_is_empty() {
-        // The shared "blank" singleton and pre-§7 bundles have an empty
-        // provider column — must not shadow a real value with "".
-        let agent = base_agent("claude", "mem1");
-        let bundle = bundle_with_provider("");
-        assert_eq!(resolve_effective_provider_id(&agent, Some(&bundle)), "claude");
-    }
-}
+// resolve_effective_provider_id (and its store-lookup helper) moved to
+// Store::resolve_effective_provider_id in backend/storage/agents.rs
+// (2026-08-15) — the identical resolution logic was independently
+// duplicated in identity/resolver/inject.rs's layer-3 credential gate,
+// found reading agent.provider directly (the same wstore-vs-id_store
+// class of bug this file's own version was fixed for in round 3 of PR
+// #2587's review). Consolidated so both call sites share one
+// implementation and can't drift on it separately again — see that
+// method's own doc comment for the full history and the tests that
+// moved with it.
 
 #[cfg(test)]
 mod resolve_vendor_env_override_tests {
@@ -372,13 +168,11 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // Shadow `agent.provider` with the bound ABF bundle's copy,
                 // the readonly-once-set source of truth (see
-                // resolve_effective_provider_id's own doc comment) — one
-                // lookup here instead of rewriting every downstream
-                // `agent.provider` read in this handler. See
-                // resolve_bound_bundle's own doc comment for why this
-                // MUST be app_state.id_store, never wstore.
-                let bundle = resolve_bound_bundle(&app_state.id_store, &agent);
-                agent.provider = resolve_effective_provider_id(&agent, bundle.as_ref());
+                // Store::resolve_effective_provider_id's own doc comment
+                // in backend/storage/agents.rs) — one lookup here instead
+                // of rewriting every downstream `agent.provider` read in
+                // this handler. MUST be app_state.id_store, never wstore.
+                agent.provider = app_state.id_store.resolve_effective_provider_id(&agent);
 
                 // Serialize the rest of this handler per agent definition —
                 // held until the function returns (guard drops at every exit

--- a/frontend/app/view/agent/agent-launch-env.test.ts
+++ b/frontend/app/view/agent/agent-launch-env.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for `resolveEffectiveLaunchProvider` — the actual fix for the
+ * PR #2592 review finding that fixing only the backend layer-3
+ * credential gate wasn't sufficient: `launchAgentDefinition` still
+ * resolved which CLI to launch from the driftable `agent.provider`
+ * column, independent of what the gate validates against the agent's
+ * bound bundle. Extracted into its own function specifically so this
+ * logic is testable in isolation — `launchAgentDefinition` itself has
+ * no existing direct-invocation test anywhere in this codebase (every
+ * caller mocks it away).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMemory = vi.fn();
+const loggerWarn = vi.fn();
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        GetMemoryCommand: (...args: unknown[]) => getMemory(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/util/logger", () => ({
+    Logger: { warn: (...args: unknown[]) => loggerWarn(...args) },
+}));
+
+import { resolveEffectiveLaunchProvider } from "./agent-launch-env";
+
+function agentWith(provider: string, memory_id: string): AgentDefinition {
+    return { id: "a1", provider, memory_id } as AgentDefinition;
+}
+
+describe("resolveEffectiveLaunchProvider", () => {
+    beforeEach(() => {
+        getMemory.mockReset();
+        loggerWarn.mockReset();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns agent.provider directly when the agent is unbound", async () => {
+        const agent = agentWith("claude", "");
+        const result = await resolveEffectiveLaunchProvider(agent);
+        expect(result).toBe("claude");
+        expect(getMemory).not.toHaveBeenCalled();
+    });
+
+    // The core regression case: a drifted agent.provider must not win
+    // over the bound bundle's own copy — this is the exact scenario the
+    // PR #2592 review flagged (gate validates "claude" from the bundle,
+    // frontend used to launch "codex" from the drifted column).
+    it("prefers the bound bundle's provider over a drifted agent.provider", async () => {
+        getMemory.mockResolvedValue({ id: "mem1", provider: "claude" });
+        const agent = agentWith("codex", "mem1");
+        const result = await resolveEffectiveLaunchProvider(agent);
+        expect(result).toBe("claude");
+        expect(getMemory).toHaveBeenCalledWith({}, { id: "mem1" });
+    });
+
+    it("falls back to agent.provider when the bundle fetch fails", async () => {
+        getMemory.mockRejectedValue(new Error("not found"));
+        const agent = agentWith("claude", "mem-deleted");
+        const result = await resolveEffectiveLaunchProvider(agent);
+        expect(result).toBe("claude");
+        expect(loggerWarn).toHaveBeenCalled();
+    });
+
+    it("falls back to agent.provider when the bundle's provider is empty", async () => {
+        getMemory.mockResolvedValue({ id: "mem1", provider: "" });
+        const agent = agentWith("claude", "mem1");
+        const result = await resolveEffectiveLaunchProvider(agent);
+        expect(result).toBe("claude");
+    });
+});

--- a/frontend/app/view/agent/agent-launch-env.ts
+++ b/frontend/app/view/agent/agent-launch-env.ts
@@ -9,6 +9,8 @@
  */
 
 import { getApi } from "@/app/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { Logger } from "@/util/logger";
 
 /**
@@ -58,4 +60,44 @@ export function agentmuxHome(): string {
  */
 export function resolveCliDir(version: string, providerId: string): string {
     return `${agentmuxHome()}/instances/v${version}/cli/${providerId}`;
+}
+
+/**
+ * Resolve the effective provider for a launch, preferring the agent's
+ * bound ABF bundle's copy over its own (driftable) `provider` field.
+ *
+ * The bundle is the readonly-once-set source of truth
+ * (ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md §7.4.1);
+ * `AgentDefinition.provider` can drift post-creation via `agent.define`'s
+ * `if_exists=update` path. The backend already resolves this way for
+ * both `agent.open`'s own spawn path (`agent_open.rs`) and the layer-3
+ * credential gate (`identity/resolver/inject.rs`) — without this, the
+ * CLI binary `launchAgentDefinition` actually launches could disagree
+ * with which provider's credentials the backend gate validates and
+ * injects (PR #2592 review — fixing only the backend gate wasn't
+ * sufficient).
+ *
+ * Extracted as its own function, separate from `launchAgentDefinition`,
+ * so this resolution logic is unit-testable in isolation — that
+ * function's own RPC/side-effect surface (Node.js checks, CLI
+ * resolution, content/skill loading, instance creation, etc.) has no
+ * existing test harness anywhere in this codebase (every caller mocks
+ * the whole function away), so testing this piece through it isn't
+ * practical.
+ *
+ * Falls back to `agent.provider` on any failure (unbound, fetch error,
+ * empty bundle provider) — this must never block a launch on its own.
+ */
+export async function resolveEffectiveLaunchProvider(agent: AgentDefinition): Promise<string> {
+    if (!agent.memory_id) return agent.provider;
+    try {
+        const bundle = await RpcApi.GetMemoryCommand(TabRpcClient, { id: agent.memory_id });
+        return bundle?.provider || agent.provider;
+    } catch (e: any) {
+        Logger.warn("agent", "Failed to resolve agent's bound bundle for provider; falling back to agent.provider", {
+            agentId: agent.id,
+            error: String(e),
+        });
+        return agent.provider;
+    }
 }

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -17,7 +17,7 @@ import { buildInstanceSlug } from "./defaults/instance-slug";
 import type { LaunchOverrides } from "./components/AgentLaunchModal";
 import { readActivitySummary } from "@/app/store/activitySummary";
 import { buildConfigFiles } from "./agent-config-builder";
-import { checkNodejsForProvider, agentmuxHome, resolveCliDir } from "./agent-launch-env";
+import { checkNodejsForProvider, agentmuxHome, resolveCliDir, resolveEffectiveLaunchProvider } from "./agent-launch-env";
 import { realAccountIdOrEmpty } from "./identity-carry-over";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
@@ -322,37 +322,11 @@ export class AgentViewModel implements ViewModel {
         overrides?: LaunchOverrides,
         targetBlockId?: string,
     ): Promise<boolean> => {
-        // Resolve the effective provider through the agent's bound ABF
-        // bundle when one exists — the bundle is the readonly-once-set
-        // source of truth (ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md
-        // §7.4.1); `agent.provider` can drift post-creation via
-        // `agent.define`'s `if_exists=update` path. The backend already
-        // resolves this way for both `agent.open`'s own spawn path
-        // (`agent_open.rs`) and the layer-3 credential gate
-        // (`identity/resolver/inject.rs`) — without this, the CLI binary
-        // this function actually launches (resolved client-side, below)
-        // could disagree with which provider's credentials the backend
-        // gate validates and injects: e.g. launching codex's binary while
-        // only claude's config-dir env var gets injected, because the
-        // gate correctly resolved "claude" from the bundle but nothing
-        // told codex about it (PR #2592 review — the gate fix alone
-        // wasn't sufficient without this). Falls back to `agent.provider`
-        // on any failure (unbound, fetch error, empty bundle provider) —
-        // this must never block a launch on its own.
-        let effectiveProvider = agent.provider;
-        if (agent.memory_id) {
-            try {
-                const bundle = await RpcApi.GetMemoryCommand(TabRpcClient, { id: agent.memory_id });
-                if (bundle?.provider) {
-                    effectiveProvider = bundle.provider;
-                }
-            } catch (e: any) {
-                Logger.warn("agent", "Failed to resolve agent's bound bundle for provider; falling back to agent.provider", {
-                    agentId: agent.id,
-                    error: String(e),
-                });
-            }
-        }
+        // See resolveEffectiveLaunchProvider's own doc comment
+        // (agent-launch-env.ts) for why this must resolve through the
+        // agent's bound bundle rather than trusting `agent.provider`
+        // directly.
+        const effectiveProvider = await resolveEffectiveLaunchProvider(agent);
 
         const provider = PROVIDERS[effectiveProvider] ?? PROVIDERS[resolveProviderAlias(effectiveProvider)];
         if (!provider) {

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -322,9 +322,41 @@ export class AgentViewModel implements ViewModel {
         overrides?: LaunchOverrides,
         targetBlockId?: string,
     ): Promise<boolean> => {
-        const provider = PROVIDERS[agent.provider] ?? PROVIDERS[resolveProviderAlias(agent.provider)];
+        // Resolve the effective provider through the agent's bound ABF
+        // bundle when one exists — the bundle is the readonly-once-set
+        // source of truth (ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md
+        // §7.4.1); `agent.provider` can drift post-creation via
+        // `agent.define`'s `if_exists=update` path. The backend already
+        // resolves this way for both `agent.open`'s own spawn path
+        // (`agent_open.rs`) and the layer-3 credential gate
+        // (`identity/resolver/inject.rs`) — without this, the CLI binary
+        // this function actually launches (resolved client-side, below)
+        // could disagree with which provider's credentials the backend
+        // gate validates and injects: e.g. launching codex's binary while
+        // only claude's config-dir env var gets injected, because the
+        // gate correctly resolved "claude" from the bundle but nothing
+        // told codex about it (PR #2592 review — the gate fix alone
+        // wasn't sufficient without this). Falls back to `agent.provider`
+        // on any failure (unbound, fetch error, empty bundle provider) —
+        // this must never block a launch on its own.
+        let effectiveProvider = agent.provider;
+        if (agent.memory_id) {
+            try {
+                const bundle = await RpcApi.GetMemoryCommand(TabRpcClient, { id: agent.memory_id });
+                if (bundle?.provider) {
+                    effectiveProvider = bundle.provider;
+                }
+            } catch (e: any) {
+                Logger.warn("agent", "Failed to resolve agent's bound bundle for provider; falling back to agent.provider", {
+                    agentId: agent.id,
+                    error: String(e),
+                });
+            }
+        }
+
+        const provider = PROVIDERS[effectiveProvider] ?? PROVIDERS[resolveProviderAlias(effectiveProvider)];
         if (!provider) {
-            Logger.error("agent", "Unknown provider in agent definition", { agentId: agent.id, provider: agent.provider });
+            Logger.error("agent", "Unknown provider in agent definition", { agentId: agent.id, provider: effectiveProvider });
             return false;
         }
 
@@ -340,9 +372,9 @@ export class AgentViewModel implements ViewModel {
         const cliDir = resolveCliDir(version, provider.id);
         const cliBin = `${cliDir}/node_modules/.bin/${provider.cliCommand}`;
 
-        Logger.info("agent", `Launching agent definition ${agent.name} (${agent.provider})`, {
+        Logger.info("agent", `Launching agent definition ${agent.name} (${effectiveProvider})`, {
             agentId: agent.id,
-            provider: agent.provider,
+            provider: effectiveProvider,
         });
 
         // Load all content for this agent
@@ -625,7 +657,7 @@ export class AgentViewModel implements ViewModel {
 
             const meta: Record<string, unknown> = {
                 agentId: agent.id,
-                agentProvider: agent.provider,
+                agentProvider: effectiveProvider,
                 agentOutputFormat: provider.styledOutputFormat,
                 agentName: instanceName,
                 agentIcon: agent.icon,
@@ -744,7 +776,7 @@ export class AgentViewModel implements ViewModel {
                     await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
                         agent_id: agent.id,
                         account_id: accountId,
-                        provider: agent.provider,
+                        provider: effectiveProvider,
                     });
                 }
             } catch (e: any) {


### PR DESCRIPTION
## Summary

Follow-up to #2587 (merged). A scoping pass over every remaining `AgentDefinition.provider` read site found the identical class of bug that PR's own review caught and fixed in `agent_open.rs` (rounds 3 and 6) independently reproduced in `identity/resolver/inject.rs`'s layer-3 spawn credential gate — this call site wasn't touched by #2587 at all, so no automated review ever saw it.

**The bug:** the layer-3 gate read `d.provider` directly off the `AgentDefinition` to decide which oauth-class provider a spawn requires credentials for. `AgentDefinition.provider` can drift post-creation (`agent.define`'s `if_exists=update` path), while the agent's bound ABF bundle's own copy is backend-enforced immutable. Concretely: an agent whose definition column drifted to e.g. `"codex"` while its bundle (and its actually-bound account) still correctly say `"claude"` got its spawn **wrongly blocked** with "no account bound for the agent's provider" — a false-positive security gate rejecting a perfectly valid, correctly-configured agent.

**Fix:** consolidated the resolution logic — previously living only in `agent_open.rs` — into a single shared `Store::resolve_effective_provider_id` (`backend/storage/agents.rs`), and pointed both `agent_open.rs` and `inject.rs` at it. Deliberately not duplicating the fix a second time: the whole reason this gap existed is that the logic lived in exactly one place and a second, independent call site quietly missed it.

## Test plan

- [x] New regression test (`inject.rs`) using two genuinely separate stores (a channel-schema `wstore`, a real `Store::open_shared`-backed `id_store` — not `open_in_memory`, since `db_agent_identity_links`' schema differs between the two).
- [x] Verified the test actually catches the bug: temporarily reverted the fix, confirmed the test fails with the exact predicted symptom (`MissingCredentials { provider: "codex" }` on a valid claude-configured agent), restored the fix, confirmed it passes.
- [x] `cargo test -p agentmux-srv` — 2295/2295 passing.

<!-- agentmux:agent_id=agenty -->