### PR TITLE
fix(agent): AgentInstallModal installs the bound bundle's provider, not a drifted agent.provider

### DIFF
--- a/.changesets/1786926699-fix-agent-agentinstallmodal-installs-the-bound-bundle-s-prov-k2ij.md
+++ b/.changesets/1786926699-fix-agent-agentinstallmodal-installs-the-bound-bundle-s-prov-k2ij.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): AgentInstallModal installs the bound bundle's provider, not a drifted agent.provider

--- a/frontend/app/view/agent/components/AgentInstallModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.test.tsx
@@ -1,0 +1,177 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentInstallModal must install the agent's EFFECTIVE (bundle-resolved)
+ * provider, not a possibly-drifted `agent.provider` column — #2594, same
+ * "gate vs. actual launch can disagree" risk class #2592/#2596/#2607/#2609
+ * fixed. This modal is the one place that actually determines which CLI
+ * package gets installed (`InstallStartCommand`'s `providerId`/
+ * `npmPackage`), so getting this wrong installs the wrong provider's CLI
+ * while the agent's real (bundle) provider stays uninstalled.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        InstallStartCommand: vi.fn().mockResolvedValue({ sessionId: "sess-1" }),
+        InstallCancelCommand: vi.fn().mockResolvedValue({}),
+        // Backs `resolveEffectiveLaunchProvider`'s bound-bundle resolution.
+        GetMemoryCommand: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/wps", () => ({ waveEventSubscribe: vi.fn(() => () => {}) }));
+vi.mock("@/app/store/global", () => ({
+    atoms: { fullConfigAtom: () => ({}) },
+    getSettingsKeyAtom: () => () => false,
+}));
+vi.mock("@/app/store/contextmenu", () => ({ ContextMenuModel: { showContextMenu: vi.fn() } }));
+vi.mock("@/app/view/term/termutil", () => ({
+    computeTermThemeFromSettings: () => [{}],
+}));
+vi.mock("@/util/clipboard", () => ({ writeText: vi.fn() }));
+
+// Stub xterm.js entirely — this test exercises provider resolution, not
+// terminal rendering, and jsdom has no canvas/ResizeObserver support xterm
+// needs for real construction.
+vi.mock("@xterm/xterm", () => ({
+    Terminal: class {
+        options: Record<string, unknown> = {};
+        onSelectionChange(): void {}
+        attachCustomKeyEventHandler(): void {}
+        loadAddon(): void {}
+        open(): void {}
+        writeln(): void {}
+        write(): void {}
+        clear(): void {}
+        dispose(): void {}
+        buffer = { active: { length: 0, getLine: () => null } };
+        getSelection(): string {
+            return "";
+        }
+    },
+}));
+vi.mock("@xterm/addon-fit", () => ({
+    FitAddon: class {
+        fit(): void {}
+    },
+}));
+
+vi.mock("../defaults/cli-catalog", () => ({
+    getCliCatalogEntry: (id: string) =>
+        id === "codex"
+            ? { displayName: "Codex", icon: "🤖", popoverMarkdown: "" }
+            : { displayName: "Claude Code", icon: "✦", popoverMarkdown: "" },
+}));
+
+vi.mock("../providers", () => ({
+    getProvider: (id: string) => {
+        if (id === "claude") {
+            return { id: "claude", cliCommand: "claude", npmPackage: null, pinnedVersion: "1.0.0" };
+        }
+        if (id === "codex") {
+            return { id: "codex", cliCommand: "codex", npmPackage: "@openai/codex", pinnedVersion: "0.116.0" };
+        }
+        return undefined;
+    },
+}));
+
+// jsdom has no ResizeObserver — AgentInstallModalPanel's onMount
+// constructs one unconditionally.
+class FakeResizeObserver {
+    observe(): void {}
+    disconnect(): void {}
+}
+(globalThis as any).ResizeObserver = FakeResizeObserver;
+
+import { AgentInstallModalPanel } from "./AgentInstallModal";
+import { RpcApi } from "@/app/store/rpc-api";
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+const ts = () => 1_700_000_000_000;
+
+const baseAgent = (over: Partial<AgentDefinition>): AgentDefinition =>
+    ({
+        id: "agent-1",
+        slug: "agent-1",
+        name: "Agent One",
+        icon: "",
+        provider: "claude",
+        description: "",
+        working_directory: "",
+        shell: "",
+        provider_flags: "",
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: ts(),
+        agent_type: "host",
+        environment: "local",
+        agent_bus_id: "",
+        is_seeded: 0,
+        memory_id: "",
+        ...over,
+    }) as AgentDefinition;
+
+describe("AgentInstallModal — installs the bound bundle's provider, not a drifted agent.provider (#2594)", () => {
+    it("starts the install against the resolved (bundle) provider, not the drifted column", async () => {
+        // Drifted `.provider` column says "claude", but the bound
+        // bundle's REAL provider is "codex" — a correct install must
+        // fetch/run codex's CLI, not claude's.
+        vi.mocked(RpcApi.GetMemoryCommand).mockResolvedValue({ provider: "codex" } as any);
+        const agent = baseAgent({ provider: "claude", memory_id: "mem-1" });
+
+        render(() => (
+            <AgentInstallModalPanel agent={agent} onCancel={vi.fn()} onInstalled={vi.fn()} />
+        ));
+
+        const installBtn = await screen.findByText("Install now");
+        fireEvent.click(installBtn);
+
+        await waitFor(() => expect(RpcApi.InstallStartCommand).toHaveBeenCalled());
+        const call = vi.mocked(RpcApi.InstallStartCommand).mock.calls[0][1];
+        expect(call).toMatchObject({
+            providerId: "codex",
+            cliCommand: "codex",
+            npmPackage: "@openai/codex",
+            pinnedVersion: "0.116.0",
+        });
+    });
+
+    it("shows the resolved (bundle) provider's display name in the header, not the drifted column's", async () => {
+        vi.mocked(RpcApi.GetMemoryCommand).mockResolvedValue({ provider: "codex" } as any);
+        const agent = baseAgent({ provider: "claude", memory_id: "mem-1", name: "Agent One" });
+
+        render(() => (
+            <AgentInstallModalPanel agent={agent} onCancel={vi.fn()} onInstalled={vi.fn()} />
+        ));
+
+        await waitFor(() => {
+            expect(screen.getByText(/Install Codex/)).toBeInTheDocument();
+        });
+    });
+
+    it("an unbound agent (no memory_id) installs its own agent.provider directly", async () => {
+        const agent = baseAgent({ provider: "codex", memory_id: "" });
+
+        render(() => (
+            <AgentInstallModalPanel agent={agent} onCancel={vi.fn()} onInstalled={vi.fn()} />
+        ));
+
+        const installBtn = await screen.findByText("Install now");
+        fireEvent.click(installBtn);
+
+        await waitFor(() => expect(RpcApi.InstallStartCommand).toHaveBeenCalled());
+        const call = vi.mocked(RpcApi.InstallStartCommand).mock.calls[0][1];
+        expect(call).toMatchObject({ providerId: "codex", cliCommand: "codex" });
+        // Unbound agents never even trigger a bundle fetch.
+        expect(RpcApi.GetMemoryCommand).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -17,7 +17,7 @@
  * xterm renders npm's output (ANSI colors preserved).
  */
 
-import { Show, createEffect, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import { Show, createEffect, createResource, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 
@@ -33,6 +33,7 @@ import { writeText as clipboardWriteText } from "@/util/clipboard";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { getProvider } from "../providers";
+import { resolveEffectiveLaunchProvider } from "../agent-launch-env";
 // Use the project's customized xterm.css copy (same one term.tsx
 // imports) rather than the raw package stylesheet. The package CSS
 // loads later in the bundle and would override our project-wide
@@ -53,8 +54,24 @@ interface AgentInstallModalPanelProps {
 }
 
 export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.Element => {
-    const catalog = () => getCliCatalogEntry(props.agent.provider);
-    const provider = () => getProvider(props.agent.provider);
+    // Resolve through the agent's bound bundle rather than the possibly-
+    // drifted `agent.provider` column directly — #2594, same "gate vs.
+    // actual launch can disagree" risk class #2592/#2596/#2607/#2609
+    // fixed. This modal determines which CLI package literally gets
+    // installed (`startInstall` below); disagreeing with what
+    // AgentPicker's checkInstalled (already fixed) decided needed
+    // installing would install the wrong provider's CLI.
+    //
+    // Used only for the cosmetic header (icon/displayName/version) —
+    // `startInstall` re-resolves directly rather than reading this
+    // resource, so a click that races the resource's own in-flight
+    // fetch still installs the correct provider (see its own comment).
+    // Falls back to `props.agent.provider` while loading/on failure,
+    // same as `resolveEffectiveLaunchProvider` itself.
+    const [resolvedProviderId] = createResource(() => props.agent, resolveEffectiveLaunchProvider);
+    const displayProviderId = () => resolvedProviderId() ?? props.agent.provider;
+    const catalog = () => getCliCatalogEntry(displayProviderId());
+    const provider = () => getProvider(displayProviderId());
     const displayName = () => catalog()?.displayName ?? props.agent.name;
     const version = () => provider()?.pinnedVersion;
 
@@ -96,9 +113,20 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     };
 
     const startInstall = async () => {
-        const prov = provider();
+        // Re-resolve directly rather than reading the `provider()`
+        // memo above — that memo backs the resource's current
+        // (possibly still-loading, or subsequently-stale if the
+        // component has been open a while) snapshot, whereas a fresh
+        // resolve here guarantees whatever actually gets installed
+        // matches the agent's bundle at the moment the user clicked,
+        // not whatever the header happened to be showing.
+        // resolveEffectiveLaunchProvider is a cheap, idempotent single
+        // RPC round-trip — no reason to trust a possibly-stale cache
+        // for the one call that determines what gets installed.
+        const resolvedId = await resolveEffectiveLaunchProvider(props.agent);
+        const prov = getProvider(resolvedId);
         if (!prov) {
-            setError(`unknown provider ${props.agent.provider}`);
+            setError(`unknown provider ${resolvedId}`);
             setPhase("failed");
             return;
         }


### PR DESCRIPTION
## Summary

Delivery-plan item 5 of #2594 (harness/model decoupling & ABF portability) — `AgentInstallModal.tsx`, "determines which CLI package literally gets installed." Same "gate vs. actual launch can disagree" risk class #2592/#2596/#2607/#2609 fixed.

`catalog`/`provider` (and everything derived from them — displayName, version, and critically `startInstall`'s `InstallStartCommand` payload: `providerId`/`cliCommand`/`npmPackage`/`pinnedVersion`) read `agent.provider` directly. If that column had drifted from the agent's bound bundle, this modal — the **one place that actually runs `npm install` for a provider's CLI** — would install the wrong provider's package while the agent's real (bundle) provider stayed uninstalled, even though AgentPicker's `checkInstalled` (already fixed in #2609) correctly identified the real provider needed installing in the first place.

## Fix

- Header display (icon/displayName/version) now resolves through a `createResource` over `resolveEffectiveLaunchProvider`, falling back to `agent.provider` while loading — same fallback contract the function itself documents.
- `startInstall` re-resolves directly (not via the resource) at click time, so a click racing the resource's own in-flight fetch still installs the correct provider rather than trusting a possibly-stale snapshot for the one call that actually matters.

## Test plan

- [x] Regression tests: a drifted-provider agent (`"claude"` column, `"codex"` bundle) must install `"codex"` (`InstallStartCommand` called with `codex`'s `providerId`/`cliCommand`/`npmPackage`/`pinnedVersion`) and show "Codex" in the header, not `"claude"`/"Claude Code".
- [x] An unbound agent (no `memory_id`) installs its own `agent.provider` directly with no bundle fetch at all — the no-drift baseline stays unchanged.
- [x] Verified the two drift-sensitive tests fail against the pre-fix code (temporarily reverted via `git stash`, kept the tests); the baseline test correctly passes both ways (proving it's a genuine no-regression check, not a tautology).
- [x] `npx tsc --noEmit -p tsconfig.json` — same 2 pre-existing, unrelated errors as `main` (`armory-view.tsx`/`warden-view.tsx`), nothing new.
- [x] `npx vitest run app/view/agent/` — 1169/1169 pass, 94/94 files, no flakes this run.
- [x] Branch was not stale — `main` had not moved since branching, no merge needed before push.

<!-- agentmux:agent_id=agenty -->