### PR TITLE
fix(identity): resolve provider through the bound bundle at the three backend clone-sites

### DIFF
--- a/.changesets/1786905565-fix-identity-resolve-provider-through-the-bound-bundle-at-th-y6jm.md
+++ b/.changesets/1786905565-fix-identity-resolve-provider-through-the-bound-bundle-at-th-y6jm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): resolve provider through the bound bundle at the three backend clone-sites

--- a/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
+++ b/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
@@ -257,12 +257,21 @@ pub fn migrate_promote_template_sessions_v1(
             // at the deterministic id. Field copies mirror
             // `agent_def_create_from_template`.
             let now = now_ms() as i64;
+            // Resolve through the template's own bound bundle when it has
+            // one, not the possibly-drifted `db_agent_definitions.provider`
+            // column directly (#2594, same pattern as
+            // `agent_def_create_from_template`/`forkagentdefinition`). Only
+            // `wstore` is available in this migration (no id_store/shared
+            // store handoff at this point in the boot sequence) — falls
+            // back to `template.provider` when the bundle isn't found via
+            // this store, same as it did before this fix.
+            let effective_provider = wstore.resolve_effective_provider_id(template);
             let mut new_def = crate::backend::storage::store::AgentDefinition {
                 id: promote_target_id.clone(),
                 slug: String::new(),
                 name: new_name.clone(),
                 icon: template.icon.clone(),
-                provider: template.provider.clone(),
+                provider: effective_provider,
                 description: template.description.clone(),
                 working_directory: String::new(),
                 shell: template.shell.clone(),

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -12,6 +12,7 @@ use super::zone_naming::{agent_archive_zone, validate_and_current};
 use crate::backend::obj::{Block, MetaMapType};
 use crate::backend::storage::filestore::{FileMeta, FileOpts, FileStore};
 use crate::backend::storage::store::Store;
+use crate::backend::storage::Memory;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -602,6 +603,57 @@ fn template_promote_clones_template_and_moves_zones() {
     // file compatibility — see the doc comment on
     // `TEMPLATE_PROMOTE_MARKER_V1`).
     assert!(!dir.path().join(TEMPLATE_PROMOTE_MARKER_V1).exists());
+}
+
+#[test]
+fn template_promote_resolves_provider_through_the_templates_bundle_not_the_drifted_column() {
+    // Template's own `.provider` column says "codex" (drifted/stale —
+    // simulates the same drift class #2592 fixed: some definition-time
+    // write path changed this column after the bundle was already
+    // provisioned/immutable), but its bound bundle's REAL provider is
+    // "claude". The promoted clone must carry "claude", not "codex"
+    // (#2594, same pattern as `agent_def_create_from_template`/
+    // `forkagentdefinition`).
+    let dir = tempdir().unwrap();
+    let wstore = open_temp_wstore(dir.path());
+    let filestore = fresh_filestore();
+
+    let bundle = Memory {
+        id: "bundle-claude".to_string(),
+        name: "Bundle".to_string(),
+        description: String::new(),
+        is_blank: false,
+        is_global: false,
+        provider: "claude".to_string(),
+        model: String::new(),
+        instructions: String::new(),
+        instructions_by_provider: "{}".to_string(),
+        context_files: "[]".to_string(),
+        mcp_servers: "[]".to_string(),
+        skills: "[]".to_string(),
+        sort_order: 0,
+        created_at: 0,
+        updated_at: 0,
+    };
+    wstore.bundle_memory_upsert(&bundle).unwrap();
+
+    let mut template = insert_template(&wstore, "tpl-drift", "Drifted", "codex");
+    template.memory_id = "bundle-claude".to_string();
+    wstore.agent_def_update(&mut template).unwrap();
+    write_session_state(&filestore, &template.id, br#"{"nodes":[]}"#).unwrap();
+
+    let stats = migrate_promote_template_sessions_v1(&wstore, &filestore, dir.path());
+    assert_eq!(stats.templates_promoted, 1);
+    assert_eq!(stats.failures, 0);
+
+    let promoted = wstore
+        .agent_def_get("template-promote-v1-tpl-drift")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        promoted.provider, "claude",
+        "promoted clone must carry the template's REAL (bundle-resolved) provider, not the drifted `codex` column"
+    );
 }
 
 #[test]

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -107,6 +107,14 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 } else {
                     "local".to_string()
                 };
+                // Template's EFFECTIVE provider — resolved through its own
+                // bound bundle when it has one, not the possibly-drifted
+                // `db_agent_definitions.provider` column directly (#2594,
+                // same "gate vs. actual launch can disagree" risk class
+                // #2592 fixed). Used for both the vendor-base-url
+                // validation below and the clone's own `provider` field so
+                // the two can't disagree with each other.
+                let effective_provider = id_store.resolve_effective_provider_id(template);
                 // Model vendor base URL: `None` (omitted) inherits the
                 // template's own value (the only behavior before this
                 // field existed on this RPC); `Some(url)` overrides it,
@@ -116,7 +124,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // declares `base_url_env_var`.
                 let chosen_model_vendor_base_url = match &cmd.model_vendor_base_url {
                     Some(url) => {
-                        crate::server::app_api::validate_vendor_base_url(&template.provider, url)
+                        crate::server::app_api::validate_vendor_base_url(&effective_provider, url)
                             .map_err(|e| format!("agentdefcreatefromtemplate: {e}"))?;
                         url.clone()
                     }
@@ -129,7 +137,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     slug: String::new(),
                     name: name.clone(),
                     icon: template.icon.clone(),
-                    provider: template.provider.clone(),
+                    provider: effective_provider.clone(),
                     description: template.description.clone(),
                     // Force re-allocation of the per-agent working
                     // directory at first launch via the new slug —
@@ -348,13 +356,18 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     cmd.branch_label.clone()
                 };
                 let branch_slug_part = crate::backend::storage::store::derive_slug(&branch_label);
+                // Source's EFFECTIVE provider — resolved through its own
+                // bound bundle when it has one, not the possibly-drifted
+                // `db_agent_definitions.provider` column directly (#2594,
+                // same pattern as the create-from-template clone site).
+                let effective_provider = id_store.resolve_effective_provider_id(&source);
                 let mut fork = AgentDefinition {
                     id: uuid::Uuid::new_v4().to_string(),
                     // Empty slug → agent_def_insert derives + resolves collisions.
                     slug: format!("{}-{}", source.slug, branch_slug_part),
                     name: fork_name,
                     icon: source.icon.clone(),
-                    provider: source.provider.clone(),
+                    provider: effective_provider,
                     description: source.description.clone(),
                     working_directory: String::new(), // force re-resolve via agentmuxHome()
                     shell: source.shell.clone(),
@@ -529,4 +542,142 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::rpc_types::RpcMessage;
+    use crate::backend::storage::Memory;
+    use crate::server::tests::test_state;
+
+    fn seed_bundle(state: &AppState, id: &str, provider: &str) {
+        let bundle = Memory {
+            id: id.to_string(),
+            name: "Bundle".to_string(),
+            description: String::new(),
+            is_blank: false,
+            is_global: false,
+            provider: provider.to_string(),
+            model: String::new(),
+            instructions: String::new(),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: 0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        state.id_store.bundle_memory_upsert(&bundle).unwrap();
+    }
+
+    // Template's own `.provider` column says "codex" (drifted/stale —
+    // simulates the same drift class #2592 fixed: some definition-time
+    // write path changed this column after the bundle was already
+    // provisioned/immutable), but its bound bundle's REAL provider is
+    // "claude". A correct clone/fork must carry "claude", not "codex".
+    fn seed_drifted_template(state: &AppState, def_id: &str, bundle_id: &str) {
+        let mut def = AgentDefinition {
+            id: def_id.to_string(),
+            slug: String::new(),
+            name: "Drifted Template".to_string(),
+            icon: String::new(),
+            provider: "codex".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 1,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: bundle_id.to_string(),
+        };
+        state.wstore.agent_def_insert(&mut def).unwrap();
+    }
+
+    #[tokio::test]
+    async fn agentdefcreatefromtemplate_resolves_provider_through_the_templates_bundle() {
+        let state = test_state();
+        seed_bundle(&state, "bundle-claude", "claude");
+        seed_drifted_template(&state, "tpl-1", "bundle-claude");
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+
+        engine.handle_message(RpcMessage {
+            command: COMMAND_AGENT_DEF_CREATE_FROM_TEMPLATE.to_string(),
+            reqid: "req-1".to_string(),
+            data: Some(serde_json::json!({
+                "template_id": "tpl-1",
+                "name": "My Clone",
+            })),
+            ..Default::default()
+        });
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: AgentDefCreateFromTemplateResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+
+        let cloned = state
+            .wstore
+            .agent_def_get(&result.definition_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            cloned.provider, "claude",
+            "clone must carry the template's REAL (bundle-resolved) provider, not the drifted `codex` column"
+        );
+    }
+
+    #[tokio::test]
+    async fn forkagentdefinition_resolves_provider_through_the_sources_bundle() {
+        let state = test_state();
+        seed_bundle(&state, "bundle-claude", "claude");
+        seed_drifted_template(&state, "src-1", "bundle-claude");
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+
+        engine.handle_message(RpcMessage {
+            command: COMMAND_FORK_AGENT_DEFINITION.to_string(),
+            reqid: "req-1".to_string(),
+            data: Some(serde_json::json!({
+                "source_id": "src-1",
+                "branch_label": "",
+            })),
+            ..Default::default()
+        });
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let fork: AgentDefinition =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+
+        assert_eq!(
+            fork.provider, "claude",
+            "fork must carry the source's REAL (bundle-resolved) provider, not the drifted `codex` column"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Delivery-plan item 2 of #2594 (harness/model decoupling & ABF portability) — the three backend clone-sites (`template.rs:119,132`, `template.rs:357`, `v1_templates.rs:265`).

`agentdefcreatefromtemplate`, `forkagentdefinition`, and the template-promote migration all cloned a source/template definition's `.provider` column directly instead of resolving through its own bound bundle — the same "gate vs. actual launch can disagree" drift class #2592 fixed for the credential gate and launch path. If a template/source's `provider` column had drifted from its (immutable) bundle copy, a clone/fork/promote would silently inherit the stale value instead of the real one.

- `agentdefcreatefromtemplate` (`template.rs:119,132`) and `forkagentdefinition` (`template.rs:357`) now call `id_store.resolve_effective_provider_id()`, already available in both RPC handler scopes. The create-from-template vendor-base-url validation now uses the same resolved value it validates the new definition against, instead of a separately-read (and possibly different) column.
- The template-promote migration (`v1_templates.rs:265`) calls `wstore.resolve_effective_provider_id()` — only `wstore` is available at that point in the boot sequence (no id_store/shared-store handoff has happened yet), which safely falls back to the drifted column when the bundle isn't found via that store — same behavior as before this fix, strictly better when the bundle is reachable.

## Test plan

- [x] Regression tests for all three sites seed a template/source with a drifted `.provider` (`"codex"`) against a bundle with the real provider (`"claude"`) and assert the clone/fork/promote carries `"claude"`.
- [x] Verified all three new tests fail against the pre-fix code (temporarily reverted the three fixes, kept the tests — all three failed with `left: "codex", right: "claude"`), then confirmed they pass again with the fix restored.
- [x] `cargo check -p agentmux-srv` — clean, no new warnings/errors.
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::storage::` — 282/282 pass.
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::agent_session::` — 35/35 pass (1 pre-existing ignore).
- [x] `cargo test -p agentmux-srv --bin agentmux-srv server::agent_handlers::` — 30/30 pass, including the 2 new RPC-level tests.
- [x] Merged latest `main` into the branch before pushing (picked up #2606).

<!-- agentmux:agent_id=agenty -->