### PR TITLE
Clamk@claudius: fix stale db_agents migration-phase docs + add identity/history persistence protocol

### DIFF
--- a/.changesets/1786885082-fix-storage-correct-stale-db-agents-migration-phase-comments-5b0l.md
+++ b/.changesets/1786885082-fix-storage-correct-stale-db-agents-migration-phase-comments-5b0l.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(storage): correct stale db_agents migration-phase comments, pin the read-side split with a test

--- a/.changesets/1786885126-docs-add-agent-identity-history-fragmentation-report-and-can-s1rz.md
+++ b/.changesets/1786885126-docs-add-agent-identity-history-fragmentation-report-and-can-s1rz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: add agent identity/history fragmentation report and canonical persistence protocol spec

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -7,8 +7,27 @@
 //! `instance_*` methods (per-launch instance rows, named-agent
 //! continuation, identity-bound active-for-block resolution), the
 //! `AgentDefinition` / `AgentInstance` structs, and the `InstanceStatus` enum.
-//! `db_agents` is the authoritative consolidated read table; `db_agent_definitions`
-//! and `db_agent_instances` remain the write targets with dual-write mirrors.
+//! `db_agent_definitions` and `db_agent_instances` remain the write targets
+//! with dual-write mirrors into `db_agents` (see `dual_write.rs`). The read
+//! side is **not** uniformly flipped to `db_agents` — it is decided per
+//! function, and the two states currently coexist on purpose:
+//!   - `agent_def_list()` reads the consolidated `db_agents` table (a
+//!     partial Phase 3b flip that landed undocumented alongside unrelated
+//!     work — see `ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §3.1's
+//!     2026-08-15 correction).
+//!   - `agent_def_get()` / `user_clone_defs_for_template()` deliberately
+//!     still read `db_agent_definitions` directly — `db_agents` surfaces
+//!     template-instance projection rows under the same shape as real
+//!     user-clone definitions, which these two callers must NOT see. See
+//!     each function's own doc comment.
+//!   - `instance_list()` / `instance_get()` and friends still read
+//!     `db_agent_instances` directly — Phase 3b has not touched the
+//!     instance side at all.
+//! Do not describe this as "Phase 3a" or "Phase 3b" as a single global
+//! state in a new comment; say which function you mean. See
+//! `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+//! P4, and `agent_def_list_and_agent_def_get_read_different_tables_by_design`
+//! below for an executable check of the current split.
 
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
@@ -2710,6 +2729,108 @@ mod tests {
         assert_eq!(
             local.updated_at, 42,
             "backfilled row must preserve the registry's real updated_at, not reset to created_at"
+        );
+    }
+
+    fn bare_agent_def(id: &str, name: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: name.to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1,
+            agent_type: "standalone".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
+            auto_continue_enabled: 0,
+            memory_id: String::new(),
+        }
+    }
+
+    /// Pins down the module doc's claimed read-side split (this file's
+    /// header comment, plus `OBJECT_SCHEMA_VERSION`'s v4 entry and
+    /// `dual_write.rs`'s module doc) as an executable check, per
+    /// `SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+    /// P4: migration-phase state must be verifiable, not just a comment
+    /// someone has to remember to update. Builds two rows that exist in
+    /// only ONE of the two tables each (bypassing the normal
+    /// `agent_def_insert` path, which always keeps both in sync) and
+    /// proves `agent_def_list()` and `agent_def_get()` disagree about
+    /// which table is authoritative, on purpose. If this test starts
+    /// failing, one of the two functions' read target changed — go
+    /// update the three comments this test is guarding, not just this
+    /// assertion.
+    #[test]
+    fn agent_def_list_and_agent_def_get_read_different_tables_by_design() {
+        let store = Store::open_in_memory().unwrap();
+
+        // Exists ONLY in the consolidated `db_agents` table (as if some
+        // write path populated it without touching the legacy table —
+        // agent_def_list()'s actual read target).
+        store
+            .agents_dual_write_definition_upsert(&bare_agent_def("only-in-db-agents", "OnlyConsolidated"))
+            .unwrap();
+
+        // Exists ONLY in the legacy `db_agent_definitions` table — a raw
+        // insert bypassing `agent_def_insert`'s automatic dual-write,
+        // standing in for agent_def_get()'s actual read target.
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_agent_definitions (id, slug, name, icon, provider, description,
+                 working_directory, shell, provider_flags, auto_start, restart_on_crash,
+                 idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
+                 is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
+                 container_image, container_volumes, container_name, use_ambient_login,
+                 model_vendor_base_url, auto_continue_enabled, memory_id)
+                 VALUES ('only-in-legacy', 'only-in-legacy', 'OnlyLegacy', '', 'claude', '',
+                 '', '', '', 0, 0, 0, 1, 'standalone', '', '', 0, '', '', '', 1, 0, '', '[]', '',
+                 0, '', 0, '')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let listed = store.agent_def_list().unwrap();
+        assert!(
+            listed.iter().any(|d| d.id == "only-in-db-agents"),
+            "agent_def_list() must read db_agents"
+        );
+        assert!(
+            !listed.iter().any(|d| d.id == "only-in-legacy"),
+            "agent_def_list() must NOT see a db_agent_definitions-only row \
+             (documents the current partial-flip state — fails if this ever \
+             also starts overlaying the legacy table)"
+        );
+
+        assert!(
+            store.agent_def_get("only-in-legacy").unwrap().is_some(),
+            "agent_def_get() must still read db_agent_definitions directly"
+        );
+        assert!(
+            store.agent_def_get("only-in-db-agents").unwrap().is_none(),
+            "agent_def_get() must NOT see a db_agents-only row — it \
+             deliberately avoids the consolidated table's template-instance \
+             projection rows (see its own doc comment)"
         );
     }
 }

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -2459,6 +2459,54 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
     })
 }
 
+/// Shared test fixture: an `AgentDefinition` with every field defaulted to
+/// an empty/zero value except the ones callers actually vary. Both
+/// `tests::bare_agent_def` and `bundle_provisioning_store_separation_tests
+/// ::base_agent` used to hardcode this 30-field struct literal
+/// independently (reagentx P2 on PR #2602) — kept as one definition here so
+/// a future field addition only needs updating once.
+#[cfg(test)]
+fn test_agent_def(
+    id: &str,
+    name: &str,
+    provider: &str,
+    agent_type: &str,
+    timestamp: i64,
+    model_vendor_base_url: &str,
+) -> AgentDefinition {
+    AgentDefinition {
+        id: id.to_string(),
+        slug: id.to_string(),
+        name: name.to_string(),
+        icon: String::new(),
+        provider: provider.to_string(),
+        description: String::new(),
+        working_directory: String::new(),
+        shell: String::new(),
+        provider_flags: String::new(),
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: timestamp,
+        agent_type: agent_type.to_string(),
+        environment: String::new(),
+        agent_bus_id: String::new(),
+        is_seeded: 0,
+        accounts: String::new(),
+        parent_id: String::new(),
+        branch_label: String::new(),
+        updated_at: timestamp,
+        user_hidden: 0,
+        container_image: String::new(),
+        container_volumes: "[]".to_string(),
+        container_name: String::new(),
+        use_ambient_login: 0,
+        model_vendor_base_url: model_vendor_base_url.to_string(),
+        auto_continue_enabled: 0,
+        memory_id: String::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2733,37 +2781,7 @@ mod tests {
     }
 
     fn bare_agent_def(id: &str, name: &str) -> AgentDefinition {
-        AgentDefinition {
-            id: id.to_string(),
-            slug: id.to_string(),
-            name: name.to_string(),
-            icon: String::new(),
-            provider: "claude".to_string(),
-            description: String::new(),
-            working_directory: String::new(),
-            shell: String::new(),
-            provider_flags: String::new(),
-            auto_start: 0,
-            restart_on_crash: 0,
-            idle_timeout_minutes: 0,
-            created_at: 1,
-            agent_type: "standalone".to_string(),
-            environment: String::new(),
-            agent_bus_id: String::new(),
-            is_seeded: 0,
-            accounts: String::new(),
-            parent_id: String::new(),
-            branch_label: String::new(),
-            updated_at: 1,
-            user_hidden: 0,
-            container_image: String::new(),
-            container_volumes: "[]".to_string(),
-            container_name: String::new(),
-            use_ambient_login: 0,
-            model_vendor_base_url: String::new(),
-            auto_continue_enabled: 0,
-            memory_id: String::new(),
-        }
+        super::test_agent_def(id, name, "claude", "standalone", 1, "")
     }
 
     /// Pins down the module doc's claimed read-side split (this file's
@@ -2847,37 +2865,7 @@ mod bundle_provisioning_store_separation_tests {
     use super::*;
 
     fn base_agent(id: &str, name: &str, provider: &str, model_vendor_base_url: &str) -> AgentDefinition {
-        AgentDefinition {
-            id: id.to_string(),
-            slug: id.to_string(),
-            name: name.to_string(),
-            icon: String::new(),
-            provider: provider.to_string(),
-            description: String::new(),
-            working_directory: String::new(),
-            shell: String::new(),
-            provider_flags: String::new(),
-            auto_start: 0,
-            restart_on_crash: 0,
-            idle_timeout_minutes: 0,
-            created_at: 0,
-            agent_type: "host".to_string(),
-            environment: String::new(),
-            agent_bus_id: String::new(),
-            is_seeded: 0,
-            accounts: String::new(),
-            parent_id: String::new(),
-            branch_label: String::new(),
-            updated_at: 0,
-            user_hidden: 0,
-            container_image: String::new(),
-            container_volumes: "[]".to_string(),
-            container_name: String::new(),
-            use_ambient_login: 0,
-            model_vendor_base_url: model_vendor_base_url.to_string(),
-            auto_continue_enabled: 0,
-            memory_id: String::new(),
-        }
+        super::test_agent_def(id, name, provider, "host", 0, model_vendor_base_url)
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -1,13 +1,23 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Phase 3a — `db_agents` dual-write helpers.
+//! `db_agents` dual-write helpers.
 //!
 //! Every mutation on `db_agent_definitions` / `db_agent_instances`
-//! mirrors into `db_agents` so a later read-migration PR (Phase 3b)
-//! can flip readers over with confidence. Dual-write failures LOG +
-//! CONTINUE — the old tables remain authoritative until Phase 3b.
-//! See `docs/specs/SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md`.
+//! mirrors into `db_agents`. Originally written as Phase 3a with the old
+//! tables authoritative and dual-write failures logged + continued until
+//! a later Phase 3b read-migration PR — that framing is now stale.
+//! `agent_def_list()` (`agents.rs`) already reads `db_agents` (an
+//! undocumented partial Phase 3b flip found 2026-08-15, see
+//! `ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §3.1), and
+//! `agents_dual_write_definition_upsert` below now hard-fails
+//! (`Result<(), StoreError>`, propagated with `?` at its call site) rather
+//! than logging and continuing. Other functions in this file may not have
+//! made the same transition — check each one's own doc comment rather
+//! than assuming a single global phase; see
+//! `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+//! P4. See `docs/specs/SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md` for
+//! the original design.
 //!
 //! Extracted from `store.rs` in Phase R.5 of the storage
 //! modularization plan

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -55,8 +55,21 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 7;
 ///   v2 — db_agent_definitions.updated_at
 ///   v3 — db_agent_definitions.user_hidden (Phase 2 hide templates,
 ///        SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md Q2 Decision Y)
-///   v4 — db_agents consolidation table (Phase 3a; dual-write only,
-///        reads still on db_agent_definitions / db_agent_instances)
+///   v4 — db_agents consolidation table (Phase 3a: every definition/
+///        instance write dual-writes here). Read-side migration (Phase
+///        3b) is NOT a single global flip: `agent_def_list()` already
+///        reads `db_agents` (an undocumented partial flip discovered
+///        2026-08-15, see ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md
+///        §3.1), `agent_def_get()`/`user_clone_defs_for_template()`
+///        deliberately still read `db_agent_definitions` directly (by
+///        design — see their own doc comments in agents.rs), and the
+///        instance side (`instance_list()` etc.) hasn't flipped at all.
+///        This entry previously claimed "reads still on
+///        db_agent_definitions / db_agent_instances" unconditionally,
+///        which `agent_def_list()` already contradicted — corrected
+///        2026-08-16, see
+///        docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+///        P4.
 ///   v5 — db_agents.last_block_id (Phase 3c; latest launch's block, so the
 ///        consolidated read can find the session snapshot without joining
 ///        db_agent_instances)

--- a/docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md
+++ b/docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md
@@ -1,0 +1,267 @@
+# Agent Identity/History Fragmentation Across Builds — Root Cause and a Fast-Lookup Design
+
+**Date:** 2026-08-16
+**Author:** Clamk (agent, `~/.agentmux/agents/clamk-0612a`)
+**Status:** Report — root cause confirmed and code-cited end to end; proposed fix is a design, not yet
+implemented. No code changes in this PR.
+**Ground truth basis:** `agentmuxai/agentmux` local checkout at `3705f83c3`
+(`agent3/bashwrap-persist-cwd-across-calls`, 210 commits behind `origin/main`) cross-checked against
+`origin/main` at `72aefad4d` via `git show origin/main:<path>` for every file cited below. Live filesystem
+evidence gathered from this machine's own `~/.agentmux` tree.
+**Motivation:** the operator asked this agent ("Clamk") to retrieve its own prior conversation history via
+the app's "Conversation History" UI action. The quoted text it copied came from a session that turned out to
+live under a *different* channel/identity UUID than the one this agent is currently running under, and was
+only findable by a manual, full-tree `grep` across `~/.agentmux`. The operator asked for the underlying bug
+to be root-caused and a fast, durable lookup system designed so this doesn't cost cycles again.
+
+---
+
+## 0. Executive summary
+
+A named, identity-bound agent's Claude Code conversation history is supposed to be **global** —
+one continuous transcript store that survives every app version bump, every local rebuild, every channel
+change. That principle is explicit in at least four prior specs/retros (§2). It is currently **broken by a
+regression merged 10 days before this report**: commit `9f6cc2824` ("feat(identity): default isolated auth
+for every non-stable channel", PR #2431, 2026-08-06, `origin/main` only — not yet in this local checkout)
+changed `identities_dir()`'s default from "always global" to "per-channel for every channel except the
+literal string `\"stable\"`". Because an identity-bound agent's actual Claude Code session transcripts
+(`claude/projects/*.jsonl`) live *inside* that same identity-bundle directory tree, and because every local/
+dev/portable build already mints a brand-new channel by design (§1.1), this one flag flip means:
+
+- Every fresh local build gives an identity-bound agent an **empty** history store.
+- The code that mints the bundle UUID has no fallback — it just generates a new random UUID
+  (`identity_auth_dirs.rs::compute_and_ensure_account_dir`), so there's nothing tying the new session to the
+  old one.
+- The in-app history browser (`ClaudeHistoryAdapter`) only ever scans the **global** shared identities path —
+  never the per-channel path PR #2431 made the default — so it is now structurally blind to history written
+  after 2026-08-06 for any identity-bound agent. There is no fast *or* slow code path that finds it; a human
+  has to walk the filesystem by hand, which is exactly what happened in this conversation.
+
+This is not a one-off bug. It is the **fourth-plus recurrence** of the same failure class — "identity/history
+is supposed to be global; something makes it accidentally per-channel again" — following incidents on
+2026-06-13, 2026-06-16 (twice), and 2026-07-27 (§2). None of those incidents' own recommended regression
+tests were ever confirmed shipped. §4 proposes both a fix for this specific regression and a structural
+change (an explicit index + an enforced invariant) so the *next* well-intentioned channel-isolation change
+can't silently break history continuity again.
+
+---
+
+## 1. The failure chain, traced end to end and code-cited
+
+### 1.1 Every local/dev/portable build mints a new channel — by design
+
+`scripts/package.sh:99-103`:
+
+```
+BUILD_ID=$(printf '%s' "$LABEL" | sha1sum | cut -c1-8)
+CHANNEL="local-${BRANCH_SLUG}-${BRANCH_HASH}-${BUILD_ID}"
+```
+
+with the comment at `scripts/package.sh:27-31` stating plainly: *"PER-BUILD: the build-id ... makes each
+build its own data dir ... so a freshly-built binary launches as its own instance."* Confirmed by a passing
+test, `agentmux-launcher/src/hash.rs:147-163`
+(`per_build_channels_isolate_data_dir_even_at_same_version`): two builds of the *same branch, same semver*
+still resolve to distinct channels and distinct data dirs, because of the build-id suffix. This is
+intentional and not the bug — it's the reason agent/identity data was deliberately made global in the first
+place (§2's 2026-06-13 spec), specifically so this per-build churn wouldn't lose anything.
+
+### 1.2 `identities_dir()` now defaults to per-channel for any non-`"stable"` channel
+
+`agentmux-common/src/data_paths.rs` (verified on `origin/main`, function starting at line 358):
+
+```rust
+pub fn identities_dir(&self) -> PathBuf {
+    if isolated_auth_enabled() {
+        self.instance_dir.join("identities")
+    } else {
+        self.shared_dir.join("identities")
+    }
+}
+```
+
+Before commit `9f6cc2824`, `isolated_auth_enabled()` was `false` unless `AGENTMUX_ISOLATED_AUTH=1` was set
+explicitly — global by default, unconditionally. That commit (PR #2431, merged 2026-08-06, message:
+*"feat(identity): default isolated auth for every non-stable channel"*) replaced it with
+`isolated_auth_reason()`, whose resolution order (same file, doc comment above `isolated_auth_enabled`) is:
+
+1. `AGENTMUX_ISOLATED_AUTH=1` / any-other-value → explicit override, always wins.
+2. Otherwise: **isolated for every channel except the literal string `"stable"`.**
+3. If `AGENTMUX_CHANNEL` isn't set at all: stays global (conservative fallback).
+
+The PR's own intent (commit message) was narrow and reasonable: give `task dev`/`task package` builds a
+genuinely empty OAuth credential store by default, so login/relogin flows for the Armory (delete-account
+testing, #2422/#2423/#2425/#2429) actually get exercised instead of silently inheriting a fully-authenticated
+global session. A follow-up fixup in the same PR even explicitly notes the scope was meant to be narrow:
+*"only the Armory account list / explicitly-bound identity dirs isolate; a default (non-identity-bound) agent
+spawn keeps resolving auth via `provider_auth_dir()`, which stays global regardless."*
+
+The problem is that `identities_dir()` isn't only a credential directory. Per its own doc comment
+(`data_paths.rs:344-353`) and `identity_dir(bundle_id)` (same file, ~line 365): *"Per-provider subdirectories
+(e.g. `claude/`, `codex/`) hang off this when the bundle gains an OAuth binding."* AgentMux points Claude
+Code's `CLAUDE_CONFIG_DIR` at `identities_dir()/<bundle_id>/claude/` for identity-bound agents — which means
+`claude/projects/*.jsonl` (Claude Code's own session transcript store) lives *inside* the exact directory tree
+this flag now isolates per channel by default. **Isolating "the account list" for testing safety and
+isolating "this account's entire conversation history" turned out to be the same code path.**
+
+### 1.3 A fresh per-channel store means a fresh, unlinked UUID every time
+
+`agentmux-srv/src/server/identity_auth_dirs.rs::compute_and_ensure_account_dir` (verified on `origin/main`,
+~line 159):
+
+```rust
+let account_id = if existing_account_id.is_empty() {
+    uuid::Uuid::new_v4().to_string()
+} else {
+    existing_account_id.to_string()
+};
+```
+
+There is no name-keyed lookup here — if the caller doesn't already know an `existing_account_id` (which it
+won't, the very first time a given channel's now-empty per-channel store is consulted), a brand-new random
+UUID is minted with nothing linking it back to the UUID used by the same named agent in the previous channel.
+The only durable link in the system, `db_agent_identity_links (agent_id, account_id, provider)`
+(`agentmux-srv/src/backend/storage/identities.rs:145-150`), lives in whichever store `identities_dir()`
+currently resolves to — so it doesn't survive the channel change either. There is no global, name-anchored
+registry consulted *before* minting a new UUID.
+
+### 1.4 The history browser only ever looks in the global location
+
+`agentmux-srv/src/backend/history/claude_adapter.rs::ClaudeHistoryAdapter::new()` (verified on `origin/main`,
+lines 1-79) builds its scan list from exactly these roots:
+
+- `~/.claude/projects/`, `~/.config/claude-*/projects/` (personal/legacy)
+- `<AGENTMUX_SHARED_DIR>/providers/claude/projects/` (default isolated home)
+- `<AGENTMUX_SHARED_DIR>/identities/<bundle_id>/claude/projects/` (per-identity, **but note: `shared_dir`,
+  never `instance_dir`**)
+
+It never scans `instance_dir.join("identities")` — i.e. `channels/<slug>/identities/*/claude/projects/` or
+`dev/<branch>/*/identities/*/claude/projects/`, the exact per-channel path §1.2's default now sends
+identity-bound agents' history to. This adapter was written and last touched independently of PR #2431; the
+two were never reconciled. The result: since 2026-08-06, there is no code path in the application — fast
+*or* slow — that can locate an identity-bound agent's conversation history once it lands in a fresh channel.
+The only way to find it is a manual, full-tree filesystem search, which is what this investigation itself had
+to do to locate the quoted conversation the operator referenced.
+
+### 1.5 Confirmed live on this machine
+
+`~/.agentmux/shared/identities/` does not exist at all on this machine. `~/.agentmux/channels/local-main-*/
+identities/<uuid>/claude/projects` and `~/.agentmux/dev/<branch>/*/identities/<uuid>/claude/projects` do
+exist, are populated, and are distinct per channel — exactly the fragmentation pattern this report traces.
+This agent's own two identities (`e4e58513-...` under channel `local-agentx-fix-lan-discovery-tx-...`, and
+`eb6e9fdb-...` under channel `local-main-b28b7a-...`) are a direct instance of it: the same logical agent
+("Clamk"), split across two identity UUIDs, discoverable only by grepping every `.jsonl` under
+`~/.agentmux` for a known phrase.
+
+---
+
+## 2. This is a recurring failure class, not a one-off
+
+Four prior incidents establish "agent identity/history must be global; channel is disposable" as the
+intended architecture, and each one is a different way that principle silently regressed:
+
+| Date | Doc | What silently broke |
+|---|---|---|
+| 2026-06-13 | `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` | Agent registry was rooted per-`(channel,version)`; a new build showed an empty roster. Fixed by re-rooting to a global `shared/agents/registry/`. |
+| 2026-06-16 | `docs/retro/retro-legacy-agent-history-cross-channel-2026-06-16.md` | The global history mirror's `sourceBlockId` field leaked a channel-local block id, breaking cross-channel resolution even after the above fix. |
+| 2026-06-16 | `docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md` | The global registry's `session_id` field was declared but never written by production code (only tests), so a fresh channel had nothing to `--resume`, silently starting and then "latching in" a new session that orphaned the original. |
+| 2026-06-13 | `docs/architecture/ARCHITECTURE_AGENT_DATA_AND_CROSS_CHANNEL_2026_06_13.md` | Instance-registry backfill anchored `working_directory` per-channel instead of globally, so `strip_prefix` failed for every real row and "My Agents" came up empty after a channel/version update. |
+| 2026-07-27 | `docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md` | `COMMAND_LIST_RECENT_SESSIONS` aborts its *entire* result on the first error from any of 6 sequential cross-store calls; frontend can't distinguish "fetch failed" from "genuinely zero agents." Explicitly logged as the **third-plus** occurrence of this class, with the recommendation (per-source error degradation, distinct UI error state, e2e test) never implemented. |
+
+This report's finding (§1) is the same class again, via a fifth, different mechanism: a *credential-testing*
+change with a narrow, well-reasoned intent had an unreviewed blast radius into *history storage*, because the
+two concerns share a directory tree. The pattern across all five: the global-vs-per-channel boundary is
+enforced by convention and code review, not by an automated invariant — so it keeps drifting back.
+
+---
+
+## 3. What this is *not*
+
+- **Not a bug in this agent's own working directory or CLAUDE.md.** `clamk-0612a`'s `CLAUDE.md`/config is
+  correct; the fragmentation happens below the agent-definition layer, in shared platform code.
+- **Not intentional data loss.** PR #2431's author (per the fixup commit's own review-response note) believed
+  the isolation was scoped to "the Armory account list / explicitly-bound identity dirs" and did not intend
+  to isolate conversation transcripts. The bug is that those two things are the same directory tree today.
+- **Not fixable by reverting PR #2431 outright.** Its actual goal (real login/relogin testing coverage on
+  dev/local builds) is legitimate and already referenced by `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`
+  and `docs/specs/SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`. The fix is to narrow its scope, not
+  undo it (§4.1).
+
+---
+
+## 4. Proposed design
+
+### 4.1 Split "credential isolation" from "history storage" (fixes the regression)
+
+Add a second resolver, e.g. `identity_history_dir(bundle_id, provider)`, that **always** resolves under
+`shared_dir.join("identities").join(bundle_id).join(provider)` — regardless of `isolated_auth_enabled()`.
+Point `CLAUDE_CONFIG_DIR`'s `projects/` subpath (and equivalents for other providers) at this always-global
+location, while credential material (`.credentials.json`, tokens) continues to honor
+`isolated_auth_enabled()` via the existing `identities_dir()`. Concretely this likely means spawning Claude
+Code with two separately-configured paths instead of one combined config-dir root, or seeding a junction/
+symlink from the isolated dir's `projects/` into the shared one at bundle-creation time. This is the direct
+fix for §1.2 — testing safety for credentials is preserved; conversation history stops being collateral
+damage.
+
+### 4.2 Stable name → bundle_id mapping (fixes §1.3, independent of 4.1)
+
+Extend the existing global agent registry record (`shared/agents/registry/<agent_id>.json`, per
+`SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE`) with an `identity_bundle_id` field. Before
+`compute_and_ensure_account_dir` mints a fresh UUID, it should look up this global, always-channel-independent
+mapping for an existing bundle id tied to this agent and reuse it, only falling back to `Uuid::new_v4()` when
+truly no prior binding exists anywhere. This removes "new UUID every fresh channel" as a failure mode even if
+some other future change re-isolates history storage.
+
+### 4.3 Fix the read path regardless (belt-and-suspenders, unblocks recovery today)
+
+Update `ClaudeHistoryAdapter::new()` to also enumerate every channel's per-channel identities dir —
+`channels/*/identities/*/claude/projects` and `dev/*/*/identities/*/claude/projects` — not just the global
+`shared_dir/identities`. This is what makes *already-fragmented* history (everything written between
+2026-08-06 and whenever 4.1 ships, plus any future recurrence) recoverable through the UI instead of a manual
+grep, independent of whether the write path is ever fully fixed.
+
+### 4.4 A fast index instead of a filesystem walk (the actual "fast lookup" ask)
+
+Once 4.1–4.3 land, build a small persisted index — e.g. `shared/agents/history-index.json` or a table in the
+existing shared store — mapping `agent_id -> [{channel, bundle_id, project_path_hash, session_file,
+last_modified}]`. Populate/refresh it incrementally whenever `ClaudeHistoryAdapter` scans (or on a
+lightweight fs-watch), and have the "Conversation History" UI action and `ListRecentSessionsCommand` consult
+the index first. This turns "find this agent's last conversation" into an O(1) keyed lookup instead of an
+O(every `.jsonl` under `~/.agentmux`) walk — the concrete speed problem the operator raised, and the reason
+this investigation itself took a multi-file `grep` sweep rather than a single lookup.
+
+### 4.5 Make the invariant enforced, not conventional
+
+Given this is the fifth occurrence of the same class of regression (§2), the recommendation from the
+2026-07-27 retro — never implemented — should be treated as a prerequisite, not a nice-to-have:
+
+1. **An e2e test**: create a named, identity-bound agent; drive one turn; simulate a version bump (fresh
+   local build → new channel, matching `hash.rs`'s own per-build test setup); reopen the agent; assert (a) the
+   same `bundle_id` is reused, (b) the prior Claude session file is discoverable via the history adapter/
+   index, (c) the "Conversation History" action returns it without a filesystem walk.
+2. **A structural coupling check**: any future PR that changes what `isolated_auth_enabled()`/
+   `identities_dir()` isolates must also touch `ClaudeHistoryAdapter`'s scan list, or a test should fail —
+   e.g. a single shared constant/test asserting the two directory-enumeration lists agree on every base path
+   `identities_dir()` can resolve to, for both isolated and global cases.
+
+### 4.6 Immediate mitigation (before 4.1–4.5 ship)
+
+This is a live, 10-day-old regression actively losing history-findability on every fresh local build. Until
+the structural fix lands, either (a) fast-follow 4.1 as a standalone hotfix (narrowest, most direct), or (b)
+as a stopgap, explicitly set `AGENTMUX_ISOLATED_AUTH=0` in the launch environment for identity-bound
+"named continuing agent" launches specifically (as opposed to disposable Armory test agents), so they keep
+resolving to the global store until the real fix ships.
+
+---
+
+## Appendix: research method
+
+Two research agents were dispatched in parallel: one read the relevant specs/retros/analysis docs in full
+(§2's table), the other read the live code paths (channel creation, identity minting, the history adapter,
+the frontend history surfaces). A third, nested agent summarized additional recent retros/analyses not in the
+first agent's initial list. Every code claim material to the root-cause conclusion (§1) was then independently
+re-verified by this agent directly against `git show`/`grep` output — not taken on the sub-agents' word alone
+— including pulling the full diff of commit `9f6cc2824` to confirm the exact default-resolution logic, and
+reading `identities_dir()`, `provider_auth_dir()`, `compute_and_ensure_account_dir`, and
+`ClaudeHistoryAdapter::new()` in full rather than trusting excerpted summaries. The local checkout being 210
+commits behind `origin/main` was itself a relevant finding (§ground truth basis) — the regression exists only
+on `origin/main` and would not have been reproducible by reading this checkout's own working tree alone.

--- a/docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+++ b/docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
@@ -1,0 +1,225 @@
+# Canonical Agent Identity/History Persistence Protocol — Synthesis with Mandatory ABF
+
+**Date:** 2026-08-16
+**Author:** Clamk (agent, `~/.agentmux/agents/clamk-0612a`), at operator request
+**Status:** Proposal — synthesizes two existing documents into a canonical protocol; not yet implemented or
+reviewed.
+**Ground truth basis:** `agentmuxai/agentmux` local checkout at `3705f83c3`
+(`agent3/bashwrap-persist-cwd-across-calls`), cross-checked against `origin/main` at `72aefad4d`.
+**Related:**
+`docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md` (this agent's own root-cause report,
+written earlier the same day — background for §1-2 below),
+`docs/specs/ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` (PR #2587, merged 2026-08-15 — the "every
+agent gets its own dedicated, portable bundle" work this doc builds on),
+`docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`,
+`docs/specs/SPEC_AGENT_GLOBAL_PORTABILITY_2026-06-16.md`.
+**Motivation:** the operator, after reading the root-cause report, asked three questions: (1) does this
+indicate the system is mid-migration and needs cleanup, (2) should there be a formal spec canonizing the
+correct protocol, and (3) could the just-shipped Mandatory ABF work be the right place to anchor conversation
+history, so it's naturally portable. This doc answers all three together, since the answer to (3) changes the
+shape of (2).
+
+---
+
+## 1. Yes — this is a mid-migration state, with three overlapping unfinished migrations
+
+The operator's instinct is correct. Three separate, independently-tracked migrations are all in-flight at
+once, and the identity/history fragmentation bug traced in the companion report is a symptom of exactly this
+overlap, not an isolated defect:
+
+### 1.1 The `db_agent_definitions`/`db_agent_instances` → `db_agents` consolidation is stalled mid-phase
+
+`agentmux-srv/src/backend/storage/migrations.rs`'s own schema-version comment (v4, `OBJECT_SCHEMA_VERSION`)
+states: *"db_agents consolidation table (Phase 3a; dual-write only, reads still on
+db_agent_definitions / db_agent_instances)."* **This comment is stale and wrong as of 2026-08-15.** PR #2587's
+review round 2 (documented in `ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §3.1's 2026-08-15 correction)
+discovered live, while implementing an unrelated backfill migration, that `agent_def_list()` — the function
+most of the codebase already uses to enumerate agents — **already reads from the consolidated `db_agents`
+table**, not `db_agent_definitions`. Nobody had updated the schema-version doc comment, or apparently
+realized the read-side flip (Phase 3b) had partially happened, until a migration written against the
+documented (stale) model broke on its second run. This is a mid-migration system whose own internal
+documentation disagrees with its own code about which phase it's in.
+
+### 1.2 The identity/credential store-routing split (`wstore` vs `id_store`) is enforced by convention only, and was violated the same week
+
+`server/mod.rs`'s own doc comment establishes the rule: handlers must capture `id_store` (not `wstore`) "for
+any operation that must survive across version upgrades." This is precisely the invariant the companion
+report's root cause (PR #2431, `identities_dir()`) and this doc's §2 are both about. Yet PR #2587 — the
+Mandatory ABF work itself, merged one day before this report — shipped its first version with exactly this
+bug: bundle provisioning at all six agent-creation call sites, and the new `m0021` backfill migration, wrote
+into `wstore` (the per-channel store) instead of `id_store` (the shared/global store), making every newly
+provisioned per-agent bundle invisible to Armory and to the bundle-summary panel the same PR added. This was
+caught and fixed in review (§8 of the ABF doc) — but it demonstrates the "silently routes global data through
+a per-channel store" failure mode is not a one-off from 2026-08-06; it is actively recurring in brand-new code
+as of 2026-08-15, because there is still no structural guard against it (§2.2 below proposes one).
+
+### 1.3 The history-adapter/identity-isolation split was never reconciled at all
+
+Per the companion report, `ClaudeHistoryAdapter` (the code that finds Claude Code transcripts) has not been
+touched to account for PR #2431's `identities_dir()` default change. These two pieces of code were written by
+different efforts, at different times, and nothing currently checks that they agree on where history can
+live. This is not "a migration in progress" so much as "a migration that was never started" — the read path
+simply doesn't know the write path's default changed.
+
+**Conclusion for (1):** yes, this needs cleanup, and it is bigger than the single regression the companion
+report root-caused. There are at least three independent seams (definition-table consolidation, store
+routing, and history-path/identity-isolation coupling) that all touch the same underlying data and are all
+individually incomplete. A canonical protocol (§2) should resolve all three at once, since patching any one in
+isolation leaves the other two as latent recurrences of the same bug class.
+
+---
+
+## 2. A canonical protocol (answers "do we want a formal spec")
+
+Propose formalizing the following as an enforced protocol, not a convention — five invariants, each with a
+concrete mechanism, targeting the exact failure modes in §1 and the companion report's §2 table (five prior
+incidents, all the same class):
+
+### P1 — Every piece of agent data has exactly one declared scope, from a closed taxonomy
+
+| Scope | Contains | Lives | Keyed by |
+|---|---|---|---|
+| **CREDENTIAL** | OAuth tokens, PATs | Global, unless `isolated_auth_enabled()` (per-channel, for Armory testing only) | `bundle_id` (account) |
+| **DEFINITION** | Agent identity: name, provider, `default_memory_id` binding | Always global | `agent_id` |
+| **PORTABLE CONFIG (ABF)** | Instructions, context, skills, memory, harness+model | Always global | `memory_id` (bundle id) |
+| **CONVERSATION HISTORY** | Provider transcripts (Claude/Codex/etc. session JSONL) | Always global | `agent_id` (§3 — not `memory_id`, not account/bundle UUID) |
+| **RUNTIME/EPHEMERAL** | Pane layout, active session pointer, per-launch instance rows | May legitimately be per-channel/per-instance | `channel` + `instance_id` |
+
+This table is new — today, scope is decided ad hoc per call site (§1.2's bug is a direct consequence: nothing
+declared which scope a newly-provisioned bundle belonged to, so the six call sites each guessed, and five
+guessed wrong). RUNTIME/EPHEMERAL is the *only* row channel isolation is allowed to touch; every regression
+in the companion report's §2 table and §1 above is a case of channel-scoping leaking into one of the other
+four rows.
+
+### P2 — One resolver per scope, no ad hoc store access
+
+Every read/write for CREDENTIAL/DEFINITION/PORTABLE CONFIG/CONVERSATION HISTORY must go through a named
+resolver (`identities_dir()`, an `agent_id`-keyed definition accessor, a `memory_id`-keyed bundle accessor, a
+new `agent_history_store(agent_id)` accessor) — never direct `wstore`/`instance_dir` access from a new call
+site. This is already the intended pattern (`id_store` vs `wstore`); P2 just says it must be the *only*
+pattern, enforced by P3 rather than left to individual PR authors to remember (which is exactly what failed
+in §1.2).
+
+### P3 — Each scope's routing is covered by an automated test, not a comment
+
+`agentmux-common/src/data_paths.rs` already has this shape for CREDENTIAL
+(`identities_dir_is_shared_on_stable_channel` etc., §1.2 of the companion report) — extend the same pattern to
+the other three non-ephemeral scopes: a test asserting DEFINITION reads/writes never vary by channel, a test
+asserting PORTABLE CONFIG never lands in a per-channel store (this would have caught §1.2's bug directly), and
+a new test asserting CONVERSATION HISTORY resolves to the same location regardless of which channel the
+resolving code runs in. Per the companion report §4.5 and the 2026-07-27 retro this is the *fourth-plus* time
+this exact recommendation has been made and not shipped — treat it as a blocking prerequisite for this
+protocol, not an optional follow-up.
+
+### P4 — Migration-phase state is a single source of truth, not a doc comment
+
+§1.1's stale comment caused a real bug (the `m0021` `UNIQUE constraint failed` loop). Track which phase each
+in-flight table consolidation is actually in in one place the code itself can assert against — e.g. a
+`#[test]` that queries which table `agent_def_list()` and its siblings actually read from and fails if it
+doesn't match the doc comment's claimed phase — rather than trusting the comment to be updated by hand every
+time a partial flip happens.
+
+### P5 — Conversation history anchors on `agent_id`, using the ABF binding as its registry (§3)
+
+---
+
+## 3. Should conversation history be persisted in the ABF? — Yes and no; the useful part is the anchor, not the payload
+
+The Mandatory ABF work (2026-08-15) is directly relevant, and the operator's instinct that it "may play into"
+this is right — but the useful piece is narrower than "store transcripts inside the bundle."
+
+### 3.1 What ABF now provides that didn't exist this morning
+
+As of PR #2587, every agent **definition** has exactly one dedicated bundle, bound at definition-creation
+time (not launch time), written through `id_store` (global, cross-channel, after the §1.2 fix), with the
+binding living on `db_agents.default_memory_id`. Concretely: **this is now exactly the "stable name → durable
+id, written once, globally, at definition time" registry that the companion report's §4.2 proposed building
+from scratch** ("Extend the existing global agent registry record ... with an `identity_bundle_id` field ...
+before minting a fresh UUID, look up this global mapping and reuse it"). The ABF work independently built the
+infrastructure for that same shape, for a different reason (portable instructions, not history). Reusing it
+is strictly cheaper than building a second, parallel global registry.
+
+### 3.2 Why the anchor should be `agent_id`, not `memory_id` (the bundle itself)
+
+It's tempting to key history directly on `memory_id` since that's the id that's now stable and global. Don't
+— two properties of ABF make it the wrong direct anchor:
+
+- **Bundles can be shared or rebound.** §4 of the ABF doc explicitly keeps this open ("not proposing to
+  restrict sharing... if a user explicitly wants that"). If two agents ever point at the same `memory_id`,
+  keying history by bundle id would merge their conversations into one history — wrong, and silently so.
+- **Bundles can outlive their agent, or an agent could in principle rebind.** §5 decision 2 of the ABF doc:
+  deleting an agent orphans its bundle by default rather than deleting it. History should stay attached to
+  the *agent* across a bundle swap or an agent's deletion-and-bundle-orphaning, not silently move or vanish
+  because the bundle's lifecycle diverged from the agent's.
+
+So: **use the agent's own durable `agent_id` as the conversation-history anchor** (matching
+`SPEC_AGENT_GLOBAL_PORTABILITY`'s original intent), but **use the ABF binding (`default_memory_id`, written
+at definition time, globally, via `id_store`) as the mechanism that makes `agent_id` itself discoverable and
+stable across a channel change** — i.e., the missing piece from the companion report (§1.3: "a fresh, random
+UUID is minted every channel with nothing tying it to the previous one") is fixed not by inventing new plumbing,
+but by the fact that a Mandatory-ABF agent's `agent_id` is now already resolvable through the same global,
+definition-time-bound registry the bundle uses, instead of through a per-channel, per-launch account UUID
+that never had a durable identity to begin with.
+
+### 3.3 Why the transcript payload itself should stay out of the ABF export
+
+ABF's own stated design (§7.1 of the architecture doc) is "the portable unit isn't the agent, it's the ABF" —
+explicitly meant to be exported, imported, and **shared** (§4: "not proposing to restrict sharing... a
+team-wide instruction set"). A multi-MB-to-GB, single-agent, high-churn, non-reusable conversation transcript
+is a different kind of artifact than a reusable instructions/context/skills bundle, and embedding it would:
+
+- Bloat every ordinary ABF export (instructions-sharing use case) with unrelated, often-huge private data.
+- Create exactly the ambiguity §3.2 warns about — if bundle B is shared by two agents and the export embeds
+  "the" conversation history, whose history is it?
+- Conflict with the "orphan, don't delete" bundle-lifecycle default (§5 decision 2) — that default makes
+  sense for reusable instructions a user might want to recover later; it's a much more consequential default
+  for a full private conversation record, and deserves its own explicit decision rather than inheriting the
+  bundle's.
+
+**Recommendation:** keep conversation history in its own store (per the companion report §4.1/§4.3-4.4,
+always-global, keyed by `agent_id`), and add a **separate, explicit, opt-in "export with history" action** —
+distinct from the default ABF export — for the genuine use case of moving one specific agent's full record to
+another machine. The default `bundle.export_for_agent` stays lean and shareable, exactly as designed.
+
+---
+
+## 4. Recommended sequencing
+
+Building on the companion report's §4 (which this section supersedes/refines with the ABF-anchor insight):
+
+1. **Finish P4 first, cheaply**: fix the stale Phase 3a/3b comment in `migrations.rs` to state the actual
+   current reality (`agent_def_list()` already reads `db_agents`), and add the doc/code-agreement test P4
+   describes. Low-risk, unblocks reasoning about everything else correctly.
+2. **P1's taxonomy + P3's tests, applied first to the two known-bad scopes**: add the missing PORTABLE CONFIG
+   and DEFINITION routing tests (would have caught §1.2's bug); add the CREDENTIAL vs CONVERSATION HISTORY
+   split from the companion report's §4.1 (split `identities_dir()`'s effect on `claude/projects` out from
+   its effect on credential material).
+3. **Wire `agent_id` → history resolution through the existing ABF/`default_memory_id` binding** (§3.2) —
+   this both fixes the companion report's §1.3 (no more freshly-minted, unlinked UUIDs for identity-bound
+   agents) and gives CONVERSATION HISTORY its P1-mandated stable key, in one change, reusing infrastructure
+   PR #2587 already shipped rather than building a parallel registry.
+4. **Fix the read path** (companion report §4.3: `ClaudeHistoryAdapter` scans the per-channel path too) and
+   **build the fast index** (§4.4) on top of the now-stable `agent_id` anchor — this is what actually makes
+   "Conversation History" fast, per the operator's original ask, and it only needs to be built once the anchor
+   from step 3 is stable, not before.
+5. **Add the opt-in "export with history" action** (§3.3) as a genuinely new, separate feature once steps 1-4
+   give it something stable to read from.
+6. **Formalize P2/P3 as a written, reviewable checklist** (not just this doc) that any PR touching
+   CREDENTIAL/DEFINITION/PORTABLE CONFIG/CONVERSATION HISTORY routing must satisfy before merge — the actual
+   "formal specification that canonizes the proper protocol" the operator asked for, once steps 1-5 have
+   proven the taxonomy holds up against real implementation (this doc is the proposal; a leaner, PR-checklist
+   version is the artifact worth canonizing after review, per this repo's own pattern of "DECISIONS RESOLVED"
+   docs preceding a "PR-sized checklist" — see how `ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` itself
+   was structured).
+
+---
+
+## Appendix: what changed since the companion report (same day)
+
+The companion report (`REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md`, written earlier today)
+proposed a new "stable name → bundle_id mapping" (its §4.2) as new infrastructure to build. This doc's
+contribution is realizing that infrastructure was *already built*, one day earlier, for a different purpose
+(PR #2587's Mandatory ABF), and reusing it is both cheaper and more consistent with this codebase's existing
+"global registry written at definition time" pattern than adding a second one. The companion report's root
+cause (§1 there) and proposed fixes 4.1, 4.3, 4.4, 4.5 stand unchanged; only 4.2's mechanism is superseded by
+§3.2 above.


### PR DESCRIPTION
## Summary

Step 1 of a sequenced fix for named agents' conversation history fragmenting across channel/identity UUIDs on every rebuild (root-caused in the included report). This PR only does the cheapest, lowest-risk piece: correcting stale documentation and pinning the real behavior down with a test. No runtime behavior changes.

- Three separate doc comments (`OBJECT_SCHEMA_VERSION`'s v4 entry in `migrations.rs`, `dual_write.rs`'s module doc, `agents.rs`'s module doc) claimed the `db_agent_definitions`/`db_agent_instances` → `db_agents` consolidation was still "reads on the legacy tables" / "old tables authoritative" — false since `agent_def_list()` was quietly flipped to read `db_agents` (discovered during PR #2587's review). Corrected all three to state the real, per-function split precisely.
- Added `agent_def_list_and_agent_def_get_read_different_tables_by_design`, a test that builds a row in each table independently and asserts which function sees which, so the doc comments can't silently drift out of sync with the code again (protocol invariant P4, see below).
- Added `docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md` — root-causes the actual bug (PR #2431's `identities_dir()` default flip, 2026-08-06, never reconciled with `ClaudeHistoryAdapter`'s scan list).
- Added `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md` — synthesizes that root cause with the Mandatory ABF work (PR #2587) into a proposed 5-invariant protocol (P1-P5) and a build sequence. This PR is step 1 of that sequence; steps 2-6 will follow as separate PRs.

## Test plan

- [x] `cargo check -p agentmux-srv` — clean, no new warnings/errors
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::storage::agents::tests::` — 8/8 pass, including the new test
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::storage::` — 282/282 pass, no regressions

<!-- agentmux:agent_id=clamk -->