### PR TITLE
Manoz@Area54 fix(browser-pane): faster connection-timeout watchdog + human-readable load-error pages

### DIFF
--- a/.changesets/1786852838-fix-browser-pane-faster-connection-timeout-watchdog-and-huma-5gqf.md
+++ b/.changesets/1786852838-fix-browser-pane-faster-connection-timeout-watchdog-and-huma-5gqf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): faster connection-timeout watchdog and human-readable load-error pages

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -55,9 +55,10 @@ wrap_task! {
     }}
 }
 
-/// Arm (or re-arm) the pane load watchdog for a main-frame browser-pane
-/// navigation that's about to start. Called from
-/// `client::lifecycle::on_before_browse`, NOT from the loading-state-change
+/// Arm a FRESH pane load watchdog — new epoch, new `PANE_LOAD_WATCHDOG_TIMEOUT_MS`
+/// deadline — for a main-frame browser-pane navigation that's about to
+/// start. Called from `client::lifecycle::on_before_browse` for a genuinely
+/// new navigation (`is_redirect == 0`), NOT from the loading-state-change
 /// handler — `on_before_browse` hands us the navigation's own target URL via
 /// CEF's `Request` object, which is the only reliable source for "what is
 /// this navigation actually trying to reach." (`Frame::url()` reflects the
@@ -65,6 +66,9 @@ wrap_task! {
 /// watchdog exists purely to handle the case where a navigation stays
 /// pending forever — that's still the PREVIOUS page.) `url` is stored
 /// alongside the arm so `fire_pane_load_watchdog` never has to re-derive it.
+///
+/// A redirect hop of an ALREADY-armed navigation must NOT call this — see
+/// `update_pane_load_watchdog_url` for why.
 pub(crate) fn arm_pane_load_watchdog(state: &Arc<AppState>, block_id: &str, browser: Browser, url: String) {
     let epoch = PANE_LOAD_WATCHDOG_NEXT_EPOCH.fetch_add(1, Ordering::Relaxed);
     state
@@ -73,6 +77,28 @@ pub(crate) fn arm_pane_load_watchdog(state: &Arc<AppState>, block_id: &str, brow
         .insert(block_id.to_string(), (Instant::now(), epoch, browser, url));
     let mut task = PaneLoadWatchdogTask::new(state.clone(), block_id.to_string(), epoch);
     post_delayed_task(ThreadId::UI, Some(&mut task), PANE_LOAD_WATCHDOG_TIMEOUT_MS);
+}
+
+/// Update the STORED target URL for an already-armed watchdog, without
+/// touching its epoch or deadline. Called from `on_before_browse` for
+/// REDIRECT hops (`is_redirect != 0`) of a navigation that's already armed.
+///
+/// Calling `arm_pane_load_watchdog` instead (an earlier version of this fix
+/// did) hands out a fresh `PANE_LOAD_WATCHDOG_TIMEOUT_MS` deadline on EVERY
+/// hop of a redirect chain, so a site that redirects a handful of times
+/// before its final hop hangs could push the actual wait arbitrarily far
+/// past the intended 20s bound before the watchdog ever fires — defeating
+/// its whole purpose (reagentx P1 on PR #2593). The error page should still
+/// report the LATEST hop being attempted if the watchdog does eventually
+/// fire, though, so the URL itself is still updated — just not the timer.
+///
+/// No-ops if nothing is currently armed for `block_id` — e.g. a redirect
+/// notification arriving after the watchdog already fired/disarmed. Whichever
+/// of those already ran owns the outcome; there's nothing to update.
+pub(crate) fn update_pane_load_watchdog_url(state: &Arc<AppState>, block_id: &str, url: String) {
+    if let Some(entry) = state.browser_pane_load_watchdog.lock().get_mut(block_id) {
+        entry.3 = url;
+    }
 }
 
 /// Runs on the CEF UI thread when a pane's load-watchdog deadline elapses.
@@ -242,6 +268,18 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
     // closed over a session.
     if let Some(block_id) = block_id {
         state.browser_pane_zoom.lock().remove(block_id);
+
+        // If this pane closes mid-navigation, its load watchdog is still
+        // armed holding a cloned `Browser`. Without this removal,
+        // `fire_pane_load_watchdog` fires up to PANE_LOAD_WATCHDOG_TIMEOUT_MS
+        // later and calls `main_frame()`/`load_url()` on a browser that's
+        // already torn down (reagentx P1 on PR #2593).
+        if state.browser_pane_load_watchdog.lock().remove(block_id).is_some() {
+            tracing::debug!(
+                block_id = %block_id,
+                "[pane-load-watchdog] pane closed mid-navigation, watchdog disarmed"
+            );
+        }
     }
 
     // Windows only:

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -295,6 +295,37 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
     }
 }
 
+/// Called from `AgentMuxHandler::on_load_start` for a browser pane's MAIN
+/// frame only (caller already filtered on `frame.is_main()`), i.e. the
+/// moment a navigation actually COMMITS and starts loading its content —
+/// disarms the pane-load-watchdog right here, rather than waiting for
+/// `on_loading_state_change_browser_pane`'s `!is_loading` (which waits for
+/// EVERY subresource too). Once the target document has committed, the
+/// watchdog's whole purpose — catching a navigation that never resolves,
+/// leaving the pane blank — no longer applies: the user is now looking at
+/// real, committed content, even if a slow image/script/iframe keeps CEF's
+/// `is_loading` true past the 20s deadline. Firing the watchdog after this
+/// point would replace an already-successfully-loaded page with a synthetic
+/// `ERR_CONNECTION_TIMED_OUT` (reagentx P1 on PR #2593, second pass; also
+/// flagged inline by Codex on the same PR).
+///
+/// No-ops if nothing is armed for this block_id — e.g. a client-side (SPA)
+/// route change, which doesn't re-arm the watchdog in the first place
+/// (`arm_pane_load_watchdog` is only called from `on_before_browse` for a
+/// genuine top-level navigation), or a commit arriving after the watchdog
+/// already fired/disarmed via some other path.
+pub fn on_load_start_browser_pane(state: &Arc<AppState>, browser: &Browser) {
+    if let Some(block_id) = resolve_pane_block_id(state, browser) {
+        if state.browser_pane_load_watchdog.lock().remove(&block_id).is_some() {
+            crate::browser_pane::trace::pane_trace(
+                &block_id,
+                "load-watchdog-disarmed",
+                "main frame committed — target document has content, watchdog no longer needed",
+            );
+        }
+    }
+}
+
 /// Called from `AgentMuxHandler::on_load_end` when `is_browser_pane` is true.
 ///
 /// Chromium creates a fresh `Chrome_RenderWidgetHostHWND` on every

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -17,11 +17,104 @@
 //! `Chrome_RenderWidgetHostHWND` child on every navigation, stranding the
 //! old subclass on a destroyed HWND.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 use cef::*;
 
 use crate::state::AppState;
+
+/// How long a browser pane's top-level navigation may sit in CEF's real
+/// "still loading" state before we give up on it ourselves and show a
+/// synthetic `ERR_CONNECTION_TIMED_OUT` page. Chromium's actual TCP
+/// connect-timeout ceiling (`net::TransportConnectJob::ConnectionTimeout()`)
+/// is 4 minutes — the SAME code Chrome itself runs, so there is no CEF
+/// setting that makes "our" timeout longer than Chrome's; they share it.
+/// This is a deliberate product choice to bound a floating pane's UX well
+/// below that ceiling instead of leaving it blank for up to 4 minutes on a
+/// silently-dropped connection.
+const PANE_LOAD_WATCHDOG_TIMEOUT_MS: i64 = 20_000;
+
+/// Monotonic arm counter for the pane load watchdog — mirrors
+/// `client::navigation`'s `PAINT_GATE_NEXT_EPOCH` pattern. Each arm
+/// (navigation start) gets a fresh epoch; the delayed watchdog task captures
+/// it and only fires if it's still current when the deadline elapses, so a
+/// navigation that finishes — or a NEW navigation that starts — before the
+/// deadline can't have a stale watchdog fire over unrelated content.
+static PANE_LOAD_WATCHDOG_NEXT_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+wrap_task! {
+    struct PaneLoadWatchdogTask {
+        state: Arc<AppState>,
+        block_id: String,
+        epoch: u64,
+    }
+    impl Task { fn execute(&self) {
+        fire_pane_load_watchdog(&self.state, &self.block_id, self.epoch);
+    }}
+}
+
+/// Arm (or re-arm) the pane load watchdog for a main-frame browser-pane
+/// navigation that's about to start. Called from
+/// `client::lifecycle::on_before_browse`, NOT from the loading-state-change
+/// handler — `on_before_browse` hands us the navigation's own target URL via
+/// CEF's `Request` object, which is the only reliable source for "what is
+/// this navigation actually trying to reach." (`Frame::url()` reflects the
+/// last COMMITTED document; for a navigation that's still pending — and a
+/// watchdog exists purely to handle the case where a navigation stays
+/// pending forever — that's still the PREVIOUS page.) `url` is stored
+/// alongside the arm so `fire_pane_load_watchdog` never has to re-derive it.
+pub(crate) fn arm_pane_load_watchdog(state: &Arc<AppState>, block_id: &str, browser: Browser, url: String) {
+    let epoch = PANE_LOAD_WATCHDOG_NEXT_EPOCH.fetch_add(1, Ordering::Relaxed);
+    state
+        .browser_pane_load_watchdog
+        .lock()
+        .insert(block_id.to_string(), (Instant::now(), epoch, browser, url));
+    let mut task = PaneLoadWatchdogTask::new(state.clone(), block_id.to_string(), epoch);
+    post_delayed_task(ThreadId::UI, Some(&mut task), PANE_LOAD_WATCHDOG_TIMEOUT_MS);
+}
+
+/// Runs on the CEF UI thread when a pane's load-watchdog deadline elapses.
+/// No-ops if the navigation already finished (disarmed by
+/// `on_loading_state_change_browser_pane`) or a newer navigation re-armed
+/// the same pane (epoch mismatch) — both mean this specific timeout is
+/// stale and must not act.
+fn fire_pane_load_watchdog(state: &Arc<AppState>, block_id: &str, epoch: u64) {
+    let entry = state.browser_pane_load_watchdog.lock().remove(block_id);
+    let Some((armed_at, armed_epoch, mut browser, target_url)) = entry else { return };
+    if armed_epoch != epoch {
+        // A newer navigation re-armed this pane after this timeout was
+        // scheduled — put the newer entry back (we shouldn't have taken it)
+        // and let its OWN watchdog, or normal load completion, own the
+        // outcome instead of forcing a timeout over content that isn't even
+        // the navigation this timeout was scheduled for.
+        state
+            .browser_pane_load_watchdog
+            .lock()
+            .insert(block_id.to_string(), (armed_at, armed_epoch, browser, target_url));
+        return;
+    }
+    let Some(mut frame) = browser.main_frame() else { return };
+    tracing::warn!(
+        "[pane-load-watchdog] navigation still loading after {}ms, forcing timeout: block_id={} url={:?}",
+        PANE_LOAD_WATCHDOG_TIMEOUT_MS,
+        block_id,
+        target_url,
+    );
+    crate::browser_pane::trace::pane_trace(
+        block_id,
+        "load-watchdog-timeout",
+        &format!("url={target_url} after {}ms", PANE_LOAD_WATCHDOG_TIMEOUT_MS),
+    );
+    crate::client::navigation::show_load_error_page(
+        &mut frame,
+        &target_url,
+        sys::cef_errorcode_t::ERR_CONNECTION_TIMED_OUT as i32,
+        "ERR_CONNECTION_TIMED_OUT",
+        true,
+    );
+}
 
 /// Called from `AgentMuxHandler::on_after_created` when the browser being
 /// registered is a pane (label prefix `browser-pane-*`).
@@ -275,6 +368,16 @@ pub fn on_loading_state_change_browser_pane(
     can_go_forward: bool,
 ) {
     if let Some(block_id) = resolve_pane_block_id(state, browser) {
+        if !is_loading {
+            // Navigation settled — either it committed normally or CEF's own
+            // `on_load_error` already showed a real error page. Either way
+            // the watchdog no longer applies to it. (Arming happens earlier,
+            // in `client::lifecycle::on_before_browse` — see
+            // `arm_pane_load_watchdog`'s doc comment for why it can't happen
+            // here.)
+            state.browser_pane_load_watchdog.lock().remove(&block_id);
+        }
+
         let url = {
             let mut b: cef::Browser = browser.clone();
             b.main_frame()

--- a/agentmux-cef/src/client/error_catalog.rs
+++ b/agentmux-cef/src/client/error_catalog.rs
@@ -1,0 +1,275 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Human-readable copy for CEF/Chromium `cef_errorcode_t` values, in the
+//! style of Chrome's own `net_error_info` strings ("This site can't be
+//! reached", "Your connection isn't private", ...).
+//!
+//! Before this module existed, the browser-pane / dev-frontend load-error
+//! page had no `<title>` element at all, so the window/tab title fell back
+//! to the page's own `data:text/html;base64,...` URI — unreadable. Every
+//! variant below fills BOTH the `<title>` and the on-page heading, so no
+//! error path can regress back to a raw data URI as the visible title.
+//!
+//! Coverage is deliberately not 1:1 with every `ERR_*` constant CEF exposes
+//! (there are ~190). The common navigation-facing failures (DNS, TCP
+//! connect/reset, TLS/cert, HTTP, blocking) are named explicitly; anything
+//! else falls through to a generic-but-still-descriptive default that uses
+//! CEF's own `error_text` for the detail line, so an unmapped code still
+//! never surfaces as a blank or URI-shaped title.
+
+use cef::sys::cef_errorcode_t;
+
+/// Human copy for one error page: window/tab title, on-page heading, and the
+/// detail sentence shown under the failed URL.
+pub(crate) struct ErrorCopy {
+    pub title: &'static str,
+    pub heading: &'static str,
+    pub detail: &'static str,
+}
+
+const fn copy(title: &'static str, heading: &'static str, detail: &'static str) -> ErrorCopy {
+    ErrorCopy { title, heading, detail }
+}
+
+/// Look up human copy for a raw `cef_errorcode_t` value (as `i32`, matching
+/// how `on_load_error` already carries the code). Falls through to a generic
+/// entry for anything not explicitly listed.
+pub(crate) fn describe(error_code_i32: i32) -> ErrorCopy {
+    // `cef_errorcode_t` variants are `#[repr(i32)]`-equivalent constants;
+    // comparing the raw i32 against `VARIANT as i32` avoids needing a
+    // `TryFrom`/exhaustive match over the whole enum.
+    let c = |v: cef_errorcode_t| v as i32;
+
+    match error_code_i32 {
+        // --- DNS -------------------------------------------------------
+        x if x == c(cef_errorcode_t::ERR_NAME_NOT_RESOLVED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The server's DNS address could not be found.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_NAME_RESOLUTION_FAILED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "DNS lookup failed.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_ICANN_NAME_COLLISION) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The requested name collides with an internal name.",
+        ),
+
+        // --- TCP connect / reset ----------------------------------------
+        x if x == c(cef_errorcode_t::ERR_CONNECTION_TIMED_OUT) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The server took too long to respond.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_TIMED_OUT) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The operation timed out.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CONNECTION_REFUSED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The server refused to connect.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CONNECTION_RESET) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The connection was reset.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CONNECTION_CLOSED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The connection was closed unexpectedly.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CONNECTION_ABORTED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The connection was aborted.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CONNECTION_FAILED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The connection failed.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_ADDRESS_UNREACHABLE) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The server's address is unreachable.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_ADDRESS_INVALID) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The server's address is invalid.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_SOCKET_NOT_CONNECTED) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The connection is not established.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_EMPTY_RESPONSE) => copy(
+            "This site can't be reached",
+            "This site can't be reached",
+            "The server didn't send any data.",
+        ),
+
+        // --- Offline / network -------------------------------------------
+        x if x == c(cef_errorcode_t::ERR_INTERNET_DISCONNECTED) => copy(
+            "No internet connection",
+            "No internet connection",
+            "Check your network cable, modem, and router, then try again.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_NETWORK_CHANGED) => copy(
+            "Network changed",
+            "Network changed",
+            "The network connection changed while the page was loading.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_NETWORK_IO_SUSPENDED) => copy(
+            "Network unavailable",
+            "Network unavailable",
+            "The network I/O was suspended (e.g. system sleep).",
+        ),
+        x if x == c(cef_errorcode_t::ERR_NETWORK_ACCESS_DENIED) => copy(
+            "Network access denied",
+            "Network access denied",
+            "The operating system denied network access to this request.",
+        ),
+
+        // --- TLS / certificate --------------------------------------------
+        x if x == c(cef_errorcode_t::ERR_SSL_PROTOCOL_ERROR) => copy(
+            "Your connection isn't private",
+            "Your connection isn't private",
+            "A TLS/SSL protocol error occurred while connecting.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CERT_COMMON_NAME_INVALID)
+            || x == c(cef_errorcode_t::ERR_CERT_AUTHORITY_INVALID)
+            || x == c(cef_errorcode_t::ERR_CERT_DATE_INVALID)
+            || x == c(cef_errorcode_t::ERR_CERT_INVALID)
+            || x == c(cef_errorcode_t::ERR_CERT_REVOKED)
+            || x == c(cef_errorcode_t::ERR_CERT_WEAK_SIGNATURE_ALGORITHM)
+            || x == c(cef_errorcode_t::ERR_CERT_WEAK_KEY)
+            || x == c(cef_errorcode_t::ERR_CERT_CONTAINS_ERRORS) =>
+        {
+            copy(
+                "Your connection isn't private",
+                "Your connection isn't private",
+                "The site's security certificate is not trusted.",
+            )
+        }
+        x if x == c(cef_errorcode_t::ERR_SSL_VERSION_OR_CIPHER_MISMATCH) => copy(
+            "Your connection isn't private",
+            "Your connection isn't private",
+            "The site uses an unsupported TLS version or cipher.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_TLS13_DOWNGRADE_DETECTED) => copy(
+            "Your connection isn't private",
+            "Your connection isn't private",
+            "A possible TLS downgrade attack was detected.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_SSL_CLIENT_AUTH_CERT_NEEDED) => copy(
+            "Client certificate required",
+            "Client certificate required",
+            "The server requires a client certificate to continue.",
+        ),
+
+        // --- HTTP / response -----------------------------------------------
+        x if x == c(cef_errorcode_t::ERR_TOO_MANY_REDIRECTS) => copy(
+            "This page isn't working",
+            "This page isn't working",
+            "The page redirected too many times.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_INVALID_RESPONSE) => copy(
+            "This page isn't working",
+            "This page isn't working",
+            "The server sent an invalid response.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_RESPONSE_HEADERS_TOO_BIG) => copy(
+            "This page isn't working",
+            "This page isn't working",
+            "The server's response headers were too large.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_CONTENT_LENGTH_MISMATCH)
+            || x == c(cef_errorcode_t::ERR_INCOMPLETE_CHUNKED_ENCODING) =>
+        {
+            copy(
+                "This page isn't working",
+                "This page isn't working",
+                "The connection was closed before the response finished.",
+            )
+        }
+
+        // --- Blocked ---------------------------------------------------------
+        x if x == c(cef_errorcode_t::ERR_BLOCKED_BY_CLIENT) => copy(
+            "This content is blocked",
+            "This content is blocked",
+            "The request was blocked (e.g. by an extension).",
+        ),
+        x if x == c(cef_errorcode_t::ERR_BLOCKED_BY_RESPONSE) => copy(
+            "This content is blocked",
+            "This content is blocked",
+            "The server's response headers blocked this request.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_BLOCKED_BY_CSP) => copy(
+            "This content is blocked",
+            "This content is blocked",
+            "Blocked by the page's Content Security Policy.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_BLOCKED_BY_ORB) => copy(
+            "This content is blocked",
+            "This content is blocked",
+            "Blocked by opaque-response-blocking (cross-origin protection).",
+        ),
+        x if x == c(cef_errorcode_t::ERR_BLOCKED_BY_ADMINISTRATOR) => copy(
+            "This content is blocked",
+            "This content is blocked",
+            "Blocked by your administrator's policy.",
+        ),
+
+        // --- Address / scheme / general request ---------------------------
+        x if x == c(cef_errorcode_t::ERR_INVALID_URL) => {
+            copy("Invalid address", "Invalid address", "The requested address is not a valid URL.")
+        }
+        x if x == c(cef_errorcode_t::ERR_UNKNOWN_URL_SCHEME)
+            || x == c(cef_errorcode_t::ERR_DISALLOWED_URL_SCHEME) =>
+        {
+            copy(
+                "Unsupported address",
+                "Unsupported address",
+                "This URL scheme is not supported here.",
+            )
+        }
+        x if x == c(cef_errorcode_t::ERR_FILE_NOT_FOUND) => {
+            copy("File not found", "File not found", "The requested file could not be found.")
+        }
+
+        // --- Proxy -------------------------------------------------------
+        x if x == c(cef_errorcode_t::ERR_PROXY_CONNECTION_FAILED)
+            || x == c(cef_errorcode_t::ERR_TUNNEL_CONNECTION_FAILED) =>
+        {
+            copy(
+                "Can't reach this page",
+                "Can't reach this page",
+                "Could not connect to the configured proxy server.",
+            )
+        }
+        x if x == c(cef_errorcode_t::ERR_MANDATORY_PROXY_CONFIGURATION_FAILED) => copy(
+            "Proxy configuration failed",
+            "Proxy configuration failed",
+            "The required proxy configuration could not be loaded.",
+        ),
+        x if x == c(cef_errorcode_t::ERR_PAC_SCRIPT_FAILED) => copy(
+            "Proxy configuration failed",
+            "Proxy configuration failed",
+            "The proxy auto-config (PAC) script failed to run.",
+        ),
+
+        // --- Generic fallback ------------------------------------------------
+        // Covers every other cef_errorcode_t: still a real title (never blank,
+        // never the data: URI), with CEF's own error_text folded in by the
+        // caller for the detail line.
+        _ => copy("This page isn't working", "This page isn't working", "Couldn't load this page."),
+    }
+}

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -510,6 +510,16 @@ wrap_load_handler! {
             inner.on_loading_state_change(browser, is_loading, can_go_back, can_go_forward);
         }
 
+        fn on_load_start(
+            &self,
+            browser: Option<&mut Browser>,
+            frame: Option<&mut Frame>,
+            transition_type: TransitionType,
+        ) {
+            let mut inner = self.inner.lock();
+            inner.on_load_start(browser, frame, transition_type);
+        }
+
         fn on_load_end(
             &self,
             browser: Option<&mut Browser>,

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -765,7 +765,7 @@ impl AgentMuxHandler {
         frame: Option<&mut Frame>,
         request: Option<&mut Request>,
         _user_gesture: ::std::os::raw::c_int,
-        _is_redirect: ::std::os::raw::c_int,
+        is_redirect: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
         if !self.is_browser_pane {
             return 0; // main app client — never gated
@@ -782,7 +782,7 @@ impl AgentMuxHandler {
             return 1; // cancel — do not let CEF hand this to the OS shell
         }
 
-        // Arm the pane-load watchdog HERE, not from `on_loading_state_change`
+        // Track the pane-load watchdog HERE, not from `on_loading_state_change`
         // — `request.url()` is this navigation's own target, independent of
         // whatever the frame's last COMMITTED document was. Using
         // `Frame::url()` instead (an earlier version did) shows the pane's
@@ -790,18 +790,35 @@ impl AgentMuxHandler {
         // one actually being navigated to, because a frame that never
         // committed this navigation still reports its old URL right up until
         // the watchdog fires. See `browser_pane::callbacks::arm_pane_load_watchdog`.
+        //
+        // `is_redirect` gates WHICH update: a fresh navigation (0) gets a new
+        // epoch + a full new deadline; a redirect hop of an ALREADY-armed
+        // navigation (nonzero) only updates the reported URL, keeping the
+        // original deadline. Treating every hop as a fresh arm (an earlier
+        // version of this fix did) let a redirect chain reset the 20s timer
+        // on each hop, so the actual wait before a timeout page appeared
+        // could grow far past the intended bound (reagentx P1 on PR #2593).
+        // See `browser_pane::callbacks::update_pane_load_watchdog_url`.
         let is_main_frame = frame.as_ref().map(|f| f.is_main() == 1).unwrap_or(false);
         if is_main_frame {
             if let Some(b) = browser.as_deref() {
                 if let Some(block_id) =
                     crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b)
                 {
-                    crate::browser_pane::callbacks::arm_pane_load_watchdog(
-                        &self.state,
-                        &block_id,
-                        b.clone(),
-                        url,
-                    );
+                    if is_redirect != 0 {
+                        crate::browser_pane::callbacks::update_pane_load_watchdog_url(
+                            &self.state,
+                            &block_id,
+                            url,
+                        );
+                    } else {
+                        crate::browser_pane::callbacks::arm_pane_load_watchdog(
+                            &self.state,
+                            &block_id,
+                            b.clone(),
+                            url,
+                        );
+                    }
                 }
             }
         }

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -761,8 +761,8 @@ impl AgentMuxHandler {
     /// internal (devtools/app) navigation regresses.
     pub(crate) fn on_before_browse(
         &mut self,
-        _browser: Option<&mut Browser>,
-        _frame: Option<&mut Frame>,
+        browser: Option<&mut Browser>,
+        frame: Option<&mut Frame>,
         request: Option<&mut Request>,
         _user_gesture: ::std::os::raw::c_int,
         _is_redirect: ::std::os::raw::c_int,
@@ -780,6 +780,30 @@ impl AgentMuxHandler {
                 "on_before_browse: blocked browser-pane navigation to a non-web external scheme (OS-handoff / UAC guard)",
             );
             return 1; // cancel — do not let CEF hand this to the OS shell
+        }
+
+        // Arm the pane-load watchdog HERE, not from `on_loading_state_change`
+        // — `request.url()` is this navigation's own target, independent of
+        // whatever the frame's last COMMITTED document was. Using
+        // `Frame::url()` instead (an earlier version did) shows the pane's
+        // PREVIOUS page in the eventual timeout error page instead of the
+        // one actually being navigated to, because a frame that never
+        // committed this navigation still reports its old URL right up until
+        // the watchdog fires. See `browser_pane::callbacks::arm_pane_load_watchdog`.
+        let is_main_frame = frame.as_ref().map(|f| f.is_main() == 1).unwrap_or(false);
+        if is_main_frame {
+            if let Some(b) = browser.as_deref() {
+                if let Some(block_id) =
+                    crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b)
+                {
+                    crate::browser_pane::callbacks::arm_pane_load_watchdog(
+                        &self.state,
+                        &block_id,
+                        b.clone(),
+                        url,
+                    );
+                }
+            }
         }
         0
     }

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -56,6 +56,7 @@ mod display;
 pub(crate) mod navigation;
 mod crash_recovery;
 mod recovery_pages;
+pub(crate) mod error_catalog;
 #[cfg(target_os = "windows")]
 mod wndproc;
 #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -319,6 +319,45 @@ impl AgentMuxHandler {
         }
     }
 
+    /// CEF fires this once a navigation has COMMITTED and the specified
+    /// frame begins loading its content — i.e. the browser now represents
+    /// the new document, even though that document's own subresources
+    /// (images/scripts/iframes) may still be in flight. Distinct from
+    /// `is_loading` going false (`on_loading_state_change`, which waits for
+    /// the ENTIRE load — all subresources too) and from `on_load_end` (whose
+    /// own doc comment there notes it can fire before the navigation
+    /// controller has finished committing the history entry — not a
+    /// reliable "has this committed" signal either).
+    ///
+    /// For browser panes only: disarms the pane-load-watchdog the moment the
+    /// TARGET document commits, same as the existing disarm-on-`!is_loading`
+    /// path in `on_loading_state_change_browser_pane`. Without this, a page
+    /// that commits and renders successfully but has one slow subresource
+    /// could still hit the watchdog's deadline (is_loading stays true until
+    /// every subresource finishes) and have `fire_pane_load_watchdog`
+    /// replace the already-loaded, visible page with a synthetic
+    /// `ERR_CONNECTION_TIMED_OUT` — flagged inline by Codex and by reagentx
+    /// P1 on PR #2593 (second pass); the "address reagentx P1s" follow-up
+    /// commit only fixed the redirect-timer and pane-close disarm gaps, not
+    /// this one.
+    pub(crate) fn on_load_start(
+        &mut self,
+        browser: Option<&mut Browser>,
+        frame: Option<&mut Frame>,
+        _transition_type: TransitionType,
+    ) {
+        if !self.is_browser_pane {
+            return;
+        }
+        let Some(frame) = frame else { return };
+        if frame.is_main() != 1 {
+            return;
+        }
+        if let Some(b) = browser.as_deref() {
+            crate::browser_pane::callbacks::on_load_start_browser_pane(&self.state, b);
+        }
+    }
+
     pub(crate) fn on_load_end(
         &mut self,
         browser: Option<&mut Browser>,

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -580,22 +580,6 @@ impl AgentMuxHandler {
         let failed_url = failed_url.map(CefString::to_string).unwrap_or_default();
         let error_code_i32 = error_code_raw as i32;
 
-        // JSON-encode the URL so it is a safe JS string literal: a real URL can
-        // contain a single quote (e.g. `?q=can't`), which would otherwise break
-        // the interpolated JS in the Retry handler below.
-        let failed_url_js =
-            serde_json::to_string(&failed_url).unwrap_or_else(|_| "\"\"".to_string());
-        // Auto-retry ONLY for the dev frontend (the main window), which commonly
-        // races the Vite dev server on launch. Browser panes load arbitrary user
-        // URLs through this SAME handler — auto-retrying their failures (offline
-        // site, DNS error, refused service) would be an unbounded reload loop, so
-        // panes get a manual Retry only.
-        let auto_retry = if self.is_browser_pane {
-            String::new()
-        } else {
-            "setTimeout(__amxRetry, 1200);".to_string()
-        };
-
         tracing::error!(
             "Load error: url={} error={} ({})",
             failed_url,
@@ -603,12 +587,66 @@ impl AgentMuxHandler {
             error_code_i32
         );
 
-        // Show a user-friendly error page.
-        let html = format!(
-            r#"<!DOCTYPE html>
+        show_load_error_page(frame, &failed_url, error_code_i32, &error_text, self.is_browser_pane);
+    }
+}
+
+/// Build the load-error page HTML for a failed navigation. Always sets an
+/// explicit `<title>` — see `error_catalog`'s module doc for why that
+/// matters: without one, the window/tab title falls back to this page's own
+/// `data:text/html;base64,...` URI. The human title/heading/detail come from
+/// `error_catalog::describe`; CEF's own `error_text` (e.g.
+/// `ERR_CONNECTION_TIMED_OUT`) and the numeric code are kept as a secondary
+/// diagnostic line underneath, not the headline.
+///
+/// `is_browser_pane` controls two things: the heading copy (a pane failing to
+/// load an arbitrary external site must never claim "Failed to load AgentMux
+/// frontend" — that copy was previously hardcoded and wrong for panes) and
+/// whether the page auto-retries (dev frontend only, see `on_load_error`'s
+/// original comment, preserved below).
+pub(crate) fn render_load_error_html(
+    failed_url: &str,
+    error_code_i32: i32,
+    error_text: &str,
+    is_browser_pane: bool,
+) -> String {
+    use crate::client::error_catalog::describe;
+    use crate::client::helpers::{html_escape, js_string_literal};
+
+    let copy = describe(error_code_i32);
+    let failed_url_safe = html_escape(failed_url);
+    let error_text_safe = html_escape(error_text);
+    let title_safe = html_escape(copy.title);
+    let heading_safe = html_escape(copy.heading);
+    let detail_safe = html_escape(copy.detail);
+    // `js_string_literal`, not hand-rolled JSON: a real URL can contain a
+    // single quote (e.g. `?q=can't`), which would otherwise break the
+    // interpolated JS in the Retry handler below.
+    let failed_url_js = js_string_literal(failed_url);
+
+    // Auto-retry ONLY for the dev frontend (the main window), which commonly
+    // races the Vite dev server on launch. Browser panes load arbitrary user
+    // URLs through this SAME handler — auto-retrying their failures (offline
+    // site, DNS error, refused service) would be an unbounded reload loop, so
+    // panes get a manual Retry only.
+    let auto_retry = if is_browser_pane {
+        String::new()
+    } else {
+        "setTimeout(__amxRetry, 1200);".to_string()
+    };
+    let dev_hint = if is_browser_pane {
+        String::new()
+    } else {
+        "<p>Make sure the Vite dev server is running:<br><code>task dev</code> or <code>npx vite</code></p>"
+            .to_string()
+    };
+
+    format!(
+        r#"<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
+    <title>{title_safe}</title>
     <style>
         body {{
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -647,11 +685,11 @@ impl AgentMuxHandler {
 </head>
 <body>
     <div class="error-container">
-        <h1>Failed to load AgentMux frontend</h1>
-        <p>Could not connect to <code>{failed_url}</code></p>
-        <p>Error: {error_text} ({error_code_i32})</p>
-        <p>Make sure the Vite dev server is running:<br>
-           <code>task dev</code> or <code>npx vite</code></p>
+        <h1>{heading_safe}</h1>
+        <p>Could not load <code>{failed_url_safe}</code></p>
+        <p>{detail_safe}</p>
+        <p style="opacity:0.7;font-size:12px;">{error_text_safe} ({error_code_i32})</p>
+        {dev_hint}
         <button class="retry" onclick="__amxRetry()">Retry</button>
     <script>
         // This error page is itself a data: URI, so location.reload() would just
@@ -664,12 +702,28 @@ impl AgentMuxHandler {
     </div>
 </body>
 </html>"#
-        );
+    )
+}
 
-        let b64 = cef::base64_encode(Some(html.as_bytes()));
-        let b64_str = CefString::from(&b64).to_string();
-        let data_uri = format!("data:text/html;base64,{}", b64_str);
-        let uri = CefString::from(data_uri.as_str());
-        frame.load_url(Some(&uri));
-    }
+/// Render `render_load_error_html` and navigate `frame` to it as a base64
+/// `data:` URI — the same mechanism `on_load_error` has always used. Shared
+/// with `browser_pane::callbacks`'s navigation watchdog, which calls this
+/// with a synthetic `ERR_CONNECTION_TIMED_OUT` when a pane's top-level
+/// navigation is still loading past its watchdog deadline — see that module
+/// for why (Chromium's real connect-timeout ceiling is 4 minutes, shared
+/// verbatim with Chrome's own net stack, which is too long to leave a pane
+/// sitting blank).
+pub(crate) fn show_load_error_page(
+    frame: &mut Frame,
+    failed_url: &str,
+    error_code_i32: i32,
+    error_text: &str,
+    is_browser_pane: bool,
+) {
+    let html = render_load_error_html(failed_url, error_code_i32, error_text, is_browser_pane);
+    let b64 = cef::base64_encode(Some(html.as_bytes()));
+    let b64_str = CefString::from(&b64).to_string();
+    let data_uri = format!("data:text/html;base64,{}", b64_str);
+    let uri = CefString::from(data_uri.as_str());
+    frame.load_url(Some(&uri));
 }

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -656,7 +656,18 @@ pub(crate) fn render_load_error_html(
     let failed_url_safe = html_escape(failed_url);
     let error_text_safe = html_escape(error_text);
     let title_safe = html_escape(copy.title);
-    let heading_safe = html_escape(copy.heading);
+    // The dev frontend (main window, !is_browser_pane) keeps its own
+    // specific heading — restored per reagentx P2 on PR #2593 (this file's
+    // own copy silently dropped it when the error page was unified with
+    // error_catalog::describe). A browser pane still uses the generic
+    // per-error-code heading: that's the actual fix this unification made
+    // (see this function's own doc comment) — a pane loading an arbitrary
+    // external site must never claim "Failed to load AgentMux frontend".
+    let heading_safe = html_escape(if is_browser_pane {
+        copy.heading
+    } else {
+        "Failed to load AgentMux frontend"
+    });
     let detail_safe = html_escape(copy.detail);
     // `js_string_literal`, not hand-rolled JSON: a real URL can contain a
     // single quote (e.g. `?q=can't`), which would otherwise break the

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -129,6 +129,34 @@ pub struct AppState {
     /// reason as `linux_paint_gate_pending` above.
     pub linux_first_paint_seen: Mutex<std::collections::HashSet<String>>,
 
+    /// Browser-pane top-level navigation watchdog. Chromium's underlying TCP
+    /// connect-timeout ceiling (`net::TransportConnectJob::ConnectionTimeout`)
+    /// is 4 minutes — the SAME ceiling real Chrome ships with, since it's the
+    /// same net-stack code — which is far too long for a floating pane to sit
+    /// on a blank "loading" state. Armed in
+    /// `client::lifecycle::on_before_browse` when a pane's main-frame
+    /// navigation is about to start, and disarmed in
+    /// `browser_pane::callbacks::on_loading_state_change_browser_pane` when it
+    /// ends (`is_loading == false`, whether the navigation committed or CEF's
+    /// own `on_load_error` already fired). If a navigation is still armed when
+    /// its delayed watchdog task runs, we cancel it ourselves and show a
+    /// synthetic `ERR_CONNECTION_TIMED_OUT` error page instead of waiting out
+    /// Chromium's full ceiling. Keyed by pane `block_id`; value is
+    /// `(armed_at, epoch, browser, url)` — `epoch` guards against a stale
+    /// timeout firing after a newer navigation re-armed the same pane (mirrors
+    /// `linux_paint_gate_pending`'s epoch pattern above); `browser` is the
+    /// cloned handle the delayed task navigates when it fires; `url` is the
+    /// navigation's OWN target URL, captured from CEF's `Request` at
+    /// `on_before_browse` time. Deliberately NOT re-derived from
+    /// `frame.main_frame().url()` at fire time — that getter reflects the
+    /// frame's last COMMITTED document, which for a navigation that never
+    /// committed (the exact case this watchdog exists for) is still the
+    /// PREVIOUS page. An earlier version did that and showed the pane's old
+    /// URL ("Could not connect to <previous page>") instead of the one the
+    /// user actually tried to reach.
+    pub browser_pane_load_watchdog:
+        Mutex<std::collections::HashMap<String, (std::time::Instant, u64, Browser, String)>>,
+
     /// Phase B.5e — host's projection of the launcher's
     /// authoritative `state.instance_registry`. Fed by
     /// `Event::WindowInstanceAssigned` /
@@ -584,6 +612,7 @@ impl Default for AppState {
             window_init_status: Mutex::new(String::new()),
             linux_paint_gate_pending: Mutex::new(std::collections::HashMap::new()),
             linux_first_paint_seen: Mutex::new(std::collections::HashSet::new()),
+            browser_pane_load_watchdog: Mutex::new(std::collections::HashMap::new()),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({


### PR DESCRIPTION
## Summary
- Adds a 20s watchdog for browser-pane top-level navigations. Chromium's real TCP connect-timeout ceiling (`net::TransportConnectJob`) is 4 minutes and is the *same* code Chrome itself runs — there's no CEF setting that makes ours longer than Chrome's, so this is a deliberate product bound rather than a config fix. Armed in `on_before_browse` using the navigation's own `Request::url()` — not `Frame::url()`, which still reports the *previous* committed page for a navigation that never committed and showed the wrong URL in an earlier version of this fix (caught via manual testing against `anthropic.ai` down + the pane's default `agentmux.ai` start page).
- Fixes the load-error page itself: it had no `<title>` at all, so the window/tab title fell back to showing its own `data:text/html;base64,...` URI. Adds an explicit title plus Chrome-style human-readable title/heading/detail text per error code (`error_catalog.rs`, ~35 explicit `ERR_*` mappings + a non-blank fallback for the rest), and stops the page claiming "Failed to load AgentMux frontend" when a browser pane fails to load an arbitrary external site (that copy was previously hardcoded and wrong for panes).

## Test plan
- [x] `cargo check -p agentmux-cef` — clean, no new warnings
- [x] Manual: loaded a down site in a browser pane, confirmed the 20s watchdog fires with the *correct* target URL (not the pane's previous page) and a human-readable title
- [x] Manual: confirmed the window/tab title is no longer a `data:` URI on load failure

<!-- agentmux:agent_id=manoz -->