### PR TITLE
Clamk@claudius: fix jekt signing-key injection gap on the normal launch path

### DIFF
--- a/.changesets/1786886693-fix-jekt-inject-host-lan-signing-keys-on-the-normal-launch-p-5ce3.md
+++ b/.changesets/1786886693-fix-jekt-inject-host-lan-signing-keys-on-the-normal-launch-p-5ce3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(jekt): inject host/LAN signing keys on the normal launch path, not just agent.open

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -877,6 +877,50 @@ pub fn write_managed_skill_file_manifest(
     }
 }
 
+/// Best-effort: mint-or-reuse `agent_slug`'s jekt/LAN signing keys
+/// (`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` §2.2,
+/// `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md` §2.1) and patch them into a
+/// `.mcp.json` file's `mcpServers.agentmux.env` block. Returns `None` on
+/// any parse failure, missing `mcpServers.agentmux.env` object, or if
+/// neither key could be ensured — callers must keep the original content
+/// in that case; this must never block writing the agent's config.
+///
+/// Shared by `agent.open` (`server/app_api/agent_open.rs`) and the
+/// `WriteAgentConfig` "click Launch" path (`server/editor_handlers.rs`) —
+/// per this module's own doc comment, the two `.mcp.json`-materializing
+/// call sites that must not drift out of sync. Before this function
+/// existed, only `agent.open` injected these keys — `WriteAgentConfig`
+/// (the path a normal Launch-button click actually goes through) silently
+/// never did, so ordinarily-launched agents' jekts rendered
+/// `TRUST=self-declared` even on builds well past both features shipping.
+/// See `docs/specs/REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md`.
+pub fn inject_jekt_signing_keys_into_mcp_json(
+    content: &str,
+    wstore: &crate::backend::storage::store::Store,
+    agent_slug: &str,
+) -> Option<String> {
+    let mut mcp_json: Value = serde_json::from_str(content).ok()?;
+    let env = mcp_json
+        .pointer_mut("/mcpServers/agentmux/env")
+        .and_then(|v| v.as_object_mut())?;
+
+    let mut patched = false;
+    if let Ok(key) = wstore.agent_jekt_key_ensure(agent_slug) {
+        use base64::Engine as _;
+        let key_b64 = base64::engine::general_purpose::STANDARD.encode(&key);
+        env.insert("AGENTMUX_JEKT_KEY".to_string(), json!(key_b64));
+        patched = true;
+    }
+    if let Ok(keypair) = wstore.agent_lan_key_ensure(agent_slug) {
+        env.insert("AGENTMUX_LAN_KEY".to_string(), json!(keypair.private_key));
+        patched = true;
+    }
+    if !patched {
+        return None;
+    }
+    serde_json::to_string_pretty(&mcp_json).ok()
+}
+
 // ============================================================
 // Tests
 // ============================================================
@@ -1372,5 +1416,55 @@ mod tests {
         );
         let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
         assert!(claude_md.content.contains("I am aria, working in /home/user/my-project."));
+    }
+
+    // docs/specs/REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md: this
+    // function exists specifically so `agent.open` and `WriteAgentConfig`
+    // (the actual "click Launch" path) can't drift out of sync on jekt/LAN
+    // key injection the way they did before this fix.
+    #[test]
+    fn inject_jekt_signing_keys_into_mcp_json_patches_both_keys_into_the_env_block() {
+        let store = crate::backend::storage::store::Store::open_in_memory().unwrap();
+        let content = serde_json::to_string(&json!({
+            "mcpServers": { "agentmux": { "type": "stdio", "command": "agentmux-mcp", "env": { "AGENTMUX_AGENT_ID": "aria" } } }
+        }))
+        .unwrap();
+
+        let rewritten = inject_jekt_signing_keys_into_mcp_json(&content, &store, "aria")
+            .expect("both keys should ensure successfully against a fresh in-memory store");
+        let parsed: Value = serde_json::from_str(&rewritten).unwrap();
+        let env = &parsed["mcpServers"]["agentmux"]["env"];
+        assert_eq!(env["AGENTMUX_AGENT_ID"], "aria", "existing fields must survive the patch");
+        assert!(env["AGENTMUX_JEKT_KEY"].is_string() && !env["AGENTMUX_JEKT_KEY"].as_str().unwrap().is_empty());
+        assert!(env["AGENTMUX_LAN_KEY"].is_string() && !env["AGENTMUX_LAN_KEY"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn inject_jekt_signing_keys_into_mcp_json_reuses_the_same_key_on_a_second_call() {
+        let store = crate::backend::storage::store::Store::open_in_memory().unwrap();
+        let content = serde_json::to_string(&json!({
+            "mcpServers": { "agentmux": { "env": { "AGENTMUX_AGENT_ID": "aria" } } }
+        }))
+        .unwrap();
+
+        let first = inject_jekt_signing_keys_into_mcp_json(&content, &store, "aria").unwrap();
+        let second = inject_jekt_signing_keys_into_mcp_json(&content, &store, "aria").unwrap();
+        let first_key = serde_json::from_str::<Value>(&first).unwrap()["mcpServers"]["agentmux"]["env"]["AGENTMUX_JEKT_KEY"].clone();
+        let second_key = serde_json::from_str::<Value>(&second).unwrap()["mcpServers"]["agentmux"]["env"]["AGENTMUX_JEKT_KEY"].clone();
+        assert_eq!(first_key, second_key, "minted-on-first-use key must be reused, not re-minted, on every materialization");
+    }
+
+    #[test]
+    fn inject_jekt_signing_keys_into_mcp_json_returns_none_when_theres_no_env_object_to_patch() {
+        let store = crate::backend::storage::store::Store::open_in_memory().unwrap();
+        // No mcpServers.agentmux.env at all -- nothing to patch into.
+        let content = serde_json::to_string(&json!({"hello": "world"})).unwrap();
+        assert!(inject_jekt_signing_keys_into_mcp_json(&content, &store, "aria").is_none());
+    }
+
+    #[test]
+    fn inject_jekt_signing_keys_into_mcp_json_returns_none_on_malformed_json() {
+        let store = crate::backend::storage::store::Store::open_in_memory().unwrap();
+        assert!(inject_jekt_signing_keys_into_mcp_json("not json", &store, "aria").is_none());
     }
 }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -768,78 +768,34 @@ pub(super) fn write_agent_config_files(
         }
     }
 
-    // Host-tier jekt sender signing key (SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md
-    // §2.2) — inject AGENTMUX_JEKT_KEY into the agentmux MCP server's own env,
-    // right alongside AGENTMUX_AGENT_ID, so `SendMessage`/`Loop` can sign
-    // outgoing jekts as this agent. Ensured (minted on first use, reused after)
-    // via the same Store this function already has; never returned over any
-    // RPC, never written anywhere but this ONE agent's own process env and
-    // srv's own local table. Best-effort: a failure here must never block
-    // agent spawn — the agent still launches, just without a key, and its
-    // jekts render TRUST=self-declared instead of host-verified until the
-    // next successful spawn.
-    if let Ok(key) = wstore.agent_jekt_key_ensure(agent_slug) {
-        if let Some(pos) = config_files.iter().position(|f| f.filename == ".mcp.json") {
-            let key_b64 = {
-                use base64::Engine as _;
-                base64::engine::general_purpose::STANDARD.encode(&key)
-            };
-            match serde_json::from_str::<serde_json::Value>(&config_files[pos].content) {
-                Ok(mut mcp_json) => {
-                    if let Some(env) = mcp_json
-                        .pointer_mut("/mcpServers/agentmux/env")
-                        .and_then(|v| v.as_object_mut())
-                    {
-                        env.insert("AGENTMUX_JEKT_KEY".to_string(), serde_json::json!(key_b64));
-                        if let Ok(rewritten) = serde_json::to_string_pretty(&mcp_json) {
-                            config_files[pos].content = rewritten;
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        agent_id = %agent.id,
-                        error = %e,
-                        "agent_open: .mcp.json failed to parse — AGENTMUX_JEKT_KEY not injected, \
-                         this agent's jekts will render TRUST=self-declared instead of host-verified"
-                    );
-                }
-            }
-        }
-    }
-
-    // LAN-tier jekt sender signing key (SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md
-    // §2.1) — same injection pattern as AGENTMUX_JEKT_KEY immediately above,
-    // asymmetric instead of symmetric: only the PRIVATE half goes into this
-    // one agent's own process env; the public half is what LAN peers query
-    // for over `GET /agentmux/reactive/agent` (see
-    // `handle_reactive_agent`/`LanDiscoveryController::find_agent_lan_pubkey`).
-    // Same best-effort guarantee — a failure here must never block agent
-    // spawn, and until the next successful spawn this agent's LAN jekts
-    // simply carry no lan_sig (TRUST=network-claimed, not lan-verified,
-    // exactly as if this feature didn't exist).
-    if let Ok(keypair) = wstore.agent_lan_key_ensure(agent_slug) {
-        if let Some(pos) = config_files.iter().position(|f| f.filename == ".mcp.json") {
-            match serde_json::from_str::<serde_json::Value>(&config_files[pos].content) {
-                Ok(mut mcp_json) => {
-                    if let Some(env) = mcp_json
-                        .pointer_mut("/mcpServers/agentmux/env")
-                        .and_then(|v| v.as_object_mut())
-                    {
-                        env.insert("AGENTMUX_LAN_KEY".to_string(), serde_json::json!(keypair.private_key));
-                        if let Ok(rewritten) = serde_json::to_string_pretty(&mcp_json) {
-                            config_files[pos].content = rewritten;
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        agent_id = %agent.id,
-                        error = %e,
-                        "agent_open: .mcp.json failed to parse — AGENTMUX_LAN_KEY not injected, \
-                         this agent's LAN jekts will render TRUST=network-claimed instead of lan-verified"
-                    );
-                }
+    // Host-tier + LAN-tier jekt sender signing keys
+    // (SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md §2.2,
+    // SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md §2.1) — inject
+    // AGENTMUX_JEKT_KEY / AGENTMUX_LAN_KEY into the agentmux MCP server's
+    // own env, right alongside AGENTMUX_AGENT_ID, so `SendMessage`/`Loop`
+    // can sign outgoing jekts as this agent. Best-effort: a failure here
+    // must never block agent spawn — the agent still launches, just
+    // without a key, and its jekts render TRUST=self-declared /
+    // TRUST=network-claimed instead of verified until the next successful
+    // materialization. Shared with `WriteAgentConfig`
+    // (server/editor_handlers.rs, the "click Launch" path) via
+    // `agent_config::inject_jekt_signing_keys_into_mcp_json` — see that
+    // function's doc comment for why this must not be duplicated inline
+    // again.
+    if let Some(pos) = config_files.iter().position(|f| f.filename == ".mcp.json") {
+        match crate::backend::agent_config::inject_jekt_signing_keys_into_mcp_json(
+            &config_files[pos].content,
+            &wstore,
+            agent_slug,
+        ) {
+            Some(rewritten) => config_files[pos].content = rewritten,
+            None => {
+                tracing::warn!(
+                    agent_id = %agent.id,
+                    "agent_open: jekt/LAN signing keys not injected into .mcp.json — \
+                     this agent's jekts will render TRUST=self-declared / TRUST=network-claimed \
+                     instead of verified"
+                );
             }
         }
     }

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -106,6 +106,7 @@ fn inject_global_bundles(claude_md: &str, id_store: &Arc<Store>) -> String {
 
 pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
+    let wstore = state.wstore.clone();
     let editor_file_watcher = state.editor_file_watcher.clone();
     let media_file_watcher = state.media_file_watcher.clone();
 
@@ -207,8 +208,9 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
         COMMAND_WRITE_AGENT_CONFIG,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
+            let wstore = wstore.clone();
             Box::pin(async move {
-                let cmd: CommandWriteAgentConfigData = serde_json::from_value(data)
+                let mut cmd: CommandWriteAgentConfigData = serde_json::from_value(data)
                     .map_err(|e| format!("writeagentconfig: {e}"))?;
                 tracing::info!(
                     working_dir = %cmd.working_dir,
@@ -216,6 +218,42 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     auto_allocate = cmd.auto_allocate,
                     "WriteAgentConfig"
                 );
+
+                // Host-tier + LAN-tier jekt sender signing keys — see
+                // `agent_config::inject_jekt_signing_keys_into_mcp_json`'s doc
+                // comment. This is the actual "click Launch" path (per this
+                // handler's own doc below); `agent.open`'s equivalent
+                // injection alone left every normally-launched agent's
+                // jekts rendering TRUST=self-declared, since the frontend's
+                // `agent-config-builder.ts` only ever sets AGENTMUX_AGENT_ID.
+                // Best-effort — a missing/unresolvable agent slug or a
+                // key-ensure failure just means this materialization goes
+                // out unsigned, same as any other spawn.
+                if let Some(pos) = cmd.files.iter().position(|f| f.path == ".mcp.json") {
+                    let agent_slug = serde_json::from_str::<serde_json::Value>(&cmd.files[pos].content)
+                        .ok()
+                        .and_then(|v| {
+                            v.pointer("/mcpServers/agentmux/env/AGENTMUX_AGENT_ID")
+                                .and_then(|s| s.as_str())
+                                .map(str::to_string)
+                        });
+                    if let Some(agent_slug) = agent_slug {
+                        if let Some(rewritten) = crate::backend::agent_config::inject_jekt_signing_keys_into_mcp_json(
+                            &cmd.files[pos].content,
+                            &wstore,
+                            &agent_slug,
+                        ) {
+                            cmd.files[pos].content = rewritten;
+                        } else {
+                            tracing::warn!(
+                                agent_slug = %agent_slug,
+                                "WriteAgentConfig: jekt/LAN signing keys not injected into .mcp.json — \
+                                 this agent's jekts will render TRUST=self-declared / TRUST=network-claimed \
+                                 instead of verified"
+                            );
+                        }
+                    }
+                }
 
                 // Resolve to a final on-disk path. For auto-generated
                 // instance paths (`auto_allocate: true`), use the
@@ -1031,5 +1069,57 @@ mod tests {
             "stale .claude/skills/deploy/SKILL.md must be removed by the writeagentconfig path too"
         );
         assert!(base_path.join(".claude/commands/deploy.md").exists());
+    }
+
+    /// docs/specs/REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md: before
+    /// this fix, `WriteAgentConfig` (the actual "click Launch" path) never
+    /// injected jekt/LAN signing keys at all -- only `agent.open` did, a
+    /// path most normal launches don't go through. This exercises the exact
+    /// slug-extraction-then-injection sequence the real handler runs,
+    /// against the real `rpc_types::AgentConfigFile{path, content}` shape
+    /// the frontend's `agent-config-builder.ts` actually produces (only
+    /// `AGENTMUX_AGENT_ID` set -- no jekt fields), the same
+    /// field-name-mismatch class of bug the test above this one guards
+    /// against for `managed_skill_file_paths`.
+    #[test]
+    fn writeagentconfig_extracts_slug_and_injects_signing_keys_into_the_real_mcp_json_shape() {
+        let store = crate::backend::storage::store::Store::open_in_memory().unwrap();
+        let files = vec![AgentConfigFile {
+            path: ".mcp.json".to_string(),
+            content: serde_json::to_string(&serde_json::json!({
+                "mcpServers": {
+                    "agentmux": {
+                        "type": "stdio",
+                        "command": "agentmux-mcp",
+                        "args": [],
+                        "env": { "AGENTMUX_AGENT_ID": "aria" }
+                    }
+                }
+            }))
+            .unwrap(),
+        }];
+
+        let pos = files.iter().position(|f| f.path == ".mcp.json").unwrap();
+        let agent_slug = serde_json::from_str::<serde_json::Value>(&files[pos].content)
+            .ok()
+            .and_then(|v| {
+                v.pointer("/mcpServers/agentmux/env/AGENTMUX_AGENT_ID")
+                    .and_then(|s| s.as_str())
+                    .map(str::to_string)
+            })
+            .expect("must extract the agent slug from the real .mcp.json shape");
+        assert_eq!(agent_slug, "aria");
+
+        let rewritten = crate::backend::agent_config::inject_jekt_signing_keys_into_mcp_json(
+            &files[pos].content,
+            &store,
+            &agent_slug,
+        )
+        .expect("keys must ensure successfully against a fresh in-memory store");
+        let parsed: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+        let env = &parsed["mcpServers"]["agentmux"]["env"];
+        assert_eq!(env["AGENTMUX_AGENT_ID"], "aria");
+        assert!(env["AGENTMUX_JEKT_KEY"].is_string() && !env["AGENTMUX_JEKT_KEY"].as_str().unwrap().is_empty());
+        assert!(env["AGENTMUX_LAN_KEY"].is_string() && !env["AGENTMUX_LAN_KEY"].as_str().unwrap().is_empty());
     }
 }

--- a/docs/specs/REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md
+++ b/docs/specs/REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md
@@ -1,0 +1,172 @@
+# Jekt Signing-Key Injection Gap — Normal-Launch Agents Never Got a Verified Identity
+
+**Date:** 2026-08-16
+**Author:** Clamk (agent, `~/.agentmux/agents/clamk-0612a`)
+**Status:** Root cause confirmed with direct evidence (live `.mcp.json`, server logs, code); fix implemented,
+tested, and included in this same change (see §4). Not yet merged.
+**Ground truth basis:** `agentmuxai/agentmux` `origin/main` at `72aefad4d` / worktree branch
+`clamk/agent-identity-history-protocol`. Live evidence gathered directly from this machine's own running
+AgentMux instance (srv `v0.55.9`) — not inferred from code reading alone.
+
+---
+
+## 0. How this was found
+
+Unrelated to this report's subject: this agent sent an outgoing jekt (agent-to-agent message) and received
+one back that rendered `TRUST=self-declared` rather than `TRUST=host-verified`, despite both agents running
+on the same machine (`DELIVERY=host`) — the case the host-tier signing feature
+(`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`) exists specifically to cover. Investigating why turned up a
+real, currently-live gap, not a stale/outdated build.
+
+---
+
+## 1. Direct evidence, in order
+
+### 1.1 This agent's actual `.mcp.json` has no signing keys
+
+```
+$ cat C:/Users/asafe/.agentmux/agents/clamk-0612a/.mcp.json
+{
+  "mcpServers": {
+    "agentmux": {
+      "type": "stdio",
+      "command": "agentmux-mcp",
+      "args": [],
+      "env": {
+        "AGENTMUX_AGENT_ID": "clamk"
+      }
+    }
+  }
+}
+```
+
+No `AGENTMUX_JEKT_KEY`, no `AGENTMUX_LAN_KEY` — only `AGENTMUX_AGENT_ID`.
+
+### 1.2 That file is current, not stale
+
+```
+$ stat C:/Users/asafe/.agentmux/agents/clamk-0612a/.mcp.json
+Modify: 2026-08-16 05:20:53.262266900 -0700   (= 2026-08-16T12:20:53Z)
+```
+
+### 1.3 The running server version already had both signing features for three+ days
+
+`VERSION_HISTORY.md`:
+```
+## 0.55.9 — 2026-08-15
+- feat(jekt): per-agent Ed25519 signing for LAN-tier jekts
+## 0.55.7 — 2026-08-13
+- feat(jekt): add host-tier per-agent HMAC signing for sender verification
+```
+
+`~/.agentmux/logs/current-srv-v0.55.9.path` was written 2026-08-16 05:17 (local), three minutes before the
+`.mcp.json` write in §1.2, and the server's own startup log line confirms it was actually running that
+version at that time:
+
+```
+{"timestamp":"2026-08-16T00:24:54.946388Z", "message":"agentmuxsrv starting","version":"0.55.9", ...}
+```
+
+So the `.mcp.json` that has no keys was written by a server build that had shipped both signing features 3
+and 1 days earlier, respectively. This rules out "hasn't been rebuilt since the feature shipped" as the
+explanation.
+
+### 1.4 The write event is identified precisely in the server log, and it isn't `agent_open`
+
+`agentmuxsrv-v0.55.9.log.2026-08-16` (JSON lines, UTC timestamps) has, at the exact second `.mcp.json` was
+last modified:
+
+```json
+{"timestamp":"2026-08-16T12:20:53.256237Z","level":"INFO","fields":{"message":"WriteAgentConfig","working_dir":"C:\\Users\\asafe\\.agentmux\\agents\\clamk-0612a","file_count":9,"auto_allocate":false},"target":"agentmux_srv::server::editor_handlers"}
+```
+
+Searching the entire log file for the strings that would appear if `agent.open`'s Rust-side key injection had
+run: zero matches for `agent_open`, zero matches for `jekt` (case-insensitive), across the whole file. The
+event that actually wrote this file was `WriteAgentConfig` (`agentmux_srv::server::editor_handlers`), not
+`agent.open`.
+
+### 1.5 Why: `WriteAgentConfig` is the real "click Launch" path, and never called the injection code
+
+Two independent code-path facts, both confirmed by reading the source (not inferred):
+
+- **`agent_open.rs` DID contain the injection logic** (before this fix — see §4): `wstore.agent_jekt_key_ensure(agent_slug)` / `wstore.agent_lan_key_ensure(agent_slug)`, called from `agent.open`'s `write_agent_config_files`, patching `.mcp.json`'s `mcpServers.agentmux.env` before writing.
+- **`editor_handlers.rs`'s `WriteAgentConfig` handler is a separate RPC path** that just persists whatever `cmd.files` the caller supplies — its own doc comment (line 253-258, pre-fix) already says this is *"the actual 'click Launch' path used on every normal agent launch (`launchAgentDefinition`/`WriteAgentConfigCommand`)"*, shared with `agent.open` only for skill-file cleanup logic (`agent_config.rs`), **not** for jekt-key injection.
+- The frontend function that actually builds `.mcp.json` content for this path, `frontend/app/view/agent/agent-config-builder.ts`, sets exactly one env var: `agentMuxServer.env["AGENTMUX_AGENT_ID"] = slug || instanceName || agent.name;` (line 432) — no jekt/LAN key handling exists there at all, confirmed by a full-file grep for `JEKT_KEY`/`LAN_KEY`/`jekt` (zero matches).
+
+**Conclusion:** the host-tier and LAN-tier jekt signing-key injection, shipped 2026-08-13 and 2026-08-15, was
+only ever wired into the `agent.open` RPC path. The path an agent actually launches through on a normal
+"click Launch" — `WriteAgentConfig`, driven by the frontend's `agent-config-builder.ts` — never called it.
+Since this machine's evidence (§1.1-1.4) shows this agent went through `WriteAgentConfig`, not `agent.open`,
+its jekts have been rendering `TRUST=self-declared` this whole time despite the signing feature being live in
+the running binary. This is not specific to this one agent — any agent launched the normal way is affected
+the same way, on any install running v0.55.7+.
+
+---
+
+## 2. Why this matters
+
+Per `CLAUDE.md`'s jekt security rules, `TRUST=self-declared` and `TRUST=host-verified` are treated very
+differently: a self-declared sender's identity is *not proven*, which is precisely the gap the signing
+feature was built to close (`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`'s own incident writeup: a
+spoofed jekt asking for a GitHub PAT, followed by a spoofed "confirmation" over muxbus). If the primary launch
+path never actually equips an agent with a signing key, that protection is live in the codebase but not in
+practice for ordinary agents — a real security-relevant gap between shipped code and shipped behavior, not
+just a cosmetic trust-badge issue.
+
+---
+
+## 3. What this is *not*
+
+- **Not a version-lag issue.** §1.3 rules this out directly — the running binary is newer than both features.
+- **Not specific to this agent.** The root cause is in shared frontend/backend code (`agent-config-builder.ts`, `editor_handlers.rs`) used by every agent's normal launch, not anything particular to `clamk-0612a`'s config.
+- **Not a signing-implementation bug.** `agent_jekt_key_ensure`/`agent_lan_key_ensure` and the HMAC/Ed25519 mechanics themselves are untouched by this report — they simply were never invoked for this code path.
+
+---
+
+## 4. Fix implemented (this change)
+
+Rather than duplicating `agent_open.rs`'s injection logic into `editor_handlers.rs` (which would reintroduce
+exactly the kind of drift `agent_config.rs`'s own module doc already warns about for the skill-file-cleanup
+logic it centralizes), extracted the injection into one shared, pure, unit-tested function:
+
+- **`agent_config::inject_jekt_signing_keys_into_mcp_json(content, wstore, agent_slug) -> Option<String>`**
+  (`agentmux-srv/src/backend/agent_config.rs`) — mints-or-reuses both keys, patches
+  `mcpServers.agentmux.env`, returns `None` (leave content untouched) on any parse failure or if there's no
+  `env` object to patch. Best-effort, matching the existing design philosophy: never blocks a spawn.
+- **`agent_open.rs`** now calls this shared function instead of its former ~75-line inline duplicate (both
+  the host-tier and LAN-tier blocks collapsed into one call + one warn-on-`None`).
+- **`editor_handlers.rs`'s `WriteAgentConfig` handler** now also calls it — extracting `agent_slug` from the
+  `.mcp.json` file already present in `cmd.files` (via `AGENTMUX_AGENT_ID` in its `env` block) before writing.
+  This is the actual fix: the normal "click Launch" path now injects keys too.
+
+**Tests added** (all passing, `cargo test -p agentmux-srv` — 2351 passed, 0 failed, 6 pre-existing ignores):
+- `agent_config::tests::inject_jekt_signing_keys_into_mcp_json_patches_both_keys_into_the_env_block`
+- `agent_config::tests::inject_jekt_signing_keys_into_mcp_json_reuses_the_same_key_on_a_second_call`
+- `agent_config::tests::inject_jekt_signing_keys_into_mcp_json_returns_none_when_theres_no_env_object_to_patch`
+- `agent_config::tests::inject_jekt_signing_keys_into_mcp_json_returns_none_on_malformed_json`
+- `editor_handlers::tests::writeagentconfig_extracts_slug_and_injects_signing_keys_into_the_real_mcp_json_shape`
+  — exercises the exact slug-extraction-then-injection sequence the real handler runs, against the real
+  `rpc_types::AgentConfigFile{path, content}` shape (not `agent_config::AgentConfigFile{filename, content}` —
+  the two are distinct types with different field names; this repo has been bitten by that mismatch silently
+  no-op'ing a shared code path before, per the neighboring `writeagentconfig_files_produce_the_expected_managed_skill_paths`
+  test's own comment).
+
+**Not fixed by this change:** any agent whose `.mcp.json` was already written before this fix lands still has
+no key — it will get one on its *next* successful `WriteAgentConfig` or `agent.open` call (i.e., its next
+launch), matching the existing best-effort/self-healing design already documented in both call sites'
+comments. No backfill migration was written for already-materialized `.mcp.json` files; relaunching is
+sufficient and matches how the feature already described its own degrade path ("until the next successful
+spawn").
+
+---
+
+## Appendix: research method
+
+Every claim above traces to a direct artifact on this machine or a direct source read, not inference:
+`.mcp.json` content and mtime were read directly; the server log line was matched by exact UTC timestamp
+against the file mtime (converted from the local `-0700` stat output); the version/feature-ship dates came
+from `VERSION_HISTORY.md`; the "which code path ran" conclusion came from a full-file string search for
+`agent_open`/`jekt` in the actual log file (absence, not presence, is the load-bearing evidence there — cross-
+checked by confirming `clamk` DOES appear 22 times in the same log, ruling out "wrong log file"). The
+frontend claim (`agent-config-builder.ts` sets only `AGENTMUX_AGENT_ID`) was a direct grep of that file, not
+a recollection.


### PR DESCRIPTION
## Summary

Root-caused and fixed why normally-launched agents' jekts render `TRUST=self-declared` instead of `TRUST=host-verified` even on builds well past when host-tier (v0.55.7) and LAN-tier (v0.55.9) signing shipped.

**Root cause, confirmed with live evidence (see the included report for full detail):** the signing-key injection code only ever lived in `agent.open`'s Rust handler. The actual "click Launch" path — `WriteAgentConfig`, driven entirely by the frontend's `agent-config-builder.ts` — writes `.mcp.json` independently and never called it. Verified directly on this machine: a running v0.55.9 instance's `.mcp.json`, rewritten today, has no `AGENTMUX_JEKT_KEY`/`AGENTMUX_LAN_KEY`; the server log shows the write came from `WriteAgentConfig` with zero `agent_open`/`jekt` log lines anywhere in the entire file.

**Fix:** extracted the injection logic into one shared, pure function (`agent_config::inject_jekt_signing_keys_into_mcp_json`), called from both `agent.open` (replacing its former inline duplicate) and `WriteAgentConfig` (new — this is the actual fix). Matches this module's own existing pattern for why shared logic lives here (its doc comment already warns about exactly this kind of two-call-site drift for the skill-file cleanup logic it centralizes).

Full evidence trail and research method: `docs/specs/REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md`.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2350 passed, 0 failed, 6 pre-existing ignores, no regressions
- [x] New tests: `inject_jekt_signing_keys_into_mcp_json_{patches_both_keys_into_the_env_block,reuses_the_same_key_on_a_second_call,returns_none_when_theres_no_env_object_to_patch,returns_none_on_malformed_json}` (agent_config.rs)
- [x] New test: `writeagentconfig_extracts_slug_and_injects_signing_keys_into_the_real_mcp_json_shape` (editor_handlers.rs) — exercises the real `rpc_types::AgentConfigFile{path, content}` shape, not just the pure function directly

<!-- agentmux:agent_id=clamk -->