### PR TITLE
Clamk@claudius: keep conversation history global under credential isolation

### DIFF
--- a/.changesets/1786887880-fix-identity-keep-conversation-history-global-when-credentia-9wuk.md
+++ b/.changesets/1786887880-fix-identity-keep-conversation-history-global-when-credentia-9wuk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): keep conversation history global when credential isolation is on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "hmac",
+ "junction",
  "serde",
  "serde_json",
  "sha2",
@@ -2420,6 +2421,16 @@ name = "json_comments"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+
+[[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "keyring"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -33,6 +33,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 # Windows page-file volume tracking (pagefile.rs), shared by agentmux-srv
 # and agentmux-cef — see docs/specs/SPEC_RAM_PAGEFILE_PRESSURE_SPLIT_2026_08_07.md §4.
 [target.'cfg(windows)'.dependencies]
+junction = "2.0.0"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_System_Registry",

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -518,12 +518,11 @@ pub fn ensure_history_link(link_path: &std::path::Path, target_dir: &std::path::
             // signal to the caller that this bundle needs manual review.
             std::fs::remove_dir(link_path)?;
         }
-        Ok(_) => {
-            // A link pointing at something else (stale/wrong target from
-            // a prior version of this function), or a file. Best-effort:
-            // drop it so the correct link can be created — its target,
-            // if it was a link, is untouched, only this pointer is
-            // replaced.
+        Ok(meta) if meta.file_type().is_symlink() => {
+            // A link already exists but pointed at something else (stale/
+            // wrong target from a prior version of this function). Safe
+            // to drop: no data lives directly at a link path, only at
+            // whatever it points to, which this doesn't touch.
             #[cfg(windows)]
             {
                 let _ = junction::delete(link_path);
@@ -532,6 +531,25 @@ pub fn ensure_history_link(link_path: &std::path::Path, target_dir: &std::path::
             {
                 let _ = std::fs::remove_file(link_path);
             }
+        }
+        Ok(_) => {
+            // A plain file (or anything else that's neither a real
+            // directory nor a link) sits where a link needs to go.
+            // Nothing in this codebase is expected to ever put a file
+            // named "projects" here, but reagentx P2 on PR #2605 caught
+            // that the previous version of this match arm silently
+            // deleted it via remove_file/junction::delete with no
+            // migration — directly contradicting this function's own
+            // never-delete-data guarantee. Surface an error instead of
+            // guessing what to do with unexpected real data.
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!(
+                    "ensure_history_link: {} exists and is neither a directory nor a link; \
+                     refusing to delete it",
+                    link_path.display()
+                ),
+            ));
         }
         Err(_) => {
             // Nothing at link_path yet — normal first-time case.
@@ -1743,6 +1761,28 @@ mod tests {
         assert_eq!(
             std::fs::read(link_path.join("session-1.jsonl")).unwrap(),
             b"isolated version -- must not be lost"
+        );
+    }
+
+    // reagentx P2 on PR #2605: the previous version of this function's
+    // fallback match arm treated "a plain file at link_path" the same as
+    // "a stale link at link_path" and deleted it outright with no
+    // migration, contradicting the function's own doc comment.
+    #[test]
+    fn ensure_history_link_refuses_to_delete_a_plain_file_at_the_link_path() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link_path = tmp.path().join("isolated").join("projects");
+        let target_dir = tmp.path().join("global").join("projects");
+
+        std::fs::create_dir_all(link_path.parent().unwrap()).unwrap();
+        std::fs::write(&link_path, b"unexpected real file, not a directory or a link").unwrap();
+
+        let result = ensure_history_link(&link_path, &target_dir);
+        assert!(result.is_err(), "a plain file at the link path must surface as an error, never be silently deleted");
+        assert_eq!(
+            std::fs::read(&link_path).unwrap(),
+            b"unexpected real file, not a directory or a link",
+            "the file must still exist, untouched, after the refused operation"
         );
     }
 }

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -375,7 +375,7 @@ impl DataPaths {
         }
     }
 
-    /// `~/.agentmux/shared/identities/<bundle_id>/<provider_dir>/projects/`
+    /// `~/.agentmux/shared/identities/<bundle_id>/<provider_dir>/<history_subdir>/`
     /// — ALWAYS this location, regardless of [`isolated_auth_enabled`].
     /// Conversation transcripts must survive a channel/build change even
     /// when the surrounding credential directory ([`identities_dir`]) is
@@ -386,19 +386,28 @@ impl DataPaths {
     /// P1) and must not share one isolation switch just because they
     /// happen to live under the same directory as far as the provider
     /// CLI is concerned. Callers that isolate credentials are expected
-    /// to redirect the isolated `<bundle_id>/<provider_dir>/projects`
+    /// to redirect the isolated `<bundle_id>/<provider_dir>/<history_subdir>`
     /// subpath to this location via [`ensure_history_link`] rather than
     /// letting the provider CLI write real session data there directly.
+    ///
+    /// `history_subdir` is caller-supplied rather than hardcoded — it is
+    /// NOT the same directory name for every provider (reagentx P1 on PR
+    /// #2605: this used to hardcode `"projects"`, which is Claude-
+    /// specific; Codex uses `"sessions"`, Gemini uses `"history"`, per
+    /// `docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md` §2.1).
+    /// Callers should read this from
+    /// `ProviderConfig::history_native_subdir`, the single source of
+    /// truth for which providers have a linkable directory at all.
     ///
     /// `bundle_id`/`provider_dir` are not path-validated here — callers
     /// must use [`sanitize_path_segment`]-checked values, same
     /// requirement as [`identity_dir`].
-    pub fn identity_history_dir(&self, bundle_id: &str, provider_dir: &str) -> PathBuf {
+    pub fn identity_history_dir(&self, bundle_id: &str, provider_dir: &str, history_subdir: &str) -> PathBuf {
         self.shared_dir
             .join("identities")
             .join(bundle_id)
             .join(provider_dir)
-            .join("projects")
+            .join(history_subdir)
     }
 
     /// `~/.agentmux/shared/identities/<bundle_id>/` — a specific

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -1794,4 +1794,41 @@ mod tests {
             "the file must still exist, untouched, after the refused operation"
         );
     }
+
+    // chatgpt-codex-connector + reagentx both claimed on PR #2605 that
+    // `std::fs::symlink_metadata` reports a Windows junction as
+    // `is_dir()=true, is_symlink()=false` — which, if true, would mean
+    // `ensure_history_link`'s `meta.is_dir() && !meta.file_type().is_symlink()`
+    // migration-branch check incorrectly treats a stale junction as a
+    // real directory. Verified empirically (twice, independently) that
+    // this claim is FALSE for the actual Rust std + toolchain this crate
+    // builds with: a real junction reports `is_dir()=false,
+    // is_symlink()=true` via `symlink_metadata` — `is_dir()=true` only
+    // shows up via `fs::metadata` (which follows the link, as
+    // documented). Kept as a permanent test, not deleted after
+    // resolving the review thread, so a future "fix" for this
+    // non-existent bug doesn't silently reintroduce one by "fixing"
+    // something that was already correct.
+    #[cfg(windows)]
+    #[test]
+    fn windows_junction_is_reported_as_symlink_not_as_a_real_directory() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link = tmp.path().join("isolated").join("linked");
+        let target = tmp.path().join("global");
+        ensure_history_link(&link, &target).unwrap();
+
+        assert!(junction::exists(&link).unwrap(), "sanity: this must actually be a junction");
+
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "a Windows junction must report is_symlink()=true via symlink_metadata"
+        );
+        assert!(
+            !meta.is_dir(),
+            "a Windows junction must NOT report is_dir()=true via symlink_metadata (only via the \
+             link-following fs::metadata) — if this ever changes, ensure_history_link's migration \
+             branch needs the junction::exists() check the (currently incorrect) review claimed was missing"
+        );
+    }
 }

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -351,9 +351,21 @@ impl DataPaths {
     ///
     /// When [`isolated_auth_enabled`] is set, this resolves to
     /// `instance_dir/identities/` instead — a channel-scoped credential
-    /// tree for destructive Armory testing (delete-account flows) that
-    /// can never touch the real global identity store other channels/
-    /// instances use. Opt-in only; default behavior above is unchanged.
+    /// tree, now the DEFAULT for every non-`"stable"` channel as of
+    /// `docs/specs/SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`
+    /// (this doc comment previously said "opt-in only; default behavior
+    /// above is unchanged" — that was accurate before that spec, stale
+    /// since, corrected 2026-08-16). Originally scoped to destructive
+    /// Armory testing (delete-account flows) that must never touch the
+    /// real global identity store other channels/instances use.
+    ///
+    /// **Isolating this directory isolates a provider's conversation
+    /// transcripts too**, since e.g. Claude Code's `projects/` lives
+    /// inside the same per-bundle directory tree as its credentials —
+    /// see [`identity_history_dir`] for the always-global path those
+    /// transcripts are kept reachable at regardless of this flag, and
+    /// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+    /// §4.1 for why that split exists.
     /// See `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`.
     pub fn identities_dir(&self) -> PathBuf {
         if isolated_auth_enabled() {
@@ -361,6 +373,32 @@ impl DataPaths {
         } else {
             self.shared_dir.join("identities")
         }
+    }
+
+    /// `~/.agentmux/shared/identities/<bundle_id>/<provider_dir>/projects/`
+    /// — ALWAYS this location, regardless of [`isolated_auth_enabled`].
+    /// Conversation transcripts must survive a channel/build change even
+    /// when the surrounding credential directory ([`identities_dir`]) is
+    /// isolated per-channel for Armory testing — history and credentials
+    /// are different data-persistence categories (CONVERSATION HISTORY
+    /// vs CREDENTIAL in
+    /// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+    /// P1) and must not share one isolation switch just because they
+    /// happen to live under the same directory as far as the provider
+    /// CLI is concerned. Callers that isolate credentials are expected
+    /// to redirect the isolated `<bundle_id>/<provider_dir>/projects`
+    /// subpath to this location via [`ensure_history_link`] rather than
+    /// letting the provider CLI write real session data there directly.
+    ///
+    /// `bundle_id`/`provider_dir` are not path-validated here — callers
+    /// must use [`sanitize_path_segment`]-checked values, same
+    /// requirement as [`identity_dir`].
+    pub fn identity_history_dir(&self, bundle_id: &str, provider_dir: &str) -> PathBuf {
+        self.shared_dir
+            .join("identities")
+            .join(bundle_id)
+            .join(provider_dir)
+            .join("projects")
     }
 
     /// `~/.agentmux/shared/identities/<bundle_id>/` — a specific
@@ -397,6 +435,126 @@ impl DataPaths {
     pub fn provider_auth_dir(&self, auth_dir_name: &str) -> PathBuf {
         self.shared_dir.join("providers").join(auth_dir_name)
     }
+}
+
+/// Best-effort: ensure `link_path` (a `projects/` subdirectory inside an
+/// [`isolated_auth_enabled`]-isolated provider credential dir) is a
+/// directory junction (Windows) / symlink (Unix) pointing at
+/// `target_dir` (the always-global [`DataPaths::identity_history_dir`]),
+/// so a provider's session transcripts stay reachable across a
+/// channel/build change even though the credential directory around them
+/// is per-channel isolated. See
+/// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+/// §4.1.
+///
+/// A Windows **junction** (not a symlink) is used deliberately —
+/// `std::os::windows::fs::symlink_dir` requires `SeCreateSymbolicLinkPrivilege`
+/// (admin, or Developer Mode enabled), which this app cannot assume every
+/// user has; junctions need no special privilege. Uses the `junction`
+/// crate (`FSCTL_SET_REPARSE_POINT` under the hood) rather than
+/// hand-rolled reparse-point FFI, for the same reason this codebase's own
+/// `bundle.rs` comment notes about Windows symlink privilege requirements
+/// — this is credential-adjacent storage, not a place to improvise
+/// low-level filesystem code.
+///
+/// Idempotent: a no-op if `link_path` is already a link pointing at
+/// `target_dir`. If a REAL directory already exists at `link_path` (data
+/// written before this function existed, or before `isolated_auth_enabled`
+/// applied to this bundle), its entries are moved into `target_dir` one
+/// by one via `rename` (atomic, same-volume — always true here, both
+/// live under the single `~/.agentmux` tree) before the now-empty
+/// directory is replaced with the link. **Never deletes or overwrites
+/// data**: an entry whose name already exists at the target is left
+/// exactly where it was, under the old per-channel path, rather than
+/// risking clobbering real history — it becomes reachable again once a
+/// human resolves the name collision, rather than silently lost. Any
+/// I/O error at any step is returned to the caller, who is expected to
+/// treat this as best-effort (log and continue spawning) per the same
+/// philosophy as the jekt-key injection in `agent_config.rs`.
+pub fn ensure_history_link(link_path: &std::path::Path, target_dir: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(target_dir)?;
+    // The `junction` crate creates the link via a plain `fs::create_dir`
+    // (not `create_dir_all`) on `link_path` itself, so its parent must
+    // already exist. Unix's `symlink` has the same requirement. Real
+    // production callers already have this (the isolated identity dir is
+    // created before this function runs), but this function must not
+    // depend on caller ordering to be correct/testable on its own.
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(windows)]
+    let already_correct = junction::exists(link_path).unwrap_or(false)
+        && junction::get_target(link_path).ok().as_deref() == Some(target_dir);
+    #[cfg(unix)]
+    let already_correct = std::fs::symlink_metadata(link_path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+        && std::fs::read_link(link_path).ok().as_deref() == Some(target_dir);
+    #[cfg(not(any(windows, unix)))]
+    let already_correct = false;
+
+    if already_correct {
+        return Ok(());
+    }
+
+    match std::fs::symlink_metadata(link_path) {
+        Ok(meta) if meta.is_dir() && !meta.file_type().is_symlink() => {
+            // Pre-existing REAL directory: migrate its contents (never
+            // clobbering an existing target entry), then remove the
+            // now-empty directory so a link can take its place.
+            for entry in std::fs::read_dir(link_path)? {
+                let entry = entry?;
+                let dest = target_dir.join(entry.file_name());
+                if !dest.exists() {
+                    std::fs::rename(entry.path(), &dest)?;
+                }
+            }
+            // Only remove if migration left it empty (i.e. every entry
+            // moved, or there were none) — a leftover name collision
+            // means real, un-migrated data is still here, and this must
+            // not silently paper over that by leaving a directory where
+            // a link was expected. Surfacing the removal error is the
+            // signal to the caller that this bundle needs manual review.
+            std::fs::remove_dir(link_path)?;
+        }
+        Ok(_) => {
+            // A link pointing at something else (stale/wrong target from
+            // a prior version of this function), or a file. Best-effort:
+            // drop it so the correct link can be created — its target,
+            // if it was a link, is untouched, only this pointer is
+            // replaced.
+            #[cfg(windows)]
+            {
+                let _ = junction::delete(link_path);
+            }
+            #[cfg(unix)]
+            {
+                let _ = std::fs::remove_file(link_path);
+            }
+        }
+        Err(_) => {
+            // Nothing at link_path yet — normal first-time case.
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        junction::create(target_dir, link_path)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target_dir, link_path)?;
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "ensure_history_link: no directory-link mechanism on this platform",
+        ));
+    }
+
+    Ok(())
 }
 
 /// Isolated per-channel auth (identity accounts + OAuth credential dirs).
@@ -1495,6 +1653,96 @@ mod tests {
         assert_eq!(
             sanitize_channel_name("experiment_42"),
             Some("experiment_42".into())
+        );
+    }
+
+    // ensure_history_link — real filesystem operations (junction on
+    // Windows, symlink on Unix), not mocked, per
+    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+    // §4.1. This is credential-adjacent storage code; these tests
+    // actually create the link and read a file back THROUGH it, rather
+    // than only asserting the `Result` came back `Ok`.
+
+    #[test]
+    fn ensure_history_link_makes_files_written_at_target_visible_through_link() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link_path = tmp.path().join("isolated").join("projects");
+        let target_dir = tmp.path().join("global").join("projects");
+
+        ensure_history_link(&link_path, &target_dir).expect("link creation must succeed");
+
+        std::fs::write(target_dir.join("session-1.jsonl"), b"hello").unwrap();
+        let via_link = std::fs::read(link_path.join("session-1.jsonl"))
+            .expect("a file written at the global target must be readable through the isolated link path");
+        assert_eq!(via_link, b"hello");
+    }
+
+    #[test]
+    fn ensure_history_link_is_idempotent() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link_path = tmp.path().join("isolated").join("projects");
+        let target_dir = tmp.path().join("global").join("projects");
+
+        ensure_history_link(&link_path, &target_dir).unwrap();
+        std::fs::write(target_dir.join("session-1.jsonl"), b"hello").unwrap();
+
+        // A second call against the already-correct link must not touch
+        // (let alone lose) the file that's already there.
+        ensure_history_link(&link_path, &target_dir).expect("re-calling on an already-correct link must succeed");
+        assert!(link_path.join("session-1.jsonl").exists());
+    }
+
+    #[test]
+    fn ensure_history_link_migrates_pre_existing_real_directory_contents() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link_path = tmp.path().join("isolated").join("projects");
+        let target_dir = tmp.path().join("global").join("projects");
+
+        // Simulate pre-fix state: link_path is a REAL directory with real
+        // session data already in it (written before this function
+        // existed / before isolation applied to this bundle).
+        std::fs::create_dir_all(&link_path).unwrap();
+        std::fs::write(link_path.join("old-session.jsonl"), b"pre-existing history").unwrap();
+
+        ensure_history_link(&link_path, &target_dir).expect("migration + link creation must succeed");
+
+        // The old file must now live at the global target, not be lost,
+        // and must still be reachable via the (now-linked) original path.
+        assert_eq!(
+            std::fs::read(target_dir.join("old-session.jsonl")).unwrap(),
+            b"pre-existing history",
+            "pre-existing history must be migrated to the global target, not lost"
+        );
+        assert_eq!(
+            std::fs::read(link_path.join("old-session.jsonl")).unwrap(),
+            b"pre-existing history",
+            "migrated history must still be reachable at the original (now-linked) path"
+        );
+    }
+
+    #[test]
+    fn ensure_history_link_never_overwrites_a_name_collision_at_the_target() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link_path = tmp.path().join("isolated").join("projects");
+        let target_dir = tmp.path().join("global").join("projects");
+
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join("session-1.jsonl"), b"global version").unwrap();
+        std::fs::create_dir_all(&link_path).unwrap();
+        std::fs::write(link_path.join("session-1.jsonl"), b"isolated version -- must not be lost").unwrap();
+
+        // The link can't be created while link_path is a non-empty real
+        // directory (the colliding entry blocks the migration's cleanup
+        // remove_dir) -- this must surface as an error, not silently
+        // clobber either copy.
+        let result = ensure_history_link(&link_path, &target_dir);
+        assert!(result.is_err(), "a name collision must surface as an error, not silently pick a winner");
+
+        // Neither copy was touched.
+        assert_eq!(std::fs::read(target_dir.join("session-1.jsonl")).unwrap(), b"global version");
+        assert_eq!(
+            std::fs::read(link_path.join("session-1.jsonl")).unwrap(),
+            b"isolated version -- must not be lost"
         );
     }
 }

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -15,7 +15,9 @@ pub mod runtime_mode;
 pub mod toolchain_path;
 
 pub use cli::{make_cli_cmd, resolve_cli_spawn_target};
-pub use data_paths::{isolated_auth_enabled, isolated_auth_reason, DataPaths, IsolatedAuthReason};
+pub use data_paths::{
+    ensure_history_link, isolated_auth_enabled, isolated_auth_reason, DataPaths, IsolatedAuthReason,
+};
 pub use errors::{AgentMuxError, AmxCode};
 pub use layout_types::{
     FlexDirection, LayoutClientSlices, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition,

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -61,6 +61,21 @@ pub struct ProviderConfig {
     /// instance-independent) and `shared/identities/<bundle>/<name>/` (per-identity)
     /// — see `DataPaths::provider_auth_dir` and `identity_dir`.
     pub auth_dir_name: &'static str,
+    /// Sub-directory (relative to this provider's config/auth dir) that
+    /// actually holds its native session/transcript history — e.g.
+    /// Claude's `"projects"`, Codex's `"sessions"`, Gemini's `"history"`.
+    /// `None` for providers with no simple directory-based history to
+    /// isolate/link (ACP providers — openclaw/pi/copilot — expose history
+    /// through the live protocol stream instead, not a fixed on-disk
+    /// path). Per-provider, filesystem-verified table:
+    /// `docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md` §2.1.
+    /// Used by `identity_auth_dirs.rs` to redirect an isolated identity's
+    /// history to the always-global
+    /// `DataPaths::identity_history_dir` — reagentx P1 on PR #2605 caught
+    /// that hardcoding `"projects"` there only worked for `claude`,
+    /// silently leaving every other OAuth-class provider's history
+    /// channel-local and unlinked.
+    pub history_native_subdir: Option<&'static str>,
     /// Extra environment variables required for auth isolation.
     /// Each entry is a `(key, value)` pair.
     pub auth_extra_env: &'static [(&'static str, &'static str)],
@@ -179,6 +194,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     styled_output_format: "claude-stream-json",
     auth_config_dir_env_var: "CLAUDE_CONFIG_DIR",
     auth_dir_name: "claude",
+    history_native_subdir: Some("projects"),
     auth_extra_env: &[],
     unset_env: &["CLAUDECODE"],
     npm_package: "@anthropic-ai/claude-code",
@@ -212,6 +228,7 @@ static CODEX: ProviderConfig = ProviderConfig {
     styled_output_format: "codex-json",
     auth_config_dir_env_var: "CODEX_HOME",
     auth_dir_name: "codex",
+    history_native_subdir: Some("sessions"),
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@openai/codex",
@@ -233,6 +250,7 @@ static GEMINI: ProviderConfig = ProviderConfig {
     styled_output_format: "gemini-json",
     auth_config_dir_env_var: "GEMINI_CLI_HOME",
     auth_dir_name: "gemini",
+    history_native_subdir: Some("history"),
     auth_extra_env: &[("GEMINI_FORCE_FILE_STORAGE", "true")],
     unset_env: &[],
     npm_package: "@google/gemini-cli",
@@ -263,6 +281,10 @@ static QWEN: ProviderConfig = ProviderConfig {
     // the Qwen analogue of GEMINI_CLI_HOME — gives per-agent auth isolation.
     auth_config_dir_env_var: "QWEN_HOME",
     auth_dir_name: "qwen",
+    // Not OAuth-class (provider_class() has no arm for "qwen") -- never
+    // reaches ensure_history_link regardless. None documents "not yet
+    // characterized" rather than asserting a specific layout.
+    history_native_subdir: None,
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@qwen-code/qwen-code",
@@ -293,6 +315,8 @@ static KIMI: ProviderConfig = ProviderConfig {
     styled_output_format: "kimi-stream-json",
     auth_config_dir_env_var: "KIMI_SHARE_DIR",
     auth_dir_name: "kimi",
+    // API-key-class, not OAuth-class -- never reaches ensure_history_link.
+    history_native_subdir: None,
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "",
@@ -324,6 +348,10 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     styled_output_format: "acp",
     auth_config_dir_env_var: "OPENCLAW_HOME",
     auth_dir_name: "openclaw",
+    // ACP-native: exposes history through the live protocol stream, not
+    // a fixed on-disk directory -- nothing for ensure_history_link to
+    // redirect. Per SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md §4.2.
+    history_native_subdir: None,
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "openclaw",
@@ -343,6 +371,9 @@ static PI: ProviderConfig = ProviderConfig {
     styled_output_format: "acp",
     auth_config_dir_env_var: "PI_HOME",
     auth_dir_name: "pi",
+    // Not OAuth-class -- never reaches ensure_history_link. Also
+    // ACP-native (see the "openclaw" entry above) if that changes.
+    history_native_subdir: None,
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@mariozechner/pi-coding-agent",
@@ -372,6 +403,8 @@ static MUX_CODE: ProviderConfig = ProviderConfig {
     styled_output_format: "claude-stream-json",
     auth_config_dir_env_var: "MUXCODE_CONFIG_DIR",
     auth_dir_name: "muxcode",
+    // Not OAuth-class -- never reaches ensure_history_link.
+    history_native_subdir: None,
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@agentmuxai/muxcode",
@@ -395,6 +428,9 @@ static COPILOT: ProviderConfig = ProviderConfig {
     styled_output_format: "acp",
     auth_config_dir_env_var: "COPILOT_HOME",
     auth_dir_name: "copilot",
+    // ACP-native, same as "openclaw" above -- no fixed on-disk history
+    // directory to redirect.
+    history_native_subdir: None,
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@github/copilot",
@@ -420,6 +456,10 @@ static ANTIGRAVITY: ProviderConfig = ProviderConfig {
     styled_output_format: "gemini-json",
     auth_config_dir_env_var: "ANTIGRAVITY_CONFIG_DIR",
     auth_dir_name: "antigravity",
+    // Not OAuth-class -- never reaches ensure_history_link. Not covered
+    // by SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md (added later);
+    // None until independently verified rather than guessed.
+    history_native_subdir: None,
     auth_extra_env: &[("ANTIGRAVITY_FORCE_FILE_STORAGE", "true")],
     unset_env: &[],
     npm_package: "@google/antigravity-cli",

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -497,6 +497,29 @@ pub fn inject_identity_env_with_broker(
                     binding.account_id,
                 );
 
+                // reagentx P1 on PR #2605: `dir` above is read from this
+                // account's PREVIOUSLY STORED SecretRef::OAuthConfigDir —
+                // this is the ordinary spawn path, not `auth.start`, which
+                // is the only place that used to (re-)create the history
+                // link. An account provisioned before this whole feature
+                // shipped, or since its last `auth.start`, would otherwise
+                // never get linked at all. Re-verify/re-create it on every
+                // spawn instead, same best-effort, non-blocking guarantee
+                // as the rest of this function.
+                if let Some(paths) = agentmux_common::DataPaths::from_env() {
+                    if let Some(provider_cfg) =
+                        crate::backend::providers::get_provider(&resolve_provider_alias(&binding.provider))
+                    {
+                        crate::server::identity_auth_dirs::link_history_if_isolated(
+                            &paths,
+                            std::path::Path::new(&dir),
+                            provider_cfg,
+                            &binding.account_id,
+                            "inject_identity_env (spawn)",
+                        );
+                    }
+                }
+
                 // Per spec §4.4 — cheap on-disk expiry probe. Reads the
                 // CLI's token file inside the bundle dir and refines
                 // the IdentityAccount's `status` so the UI can show
@@ -729,6 +752,102 @@ mod tests {
         // And does NOT set the anthropic api-key env var — dispatch
         // is by provider class, not by token shape.
         assert!(env.get("ANTHROPIC_API_KEY").is_none());
+    }
+
+    // reagentx P1 on PR #2605: this is the ordinary spawn path (not
+    // `auth.start`) — it reads a PREVIOUSLY STORED OAuthConfigDir, which
+    // is exactly the case an account provisioned before the history-link
+    // feature existed (or since its last `auth.start`) is in. Proves the
+    // link now gets (re-)created here too, not only at auth.start.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn inject_oauth_class_links_conversation_history_on_the_ordinary_spawn_path() {
+        let _lock = crate::test_support::ISOLATED_AUTH_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        let paths = agentmux_common::DataPaths::resolve(
+            "0.0.0-test",
+            &agentmux_common::RuntimeMode::Installed,
+        )
+        .unwrap();
+        paths.ensure_dirs().unwrap();
+        for (k, v) in paths.to_env_vars() {
+            std::env::set_var(k, v);
+        }
+
+        // A credential dir that ALREADY exists on disk, under the isolated
+        // (per-channel) tree, with real pre-existing history in it — the
+        // account was provisioned (auth.start ran) before this test's
+        // spawn-time call, exactly like a real already-connected account.
+        let isolated_dir = paths.instance_dir.join("identities").join("acct-claude").join("claude");
+        std::fs::create_dir_all(isolated_dir.join("projects")).unwrap();
+        std::fs::write(
+            isolated_dir.join("projects").join("existing-session.jsonl"),
+            b"pre-existing history",
+        )
+        .unwrap();
+
+        let store = make_store();
+        let mut def = crate::backend::storage::store::AgentDefinition {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        store.agent_def_insert(&mut def).unwrap();
+
+        let claude = make_account(
+            "acct-claude",
+            "claude",
+            SecretRef::OAuthConfigDir { dir: isolated_dir.to_string_lossy().to_string() },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store.agent_identity_link("def-1", "acct-claude", "claude").unwrap();
+        insert_block_for_agent(&store, "block-oauth-history", "def-1");
+        let inst = make_instance("block-oauth-history", "id-oauth");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store.clone(), store, "block-oauth-history", &mut env).unwrap();
+
+        let global_history = paths.identity_history_dir("acct-claude", "claude", "projects");
+        let via_link = std::fs::read(global_history.join("existing-session.jsonl"))
+            .expect("pre-existing history must have been migrated to the global location by the spawn-time link");
+        assert_eq!(via_link, b"pre-existing history");
+
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+        for (k, _) in paths.to_env_vars() {
+            std::env::remove_var(k);
+        }
     }
 
     #[cfg(debug_assertions)]

--- a/agentmux-srv/src/server/identity_auth_dirs.rs
+++ b/agentmux-srv/src/server/identity_auth_dirs.rs
@@ -11,8 +11,56 @@
 //! `identity_handlers::register_identity_handlers` don't need touching)
 //! and `compute_and_ensure_account_dir` (the live direct-account path).
 
-use crate::backend::providers::get_provider;
+use crate::backend::providers::{get_provider, ProviderConfig};
 use crate::backend::storage::store::Store;
+
+/// Best-effort: if `provider` has a linkable native history directory
+/// ([`ProviderConfig::history_native_subdir`], `None` for providers with
+/// no fixed on-disk history to redirect) and credential isolation is
+/// currently on, ensure `dir/<subdir>` is linked to the always-global
+/// history location for `entity_id` (a bundle id or account id — same
+/// namespace, see [`DataPaths::identity_dir`]). No-op when isolation is
+/// off (`dir` is already inside the global tree, so `dir/<subdir>`
+/// already IS the global location) or the provider has no linkable
+/// subdir. Never fails the caller — logs and continues, same philosophy
+/// as every other soft-fail in this module.
+///
+/// Three call sites need this identically: `compute_and_ensure_bundle_dir`
+/// and `compute_and_ensure_account_dir` below (both `auth.start`-time),
+/// and `inject::inject_identity_env_with_broker`'s OAuth branch (the
+/// ordinary spawn-time path, which reads a *previously stored*
+/// `OAuthConfigDir` and — before this shared helper existed — never
+/// re-verified the link at all; reagentx P1 on PR #2605: an account
+/// provisioned before this whole feature shipped, or since its last
+/// `auth.start`, never got linked until this fix). One function so they
+/// can't drift on the condition again.
+pub(crate) fn link_history_if_isolated(
+    paths: &agentmux_common::DataPaths,
+    dir: &std::path::Path,
+    provider: &ProviderConfig,
+    entity_id: &str,
+    log_ctx: &str,
+) {
+    let Some(subdir) = provider.history_native_subdir else {
+        return;
+    };
+    if !agentmux_common::isolated_auth_enabled() {
+        return;
+    }
+    if let Err(e) = agentmux_common::ensure_history_link(
+        &dir.join(subdir),
+        &paths.identity_history_dir(entity_id, provider.auth_dir_name, subdir),
+    ) {
+        tracing::warn!(
+            target: "identity",
+            provider_id = provider.id,
+            entity_id,
+            error = %e,
+            "{log_ctx}: failed to link conversation history to the global location — \
+             this history may not survive a channel/build change"
+        );
+    }
+}
 
 /// Compute the per-bundle OAuth config dir + ensure it exists +
 /// override the provider's `auth_config_dir_env_var` entry in `auth_env`.
@@ -113,23 +161,7 @@ pub(crate) fn compute_and_ensure_bundle_dir(
         );
         return None;
     }
-    // See the identical block in compute_and_ensure_account_dir (the live
-    // sibling of this vestigial function) for why this exists.
-    if agentmux_common::isolated_auth_enabled() {
-        if let Err(e) = agentmux_common::ensure_history_link(
-            &dir.join("projects"),
-            &paths.identity_history_dir(bundle_id, provider.auth_dir_name),
-        ) {
-            tracing::warn!(
-                target: "identity",
-                provider_id,
-                bundle_id,
-                error = %e,
-                "auth.start: failed to link conversation history to the global location — \
-                 this bundle's history may not survive a channel/build change"
-            );
-        }
-    }
+    link_history_if_isolated(&paths, &dir, provider, bundle_id, "auth.start");
     let dir_str = dir.to_string_lossy().to_string();
     // Override (or insert) the provider's config-dir env var. The
     // frontend may have computed the legacy ambient dir via
@@ -263,31 +295,7 @@ pub(crate) fn compute_and_ensure_account_dir(
         );
         return (account_id, None);
     }
-    // Keep conversation-history transcripts (e.g. Claude Code's own
-    // `projects/` subdir) reachable at a stable, always-global location
-    // even when this credential dir is per-channel isolated — see
-    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
-    // §4.1. Best-effort: never abort auth.start over this, same
-    // philosophy as every other soft-fail in this function. Only
-    // meaningful when isolated_auth_enabled() — when it's off, `dir` is
-    // already inside the global identities tree and `dir/projects`
-    // already IS the global location, so linking it to itself would be
-    // pointless.
-    if agentmux_common::isolated_auth_enabled() {
-        if let Err(e) = agentmux_common::ensure_history_link(
-            &dir.join("projects"),
-            &paths.identity_history_dir(&account_id, provider.auth_dir_name),
-        ) {
-            tracing::warn!(
-                target: "identity",
-                provider_id,
-                account_id,
-                error = %e,
-                "auth.start (direct-account): failed to link conversation history to the global \
-                 location — this account's history may not survive a channel/build change"
-            );
-        }
-    }
+    link_history_if_isolated(&paths, &dir, provider, &account_id, "auth.start (direct-account)");
     let dir_str = dir.to_string_lossy().to_string();
     auth_env.insert(provider.auth_config_dir_env_var.to_string(), dir_str.clone());
     tracing::info!(
@@ -410,7 +418,7 @@ mod tests {
             "precondition: the credential dir must actually be the per-channel isolated one, not the global one, or this test isn't exercising the code path it claims to"
         );
 
-        let global_history = paths.identity_history_dir(&account_id, "claude");
+        let global_history = paths.identity_history_dir(&account_id, "claude", "projects");
         std::fs::write(global_history.join("real-session.jsonl"), b"a real session").unwrap();
         let via_isolated_path = std::fs::read(dir.join("projects").join("real-session.jsonl"))
             .expect("a file written at the global history location must be readable through the isolated credential dir's projects/ subpath");

--- a/agentmux-srv/src/server/identity_auth_dirs.rs
+++ b/agentmux-srv/src/server/identity_auth_dirs.rs
@@ -47,6 +47,26 @@ pub(crate) fn link_history_if_isolated(
     if !agentmux_common::isolated_auth_enabled() {
         return;
     }
+    // reagentx P2 / chatgpt-codex-connector on PR #2605: `identity_dir`'s
+    // safe-path-segment rejection (empty / `.` / `..` / a segment with
+    // `/`, `\`, a drive-letter colon, …) is validated HERE, once, for
+    // every caller — `identity_auth_dirs.rs`'s own two call sites happen
+    // to already validate `entity_id` earlier in their own function body
+    // (via this same check) before ever reaching this point, but
+    // `inject.rs`'s ordinary-spawn call site reads `entity_id` straight
+    // from a stored `binding.account_id` with no such upstream check.
+    // Rather than trust every current AND future caller to remember
+    // this, `identity_history_dir`'s own documented precondition is
+    // enforced right here instead.
+    if paths.identity_dir(entity_id).is_none() {
+        tracing::warn!(
+            target: "identity",
+            provider_id = provider.id,
+            entity_id,
+            "{log_ctx}: entity_id is not a safe path segment — skipping history link"
+        );
+        return;
+    }
     if let Err(e) = agentmux_common::ensure_history_link(
         &dir.join(subdir),
         &paths.identity_history_dir(entity_id, provider.auth_dir_name, subdir),
@@ -423,6 +443,45 @@ mod tests {
         let via_isolated_path = std::fs::read(dir.join("projects").join("real-session.jsonl"))
             .expect("a file written at the global history location must be readable through the isolated credential dir's projects/ subpath");
         assert_eq!(via_isolated_path, b"a real session");
+
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+        for (k, _) in paths.to_env_vars() {
+            std::env::remove_var(k);
+        }
+    }
+
+    // reagentx P2 / chatgpt-codex-connector on PR #2605: link_history_if_isolated
+    // must reject an unsafe entity_id itself (defense in depth), not
+    // rely on every caller having already validated it upstream —
+    // inject.rs's spawn-path call site passes a stored account_id with
+    // no such upstream check.
+    #[test]
+    fn link_history_if_isolated_rejects_an_unsafe_entity_id() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        let paths = agentmux_common::DataPaths::resolve(
+            "0.0.0-test",
+            &agentmux_common::RuntimeMode::Installed,
+        )
+        .unwrap();
+        paths.ensure_dirs().unwrap();
+        for (k, v) in paths.to_env_vars() {
+            std::env::set_var(k, v);
+        }
+
+        let provider = get_provider("claude").unwrap();
+        let dir = tmp.path().join("some-credential-dir");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Must not panic, must not create anything under
+        // shared/identities/../ — an unsafe segment is simply skipped.
+        link_history_if_isolated(&paths, &dir, provider, "../escape", "test");
+        assert!(
+            !paths.shared_dir.join("identities").parent().unwrap().join("escape").exists(),
+            "an unsafe entity_id must never be used to construct a real filesystem path"
+        );
 
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
         std::env::remove_var("AGENTMUX_ISOLATED_AUTH");

--- a/agentmux-srv/src/server/identity_auth_dirs.rs
+++ b/agentmux-srv/src/server/identity_auth_dirs.rs
@@ -113,6 +113,23 @@ pub(crate) fn compute_and_ensure_bundle_dir(
         );
         return None;
     }
+    // See the identical block in compute_and_ensure_account_dir (the live
+    // sibling of this vestigial function) for why this exists.
+    if agentmux_common::isolated_auth_enabled() {
+        if let Err(e) = agentmux_common::ensure_history_link(
+            &dir.join("projects"),
+            &paths.identity_history_dir(bundle_id, provider.auth_dir_name),
+        ) {
+            tracing::warn!(
+                target: "identity",
+                provider_id,
+                bundle_id,
+                error = %e,
+                "auth.start: failed to link conversation history to the global location — \
+                 this bundle's history may not survive a channel/build change"
+            );
+        }
+    }
     let dir_str = dir.to_string_lossy().to_string();
     // Override (or insert) the provider's config-dir env var. The
     // frontend may have computed the legacy ambient dir via
@@ -246,6 +263,31 @@ pub(crate) fn compute_and_ensure_account_dir(
         );
         return (account_id, None);
     }
+    // Keep conversation-history transcripts (e.g. Claude Code's own
+    // `projects/` subdir) reachable at a stable, always-global location
+    // even when this credential dir is per-channel isolated — see
+    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+    // §4.1. Best-effort: never abort auth.start over this, same
+    // philosophy as every other soft-fail in this function. Only
+    // meaningful when isolated_auth_enabled() — when it's off, `dir` is
+    // already inside the global identities tree and `dir/projects`
+    // already IS the global location, so linking it to itself would be
+    // pointless.
+    if agentmux_common::isolated_auth_enabled() {
+        if let Err(e) = agentmux_common::ensure_history_link(
+            &dir.join("projects"),
+            &paths.identity_history_dir(&account_id, provider.auth_dir_name),
+        ) {
+            tracing::warn!(
+                target: "identity",
+                provider_id,
+                account_id,
+                error = %e,
+                "auth.start (direct-account): failed to link conversation history to the global \
+                 location — this account's history may not survive a channel/build change"
+            );
+        }
+    }
     let dir_str = dir.to_string_lossy().to_string();
     auth_env.insert(provider.auth_config_dir_env_var.to_string(), dir_str.clone());
     tracing::info!(
@@ -329,6 +371,53 @@ mod tests {
         assert_eq!(account_id, "acc-reconnect", "reconnect must reuse the supplied id, not mint a new one");
 
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        for (k, _) in paths.to_env_vars() {
+            std::env::remove_var(k);
+        }
+    }
+
+    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+    // §4.1: when the credential dir is per-channel isolated, its
+    // `projects/` subpath must become a link to the always-global
+    // history location, not a real (fresh, empty, orphan-prone)
+    // directory. This is the actual end-to-end wiring test — the
+    // `ensure_history_link` unit tests in `agentmux-common` only prove
+    // the linking primitive works in isolation, not that this call site
+    // actually invokes it with the right paths.
+    #[test]
+    fn compute_account_dir_links_projects_to_the_global_history_location_when_isolated() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        let paths = agentmux_common::DataPaths::resolve(
+            "0.0.0-test",
+            &agentmux_common::RuntimeMode::Installed,
+        )
+        .unwrap();
+        paths.ensure_dirs().unwrap();
+        for (k, v) in paths.to_env_vars() {
+            std::env::set_var(k, v);
+        }
+        assert!(agentmux_common::isolated_auth_enabled(), "precondition: this test needs isolation actually on");
+
+        let wstore = Store::open_in_memory().unwrap();
+        let mut env = std::collections::HashMap::new();
+        let (account_id, dir) = compute_and_ensure_account_dir(&wstore, "", "claude", &mut env);
+        let dir = std::path::PathBuf::from(dir.expect("oauth-class provider must yield a dir"));
+        assert!(
+            dir.starts_with(&paths.instance_dir),
+            "precondition: the credential dir must actually be the per-channel isolated one, not the global one, or this test isn't exercising the code path it claims to"
+        );
+
+        let global_history = paths.identity_history_dir(&account_id, "claude");
+        std::fs::write(global_history.join("real-session.jsonl"), b"a real session").unwrap();
+        let via_isolated_path = std::fs::read(dir.join("projects").join("real-session.jsonl"))
+            .expect("a file written at the global history location must be readable through the isolated credential dir's projects/ subpath");
+        assert_eq!(via_isolated_path, b"a real session");
+
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
         for (k, _) in paths.to_env_vars() {
             std::env::remove_var(k);
         }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -6,7 +6,7 @@ mod files;
 pub(crate) mod app_api;
 mod agent_handlers;
 mod editor_handlers;
-mod identity_auth_dirs;
+pub(crate) mod identity_auth_dirs;
 mod identity_auth_persist;
 mod identity_auth_spawn;
 mod identity_handlers;

--- a/docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md
+++ b/docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md
@@ -1,0 +1,267 @@
+# Agent Identity/History Fragmentation Across Builds — Root Cause and a Fast-Lookup Design
+
+**Date:** 2026-08-16
+**Author:** Clamk (agent, `~/.agentmux/agents/clamk-0612a`)
+**Status:** Report — root cause confirmed and code-cited end to end; proposed fix is a design, not yet
+implemented. No code changes in this PR.
+**Ground truth basis:** `agentmuxai/agentmux` local checkout at `3705f83c3`
+(`agent3/bashwrap-persist-cwd-across-calls`, 210 commits behind `origin/main`) cross-checked against
+`origin/main` at `72aefad4d` via `git show origin/main:<path>` for every file cited below. Live filesystem
+evidence gathered from this machine's own `~/.agentmux` tree.
+**Motivation:** the operator asked this agent ("Clamk") to retrieve its own prior conversation history via
+the app's "Conversation History" UI action. The quoted text it copied came from a session that turned out to
+live under a *different* channel/identity UUID than the one this agent is currently running under, and was
+only findable by a manual, full-tree `grep` across `~/.agentmux`. The operator asked for the underlying bug
+to be root-caused and a fast, durable lookup system designed so this doesn't cost cycles again.
+
+---
+
+## 0. Executive summary
+
+A named, identity-bound agent's Claude Code conversation history is supposed to be **global** —
+one continuous transcript store that survives every app version bump, every local rebuild, every channel
+change. That principle is explicit in at least four prior specs/retros (§2). It is currently **broken by a
+regression merged 10 days before this report**: commit `9f6cc2824` ("feat(identity): default isolated auth
+for every non-stable channel", PR #2431, 2026-08-06, `origin/main` only — not yet in this local checkout)
+changed `identities_dir()`'s default from "always global" to "per-channel for every channel except the
+literal string `\"stable\"`". Because an identity-bound agent's actual Claude Code session transcripts
+(`claude/projects/*.jsonl`) live *inside* that same identity-bundle directory tree, and because every local/
+dev/portable build already mints a brand-new channel by design (§1.1), this one flag flip means:
+
+- Every fresh local build gives an identity-bound agent an **empty** history store.
+- The code that mints the bundle UUID has no fallback — it just generates a new random UUID
+  (`identity_auth_dirs.rs::compute_and_ensure_account_dir`), so there's nothing tying the new session to the
+  old one.
+- The in-app history browser (`ClaudeHistoryAdapter`) only ever scans the **global** shared identities path —
+  never the per-channel path PR #2431 made the default — so it is now structurally blind to history written
+  after 2026-08-06 for any identity-bound agent. There is no fast *or* slow code path that finds it; a human
+  has to walk the filesystem by hand, which is exactly what happened in this conversation.
+
+This is not a one-off bug. It is the **fourth-plus recurrence** of the same failure class — "identity/history
+is supposed to be global; something makes it accidentally per-channel again" — following incidents on
+2026-06-13, 2026-06-16 (twice), and 2026-07-27 (§2). None of those incidents' own recommended regression
+tests were ever confirmed shipped. §4 proposes both a fix for this specific regression and a structural
+change (an explicit index + an enforced invariant) so the *next* well-intentioned channel-isolation change
+can't silently break history continuity again.
+
+---
+
+## 1. The failure chain, traced end to end and code-cited
+
+### 1.1 Every local/dev/portable build mints a new channel — by design
+
+`scripts/package.sh:99-103`:
+
+```
+BUILD_ID=$(printf '%s' "$LABEL" | sha1sum | cut -c1-8)
+CHANNEL="local-${BRANCH_SLUG}-${BRANCH_HASH}-${BUILD_ID}"
+```
+
+with the comment at `scripts/package.sh:27-31` stating plainly: *"PER-BUILD: the build-id ... makes each
+build its own data dir ... so a freshly-built binary launches as its own instance."* Confirmed by a passing
+test, `agentmux-launcher/src/hash.rs:147-163`
+(`per_build_channels_isolate_data_dir_even_at_same_version`): two builds of the *same branch, same semver*
+still resolve to distinct channels and distinct data dirs, because of the build-id suffix. This is
+intentional and not the bug — it's the reason agent/identity data was deliberately made global in the first
+place (§2's 2026-06-13 spec), specifically so this per-build churn wouldn't lose anything.
+
+### 1.2 `identities_dir()` now defaults to per-channel for any non-`"stable"` channel
+
+`agentmux-common/src/data_paths.rs` (verified on `origin/main`, function starting at line 358):
+
+```rust
+pub fn identities_dir(&self) -> PathBuf {
+    if isolated_auth_enabled() {
+        self.instance_dir.join("identities")
+    } else {
+        self.shared_dir.join("identities")
+    }
+}
+```
+
+Before commit `9f6cc2824`, `isolated_auth_enabled()` was `false` unless `AGENTMUX_ISOLATED_AUTH=1` was set
+explicitly — global by default, unconditionally. That commit (PR #2431, merged 2026-08-06, message:
+*"feat(identity): default isolated auth for every non-stable channel"*) replaced it with
+`isolated_auth_reason()`, whose resolution order (same file, doc comment above `isolated_auth_enabled`) is:
+
+1. `AGENTMUX_ISOLATED_AUTH=1` / any-other-value → explicit override, always wins.
+2. Otherwise: **isolated for every channel except the literal string `"stable"`.**
+3. If `AGENTMUX_CHANNEL` isn't set at all: stays global (conservative fallback).
+
+The PR's own intent (commit message) was narrow and reasonable: give `task dev`/`task package` builds a
+genuinely empty OAuth credential store by default, so login/relogin flows for the Armory (delete-account
+testing, #2422/#2423/#2425/#2429) actually get exercised instead of silently inheriting a fully-authenticated
+global session. A follow-up fixup in the same PR even explicitly notes the scope was meant to be narrow:
+*"only the Armory account list / explicitly-bound identity dirs isolate; a default (non-identity-bound) agent
+spawn keeps resolving auth via `provider_auth_dir()`, which stays global regardless."*
+
+The problem is that `identities_dir()` isn't only a credential directory. Per its own doc comment
+(`data_paths.rs:344-353`) and `identity_dir(bundle_id)` (same file, ~line 365): *"Per-provider subdirectories
+(e.g. `claude/`, `codex/`) hang off this when the bundle gains an OAuth binding."* AgentMux points Claude
+Code's `CLAUDE_CONFIG_DIR` at `identities_dir()/<bundle_id>/claude/` for identity-bound agents — which means
+`claude/projects/*.jsonl` (Claude Code's own session transcript store) lives *inside* the exact directory tree
+this flag now isolates per channel by default. **Isolating "the account list" for testing safety and
+isolating "this account's entire conversation history" turned out to be the same code path.**
+
+### 1.3 A fresh per-channel store means a fresh, unlinked UUID every time
+
+`agentmux-srv/src/server/identity_auth_dirs.rs::compute_and_ensure_account_dir` (verified on `origin/main`,
+~line 159):
+
+```rust
+let account_id = if existing_account_id.is_empty() {
+    uuid::Uuid::new_v4().to_string()
+} else {
+    existing_account_id.to_string()
+};
+```
+
+There is no name-keyed lookup here — if the caller doesn't already know an `existing_account_id` (which it
+won't, the very first time a given channel's now-empty per-channel store is consulted), a brand-new random
+UUID is minted with nothing linking it back to the UUID used by the same named agent in the previous channel.
+The only durable link in the system, `db_agent_identity_links (agent_id, account_id, provider)`
+(`agentmux-srv/src/backend/storage/identities.rs:145-150`), lives in whichever store `identities_dir()`
+currently resolves to — so it doesn't survive the channel change either. There is no global, name-anchored
+registry consulted *before* minting a new UUID.
+
+### 1.4 The history browser only ever looks in the global location
+
+`agentmux-srv/src/backend/history/claude_adapter.rs::ClaudeHistoryAdapter::new()` (verified on `origin/main`,
+lines 1-79) builds its scan list from exactly these roots:
+
+- `~/.claude/projects/`, `~/.config/claude-*/projects/` (personal/legacy)
+- `<AGENTMUX_SHARED_DIR>/providers/claude/projects/` (default isolated home)
+- `<AGENTMUX_SHARED_DIR>/identities/<bundle_id>/claude/projects/` (per-identity, **but note: `shared_dir`,
+  never `instance_dir`**)
+
+It never scans `instance_dir.join("identities")` — i.e. `channels/<slug>/identities/*/claude/projects/` or
+`dev/<branch>/*/identities/*/claude/projects/`, the exact per-channel path §1.2's default now sends
+identity-bound agents' history to. This adapter was written and last touched independently of PR #2431; the
+two were never reconciled. The result: since 2026-08-06, there is no code path in the application — fast
+*or* slow — that can locate an identity-bound agent's conversation history once it lands in a fresh channel.
+The only way to find it is a manual, full-tree filesystem search, which is what this investigation itself had
+to do to locate the quoted conversation the operator referenced.
+
+### 1.5 Confirmed live on this machine
+
+`~/.agentmux/shared/identities/` does not exist at all on this machine. `~/.agentmux/channels/local-main-*/
+identities/<uuid>/claude/projects` and `~/.agentmux/dev/<branch>/*/identities/<uuid>/claude/projects` do
+exist, are populated, and are distinct per channel — exactly the fragmentation pattern this report traces.
+This agent's own two identities (`e4e58513-...` under channel `local-agentx-fix-lan-discovery-tx-...`, and
+`eb6e9fdb-...` under channel `local-main-b28b7a-...`) are a direct instance of it: the same logical agent
+("Clamk"), split across two identity UUIDs, discoverable only by grepping every `.jsonl` under
+`~/.agentmux` for a known phrase.
+
+---
+
+## 2. This is a recurring failure class, not a one-off
+
+Four prior incidents establish "agent identity/history must be global; channel is disposable" as the
+intended architecture, and each one is a different way that principle silently regressed:
+
+| Date | Doc | What silently broke |
+|---|---|---|
+| 2026-06-13 | `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` | Agent registry was rooted per-`(channel,version)`; a new build showed an empty roster. Fixed by re-rooting to a global `shared/agents/registry/`. |
+| 2026-06-16 | `docs/retro/retro-legacy-agent-history-cross-channel-2026-06-16.md` | The global history mirror's `sourceBlockId` field leaked a channel-local block id, breaking cross-channel resolution even after the above fix. |
+| 2026-06-16 | `docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md` | The global registry's `session_id` field was declared but never written by production code (only tests), so a fresh channel had nothing to `--resume`, silently starting and then "latching in" a new session that orphaned the original. |
+| 2026-06-13 | `docs/architecture/ARCHITECTURE_AGENT_DATA_AND_CROSS_CHANNEL_2026_06_13.md` | Instance-registry backfill anchored `working_directory` per-channel instead of globally, so `strip_prefix` failed for every real row and "My Agents" came up empty after a channel/version update. |
+| 2026-07-27 | `docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md` | `COMMAND_LIST_RECENT_SESSIONS` aborts its *entire* result on the first error from any of 6 sequential cross-store calls; frontend can't distinguish "fetch failed" from "genuinely zero agents." Explicitly logged as the **third-plus** occurrence of this class, with the recommendation (per-source error degradation, distinct UI error state, e2e test) never implemented. |
+
+This report's finding (§1) is the same class again, via a fifth, different mechanism: a *credential-testing*
+change with a narrow, well-reasoned intent had an unreviewed blast radius into *history storage*, because the
+two concerns share a directory tree. The pattern across all five: the global-vs-per-channel boundary is
+enforced by convention and code review, not by an automated invariant — so it keeps drifting back.
+
+---
+
+## 3. What this is *not*
+
+- **Not a bug in this agent's own working directory or CLAUDE.md.** `clamk-0612a`'s `CLAUDE.md`/config is
+  correct; the fragmentation happens below the agent-definition layer, in shared platform code.
+- **Not intentional data loss.** PR #2431's author (per the fixup commit's own review-response note) believed
+  the isolation was scoped to "the Armory account list / explicitly-bound identity dirs" and did not intend
+  to isolate conversation transcripts. The bug is that those two things are the same directory tree today.
+- **Not fixable by reverting PR #2431 outright.** Its actual goal (real login/relogin testing coverage on
+  dev/local builds) is legitimate and already referenced by `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`
+  and `docs/specs/SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`. The fix is to narrow its scope, not
+  undo it (§4.1).
+
+---
+
+## 4. Proposed design
+
+### 4.1 Split "credential isolation" from "history storage" (fixes the regression)
+
+Add a second resolver, e.g. `identity_history_dir(bundle_id, provider)`, that **always** resolves under
+`shared_dir.join("identities").join(bundle_id).join(provider)` — regardless of `isolated_auth_enabled()`.
+Point `CLAUDE_CONFIG_DIR`'s `projects/` subpath (and equivalents for other providers) at this always-global
+location, while credential material (`.credentials.json`, tokens) continues to honor
+`isolated_auth_enabled()` via the existing `identities_dir()`. Concretely this likely means spawning Claude
+Code with two separately-configured paths instead of one combined config-dir root, or seeding a junction/
+symlink from the isolated dir's `projects/` into the shared one at bundle-creation time. This is the direct
+fix for §1.2 — testing safety for credentials is preserved; conversation history stops being collateral
+damage.
+
+### 4.2 Stable name → bundle_id mapping (fixes §1.3, independent of 4.1)
+
+Extend the existing global agent registry record (`shared/agents/registry/<agent_id>.json`, per
+`SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE`) with an `identity_bundle_id` field. Before
+`compute_and_ensure_account_dir` mints a fresh UUID, it should look up this global, always-channel-independent
+mapping for an existing bundle id tied to this agent and reuse it, only falling back to `Uuid::new_v4()` when
+truly no prior binding exists anywhere. This removes "new UUID every fresh channel" as a failure mode even if
+some other future change re-isolates history storage.
+
+### 4.3 Fix the read path regardless (belt-and-suspenders, unblocks recovery today)
+
+Update `ClaudeHistoryAdapter::new()` to also enumerate every channel's per-channel identities dir —
+`channels/*/identities/*/claude/projects` and `dev/*/*/identities/*/claude/projects` — not just the global
+`shared_dir/identities`. This is what makes *already-fragmented* history (everything written between
+2026-08-06 and whenever 4.1 ships, plus any future recurrence) recoverable through the UI instead of a manual
+grep, independent of whether the write path is ever fully fixed.
+
+### 4.4 A fast index instead of a filesystem walk (the actual "fast lookup" ask)
+
+Once 4.1–4.3 land, build a small persisted index — e.g. `shared/agents/history-index.json` or a table in the
+existing shared store — mapping `agent_id -> [{channel, bundle_id, project_path_hash, session_file,
+last_modified}]`. Populate/refresh it incrementally whenever `ClaudeHistoryAdapter` scans (or on a
+lightweight fs-watch), and have the "Conversation History" UI action and `ListRecentSessionsCommand` consult
+the index first. This turns "find this agent's last conversation" into an O(1) keyed lookup instead of an
+O(every `.jsonl` under `~/.agentmux`) walk — the concrete speed problem the operator raised, and the reason
+this investigation itself took a multi-file `grep` sweep rather than a single lookup.
+
+### 4.5 Make the invariant enforced, not conventional
+
+Given this is the fifth occurrence of the same class of regression (§2), the recommendation from the
+2026-07-27 retro — never implemented — should be treated as a prerequisite, not a nice-to-have:
+
+1. **An e2e test**: create a named, identity-bound agent; drive one turn; simulate a version bump (fresh
+   local build → new channel, matching `hash.rs`'s own per-build test setup); reopen the agent; assert (a) the
+   same `bundle_id` is reused, (b) the prior Claude session file is discoverable via the history adapter/
+   index, (c) the "Conversation History" action returns it without a filesystem walk.
+2. **A structural coupling check**: any future PR that changes what `isolated_auth_enabled()`/
+   `identities_dir()` isolates must also touch `ClaudeHistoryAdapter`'s scan list, or a test should fail —
+   e.g. a single shared constant/test asserting the two directory-enumeration lists agree on every base path
+   `identities_dir()` can resolve to, for both isolated and global cases.
+
+### 4.6 Immediate mitigation (before 4.1–4.5 ship)
+
+This is a live, 10-day-old regression actively losing history-findability on every fresh local build. Until
+the structural fix lands, either (a) fast-follow 4.1 as a standalone hotfix (narrowest, most direct), or (b)
+as a stopgap, explicitly set `AGENTMUX_ISOLATED_AUTH=0` in the launch environment for identity-bound
+"named continuing agent" launches specifically (as opposed to disposable Armory test agents), so they keep
+resolving to the global store until the real fix ships.
+
+---
+
+## Appendix: research method
+
+Two research agents were dispatched in parallel: one read the relevant specs/retros/analysis docs in full
+(§2's table), the other read the live code paths (channel creation, identity minting, the history adapter,
+the frontend history surfaces). A third, nested agent summarized additional recent retros/analyses not in the
+first agent's initial list. Every code claim material to the root-cause conclusion (§1) was then independently
+re-verified by this agent directly against `git show`/`grep` output — not taken on the sub-agents' word alone
+— including pulling the full diff of commit `9f6cc2824` to confirm the exact default-resolution logic, and
+reading `identities_dir()`, `provider_auth_dir()`, `compute_and_ensure_account_dir`, and
+`ClaudeHistoryAdapter::new()` in full rather than trusting excerpted summaries. The local checkout being 210
+commits behind `origin/main` was itself a relevant finding (§ground truth basis) — the regression exists only
+on `origin/main` and would not have been reproducible by reading this checkout's own working tree alone.

--- a/docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+++ b/docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
@@ -1,0 +1,225 @@
+# Canonical Agent Identity/History Persistence Protocol — Synthesis with Mandatory ABF
+
+**Date:** 2026-08-16
+**Author:** Clamk (agent, `~/.agentmux/agents/clamk-0612a`), at operator request
+**Status:** Proposal — synthesizes two existing documents into a canonical protocol; not yet implemented or
+reviewed.
+**Ground truth basis:** `agentmuxai/agentmux` local checkout at `3705f83c3`
+(`agent3/bashwrap-persist-cwd-across-calls`), cross-checked against `origin/main` at `72aefad4d`.
+**Related:**
+`docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md` (this agent's own root-cause report,
+written earlier the same day — background for §1-2 below),
+`docs/specs/ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` (PR #2587, merged 2026-08-15 — the "every
+agent gets its own dedicated, portable bundle" work this doc builds on),
+`docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`,
+`docs/specs/SPEC_AGENT_GLOBAL_PORTABILITY_2026-06-16.md`.
+**Motivation:** the operator, after reading the root-cause report, asked three questions: (1) does this
+indicate the system is mid-migration and needs cleanup, (2) should there be a formal spec canonizing the
+correct protocol, and (3) could the just-shipped Mandatory ABF work be the right place to anchor conversation
+history, so it's naturally portable. This doc answers all three together, since the answer to (3) changes the
+shape of (2).
+
+---
+
+## 1. Yes — this is a mid-migration state, with three overlapping unfinished migrations
+
+The operator's instinct is correct. Three separate, independently-tracked migrations are all in-flight at
+once, and the identity/history fragmentation bug traced in the companion report is a symptom of exactly this
+overlap, not an isolated defect:
+
+### 1.1 The `db_agent_definitions`/`db_agent_instances` → `db_agents` consolidation is stalled mid-phase
+
+`agentmux-srv/src/backend/storage/migrations.rs`'s own schema-version comment (v4, `OBJECT_SCHEMA_VERSION`)
+states: *"db_agents consolidation table (Phase 3a; dual-write only, reads still on
+db_agent_definitions / db_agent_instances)."* **This comment is stale and wrong as of 2026-08-15.** PR #2587's
+review round 2 (documented in `ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §3.1's 2026-08-15 correction)
+discovered live, while implementing an unrelated backfill migration, that `agent_def_list()` — the function
+most of the codebase already uses to enumerate agents — **already reads from the consolidated `db_agents`
+table**, not `db_agent_definitions`. Nobody had updated the schema-version doc comment, or apparently
+realized the read-side flip (Phase 3b) had partially happened, until a migration written against the
+documented (stale) model broke on its second run. This is a mid-migration system whose own internal
+documentation disagrees with its own code about which phase it's in.
+
+### 1.2 The identity/credential store-routing split (`wstore` vs `id_store`) is enforced by convention only, and was violated the same week
+
+`server/mod.rs`'s own doc comment establishes the rule: handlers must capture `id_store` (not `wstore`) "for
+any operation that must survive across version upgrades." This is precisely the invariant the companion
+report's root cause (PR #2431, `identities_dir()`) and this doc's §2 are both about. Yet PR #2587 — the
+Mandatory ABF work itself, merged one day before this report — shipped its first version with exactly this
+bug: bundle provisioning at all six agent-creation call sites, and the new `m0021` backfill migration, wrote
+into `wstore` (the per-channel store) instead of `id_store` (the shared/global store), making every newly
+provisioned per-agent bundle invisible to Armory and to the bundle-summary panel the same PR added. This was
+caught and fixed in review (§8 of the ABF doc) — but it demonstrates the "silently routes global data through
+a per-channel store" failure mode is not a one-off from 2026-08-06; it is actively recurring in brand-new code
+as of 2026-08-15, because there is still no structural guard against it (§2.2 below proposes one).
+
+### 1.3 The history-adapter/identity-isolation split was never reconciled at all
+
+Per the companion report, `ClaudeHistoryAdapter` (the code that finds Claude Code transcripts) has not been
+touched to account for PR #2431's `identities_dir()` default change. These two pieces of code were written by
+different efforts, at different times, and nothing currently checks that they agree on where history can
+live. This is not "a migration in progress" so much as "a migration that was never started" — the read path
+simply doesn't know the write path's default changed.
+
+**Conclusion for (1):** yes, this needs cleanup, and it is bigger than the single regression the companion
+report root-caused. There are at least three independent seams (definition-table consolidation, store
+routing, and history-path/identity-isolation coupling) that all touch the same underlying data and are all
+individually incomplete. A canonical protocol (§2) should resolve all three at once, since patching any one in
+isolation leaves the other two as latent recurrences of the same bug class.
+
+---
+
+## 2. A canonical protocol (answers "do we want a formal spec")
+
+Propose formalizing the following as an enforced protocol, not a convention — five invariants, each with a
+concrete mechanism, targeting the exact failure modes in §1 and the companion report's §2 table (five prior
+incidents, all the same class):
+
+### P1 — Every piece of agent data has exactly one declared scope, from a closed taxonomy
+
+| Scope | Contains | Lives | Keyed by |
+|---|---|---|---|
+| **CREDENTIAL** | OAuth tokens, PATs | Global, unless `isolated_auth_enabled()` (per-channel, for Armory testing only) | `bundle_id` (account) |
+| **DEFINITION** | Agent identity: name, provider, `default_memory_id` binding | Always global | `agent_id` |
+| **PORTABLE CONFIG (ABF)** | Instructions, context, skills, memory, harness+model | Always global | `memory_id` (bundle id) |
+| **CONVERSATION HISTORY** | Provider transcripts (Claude/Codex/etc. session JSONL) | Always global | `agent_id` (§3 — not `memory_id`, not account/bundle UUID) |
+| **RUNTIME/EPHEMERAL** | Pane layout, active session pointer, per-launch instance rows | May legitimately be per-channel/per-instance | `channel` + `instance_id` |
+
+This table is new — today, scope is decided ad hoc per call site (§1.2's bug is a direct consequence: nothing
+declared which scope a newly-provisioned bundle belonged to, so the six call sites each guessed, and five
+guessed wrong). RUNTIME/EPHEMERAL is the *only* row channel isolation is allowed to touch; every regression
+in the companion report's §2 table and §1 above is a case of channel-scoping leaking into one of the other
+four rows.
+
+### P2 — One resolver per scope, no ad hoc store access
+
+Every read/write for CREDENTIAL/DEFINITION/PORTABLE CONFIG/CONVERSATION HISTORY must go through a named
+resolver (`identities_dir()`, an `agent_id`-keyed definition accessor, a `memory_id`-keyed bundle accessor, a
+new `agent_history_store(agent_id)` accessor) — never direct `wstore`/`instance_dir` access from a new call
+site. This is already the intended pattern (`id_store` vs `wstore`); P2 just says it must be the *only*
+pattern, enforced by P3 rather than left to individual PR authors to remember (which is exactly what failed
+in §1.2).
+
+### P3 — Each scope's routing is covered by an automated test, not a comment
+
+`agentmux-common/src/data_paths.rs` already has this shape for CREDENTIAL
+(`identities_dir_is_shared_on_stable_channel` etc., §1.2 of the companion report) — extend the same pattern to
+the other three non-ephemeral scopes: a test asserting DEFINITION reads/writes never vary by channel, a test
+asserting PORTABLE CONFIG never lands in a per-channel store (this would have caught §1.2's bug directly), and
+a new test asserting CONVERSATION HISTORY resolves to the same location regardless of which channel the
+resolving code runs in. Per the companion report §4.5 and the 2026-07-27 retro this is the *fourth-plus* time
+this exact recommendation has been made and not shipped — treat it as a blocking prerequisite for this
+protocol, not an optional follow-up.
+
+### P4 — Migration-phase state is a single source of truth, not a doc comment
+
+§1.1's stale comment caused a real bug (the `m0021` `UNIQUE constraint failed` loop). Track which phase each
+in-flight table consolidation is actually in in one place the code itself can assert against — e.g. a
+`#[test]` that queries which table `agent_def_list()` and its siblings actually read from and fails if it
+doesn't match the doc comment's claimed phase — rather than trusting the comment to be updated by hand every
+time a partial flip happens.
+
+### P5 — Conversation history anchors on `agent_id`, using the ABF binding as its registry (§3)
+
+---
+
+## 3. Should conversation history be persisted in the ABF? — Yes and no; the useful part is the anchor, not the payload
+
+The Mandatory ABF work (2026-08-15) is directly relevant, and the operator's instinct that it "may play into"
+this is right — but the useful piece is narrower than "store transcripts inside the bundle."
+
+### 3.1 What ABF now provides that didn't exist this morning
+
+As of PR #2587, every agent **definition** has exactly one dedicated bundle, bound at definition-creation
+time (not launch time), written through `id_store` (global, cross-channel, after the §1.2 fix), with the
+binding living on `db_agents.default_memory_id`. Concretely: **this is now exactly the "stable name → durable
+id, written once, globally, at definition time" registry that the companion report's §4.2 proposed building
+from scratch** ("Extend the existing global agent registry record ... with an `identity_bundle_id` field ...
+before minting a fresh UUID, look up this global mapping and reuse it"). The ABF work independently built the
+infrastructure for that same shape, for a different reason (portable instructions, not history). Reusing it
+is strictly cheaper than building a second, parallel global registry.
+
+### 3.2 Why the anchor should be `agent_id`, not `memory_id` (the bundle itself)
+
+It's tempting to key history directly on `memory_id` since that's the id that's now stable and global. Don't
+— two properties of ABF make it the wrong direct anchor:
+
+- **Bundles can be shared or rebound.** §4 of the ABF doc explicitly keeps this open ("not proposing to
+  restrict sharing... if a user explicitly wants that"). If two agents ever point at the same `memory_id`,
+  keying history by bundle id would merge their conversations into one history — wrong, and silently so.
+- **Bundles can outlive their agent, or an agent could in principle rebind.** §5 decision 2 of the ABF doc:
+  deleting an agent orphans its bundle by default rather than deleting it. History should stay attached to
+  the *agent* across a bundle swap or an agent's deletion-and-bundle-orphaning, not silently move or vanish
+  because the bundle's lifecycle diverged from the agent's.
+
+So: **use the agent's own durable `agent_id` as the conversation-history anchor** (matching
+`SPEC_AGENT_GLOBAL_PORTABILITY`'s original intent), but **use the ABF binding (`default_memory_id`, written
+at definition time, globally, via `id_store`) as the mechanism that makes `agent_id` itself discoverable and
+stable across a channel change** — i.e., the missing piece from the companion report (§1.3: "a fresh, random
+UUID is minted every channel with nothing tying it to the previous one") is fixed not by inventing new plumbing,
+but by the fact that a Mandatory-ABF agent's `agent_id` is now already resolvable through the same global,
+definition-time-bound registry the bundle uses, instead of through a per-channel, per-launch account UUID
+that never had a durable identity to begin with.
+
+### 3.3 Why the transcript payload itself should stay out of the ABF export
+
+ABF's own stated design (§7.1 of the architecture doc) is "the portable unit isn't the agent, it's the ABF" —
+explicitly meant to be exported, imported, and **shared** (§4: "not proposing to restrict sharing... a
+team-wide instruction set"). A multi-MB-to-GB, single-agent, high-churn, non-reusable conversation transcript
+is a different kind of artifact than a reusable instructions/context/skills bundle, and embedding it would:
+
+- Bloat every ordinary ABF export (instructions-sharing use case) with unrelated, often-huge private data.
+- Create exactly the ambiguity §3.2 warns about — if bundle B is shared by two agents and the export embeds
+  "the" conversation history, whose history is it?
+- Conflict with the "orphan, don't delete" bundle-lifecycle default (§5 decision 2) — that default makes
+  sense for reusable instructions a user might want to recover later; it's a much more consequential default
+  for a full private conversation record, and deserves its own explicit decision rather than inheriting the
+  bundle's.
+
+**Recommendation:** keep conversation history in its own store (per the companion report §4.1/§4.3-4.4,
+always-global, keyed by `agent_id`), and add a **separate, explicit, opt-in "export with history" action** —
+distinct from the default ABF export — for the genuine use case of moving one specific agent's full record to
+another machine. The default `bundle.export_for_agent` stays lean and shareable, exactly as designed.
+
+---
+
+## 4. Recommended sequencing
+
+Building on the companion report's §4 (which this section supersedes/refines with the ABF-anchor insight):
+
+1. **Finish P4 first, cheaply**: fix the stale Phase 3a/3b comment in `migrations.rs` to state the actual
+   current reality (`agent_def_list()` already reads `db_agents`), and add the doc/code-agreement test P4
+   describes. Low-risk, unblocks reasoning about everything else correctly.
+2. **P1's taxonomy + P3's tests, applied first to the two known-bad scopes**: add the missing PORTABLE CONFIG
+   and DEFINITION routing tests (would have caught §1.2's bug); add the CREDENTIAL vs CONVERSATION HISTORY
+   split from the companion report's §4.1 (split `identities_dir()`'s effect on `claude/projects` out from
+   its effect on credential material).
+3. **Wire `agent_id` → history resolution through the existing ABF/`default_memory_id` binding** (§3.2) —
+   this both fixes the companion report's §1.3 (no more freshly-minted, unlinked UUIDs for identity-bound
+   agents) and gives CONVERSATION HISTORY its P1-mandated stable key, in one change, reusing infrastructure
+   PR #2587 already shipped rather than building a parallel registry.
+4. **Fix the read path** (companion report §4.3: `ClaudeHistoryAdapter` scans the per-channel path too) and
+   **build the fast index** (§4.4) on top of the now-stable `agent_id` anchor — this is what actually makes
+   "Conversation History" fast, per the operator's original ask, and it only needs to be built once the anchor
+   from step 3 is stable, not before.
+5. **Add the opt-in "export with history" action** (§3.3) as a genuinely new, separate feature once steps 1-4
+   give it something stable to read from.
+6. **Formalize P2/P3 as a written, reviewable checklist** (not just this doc) that any PR touching
+   CREDENTIAL/DEFINITION/PORTABLE CONFIG/CONVERSATION HISTORY routing must satisfy before merge — the actual
+   "formal specification that canonizes the proper protocol" the operator asked for, once steps 1-5 have
+   proven the taxonomy holds up against real implementation (this doc is the proposal; a leaner, PR-checklist
+   version is the artifact worth canonizing after review, per this repo's own pattern of "DECISIONS RESOLVED"
+   docs preceding a "PR-sized checklist" — see how `ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` itself
+   was structured).
+
+---
+
+## Appendix: what changed since the companion report (same day)
+
+The companion report (`REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md`, written earlier today)
+proposed a new "stable name → bundle_id mapping" (its §4.2) as new infrastructure to build. This doc's
+contribution is realizing that infrastructure was *already built*, one day earlier, for a different purpose
+(PR #2587's Mandatory ABF), and reusing it is both cheaper and more consistent with this codebase's existing
+"global registry written at definition time" pattern than adding a second one. The companion report's root
+cause (§1 there) and proposed fixes 4.1, 4.3, 4.4, 4.5 stand unchanged; only 4.2's mechanism is superseded by
+§3.2 above.


### PR DESCRIPTION
## Summary

Step 3 of #2603 (agent identity/history persistence protocol). Fixes the actual, currently-live regression root-caused in `docs/specs/REPORT_AGENT_IDENTITY_HISTORY_FRAGMENTATION_2026_08_16.md`: `identities_dir()` isolating a provider's credential directory per-channel (the default for every non-`stable` channel since PR #2431) silently isolates that provider's conversation transcripts too, since e.g. Claude Code's `projects/` lives inside the same directory tree as its credentials.

**Fix:** `DataPaths::identity_history_dir()` always resolves globally, independent of `isolated_auth_enabled()`. `ensure_history_link()` makes an isolated credential dir's `projects/` subpath a directory junction (Windows) / symlink (Unix) pointing at that global location — so the provider CLI is unaware anything changed, but its session data lands in one stable place regardless of which channel/build spawned it. Migrates any pre-existing real directory's contents into the global target first (never overwriting, never deleting), so history that predates this fix isn't orphaned.

Used the `junction` crate on Windows rather than `std::os::windows::fs::symlink_dir` (requires `SeCreateSymbolicLinkPrivilege` — admin or Developer Mode, which this app can't assume) or hand-rolled `DeviceIoControl`/`FSCTL_SET_REPARSE_POINT` FFI (this is credential-adjacent storage — not a place to improvise low-level filesystem code).

Wired into both `identity_auth_dirs.rs` call sites, gated on `isolated_auth_enabled()` (a no-op when off, since `dir/projects` already IS the global location in that case).

## Verification

Beyond `cargo test`, verified empirically on this real Windows machine before wiring into any credential-handling code:
- Created a real junction via the new code, confirmed its type (`Junction`) and target via PowerShell `Get-Item`
- Confirmed a file written at the global target reads back through the isolated link path, both via Rust's own `fs` APIs and native `Get-Content`
- The migration test caught a real bug during development (`junction::create` needs the link's parent dir to pre-exist, not just the target) — fixed before this PR, not left for review to catch

## Test plan

- [x] `cargo test -p agentmux-common --lib` — 148 passed, including 4 new tests on `ensure_history_link` (creation + read-through, idempotency, pre-existing-directory migration, never-overwrite-on-collision)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2346 passed, 0 failed, 6 pre-existing ignores, including a new end-to-end test (`compute_account_dir_links_projects_to_the_global_history_location_when_isolated`) exercising the real `compute_and_ensure_account_dir` call site, not just the linking primitive in isolation
- [x] `cargo check --workspace` — clean

<!-- agentmux:agent_id=clamk -->