### PR TITLE
Resolve AgentLaunchModal.tsx's provider through the bound bundle

### DIFF
--- a/.changesets/1786855635-fix-agent-launch-modal-resolves-provider-through-the-bound-b-t2me.md
+++ b/.changesets/1786855635-fix-agent-launch-modal-resolves-provider-through-the-bound-b-t2me.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): launch modal resolves provider through the bound bundle, not the driftable agent column

--- a/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
@@ -16,7 +16,7 @@
  * AuthFlowController.
  */
 
-import { render, screen } from "@solidjs/testing-library";
+import { cleanup, render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,6 +35,12 @@ vi.mock("@/app/store/rpc-api", () => {
         // undefined, which the store treats as "unavailable"; fine as a
         // default for tests that don't care about Docker state.
         ContainerRuntimeAvailableCommand: vi.fn(),
+        // Backs `effectiveProviderId`'s bound-bundle resolution (PR
+        // following #2592/#2594) — resolves to `undefined` by default so
+        // existing tests (none of whose agent fixtures set `memory_id`)
+        // never even trigger the fetch; tests that DO exercise the
+        // resolution set their own `mockResolvedValue`.
+        GetMemoryCommand: vi.fn().mockResolvedValue(undefined),
     };
     return { RpcApi };
 });
@@ -115,6 +121,26 @@ const claudeAgent = {
     is_seeded: 0,
 } as AgentDefinition;
 
+// The same drift scenario PR #2592 fixed on the backend: the agent's own
+// `provider` column says "codex" (unrecognized by this file's
+// `getProvider` mock, which only knows "claude"), but it's bound to a
+// bundle whose provider correctly says "claude".
+const driftedProviderAgent = {
+    ...claudeAgent,
+    id: "agent-drift",
+    provider: "codex",
+    memory_id: "mem-bundle-1",
+} as AgentDefinition;
+
+const driftedAgentsBundle: Memory = {
+    id: "mem-bundle-1",
+    name: "Drift Test Bundle",
+    is_blank: false,
+    provider: "claude",
+    created_at: ts(),
+    updated_at: ts(),
+};
+
 const workAccount = {
     id: "acct-work",
     name: "Work",
@@ -159,6 +185,13 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+    // This file only ever had one test before; adding more exposed that
+    // it never unmounted between runs (no global afterEach(cleanup) in
+    // test/vitest-setup.ts, unlike files that call this explicitly).
+    // Without it, a still-live component from a prior test's render
+    // (including its still-reactive createResource calls) can pollute
+    // the next test's DOM queries.
+    cleanup();
     vi.restoreAllMocks();
 });
 
@@ -210,5 +243,43 @@ describe("AgentLaunchModal — memory change must not reset auth state (§6.10)"
         ).not.toBeInTheDocument();
         expect((identitySelect as HTMLSelectElement).value).toBe("acct-work");
         expect((memorySelect as HTMLSelectElement).value).toBe("mem-personal");
+    });
+});
+
+describe("AgentLaunchModal — provider resolution through the bound bundle", () => {
+    // The core regression case: if this modal resolved the drifted
+    // "codex" column instead of the bundle's "claude", accountsForProvider
+    // would find no matching account for "codex" (workAccount is
+    // claude-provider) and the Account selector would never auto-pick
+    // acct-work — offering the wrong provider's auth flow entirely (or
+    // none at all) for a perfectly valid, correctly-configured agent.
+    it("resolves the effective provider through the bound bundle, not a drifted agent.provider", async () => {
+        vi.mocked(RpcApi.GetMemoryCommand).mockResolvedValue(driftedAgentsBundle);
+
+        render(() => (
+            <AgentLaunchModalPanel
+                agent={driftedProviderAgent}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />
+        ));
+
+        const identitySelect = await screen.findByLabelText("Account");
+        expect((identitySelect as HTMLSelectElement).value).toBe("acct-work");
+        expect(RpcApi.GetMemoryCommand).toHaveBeenCalledWith({}, { id: "mem-bundle-1" });
+    });
+
+    it("falls back to agent.provider when the agent has no bound bundle", async () => {
+        render(() => (
+            <AgentLaunchModalPanel
+                agent={claudeAgent}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />
+        ));
+
+        const identitySelect = await screen.findByLabelText("Account");
+        expect((identitySelect as HTMLSelectElement).value).toBe("acct-work");
+        expect(RpcApi.GetMemoryCommand).not.toHaveBeenCalled();
     });
 });

--- a/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
@@ -16,7 +16,7 @@
  * AuthFlowController.
  */
 
-import { cleanup, render, screen } from "@solidjs/testing-library";
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -73,17 +73,33 @@ vi.mock("@/app/errors/translate", () => ({
 
 // Stub the providers module so the agent's provider entry exists.
 vi.mock("../providers", () => ({
-    getProvider: (id: string) =>
-        id === "claude"
-            ? {
-                  id: "claude",
-                  authType: "oauth",
-                  authCommand: "claude",
-                  authCheckArgs: [],
-                  npmPackage: null,
-                  cliCommand: "claude",
-              }
-            : undefined,
+    getProvider: (id: string) => {
+        if (id === "claude") {
+            return {
+                id: "claude",
+                authType: "oauth",
+                authCommand: "claude",
+                authCheckArgs: [],
+                npmPackage: null,
+                cliCommand: "claude",
+            };
+        }
+        // Recognized (unlike "codex" below, which stays undefined) —
+        // needed for the auto-pick race regression test, where the
+        // STALE provider must itself be valid (with its own account)
+        // for the bug to manifest at all.
+        if (id === "gemini") {
+            return {
+                id: "gemini",
+                authType: "oauth",
+                authCommand: "gemini",
+                authCheckArgs: [],
+                npmPackage: null,
+                cliCommand: "gemini",
+            };
+        }
+        return undefined;
+    },
 }));
 
 // Stub the cli-catalog so displayName resolves.
@@ -141,10 +157,43 @@ const driftedAgentsBundle: Memory = {
     updated_at: ts(),
 };
 
+// The auto-pick race scenario from the round-2 review: the stale
+// `agent.provider` value must itself be a RECOGNIZED provider with its
+// own account for the bug to manifest — "codex" above is unrecognized,
+// so it never reaches this code path at all.
+const raceDriftAgent = {
+    ...claudeAgent,
+    id: "agent-race",
+    provider: "gemini",
+    memory_id: "mem-bundle-race",
+} as AgentDefinition;
+
+const raceDriftBundle: Memory = {
+    id: "mem-bundle-race",
+    name: "Race Test Bundle",
+    is_blank: false,
+    provider: "claude",
+    created_at: ts(),
+    updated_at: ts(),
+};
+
 const workAccount = {
     id: "acct-work",
     name: "Work",
     provider: "claude",
+    kind: "oauth",
+    secret_ref: { backend: "env" },
+    context: {},
+    assigned_agents: [],
+    status: "valid",
+    created_at: "",
+    updated_at: "",
+} as unknown as import("@/app/view/identity/identity-model").Account;
+
+const geminiAccount = {
+    id: "acct-gemini",
+    name: "Gemini",
+    provider: "gemini",
     kind: "oauth",
     secret_ref: { backend: "env" },
     context: {},
@@ -281,5 +330,79 @@ describe("AgentLaunchModal — provider resolution through the bound bundle", ()
         const identitySelect = await screen.findByLabelText("Account");
         expect((identitySelect as HTMLSelectElement).value).toBe("acct-work");
         expect(RpcApi.GetMemoryCommand).not.toHaveBeenCalled();
+    });
+
+    // Round-2 review finding on PR #2596: the account auto-pick effect
+    // only fires while `accountId()` is empty, and once it commits it
+    // never re-evaluates (Solid drops `provider()` from the effect's
+    // tracked deps the moment it takes the early-return path). If the
+    // modal exposed the STALE `agent.provider` while the bundle fetch was
+    // still in flight, and that stale value happened to be a recognized
+    // provider with its own account, the effect could commit to the WRONG
+    // account before the bundle resolves — and then never self-correct.
+    it("does not auto-pick the wrong account for a recognized-but-stale provider before the bundle resolves", async () => {
+        // Deliberately let accounts resolve BEFORE the bundle so the
+        // auto-pick effect gets a chance to fire against the stale
+        // `agent.provider` ("gemini") first — this is what makes the race
+        // actually reproducible instead of both fetches settling in the
+        // same microtask batch.
+        vi.mocked(refreshAccountCache).mockResolvedValue([workAccount, geminiAccount]);
+        let resolveBundle!: (m: Memory) => void;
+        vi.mocked(RpcApi.GetMemoryCommand).mockReturnValue(
+            new Promise<Memory>((resolve) => {
+                resolveBundle = resolve;
+            }),
+        );
+        const onSubmit = vi.fn();
+
+        render(() => (
+            <AgentLaunchModalPanel
+                agent={raceDriftAgent}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+
+        // Let the already-resolved accounts fetch fully settle —
+        // including the auto-pick effect's own commit — before the
+        // bundle resolves. This is the race window the round-2 review
+        // flagged: under the bug, the auto-pick effect commits to the
+        // still-stale `agent.provider` ("gemini") here and never gets a
+        // chance to reconsider once the bundle resolves. A macrotask
+        // flush (not just a microtask) is needed since the account
+        // fetch's promise chain + Solid's own effect scheduling both run
+        // across several microtask ticks.
+        await new Promise((r) => setTimeout(r, 0));
+
+        resolveBundle(raceDriftBundle);
+        await screen.findByLabelText("Account");
+
+        // Ground-truth check: read the actual committed `accountId`
+        // signal, not the rendered `<select>.value` — once the resolved
+        // provider narrows the option list to a single entry, a stale
+        // selected id that's no longer a listed option gets implicitly
+        // reselected by the DOM itself (jsdom/browser `<select>`
+        // behavior), which makes the widget's displayed value look
+        // "self-corrected" even though the underlying signal driving
+        // submission never changed. `useLaunchAuthGate`'s
+        // `accountSupplies` reads that real signal against the current
+        // provider — under the bug it stays false (stale "acct-gemini"
+        // doesn't supply "claude"), so the Connect CTA stays mounted and
+        // Launch stays blocked despite a valid, correct account existing.
+        const user = userEvent.setup();
+        await user.type(screen.getByLabelText("Agent name"), "race-test");
+
+        await waitFor(() => {
+            expect(
+                screen.queryByRole("button", { name: /connect/i }),
+            ).not.toBeInTheDocument();
+        });
+        const launchButton = screen.getByRole("button", { name: /^launch$/i });
+        expect(launchButton).not.toBeDisabled();
+
+        await user.click(launchButton);
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({ accountId: "acct-work" }),
+        );
     });
 });

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -135,16 +135,33 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // provider.
     //
     // `createResource` rather than an inline async fetch inside the
-    // memo below: memos must stay synchronous, so the fetch lives here
-    // and downstream memos read `effectiveProviderId()`, which starts
-    // as `props.agent.provider` (safe default) and reactively updates
-    // once the bundle resolves — same fallback-on-anything-but-success
-    // semantics as `resolveEffectiveLaunchProvider`.
+    // memo below: memos must stay synchronous, so the fetch lives here.
     const [boundBundle] = createResource(
         () => props.agent.memory_id || undefined,
         (memoryId) => RpcApi.GetMemoryCommand(TabRpcClient, { id: memoryId }).catch(() => undefined),
     );
-    const effectiveProviderId = createMemo(() => boundBundle()?.provider || props.agent.provider);
+    // While a BOUND agent's bundle fetch is still in flight, resolve to
+    // "" (empty/unknown) rather than falling back to `props.agent.provider`
+    // — P1 fix, ReAgent review on PR #2596: the account auto-pick
+    // `createEffect` below only picks when `accountId()` is still empty,
+    // and once it picks it never re-evaluates (Solid stops tracking
+    // `provider()` as a dependency the moment the effect returns early on
+    // `accountId()` being set). If the STALE `agent.provider` value was
+    // itself a real, recognized provider with its own account, the
+    // effect would auto-pick that WRONG account on the synchronous
+    // pre-resolution render and then never self-correct once the bundle
+    // resolves the real provider — silently defeating this whole fix for
+    // exactly the drift case it exists to close. Exposing "" (which
+    // resolves to no provider / no accounts) during the loading window
+    // instead means nothing gets auto-picked until the real value is
+    // known, so the auto-pick effect only ever fires once, against the
+    // correct resolved provider. `boundBundle.loading` is `false` for an
+    // unbound agent (the fetcher never runs when the resource's source is
+    // falsy), so this adds no delay for the common unbound case.
+    const effectiveProviderId = createMemo(() => {
+        if (props.agent.memory_id && boundBundle.loading) return "";
+        return boundBundle()?.provider || props.agent.provider;
+    });
 
     const catalog = createMemo(() => getCliCatalogEntry(effectiveProviderId()));
     const displayName = () => catalog()?.displayName ?? props.agent.name;

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -13,7 +13,7 @@
  * panel only. See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
 
-import { createEffect, createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -120,13 +120,39 @@ interface LaunchFormState {
 }
 
 export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
-    const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
+    // Resolve the effective provider through the agent's bound ABF
+    // bundle, not `props.agent.provider` directly — same fix as
+    // `resolveEffectiveLaunchProvider` (agent-launch-env.ts), applied
+    // here because this modal independently gates which accounts are
+    // offered and drives the entire pre-launch auth flow
+    // (`PreLaunchAuthPanel`, below) from the provider it resolves, all
+    // BEFORE the launch RPC ever reaches the backend's already-correct
+    // resolution (PR #2592; see issue #2594 for the full remaining
+    // scope). `agent.provider` can drift post-creation via
+    // `agent.define`'s `if_exists=update` path while the bundle's own
+    // copy is backend-enforced immutable — without this, a user could
+    // be offered accounts for / walked through auth for the WRONG
+    // provider.
+    //
+    // `createResource` rather than an inline async fetch inside the
+    // memo below: memos must stay synchronous, so the fetch lives here
+    // and downstream memos read `effectiveProviderId()`, which starts
+    // as `props.agent.provider` (safe default) and reactively updates
+    // once the bundle resolves — same fallback-on-anything-but-success
+    // semantics as `resolveEffectiveLaunchProvider`.
+    const [boundBundle] = createResource(
+        () => props.agent.memory_id || undefined,
+        (memoryId) => RpcApi.GetMemoryCommand(TabRpcClient, { id: memoryId }).catch(() => undefined),
+    );
+    const effectiveProviderId = createMemo(() => boundBundle()?.provider || props.agent.provider);
+
+    const catalog = createMemo(() => getCliCatalogEntry(effectiveProviderId()));
     const displayName = () => catalog()?.displayName ?? props.agent.name;
     // Declared early — `createMemo`'s first run is synchronous (unlike
     // `createEffect`, which defers to after setup completes), so any
     // memo below that reads `provider()` needs the binding to already
     // exist at the point it's created.
-    const provider = createMemo(() => getProvider(props.agent.provider));
+    const provider = createMemo(() => getProvider(effectiveProviderId()));
 
     // Form + submit state live in the launch-flow-state reducer slice
     // (Stage 2b/2c of SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).


### PR DESCRIPTION
## Summary

Item 1 of #2594's delivery plan — the highest-impact remaining site after #2592 fixed the backend credential gate and launch path.

`AgentLaunchModalPanel` resolved `provider`/`catalog` directly from `props.agent.provider`, which drives which accounts are offered (`accountsForProvider`, auto-pick) and the entire pre-launch OAuth/API-key flow (`PreLaunchAuthPanel`) — all client-side, before the launch RPC ever reaches the backend's already-correct bundle-aware resolution. `agent.provider` can drift post-creation via `agent.define`'s `if_exists=update` path while the agent's bound ABF bundle's own copy is backend-enforced immutable — without this fix, a user could be shown accounts for, or walked through auth for, the wrong provider entirely.

**Fix:** added a `createResource`-backed `effectiveProviderId` (memos must stay synchronous, so the bundle fetch lives in a resource) — `catalog`/`provider` memos read the resolved value, starting as `props.agent.provider` and reactively updating once the bundle resolves. Every downstream consumer picks this up for free with no other call-site changes.

**Also fixed:** the integration test file had no `afterEach(cleanup())` — it only ever had one test before, so cross-test pollution was never observable. Added it.

## Test plan

- [x] 2 new tests: the core regression case (verified it actually fails against the reverted code, with the predicted symptom — Account selector never renders because the drifted provider is unrecognized), and the no-bundle fallback case.
- [x] `tsc --noEmit` clean (2 pre-existing, unrelated baseline errors only).
- [x] Full frontend suite: 2629 passed, 0 failed.

<!-- agentmux:agent_id=agenty -->
