### PR TITLE
Manoz@Area54 feat(browser-pane): unified context menu replaces Chromium's native right-click menu

### DIFF
--- a/.changesets/1786856221-feat-browser-pane-unified-context-menu-replaces-chromium-s-n-ysgw.md
+++ b/.changesets/1786856221-feat-browser-pane-unified-context-menu-replaces-chromium-s-n-ysgw.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(browser-pane): unified context menu replaces Chromium's native right-click menu

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -146,9 +146,12 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
 
     // Cross-platform: drop this pane's zoom-factor entry so
     // `browser_pane_zoom` doesn't grow unboundedly as panes are opened and
-    // closed over a session.
+    // closed over a session. Same for the stashed context-menu frame
+    // (SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md) — also holds a
+    // cloned `Frame` that must not outlive the closing browser.
     if let Some(block_id) = block_id {
         state.browser_pane_zoom.lock().remove(block_id);
+        state.browser_pane_context_menu_frame.lock().remove(block_id);
     }
 
     // Windows only:

--- a/agentmux-cef/src/browser_panes/navigation.rs
+++ b/agentmux-cef/src/browser_panes/navigation.rs
@@ -128,19 +128,37 @@ impl BrowserPaneManager {
     /// PR #2599). `Frame::copy/cut/paste` operate on whatever is currently
     /// selected/focused in that frame, exactly like CEF's own native menu
     /// commands would have.
+    ///
+    /// Uses `state.browser_pane_context_menu_frame`'s stashed frame — the
+    /// ACTUAL frame `client::context_menu::run_context_menu` saw the
+    /// right-click land on — instead of unconditionally
+    /// `b.main_frame()`. For a page with sub-frames/iframes (ads, embeds,
+    /// widgets), the selection/focus can live in a sub-frame; acting on
+    /// `main_frame()` there would silently no-op or paste into the wrong
+    /// place (reagentx P1, second finding on PR #2599). Falls back to
+    /// `main_frame()` only if nothing was stashed (e.g. this pane never had
+    /// its context menu invoked in this session).
+    fn edit_target_frame(&self, block_id: &str, state: &Arc<AppState>, browser: &mut Browser) -> Option<Frame> {
+        state
+            .browser_pane_context_menu_frame
+            .lock()
+            .get(block_id)
+            .cloned()
+            .or_else(|| browser.main_frame())
+    }
     pub fn copy(&self, block_id: &str, state: &Arc<AppState>) {
         if let Some(mut b) = self.live_browser(state, block_id) {
-            if let Some(frame) = b.main_frame() { frame.copy(); }
+            if let Some(frame) = self.edit_target_frame(block_id, state, &mut b) { frame.copy(); }
         }
     }
     pub fn cut(&self, block_id: &str, state: &Arc<AppState>) {
         if let Some(mut b) = self.live_browser(state, block_id) {
-            if let Some(frame) = b.main_frame() { frame.cut(); }
+            if let Some(frame) = self.edit_target_frame(block_id, state, &mut b) { frame.cut(); }
         }
     }
     pub fn paste(&self, block_id: &str, state: &Arc<AppState>) {
         if let Some(mut b) = self.live_browser(state, block_id) {
-            if let Some(frame) = b.main_frame() { frame.paste(); }
+            if let Some(frame) = self.edit_target_frame(block_id, state, &mut b) { frame.paste(); }
         }
     }
 }

--- a/agentmux-cef/src/browser_panes/navigation.rs
+++ b/agentmux-cef/src/browser_panes/navigation.rs
@@ -94,7 +94,16 @@ impl BrowserPaneManager {
         if current_url.is_empty() {
             return;
         }
-        let src_url = format!("view-source:{current_url}");
+        // Already viewing source (e.g. the menu item was clicked again, or
+        // the pane's history is currently on a view-source: page) — reuse
+        // the URL as-is instead of stacking another prefix onto it
+        // (reagentx P2 on PR #2599: view-source:view-source:https://... is
+        // not a real page).
+        let src_url = if current_url.starts_with("view-source:") {
+            current_url
+        } else {
+            format!("view-source:{current_url}")
+        };
         frame.load_url(Some(&CefString::from(src_url.as_str())));
     }
 

--- a/agentmux-cef/src/browser_panes/navigation.rs
+++ b/agentmux-cef/src/browser_panes/navigation.rs
@@ -72,6 +72,45 @@ impl BrowserPaneManager {
     pub fn reload(&self, block_id: &str, state: &Arc<AppState>) {
         if let Some(mut b) = self.live_browser(state, block_id) { b.reload(); }
     }
+
+    /// "Print" from the unified browser-pane context menu
+    /// (SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md) — CEF's own
+    /// print UI for the pane's current page, same as `CefBrowserHost::Print`
+    /// used anywhere else in Chromium.
+    pub fn print(&self, block_id: &str, state: &Arc<AppState>) {
+        if let Some(mut b) = self.live_browser(state, block_id) {
+            if let Some(host) = b.host() { host.print(); }
+        }
+    }
+
+    /// "View Page Source" — navigates via CEF's built-in `view-source:`
+    /// scheme (added to `PANE_ALLOWED_NAV_SCHEMES` alongside this feature;
+    /// Chromium renders it internally, same as `chrome-devtools:`, so it
+    /// carries none of the OS-handoff risk that allowlist exists to block).
+    pub fn view_source(&self, block_id: &str, state: &Arc<AppState>) {
+        let Some(mut b) = self.live_browser(state, block_id) else { return };
+        let Some(frame) = b.main_frame() else { return };
+        let current_url = CefString::from(&ImplFrame::url(&frame)).to_string();
+        if current_url.is_empty() {
+            return;
+        }
+        let src_url = format!("view-source:{current_url}");
+        frame.load_url(Some(&CefString::from(src_url.as_str())));
+    }
+
+    /// "Inspect Element" — opens CEF's own DevTools window, jumping straight
+    /// to the element under the right-click point (mirrors Chrome's
+    /// behavior). `x`/`y` are view-local coordinates, the same ones CEF's
+    /// `ContextMenuParams::xcoord/ycoord` reported when the menu was
+    /// suppressed — see `client::context_menu`. `None` for
+    /// window_info/client/settings uses CEF's default popup DevTools window.
+    pub fn inspect_element(&self, block_id: &str, state: &Arc<AppState>, x: i32, y: i32) {
+        if let Some(mut b) = self.live_browser(state, block_id) {
+            if let Some(host) = b.host() {
+                host.show_dev_tools(None, None, None, Some(&Point { x, y }));
+            }
+        }
+    }
 }
 
 // `View::set_bounds` must run on the CEF UI thread; `resize()` is called from

--- a/agentmux-cef/src/browser_panes/navigation.rs
+++ b/agentmux-cef/src/browser_panes/navigation.rs
@@ -120,6 +120,29 @@ impl BrowserPaneManager {
             }
         }
     }
+
+    /// "Copy" / "Cut" / "Paste" from the unified browser-pane context menu.
+    /// Added because suppressing CEF's native menu (SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md)
+    /// also removed its built-in Cut/Copy/Paste for a text selection or an
+    /// editable web form field, with nothing replacing them (reagentx P2 on
+    /// PR #2599). `Frame::copy/cut/paste` operate on whatever is currently
+    /// selected/focused in that frame, exactly like CEF's own native menu
+    /// commands would have.
+    pub fn copy(&self, block_id: &str, state: &Arc<AppState>) {
+        if let Some(mut b) = self.live_browser(state, block_id) {
+            if let Some(frame) = b.main_frame() { frame.copy(); }
+        }
+    }
+    pub fn cut(&self, block_id: &str, state: &Arc<AppState>) {
+        if let Some(mut b) = self.live_browser(state, block_id) {
+            if let Some(frame) = b.main_frame() { frame.cut(); }
+        }
+    }
+    pub fn paste(&self, block_id: &str, state: &Arc<AppState>) {
+        if let Some(mut b) = self.live_browser(state, block_id) {
+            if let Some(frame) = b.main_frame() { frame.paste(); }
+        }
+    }
 }
 
 // `View::set_bounds` must run on the CEF UI thread; `resize()` is called from

--- a/agentmux-cef/src/client/context_menu.rs
+++ b/agentmux-cef/src/client/context_menu.rs
@@ -38,6 +38,7 @@ impl AgentMuxHandler {
     pub(crate) fn run_context_menu(
         &mut self,
         browser: Option<&mut Browser>,
+        frame: Option<&mut Frame>,
         params: Option<&mut ContextMenuParams>,
         callback: Option<&mut RunContextMenuCallback>,
     ) -> ::std::os::raw::c_int {
@@ -61,11 +62,28 @@ impl AgentMuxHandler {
             return 0;
         };
 
+        // Stash the ACTUAL frame that was right-clicked (not necessarily
+        // `browser.main_frame()` — a page with sub-frames/iframes, e.g. ads
+        // or embeds, can have the selection/focus live in one of those
+        // instead) so the Copy/Cut/Paste menu items act on the right frame
+        // when the user clicks one, rather than always the top-level frame
+        // regardless of where the right-click actually landed (reagentx P1
+        // on PR #2599). Print/View Source/Inspect/Reload/Back/Forward stay
+        // top-level-only — CEF's own equivalents for those are Browser-level
+        // (or, for View Source, an accepted simplification — see
+        // `browser_panes::navigation::view_source`'s doc comment).
+        if let Some(f) = frame.as_deref() {
+            self.state
+                .browser_pane_context_menu_frame
+                .lock()
+                .insert(block_id.clone(), f.clone());
+        }
+
         // Coordinates are relative to the PANE's own render view origin, not
         // the main window — the frontend translates them using the pane's
         // own DOM wrapper rect (`.block-<block_id>`), which the native
-        // overlay is always positioned to exactly match. See
-        // `browser-pane-context-menu-bridge.ts`.
+        // overlay is always positioned to exactly match. See the
+        // `browser-pane-context-menu` listener in `blockframe.tsx`.
         let x = p.xcoord();
         let y = p.ycoord();
         let link_url = CefString::from(&p.link_url()).to_string();

--- a/agentmux-cef/src/client/context_menu.rs
+++ b/agentmux-cef/src/client/context_menu.rs
@@ -19,14 +19,14 @@ use cef::*;
 use super::AgentMuxHandler;
 
 impl AgentMuxHandler {
-    /// Runs on CEF's `run_context_menu`. ALWAYS suppresses CEF's native menu
-    /// for a browser pane — returns 1 (handled) and calls `callback.cancel()`
-    /// unconditionally, including when `block_id`/`params` can't be resolved,
-    /// since falling through to Chromium's own Back/Forward/Print/View
-    /// Source/Inspect menu in that edge case would be a worse and more
-    /// confusing experience than the pane simply not showing a context menu
-    /// that one time (same posture as other block_id-resolution failures
-    /// elsewhere in this file, e.g. `on_loading_state_change_browser_pane`).
+    /// Runs on CEF's `run_context_menu`. Suppresses CEF's native menu for a
+    /// browser pane — returns 1 (handled) and calls `callback.cancel()` —
+    /// ONLY when `browser-pane-context-menu` was actually routed somewhere a
+    /// listener can hear it. When `block_id`/`params` can't be resolved, OR
+    /// the pane's owning window can't be determined, falls through to CEF's
+    /// own native menu (return 0) instead: suppressing unconditionally in
+    /// that case would show NO menu at all (reagentx P1 on PR #2599) — worse
+    /// than Chromium's native one.
     ///
     /// `cancel()`, never `cont()`: `cont()` tells CEF a specific native menu
     /// command was chosen (by id) and to execute it — we're not running any
@@ -42,18 +42,23 @@ impl AgentMuxHandler {
         callback: Option<&mut RunContextMenuCallback>,
     ) -> ::std::os::raw::c_int {
         let Some(cb) = callback else { return 0 };
-        let suppress = |cb: &mut RunContextMenuCallback| {
-            cb.cancel();
-            1
-        };
-        let Some(b) = browser.as_deref() else {
-            return suppress(cb);
-        };
+        let Some(b) = browser.as_deref() else { return 0 };
         let Some(block_id) = crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b) else {
-            return suppress(cb);
+            return 0;
         };
-        let Some(p) = params else {
-            return suppress(cb);
+        let Some(p) = params else { return 0 };
+
+        // Route to the pane's ACTUAL owning window, not just "main" — a pane
+        // torn off into its own floating window has its own JS context, and
+        // `blockframe.tsx`'s listener there is what needs this event. Same
+        // fix already applied to `browser-pane-shortcut` (codex P2 on
+        // #2548) — see that call site for the identical pattern.
+        let Some(window_label) = self.state.browser_pane_window_label(&block_id) else {
+            tracing::warn!(
+                "[browser-pane-context-menu] no owning window label for block_id={}, falling back to CEF's native menu",
+                block_id
+            );
+            return 0;
         };
 
         // Coordinates are relative to the PANE's own render view origin, not
@@ -72,8 +77,9 @@ impl AgentMuxHandler {
         let can_go_back = b_owned.can_go_back() != 0;
         let can_go_forward = b_owned.can_go_forward() != 0;
 
-        crate::events::emit_event_from_state(
+        let delivered = crate::events::emit_event_to_window(
             &self.state,
+            &window_label,
             "browser-pane-context-menu",
             &serde_json::json!({
                 "block_id": block_id,
@@ -87,7 +93,11 @@ impl AgentMuxHandler {
                 "can_go_forward": can_go_forward,
             }),
         );
+        if !delivered {
+            return 0;
+        }
 
-        suppress(cb)
+        cb.cancel();
+        1
     }
 }

--- a/agentmux-cef/src/client/context_menu.rs
+++ b/agentmux-cef/src/client/context_menu.rs
@@ -1,0 +1,93 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ContextMenuHandler` body for browser panes — suppresses CEF's native
+//! Chrome-style right-click menu (Back/Forward/Reload/Print/View Page
+//! Source/Inspect) and hands control to the frontend's own unified pane
+//! context menu instead. See
+//! docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md.
+//!
+//! Main-app windows never install this handler at all (see
+//! `client::handlers::AgentMuxClient::context_menu_handler`, gated on
+//! `is_browser_pane`) — the main app's own right-click menu is handled
+//! entirely in DOM via `app.tsx`'s `onContextMenu={showTextInputContextMenu}`,
+//! which already works because the main app IS its own DOM content, unlike a
+//! browser pane's native overlay.
+
+use cef::*;
+
+use super::AgentMuxHandler;
+
+impl AgentMuxHandler {
+    /// Runs on CEF's `run_context_menu`. ALWAYS suppresses CEF's native menu
+    /// for a browser pane — returns 1 (handled) and calls `callback.cancel()`
+    /// unconditionally, including when `block_id`/`params` can't be resolved,
+    /// since falling through to Chromium's own Back/Forward/Print/View
+    /// Source/Inspect menu in that edge case would be a worse and more
+    /// confusing experience than the pane simply not showing a context menu
+    /// that one time (same posture as other block_id-resolution failures
+    /// elsewhere in this file, e.g. `on_loading_state_change_browser_pane`).
+    ///
+    /// `cancel()`, never `cont()`: `cont()` tells CEF a specific native menu
+    /// command was chosen (by id) and to execute it — we're not running any
+    /// CEF-native command through this path at all. The frontend's menu
+    /// items (Back/Forward/Reload/Print/View Source/Inspect/split/replace/
+    /// color/close) each invoke their own existing IPC command directly
+    /// (`browser_pane_go_back`, `browser_pane_print`, etc.) once the user
+    /// clicks one — entirely independent of this callback.
+    pub(crate) fn run_context_menu(
+        &mut self,
+        browser: Option<&mut Browser>,
+        params: Option<&mut ContextMenuParams>,
+        callback: Option<&mut RunContextMenuCallback>,
+    ) -> ::std::os::raw::c_int {
+        let Some(cb) = callback else { return 0 };
+        let suppress = |cb: &mut RunContextMenuCallback| {
+            cb.cancel();
+            1
+        };
+        let Some(b) = browser.as_deref() else {
+            return suppress(cb);
+        };
+        let Some(block_id) = crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b) else {
+            return suppress(cb);
+        };
+        let Some(p) = params else {
+            return suppress(cb);
+        };
+
+        // Coordinates are relative to the PANE's own render view origin, not
+        // the main window — the frontend translates them using the pane's
+        // own DOM wrapper rect (`.block-<block_id>`), which the native
+        // overlay is always positioned to exactly match. See
+        // `browser-pane-context-menu-bridge.ts`.
+        let x = p.xcoord();
+        let y = p.ycoord();
+        let link_url = CefString::from(&p.link_url()).to_string();
+        let page_url = CefString::from(&p.page_url()).to_string();
+        let selection_text = CefString::from(&p.selection_text()).to_string();
+        let is_editable = p.is_editable() != 0;
+
+        let mut b_owned = b.clone();
+        let can_go_back = b_owned.can_go_back() != 0;
+        let can_go_forward = b_owned.can_go_forward() != 0;
+
+        crate::events::emit_event_from_state(
+            &self.state,
+            "browser-pane-context-menu",
+            &serde_json::json!({
+                "block_id": block_id,
+                "x": x,
+                "y": y,
+                "link_url": link_url,
+                "page_url": page_url,
+                "selection_text": selection_text,
+                "is_editable": is_editable,
+                "can_go_back": can_go_back,
+                "can_go_forward": can_go_forward,
+            }),
+        );
+
+        suppress(cb)
+    }
+}

--- a/agentmux-cef/src/client/context_menu.rs
+++ b/agentmux-cef/src/client/context_menu.rs
@@ -81,9 +81,12 @@ impl AgentMuxHandler {
 
         // Coordinates are relative to the PANE's own render view origin, not
         // the main window — the frontend translates them using the pane's
-        // own DOM wrapper rect (`.block-<block_id>`), which the native
-        // overlay is always positioned to exactly match. See the
-        // `browser-pane-context-menu` listener in `blockframe.tsx`.
+        // own `.browser-placeholder` rect (the inner content element the
+        // native overlay is positioned to exactly match — NOT the outer
+        // `.block-<block_id>` wrapper, which also contains the header/title
+        // bar/nav bar above it; using that offset the menu downward by the
+        // header chrome's height, reagentx P1 on an earlier PR #2599 pass).
+        // See the `browser-pane-context-menu` listener in `blockframe.tsx`.
         let x = p.xcoord();
         let y = p.ycoord();
         let link_url = CefString::from(&p.link_url()).to_string();

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -42,6 +42,17 @@ wrap_client! {
             Some(AgentMuxRequestHandler::new(self.inner.clone()))
         }
 
+        fn context_menu_handler(&self) -> Option<ContextMenuHandler> {
+            // Browser panes only — see SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md.
+            // The main app client's own right-click menu is DOM-level
+            // (app.tsx's onContextMenu={showTextInputContextMenu}) and needs
+            // no CEF-level override.
+            if !self.is_browser_pane {
+                return None;
+            }
+            Some(AgentMuxContextMenuHandler::new(self.inner.clone()))
+        }
+
         fn drag_handler(&self) -> Option<DragHandler> {
             if self.is_browser_pane {
                 return None;
@@ -596,6 +607,37 @@ wrap_request_handler! {
             inner.on_auth_credentials(
                 browser, origin_url, is_proxy, host, port, realm, scheme, callback,
             )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContextMenuHandler — browser panes only: suppress CEF's native menu
+// ---------------------------------------------------------------------------
+//
+// See client::context_menu::AgentMuxHandler::run_context_menu and
+// docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md. Only
+// `run_context_menu` is overridden; `on_before_context_menu` /
+// `on_context_menu_command` / `on_context_menu_dismissed` keep their default
+// (no-op) implementations — nothing to do there since we never let CEF's
+// menu model get used at all.
+
+wrap_context_menu_handler! {
+    struct AgentMuxContextMenuHandler {
+        inner: Arc<Mutex<AgentMuxHandler>>,
+    }
+
+    impl ContextMenuHandler {
+        fn run_context_menu(
+            &self,
+            browser: Option<&mut Browser>,
+            _frame: Option<&mut Frame>,
+            params: Option<&mut ContextMenuParams>,
+            _model: Option<&mut MenuModel>,
+            callback: Option<&mut RunContextMenuCallback>,
+        ) -> ::std::os::raw::c_int {
+            let mut inner = self.inner.lock();
+            inner.run_context_menu(browser, params, callback)
         }
     }
 }

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -631,13 +631,13 @@ wrap_context_menu_handler! {
         fn run_context_menu(
             &self,
             browser: Option<&mut Browser>,
-            _frame: Option<&mut Frame>,
+            frame: Option<&mut Frame>,
             params: Option<&mut ContextMenuParams>,
             _model: Option<&mut MenuModel>,
             callback: Option<&mut RunContextMenuCallback>,
         ) -> ::std::os::raw::c_int {
             let mut inner = self.inner.lock();
-            inner.run_context_menu(browser, params, callback)
+            inner.run_context_menu(browser, frame, params, callback)
         }
     }
 }

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -56,6 +56,7 @@ mod display;
 pub(crate) mod navigation;
 mod crash_recovery;
 mod recovery_pages;
+mod context_menu;
 #[cfg(target_os = "windows")]
 mod wndproc;
 #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -687,6 +687,12 @@ pub fn url_host(url: &str) -> Option<String> {
 const PANE_ALLOWED_NAV_SCHEMES: &[&str] = &[
     "http", "https", "about", "data", "blob", "ws", "wss", "devtools",
     "chrome-devtools", "chrome",
+    // "View Page Source" (browser-pane context menu, SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md)
+    // navigates via a `view-source:<url>` prefix. Like `chrome-devtools:`,
+    // Chromium renders this internally (a read-only source view) — it is
+    // never handed to the OS shell, so it carries none of the UAC/OS-handoff
+    // risk this allowlist exists to block.
+    "view-source",
 ];
 
 /// The scheme of `url` (lowercased) if it has one — the run of

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -691,7 +691,11 @@ const PANE_ALLOWED_NAV_SCHEMES: &[&str] = &[
     // navigates via a `view-source:<url>` prefix. Like `chrome-devtools:`,
     // Chromium renders this internally (a read-only source view) — it is
     // never handed to the OS shell, so it carries none of the UAC/OS-handoff
-    // risk this allowlist exists to block.
+    // risk this allowlist exists to block. IMPORTANT: being in this list is
+    // NOT sufficient on its own for "view-source" — see
+    // `is_disallowed_pane_nav_scheme`'s nested-scheme check below. Membership
+    // here only says the OUTER `view-source:` prefix itself isn't handed to
+    // the OS shell; it says nothing about what comes after the colon.
     "view-source",
 ];
 
@@ -727,7 +731,32 @@ fn url_scheme(url: &str) -> Option<String> {
 pub fn is_disallowed_pane_nav_scheme(url: &str) -> bool {
     match url_scheme(url) {
         None => false, // relative / scheme-less — resolves against current origin
-        Some(scheme) => !PANE_ALLOWED_NAV_SCHEMES.contains(&scheme.as_str()),
+        Some(scheme) => {
+            if !PANE_ALLOWED_NAV_SCHEMES.contains(&scheme.as_str()) {
+                return true;
+            }
+            // `view-source:` wraps an arbitrary NESTED target URL that
+            // Chromium fetches and renders as source text — `url_scheme`
+            // above only inspects up to the FIRST colon, so
+            // `view-source:file:///etc/passwd` has outer scheme
+            // "view-source" (allowed) while the nested target
+            // (`file:///etc/passwd`) was never validated at all. A
+            // compromised/malicious page loaded in the pane can trigger this
+            // itself via `window.location`, letting it read and display
+            // local file contents in the pane — exactly what this allowlist
+            // exists to prevent (reagentx P0 on PR #2599). Restrict the
+            // nested target to http(s) specifically — narrower than the
+            // full `PANE_ALLOWED_NAV_SCHEMES` list, since that's the only
+            // thing `browser_panes::navigation::view_source()` itself ever
+            // generates (it always prepends `view-source:` to the pane's
+            // own already-http(s) `frame.url()`).
+            if scheme == "view-source" {
+                let nested = url.trim().splitn(2, ':').nth(1).unwrap_or("");
+                let nested_scheme = url_scheme(nested);
+                return !matches!(nested_scheme.as_deref(), Some("http") | Some("https"));
+            }
+            false
+        }
     }
 }
 
@@ -853,6 +882,36 @@ mod external_url_tests {
             "steam://run/1",
             "callto:foo",
             "custom-installer://elevate",
+        ] {
+            assert!(is_disallowed_pane_nav_scheme(u), "should block: {u}");
+        }
+    }
+
+    #[test]
+    fn view_source_of_http_https_is_allowed() {
+        for u in [
+            "view-source:https://example.com/page",
+            "view-source:http://127.0.0.1:5173/",
+        ] {
+            assert!(!is_disallowed_pane_nav_scheme(u), "should allow: {u}");
+        }
+    }
+
+    #[test]
+    fn view_source_of_non_http_nested_scheme_is_blocked() {
+        // reagentx P0 on PR #2599: view-source: wraps an arbitrary nested
+        // target that Chromium fetches and renders as source text.
+        // url_scheme() only inspects up to the FIRST colon, so a naive
+        // allowlist entry for "view-source" alone would let a page navigate
+        // itself to view-source:file:///... and have local file contents
+        // rendered in the pane.
+        for u in [
+            "view-source:file:///etc/passwd",
+            "view-source:file:///C:/Windows/System32/config/SAM",
+            "view-source:chrome://settings",
+            "view-source:vscode://file/x",
+            "view-source:",
+            "view-source:not-a-url",
         ] {
             assert!(is_disallowed_pane_nav_scheme(u), "should block: {u}");
         }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -530,6 +530,23 @@ async fn route_command(
             state.browser_panes.reload(block_id, state);
             Ok(serde_json::json!(true))
         }
+        "browser_pane_print" => {
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            state.browser_panes.print(block_id, state);
+            Ok(serde_json::json!(true))
+        }
+        "browser_pane_view_source" => {
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            state.browser_panes.view_source(block_id, state);
+            Ok(serde_json::json!(true))
+        }
+        "browser_pane_inspect_element" => {
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+            let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+            state.browser_panes.inspect_element(block_id, state, x, y);
+            Ok(serde_json::json!(true))
+        }
         "browser_pane_focus" => {
             let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
             tracing::info!("[ipc] browser_pane_focus block_id={}", block_id);

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -547,6 +547,21 @@ async fn route_command(
             state.browser_panes.inspect_element(block_id, state, x, y);
             Ok(serde_json::json!(true))
         }
+        "browser_pane_copy" => {
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            state.browser_panes.copy(block_id, state);
+            Ok(serde_json::json!(true))
+        }
+        "browser_pane_cut" => {
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            state.browser_panes.cut(block_id, state);
+            Ok(serde_json::json!(true))
+        }
+        "browser_pane_paste" => {
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            state.browser_panes.paste(block_id, state);
+            Ok(serde_json::json!(true))
+        }
         "browser_pane_focus" => {
             let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
             tracing::info!("[ipc] browser_pane_focus block_id={}", block_id);

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use parking_lot::Mutex;
 
-use cef::Browser;
+use cef::{Browser, Frame};
 
 mod drag;
 mod window_meta;
@@ -479,6 +479,20 @@ pub struct AppState {
     /// fresh navigation replaces the page's own DOM/style state.
     pub browser_pane_zoom: Mutex<std::collections::HashMap<String, f64>>,
 
+    /// The specific `Frame` right-clicked to open the unified browser-pane
+    /// context menu (SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md),
+    /// keyed by pane `block_id`. Populated by `client::context_menu`'s
+    /// `run_context_menu` from CEF's own `frame` callback param — that's the
+    /// actual frame that was right-clicked, which for a page containing
+    /// sub-frames/iframes (ads, embeds, widgets) is NOT always
+    /// `browser.main_frame()`. Consumed by the Copy/Cut/Paste menu items
+    /// (`browser_panes::navigation::copy/cut/paste`) so they operate on
+    /// whichever frame actually holds the selection/focus, instead of always
+    /// acting on the top-level frame regardless of where the user actually
+    /// right-clicked (reagentx P1 on PR #2599). Cleared on pane close
+    /// alongside `browser_pane_zoom` (see `browser_pane::callbacks::on_before_close_browser_pane`).
+    pub browser_pane_context_menu_frame: Mutex<std::collections::HashMap<String, Frame>>,
+
     /// Browser DOM API state — CDP target cache + future connection
     /// pool. See `crate::browser_api`.
     pub browser_api: crate::browser_api::BrowserApiState,
@@ -631,6 +645,7 @@ impl Default for AppState {
             // active_drag deleted (PR #5 H.3) — see HostState.active_drag.
             browser_panes: crate::browser_panes::BrowserPaneManager::new(),
             browser_pane_zoom: Mutex::new(std::collections::HashMap::new()),
+            browser_pane_context_menu_frame: Mutex::new(std::collections::HashMap::new()),
             browser_api: crate::browser_api::BrowserApiState::new(),
             debug_port: Mutex::new(0),
             cef_cache_dir: Mutex::new(None),

--- a/docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md
+++ b/docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md
@@ -1,0 +1,219 @@
+# SPEC — Browser pane: replace Chromium's native right-click menu with the app's own
+
+**Date:** 2026-08-15
+**Type:** Feature (design proposal — not yet implemented)
+**Status:** Draft
+**Scope:** `agentmux-cef` (new `ContextMenuHandler` impl, browser-pane only) +
+`frontend/app/view/browser/browser-model.ts` (new `getBodyContextMenuItems`
+implementation) + `frontend/app/block/blockframe.tsx` (no change expected —
+existing extension point should just work, see below).
+
+## Problem
+
+Right-clicking inside a browser pane's content shows Chromium's own native
+context menu (Back / Forward / Reload / Print / Save As / View Page Source /
+Inspect, laid out Chrome-style) instead of AgentMux's own pane context menu
+(the split-up/down/left/right + replace + color + close menu every other
+pane type shows). This is inconsistent with the rest of the app and doesn't
+compose with pane-level actions (split, replace, etc.) while on a web page.
+
+Goal: right-clicking a browser pane's content shows the SAME app-style menu
+every other pane uses (`buildPaneContextMenu` — split, replace, color, close,
+etc.), extended with the browser-specific actions users still need: Back,
+Forward, Reload, Print, View Page Source, Copy Link Address (when over a
+link), Inspect Element / DevTools. Not a redesign of the menu system — an
+extension, using the extension point that already exists for this purpose.
+
+## Root cause (why the native menu wins today)
+
+Same root cause family as the click-to-select and click-dismisses-menus
+issues (see the two sibling specs). Per
+`docs/specs/SPEC_NATIVE_BROWSER_PANE_2026_04_17.md`, a browser pane's content
+is a native, sibling `CefBrowserView` (CEF Views `AddOverlayView`), not DOM.
+`blockframe.tsx`'s body already has an `onContextMenu` handler
+(`onBodyContextMenu`, `blockframe.tsx:866`) that builds exactly the menu we
+want — `buildPaneContextMenu` plus any `viewModel.getBodyContextMenuItems()`
+— but it's a **DOM** `contextmenu` event handler, so it never fires for a
+right-click landing on the pane's native overlay content. CEF's own default
+`ContextMenuHandler` behavior (used because AgentMux doesn't implement the
+interface at all today — confirmed, zero references to
+`ContextMenuHandler`/`on_before_context_menu`/`run_context_menu` anywhere in
+`agentmux-cef/src`) takes over instead and shows the native OS-style menu.
+
+## Existing extension point (reuse, don't invent a new one)
+
+`ViewModel` already supports pane-type-specific context menu items via two
+optional methods (`frontend/types/custom.d.ts:517-518`):
+
+```ts
+getSettingsMenuItems?: () => ContextMenuItem[];      // header right-click, appended
+getBodyContextMenuItems?: () => ContextMenuItem[];   // body right-click, PREPENDED
+```
+
+`getBodyContextMenuItems` is exactly what we need — `blockframe.tsx`'s
+`onBodyContextMenu` already prepends its result (with a trailing separator)
+before the shared `buildPaneContextMenu` items:
+
+```ts
+// blockframe.tsx:866-883
+const onBodyContextMenu = (e: MouseEvent) => {
+    ...
+    const bodyItems = props.viewModel?.getBodyContextMenuItems?.();
+    if (bodyItems && bodyItems.length > 0) menu.push(...bodyItems, { type: "separator" });
+    menu.push(...buildPaneContextMenu(blockData(), {...}, props.viewModel));
+    ContextMenuModel.showContextMenu(menu, e);
+};
+```
+
+`termViewModel.ts` and `sysinfo-model.ts` already implement this pattern —
+`termViewModel.ts` is the closest precedent (adds actions specific to its own
+content type). `browser-model.ts` implementing the same method is the
+"retain these functions, add them to the general menu" the user asked for —
+it is literally what this extension point is for.
+
+**The gap is only that nothing ever calls `onBodyContextMenu` for a browser
+pane**, because CEF intercepts the right-click natively before it becomes a
+DOM `contextmenu` event. Closing that gap is the actual work here.
+
+## Proposed design
+
+### 1. Suppress CEF's native menu and capture its params (backend)
+
+CEF's `ContextMenuHandler` trait is confirmed available in the vendored
+bindings (`cef` crate v148, `ImplContextMenuHandler`) with everything needed:
+
+```rust
+fn on_before_context_menu(&self, browser, frame, params: Option<&mut ContextMenuParams>, model: Option<&mut MenuModel>);
+fn run_context_menu(&self, browser, frame, params, model, callback: Option<&mut RunContextMenuCallback>) -> c_int;
+fn on_context_menu_command(&self, browser, frame, params, command_id: c_int, event_flags: EventFlags) -> c_int;
+```
+
+`ContextMenuParams` (`ImplContextMenuParams`) exposes everything the app-side
+menu needs to build browser-specific items and position itself correctly:
+
+| Getter | Use |
+|---|---|
+| `xcoord()` / `ycoord()` | Where to render the app's own popover menu |
+| `link_url()` | Populates "Copy Link Address" (only shown when non-empty) |
+| `page_url()` | For "View Page Source" / "Print" targeting |
+| `selection_text()` | Could gate a "Copy" item, mirrors other panes' copy handling in `pane-actions.ts` |
+| `is_editable()` / `edit_state_flags()` | Whether to show Cut/Copy/Paste for an editable field (e.g. a web form's `<input>`) |
+| `media_type()` / `has_image_contents()` | Could gate "Copy Image" / "Save Image As" (stretch — not required for v1) |
+
+Add a new browser-pane-scoped `ContextMenuHandler` impl (mirrors how
+`RequestHandler`/`LoadHandler` are already scoped per-handler in
+`client/handlers.rs`). Wire it the same way `on_before_browse` already gates
+on `self.is_browser_pane` — this must NOT change context-menu behavior for
+the main app UI (right-clicking the app chrome itself must keep working
+exactly as it does today; this is browser-pane-only).
+
+In `run_context_menu`:
+1. Resolve `block_id` via the existing
+   `browser_pane::callbacks::resolve_pane_block_id` helper (same one
+   `on_before_browse` now uses for the load watchdog).
+2. Translate `params.xcoord()`/`ycoord()` (frame-relative) into
+   window/screen coordinates the frontend can use to position its popover —
+   check how the click-to-select flow or the pane's own screen-position
+   tracking (`ui_tasks/pane_geometry.rs`) already does this translation, to
+   reuse rather than re-derive it.
+3. Emit a new event, e.g. `browser-pane-context-menu`, carrying `block_id`,
+   the translated coordinates, and the subset of `ContextMenuParams` fields
+   above (link URL, selection text, editable state, can-go-back/forward —
+   the latter two already available via `browser.can_go_back()`/
+   `can_go_forward()`, no new CEF surface needed).
+4. Call `callback.cancel()` (never `.cont()` — that would still show CEF's
+   native menu) and return `1` (handled) so CEF suppresses its own menu
+   entirely. `on_before_context_menu`'s `model.clear()` is a documented
+   alternative/belt-and-suspenders (clear the model before CEF would show
+   it), but suppressing in `run_context_menu` + `cancel()` is the more
+   direct mechanism and avoids relying on the empty-model side effect.
+
+This is the same "native event in, IPC event out, frontend renders its own
+UI" shape as `browser-pane-clicked` (click-to-select) — no new architectural
+pattern, just a second application of the existing one.
+
+### 2. Render the app's menu (frontend)
+
+- `browser-model.ts` implements `getBodyContextMenuItems()`-equivalent
+  content: Back (disabled if `!canGoBack`), Forward (disabled if
+  `!canGoForward`), Reload — all three call the model's own existing
+  `goBack()`/`goForward()`/`reload()` (already implemented, see
+  `browser-model.ts:517-543`, no new IPC needed for these three), then Print,
+  View Page Source, Copy Link Address (conditional on `link_url` being
+  present), Inspect Element (new — see below).
+- A new always-mounted listener (same shape as the click-dismiss-menus fix in
+  the sibling spec) receives `browser-pane-context-menu`, resolves the
+  target pane's `BrowserModel`/`ViewModel`, and calls
+  `ContextMenuModel.showContextMenu(menu, {clientX, clientY})` directly at
+  the translated coordinates — `blockframe.tsx`'s `onBodyContextMenu` itself
+  is never invoked (there's no real DOM event to intercept), but it can stay
+  exactly as-is; this is a second caller of `ContextMenuModel.showContextMenu`
+  and `buildPaneContextMenu`, not a change to the existing one.
+- Menu ordering should match `onBodyContextMenu`'s existing convention:
+  browser-specific items first, separator, then the shared
+  `buildPaneContextMenu` (split/replace/color/close) — i.e. build the exact
+  same `menu` array `onBodyContextMenu` would have built, had the DOM event
+  fired.
+
+### 3. New actions needing backend support
+
+Print, View Page Source, and Inspect Element have no existing IPC path
+(unlike Back/Forward/Reload, which reuse `browser-model.ts`'s existing
+methods):
+
+- **Print**: CEF exposes `CefBrowserHost::Print()` (triggers the native/CEF
+  print UI for that browser) — check `ImplBrowserHost` in the vendored
+  bindings for the Rust method name; if unavailable, `frame.execute_java_script("window.print()")`
+  is a viable fallback (same injection mechanism already used elsewhere in
+  `on_load_end`).
+- **View Page Source**: Chromium supports a `view-source:` URL prefix
+  (`view-source:<page_url>`) that can be loaded via the pane's existing
+  `navigate()`/`frame.load_url()` path — likely doesn't need any new backend
+  command, just a frontend-side URL transform before calling the pane's
+  existing navigate flow. Needs verification that CEF's `view-source:` scheme
+  isn't blocked by `on_before_browse`'s `is_disallowed_pane_nav_scheme` guard
+  (added in this same session for the OS-handoff/UAC fix) — if it is, that
+  guard needs a `view-source:` carve-out.
+- **Inspect Element**: CEF exposes `CefBrowserHost::ShowDevTools()` (with an
+  optional inspect-element point). Needs a new IPC command (e.g.
+  `browser.inspectElement`) since nothing in the app currently opens
+  DevTools for an arbitrary browser pane.
+
+## Scope / caveats
+
+- Windows + macOS only initially, following the same platform split as the
+  two sibling native-overlay specs (`resolve_pane_block_id` and
+  `can_go_back`/`can_go_forward` are platform-agnostic, but this whole
+  feature depends on `ContextMenuHandler` being wired into the browser-pane
+  CEF client the same way `RequestHandler`/`LoadHandler` are — need to
+  confirm CEF's context-menu callback fires identically cross-platform before
+  assuming Linux gets this for free; unlike the click events, context-menu
+  handling is NOT part of the Windows-HWND-subclass/macOS-swizzle machinery,
+  so this may not have the same Linux gap as the other two specs — needs
+  verification during implementation, not assumed here).
+- "Save As" / "Save Image As" / spell-check suggestions / "Cast" are out of
+  scope for v1 — not mentioned by the user, and each adds its own file-dialog
+  or media-specific complexity. Can be added later as more
+  `getBodyContextMenuItems()` entries without touching the suppression
+  mechanism.
+- Must not regress right-click behavior on the main app UI or on
+  non-browser-pane native overlays if any exist — scope the new
+  `ContextMenuHandler` impl to `is_browser_pane` exactly like
+  `on_before_browse` already does.
+
+## Verification plan (once implemented)
+
+- Right-click a loaded browser pane's body → app-style menu appears (not
+  Chromium's native one), positioned at the cursor.
+- Back/Forward disabled state matches the pane's actual history state.
+- Reload, Back, Forward all work from the new menu.
+- Copy Link Address appears only when right-clicking an actual link, and the
+  clipboard content is correct.
+- Print opens print output/dialog for the pane's current page.
+- View Page Source shows the page's HTML source.
+- Inspect Element opens DevTools, ideally scrolled/highlighted to the
+  clicked element if CEF's inspect-element-at-point is wired through.
+- Split/Replace/Color/Close items from the shared menu all still work
+  identically to how they work from a normal pane's context menu.
+- Right-clicking the pane HEADER (already real DOM) is unaffected — confirm
+  no regression there, since this change is body-only.

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -893,11 +893,9 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
     // never fires there, so `onBodyContextMenu` above is never reached by a
     // right-click landing on the pane's actual content. The host instead
     // emits `browser-pane-context-menu` with the click point in the PANE's
-    // own coordinate space; translate it into window-client coordinates
-    // using `frameEl`'s rect (the native overlay is always positioned to
-    // exactly match this wrapper) and drive the exact same `onBodyContextMenu`
-    // path via a synthetic event, so composition/ordering matches every
-    // other pane type exactly. See
+    // own coordinate space; translate it into window-client coordinates and
+    // drive the exact same `onBodyContextMenu` path via a synthetic event,
+    // so composition/ordering matches every other pane type exactly. See
     // docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md.
     onMount(() => {
         const unsubPromise = listenEvent<{
@@ -911,7 +909,15 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
             can_go_forward: boolean;
         }>("browser-pane-context-menu", (payload) => {
             if (payload.block_id !== nodeModel.blockId) return;
-            const rect = frameEl()?.getBoundingClientRect();
+            // CEF's xcoord/ycoord are relative to the browser render view,
+            // which browser-view.tsx positions against the INNER
+            // `.browser-placeholder` div — not `frameEl` (the outer wrapper,
+            // which also contains the header/title bar/nav bar above the
+            // content). Using frameEl's rect offset the menu downward by
+            // that header chrome's height (reagentx P1 on PR #2599).
+            const rect = frameEl()
+                ?.querySelector<HTMLElement>(".browser-placeholder")
+                ?.getBoundingClientRect();
             if (!rect) return;
             const synthetic = {
                 clientX: rect.left + payload.x,

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -22,7 +22,7 @@ import { IconButton, ToggleIconButton } from "@/element/iconbutton";
 import { BlockStatsBadge } from "@/element/blockstats";
 import { MenuButton } from "@/element/menubutton";
 import { MicButton } from "@/app/element/MicButton";
-import { invokeCommand } from "@/app/platform/ipc";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import { NodeModel } from "@/layout/index";
 import * as util from "@/util/util";
 import { computeBgStyleFromMeta } from "@/util/waveutil";
@@ -862,13 +862,18 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
         <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} viewModel={null} />
     );
 
-    // Body right-click handler
-    const onBodyContextMenu = (e: MouseEvent) => {
+    // Body right-click handler. `browserCtx` is only ever passed by the
+    // synthetic browser-pane path below (real DOM contextmenu events never
+    // carry it) — see getBodyContextMenuItems's doc comment in custom.d.ts.
+    const onBodyContextMenu = (
+        e: MouseEvent,
+        browserCtx?: Parameters<NonNullable<ViewModel["getBodyContextMenuItems"]>>[0]
+    ) => {
         if (!blockData() || props.preview) return;
         e.preventDefault();
         e.stopPropagation();
         const menu: ContextMenuItem[] = [];
-        const bodyItems = props.viewModel?.getBodyContextMenuItems?.();
+        const bodyItems = props.viewModel?.getBodyContextMenuItems?.(browserCtx);
 
         if (bodyItems && bodyItems.length > 0) {
             menu.push(...bodyItems, { type: "separator" });
@@ -881,6 +886,51 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
         }, props.viewModel));
         ContextMenuModel.showContextMenu(menu, e);
     };
+
+    // Browser panes: CEF's native context menu is suppressed at the host
+    // level (client::context_menu::run_context_menu) because a pane's
+    // content is a native overlay, not DOM — a real `contextmenu` DOM event
+    // never fires there, so `onBodyContextMenu` above is never reached by a
+    // right-click landing on the pane's actual content. The host instead
+    // emits `browser-pane-context-menu` with the click point in the PANE's
+    // own coordinate space; translate it into window-client coordinates
+    // using `frameEl`'s rect (the native overlay is always positioned to
+    // exactly match this wrapper) and drive the exact same `onBodyContextMenu`
+    // path via a synthetic event, so composition/ordering matches every
+    // other pane type exactly. See
+    // docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md.
+    onMount(() => {
+        const unsubPromise = listenEvent<{
+            block_id: string;
+            x: number;
+            y: number;
+            link_url: string;
+            selection_text: string;
+            is_editable: boolean;
+            can_go_back: boolean;
+            can_go_forward: boolean;
+        }>("browser-pane-context-menu", (payload) => {
+            if (payload.block_id !== nodeModel.blockId) return;
+            const rect = frameEl()?.getBoundingClientRect();
+            if (!rect) return;
+            const synthetic = {
+                clientX: rect.left + payload.x,
+                clientY: rect.top + payload.y,
+                preventDefault: () => {},
+                stopPropagation: () => {},
+            } as unknown as MouseEvent;
+            onBodyContextMenu(synthetic, {
+                x: payload.x,
+                y: payload.y,
+                linkUrl: payload.link_url || undefined,
+                selectionText: payload.selection_text || undefined,
+                isEditable: payload.is_editable,
+                canGoBack: payload.can_go_back,
+                canGoForward: payload.can_go_forward,
+            });
+        });
+        onCleanup(() => { void unsubPromise.then((unsub) => unsub()); });
+    });
 
     return (
         <div

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -7,6 +7,7 @@
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
 import {
     type BrowserPaneCommand,
     type BrowserPaneEvent,
@@ -543,6 +544,66 @@ export class BrowserViewModel implements ViewModel {
                 this._dispatch({ type: "Navigate", url }, "reload-restore");
             });
         }
+    }
+
+    /**
+     * Browser-pane-specific items for the unified pane context menu
+     * (SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md). `browserCtx` is
+     * only populated for the synthetic menu path (blockframe.tsx, driven by
+     * the backend's `browser-pane-context-menu` event) — a browser pane has
+     * no real DOM `contextmenu` event to call this without it.
+     */
+    getBodyContextMenuItems(browserCtx?: {
+        x?: number;
+        y?: number;
+        linkUrl?: string;
+        selectionText?: string;
+        isEditable?: boolean;
+        canGoBack?: boolean;
+        canGoForward?: boolean;
+    }): ContextMenuItem[] {
+        const items: ContextMenuItem[] = [
+            { label: "Back", enabled: browserCtx?.canGoBack ?? this.canGoBackAtom(), click: () => this.goBack() },
+            {
+                label: "Forward",
+                enabled: browserCtx?.canGoForward ?? this.canGoForwardAtom(),
+                click: () => this.goForward(),
+            },
+            { label: "Reload", click: () => this.reload() },
+        ];
+        if (browserCtx?.linkUrl) {
+            items.push(
+                { type: "separator" },
+                {
+                    label: "Copy Link Address",
+                    click: () => { void clipboardWriteText(browserCtx.linkUrl!); },
+                },
+            );
+        }
+        items.push(
+            { type: "separator" },
+            {
+                label: "Print",
+                click: () => { invokeCommand("browser_pane_print", { block_id: this.blockId }).catch(() => {}); },
+            },
+            {
+                label: "View Page Source",
+                click: () => {
+                    invokeCommand("browser_pane_view_source", { block_id: this.blockId }).catch(() => {});
+                },
+            },
+            {
+                label: "Inspect Element",
+                click: () => {
+                    invokeCommand("browser_pane_inspect_element", {
+                        block_id: this.blockId,
+                        x: browserCtx?.x ?? 0,
+                        y: browserCtx?.y ?? 0,
+                    }).catch(() => {});
+                },
+            },
+        );
+        return items;
     }
 
     onError(msg: string): void {

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -569,8 +569,47 @@ export class BrowserViewModel implements ViewModel {
                 enabled: browserCtx?.canGoForward ?? this.canGoForwardAtom(),
                 click: () => this.goForward(),
             },
-            { label: "Reload", click: () => this.reload() },
+            {
+                label: "Reload",
+                // NOT this.reload() -- that method only does local reducer
+                // state tricks (UrlCleared + re-Navigate) and never touches
+                // the real native CEF browser view, so it's a no-op against
+                // the actual page (reagentx P1 on PR #2599). The toolbar
+                // Reload button (browser-nav-bar.tsx) has never called
+                // reload() either -- it invokes the backend command
+                // directly, which this now matches.
+                click: () => {
+                    invokeCommand("browser_pane_reload", { block_id: this.blockId }).catch(() => {});
+                },
+            },
         ];
+        // Suppressing CEF's native menu also removed its built-in Cut/Copy/
+        // Paste for a text selection or an editable web form field, with
+        // nothing replacing them (reagentx P2 on PR #2599). `Frame::copy/
+        // cut/paste` on the host operate on whatever is currently selected/
+        // focused, same as the native commands would have.
+        if (browserCtx?.selectionText || browserCtx?.isEditable) {
+            const editItems: ContextMenuItem[] = [];
+            if (browserCtx.isEditable && browserCtx.selectionText) {
+                editItems.push({
+                    label: "Cut",
+                    click: () => { invokeCommand("browser_pane_cut", { block_id: this.blockId }).catch(() => {}); },
+                });
+            }
+            if (browserCtx.selectionText) {
+                editItems.push({
+                    label: "Copy",
+                    click: () => { invokeCommand("browser_pane_copy", { block_id: this.blockId }).catch(() => {}); },
+                });
+            }
+            if (browserCtx.isEditable) {
+                editItems.push({
+                    label: "Paste",
+                    click: () => { invokeCommand("browser_pane_paste", { block_id: this.blockId }).catch(() => {}); },
+                });
+            }
+            items.push({ type: "separator" }, ...editItems);
+        }
         if (browserCtx?.linkUrl) {
             items.push(
                 { type: "separator" },

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -515,7 +515,20 @@ declare global {
         viewComponent: ViewComponent<any>;
         isBasicTerm?: () => boolean;
         getSettingsMenuItems?: () => ContextMenuItem[];
-        getBodyContextMenuItems?: () => ContextMenuItem[];
+        /** `browserCtx` is populated only for a browser pane's synthetic
+         *  context menu (its native overlay content has no real DOM
+         *  `contextmenu` event to carry this info — see
+         *  SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md). Every other
+         *  view type's implementation simply ignores the extra argument. */
+        getBodyContextMenuItems?: (browserCtx?: {
+            x?: number;
+            y?: number;
+            linkUrl?: string;
+            selectionText?: string;
+            isEditable?: boolean;
+            canGoBack?: boolean;
+            canGoForward?: boolean;
+        }) => ContextMenuItem[];
         giveFocus?: () => boolean;
         keyDownHandler?: (e: WaveKeyboardEvent) => boolean;
         dispose?: () => void;


### PR DESCRIPTION
## Summary
- Right-clicking a browser pane's content showed Chromium's own native context menu (Back/Forward/Reload/Print/Save As/View Page Source/Inspect) instead of AgentMux's own pane menu (split/replace/color/close). Implements CEF's `ContextMenuHandler` for browser panes only (`run_context_menu`, gated on `is_browser_pane` — the main app's own right-click menu is unaffected, it's handled entirely in DOM via `app.tsx`'s `onContextMenu={showTextInputContextMenu}`). Always suppresses the native menu (`callback.cancel()`, never `.cont()` — no CEF-native command is ever run through this path) and emits `browser-pane-context-menu` with the click point (pane-local coordinates) plus link URL / selection text / editable state / back-forward history.
- The frontend already has an extension point for exactly this — `getBodyContextMenuItems()`, already used by `termViewModel.ts`/`sysinfo-model.ts` — but a browser pane's native overlay content has no real DOM `contextmenu` event to trigger it. `blockframe.tsx` now also listens for `browser-pane-context-menu`, translates the pane-local click point into window-client coordinates via the pane's own DOM wrapper rect (`frameEl`, which the native overlay is always positioned to exactly match), and drives the *identical* `onBodyContextMenu` code path via a synthetic event — so item composition/ordering matches every other pane type exactly, no duplicated menu-building logic.
- `BrowserModel.getBodyContextMenuItems()` provides Back / Forward / Reload (reusing the existing `goBack()`/`goForward()`/`reload()` — no new backend surface needed), Copy Link Address (only when right-clicking an actual link), Print, View Page Source, and Inspect Element.
- Print / View Page Source / Inspect Element needed new backend surface: three `browser_pane_*` IPC commands backed by CEF's own `BrowserHost::print()`/`show_dev_tools()` and a `view-source:` navigation (added `"view-source"` to `PANE_ALLOWED_NAV_SCHEMES` — Chromium renders it internally, same as `chrome-devtools:`, so it carries none of the OS-handoff/UAC risk that allowlist exists to block).

Design doc: `docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md`.

## Scope / caveats
- Unlike the two sibling native-overlay fixes (click-to-select, click-dismisses-menus), CEF's context-menu callback is NOT part of the Windows-HWND-subclass/macOS-swizzle machinery — it's a standard CEF client handler, so this should work identically on all three platforms including Linux. Flagged as needing verification during manual testing, not assumed.
- Out of scope for v1 (noted in the spec): Save As / Save Image As / spell-check suggestions / Cast.

## Test plan
- [x] `cargo check -p agentmux-cef` clean, no new warnings
- [x] `tsc --noEmit` clean (2 pre-existing, unrelated errors in armory-view.tsx/warden-view.tsx, present on main before this change)
- [x] Full `vitest` suite: 2626 passed. One unrelated flaky test (`tool-renderers/registry.test.ts`, a timing-sensitive test with no connection to browser panes) failed under full-suite parallel load but passes cleanly in isolation (2755ms) — not a regression from this change.
- [ ] Manual: right-click a loaded browser pane, confirm the app-style menu appears (not Chromium's), Back/Forward reflect real history state, Reload/Print/View Source/Inspect Element all work, Copy Link Address appears only over a link, split/replace/color/close all still work
- [ ] Manual: confirm the pane HEADER's right-click menu (already real DOM, untouched by this change) still works identically

<!-- agentmux:agent_id=manoz -->