### PR TITLE
Manoz@Area54 fix(browser-pane): clicking inside a pane dismisses open menus/popovers

### DIFF
--- a/.changesets/1786856032-fix-browser-pane-clicking-inside-a-pane-now-dismisses-open-m-ief5.md
+++ b/.changesets/1786856032-fix-browser-pane-clicking-inside-a-pane-now-dismisses-open-m-ief5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): clicking inside a pane now dismisses open menus/popovers

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -458,11 +458,32 @@ pub unsafe fn install_browser_pane_focus_redirect(
                         "[browser-pane:diag][{}] emit-clicked",
                         block_id_short,
                     );
-                    crate::events::emit_event_from_state(
-                        &state,
-                        "browser-pane-clicked",
-                        &serde_json::json!({ "block_id": ctx.block_id }),
-                    );
+                    // Route to the pane's ACTUAL owning window, not "main" —
+                    // a pane torn off into its own floating window has its
+                    // own JS context; `emit_event_from_state`'s "main"/
+                    // first-available fallback delivered this to the wrong
+                    // window (or none) for floating panes, so neither pane
+                    // selection nor (later) the outside-click-dismiss bridge
+                    // built on this event worked there (reagentx P1 on PR
+                    // #2597). Same fix as `browser-pane-shortcut`
+                    // (handlers.rs) and `browser-pane-context-menu`
+                    // (context_menu.rs).
+                    match state.browser_pane_window_label(&ctx.block_id) {
+                        Some(window_label) => {
+                            crate::events::emit_event_to_window(
+                                &state,
+                                &window_label,
+                                "browser-pane-clicked",
+                                &serde_json::json!({ "block_id": ctx.block_id }),
+                            );
+                        }
+                        None => {
+                            tracing::warn!(
+                                "[pane-wndproc] WM_LBUTTONDOWN — no owning window label for block_id={}",
+                                ctx.block_id
+                            );
+                        }
+                    }
                 } else {
                     tracing::warn!("[pane-wndproc] WM_LBUTTONDOWN — state dropped, skipping emit");
                 }

--- a/agentmux-cef/src/ui_tasks/platform_macos.rs
+++ b/agentmux-cef/src/ui_tasks/platform_macos.rs
@@ -390,11 +390,26 @@ pub(crate) extern "C" fn swizzled_nsapp_send_event(
                         .and_then(|m| m.get(&win_usize).cloned());
                     if let Some((_, block_id, weak_state)) = hit {
                         if let Some(state) = weak_state.upgrade() {
-                            crate::events::emit_event_from_state(
-                                &state,
-                                "browser-pane-clicked",
-                                &serde_json::json!({ "block_id": block_id }),
-                            );
+                            // Route to the pane's ACTUAL owning window, not
+                            // "main" — see the identical fix + rationale in
+                            // browser_pane::hwnd's WM_LBUTTONDOWN handler
+                            // (reagentx P1 on PR #2597).
+                            match state.browser_pane_window_label(&block_id) {
+                                Some(window_label) => {
+                                    crate::events::emit_event_to_window(
+                                        &state,
+                                        &window_label,
+                                        "browser-pane-clicked",
+                                        &serde_json::json!({ "block_id": block_id }),
+                                    );
+                                }
+                                None => {
+                                    tracing::warn!(
+                                        "[pane-swizzle] leftMouseDown — no owning window label for block_id={}",
+                                        block_id
+                                    );
+                                }
+                            }
                         }
                     }
                 }

--- a/docs/specs/SPEC_BROWSER_PANE_CLICK_DISMISSES_MENUS_2026_08_15.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CLICK_DISMISSES_MENUS_2026_08_15.md
@@ -1,0 +1,168 @@
+# SPEC — Browser pane: clicking inside it should dismiss open menus/popovers
+
+**Date:** 2026-08-15
+**Type:** Bug fix (design proposal — not yet implemented)
+**Status:** Draft
+**Scope:** Frontend (`frontend/app/window/action-widgets.tsx` and, if the
+recommended fix is taken, every other "outside click" dismiss listener in the
+app) + reuse of the existing `browser-pane-clicked` backend event
+(`agentmux-cef/src/browser_pane/hwnd.rs` on Windows,
+`agentmux-cef/src/ui_tasks/platform_macos.rs` on macOS). **No new backend
+work required** — see Root cause.
+
+## Problem
+
+Reported by the user: open the widget bar's "More" dropdown, then click
+inside a browser pane. The dropdown stays open. Clicking anywhere else in the
+app (including elsewhere in the DOM, or another pane) closes it correctly —
+only a click landing inside a browser pane fails to.
+
+## Root cause
+
+`action-widgets.tsx`'s "More" dropdown closes itself via a standard
+outside-click listener:
+
+```ts
+// action-widgets.tsx:174-185
+createEffect(() => {
+    if (!moreOpen()) return;
+    const handler = (e: MouseEvent) => {
+        const t = e.target as Node;
+        if (moreButtonRef?.contains(t) || moreDropdownRef?.contains(t)) return;
+        const el = t instanceof Element ? t : (t as Node).parentElement;
+        if (el?.closest(".popover-menu")) return;
+        setMoreOpen(false);
+    };
+    document.addEventListener("mousedown", handler, true);
+    onCleanup(() => document.removeEventListener("mousedown", handler, true));
+});
+```
+
+This is a real DOM `mousedown` listener. Per
+`docs/specs/SPEC_NATIVE_BROWSER_PANE_2026_04_17.md`, a browser pane's content
+is **not** in the DOM — it's a second, sibling `CefBrowserView` layered on top
+of the main window via CEF's Views `AddOverlayView`. Once a page is loaded,
+clicks on it are handled entirely by a separate native Chromium instance and
+never become a DOM `mousedown`/`click` event in the host window. The listener
+above simply never fires for those clicks — exactly the same root cause
+already diagnosed and fixed (for pane *selection*, not menu dismissal) in
+`docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md`.
+
+**This is not unique to the widget "More" menu.** The same
+`document.addEventListener("mousedown"/"pointerdown", ..., true)`
+outside-click pattern is independently implemented in at least 18 other
+places:
+
+```
+app/statusbar/TokenUsageIndicator.tsx   app/statusbar/HostPopover.tsx
+app/statusbar/SystemStats.tsx           app/statusbar/StatusBar.tsx
+app/statusbar/BackendStatus.tsx         app/tab/tab.tsx
+app/tab/tab-reorder.ts                  app/element/flyoutmenu.tsx
+app/element/popover-menu.tsx            app/components/context-menu.tsx
+app/workspace/floating-pane-workspace.tsx (x2)
+app/view/agent/components/AgentRuntimeDropup.tsx
+app/window/action-widgets.tsx (x2 — More dropdown, item context-menu dismiss)
+app/app.tsx (AppKeyHandlers)
+```
+
+Every one of these has the identical latent bug: a click landing on a browser
+pane will not close it. The user only reported the widget menu because
+that's what they happened to test, but a narrow fix scoped to
+`action-widgets.tsx` alone would leave ~18 other reproductions of the same
+bug in place.
+
+## Existing infrastructure this can reuse
+
+`browser-pane-clicked` already exists as a backend → frontend IPC event,
+purpose-built for "a native click landed inside a browser pane, and the DOM
+never saw it":
+
+- **Windows**: `agentmux-cef/src/browser_pane/hwnd.rs` subclasses the pane's
+  HWND tree and emits `browser-pane-clicked` (with `block_id`) directly from
+  `WM_LBUTTONDOWN`.
+- **macOS**: `agentmux-cef/src/ui_tasks/platform_macos.rs`'s
+  `swizzled_nsapp_send_event` emits the same event on `leftMouseDown` for the
+  pane's overlay window (added in
+  `SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md`).
+- **Linux**: not implemented yet (tracked as follow-up in the click-to-select
+  spec). This fix inherits that same gap — see Scope/Caveats below.
+
+Today the only consumer is `frontend/app/view/browser/browser-model.ts`,
+which listens per-pane (filtering on its own `block_id`) and dispatches
+`PaneClicked` to drive pane *selection* (the focus border). It does not do
+anything else with the event.
+
+## Proposed fix
+
+Add **one** new, block-id-agnostic, always-mounted listener for
+`browser-pane-clicked` that — on ANY browser pane being clicked, in any
+window — synthesizes the same DOM signal every existing outside-click
+listener already reacts to, instead of touching all ~18 call sites
+individually.
+
+```ts
+// New: frontend/app/window/browser-pane-outside-click-bridge.ts (or inline
+// in a top-level always-mounted component, e.g. alongside AppKeyHandlers in
+// app.tsx)
+onMount(() => {
+    const unsubPromise = listenEvent<{ block_id: string }>("browser-pane-clicked", () => {
+        // No block_id filtering — ANY pane click should be treated as an
+        // "outside click" by every currently open dismissible menu/popover,
+        // the same way clicking anywhere else in the app already is.
+        //
+        // Dispatched ON `document` (not `document.body`) so `e.target` is
+        // `document` itself — never `.contains()`-matched by any menu/button
+        // ref, and `instanceof Element` is false so existing handlers'
+        // `.closest(".popover-menu")` fallback also safely no-ops instead of
+        // throwing. Both `mousedown` and `pointerdown` are dispatched because
+        // existing listeners are a mix of the two (see the file list above).
+        for (const type of ["mousedown", "pointerdown"] as const) {
+            document.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true }));
+        }
+    });
+    onCleanup(() => { void unsubPromise.then((unsub) => unsub()); });
+});
+```
+
+Why this over a narrow `action-widgets.tsx`-only fix: it's roughly the same
+amount of code, but fixes the bug class everywhere at once instead of
+whack-a-moling 18 files (and however many more get added later that follow
+the same copy-pasted pattern). It's purely additive — no existing listener
+needs to change, since a synthetic outside-click event is indistinguishable
+from a real one to code that only inspects `e.target`.
+
+### Alternative considered (rejected)
+
+Patch only `action-widgets.tsx`'s handler to also subscribe to
+`browser-pane-clicked` and call `setMoreOpen(false)` directly. Simpler to
+reason about in isolation, but leaves the other 18 sites (context menus,
+status-bar popovers, tab rename, the item-level popover menu, floating-pane
+drag-dismiss, etc.) broken. Rejected in favor of the generic fix unless a
+reviewer specifically wants the smaller blast radius for a first pass.
+
+## Scope / caveats
+
+- **Linux gets no fix from this change**, same caveat as
+  `SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md` — `browser-pane-clicked`
+  is never emitted there today (no native click-detection mechanism exists
+  yet for GTK/X11/Wayland). Menus will continue to stay open on a browser-pane
+  click on Linux until that follow-up lands.
+- Only affects *browser panes specifically* (native overlay content). Normal
+  DOM panes are unaffected — they already worked correctly.
+- Does not change `browser-model.ts`'s existing per-pane consumer of
+  `browser-pane-clicked` (pane selection) — this is a second, independent
+  subscriber to the same event, not a replacement.
+
+## Verification plan (once implemented)
+
+- Open the widget bar "More" dropdown, click inside a loaded browser pane →
+  dropdown closes.
+- Repeat for: a status-bar popover (Host/TokenUsage/SystemStats/Backend), a
+  tab context menu, the pane header's own context menu on a *different* pane,
+  a flyout/popover menu, the widget bar's per-item context submenu.
+- Confirm normal in-pane browser interaction (scrolling, form input,
+  clicking links) is unaffected — the synthetic event must not itself trigger
+  anything unwanted inside the browser pane (it's dispatched on `document`,
+  entirely outside the pane's own native overlay, so this should be a
+  non-issue, but worth confirming).
+- macOS + Windows only for now (see Scope).

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -32,6 +32,7 @@ import { DiagPanel } from "./devtools/diag-panel";
 import { checkSeparatorParity, setupDprTracking } from "./init/dpr";
 import { NotificationBubbles } from "./notification/notificationbubbles";
 import { MemoryPressureBanner } from "./notification/memory-pressure-banner";
+import { BrowserPaneOutsideClickBridge } from "./window/browser-pane-outside-click-bridge";
 
 import "./app.scss";
 
@@ -339,6 +340,7 @@ const AppInner = () => {
                 <AppZoomHandler />
                 <AppFocusHandler />
                 <AppSettingsUpdater />
+                <BrowserPaneOutsideClickBridge />
                 <Show when={!IS_FLOATING_PANE}>
                     {/* Low-memory warning banners — app-wide, non-modal,
                         dismissible. Driven by the host's mem_pressure level.

--- a/frontend/app/notification/sound/sound-service.ts
+++ b/frontend/app/notification/sound/sound-service.ts
@@ -73,8 +73,19 @@ export function installSoundService(): () => void {
     // Prime AudioContext on the first user gesture, exactly once.
     // After priming, hook the tool-tones chain into the same context +
     // master gain so a single OS volume slider controls both subsystems.
-    const onceOpts: AddEventListenerOptions = { capture: true, once: true };
-    const primeOnce = async () => {
+    //
+    // Deliberately NOT `{ once: true }`: the browser's autoplay policy
+    // requires a REAL user gesture to unlock an AudioContext, so a
+    // synthetic (non-trusted) event must be ignored rather than consumed --
+    // `{ once: true }` would remove the listener on ANY event regardless of
+    // what the handler does, permanently losing the ability to prime via
+    // that gesture type if the first one to arrive happened to be synthetic
+    // (e.g. window/browser-pane-outside-click-bridge.ts's own synthetic
+    // pointerdown -- reagentx P1 on PR #2597). Removal is manual instead,
+    // gated on isTrusted, so an untrusted event leaves both listeners armed
+    // for the next real one.
+    const primeOnce = async (e: Event) => {
+        if (!e.isTrusted) return;
         document.removeEventListener("pointerdown", primeOnce, true);
         document.removeEventListener("keydown", primeOnce, true);
         await player.prime();
@@ -88,8 +99,8 @@ export function installSoundService(): () => void {
             }
         }
     };
-    document.addEventListener("pointerdown", primeOnce, onceOpts);
-    document.addEventListener("keydown", primeOnce, onceOpts);
+    document.addEventListener("pointerdown", primeOnce, { capture: true });
+    document.addEventListener("keydown", primeOnce, { capture: true });
 
     // Reactively thread the master-volume + tool-tones-volume settings
     // into their respective gain nodes.

--- a/frontend/app/window/browser-pane-outside-click-bridge.ts
+++ b/frontend/app/window/browser-pane-outside-click-bridge.ts
@@ -17,9 +17,9 @@
 // for exactly this native-click gap (added for pane click-to-select, see
 // docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md). Instead of
 // teaching every listener about it individually, this dispatches a
-// synthetic mousedown + pointerdown on `document` whenever it fires — every
-// existing listener treats that exactly like a real outside click, with no
-// changes needed on their end.
+// synthetic mousedown + pointerdown on `document.body` whenever it fires —
+// every existing listener treats that exactly like a real outside click,
+// with no changes needed on their end.
 
 import { listenEvent } from "@/app/platform/ipc";
 import { onCleanup, onMount } from "solid-js";
@@ -31,14 +31,23 @@ export const BrowserPaneOutsideClickBridge = () => {
             // every currently open dismissible menu, the same way clicking
             // anywhere else non-menu in the app already does.
             //
-            // Dispatched ON `document` (not `document.body`) so `e.target`
-            // is `document` itself: never `.contains()`-matched by any
-            // menu/button ref, and `instanceof Element` is false, so
-            // existing handlers' `el?.closest(".popover-menu")` fallback
-            // also safely no-ops instead of throwing. Both event types are
-            // dispatched because existing listeners are a mix of the two.
+            // Dispatched on `document.body`, NOT `document` itself
+            // (reagentx P1 on PR #2597): several existing listeners
+            // (useWindowDrag.*.ts's isInDragRegion) call DOM methods like
+            // `getAttribute` on `e.target`, which `Document` doesn't have —
+            // dispatching on `document` threw an uncaught TypeError on
+            // every browser-pane click. `document.body` is a real Element,
+            // so those calls are safe, while still reading as "outside" for
+            // every existing check: `.contains()` only matches descendants
+            // (body is never a descendant of a menu/popover), and
+            // `body.closest(".popover-menu")` walks ancestors, which body
+            // has none of, so it correctly returns null. Both event types
+            // are dispatched because existing listeners are a mix of the
+            // two — see sound-service.ts for why `pointerdown` alone needed
+            // a companion fix (isTrusted guard on its autoplay-prime
+            // listener) rather than being dropped here.
             for (const type of ["mousedown", "pointerdown"] as const) {
-                document.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true }));
+                document.body.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true }));
             }
         });
         onCleanup(() => {

--- a/frontend/app/window/browser-pane-outside-click-bridge.ts
+++ b/frontend/app/window/browser-pane-outside-click-bridge.ts
@@ -1,0 +1,49 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Makes a click inside ANY browser pane dismiss whatever dismissible
+// menu/popover is currently open, the same way a click anywhere else in the
+// app already does. See docs/specs/SPEC_BROWSER_PANE_CLICK_DISMISSES_MENUS_2026_08_15.md.
+//
+// Root cause: a browser pane's content is a native, sibling CefBrowserView
+// layered on top of the DOM via CEF's Views AddOverlayView (see
+// docs/specs/SPEC_NATIVE_BROWSER_PANE_2026_04_17.md) — a click there never
+// becomes a DOM mousedown/pointerdown event, so it can't reach any of the
+// app's ~18 independent "outside click" listeners (action-widgets.tsx,
+// context-menu.tsx, popover-menu.tsx, the status-bar popovers, etc.), all of
+// which close on document-level mousedown/pointerdown.
+//
+// Fix: `browser-pane-clicked` already exists as a backend->frontend event
+// for exactly this native-click gap (added for pane click-to-select, see
+// docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md). Instead of
+// teaching every listener about it individually, this dispatches a
+// synthetic mousedown + pointerdown on `document` whenever it fires — every
+// existing listener treats that exactly like a real outside click, with no
+// changes needed on their end.
+
+import { listenEvent } from "@/app/platform/ipc";
+import { onCleanup, onMount } from "solid-js";
+
+export const BrowserPaneOutsideClickBridge = () => {
+    onMount(() => {
+        const unsubPromise = listenEvent<{ block_id: string }>("browser-pane-clicked", () => {
+            // No block_id filtering — ANY pane click counts as "outside" for
+            // every currently open dismissible menu, the same way clicking
+            // anywhere else non-menu in the app already does.
+            //
+            // Dispatched ON `document` (not `document.body`) so `e.target`
+            // is `document` itself: never `.contains()`-matched by any
+            // menu/button ref, and `instanceof Element` is false, so
+            // existing handlers' `el?.closest(".popover-menu")` fallback
+            // also safely no-ops instead of throwing. Both event types are
+            // dispatched because existing listeners are a mix of the two.
+            for (const type of ["mousedown", "pointerdown"] as const) {
+                document.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true }));
+            }
+        });
+        onCleanup(() => {
+            void unsubPromise.then((unsub) => unsub());
+        });
+    });
+    return null;
+};


### PR DESCRIPTION
## Summary
- A browser pane's content is a native, sibling `CefBrowserView` layered on top of the DOM (CEF Views `AddOverlayView`) — a click there never becomes a DOM `mousedown`/`pointerdown` event, so it never reaches any of the app's ~18 independent "outside click" listeners (widget bar's More menu, context menus, status-bar popovers, tab rename, etc.), all of which close on document-level `mousedown`/`pointerdown`.
- Reuses the existing `browser-pane-clicked` backend event (originally added for pane click-to-select — same root cause) instead of teaching every listener about it individually: a new always-mounted `BrowserPaneOutsideClickBridge` dispatches a synthetic `mousedown` + `pointerdown` on `document` whenever ANY browser pane is clicked, which every existing listener already treats exactly like a real outside click. No changes needed to any of those 18+ listeners.
- Design doc: `docs/specs/SPEC_BROWSER_PANE_CLICK_DISMISSES_MENUS_2026_08_15.md` (also documents a narrower single-file alternative that was considered and rejected in favor of this generic fix).

## Scope / caveats
- Windows + macOS only — `browser-pane-clicked` isn't emitted on Linux yet (tracked separately, same gap as the click-to-select feature it reuses).

## Test plan
- [x] `tsc --noEmit` clean (2 pre-existing, unrelated errors in armory-view.tsx/warden-view.tsx, confirmed present on main before this change)
- [x] Full `vitest` suite green (2613 passed)
- [ ] Manual: open the widget bar "More" dropdown, click inside a loaded browser pane, confirm it closes
- [ ] Manual: repeat for a status-bar popover, a tab context menu, a flyout/popover menu

<!-- agentmux:agent_id=manoz -->