### PR TITLE
fix(lan): stop blank-TXT mDNS re-resolutions from clobbering LAN peer metadata

### DIFF
--- a/.changesets/1786856101-fix-lan-stop-mdns-re-resolutions-with-blank-txt-records-from-xyyw.md
+++ b/.changesets/1786856101-fix-lan-stop-mdns-re-resolutions-with-blank-txt-records-from-xyyw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(lan): stop mDNS re-resolutions with blank TXT records from clobbering known-good LAN peer metadata

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -396,15 +396,29 @@ impl LanDiscovery {
     fn handle_event(&self, event: ServiceEvent) {
         match event {
             ServiceEvent::ServiceResolved(info) => {
+                let fullname = info.get_fullname().to_string();
+
+                // Skip self. Compared by `fullname` (deterministic from
+                // `service_name`, set once at registration — see `start()`)
+                // rather than the TXT-record `instance_id` property: on this
+                // machine's own virtual/link-local interfaces (WSL/Hyper-V/
+                // VPN adapters), `enable_addr_auto()` re-fires
+                // `ServiceResolved` far more often than fresh TXT data
+                // arrives — most of those events resolve with an empty TXT
+                // record (confirmed via `LAN peer discovered` log: ~96% of
+                // events for this instance's own addresses logged
+                // `peer_id=""`). Comparing on `instance_id` alone meant a
+                // blank-TXT self-resolution was never recognized as self and
+                // was inserted as a phantom peer that could never self-heal
+                // (see the instance_id-preservation fix below for why).
+                if fullname == self.service_fullname {
+                    return;
+                }
+
                 let peer_id = info
                     .get_property_val_str("instance_id")
                     .unwrap_or_default()
                     .to_string();
-
-                // Skip self
-                if peer_id == self.instance_id {
-                    return;
-                }
 
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -432,7 +446,6 @@ impl LanDiscovery {
                     .unwrap_or_default()
                     .to_string();
 
-                let fullname = info.get_fullname().to_string();
                 let mut instances = self.instances.write();
                 let entry = instances.entry(fullname).or_insert_with(|| LanInstance {
                     instance_id: peer_id.clone(),
@@ -446,11 +459,28 @@ impl LanDiscovery {
                     last_seen: now,
                 });
                 entry.last_seen = now;
-                entry.hostname = hostname;
-                entry.version = version;
                 entry.address = address;
                 entry.port = info.get_port();
-                entry.auth_key = auth_key;
+                // TXT-derived fields only: `enable_addr_auto()` re-fires
+                // `ServiceResolved` on every interface/address change, and
+                // most of those re-fires resolve with an empty TXT record
+                // (see the self-skip comment above) — apply a value only
+                // when this event actually carried one, so a stale re-fire
+                // never erases previously-known-good peer identity. Address/
+                // port come from the SRV/A record, not TXT, and are always
+                // populated, so they're safe to overwrite unconditionally.
+                if !peer_id.is_empty() {
+                    entry.instance_id = peer_id.clone();
+                }
+                if !hostname.is_empty() {
+                    entry.hostname = hostname;
+                }
+                if !version.is_empty() {
+                    entry.version = version;
+                }
+                if !auth_key.is_empty() {
+                    entry.auth_key = auth_key;
+                }
                 drop(instances);
 
                 tracing::info!(
@@ -1235,6 +1265,179 @@ mod tests {
         assert_eq!(received["version"], "1.2.3");
         assert_eq!(received["port"], 9999);
         assert_eq!(received["auth_key"], "secret-key");
+    }
+}
+
+// -- `handle_event` self-skip + TXT-clobber regression tests --
+//
+// See docs/specs/SPEC_LAN_DISCOVERY_TXT_CLOBBER_FIX_2026_08_16.md. Root
+// cause: `enable_addr_auto()` makes mdns-sd re-fire `ServiceResolved` for
+// the SAME service far more often than fresh TXT data actually arrives —
+// live logs showed ~96% of resolution events for this instance's own
+// virtual/link-local addresses carrying an empty TXT record while
+// address/port were always populated. These tests exercise
+// `LanDiscovery::handle_event` directly against hand-built `ServiceInfo`
+// values (no real daemon register/browse — construction of a
+// `ServiceDaemon` is required only to satisfy the struct field, exactly
+// as the existing ignored round-trip test above already relies on being
+// safe) so they run fast and are not subject to that test's documented
+// multicast flakiness.
+#[cfg(test)]
+mod handle_event_tests {
+    use super::{LanDiscovery, LanInstance, SERVICE_TYPE};
+    use mdns_sd::{ServiceEvent, ServiceInfo};
+    use parking_lot::{Mutex, RwLock};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Build a `ServiceInfo` for `instance_id`, mirroring the exact
+    /// `service_name`/host-name shape `LanDiscovery::start()` registers
+    /// with, so `get_fullname()` matches what production code would
+    /// compute for the same `instance_id`.
+    fn test_service_info(instance_id: &str, port: u16, properties: &[(&str, &str)]) -> ServiceInfo {
+        let service_name = format!("agentmux-{instance_id}");
+        ServiceInfo::new(
+            SERVICE_TYPE,
+            &service_name,
+            "test-host.local.",
+            "127.0.0.1",
+            port,
+            properties,
+        )
+        .expect("ServiceInfo::new should succeed for a well-formed test fixture")
+    }
+
+    /// A `LanDiscovery` whose `service_fullname` is derived the same way
+    /// production's `start()` derives it (from a real `ServiceInfo` for
+    /// `self_instance_id`), so the self-skip comparison in `handle_event`
+    /// is exercised exactly as it runs in production — not asserted
+    /// against a hand-typed guess at mdns-sd's fullname format.
+    fn test_discovery(self_instance_id: &str) -> LanDiscovery {
+        let self_info = test_service_info(self_instance_id, 0, &[]);
+        LanDiscovery {
+            daemon: mdns_sd::ServiceDaemon::new().expect("daemon construction (no register/browse)"),
+            instances: Arc::new(RwLock::new(HashMap::new())),
+            instance_id: self_instance_id.to_string(),
+            event_bus: Arc::new(crate::backend::eventbus::EventBus::new()),
+            service_fullname: self_info.get_fullname().to_string(),
+            auth_key: String::new(),
+            hostname: String::new(),
+            version: String::new(),
+            port: 0,
+            udp_cancel: Mutex::new(None),
+        }
+    }
+
+    fn get(instances: &[LanInstance], instance_id: &str) -> Option<LanInstance> {
+        instances.iter().find(|i| i.instance_id == instance_id).cloned()
+    }
+
+    #[test]
+    fn self_resolution_with_blank_txt_is_never_inserted_as_a_peer() {
+        // This is the exact failure mode from the live logs: mdns-sd
+        // re-resolves this instance's own service on a virtual/link-local
+        // interface and the TXT record (instance_id/hostname/version/
+        // auth_key) comes back empty. Skipping by `fullname` (SRV-record
+        // derived, always present) rather than the TXT `instance_id`
+        // property must catch this even though the property itself is
+        // blank on this event.
+        let discovery = test_discovery("self-id");
+        let blank_self_event = test_service_info("self-id", 56023, &[]);
+
+        discovery.handle_event(ServiceEvent::ServiceResolved(blank_self_event));
+
+        assert!(
+            discovery.get_instances().is_empty(),
+            "a blank-TXT resolution of this instance's own service must never appear as a peer"
+        );
+    }
+
+    #[test]
+    fn self_resolution_with_full_txt_is_also_never_inserted_as_a_peer() {
+        // Sanity check that the fullname-based skip doesn't regress the
+        // straightforward case (this was already correct before the fix).
+        let discovery = test_discovery("self-id");
+        let full_self_event =
+            test_service_info("self-id", 56023, &[("instance_id", "self-id"), ("hostname", "myhost")]);
+
+        discovery.handle_event(ServiceEvent::ServiceResolved(full_self_event));
+
+        assert!(discovery.get_instances().is_empty());
+    }
+
+    #[test]
+    fn blank_txt_refire_does_not_clobber_previously_known_good_peer_fields() {
+        let discovery = test_discovery("self-id");
+
+        let full_event = test_service_info(
+            "peer-1",
+            9999,
+            &[
+                ("instance_id", "peer-1"),
+                ("hostname", "realhost"),
+                ("version", "1.2.3"),
+                ("auth_key", "secret"),
+            ],
+        );
+        discovery.handle_event(ServiceEvent::ServiceResolved(full_event));
+
+        let after_full = get(&discovery.get_instances(), "peer-1").expect("peer-1 should be discovered");
+        assert_eq!(after_full.hostname, "realhost");
+        assert_eq!(after_full.version, "1.2.3");
+        assert_eq!(after_full.auth_key, "secret");
+
+        // Same service (same fullname), a re-resolution with an empty TXT
+        // record — exactly what mdns-sd's `enable_addr_auto()` produces on
+        // most re-fires per the live-log evidence.
+        let blank_refire = test_service_info("peer-1", 9999, &[]);
+        discovery.handle_event(ServiceEvent::ServiceResolved(blank_refire));
+
+        let instances = discovery.get_instances();
+        assert_eq!(instances.len(), 1, "the blank re-fire must update the existing entry, not create a duplicate");
+        let after_blank = get(&instances, "peer-1").expect("peer-1 must still be present");
+        assert_eq!(after_blank.hostname, "realhost", "hostname must survive a blank-TXT re-fire");
+        assert_eq!(after_blank.version, "1.2.3", "version must survive a blank-TXT re-fire");
+        assert_eq!(after_blank.auth_key, "secret", "auth_key must survive a blank-TXT re-fire");
+        assert_eq!(after_blank.instance_id, "peer-1", "instance_id must survive a blank-TXT re-fire");
+    }
+
+    #[test]
+    fn address_and_port_still_update_unconditionally_on_a_blank_txt_refire() {
+        // address/port come from the SRV/A record, not TXT, and are always
+        // populated by mdns-sd — a genuine interface/address change must
+        // still be reflected even when the TXT-derived fields are absent
+        // on that same event.
+        let discovery = test_discovery("self-id");
+
+        let first = test_service_info("peer-1", 9999, &[("instance_id", "peer-1"), ("hostname", "realhost")]);
+        discovery.handle_event(ServiceEvent::ServiceResolved(first));
+        assert_eq!(get(&discovery.get_instances(), "peer-1").unwrap().port, 9999);
+
+        let moved = test_service_info("peer-1", 8888, &[]);
+        discovery.handle_event(ServiceEvent::ServiceResolved(moved));
+
+        let instances = discovery.get_instances();
+        let entry = get(&instances, "peer-1").expect("peer-1 must still be present");
+        assert_eq!(entry.port, 8888, "port must update even on a blank-TXT event");
+        assert_eq!(entry.hostname, "realhost", "hostname must still survive despite the address/port change");
+    }
+
+    #[test]
+    fn a_new_peer_first_seen_via_blank_txt_has_no_data_to_preserve() {
+        // Not a regression this fix is responsible for solving — merely
+        // documents the expected (acceptable) behavior for a genuinely
+        // first-seen blank-TXT event: nothing was ever known, so nothing
+        // can be preserved. hostname stays empty until a TXT-bearing event
+        // eventually arrives.
+        let discovery = test_discovery("self-id");
+        let blank_first = test_service_info("peer-2", 7777, &[]);
+
+        discovery.handle_event(ServiceEvent::ServiceResolved(blank_first));
+
+        let instances = discovery.get_instances();
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].hostname, "");
+        assert_eq!(instances[0].instance_id, "");
     }
 }
 

--- a/docs/specs/SPEC_LAN_DISCOVERY_TXT_CLOBBER_FIX_2026_08_16.md
+++ b/docs/specs/SPEC_LAN_DISCOVERY_TXT_CLOBBER_FIX_2026_08_16.md
@@ -1,0 +1,200 @@
+# SPEC: LAN discovery peer metadata gets clobbered blank by TXT-less mDNS re-resolutions
+
+**Date:** 2026-08-16
+**Status:** Root cause confirmed, fix implemented and verified with new unit
+tests (all passing — see §5) in `agentmux-srv/src/backend/lan_discovery.rs`
+(not yet committed/PR'd)
+**Reported by:** repo owner, live session — network panel showed blank hostname
+fields, a literal `"v"` where a version should render, and a peer's own
+`instance_id` string (`"v0.55.6"`) displayed in place of its hostname.
+
+## 1. Symptom
+
+In the status-bar network popover (`HostPopover.tsx`), LAN peer rows
+intermittently show:
+
+- Blank hostname (falls back to `instance_id`, e.g. a peer literally labeled
+  `v0.55.6` instead of its real hostname `starpower`).
+- A bare `"v"` with nothing after it — `HostPopover.tsx:241` renders
+  `v{inst.version}`; an empty `version` string collapses to just `"v"`.
+- Real, previously-discovered peers phantom-duplicating or losing their name
+  entirely over time, not just on first discovery.
+
+Also observed via `DiscoverAgents`: two `lan` entries for this machine's own
+addresses with every field blank (`hostname: ""`, `instance_id: ""`,
+`auth_key: ""`) but a real port matching an actual local instance.
+
+## 2. Reproduction / evidence
+
+Queried the live srv's own structured logs for every `LAN peer discovered`
+event emitted during normal operation (`muxlog srv grep "LAN peer discovered"
+--raw`):
+
+```
+peer_id counts:
+   3776 ""
+     42 "v0.55.6"
+     76 "v0.55.8"
+     32 "v0.55.9"
+```
+
+```
+address counts (top 8, all local-machine virtual/link-local adapters):
+    419 172.23.176.1
+    415 fe80::296f:55a:b354:43c1
+    412 192.168.153.1
+    403 fe80::142e:c4b3:9f29:8348
+    391 192.168.116.1
+    384 fe80::3ccb:9537:8f8b:b7b1
+    383 192.168.1.230
+    371 fe80::4330:1668:b280:f907
+```
+
+`address` is **never** blank across ~3900 events; `peer_id` (the TXT record's
+`instance_id` property) is blank in **~96%** of them. The addresses receiving
+the overwhelming majority of events are this machine's own WSL2/Hyper-V/VPN
+virtual adapters and link-local (`fe80::`) interfaces — i.e. this instance
+re-resolving *itself* across every local network interface it has, not
+distinct remote peers.
+
+## 3. Root cause
+
+`mdns_sd`'s `enable_addr_auto()` (`lan_discovery.rs::start()`) makes the
+daemon continuously track address changes per network interface and re-fire
+`ServiceEvent::ServiceResolved` far more often than fresh TXT record data is
+actually refreshed. The large majority of these re-fires resolve with an
+**empty TXT record** — `info.get_property_val_str("instance_id"/"hostname"/
+"version"/"auth_key")` all return `None` — while the SRV/A-record-derived
+`address`/`port` are always present. This is expected behavior from the mDNS
+resolver, not a malformed-packet or malicious scenario; the bug is entirely
+in how `handle_event` (previously) consumed these events.
+
+Two compounding bugs in `LanDiscovery::handle_event`
+(`agentmux-srv/src/backend/lan_discovery.rs`), both stemming from that one
+mDNS behavior:
+
+### 3.1 Self-filtering used the wrong (and frequently blank) key
+
+```rust
+let peer_id = info.get_property_val_str("instance_id").unwrap_or_default().to_string();
+if peer_id == self.instance_id {
+    return;
+}
+```
+
+When the *first* `ServiceResolved` event for this instance's own service
+happens to be one of the ~96% blank-TXT re-fires, `peer_id` is `""`, which
+never equals `self.instance_id`. The self-check silently fails, and this
+instance's own service gets inserted into its own peer list as a phantom
+"peer" — one entry per local virtual/link-local interface address mdns-sd
+enumerates.
+
+### 3.2 Known-good TXT fields were overwritten unconditionally on every event
+
+```rust
+entry.hostname = hostname;   // always applied, even when hostname == ""
+entry.version = version;
+entry.auth_key = auth_key;
+```
+
+Because the same peer's `fullname` key receives hundreds of re-resolution
+events and only a handful carry real TXT data, whichever event happens to
+arrive *last* wins — overwhelmingly a blank one. A real, previously-correctly
+-resolved peer (e.g. `starpower`, hostname populated) would regress to a
+blank hostname/version/auth_key shortly after being discovered correctly,
+because subsequent blank-TXT re-fires for the same service kept clobbering
+the good data.
+
+`entry.instance_id` was *not* subject to 3.2 (it's only set once, in
+`or_insert_with`) — which is actually what makes 3.1's phantom self-entries
+permanent: once inserted with `instance_id: ""`, nothing ever updates it, so
+the entry can never retroactively be recognized as self.
+
+## 4. Fix (implemented)
+
+Both fixes are root-cause, not symptom patches — they change *what mDNS
+event data is trusted for what purpose*, not add defensive UI fallbacks.
+
+1. **Self-filtering by `fullname`, not TXT-derived `instance_id`.**
+   `fullname` (`info.get_fullname()`) is deterministic from `service_name`
+   (`format!("agentmux-{}", &instance_id)`, set once at registration) and
+   comes from the SRV record, which — like `address`/`port` — is always
+   present, unlike TXT. Comparing against `self.service_fullname` (already
+   stored on `LanDiscovery`) correctly identifies self on every single event,
+   including the blank-TXT ones, closing the phantom-self-peer hole at its
+   source instead of trying to patch it up after insertion.
+
+2. **Preserve prior TXT-derived fields when a re-fire has none.** `hostname`,
+   `version`, `auth_key`, and (for defense in depth) `instance_id` are now
+   only written into the entry when the *current* event actually carried a
+   non-empty value; a blank re-fire no longer erases previously-known-good
+   data. `address`/`port` remain unconditional overwrites since they come
+   from the SRV/A record and are always populated correctly, including on
+   genuine address changes that should be reflected immediately.
+
+Both changes are in `LanDiscovery::handle_event`,
+`agentmux-srv/src/backend/lan_discovery.rs`.
+
+## 5. Verification
+
+**Automated — done, all passing.** Rather than extracting a separate
+`merge_lan_instance` free function, `handle_event` is tested directly: it
+takes `&self` (private, but reachable from a child `#[cfg(test)]` module in
+the same file per normal Rust privacy) and a real `ServiceEvent`/
+`ServiceInfo`, both fully constructible without registering or browsing on
+the real mDNS daemon (only `ServiceDaemon::new()` is called, to satisfy the
+struct field — no `.register()`/`.browse()`, so none of the multicast
+flakiness documented on the existing `#[ignore]`d round-trip test applies).
+Added `handle_event_tests` (`agentmux-srv/src/backend/lan_discovery.rs`):
+
+- `self_resolution_with_blank_txt_is_never_inserted_as_a_peer` — the exact
+  live-log failure mode: a `ServiceResolved` for this instance's own service
+  with an empty TXT record must not appear in `get_instances()`.
+- `self_resolution_with_full_txt_is_also_never_inserted_as_a_peer` — sanity
+  check the straightforward case wasn't regressed.
+- `blank_txt_refire_does_not_clobber_previously_known_good_peer_fields` —
+  discovers a real peer with full TXT data, then re-fires the same
+  `fullname` with an empty TXT record; asserts `hostname`/`version`/
+  `auth_key`/`instance_id` all survive unchanged.
+- `address_and_port_still_update_unconditionally_on_a_blank_txt_refire` —
+  confirms the SRV-record-derived fields keep updating live even when the
+  TXT-derived fields in that same event don't.
+- `a_new_peer_first_seen_via_blank_txt_has_no_data_to_preserve` — documents
+  the expected (acceptable, not a regression) behavior when there was never
+  any good data to preserve in the first place.
+
+Ran via (this crate is bin-only, no lib target — `--bin`, not `--lib`):
+
+```
+cargo test -p agentmux-srv --bin agentmux-srv backend::lan_discovery::
+```
+
+Result: **28 passed; 0 failed; 1 ignored** (the ignored one is the
+pre-existing, documented-flaky real-multicast round-trip test, unrelated to
+this change and untouched by it). `cargo clippy -p agentmux-srv --bin
+agentmux-srv --tests` produced zero warnings in the new `handle_event_tests`
+module (two pre-existing style hints elsewhere in the file, in the
+untouched ignored test, are unrelated).
+
+**Not yet done:**
+- Manual: rebuild, run two instances (or reuse the existing multi-channel
+  setup — AgentX/Lark/AgentY/Loap already running this session), confirm the
+  network popover shows stable, correct hostnames/versions for every real
+  peer and zero phantom self-entries over several minutes of runtime.
+- Re-run the same `muxlog srv grep "LAN peer discovered" --raw` peer_id/
+  address tally used to diagnose this against a rebuilt instance — after the
+  fix, self-address entries (the WSL/Hyper-V/VPN/link-local ones) should no
+  longer appear as `LanInstance` rows in `get_instances()`/`laninstances`
+  broadcasts at all (they're filtered before reaching the map), and real
+  peers' stored `hostname`/`version`/`auth_key` should stay populated even
+  while blank re-fires continue arriving.
+
+## 6. Out of scope
+
+- Reducing the sheer volume of redundant re-resolution events
+  (`enable_addr_auto()`'s chattiness itself) — cosmetic/log-noise concern,
+  not correctness; not addressed here.
+- The pre-existing `LAN_AGENT_CACHE_TTL_SECS`/`pubkey_cache` logic in
+  `LanDiscoveryController` — unaffected by this bug (keyed by `agent_id` via
+  a separate peer-fan-out HTTP call, not by the mDNS-populated `instances`
+  map's TXT fields).


### PR DESCRIPTION
## Summary

- Network panel was showing blank peer hostnames, a bare `v` where a version should render, and a peer's `instance_id` (e.g. `v0.55.6`) displayed in place of its hostname.
- Root cause: `enable_addr_auto()` makes mdns-sd re-fire `ServiceResolved` for the same service far more often than TXT record data actually refreshes. Live log evidence: ~96% of `LAN peer discovered` events for this instance's own virtual/link-local addresses (WSL2/Hyper-V/VPN adapters) carried an empty TXT record while address/port were always populated.
- Two bugs let that noise corrupt the peer list:
  1. Self-filtering compared `peer_id` (TXT-derived `instance_id`), which is blank on ~96% of self-resolution events — so this instance's own service slipped through as a phantom "peer" per virtual interface.
  2. `hostname`/`version`/`auth_key` were overwritten unconditionally on every event, so a real peer's correctly-resolved data would regress to blank the next time a noisy blank-TXT re-fire arrived for the same service.
- Fix: skip self by `fullname` (SRV-derived, always present, deterministic from `service_name`) instead of the TXT-derived `instance_id`; only apply TXT-derived fields (`hostname`/`version`/`auth_key`/`instance_id`) to the stored entry when the current event actually carried a non-empty value, so a blank re-fire can no longer erase known-good data. `address`/`port` (SRV/A-record derived, always populated) remain unconditional overwrites.

Full root-cause writeup with log evidence: `docs/specs/SPEC_LAN_DISCOVERY_TXT_CLOBBER_FIX_2026_08_16.md`.

## Test plan

- [x] New unit tests in `handle_event_tests` (`agentmux-srv/src/backend/lan_discovery.rs`) exercise `handle_event` directly against hand-built `ServiceInfo`/`ServiceEvent` values (no real daemon register/browse, so none of the existing `#[ignore]`d test's documented multicast flakiness applies):
  - self-resolution with blank TXT is never inserted as a peer (the exact live-log failure mode)
  - self-resolution with full TXT is also never inserted (no regression)
  - a blank-TXT re-fire does not clobber a previously-known-good peer's hostname/version/auth_key/instance_id
  - address/port still update unconditionally on a blank-TXT re-fire
  - a genuinely new peer first seen via blank TXT has no data to preserve (documents expected behavior, not a regression)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::lan_discovery::` — 28 passed, 0 failed, 1 ignored (pre-existing, documented-flaky real-multicast test, untouched)
- [x] `cargo clippy -p agentmux-srv --bin agentmux-srv --tests` — zero warnings in the new/changed code
- [ ] Manual: rebuild + run multi-instance, confirm network panel shows stable correct hostnames/versions and zero phantom self-entries over time (not yet done — noted as follow-up in the spec)

<!-- agentmux:agent_id=agentx -->