### PR TITLE
fix(agent): AgentPicker resolves provider through the bound bundle for install-check, prereq-probe, and add-account

### DIFF
--- a/.changesets/1786925818-fix-agent-agentpicker-resolves-provider-through-the-bound-bu-04jt.md
+++ b/.changesets/1786925818-fix-agent-agentpicker-resolves-provider-through-the-bound-bu-04jt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): AgentPicker resolves provider through the bound bundle for install-check, prereq-probe, and add-account

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -29,6 +29,12 @@ vi.mock("@/app/store/rpc-api", () => {
         ListNamedAgentsCommand: vi.fn().mockResolvedValue([]),
         InstallCheckCommand: vi.fn().mockResolvedValue({ installed: true }),
         ResolvePrereqsCommand: vi.fn().mockResolvedValue({ results: [] }),
+        // Backs `resolveEffectiveLaunchProvider`'s bound-bundle resolution
+        // (#2594) — resolves to `undefined` by default so existing tests
+        // (none of whose agent fixtures set `memory_id`) never even
+        // trigger the fetch; the drift-regression tests below set their
+        // own `.mockResolvedValue`.
+        GetMemoryCommand: vi.fn().mockResolvedValue(undefined),
         AgentSessionReadCommand: vi
             .fn()
             .mockResolvedValue({ content: null, modts: null }),
@@ -80,15 +86,29 @@ vi.mock("@/util/platformutil", () => ({
 }));
 
 vi.mock("../providers", () => ({
-    getProvider: (id: string) =>
-        id === "claude"
-            ? {
-                  id: "claude",
-                  npmPackage: null, // no install needed
-                  cliCommand: "claude",
-                  systemPrereqs: [],
-              }
-            : undefined,
+    getProvider: (id: string) => {
+        if (id === "claude") {
+            return {
+                id: "claude",
+                npmPackage: null, // no install needed
+                cliCommand: "claude",
+                systemPrereqs: [],
+            };
+        }
+        // Recognized and npm-installable (unlike "claude" above) — needed
+        // for the #2594 bundle-resolution regression tests below, where
+        // the REAL (bundle) provider must require an install check for
+        // the fix to be observable at all.
+        if (id === "codex") {
+            return {
+                id: "codex",
+                npmPackage: ["@openai/codex-cli"],
+                cliCommand: "codex",
+                systemPrereqs: [{ tool: "git", label: "Git", installUrls: {}, installLinkText: {} }],
+            };
+        }
+        return undefined;
+    },
 }));
 
 vi.mock("./AgentCard", () => ({
@@ -339,5 +359,96 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         expect(overrides.memoryId).toBe("mem-notes");
         expect(overrides.instanceName).toBe("Mary");
         expect(overrides.continueOfInstanceId).toBeUndefined();
+    });
+
+    // #2594 — AgentPicker's install-check/prereq-probe/cache-invalidation
+    // sites used to read `agent.provider` directly instead of resolving
+    // through the agent's bound bundle, the same "gate vs. actual launch
+    // can disagree" risk class #2592/#2596 fixed for the credential gate
+    // and AgentLaunchModal. These pin the fix at each remaining live site.
+    describe("resolves through the bound bundle, not a drifted agent.provider (#2594)", () => {
+        // Stale `.provider` column ("claude", not npm-installable) vs. the
+        // REAL bundle provider ("codex", npm-installable + has a system
+        // prereq) — chosen so the two providers behave differently enough
+        // that reading the wrong one is observable (no RPC call at all
+        // under the bug, vs. a real call with the fix).
+        const driftedTemplate = baseDef({
+            id: "tpl-drift",
+            slug: "drift",
+            name: "Drifted Template",
+            is_seeded: 1,
+            provider: "claude",
+            memory_id: "mem-drift",
+        });
+
+        beforeEach(() => {
+            vi.mocked(RpcApi.ListAgentDefinitionsCommand).mockResolvedValue([driftedTemplate]);
+            vi.mocked(RpcApi.GetMemoryCommand).mockResolvedValue({ provider: "codex" } as any);
+        });
+
+        it("checks install state against the bundle's provider, not the drifted column", async () => {
+            const model = makeMockModel();
+            render(() => <AgentPicker model={model as any} />);
+            const card = await screen.findByTestId("agent-card-tpl-drift");
+            fireEvent.click(card);
+
+            await waitFor(() => expect(RpcApi.InstallCheckCommand).toHaveBeenCalled());
+            const call = vi.mocked(RpcApi.InstallCheckCommand).mock.calls[0][1];
+            expect(call).toEqual({ providerId: "codex", cliCommand: "codex" });
+        });
+
+        it("probes system prereqs against the bundle's provider, not the drifted column", async () => {
+            vi.mocked(RpcApi.ResolvePrereqsCommand).mockResolvedValue({
+                results: [{ tool: "git", found: false }],
+            } as any);
+            const model = makeMockModel();
+            render(() => <AgentPicker model={model as any} />);
+            const card = await screen.findByTestId("agent-card-tpl-drift");
+            fireEvent.click(card);
+
+            await waitFor(() => expect(RpcApi.ResolvePrereqsCommand).toHaveBeenCalled());
+            const call = vi.mocked(RpcApi.ResolvePrereqsCommand).mock.calls[0][1];
+            expect(call).toEqual({ tools: ["git"] });
+        });
+
+        it("marks the just-installed (drifted) agent's own install cache via the resolved provider", async () => {
+            vi.mocked(RpcApi.InstallCheckCommand).mockResolvedValue({ installed: false });
+            // Explicit no-missing-prereqs default — `vi.clearAllMocks()`
+            // in the outer `beforeEach` clears call history but not a
+            // prior test's `.mockResolvedValue`, so this can't rely on
+            // the module-level default surviving test order.
+            vi.mocked(RpcApi.ResolvePrereqsCommand).mockResolvedValue({
+                results: [{ tool: "git", found: true }],
+            } as any);
+            const model = makeMockModel();
+            render(() => <AgentPicker model={model as any} />);
+            const card = await screen.findByTestId("agent-card-tpl-drift");
+            fireEvent.click(card);
+
+            // installed === false → the install-agent modal opens.
+            await waitFor(() => expect(modalLayerOpen).toHaveBeenCalled());
+            const installReq = modalLayerOpen.mock.calls[0][0];
+            expect(installReq.kind).toBe("install-agent");
+
+            // Simulate a successful install; onInstalled resolves the
+            // agent's bundle provider again to update the cache.
+            await installReq.onInstalled(true);
+
+            // Continuing to launch opens the create-from-template modal —
+            // a second `.open` call.
+            expect(modalLayerOpen).toHaveBeenCalledTimes(2);
+            expect(modalLayerOpen.mock.calls[1][0].kind).toBe("create-from-template");
+
+            // The real proof: clicking the SAME card again must not
+            // re-check install state — under the bug, `onInstalled`'s
+            // cache write compared the drifted `agent.provider` ("claude")
+            // against the resolved canonical ("codex") and never matched,
+            // so the agent's own cache entry stayed unset and every
+            // subsequent click re-triggered InstallCheckCommand.
+            vi.mocked(RpcApi.InstallCheckCommand).mockClear();
+            fireEvent.click(card);
+            await waitFor(() => expect(modalLayerOpen).toHaveBeenCalledTimes(3));
+            expect(RpcApi.InstallCheckCommand).not.toHaveBeenCalled();
+        });
     });
 });

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -42,6 +42,7 @@ import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
 import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
+import { resolveEffectiveLaunchProvider } from "../agent-launch-env";
 import { realAccountIdOrEmpty } from "../identity-carry-over";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { AgentCard } from "./AgentCard";
@@ -140,7 +141,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // there scoped to that tier's data source — not here.
 
     const checkInstalled = async (agent: AgentDefinition) => {
-        const prov = getProvider(agent.provider);
+        // Resolve through the agent's bound bundle rather than reading
+        // the possibly-drifted `agent.provider` column directly — #2594,
+        // same "gate vs. actual launch can disagree" risk class #2592/
+        // #2596 fixed. Without this, a drifted agent could get its CLI
+        // never checked/installed (wrong provider's npmPackage/cliCommand
+        // resolved here) while the actual launch (agent-model.ts, already
+        // resolved this way) spawns the real, uninstalled provider.
+        const providerId = await resolveEffectiveLaunchProvider(agent);
+        const prov = getProvider(providerId);
         // Non-npm providers (kimi via pip, system-PATH CLIs) don't go
         // through the install modal — never show the ribbon.
         if (!prov?.npmPackage || prov.npmPackage.length === 0) {
@@ -196,14 +205,19 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         // #1624 PR-C Part B) — it starts directly from the launch
         // modal's auth panel. This now only fires for the "+ Add
         // account" (manual/API-key) button.
-        onRequestAddAccount: (current: LaunchFormStateWire) => {
+        onRequestAddAccount: async (current: LaunchFormStateWire) => {
+            // Resolve through the bound bundle (#2594) — offering an
+            // "add account" flow for the drifted `agent.provider` instead
+            // of the bundle's real provider would create an account the
+            // agent can never actually use at launch.
+            const providerId = await resolveEffectiveLaunchProvider(agent);
             // Thread the user's whole live form snapshot through the
             // add-account round-trip so name/runtime/image/memory
             // survive alongside the freshly-created account id.
             modalLayer.replace({
                 kind: "add-account" as const,
                 originBlockId: props.model.blockId,
-                provider: agent.provider,
+                provider: providerId,
                 onCreated: (id: string) => {
                     modalLayer.replace(
                         buildLaunchRequest(agent, {
@@ -335,31 +349,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         refocusNode(blockId);
     };
 
-    // Extracted from the install branch of handleSelect so the
-    // prereq modal's "Launch anyway" path can route to install when
-    // needed. Same shape as the existing inline install request.
-    const buildInstallRequest = (agent: AgentDefinition) => ({
-        kind: "install-agent" as const,
-        agent,
-        originBlockId: props.model.blockId,
-        onInstalled: (continueToLaunch: boolean) => {
-            const canonical = getProvider(agent.provider)?.id ?? agent.provider;
-            setInstallState((s) => {
-                const next = { ...s };
-                for (const a of agents()) {
-                    if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
-                        next[a.id] = true;
-                    }
-                }
-                return next;
-            });
-            if (continueToLaunch) {
-                modalLayer.replace(buildLaunchRequest(agent));
-            } else {
-                modalLayer.close();
-            }
-        },
-    });
+    // (`buildInstallRequest` — the generic, pre-two-tier install
+    // request builder — was removed 2026-08-16 as dead code: the
+    // Phase 1 rewrite left `handleSelect`, its only caller, deleted
+    // (see the `handleSelect` removal note below), and nothing else
+    // ever called it. `buildTemplateInstallRequest` below is the only
+    // live install-request builder now.)
 
     // Clicking the card opens either the install or launch modal in
     // the tab-scoped layer, depending on whether the agent's CLI is
@@ -388,7 +383,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         }
     };
     const probeMissingPrereqs = async (agent: AgentDefinition) => {
-        const prov = getProvider(agent.provider);
+        // Resolve through the bound bundle (#2594) — probing prereqs for
+        // the drifted `agent.provider` instead of the bundle's real
+        // provider could pass a launch through with the ACTUAL provider's
+        // system prereqs never checked.
+        const providerId = await resolveEffectiveLaunchProvider(agent);
+        const prov = getProvider(providerId);
         const reqs = prov?.systemPrereqs ?? [];
         if (reqs.length === 0) return [];
         const uncached = reqs.filter((r) => !prereqCache.has(r.tool));
@@ -577,12 +577,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
 
             let installed = installState()[agent.id];
             if (installed === undefined) {
-                const prov = getProvider(agent.provider);
-                const isNpmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
-                if (isNpmInstallable) {
-                    await checkInstalled(agent);
-                    installed = installState()[agent.id];
-                }
+                // `checkInstalled` already resolves through the bundle
+                // and itself no-ops (leaving `installed` as `undefined`)
+                // for a non-npm-installable provider — no need to
+                // duplicate that check here with a second, un-resolved
+                // `agent.provider` read (#2594: two places deciding "does
+                // this need installing" from two different provider
+                // values is exactly the drift class #2592/#2596 fixed).
+                await checkInstalled(agent);
+                installed = installState()[agent.id];
             }
 
             const missing = await probeMissingPrereqs(agent);
@@ -651,12 +654,26 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         kind: "install-agent" as const,
         agent,
         originBlockId: props.model.blockId,
-        onInstalled: (continueToLaunch: boolean) => {
-            const canonical = getProvider(agent.provider)?.id ?? agent.provider;
+        onInstalled: async (continueToLaunch: boolean) => {
+            // Resolve THIS agent's effective (bundle) provider — #2594.
+            // Reading `agent.provider` directly here would compare the
+            // just-installed CLI's canonical id against `agent`'s own
+            // possibly-drifted column, missing the exact row this cache
+            // update exists to set (the agent the user just installed
+            // for). Other agents in the bulk-invalidation loop below are
+            // still compared via their own `.provider` column as a
+            // cache-priming heuristic only — any of THEM that has also
+            // drifted just misses this shortcut and gets a correct,
+            // resolved answer next time it hits `checkInstalled` itself
+            // (now fixed too), never a wrong CLI/credential outcome.
+            const canonicalId = await resolveEffectiveLaunchProvider(agent);
+            const canonical = getProvider(canonicalId)?.id ?? canonicalId;
             setInstallState((s) => {
                 const next = { ...s };
                 for (const a of agents()) {
-                    if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
+                    const aProviderId =
+                        a.id === agent.id ? canonical : (getProvider(a.provider)?.id ?? a.provider);
+                    if (aProviderId === canonical) {
                         next[a.id] = true;
                     }
                 }


### PR DESCRIPTION
## Summary

Delivery-plan item 4 of #2594 (harness/model decoupling & ABF portability) — the `AgentPicker.tsx` portion of "AgentPicker.tsx, AgentInstallModal.tsx, and the two smaller identity-linking sites." The issue text explicitly allows these to "land together or split further" — splitting here: `AgentInstallModal.tsx` and the identity-linking sites (`bind-to-agent-menu.ts`, `agent-identity-links-panel.tsx:271`) each need their own treatment (the install modal needs an async-resolution-with-loading-guard rewrite similar in scope to #2596) and will follow as separate PRs.

Five live call sites in `AgentPicker.tsx` read `agent.provider` directly instead of resolving through the agent's bound bundle — the same "gate vs. actual launch can disagree" risk class #2592/#2596/#2607 fixed:

- `checkInstalled` / `handleTemplateSelect`'s install-check gating — could check/install the WRONG provider's CLI, or skip the check entirely, while the actual launch (`agent-model.ts`, already resolves correctly via `resolveEffectiveLaunchProvider`) spawns the real, uninstalled provider.
- `onRequestAddAccount` — could open an "add account" flow for the drifted provider, creating an account the agent can never actually use at launch.
- `probeMissingPrereqs` — could probe system prereqs for the wrong provider, letting a launch through with the real provider's prereqs never checked.
- `buildTemplateInstallRequest`'s `onInstalled` cache-invalidation — compared the just-installed agent's own drifted `.provider` against the resolved canonical id, so its own cache entry could never match and get marked installed (every subsequent click re-triggered an install check).

## Other changes

- `handleTemplateSelect` had a second, redundant `agent.provider` read duplicating `checkInstalled`'s own npm-installable check — removed outright in favor of always calling `checkInstalled` (which already handles the "no install needed" case internally), so there's one fewer place for the two to independently drift again.
- `buildInstallRequest` — the generic, pre-two-tier install-request builder containing the same unfixed pattern — turned out to be **dead code** (its only caller, the legacy single-tier `handleSelect`, was already removed in the Phase 1 rewrite; `buildTemplateInstallRequest` is the only live install-request builder). Deleted rather than patched.
- The bulk cache-invalidation loop over ALL agents in `buildTemplateInstallRequest`'s `onInstalled` still compares *other* agents via their own `.provider` column as a heuristic — a deliberate scope boundary: any of them that has also drifted just misses the bulk shortcut and gets a correct, resolved answer the next time it hits `checkInstalled` itself (now fixed), never a wrong CLI/credential outcome.

## Test plan

- [x] Regression tests seed a template with a drifted `.provider` (`"claude"`, not npm-installable) against a bundle resolving to a different, npm-installable provider (`"codex"`), and assert: `InstallCheckCommand`/`ResolvePrereqsCommand` are called with the bundle's provider, and the just-installed agent's own cache entry is correctly marked (a second click doesn't re-check).
- [x] Verified all three new tests fail against the pre-fix code (temporarily reverted via `git stash`, kept the tests) — presence/absence of RPC calls and wrong `kind` assertions all failed as expected.
- [x] `npx tsc --noEmit -p tsconfig.json` — same 2 pre-existing, unrelated errors as `main` (`armory-view.tsx`/`warden-view.tsx`), nothing new.
- [x] `npx vitest run app/view/agent/ app/view/identity/` — 1206/1207 pass; the 1 failure (`tool-renderers/registry.test.ts`, a timeout) is the same pre-existing flake already confirmed unrelated in #2608's PR.
- [x] Branch was not stale — `main` had not moved since branching, no merge needed before push.

<!-- agentmux:agent_id=agenty -->