### PR TITLE
chore: release v0.55.10

### DIFF
--- a/.changesets/1786818961-fix-bashwrap-exempt-declared-background-tasks-from-the-idle--xy8k.md
+++ b/.changesets/1786818961-fix-bashwrap-exempt-declared-background-tasks-from-the-idle--xy8k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bashwrap): exempt declared-background tasks from the idle-kill timeout

--- a/.changesets/1786820082-feat-srv-durable-background-task-registry-db-background-task-n7g3.md
+++ b/.changesets/1786820082-feat-srv-durable-background-task-registry-db-background-task-n7g3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): durable Background Task Registry (db_background_tasks)

--- a/.changesets/1786839907-fix-identity-layer-3-credential-gate-resolves-provider-throu-k984.md
+++ b/.changesets/1786839907-fix-identity-layer-3-credential-gate-resolves-provider-throu-k984.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): layer-3 credential gate resolves provider through the bound bundle, not the driftable agent column

--- a/.changesets/1786856101-fix-lan-stop-mdns-re-resolutions-with-blank-txt-records-from-xyyw.md
+++ b/.changesets/1786856101-fix-lan-stop-mdns-re-resolutions-with-blank-txt-records-from-xyyw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan): stop mDNS re-resolutions with blank TXT records from clobbering known-good LAN peer metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.9"
+version = "0.55.10"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.9"
+version = "0.55.10"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.9"
+version = "0.55.10"
 dependencies = [
  "base64",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.9"
+version = "0.55.10"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.9"
+version = "0.55.10"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.9"
+version = "0.55.10"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.9"
+version = "0.55.10"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.55.10 — 2026-08-16
+
+- fix(bashwrap): exempt declared-background tasks from the idle-kill timeout
+- feat(srv): durable Background Task Registry (db_background_tasks)
+- fix(identity): layer-3 credential gate resolves provider through the bound bundle, not the driftable agent column
+- fix(lan): stop mDNS re-resolutions with blank TXT records from clobbering known-good LAN peer metadata
+
+
 ## 0.55.9 — 2026-08-15
 
 - feat(instance-panel): show a red pill when this instance has no valid muxbus session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.9",
+  "version": "0.55.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.9",
+      "version": "0.55.10",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.9",
+  "version": "0.55.10",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Forced patch release (`--as patch`) consuming 4 pending changesets, including a queued `minor` (durable Background Task Registry) that ships under this patch version per the documented override behavior.
- Bumps 0.55.9 -> 0.55.10 across package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md (all 5 locations verified to agree by scripts/release.sh's consistency check).

## Changesets consumed
- fix(bashwrap): exempt declared-background tasks from the idle-kill timeout
- feat(srv): durable Background Task Registry (db_background_tasks)
- fix(identity): layer-3 credential gate resolves provider through the bound bundle, not the driftable agent column
- fix(lan): stop mDNS re-resolutions with blank TXT records from clobbering known-good LAN peer metadata

## Test plan
- [x] `scripts/release.sh` consistency guard passed (all 5 version locations agree at 0.55.10)
- [ ] CI green
- [ ] reagent review

<!-- agentmux:agent_id=agentx -->