### PR TITLE
fix(identity): remove the post-creation model-vendor-base-url editor from AgentIdentityModal

### DIFF
--- a/.changesets/1786924587-fix-identity-remove-the-post-creation-model-vendor-base-url--34n9.md
+++ b/.changesets/1786924587-fix-identity-remove-the-post-creation-model-vendor-base-url--34n9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): remove the post-creation model-vendor-base-url editor from AgentIdentityModal

--- a/frontend/app/view/agent/components/AgentIdentityModal.scss
+++ b/frontend/app/view/agent/components/AgentIdentityModal.scss
@@ -16,64 +16,10 @@
 // The ambient-login opt-in row that used to live here was removed (reagent
 // P1 on #2262 — see AgentIdentityModal.tsx's doc comment): the layer-3
 // spawn gate no longer honors use_ambient_login at all, so the toggle was
-// dead UI promising a fallback that no longer existed.
-
-.agent-identity-vendor-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1-5);
-    padding: var(--space-3) var(--space-5);
-    border-top: 1px solid var(--border-color);
-}
-
-.agent-identity-vendor-label {
-    font-size: var(--text-sm);
-    font-weight: var(--font-weight-medium);
-    opacity: 0.75;
-}
-
-.agent-identity-vendor-row {
-    display: flex;
-    gap: var(--space-2);
-}
-
-.agent-identity-vendor-input {
-    flex: 1;
-    padding: var(--space-1-5) var(--space-2);
-    font-size: var(--text-sm);
-    background: var(--main-bg-color);
-    color: var(--main-text-color);
-    border: 1px solid var(--border-color);
-    border-radius: 0;
-}
-
-.agent-identity-vendor-save-btn {
-    padding: var(--space-1-5) var(--space-3);
-    font-size: var(--text-sm);
-    color: var(--button-text-color);
-    background: var(--accent-color);
-    border: none;
-    border-radius: 0;
-    cursor: default;
-
-    &:disabled {
-        opacity: 0.5;
-    }
-
-    &:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--accent-color) 85%, var(--main-text-color));
-    }
-}
-
-.agent-identity-vendor-hint {
-    font-size: 0.8em;
-    opacity: 0.6;
-}
-
-.agent-identity-vendor-error {
-    font-size: 0.85em;
-    color: var(--warning-color, #d97706);
-}
+// dead UI promising a fallback that no longer existed. The model-vendor /
+// custom-endpoint editor that used to live below it was removed for the
+// same "dead/misleading UI" reason (issue #2594) — see
+// AgentIdentityModal.tsx's doc comment.
 
 .agent-modal-footer {
     display: flex;

--- a/frontend/app/view/agent/components/AgentIdentityModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityModal.test.tsx
@@ -1,0 +1,94 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentIdentityModal must not offer a way to edit `model_vendor_base_url`
+ * after the agent's bundle already exists.
+ *
+ * Issue #2594 ("needs a product decision" item, resolved 2026-08-16):
+ * this modal used to let a user write a NEW `model_vendor_base_url`
+ * straight onto `AgentDefinition` post-creation — the one remaining
+ * post-creation write path for a field the Mandatory ABF architecture
+ * (`ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §7.4.1) treats as
+ * set-once at definition/bundle-creation time, same as `provider` (which
+ * this same modal has never let a user edit). The bundle has no field to
+ * mirror the raw base-url string into either, so there was no bundle
+ * value to "resolve through" the way #2592/#2607 fixed provider drift —
+ * the only consistent fix is to stop writing a second, divergent copy of
+ * this field after creation at all. The definition-time UI
+ * (`AgentCreateFromTemplateModal.tsx`) is unaffected; it still sets the
+ * value once, before/at bundle provisioning.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentIdentityModalPanel } from "./AgentIdentityModal";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { UpdateAgentDefinitionCommand: vi.fn() },
+}));
+
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+vi.mock("@/app/view/identity/identity-model", () => ({
+    IdentityViewModel: class {
+        dispose(): void {}
+    },
+    serializeAgentAccounts: vi.fn(() => ""),
+}));
+
+vi.mock("./AgentIdentityPanel", () => ({
+    AgentIdentityPanel: () => <div data-testid="identity-panel-stub" />,
+}));
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+const claudeAgent = {
+    id: "agent-1",
+    name: "Claude Agent",
+    icon: "✦",
+    provider: "claude", // PROVIDERS["claude"].baseUrlEnvVar is set — the
+    // one case where the (now-removed) vendor section used to render.
+    description: "",
+    working_directory: "",
+    shell: "",
+    provider_flags: "",
+    auto_start: 0,
+    restart_on_crash: 0,
+    idle_timeout_minutes: 0,
+    created_at: 0,
+    agent_type: "host",
+    environment: "",
+    agent_bus_id: "",
+    is_seeded: 0,
+    accounts: "",
+    parent_id: "",
+    branch_label: "",
+    updated_at: 0,
+    user_hidden: 0,
+    container_image: "",
+    container_volumes: "[]",
+    container_name: "",
+    use_ambient_login: 0,
+    // Already has a bundle — the exact "already exists and is supposed to
+    // be immutable" state the issue calls out.
+    memory_id: "mem-1",
+    model_vendor_base_url: "",
+    auto_continue_enabled: 0,
+} as unknown as AgentDefinition;
+
+describe("AgentIdentityModal — no post-creation model-vendor edit surface", () => {
+    it("does not render a way to edit model_vendor_base_url for an agent whose bundle already exists", () => {
+        render(() => (
+            <AgentIdentityModalPanel agent={claudeAgent} blockId="block-1" onClose={vi.fn()} />
+        ));
+
+        expect(screen.queryByTestId("agent-identity-vendor-base-url-input")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("agent-identity-vendor-base-url-save")).not.toBeInTheDocument();
+        expect(screen.queryByText("Model Vendor / Custom Endpoint")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/app/view/agent/components/AgentIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityModal.tsx
@@ -28,10 +28,24 @@
  * `use_ambient_login` DB column/field itself is untouched (still read and
  * logged, just never gates) — only this now-dead UI is removed.
  *
+ * The "Model Vendor / Custom Endpoint" editor that used to live here was
+ * also removed (issue #2594, 2026-08-16): `model_vendor_base_url` is a
+ * set-once-at-creation field under the Mandatory ABF architecture
+ * (`ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §7.4.1) — same
+ * immutability contract `provider` already has, which this modal has
+ * never let a user edit either. Editing it here wrote straight onto
+ * `AgentDefinition` post-creation with no bundle-side field to keep in
+ * sync (unlike `provider`, the bundle has no base-url column at all), so
+ * every save silently diverged the agent from whatever its bundle was
+ * actually provisioned with. The definition-time editor in
+ * `AgentCreateFromTemplateModal.tsx` is unaffected — it still sets the
+ * value once, before/at bundle provisioning, which is the correct place
+ * for it.
+ *
  * Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md §4.
  */
 
-import { createMemo, createSignal, onCleanup, Show, type JSX } from "solid-js";
+import { createSignal, onCleanup, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import {
@@ -40,7 +54,6 @@ import {
     type AgentAccounts,
 } from "@/app/view/identity/identity-model";
 import { AgentIdentityPanel } from "./AgentIdentityPanel";
-import { PROVIDERS } from "../providers/catalog";
 
 interface AgentIdentityModalPanelProps {
     agent: AgentDefinition;
@@ -88,39 +101,6 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
         setLiveAgent({ ...a, accounts: serialized });
     };
 
-    // ── Model vendor / custom endpoint ─────────────────────────────
-    // Only providers that declare `baseUrlEnvVar` (currently just claude)
-    // can actually be redirected — see agent_define::validate_vendor_base_url
-    // on the backend, which rejects a non-empty override for any other
-    // provider.
-    const supportsCustomEndpoint = createMemo(
-        () => !!PROVIDERS[liveAgent().provider]?.baseUrlEnvVar,
-    );
-    const [modelVendorBaseUrl, setModelVendorBaseUrl] = createSignal(
-        props.agent.model_vendor_base_url ?? "",
-    );
-    const [vendorSaving, setVendorSaving] = createSignal(false);
-    const [vendorError, setVendorError] = createSignal<string | null>(null);
-
-    const handleVendorSave = async (): Promise<void> => {
-        const a = liveAgent();
-        const url = modelVendorBaseUrl().trim();
-        setVendorSaving(true);
-        setVendorError(null);
-        try {
-            await RpcApi.UpdateAgentDefinitionCommand(TabRpcClient, {
-                ...basePayload(a),
-                accounts: a.accounts,
-                model_vendor_base_url: url,
-            });
-            setLiveAgent({ ...a, model_vendor_base_url: url });
-        } catch (e) {
-            setVendorError((e as Error)?.message ?? String(e));
-        } finally {
-            setVendorSaving(false);
-        }
-    };
-
     return (
         <div class="agent-identity-modal-body">
             <AgentIdentityPanel
@@ -128,37 +108,6 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
                 model={model}
                 onUpdate={handleUpdate}
             />
-            <Show when={supportsCustomEndpoint()}>
-                <div class="agent-identity-vendor-section">
-                    <span class="agent-identity-vendor-label">Model Vendor / Custom Endpoint</span>
-                    <div class="agent-identity-vendor-row">
-                        <input
-                            type="text"
-                            class="agent-identity-vendor-input"
-                            placeholder={`Default (${PROVIDERS[liveAgent().provider]?.baseUrlEnvVar})`}
-                            value={modelVendorBaseUrl()}
-                            onInput={(e) => setModelVendorBaseUrl(e.currentTarget.value)}
-                            disabled={vendorSaving()}
-                            data-testid="agent-identity-vendor-base-url-input"
-                        />
-                        <button
-                            class="agent-identity-vendor-save-btn"
-                            disabled={vendorSaving() || modelVendorBaseUrl().trim() === (liveAgent().model_vendor_base_url ?? "")}
-                            onClick={() => void handleVendorSave()}
-                            data-testid="agent-identity-vendor-base-url-save"
-                        >
-                            {vendorSaving() ? "Saving…" : "Save"}
-                        </button>
-                    </div>
-                    <span class="agent-identity-vendor-hint">
-                        Redirect this agent's harness at a custom API endpoint instead
-                        of the default vendor. Leave blank to use the default.
-                    </span>
-                    <Show when={vendorError()}>
-                        <div class="agent-identity-vendor-error">{vendorError()}</div>
-                    </Show>
-                </div>
-            </Show>
             <div class="agent-modal-footer">
                 <button
                     class="agent-modal-done-btn"


### PR DESCRIPTION
## Summary

Delivery-plan item 3 of #2594 (harness/model decoupling & ABF portability) — the "needs a product decision" item on `AgentIdentityModal.tsx`. **Decision made directly with the human operator in this conversation** (not via jekt/relay): remove the edit surface.

`AgentIdentityModal.tsx` let a user actively edit `model_vendor_base_url` on the agent definition after its bundle already exists — the one remaining post-creation write path for a field the Mandatory ABF architecture (`ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md` §7.4.1) treats as set-once at definition/bundle-creation time, same as `provider` (which this modal has never let a user edit either — there's no provider field in this UI at all).

Unlike `provider`, the bundle (`Memory`) has **no field to mirror the raw base-url string into at all** — `m0021`'s backfill migration only derives a coarse `"custom"` vendor *label* into the bundle's `model` column, never the actual URL string. So there's no bundle-side value to resolve reads through the way #2592/#2607 fixed provider drift (`resolve_effective_provider_id`) — every post-creation edit here just wrote a second, permanently-diverging copy onto `AgentDefinition` with nowhere for it to reconcile. The only consistent fix available at this scope is to stop allowing that second write at all, matching how `provider` is already handled.

The definition-time editor in `AgentCreateFromTemplateModal.tsx` is unaffected — it still sets the value once, before/at bundle provisioning, which is the correct place for it.

## Changes

- Removed the "Model Vendor / Custom Endpoint" section (`supportsCustomEndpoint` memo, `modelVendorBaseUrl`/`vendorSaving`/`vendorError` signals, `handleVendorSave`) from `AgentIdentityModal.tsx`.
- Removed the now-dead `.agent-identity-vendor-*` SCSS rules.
- No backend changes — `updateagent`'s handling of `model_vendor_base_url` is untouched (still supports `AgentCreateFromTemplateModal`'s definition-time write via `agentdefcreatefromtemplate`, a separate RPC).

## Test plan

- [x] New regression test renders `AgentIdentityModalPanel` for an agent whose bundle already exists (`memory_id` set) and provider supports a custom endpoint (`claude`), asserts no vendor-editing input/save-button/label is present.
- [x] Verified the test fails against the pre-fix code (found the real `<input data-testid="agent-identity-vendor-base-url-input">` in the DOM).
- [x] `npx tsc --noEmit -p tsconfig.json` — same 2 pre-existing, unrelated errors as `main` (`armory-view.tsx`/`warden-view.tsx` `MetaType` — confirmed via `git stash`), nothing new.
- [x] `npx vitest run app/view/agent/components/` — 341/342 pass; the 1 failure (`tool-renderers/registry.test.ts`, a timeout) is a pre-existing flake unrelated to this change — passes cleanly in isolation.
- [x] Confirmed no other frontend references to the removed CSS classes/handlers remain.
- [x] Branch was not stale — `main` had not moved since branching, no merge needed before push.

<!-- agentmux:agent_id=agenty -->