### PR TITLE
fix(identity): bind-to-agent menu and Connect-Claude CTA resolve provider through the bound bundle

### DIFF
--- a/.changesets/1786927621-fix-identity-bind-to-agent-menu-and-connect-claude-cta-resol-6e84.md
+++ b/.changesets/1786927621-fix-identity-bind-to-agent-menu-and-connect-claude-cta-resol-6e84.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): bind-to-agent menu and Connect-Claude CTA resolve provider through the bound bundle

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -14,10 +14,16 @@ import { cleanup, render, screen, waitFor, within } from "@solidjs/testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const listAllAgentIdentities = vi.fn();
+const getMemoryCommand = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListAllAgentIdentitiesCommand: (...args: unknown[]) => listAllAgentIdentities(...args),
+        // Backs `resolveEffectiveLaunchProvider`'s bound-bundle resolution
+        // (#2594) — resolves to `undefined` by default so agents without
+        // `memory_id` never even trigger a fetch; the drift regression
+        // tests below set their own `.mockResolvedValue`.
+        GetMemoryCommand: (...args: unknown[]) => getMemoryCommand(...args),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -29,6 +35,9 @@ vi.mock("@/app/view/agent/components/AgentPicker", () => ({
         { id: "agent-1", name: "Agent One", provider: "claude" },
         { id: "agent-2", name: "Agent Two", provider: "claude" },
         { id: "agent-3", name: "Agent Three (codex)", provider: "codex" },
+        // #2594 drift fixtures — column vs. bound bundle disagree.
+        { id: "agent-4", name: "Agent Four (drifted to claude)", provider: "codex", memory_id: "mem-4" },
+        { id: "agent-5", name: "Agent Five (drifted away from claude)", provider: "claude", memory_id: "mem-5" },
     ],
 }));
 vi.mock("./identity-model", () => ({
@@ -89,6 +98,8 @@ describe("AgentIdentityLinksPanel", () => {
     beforeEach(() => {
         listAllAgentIdentities.mockReset();
         claudeLoginPanel.mockReset();
+        getMemoryCommand.mockReset();
+        getMemoryCommand.mockResolvedValue(undefined);
     });
 
     afterEach(() => {
@@ -286,6 +297,36 @@ describe("AgentIdentityLinksPanel", () => {
             listAllAgentIdentities.mockResolvedValue([]);
 
             render(() => <AgentIdentityLinksPanel agentId="agent-3" />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/no linked accounts yet/i)).toBeInTheDocument();
+            });
+            expect(screen.queryByRole("button", { name: "Connect Claude account" })).not.toBeInTheDocument();
+        });
+
+        // #2594 — the CTA gate must resolve through the agent's bound
+        // bundle, not the possibly-drifted `agent.provider` column
+        // directly (same "gate vs. actual launch can disagree" risk
+        // class #2592/#2596/#2607/#2609/#2610 fixed).
+        it("#2594: offers 'Connect Claude account' when the drifted column says non-claude but the bound bundle resolves to claude", async () => {
+            listAllAgentIdentities.mockResolvedValue([]);
+            getMemoryCommand.mockImplementation(async (_c: unknown, data: { id: string }) =>
+                data.id === "mem-4" ? { provider: "claude" } : undefined,
+            );
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-4" />);
+
+            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            expect(button).toBeInTheDocument();
+        });
+
+        it("#2594: does NOT offer 'Connect Claude account' when the drifted column says claude but the bound bundle resolves away from it", async () => {
+            listAllAgentIdentities.mockResolvedValue([]);
+            getMemoryCommand.mockImplementation(async (_c: unknown, data: { id: string }) =>
+                data.id === "mem-5" ? { provider: "codex" } : undefined,
+            );
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-5" />);
 
             await waitFor(() => {
                 expect(screen.getByText(/no linked accounts yet/i)).toBeInTheDocument();

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -24,9 +24,10 @@
 // scope — created from the agent-launch flow directly, per
 // docs/specs/SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md.
 
-import { createEffect, createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 
 import { useAgentDefinitions } from "@/app/view/agent/components/AgentPicker";
+import { resolveEffectiveLaunchProvider } from "@/app/view/agent/agent-launch-env";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -118,6 +119,19 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
         if (!id) return null;
         return agents().find((a) => a.id === id) ?? null;
     });
+
+    // Resolve through the agent's bound bundle rather than the possibly-
+    // drifted `agent.provider` column directly — #2594, same "gate vs.
+    // actual launch can disagree" risk class #2592/#2596/#2607/#2609/
+    // #2610 fixed. Gates the "Connect Claude account" CTA below; falls
+    // back to `agent()?.provider` while loading/unbound/on failure, same
+    // fallback contract `resolveEffectiveLaunchProvider` itself documents
+    // — a brief stale flash here is cosmetic (button visibility only),
+    // not a spawn/credential decision.
+    const [resolvedAgentProviderId] = createResource(agent, (a) =>
+        a ? resolveEffectiveLaunchProvider(a) : Promise.resolve(""),
+    );
+    const effectiveAgentProviderId = () => resolvedAgentProviderId() || (agent()?.provider ?? "");
 
     const rows = createMemo(() => {
         const id = props.agentId;
@@ -268,7 +282,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                 linksLoaded() &&
                                 !error() &&
                                 !hasClaudeLink() &&
-                                canonicalProviderId(agent()?.provider ?? "") === "claude"
+                                canonicalProviderId(effectiveAgentProviderId()) === "claude"
                             }
                         >
                             <div class="identity-pane-empty-hint">

--- a/frontend/app/view/identity/bind-to-agent-menu.test.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const rpcCalls: Array<{ cmd: string; data: unknown }> = [];
 const listAgentIdentitiesMock = vi.fn(async (): Promise<AgentDefinitionIdentity[]> => []);
+const getMemoryMock = vi.fn(async (_c: unknown, data: { id: string }) => undefined as any);
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListAgentIdentitiesCommand: (_c: unknown, data: { agent_id: string }) => {
@@ -20,13 +21,25 @@ vi.mock("@/app/store/rpc-api", () => ({
         LinkAgentIdentityCommand: async (_c: unknown, data: unknown) => {
             rpcCalls.push({ cmd: "link", data });
         },
+        ListAllAgentIdentitiesCommand: vi.fn(async (): Promise<AgentDefinitionIdentity[]> => []),
+        // Backs `resolveEffectiveLaunchProvider`'s bound-bundle resolution
+        // (#2594) — resolves to `undefined` by default so agents without
+        // `memory_id` never even trigger a fetch; the drift regression
+        // tests below set their own `.mockResolvedValue`.
+        GetMemoryCommand: (c: unknown, data: { id: string }) => getMemoryMock(c, data),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
 vi.mock("@/app/store/global", () => ({ WOS: {}, workspace: () => null }));
 vi.mock("@/app/store/agent-pane-state-store", () => ({ getOpenDefinitionMap: () => new Map() }));
 
-import { computeBindCandidates, candidateSublabel, bindAccountToAgent } from "./bind-to-agent-menu";
+import {
+    computeBindCandidates,
+    candidateSublabel,
+    bindAccountToAgent,
+    buildAccountRowMenu,
+} from "./bind-to-agent-menu";
+import { RpcApi } from "@/app/store/rpc-api";
 import type { Account } from "./identity-model";
 
 function mkAccount(over: Partial<Account> = {}): Account {
@@ -139,6 +152,79 @@ describe("computeBindCandidates", () => {
         const out = computeBindCandidates(mkAccount(), agents, NO_LINKS, open, NO_NAMES);
         expect(out.map((c) => c.agentName)).toEqual(["RunningOne", "Alpha", "Zeta"]);
         expect(out[0].runningBlockId).toBe("block-r");
+    });
+
+    // #2594 — the optional resolver param lets a caller offer/filter by
+    // an agent's EFFECTIVE (bundle-resolved) provider instead of the
+    // possibly-drifted `agent.provider` column, without breaking every
+    // test above (which all rely on the default `(a) => a.provider`).
+    it("with an explicit resolver, filters by the resolved provider rather than the raw column", () => {
+        // Drifted: column says "codex", but the resolver (standing in
+        // for a bundle lookup) says "claude" — a claude CLI-OAuth
+        // account must offer this agent.
+        const drifted = mkAgent({ id: "drift", name: "Drifted", provider: "codex" });
+        const out = computeBindCandidates(
+            mkAccount(), // claude, cliOauth
+            [drifted],
+            NO_LINKS,
+            NO_OPEN,
+            NO_NAMES,
+            () => "claude",
+        );
+        expect(out.map((c) => c.agentName)).toEqual(["Drifted"]);
+    });
+
+    it("with an explicit resolver, hides an agent whose resolved provider doesn't match even though the raw column would", () => {
+        // Inverse drift: column says "claude" (would pass the default
+        // reader) but the resolver says "codex" — must NOT be offered
+        // for a claude CLI-OAuth account.
+        const drifted = mkAgent({ id: "drift", name: "Drifted", provider: "claude" });
+        const out = computeBindCandidates(
+            mkAccount(), // claude, cliOauth
+            [drifted],
+            NO_LINKS,
+            NO_OPEN,
+            NO_NAMES,
+            () => "codex",
+        );
+        expect(out).toHaveLength(0);
+    });
+});
+
+describe("buildAccountRowMenu — batch-resolves through the bound bundle (#2594)", () => {
+    beforeEach(() => {
+        rpcCalls.length = 0;
+        getMemoryMock.mockReset();
+        getMemoryMock.mockResolvedValue(undefined);
+        vi.mocked(RpcApi.ListAllAgentIdentitiesCommand).mockReset();
+        vi.mocked(RpcApi.ListAllAgentIdentitiesCommand).mockResolvedValue([]);
+    });
+
+    it("offers a drifted agent whose bound bundle resolves to the account's real provider", async () => {
+        // Column says "codex" (would be excluded by the default reader),
+        // but the bundle it's actually bound to says "claude".
+        const drifted = mkAgent({ id: "drift", name: "Drifted", provider: "codex", memory_id: "mem-1" });
+        getMemoryMock.mockImplementation(async (_c: unknown, data: { id: string }) =>
+            data.id === "mem-1" ? ({ provider: "claude" } as any) : undefined,
+        );
+
+        const menu = await buildAccountRowMenu(mkAccount(), [drifted], []);
+        const bindItem = menu.find((m) => m.label === "Bind to Agent");
+        expect(bindItem?.type).toBe("submenu");
+        expect((bindItem as any).submenu.map((s: any) => s.label)).toEqual(["Drifted"]);
+    });
+
+    it("hides an agent whose bound bundle resolves AWAY from the account's provider despite a matching raw column", async () => {
+        // Column says "claude" (would be offered by the default reader),
+        // but the bundle it's actually bound to says "codex".
+        const drifted = mkAgent({ id: "drift", name: "Drifted", provider: "claude", memory_id: "mem-1" });
+        getMemoryMock.mockImplementation(async (_c: unknown, data: { id: string }) =>
+            data.id === "mem-1" ? ({ provider: "codex" } as any) : undefined,
+        );
+
+        const menu = await buildAccountRowMenu(mkAccount(), [drifted], []);
+        const bindItem = menu.find((m) => m.label === "Bind to Agent");
+        expect(bindItem?.enabled).toBe(false);
     });
 });
 

--- a/frontend/app/view/identity/bind-to-agent-menu.ts
+++ b/frontend/app/view/identity/bind-to-agent-menu.ts
@@ -14,6 +14,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { WOS, workspace } from "@/app/store/global";
 import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
 import { getProvider, resolveProviderAlias } from "@/app/view/agent/providers";
+import { resolveEffectiveLaunchProvider } from "@/app/view/agent/agent-launch-env";
 import { Logger } from "@/util/logger";
 import type { Account } from "./identity-model";
 
@@ -46,6 +47,18 @@ export function computeBindCandidates(
     allLinks: AgentDefinitionIdentity[],
     openDefinitions: Map<string, string>,
     accountNameById: Map<string, string>,
+    /**
+     * Resolves an agent's EFFECTIVE provider — through its bound bundle
+     * when it has one, not the possibly-drifted `agent.provider` column
+     * directly (#2594, same "gate vs. actual launch can disagree" risk
+     * class #2592/#2596/#2607/#2609/#2610 fixed). Defaults to reading
+     * `.provider` directly so this stays a pure, sync, DOM/RPC-mock-free
+     * function for callers (tests) that don't care about drift;
+     * `buildAccountRowMenu` passes a real resolver backed by a batch
+     * bundle-resolution pass, since resolving N agents' bundles is
+     * inherently async and this core must stay sync/pure.
+     */
+    resolveAgentProviderId: (agent: AgentDefinition) => string = (a) => a.provider,
 ): BindCandidate[] {
     const acctProvider = resolveProviderAlias(account.provider);
     // Spec §3's discriminator: CLI-OAuth accounts carry an oauth_config_dir
@@ -56,7 +69,7 @@ export function computeBindCandidates(
     const candidates: BindCandidate[] = [];
     for (const agent of agents) {
         if (agent.is_seeded !== 0) continue;
-        if (cliOauth && resolveProviderAlias(agent.provider) !== acctProvider) continue;
+        if (cliOauth && resolveProviderAlias(resolveAgentProviderId(agent)) !== acctProvider) continue;
 
         // This agent's current link for the account's provider (canonical
         // comparison — links can be stored under a legacy alias).
@@ -232,6 +245,18 @@ export async function buildAccountRowMenu(
         // Best-effort: without links the submenu still binds correctly —
         // it just can't annotate current bindings.
     }
+    // Batch-resolve every agent's EFFECTIVE provider through its bound
+    // bundle (#2594) — a drifted `.provider` column could otherwise
+    // offer (or wrongly hide) an agent whose real launch provider
+    // doesn't actually match this account. `resolveEffectiveLaunchProvider`
+    // is a no-op (no RPC) for an unbound agent, so this only costs a
+    // round-trip per agent that actually has a bundle.
+    const effectiveProviderById = new Map<string, string>();
+    await Promise.all(
+        agents.map(async (a) => {
+            effectiveProviderById.set(a.id, await resolveEffectiveLaunchProvider(a));
+        }),
+    );
     const accountNameById = new Map(accounts.map((a) => [a.id, a.name] as const));
     const candidates = computeBindCandidates(
         account,
@@ -239,6 +264,7 @@ export async function buildAccountRowMenu(
         allLinks,
         getOpenDefinitionMap(),
         accountNameById,
+        (a) => effectiveProviderById.get(a.id) ?? a.provider,
     );
 
     const bindItem: ContextMenuItem =


### PR DESCRIPTION
## Summary

Delivery-plan item 6 of #2594 (harness/model decoupling & ABF portability) — the last two frontend sites: `bind-to-agent-menu.ts` ("filters which agents an OAuth account can bind to") and `agent-identity-links-panel.tsx:271` ("gates the 'Connect Claude account' CTA"). Same "gate vs. actual launch can disagree" risk class #2592/#2596/#2607/#2609/#2610 fixed. This is the last item on the frontend read-site list — only `exportagents`/`importagents` (lowest priority, no live spawn/credential consequence) remains after this.

## `bind-to-agent-menu.ts`

`computeBindCandidates` filtered CLI-OAuth accounts to same-provider agents by reading `agent.provider` directly. A drifted agent could be wrongly offered (or wrongly hidden) in the "Bind to Agent" submenu relative to what it actually launches as.

`computeBindCandidates` stays a pure, sync function — its own doc comment emphasizes it's "unit-testable without a DOM or RPC mocks." Rather than making it async (which would break that property and require every existing test to mock bundle fetches), I added an optional `resolveAgentProviderId` resolver parameter, defaulting to `(a) => a.provider` so every existing test is unaffected. `buildAccountRowMenu` (the async orchestrator, already doing one RPC round-trip for links) now batch-resolves every agent's effective provider first and passes a map-backed resolver.

## `agent-identity-links-panel.tsx`

The empty-state "Connect Claude account" CTA was gated on `agent()?.provider` directly — could offer the CTA for an agent that doesn't actually resolve to claude (linking an unrelated account to the wrong agent), or hide it for one that does. Now resolves via `createResource` over `resolveEffectiveLaunchProvider`, falling back to the raw column while loading (cosmetic-only risk here — button visibility, not a spawn/credential decision).

## Test plan

- [x] `computeBindCandidates` gains two resolver-aware cases: offers on drift-INTO-match, hides on drift-AWAY.
- [x] `buildAccountRowMenu` gains two batch-resolution cases exercising the same via `GetMemoryCommand` mocks.
- [x] `agent-identity-links-panel` gains two drift fixtures (agent-4 drifts INTO claude, agent-5 drifts AWAY from it) asserting the CTA follows the resolved provider, not the raw column.
- [x] All six new tests verified to fail against the pre-fix code (temporarily reverted each file via `git stash`, kept the tests).
- [x] All pre-existing tests in both files pass unchanged (the resolver defaults preserve prior behavior exactly).
- [x] `npx tsc --noEmit -p tsconfig.json` — same 2 pre-existing, unrelated errors as `main` (`armory-view.tsx`/`warden-view.tsx`), nothing new.
- [x] `npx vitest run app/view/identity/ app/view/agent/` — 1216/1216 pass, 99/99 files, no flakes this run.
- [x] Branch was not stale — `main` had not moved since branching, no merge needed before push.

<!-- agentmux:agent_id=agenty -->