### PR TITLE
Clamk@claudius: fast agent_id-keyed Conversation History lookup

### DIFF
--- a/.changesets/1786904766-fix-history-claudehistoryadapter-now-scans-per-channel-isola-543k.md
+++ b/.changesets/1786904766-fix-history-claudehistoryadapter-now-scans-per-channel-isola-543k.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(history): ClaudeHistoryAdapter now scans per-channel isolated identity dirs too

--- a/.changesets/1786927133-feat-history-fast-agent-id-keyed-conversation-history-lookup-g22r.md
+++ b/.changesets/1786927133-feat-history-fast-agent-id-keyed-conversation-history-lookup-g22r.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(history): fast agent_id-keyed Conversation History lookup

--- a/agentmux-srv/src/backend/history/adapter.rs
+++ b/agentmux-srv/src/backend/history/adapter.rs
@@ -58,6 +58,21 @@ pub struct SessionMeta {
     pub git_branch: String,
     pub total_tokens: u64,
     pub subagent_count: u32,
+    /// The identity bundle id (`db_accounts.id` / the `<bundle_id>` path
+    /// segment under `identities/`) this session was discovered under, if
+    /// any. Empty for sessions found via a non-bundle base_dir (personal
+    /// `~/.claude`, the default `<shared>/providers/claude/projects`, or
+    /// legacy `~/.config/claude-*`) — those aren't attributable to a
+    /// specific identity. Lets `SessionIndex` answer "this agent's
+    /// sessions" in O(sessions for this identity) instead of a full scan;
+    /// see `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+    /// §4.4. An agent's own id is resolved from this via
+    /// `db_agent_identity_links` (`Store::agent_identity_list_for_agent`),
+    /// not stored here directly — the same bundle can in principle be
+    /// shared, and this field reflects the filesystem fact (which bundle),
+    /// not a specific agent's claim on it.
+    #[serde(default)]
+    pub identity_id: String,
 }
 
 /// Full parsed session — produced on demand when user opens a conversation.

--- a/agentmux-srv/src/backend/history/claude_adapter.rs
+++ b/agentmux-srv/src/backend/history/claude_adapter.rs
@@ -6,8 +6,17 @@
 //! the AgentMux-isolated homes that current agents actually write to:
 //!   - ~/.claude/projects/ and ~/.config/claude-*/projects/ (global / legacy)
 //!   - <AGENTMUX_SHARED_DIR>/providers/claude/projects/ (default isolated home)
-//!   - <AGENTMUX_SHARED_DIR>/identities/<bundle_id>/claude/projects/ (per-identity)
+//!   - <AGENTMUX_SHARED_DIR>/identities/<bundle_id>/claude/projects/ (per-identity, global)
+//!   - <home>/channels/*/identities/*/claude/projects/ and
+//!     <home>/dev/*/(*/)?identities/*/claude/projects/ (per-channel isolated —
+//!     Step 4 of docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md.
+//!     Step 3 links these forward to the global location, but history written
+//!     before that fix landed, or for a bundle whose link creation failed
+//!     (best-effort, can fail), still has real data only under these
+//!     per-channel paths — scanned here so it stays discoverable rather than
+//!     requiring a manual filesystem search.)
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -16,20 +25,41 @@ use std::time::UNIX_EPOCH;
 use super::adapter::*;
 
 pub struct ClaudeHistoryAdapter {
-    /// All base directories to scan for project folders.
+    /// All base directories to scan for project folders. Deduplicated by
+    /// canonical (symlink/junction-resolved) path at construction time —
+    /// after Step 3 above, a per-channel isolated `projects/` dir may be a
+    /// junction pointing at the exact same physical location as one of the
+    /// global `<shared>/...` entries, and scanning both would surface every
+    /// session twice.
     base_dirs: Vec<PathBuf>,
 }
 
 impl ClaudeHistoryAdapter {
+    /// Push `path` onto `dirs` iff it's a real directory AND its
+    /// canonical (symlink/junction-resolved) form hasn't already been
+    /// pushed — the dedup key, not `path` itself, since two different
+    /// `base_dirs` entries can be different paths to the same physical
+    /// directory (a per-channel isolated `projects/` junction and the
+    /// global location it points at). Falls back to the literal path
+    /// when canonicalization fails (e.g. a dangling/broken link) rather
+    /// than silently dropping it.
+    fn push_deduped_dir(dirs: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+        if !path.is_dir() {
+            return;
+        }
+        let key = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if seen.insert(key) {
+            dirs.push(path);
+        }
+    }
+
     pub fn new() -> Self {
         let mut base_dirs = Vec::new();
+        let mut seen_canonical: HashSet<PathBuf> = HashSet::new();
 
         if let Some(home) = dirs::home_dir() {
             // User's personal (non-isolated) Claude sessions
-            let personal = home.join(".claude").join("projects");
-            if personal.is_dir() {
-                base_dirs.push(personal);
-            }
+            Self::push_deduped_dir(&mut base_dirs, &mut seen_canonical, home.join(".claude").join("projects"));
 
             // Legacy multi-account convention: ~/.config/claude-*/projects/
             let config_dir = home.join(".config");
@@ -39,10 +69,7 @@ impl ClaudeHistoryAdapter {
                         let name = entry.file_name();
                         let name_str = name.to_string_lossy();
                         if name_str.starts_with("claude-") {
-                            let projects = entry.path().join("projects");
-                            if projects.is_dir() {
-                                base_dirs.push(projects);
-                            }
+                            Self::push_deduped_dir(&mut base_dirs, &mut seen_canonical, entry.path().join("projects"));
                         }
                     }
                 }
@@ -54,28 +81,77 @@ impl ClaudeHistoryAdapter {
         // Without these, the history browse misses every AgentMux agent
         // conversation. See docs/specs/SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md.
         //   <shared>/providers/claude/projects/              (default, account-wide)
-        //   <shared>/identities/<bundle_id>/claude/projects/ (per-identity bundles)
+        //   <shared>/identities/<bundle_id>/claude/projects/ (per-identity bundles, global)
         // `AGENTMUX_SHARED_DIR` is exported by the launcher; fall back to
         // ~/.agentmux/shared so discovery still works in plain/test contexts.
         let shared_dir = std::env::var_os("AGENTMUX_SHARED_DIR")
             .map(PathBuf::from)
             .or_else(|| dirs::home_dir().map(|h| h.join(".agentmux").join("shared")));
-        if let Some(shared) = shared_dir {
-            let default_projects = shared.join("providers").join("claude").join("projects");
-            if default_projects.is_dir() {
-                base_dirs.push(default_projects);
-            }
+        if let Some(shared) = &shared_dir {
+            Self::push_deduped_dir(&mut base_dirs, &mut seen_canonical, shared.join("providers").join("claude").join("projects"));
             if let Ok(entries) = fs::read_dir(shared.join("identities")) {
                 for entry in entries.flatten() {
-                    let projects = entry.path().join("claude").join("projects");
-                    if projects.is_dir() {
-                        base_dirs.push(projects);
-                    }
+                    Self::push_deduped_dir(&mut base_dirs, &mut seen_canonical, entry.path().join("claude").join("projects"));
                 }
             }
         }
 
+        // Per-channel ISOLATED identity dirs (SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+        // §4.4) — `<home>/channels/*/identities/*/claude/projects` and
+        // `<home>/dev/*/identities/*/claude/projects` (or, when a dev clone
+        // id is in play, one level deeper: `<home>/dev/*/*/identities/*/...`).
+        // `home_dir` is re-derived the same way `DataPaths::from_env()`
+        // itself derives it (AGENTMUX_HOME_OVERRIDE or the OS home dir),
+        // not read from an env var AgentMux doesn't currently export for
+        // this purpose.
+        if let Some(paths) = agentmux_common::DataPaths::from_env() {
+            for root_name in ["channels", "dev"] {
+                Self::scan_isolated_identities_under(
+                    &paths.home_dir.join(root_name),
+                    &mut base_dirs,
+                    &mut seen_canonical,
+                    2,
+                );
+            }
+        }
+
         ClaudeHistoryAdapter { base_dirs }
+    }
+
+    /// Find every `identities/` directory up to `max_depth` levels under
+    /// `root`, and for each, every `<bundle_id>/claude/projects` that
+    /// exists. Bounded, not an unbounded recursive walk — channel/dev
+    /// directory layouts are shallow by construction
+    /// (`channels/<slug>/identities/`, `dev/<branch>/identities/` or
+    /// `dev/<branch>/<clone_id>/identities/`), so depth 2 covers every
+    /// known layout without risking an expensive filesystem walk if
+    /// something unexpected is nested underneath.
+    fn scan_isolated_identities_under(
+        root: &Path,
+        base_dirs: &mut Vec<PathBuf>,
+        seen: &mut HashSet<PathBuf>,
+        max_depth: u8,
+    ) {
+        let Ok(entries) = fs::read_dir(root) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let identities = path.join("identities");
+            if identities.is_dir() {
+                if let Ok(id_entries) = fs::read_dir(&identities) {
+                    for id_entry in id_entries.flatten() {
+                        Self::push_deduped_dir(base_dirs, seen, id_entry.path().join("claude").join("projects"));
+                    }
+                }
+            }
+            if max_depth > 1 {
+                Self::scan_isolated_identities_under(&path, base_dirs, seen, max_depth - 1);
+            }
+        }
     }
 
     /// Count subagent JSONL files in a session's subagents/ directory.
@@ -503,5 +579,125 @@ impl HistoryAdapter for ClaudeHistoryAdapter {
         }
 
         Ok(Some(HistorySession { meta, messages }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn push_deduped_dir_skips_a_path_that_is_not_a_real_directory() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::push_deduped_dir(&mut dirs, &mut seen, tmp.path().join("does-not-exist"));
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn push_deduped_dir_pushes_a_real_directory_once() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("real");
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::push_deduped_dir(&mut dirs, &mut seen, dir.clone());
+        ClaudeHistoryAdapter::push_deduped_dir(&mut dirs, &mut seen, dir);
+        assert_eq!(dirs.len(), 1, "calling twice with the identical path must not duplicate it");
+    }
+
+    // The actual motivating case: after Step 3
+    // (SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md §4.1),
+    // an isolated bundle's projects/ is a junction pointing at the exact
+    // global path this adapter also scans directly — without dedup by
+    // canonical path, every session under it would appear twice.
+    #[cfg(windows)]
+    #[test]
+    fn push_deduped_dir_treats_a_junction_and_its_target_as_the_same_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let target = tmp.path().join("global").join("projects");
+        let link = tmp.path().join("isolated").join("projects");
+        agentmux_common::ensure_history_link(&link, &target).unwrap();
+
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::push_deduped_dir(&mut dirs, &mut seen, target.clone());
+        ClaudeHistoryAdapter::push_deduped_dir(&mut dirs, &mut seen, link);
+        assert_eq!(
+            dirs.len(),
+            1,
+            "the junction and its target must be recognized as the same physical location, not scanned twice"
+        );
+    }
+
+    #[test]
+    fn scan_isolated_identities_finds_a_channel_scoped_projects_dir_at_depth_one() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let projects = tmp
+            .path()
+            .join("local-main-abc123")
+            .join("identities")
+            .join("bundle-1")
+            .join("claude")
+            .join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::scan_isolated_identities_under(tmp.path(), &mut dirs, &mut seen, 2);
+        assert_eq!(dirs, vec![projects]);
+    }
+
+    #[test]
+    fn scan_isolated_identities_finds_a_dev_clone_scoped_projects_dir_at_depth_two() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let projects = tmp
+            .path()
+            .join("main")
+            .join("a1b2c3d4")
+            .join("identities")
+            .join("bundle-2")
+            .join("claude")
+            .join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::scan_isolated_identities_under(tmp.path(), &mut dirs, &mut seen, 2);
+        assert_eq!(dirs, vec![projects]);
+    }
+
+    #[test]
+    fn scan_isolated_identities_does_not_descend_past_max_depth() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Three levels deep -- depth 2 must not find this.
+        let projects = tmp
+            .path()
+            .join("main")
+            .join("a1b2c3d4")
+            .join("extra-nesting")
+            .join("identities")
+            .join("bundle-3")
+            .join("claude")
+            .join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::scan_isolated_identities_under(tmp.path(), &mut dirs, &mut seen, 2);
+        assert!(dirs.is_empty(), "must not walk past the bounded depth");
+    }
+
+    #[test]
+    fn scan_isolated_identities_ignores_directories_with_no_identities_subdir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("some-channel").join("data")).unwrap();
+
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        ClaudeHistoryAdapter::scan_isolated_identities_under(tmp.path(), &mut dirs, &mut seen, 2);
+        assert!(dirs.is_empty());
     }
 }

--- a/agentmux-srv/src/backend/history/claude_adapter.rs
+++ b/agentmux-srv/src/backend/history/claude_adapter.rs
@@ -188,6 +188,30 @@ impl ClaudeHistoryAdapter {
         result = result.replace('-', "/");
         result
     }
+
+    /// Parse the identity bundle id a session's absolute file path was
+    /// discovered under, if any: `.../identities/<bundle_id>/claude/...`
+    /// (both the always-global `<shared>/identities/...` location and the
+    /// per-channel isolated `<home>/channels/*/identities/...` /
+    /// `<home>/dev/*/(*/)?identities/...` locations share this same
+    /// `identities/<bundle_id>/claude/` shape — see `new()`'s scan roots).
+    /// Empty string for any other base_dir (personal `~/.claude`, the
+    /// default `<shared>/providers/claude/projects`, legacy
+    /// `~/.config/claude-*`) — those have no bundle to attribute to.
+    fn identity_id_from_path(path: &Path) -> String {
+        let components: Vec<String> = path
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        for (i, comp) in components.iter().enumerate() {
+            if comp == "identities" && components.get(i + 2).map(String::as_str) == Some("claude") {
+                if let Some(bundle_id) = components.get(i + 1) {
+                    return bundle_id.clone();
+                }
+            }
+        }
+        String::new()
+    }
 }
 
 impl HistoryAdapter for ClaudeHistoryAdapter {
@@ -447,6 +471,7 @@ impl HistoryAdapter for ClaudeHistoryAdapter {
             git_branch,
             total_tokens,
             subagent_count,
+            identity_id: Self::identity_id_from_path(path),
         }))
     }
 

--- a/agentmux-srv/src/backend/history/index.rs
+++ b/agentmux-srv/src/backend/history/index.rs
@@ -27,6 +27,14 @@ fn default_isolated_roots() -> Vec<PathBuf> {
 pub struct SessionIndex {
     /// session_id -> SessionMeta
     sessions: Mutex<HashMap<String, SessionMeta>>,
+    /// identity_id -> session_ids (only non-empty `SessionMeta::identity_id`
+    /// values are indexed here). Maintained alongside `sessions` so "this
+    /// identity's sessions" is an O(k) HashMap lookup + small per-identity
+    /// sort, not an O(total sessions) scan of everything on disk — see
+    /// `list_for_identity` and
+    /// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+    /// §4.4.
+    by_identity: Mutex<HashMap<String, Vec<String>>>,
     /// Adapters for all registered providers
     adapters: Vec<Box<dyn HistoryAdapter>>,
     /// Roots under which destructive ops (delete/clear) are allowed.
@@ -45,6 +53,7 @@ impl SessionIndex {
     ) -> Self {
         SessionIndex {
             sessions: Mutex::new(HashMap::new()),
+            by_identity: Mutex::new(HashMap::new()),
             adapters,
             isolated_roots,
         }
@@ -64,6 +73,7 @@ impl SessionIndex {
         let mut new_count: u32 = 0;
 
         let mut new_sessions: HashMap<String, SessionMeta> = HashMap::new();
+        let mut new_by_identity: HashMap<String, Vec<String>> = HashMap::new();
 
         for adapter in &self.adapters {
             let files = match adapter.discover_files() {
@@ -83,6 +93,12 @@ impl SessionIndex {
             for file in &files {
                 match adapter.extract_meta(&file.file_path) {
                     Ok(Some(meta)) => {
+                        if !meta.identity_id.is_empty() {
+                            new_by_identity
+                                .entry(meta.identity_id.clone())
+                                .or_default()
+                                .push(meta.session_id.clone());
+                        }
                         new_sessions.insert(meta.session_id.clone(), meta);
                     }
                     Ok(None) => {} // empty/invalid session
@@ -108,40 +124,46 @@ impl SessionIndex {
         }
 
         *sessions = new_sessions;
+        *self.by_identity.lock().unwrap() = new_by_identity;
 
         (discovered, updated, new_count)
     }
 
-    /// List sessions with pagination and optional filters.
-    pub fn list(
+    /// This identity's sessions, sorted/paginated the same way `list` is —
+    /// but via the `by_identity` index instead of scanning every session on
+    /// disk. `identity_id` is a bundle/account id (`SessionMeta::identity_id`
+    /// — see its own doc comment); resolving an `agent_id` to one is the
+    /// caller's job (`Store::agent_identity_list_for_agent`), not this
+    /// index's — a bundle is a filesystem fact, which agent(s) claim it is
+    /// a database fact, and this module has no Store access by design (it's
+    /// pure discovery/indexing over the filesystem).
+    pub fn list_for_identity(
         &self,
-        provider: Option<&str>,
-        project: Option<&str>,
+        identity_id: &str,
         offset: usize,
         limit: usize,
         sort_by: &str,
         sort_dir: &str,
     ) -> (Vec<SessionMeta>, u32, bool) {
+        let by_identity = self.by_identity.lock().unwrap();
+        let Some(session_ids) = by_identity.get(identity_id) else {
+            return (Vec::new(), 0, false);
+        };
         let sessions = self.sessions.lock().unwrap();
+        let mut filtered: Vec<&SessionMeta> =
+            session_ids.iter().filter_map(|id| sessions.get(id)).collect();
+        Self::sort_sessions(&mut filtered, sort_by, sort_dir);
 
-        let mut filtered: Vec<&SessionMeta> = sessions
-            .values()
-            .filter(|s| {
-                if let Some(p) = provider {
-                    if s.provider != p {
-                        return false;
-                    }
-                }
-                if let Some(proj) = project {
-                    if !s.working_directory.contains(proj) {
-                        return false;
-                    }
-                }
-                true
-            })
-            .collect();
+        let total = filtered.len() as u32;
+        let has_more = offset + limit < filtered.len();
+        let page: Vec<SessionMeta> = filtered.into_iter().skip(offset).take(limit).cloned().collect();
+        (page, total, has_more)
+    }
 
-        // Sort
+    /// Shared sort logic between `list` (scans everything) and
+    /// `list_for_identity` (scans one identity's sessions) — extracted so
+    /// the two can't silently diverge on sort semantics.
+    pub(crate) fn sort_sessions(filtered: &mut [&SessionMeta], sort_by: &str, sort_dir: &str) {
         let desc = sort_dir != "asc";
         match sort_by {
             "created_at" | "created" => {
@@ -182,6 +204,38 @@ impl SessionIndex {
                 });
             }
         }
+    }
+
+    /// List sessions with pagination and optional filters.
+    pub fn list(
+        &self,
+        provider: Option<&str>,
+        project: Option<&str>,
+        offset: usize,
+        limit: usize,
+        sort_by: &str,
+        sort_dir: &str,
+    ) -> (Vec<SessionMeta>, u32, bool) {
+        let sessions = self.sessions.lock().unwrap();
+
+        let mut filtered: Vec<&SessionMeta> = sessions
+            .values()
+            .filter(|s| {
+                if let Some(p) = provider {
+                    if s.provider != p {
+                        return false;
+                    }
+                }
+                if let Some(proj) = project {
+                    if !s.working_directory.contains(proj) {
+                        return false;
+                    }
+                }
+                true
+            })
+            .collect();
+
+        Self::sort_sessions(&mut filtered, sort_by, sort_dir);
 
         let total = filtered.len() as u32;
         let has_more = offset + limit < filtered.len();
@@ -302,6 +356,7 @@ mod tests {
         files: Vec<DiscoveredFile>,
         provider: String,
         working_directory: String,
+        identity_id: String,
     }
     impl HistoryAdapter for MockAdapter {
         fn provider(&self) -> &str {
@@ -334,6 +389,7 @@ mod tests {
                 git_branch: String::new(),
                 total_tokens: 0,
                 subagent_count: 0,
+                identity_id: self.identity_id.clone(),
             }))
         }
         fn parse_file(&self, _: &str) -> Result<Option<HistorySession>, HistoryError> {
@@ -361,6 +417,7 @@ mod tests {
                 files: vec![DiscoveredFile { file_path: fp.clone(), mtime_ms: 0 }],
                 provider: "mock".into(),
                 working_directory: "/proj".into(),
+                identity_id: String::new(),
             })],
             vec![dir.clone()],
         );
@@ -391,6 +448,7 @@ mod tests {
                 ],
                 provider: "mock".into(),
                 working_directory: "/proj".into(),
+                identity_id: String::new(),
             })],
             vec![dir.clone()],
         );
@@ -419,6 +477,7 @@ mod tests {
                 files: vec![DiscoveredFile { file_path: fp.clone(), mtime_ms: 0 }],
                 provider: "claude".into(),
                 working_directory: "/home/me/.claude".into(),
+                identity_id: String::new(),
             })],
             // isolated roots deliberately do NOT include `dir`.
             vec![std::env::temp_dir().join("amux-some-other-isolated-root")],
@@ -429,6 +488,137 @@ mod tests {
         assert!(std::path::Path::new(&fp).exists(), "file must be intact");
         assert_eq!(idx.clear(None, None), 0, "clear-all must skip it");
         assert!(std::path::Path::new(&fp).exists(), "still intact after clear");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+    // §4.4: list_for_identity is the actual "fast lookup" this whole step
+    // exists for — an O(sessions for this identity) HashMap-backed lookup
+    // instead of list()'s O(total sessions on disk) scan.
+
+    #[test]
+    fn list_for_identity_returns_only_that_identitys_sessions() {
+        let dir = std::env::temp_dir().join(format!("amux-hist-idx-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let a1 = write_session(&dir, "a1");
+        let a2 = write_session(&dir, "a2");
+        let b1 = write_session(&dir, "b1");
+        let unattributed = write_session(&dir, "unattributed");
+
+        let idx = SessionIndex::with_isolated_roots(
+            vec![
+                Box::new(MockAdapter {
+                    files: vec![
+                        DiscoveredFile { file_path: a1, mtime_ms: 1 },
+                        DiscoveredFile { file_path: a2, mtime_ms: 2 },
+                    ],
+                    provider: "mock".into(),
+                    working_directory: "/proj".into(),
+                    identity_id: "identity-a".into(),
+                }),
+                Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: b1, mtime_ms: 1 }],
+                    provider: "mock".into(),
+                    working_directory: "/proj".into(),
+                    identity_id: "identity-b".into(),
+                }),
+                Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: unattributed, mtime_ms: 1 }],
+                    provider: "mock".into(),
+                    working_directory: "/proj".into(),
+                    identity_id: String::new(),
+                }),
+            ],
+            vec![dir.clone()],
+        );
+        idx.refresh();
+
+        let (sessions_a, total_a, _) = idx.list_for_identity("identity-a", 0, 10, "created_at", "desc");
+        assert_eq!(total_a, 2);
+        let ids_a: std::collections::HashSet<_> = sessions_a.iter().map(|s| s.session_id.clone()).collect();
+        assert_eq!(ids_a, std::collections::HashSet::from(["a1".to_string(), "a2".to_string()]));
+
+        let (sessions_b, total_b, _) = idx.list_for_identity("identity-b", 0, 10, "created_at", "desc");
+        assert_eq!(total_b, 1);
+        assert_eq!(sessions_b[0].session_id, "b1");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn list_for_identity_returns_empty_for_an_unknown_identity() {
+        let idx = SessionIndex::with_isolated_roots(vec![], vec![]);
+        idx.refresh();
+        let (sessions, total, has_more) = idx.list_for_identity("no-such-identity", 0, 10, "created_at", "desc");
+        assert!(sessions.is_empty());
+        assert_eq!(total, 0);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn list_for_identity_paginates_and_respects_sort_direction() {
+        let dir = std::env::temp_dir().join(format!("amux-hist-idx-page-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let files: Vec<DiscoveredFile> = (0..3)
+            .map(|i| DiscoveredFile { file_path: write_session(&dir, &format!("s{i}")), mtime_ms: i })
+            .collect();
+
+        let idx = SessionIndex::with_isolated_roots(
+            vec![Box::new(MockAdapter {
+                files,
+                provider: "mock".into(),
+                working_directory: "/proj".into(),
+                identity_id: "identity-a".into(),
+            })],
+            vec![dir.clone()],
+        );
+        idx.refresh();
+
+        let (page1, total, has_more) = idx.list_for_identity("identity-a", 0, 2, "created_at", "desc");
+        assert_eq!(total, 3);
+        assert_eq!(page1.len(), 2);
+        assert!(has_more);
+        let (page2, _, has_more2) = idx.list_for_identity("identity-a", 2, 2, "created_at", "desc");
+        assert_eq!(page2.len(), 1);
+        assert!(!has_more2);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn refresh_rebuilds_the_identity_index_from_scratch_each_time() {
+        // A session that's re-discovered under a DIFFERENT identity on a
+        // second refresh (e.g. its bundle got re-linked) must not leave a
+        // stale entry under the old identity_id.
+        let dir = std::env::temp_dir().join(format!("amux-hist-idx-rebuild-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let fp = write_session(&dir, "moved");
+
+        let idx = SessionIndex::with_isolated_roots(
+            vec![Box::new(MockAdapter {
+                files: vec![DiscoveredFile { file_path: fp.clone(), mtime_ms: 1 }],
+                provider: "mock".into(),
+                working_directory: "/proj".into(),
+                identity_id: "identity-old".into(),
+            })],
+            vec![dir.clone()],
+        );
+        idx.refresh();
+        assert_eq!(idx.list_for_identity("identity-old", 0, 10, "created_at", "desc").1, 1);
+
+        let idx2 = SessionIndex::with_isolated_roots(
+            vec![Box::new(MockAdapter {
+                files: vec![DiscoveredFile { file_path: fp, mtime_ms: 1 }],
+                provider: "mock".into(),
+                working_directory: "/proj".into(),
+                identity_id: "identity-new".into(),
+            })],
+            vec![dir.clone()],
+        );
+        idx2.refresh();
+        assert_eq!(idx2.list_for_identity("identity-old", 0, 10, "created_at", "desc").1, 0, "stale identity must not linger");
+        assert_eq!(idx2.list_for_identity("identity-new", 0, 10, "created_at", "desc").1, 1);
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/agentmux-srv/src/backend/history/mod.rs
+++ b/agentmux-srv/src/backend/history/mod.rs
@@ -28,6 +28,14 @@ impl HistoryService {
         }
     }
 
+    /// Construct directly from a `SessionIndex` — used by tests that need
+    /// to inject a mock adapter instead of `ClaudeHistoryAdapter::new()`'s
+    /// real filesystem scan.
+    #[cfg(test)]
+    fn from_index(index: SessionIndex) -> Self {
+        HistoryService { index: Arc::new(index) }
+    }
+
     /// List sessions with pagination and filters.
     /// Lazy-initializes the index on first call.
     pub fn list(
@@ -49,6 +57,58 @@ impl HistoryService {
 
         serde_json::json!({
             "sessions": sessions,
+            "total": total,
+            "has_more": has_more,
+        })
+    }
+
+    /// This agent's own sessions — the actual "fast Conversation History
+    /// lookup" protocol §4.4 asks for, resolving `agent_id` to its bound
+    /// identity bundle(s) (`Store::agent_identity_list_for_agent`, the
+    /// same `db_agent_identity_links` table `identity_auth_dirs.rs`
+    /// already keys off) and querying `SessionIndex::list_for_identity`'s
+    /// O(sessions for this identity) HashMap-backed path instead of
+    /// `list()`'s O(total sessions on disk) scan. An agent normally has
+    /// at most one linked account per provider, but this merges across
+    /// however many exist rather than assuming exactly one.
+    pub fn list_for_agent(
+        &self,
+        store: &crate::backend::storage::store::Store,
+        agent_id: &str,
+        offset: usize,
+        limit: usize,
+        sort_by: &str,
+        sort_dir: &str,
+    ) -> serde_json::Value {
+        if self.index.is_empty() {
+            self.index.refresh();
+        }
+
+        let links = match store.agent_identity_list_for_agent(agent_id) {
+            Ok(l) => l,
+            Err(e) => {
+                return serde_json::json!({ "error": format!("failed to resolve agent's linked identities: {e}") });
+            }
+        };
+        if links.is_empty() {
+            return serde_json::json!({ "sessions": [], "total": 0, "has_more": false });
+        }
+
+        let mut merged: Vec<adapter::SessionMeta> = Vec::new();
+        for link in &links {
+            let (sessions, _total, _has_more) =
+                self.index.list_for_identity(&link.account_id, 0, usize::MAX, sort_by, sort_dir);
+            merged.extend(sessions);
+        }
+        let mut refs: Vec<&adapter::SessionMeta> = merged.iter().collect();
+        index::SessionIndex::sort_sessions(&mut refs, sort_by, sort_dir);
+
+        let total = refs.len() as u32;
+        let has_more = offset + limit < refs.len();
+        let page: Vec<adapter::SessionMeta> = refs.into_iter().skip(offset).take(limit).cloned().collect();
+
+        serde_json::json!({
+            "sessions": page,
             "total": total,
             "has_more": has_more,
         })
@@ -97,5 +157,150 @@ impl HistoryService {
         }
         let deleted = self.index.clear(provider, project);
         serde_json::json!({ "deleted": deleted })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::store::Store;
+
+    /// Adapter that "discovers" caller-supplied files, tagging each with a
+    /// fixed identity_id -- just enough to exercise the agent_id ->
+    /// identity_id -> sessions chain end to end.
+    struct MockAdapter {
+        files: Vec<DiscoveredFile>,
+        identity_id: String,
+    }
+    impl HistoryAdapter for MockAdapter {
+        fn provider(&self) -> &str {
+            "mock"
+        }
+        fn discover_files(&self) -> Result<Vec<DiscoveredFile>, HistoryError> {
+            Ok(self.files.iter().map(|f| DiscoveredFile { file_path: f.file_path.clone(), mtime_ms: f.mtime_ms }).collect())
+        }
+        fn extract_meta(&self, file_path: &str) -> Result<Option<SessionMeta>, HistoryError> {
+            let id = std::path::Path::new(file_path)
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            Ok(Some(SessionMeta {
+                session_id: id,
+                file_path: file_path.to_string(),
+                provider: "mock".to_string(),
+                model: String::new(),
+                slug: String::new(),
+                working_directory: "/proj".to_string(),
+                created_at: 0,
+                modified_at: 0,
+                message_count: 0,
+                first_user_message: String::new(),
+                file_size_bytes: 0,
+                git_branch: String::new(),
+                total_tokens: 0,
+                subagent_count: 0,
+                identity_id: self.identity_id.clone(),
+            }))
+        }
+        fn parse_file(&self, _: &str) -> Result<Option<HistorySession>, HistoryError> {
+            Ok(None)
+        }
+    }
+
+    fn write_session(dir: &std::path::Path, id: &str) -> String {
+        let f = dir.join(format!("{id}.jsonl"));
+        std::fs::write(&f, b"{}").unwrap();
+        f.to_string_lossy().into_owned()
+    }
+
+    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+    // §4.4: the actual end-to-end feature -- agent_id resolves through a
+    // real db_agent_identity_links row (not a mocked lookup) to the
+    // sessions found under that link's account_id.
+    #[test]
+    fn list_for_agent_resolves_through_a_real_identity_link_to_the_right_sessions() {
+        let dir = std::env::temp_dir().join(format!("amux-hist-svc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mine = write_session(&dir, "mine");
+        let someone_elses = write_session(&dir, "someone-elses");
+
+        let index = SessionIndex::with_isolated_roots(
+            vec![
+                Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: mine, mtime_ms: 1 }],
+                    identity_id: "acct-mine".to_string(),
+                }),
+                Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: someone_elses, mtime_ms: 1 }],
+                    identity_id: "acct-someone-else".to_string(),
+                }),
+            ],
+            vec![dir.clone()],
+        );
+        let service = HistoryService::from_index(index);
+
+        let store = Store::open_in_memory().unwrap();
+        let mut def = crate::backend::storage::store::AgentDefinition {
+            id: "agent-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        store.agent_def_insert(&mut def).unwrap();
+        store
+            .identity_upsert(&crate::backend::storage::store::IdentityAccount {
+                id: "acct-mine".to_string(),
+                name: "claude-acct-mine".to_string(),
+                provider: "claude".to_string(),
+                kind: "pat".to_string(),
+                display_name: String::new(),
+                secret_ref: crate::backend::storage::store::SecretRef::OAuthConfigDir { dir: String::new() },
+                context: serde_json::json!({}),
+                status: "unknown".to_string(),
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+        store.agent_identity_link("agent-1", "acct-mine", "claude").unwrap();
+
+        let result = service.list_for_agent(&store, "agent-1", 0, 10, "created_at", "desc");
+        assert_eq!(result["total"], 1);
+        assert_eq!(result["sessions"][0]["session_id"], "mine");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_for_agent_returns_empty_for_an_agent_with_no_linked_identity() {
+        let service = HistoryService::from_index(SessionIndex::with_isolated_roots(vec![], vec![]));
+        let store = Store::open_in_memory().unwrap();
+        let result = service.list_for_agent(&store, "agent-with-no-links", 0, 10, "created_at", "desc");
+        assert_eq!(result["total"], 0);
+        assert_eq!(result["sessions"].as_array().unwrap().len(), 0);
     }
 }

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -186,6 +186,25 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
             );
             WebReturnType::success(result)
         }
+        ("history", "ListForAgent") => {
+            let agent_id: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let offset: usize = service::get_arg(args, 1).unwrap_or(0);
+            let limit: usize = service::get_arg(args, 2).unwrap_or(50);
+            let sort_by: String = service::get_arg(args, 3).unwrap_or_else(|_| "modified_at".to_string());
+            let sort_dir: String = service::get_arg(args, 4).unwrap_or_else(|_| "desc".to_string());
+            let result = state.history_service.list_for_agent(
+                &state.id_store,
+                &agent_id,
+                offset,
+                limit,
+                &sort_by,
+                &sort_dir,
+            );
+            WebReturnType::success(result)
+        }
         ("history", "Get") => {
             let session_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,


### PR DESCRIPTION
## Summary

Step 4b of #2603 (protocol §4.4, second half — the fast index, split from Step 4a's read-path fix in #2606, merged).

Before this, "this agent's conversation history" wasn't a queryable concept at all. The only lookup (`history.List`) filters by provider + a `working_directory` substring match across every session found on disk (personal + AgentMux both), and `SessionMeta` had no `agent_id`/identity field anywhere. This is the actual gap behind the operator's original ask that started this whole investigation: finding a specific agent's last conversation fast, without a manual filesystem grep.

- `SessionMeta` gains `identity_id`: the bundle/account id a session was discovered under (parsed from its file path), empty for personal/default non-bundle sessions.
- `SessionIndex` maintains a `by_identity: HashMap<identity_id, Vec<session_id>>` alongside the existing sessions map, rebuilt on every `refresh()`. New `list_for_identity()` is O(sessions for this identity), not O(total sessions on disk) like `list()`.
- `HistoryService::list_for_agent(store, agent_id, ...)` resolves `agent_id` to its linked identity bundle(s) via `Store::agent_identity_list_for_agent` (the same `db_agent_identity_links` table `identity_auth_dirs.rs` already keys off).
- New RPC: `history.ListForAgent(agent_id, offset, limit, sort_by, sort_dir)`.

**Not yet wired to a frontend UI action** — this PR is the backend lookup path; surfacing it as an actual "Conversation History" button is a follow-up.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2367 passed, 0 failed, 6 pre-existing ignores
- [x] `cargo check --workspace` — clean
- [x] 9 new tests, including one exercising the real `db_agent_identity_links` FK path end to end (agent definition row + account row + link row, not a mocked lookup)

<!-- agentmux:agent_id=clamk -->