### PR TITLE
Clamk@claudius: opt-in bundle.export_for_agent_with_history action

### DIFF
--- a/.changesets/1786927950-feat-armory-opt-in-bundle-export-for-agent-with-history-acti-1ayu.md
+++ b/.changesets/1786927950-feat-armory-opt-in-bundle-export-for-agent-with-history-acti-1ayu.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): opt-in bundle.export_for_agent_with_history action

--- a/agentmux-srv/src/backend/history/mod.rs
+++ b/agentmux-srv/src/backend/history/mod.rs
@@ -30,9 +30,12 @@ impl HistoryService {
 
     /// Construct directly from a `SessionIndex` — used by tests that need
     /// to inject a mock adapter instead of `ClaudeHistoryAdapter::new()`'s
-    /// real filesystem scan.
+    /// real filesystem scan. `pub(crate)` (not private) so tests in other
+    /// modules (e.g. `app_api::bundle`'s `bundle.export_for_agent_with_history`
+    /// tests) can build an isolated `HistoryService` too, instead of
+    /// depending on `AppState::history_service`'s real filesystem scan.
     #[cfg(test)]
-    fn from_index(index: SessionIndex) -> Self {
+    pub(crate) fn from_index(index: SessionIndex) -> Self {
         HistoryService { index: Arc::new(index) }
     }
 
@@ -62,6 +65,46 @@ impl HistoryService {
         })
     }
 
+    /// Typed core of `list_for_agent` — the JSON-returning method wraps
+    /// this. Exists as its own function so other backend code (e.g.
+    /// `bundle.rs`'s `bundle.export_for_agent_with_history`) can get this
+    /// agent's `SessionMeta` list directly, without a JSON
+    /// serialize/deserialize round-trip through the RPC-facing shape.
+    pub fn sessions_for_agent(
+        &self,
+        store: &crate::backend::storage::store::Store,
+        agent_id: &str,
+        offset: usize,
+        limit: usize,
+        sort_by: &str,
+        sort_dir: &str,
+    ) -> Result<(Vec<SessionMeta>, u32, bool), String> {
+        if self.index.is_empty() {
+            self.index.refresh();
+        }
+
+        let links = store
+            .agent_identity_list_for_agent(agent_id)
+            .map_err(|e| format!("failed to resolve agent's linked identities: {e}"))?;
+        if links.is_empty() {
+            return Ok((Vec::new(), 0, false));
+        }
+
+        let mut merged: Vec<SessionMeta> = Vec::new();
+        for link in &links {
+            let (sessions, _total, _has_more) =
+                self.index.list_for_identity(&link.account_id, 0, usize::MAX, sort_by, sort_dir);
+            merged.extend(sessions);
+        }
+        let mut refs: Vec<&SessionMeta> = merged.iter().collect();
+        index::SessionIndex::sort_sessions(&mut refs, sort_by, sort_dir);
+
+        let total = refs.len() as u32;
+        let has_more = offset + limit < refs.len();
+        let page: Vec<SessionMeta> = refs.into_iter().skip(offset).take(limit).cloned().collect();
+        Ok((page, total, has_more))
+    }
+
     /// This agent's own sessions — the actual "fast Conversation History
     /// lookup" protocol §4.4 asks for, resolving `agent_id` to its bound
     /// identity bundle(s) (`Store::agent_identity_list_for_agent`, the
@@ -80,32 +123,10 @@ impl HistoryService {
         sort_by: &str,
         sort_dir: &str,
     ) -> serde_json::Value {
-        if self.index.is_empty() {
-            self.index.refresh();
-        }
-
-        let links = match store.agent_identity_list_for_agent(agent_id) {
-            Ok(l) => l,
-            Err(e) => {
-                return serde_json::json!({ "error": format!("failed to resolve agent's linked identities: {e}") });
-            }
+        let (page, total, has_more) = match self.sessions_for_agent(store, agent_id, offset, limit, sort_by, sort_dir) {
+            Ok(r) => r,
+            Err(e) => return serde_json::json!({ "error": e }),
         };
-        if links.is_empty() {
-            return serde_json::json!({ "sessions": [], "total": 0, "has_more": false });
-        }
-
-        let mut merged: Vec<adapter::SessionMeta> = Vec::new();
-        for link in &links {
-            let (sessions, _total, _has_more) =
-                self.index.list_for_identity(&link.account_id, 0, usize::MAX, sort_by, sort_dir);
-            merged.extend(sessions);
-        }
-        let mut refs: Vec<&adapter::SessionMeta> = merged.iter().collect();
-        index::SessionIndex::sort_sessions(&mut refs, sort_by, sort_dir);
-
-        let total = refs.len() as u32;
-        let has_more = offset + limit < refs.len();
-        let page: Vec<adapter::SessionMeta> = refs.into_iter().skip(offset).take(limit).cloned().collect();
 
         serde_json::json!({
             "sessions": page,

--- a/agentmux-srv/src/backend/history/mod.rs
+++ b/agentmux-srv/src/backend/history/mod.rs
@@ -70,6 +70,17 @@ impl HistoryService {
     /// `bundle.rs`'s `bundle.export_for_agent_with_history`) can get this
     /// agent's `SessionMeta` list directly, without a JSON
     /// serialize/deserialize round-trip through the RPC-facing shape.
+    ///
+    /// `force_refresh`: reagentx P1 on PR #2613 — the lazy
+    /// refresh-only-if-empty behavior (shared with `list`/`get`, fine for
+    /// an interactive browse where slight staleness is an acceptable
+    /// trade for speed) is wrong for a caller claiming completeness, like
+    /// `bundle.export_for_agent_with_history`: once the index has been
+    /// populated once (by ANY prior call, interactive or otherwise), a
+    /// session created since then would silently be missing from an
+    /// export that reports itself as the full record. `list_for_agent`
+    /// (the interactive RPC) passes `false`, preserving its existing
+    /// speed/freshness trade-off; the export path passes `true`.
     pub fn sessions_for_agent(
         &self,
         store: &crate::backend::storage::store::Store,
@@ -78,8 +89,9 @@ impl HistoryService {
         limit: usize,
         sort_by: &str,
         sort_dir: &str,
+        force_refresh: bool,
     ) -> Result<(Vec<SessionMeta>, u32, bool), String> {
-        if self.index.is_empty() {
+        if force_refresh || self.index.is_empty() {
             self.index.refresh();
         }
 
@@ -123,7 +135,7 @@ impl HistoryService {
         sort_by: &str,
         sort_dir: &str,
     ) -> serde_json::Value {
-        let (page, total, has_more) = match self.sessions_for_agent(store, agent_id, offset, limit, sort_by, sort_dir) {
+        let (page, total, has_more) = match self.sessions_for_agent(store, agent_id, offset, limit, sort_by, sort_dir, false) {
             Ok(r) => r,
             Err(e) => return serde_json::json!({ "error": e }),
         };
@@ -323,5 +335,144 @@ mod tests {
         let result = service.list_for_agent(&store, "agent-with-no-links", 0, 10, "created_at", "desc");
         assert_eq!(result["total"], 0);
         assert_eq!(result["sessions"].as_array().unwrap().len(), 0);
+    }
+
+    fn insert_test_agent_and_link(store: &Store, agent_id: &str, account_id: &str) {
+        let mut def = crate::backend::storage::store::AgentDefinition {
+            id: agent_id.to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        store.agent_def_insert(&mut def).unwrap();
+        store
+            .identity_upsert(&crate::backend::storage::store::IdentityAccount {
+                id: account_id.to_string(),
+                name: format!("claude-{account_id}"),
+                provider: "claude".to_string(),
+                kind: "pat".to_string(),
+                display_name: String::new(),
+                secret_ref: crate::backend::storage::store::SecretRef::OAuthConfigDir { dir: String::new() },
+                context: serde_json::json!({}),
+                status: "unknown".to_string(),
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+        store.agent_identity_link(agent_id, account_id, "claude").unwrap();
+    }
+
+    /// Unlike `MockAdapter` (a fixed file list captured at construction),
+    /// this re-scans a real directory on every `discover_files()` call --
+    /// needed to exercise `refresh()`'s actual re-scan behavior, not just
+    /// the in-memory index it populates.
+    struct DynamicMockAdapter {
+        dir: std::path::PathBuf,
+        identity_id: String,
+    }
+    impl HistoryAdapter for DynamicMockAdapter {
+        fn provider(&self) -> &str {
+            "mock"
+        }
+        fn discover_files(&self) -> Result<Vec<DiscoveredFile>, HistoryError> {
+            let entries = std::fs::read_dir(&self.dir).map_err(|e| HistoryError::Other(e.to_string()))?;
+            Ok(entries
+                .flatten()
+                .map(|e| DiscoveredFile { file_path: e.path().to_string_lossy().into_owned(), mtime_ms: 0 })
+                .collect())
+        }
+        fn extract_meta(&self, file_path: &str) -> Result<Option<SessionMeta>, HistoryError> {
+            let id = std::path::Path::new(file_path)
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            Ok(Some(SessionMeta {
+                session_id: id,
+                file_path: file_path.to_string(),
+                provider: "mock".to_string(),
+                model: String::new(),
+                slug: String::new(),
+                working_directory: "/proj".to_string(),
+                created_at: 0,
+                modified_at: 0,
+                message_count: 0,
+                first_user_message: String::new(),
+                file_size_bytes: 0,
+                git_branch: String::new(),
+                total_tokens: 0,
+                subagent_count: 0,
+                identity_id: self.identity_id.clone(),
+            }))
+        }
+        fn parse_file(&self, _: &str) -> Result<Option<HistorySession>, HistoryError> {
+            Ok(None)
+        }
+    }
+
+    // reagentx P1 on PR #2613: sessions_for_agent's lazy
+    // refresh-only-if-empty behavior is wrong for a caller claiming
+    // completeness -- a session created after the index was first
+    // populated (by ANY prior call) must still show up when
+    // force_refresh=true, and must NOT show up when force_refresh=false
+    // (proving the two modes are genuinely different, not that refresh
+    // just always happens to run).
+    #[test]
+    fn force_refresh_true_picks_up_a_session_created_after_first_population_false_does_not() {
+        let dir = std::env::temp_dir().join(format!("amux-hist-force-refresh-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        write_session(&dir, "first");
+
+        let index = SessionIndex::with_isolated_roots(
+            vec![Box::new(DynamicMockAdapter { dir: dir.clone(), identity_id: "acct-mine".to_string() })],
+            vec![dir.clone()],
+        );
+        let service = HistoryService::from_index(index);
+        let store = Store::open_in_memory().unwrap();
+        insert_test_agent_and_link(&store, "agent-1", "acct-mine");
+
+        // First call populates the index (empty -> refresh runs regardless
+        // of force_refresh).
+        let (first_pass, total1, _) = service.sessions_for_agent(&store, "agent-1", 0, 10, "created_at", "desc", false).unwrap();
+        assert_eq!(total1, 1);
+        assert_eq!(first_pass[0].session_id, "first");
+
+        // A new session appears on disk after that first population.
+        write_session(&dir, "second");
+
+        let (stale, total_stale, _) =
+            service.sessions_for_agent(&store, "agent-1", 0, 10, "created_at", "desc", false).unwrap();
+        assert_eq!(total_stale, 1, "force_refresh=false must NOT see the new session (index already non-empty)");
+
+        let (fresh, total_fresh, _) =
+            service.sessions_for_agent(&store, "agent-1", 0, 10, "created_at", "desc", true).unwrap();
+        assert_eq!(total_fresh, 2, "force_refresh=true must see the new session");
+        assert!(fresh.iter().any(|s| s.session_id == "second"));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -347,6 +347,14 @@ pub const COMMAND_BUNDLE_IMPORT_COMMIT: &str = "bundle.import.commit";
 // entry points that touch db_agent_native_memory.
 pub const COMMAND_BUNDLE_EXPORT_FOR_AGENT: &str = "bundle.export_for_agent";
 pub const COMMAND_BUNDLE_IMPORT_FOR_AGENT: &str = "bundle.import_for_agent";
+// SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md §3.3 —
+// deliberately separate from bundle.export_for_agent: a bundle is meant to
+// be shared/reused across agents and machines, while conversation history
+// is private, potentially large, and belongs to exactly one agent. This
+// is the explicit, opt-in action for the narrower case of actually moving
+// one agent's full record to another machine — never bundled into the
+// default export by default.
+pub const COMMAND_BUNDLE_EXPORT_FOR_AGENT_WITH_HISTORY: &str = "bundle.export_for_agent_with_history";
 // Structural ABF validator — Armory Bundle Format (ABF) UI-alignment pass.
 // Read-only: fetches the bundle and runs the pure bundle_validate module
 // against it, no Store writes.

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -630,6 +630,18 @@ struct ExportForAgentWithHistoryReq {
     agent_id: String,
 }
 
+/// Per-transcript size ceiling for `bundle.export_for_agent_with_history`.
+/// reagentx P1 on PR #2613: reading every session fully into a `String`
+/// with no bound could exhaust server memory for the multi-GB histories
+/// this feature exists to migrate. Unlike `MAX_ABF_FILE_SIZE_BYTES`
+/// (context files, truncated with a warning when oversized — fine, since
+/// a partial context file is still useful), a transcript is skipped
+/// ENTIRELY rather than truncated: JSONL requires whole lines, and a
+/// truncated mid-record file could fail to parse (or silently misparse)
+/// on the receiving end, which is worse than the session being visibly
+/// absent with a warning explaining why.
+const MAX_HISTORY_SESSION_FILE_SIZE_BYTES: u64 = 200 * 1024 * 1024;
+
 /// `bundle.export_for_agent_with_history` —
 /// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
 /// §3.3. Deliberately a SEPARATE, explicit, opt-in action from
@@ -641,16 +653,30 @@ struct ExportForAgentWithHistoryReq {
 /// `history/<provider>/<session_id>.jsonl`. Always returns a zip — a
 /// multi-file, potentially large archive has no sensible inline-JSON
 /// shape, unlike the plain export's optional format. A transcript that
-/// fails to read (deleted, permission issue) is warned about and skipped,
+/// fails to read (deleted, permission issue, or over
+/// `MAX_HISTORY_SESSION_FILE_SIZE_BYTES`) is warned about and skipped,
 /// never fails the whole export — same best-effort philosophy as the
 /// memory-splicing step above.
+///
+/// reagentx P1 on PR #2613, both addressed:
+/// - `sessions_for_agent(..., force_refresh: true)` — this export claims
+///   completeness ("included N of N known sessions"), so it can't rely on
+///   the interactive lazy-refresh-if-empty behavior; a session created
+///   since the index was first populated (by ANY prior call) must not be
+///   silently missing.
+/// - the actual file reads + zip + base64 encode run inside
+///   `spawn_blocking` — synchronous, potentially slow I/O and CPU work
+///   that must not block the async RPC worker thread. Only the already-
+///   resolved, owned `export`/`sessions` data crosses into the blocking
+///   closure; the `Store`/`HistoryService` DB lookups above stay on the
+///   async side, unchanged.
 async fn bundle_export_for_agent_with_history_impl(
     id_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
     history_service: &crate::backend::history::HistoryService,
     req: ExportForAgentWithHistoryReq,
 ) -> Result<serde_json::Value, String> {
-    let (mut export, _agent, mut all_warnings, missing_skill_ids) = build_export_for_agent(
+    let (export, _agent, all_warnings, missing_skill_ids) = build_export_for_agent(
         id_store,
         wstore,
         &req.bundle_id,
@@ -660,39 +686,62 @@ async fn bundle_export_for_agent_with_history_impl(
     .await?;
 
     let (sessions, session_count, _has_more) = history_service
-        .sessions_for_agent(id_store, &req.agent_id, 0, usize::MAX, "modified_at", "desc")
+        .sessions_for_agent(id_store, &req.agent_id, 0, usize::MAX, "modified_at", "desc", true)
         .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
 
-    let mut included = 0u32;
-    for session in &sessions {
-        match std::fs::read_to_string(&session.file_path) {
-            Ok(content) => {
-                export.files.push(crate::backend::bundle_export::BundleExportFile {
-                    path: format!("history/{}/{}.jsonl", session.provider, session.session_id),
-                    content,
-                });
-                included += 1;
+    tokio::task::spawn_blocking(move || {
+        let mut export = export;
+        let mut all_warnings = all_warnings;
+        let mut included = 0u32;
+        for session in &sessions {
+            match std::fs::metadata(&session.file_path) {
+                Ok(meta) if meta.len() > MAX_HISTORY_SESSION_FILE_SIZE_BYTES => {
+                    all_warnings.push(format!(
+                        "history: skipped session {} ({}) — {} bytes exceeds the {} byte limit",
+                        session.session_id, session.file_path, meta.len(), MAX_HISTORY_SESSION_FILE_SIZE_BYTES
+                    ));
+                    continue;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    all_warnings.push(format!(
+                        "history: failed to read session {} ({}): {e}",
+                        session.session_id, session.file_path
+                    ));
+                    continue;
+                }
             }
-            Err(e) => all_warnings.push(format!(
-                "history: failed to read session {} ({}): {e}",
-                session.session_id, session.file_path
-            )),
+            match std::fs::read_to_string(&session.file_path) {
+                Ok(content) => {
+                    export.files.push(crate::backend::bundle_export::BundleExportFile {
+                        path: format!("history/{}/{}.jsonl", session.provider, session.session_id),
+                        content,
+                    });
+                    included += 1;
+                }
+                Err(e) => all_warnings.push(format!(
+                    "history: failed to read session {} ({}): {e}",
+                    session.session_id, session.file_path
+                )),
+            }
         }
-    }
-    all_warnings.push(format!("history: included {included} of {session_count} known session(s)"));
+        all_warnings.push(format!("history: included {included} of {session_count} known session(s)"));
 
-    let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
-        .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
-    use base64::Engine as _;
-    let encoded = base64::engine::general_purpose::STANDARD.encode(&zip_bytes);
-    Ok(json!({
-        "root_slug": export.root_slug,
-        "skipped_skills": export.skipped_skills,
-        "warnings": all_warnings,
-        "missing_skill_ids": missing_skill_ids,
-        "history_session_count": included,
-        "zip_base64": encoded,
-    }))
+        let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
+            .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
+        use base64::Engine as _;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&zip_bytes);
+        Ok(json!({
+            "root_slug": export.root_slug,
+            "skipped_skills": export.skipped_skills,
+            "warnings": all_warnings,
+            "missing_skill_ids": missing_skill_ids,
+            "history_session_count": included,
+            "zip_base64": encoded,
+        }))
+    })
+    .await
+    .map_err(|e| format!("bundle.export_for_agent_with_history: blocking task panicked: {e}"))?
 }
 
 fn register_bundle_export_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -3317,6 +3366,57 @@ mod export_import_for_agent_tests {
             assert!(
                 warnings.iter().any(|w| w.as_str().unwrap_or("").contains("failed to read session")),
                 "must warn about the unreadable session: {warnings:?}"
+            );
+        }
+
+        // reagentx P1 on PR #2613: an oversized transcript must be skipped
+        // (never truncated -- a partial JSONL file can fail or misparse on
+        // the receiving end) and warned about, not silently included or
+        // read into memory unbounded.
+        #[tokio::test]
+        async fn skips_and_warns_on_a_transcript_over_the_size_limit() {
+            let state = test_state();
+            let config_dir = tempfile::tempdir().unwrap();
+            make_agent(&state, "agent-1", "/work/proj", config_dir.path());
+            make_bundle(&state, "bundle-1", "Be helpful.");
+            link_agent_to_identity(&state, "agent-1", "acct-mine");
+
+            let session_dir = tempfile::tempdir().unwrap();
+            let oversized_path = session_dir.path().join("sess-huge.jsonl");
+            {
+                // Sparse file -- claims MAX_HISTORY_SESSION_FILE_SIZE_BYTES + 1
+                // bytes via metadata without actually writing/allocating
+                // that much, matching read_abf_file_path's own sparse-file
+                // test technique above.
+                let file = std::fs::File::create(&oversized_path).unwrap();
+                file.set_len(MAX_HISTORY_SESSION_FILE_SIZE_BYTES + 1).unwrap();
+            }
+
+            let index = SessionIndex::with_isolated_roots(
+                vec![Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: oversized_path.to_string_lossy().into_owned(), mtime_ms: 1 }],
+                    identity_id: "acct-mine".to_string(),
+                })],
+                vec![session_dir.path().to_path_buf()],
+            );
+            let history_service = HistoryService::from_index(index);
+
+            let result = bundle_export_for_agent_with_history_impl(
+                &state.id_store,
+                &state.wstore,
+                &history_service,
+                ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(result["history_session_count"], 0, "oversized session must not count as included");
+            let paths = unzip_paths(result["zip_base64"].as_str().unwrap());
+            assert!(!paths.iter().any(|p| p.contains("sess-huge")), "oversized session must not be in the zip: {paths:?}");
+            let warnings = result["warnings"].as_array().unwrap();
+            assert!(
+                warnings.iter().any(|w| w.as_str().unwrap_or("").contains("exceeds") && w.as_str().unwrap_or("").contains("sess-huge")),
+                "must warn about the size limit: {warnings:?}"
             );
         }
     }

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -658,26 +658,36 @@ const MAX_HISTORY_SESSION_FILE_SIZE_BYTES: u64 = 200 * 1024 * 1024;
 /// never fails the whole export — same best-effort philosophy as the
 /// memory-splicing step above.
 ///
-/// reagentx P1 on PR #2613, both addressed:
+/// reagentx P1 on PR #2613, all addressed:
 /// - `sessions_for_agent(..., force_refresh: true)` — this export claims
 ///   completeness ("included N of N known sessions"), so it can't rely on
 ///   the interactive lazy-refresh-if-empty behavior; a session created
 ///   since the index was first populated (by ANY prior call) must not be
 ///   silently missing.
-/// - the actual file reads + zip + base64 encode run inside
+/// - `sessions_for_agent` itself runs inside its own `spawn_blocking` —
+///   `force_refresh: true` means it calls `SessionIndex::refresh()`,
+///   which synchronously walks and parses every session file for every
+///   provider on disk. A second review round caught that only the LATER
+///   file-read/zip/encode step (below) had been moved off the async
+///   worker thread; this earlier, more expensive full-index-rebuild step
+///   was still running inline on it. Takes `Arc<Store>`/
+///   `Arc<HistoryService>` (not bare refs) specifically so a clone can
+///   cross into this closure — `build_export_for_agent` above still
+///   receives them by reference (`Arc` derefs to `&Store` for free), no
+///   signature change needed there.
+/// - the actual file reads + zip + base64 encode run inside their own
 ///   `spawn_blocking` — synchronous, potentially slow I/O and CPU work
-///   that must not block the async RPC worker thread. Only the already-
-///   resolved, owned `export`/`sessions` data crosses into the blocking
-///   closure; the `Store`/`HistoryService` DB lookups above stay on the
-///   async side, unchanged.
+///   that must not block the async RPC worker thread either. Only the
+///   already-resolved, owned `export`/`sessions` data crosses into that
+///   closure.
 async fn bundle_export_for_agent_with_history_impl(
-    id_store: &crate::backend::storage::store::Store,
+    id_store: Arc<crate::backend::storage::store::Store>,
     wstore: &crate::backend::storage::store::Store,
-    history_service: &crate::backend::history::HistoryService,
+    history_service: Arc<crate::backend::history::HistoryService>,
     req: ExportForAgentWithHistoryReq,
 ) -> Result<serde_json::Value, String> {
     let (export, _agent, all_warnings, missing_skill_ids) = build_export_for_agent(
-        id_store,
+        &id_store,
         wstore,
         &req.bundle_id,
         &req.agent_id,
@@ -685,9 +695,17 @@ async fn bundle_export_for_agent_with_history_impl(
     )
     .await?;
 
-    let (sessions, session_count, _has_more) = history_service
-        .sessions_for_agent(id_store, &req.agent_id, 0, usize::MAX, "modified_at", "desc", true)
-        .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
+    let agent_id = req.agent_id.clone();
+    let (sessions, session_count, _has_more) = {
+        let id_store = id_store.clone();
+        let history_service = history_service.clone();
+        tokio::task::spawn_blocking(move || {
+            history_service.sessions_for_agent(&id_store, &agent_id, 0, usize::MAX, "modified_at", "desc", true)
+        })
+        .await
+        .map_err(|e| format!("bundle.export_for_agent_with_history: blocking task panicked: {e}"))?
+        .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?
+    };
 
     tokio::task::spawn_blocking(move || {
         let mut export = export;
@@ -774,7 +792,7 @@ fn register_bundle_export_for_agent_with_history(engine: &Arc<WshRpcEngine>, sta
             Box::pin(async move {
                 let req: ExportForAgentWithHistoryReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
-                bundle_export_for_agent_with_history_impl(&id_store, &wstore, &history_service, req)
+                bundle_export_for_agent_with_history_impl(id_store, &wstore, history_service, req)
                     .await
                     .map(Some)
             })
@@ -3290,9 +3308,9 @@ mod export_import_for_agent_tests {
             let history_service = HistoryService::from_index(index);
 
             let result = bundle_export_for_agent_with_history_impl(
-                &state.id_store,
+                state.id_store.clone(),
                 &state.wstore,
-                &history_service,
+                std::sync::Arc::new(history_service),
                 ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
             )
             .await
@@ -3315,9 +3333,9 @@ mod export_import_for_agent_tests {
             let history_service = HistoryService::from_index(SessionIndex::with_isolated_roots(vec![], vec![]));
 
             let result = bundle_export_for_agent_with_history_impl(
-                &state.id_store,
+                state.id_store.clone(),
                 &state.wstore,
-                &history_service,
+                std::sync::Arc::new(history_service),
                 ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
             )
             .await
@@ -3353,9 +3371,9 @@ mod export_import_for_agent_tests {
             let history_service = HistoryService::from_index(index);
 
             let result = bundle_export_for_agent_with_history_impl(
-                &state.id_store,
+                state.id_store.clone(),
                 &state.wstore,
-                &history_service,
+                std::sync::Arc::new(history_service),
                 ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
             )
             .await
@@ -3402,9 +3420,9 @@ mod export_import_for_agent_tests {
             let history_service = HistoryService::from_index(index);
 
             let result = bundle_export_for_agent_with_history_impl(
-                &state.id_store,
+                state.id_store.clone(),
                 &state.wstore,
-                &history_service,
+                std::sync::Arc::new(history_service),
                 ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
             )
             .await

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -642,6 +642,39 @@ struct ExportForAgentWithHistoryReq {
 /// absent with a warning explaining why.
 const MAX_HISTORY_SESSION_FILE_SIZE_BYTES: u64 = 200 * 1024 * 1024;
 
+/// Aggregate ceiling across every session included in one
+/// `bundle.export_for_agent_with_history` call. reagentx P1, third review
+/// round: a per-file cap alone doesn't bound an agent with many sessions
+/// each just under it — this is the analogous total cap the sibling
+/// import path already enforces (`MAX_TOTAL_UNCOMPRESSED_BYTES`,
+/// `bundle_import.rs`), sized larger since export's job is specifically
+/// to carry as much real history as reasonably fits, not to validate a
+/// small hand-authored bundle. Sessions are processed in
+/// `sessions_for_agent`'s existing `modified_at desc` order, so hitting
+/// this cap keeps the most recent conversations and cuts off the oldest
+/// — the same priority a human moving "my history" to a new machine would
+/// want. Unlike import's reject-the-whole-thing-on-overflow behavior,
+/// export keeps its existing best-effort philosophy: stop including
+/// further sessions and say so in a warning, never fail the call outright.
+const MAX_TOTAL_HISTORY_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Given per-session sizes already in priority order (most-recent-first,
+/// matching `sessions_for_agent`'s `modified_at desc` sort), decide how
+/// many fit within `total_cap`. Returns `(count_included, stopped_at_cap)`.
+/// Pure — no I/O — deliberately extracted so this decision is testable
+/// with tiny numbers instead of needing real `MAX_TOTAL_HISTORY_BYTES`-
+/// scale files on disk.
+fn sessions_within_total_budget(sizes: &[u64], total_cap: u64) -> (usize, bool) {
+    let mut total = 0u64;
+    for (i, &size) in sizes.iter().enumerate() {
+        if total + size > total_cap {
+            return (i, true);
+        }
+        total += size;
+    }
+    (sizes.len(), false)
+}
+
 /// `bundle.export_for_agent_with_history` —
 /// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
 /// §3.3. Deliberately a SEPARATE, explicit, opt-in action from
@@ -680,6 +713,10 @@ const MAX_HISTORY_SESSION_FILE_SIZE_BYTES: u64 = 200 * 1024 * 1024;
 ///   that must not block the async RPC worker thread either. Only the
 ///   already-resolved, owned `export`/`sessions` data crosses into that
 ///   closure.
+/// - `MAX_TOTAL_HISTORY_BYTES` — a third review round caught that the
+///   per-session cap alone doesn't bound an agent with MANY sessions each
+///   just under it; the sibling import path enforces an analogous total
+///   cap (`MAX_TOTAL_UNCOMPRESSED_BYTES`). See `sessions_within_total_budget`.
 async fn bundle_export_for_agent_with_history_impl(
     id_store: Arc<crate::backend::storage::store::Store>,
     wstore: &crate::backend::storage::store::Store,
@@ -710,25 +747,43 @@ async fn bundle_export_for_agent_with_history_impl(
     tokio::task::spawn_blocking(move || {
         let mut export = export;
         let mut all_warnings = all_warnings;
-        let mut included = 0u32;
+
+        // Pass 1: stat every session, drop per-file-oversized ones. No
+        // reads yet — just sizes, so the pure budget decision below (pass
+        // 2) can be tested with tiny numbers instead of real files.
+        let mut sized: Vec<(&crate::backend::history::adapter::SessionMeta, u64)> = Vec::new();
         for session in &sessions {
             match std::fs::metadata(&session.file_path) {
                 Ok(meta) if meta.len() > MAX_HISTORY_SESSION_FILE_SIZE_BYTES => {
                     all_warnings.push(format!(
-                        "history: skipped session {} ({}) — {} bytes exceeds the {} byte limit",
+                        "history: skipped session {} ({}) — {} bytes exceeds the {} byte per-session limit",
                         session.session_id, session.file_path, meta.len(), MAX_HISTORY_SESSION_FILE_SIZE_BYTES
                     ));
-                    continue;
                 }
-                Ok(_) => {}
-                Err(e) => {
-                    all_warnings.push(format!(
-                        "history: failed to read session {} ({}): {e}",
-                        session.session_id, session.file_path
-                    ));
-                    continue;
-                }
+                Ok(meta) => sized.push((session, meta.len())),
+                Err(e) => all_warnings.push(format!(
+                    "history: failed to read session {} ({}): {e}",
+                    session.session_id, session.file_path
+                )),
             }
+        }
+
+        // Pass 2: how many of the (already most-recent-first-ordered)
+        // remaining sessions fit within the aggregate cap.
+        let sizes: Vec<u64> = sized.iter().map(|(_, size)| *size).collect();
+        let sized_count = sized.len();
+        let (fit_count, stopped_at_total_cap) = sessions_within_total_budget(&sizes, MAX_TOTAL_HISTORY_BYTES);
+        if stopped_at_total_cap {
+            let total: u64 = sizes[..fit_count].iter().sum();
+            all_warnings.push(format!(
+                "history: stopped after {total} bytes (limit {MAX_TOTAL_HISTORY_BYTES}) — {} additional session(s) omitted, oldest first",
+                sized_count - fit_count
+            ));
+        }
+
+        // Pass 3: actually read + include only what fit.
+        let mut included = 0u32;
+        for (session, _size) in sized.into_iter().take(fit_count) {
             match std::fs::read_to_string(&session.file_path) {
                 Ok(content) => {
                     export.files.push(crate::backend::bundle_export::BundleExportFile {
@@ -3436,6 +3491,52 @@ mod export_import_for_agent_tests {
                 warnings.iter().any(|w| w.as_str().unwrap_or("").contains("exceeds") && w.as_str().unwrap_or("").contains("sess-huge")),
                 "must warn about the size limit: {warnings:?}"
             );
+        }
+
+        // reagentx P1, third review round: a per-session cap alone doesn't
+        // bound an agent with many sessions each just under it. These
+        // exercise the pure sessions_within_total_budget decision directly
+        // with tiny numbers -- MAX_TOTAL_HISTORY_BYTES is 500 MiB, real
+        // enough files to trigger it would make this test slow and wasteful
+        // for no extra confidence over testing the same logic with small
+        // inputs.
+        #[test]
+        fn total_budget_includes_everything_when_under_the_cap() {
+            let (count, stopped) = sessions_within_total_budget(&[10, 10, 10], 100);
+            assert_eq!(count, 3);
+            assert!(!stopped);
+        }
+
+        #[test]
+        fn total_budget_stops_at_the_first_session_that_would_exceed_the_cap() {
+            // Most-recent-first order: [10, 10, 10] with cap 25 -- the
+            // third one (cumulative 30) doesn't fit, so only the first two
+            // (most recent) are included.
+            let (count, stopped) = sessions_within_total_budget(&[10, 10, 10], 25);
+            assert_eq!(count, 2, "must include the two most-recent sessions, not just any two that individually fit");
+            assert!(stopped);
+        }
+
+        #[test]
+        fn total_budget_includes_nothing_when_the_first_session_alone_exceeds_the_cap() {
+            let (count, stopped) = sessions_within_total_budget(&[50, 10], 25);
+            assert_eq!(count, 0);
+            assert!(stopped);
+        }
+
+        #[test]
+        fn total_budget_handles_an_empty_list() {
+            let (count, stopped) = sessions_within_total_budget(&[], 100);
+            assert_eq!(count, 0);
+            assert!(!stopped);
+        }
+
+        #[test]
+        fn total_budget_includes_a_session_that_exactly_fills_the_remaining_cap() {
+            // 10 + 15 == 25 exactly -- must NOT be treated as exceeding.
+            let (count, stopped) = sessions_within_total_budget(&[10, 15], 25);
+            assert_eq!(count, 2);
+            assert!(!stopped);
         }
     }
 }

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -29,6 +29,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_bundle_import_preview(engine, state);
     register_bundle_import_commit(engine, state);
     register_bundle_export_for_agent(engine, state);
+    register_bundle_export_for_agent_with_history(engine, state);
     register_bundle_import_for_agent(engine, state);
     register_bundle_validate(engine, state);
 }
@@ -499,19 +500,32 @@ struct ExportForAgentReq {
 /// happens to be attached" guess. Extracted from the RPC closure into a
 /// directly-callable, directly-testable function, matching
 /// `bundle_import_preview_impl`'s pattern.
-async fn bundle_export_for_agent_impl(
+/// Shared by `bundle_export_for_agent_impl` and
+/// `bundle_export_for_agent_with_history_impl`: resolve the bundle + agent,
+/// build the base `BundleExport`, splice in native memory. Returns the
+/// export, the resolved agent (the history variant needs its id), combined
+/// warnings, and missing skill ids. Everything after this point (whether to
+/// zip, whether to also append history files) is caller-specific.
+async fn build_export_for_agent(
     id_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
-    req: ExportForAgentReq,
-) -> Result<serde_json::Value, String> {
+    bundle_id: &str,
+    agent_id: &str,
+    err_prefix: &str,
+) -> Result<(
+    crate::backend::bundle_export::BundleExport,
+    crate::backend::storage::store::AgentDefinition,
+    Vec<String>,
+    Vec<String>,
+), String> {
     let bundle = id_store
-        .bundle_memory_get(&req.bundle_id)
-        .map_err(|e| format!("bundle.export_for_agent: {e}"))?
-        .ok_or_else(|| format!("bundle.export_for_agent: no bundle with id {}", req.bundle_id))?;
+        .bundle_memory_get(bundle_id)
+        .map_err(|e| format!("{err_prefix}: {e}"))?
+        .ok_or_else(|| format!("{err_prefix}: no bundle with id {bundle_id}"))?;
     let agent = wstore
-        .agent_def_get(&req.agent_id)
-        .map_err(|e| format!("bundle.export_for_agent: {e}"))?
-        .ok_or_else(|| format!("bundle.export_for_agent: no agent with id {}", req.agent_id))?;
+        .agent_def_get(agent_id)
+        .map_err(|e| format!("{err_prefix}: {e}"))?
+        .ok_or_else(|| format!("{err_prefix}: no agent with id {agent_id}"))?;
 
     let mut handler_warnings: Vec<String> = Vec::new();
     let skill_ids: Vec<String> = crate::backend::bundle_export::parse_json_field_or_warn(
@@ -526,7 +540,7 @@ async fn bundle_export_for_agent_impl(
             Ok(Some(skill)) => skills.push(skill),
             Ok(None) => missing_skill_ids.push(id.clone()),
             Err(e) => {
-                return Err(format!("bundle.export_for_agent: failed to look up skill {id}: {e}"));
+                return Err(format!("{err_prefix}: failed to look up skill {id}: {e}"));
             }
         }
     }
@@ -572,11 +586,21 @@ async fn bundle_export_for_agent_impl(
         }
         Err(e) => handler_warnings.push(format!("native memory: failed to list: {e}")),
     }
-    splice_memory_component(&mut export, &memory_files)
-        .map_err(|e| format!("bundle.export_for_agent: {e}"))?;
+    splice_memory_component(&mut export, &memory_files).map_err(|e| format!("{err_prefix}: {e}"))?;
 
     let mut all_warnings = export.warnings.clone();
     all_warnings.append(&mut handler_warnings);
+
+    Ok((export, agent, all_warnings, missing_skill_ids))
+}
+
+async fn bundle_export_for_agent_impl(
+    id_store: &crate::backend::storage::store::Store,
+    wstore: &crate::backend::storage::store::Store,
+    req: ExportForAgentReq,
+) -> Result<serde_json::Value, String> {
+    let (export, _agent, all_warnings, missing_skill_ids) =
+        build_export_for_agent(id_store, wstore, &req.bundle_id, &req.agent_id, "bundle.export_for_agent").await?;
 
     if req.format == "zip" {
         let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
@@ -600,6 +624,77 @@ async fn bundle_export_for_agent_impl(
     Ok(result)
 }
 
+#[derive(serde::Deserialize)]
+struct ExportForAgentWithHistoryReq {
+    bundle_id: String,
+    agent_id: String,
+}
+
+/// `bundle.export_for_agent_with_history` —
+/// `docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md`
+/// §3.3. Deliberately a SEPARATE, explicit, opt-in action from
+/// `bundle.export_for_agent` — see `COMMAND_BUNDLE_EXPORT_FOR_AGENT_WITH_HISTORY`'s
+/// doc comment for why conversation transcripts must never ride along in
+/// the default (shareable, reusable-across-agents) bundle export. Builds
+/// the identical base export, then appends every session
+/// `HistoryService::sessions_for_agent` finds for this agent under
+/// `history/<provider>/<session_id>.jsonl`. Always returns a zip — a
+/// multi-file, potentially large archive has no sensible inline-JSON
+/// shape, unlike the plain export's optional format. A transcript that
+/// fails to read (deleted, permission issue) is warned about and skipped,
+/// never fails the whole export — same best-effort philosophy as the
+/// memory-splicing step above.
+async fn bundle_export_for_agent_with_history_impl(
+    id_store: &crate::backend::storage::store::Store,
+    wstore: &crate::backend::storage::store::Store,
+    history_service: &crate::backend::history::HistoryService,
+    req: ExportForAgentWithHistoryReq,
+) -> Result<serde_json::Value, String> {
+    let (mut export, _agent, mut all_warnings, missing_skill_ids) = build_export_for_agent(
+        id_store,
+        wstore,
+        &req.bundle_id,
+        &req.agent_id,
+        "bundle.export_for_agent_with_history",
+    )
+    .await?;
+
+    let (sessions, session_count, _has_more) = history_service
+        .sessions_for_agent(id_store, &req.agent_id, 0, usize::MAX, "modified_at", "desc")
+        .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
+
+    let mut included = 0u32;
+    for session in &sessions {
+        match std::fs::read_to_string(&session.file_path) {
+            Ok(content) => {
+                export.files.push(crate::backend::bundle_export::BundleExportFile {
+                    path: format!("history/{}/{}.jsonl", session.provider, session.session_id),
+                    content,
+                });
+                included += 1;
+            }
+            Err(e) => all_warnings.push(format!(
+                "history: failed to read session {} ({}): {e}",
+                session.session_id, session.file_path
+            )),
+        }
+    }
+    all_warnings.push(format!("history: included {included} of {session_count} known session(s)"));
+
+    let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
+        .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
+    use base64::Engine as _;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&zip_bytes);
+    Ok(json!({
+        "root_slug": export.root_slug,
+        "skipped_skills": export.skipped_skills,
+        "warnings": all_warnings,
+        "missing_skill_ids": missing_skill_ids,
+        "history_session_count": included,
+        "zip_base64": encoded,
+    }))
+}
+
 fn register_bundle_export_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
     let wstore = state.wstore.clone();
@@ -612,6 +707,27 @@ fn register_bundle_export_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState
                 let req: ExportForAgentReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.export_for_agent: {e}"))?;
                 bundle_export_for_agent_impl(&id_store, &wstore, req).await.map(Some)
+            })
+        }),
+    );
+}
+
+fn register_bundle_export_for_agent_with_history(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let wstore = state.wstore.clone();
+    let history_service = state.history_service.clone();
+    engine.register_handler(
+        COMMAND_BUNDLE_EXPORT_FOR_AGENT_WITH_HISTORY,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let wstore = wstore.clone();
+            let history_service = history_service.clone();
+            Box::pin(async move {
+                let req: ExportForAgentWithHistoryReq = serde_json::from_value(data)
+                    .map_err(|e| format!("bundle.export_for_agent_with_history: {e}"))?;
+                bundle_export_for_agent_with_history_impl(&id_store, &wstore, &history_service, req)
+                    .await
+                    .map(Some)
             })
         }),
     );
@@ -3027,5 +3143,181 @@ mod export_import_for_agent_tests {
         let manifest: serde_json::Value = serde_json::from_str(manifest_file["content"].as_str().unwrap()).unwrap();
         assert!(manifest["provider"].is_null(), "unset provider must not export as an empty string");
         assert!(manifest["model"].is_null(), "unset model must not export as an empty string");
+    }
+
+    // docs/specs/SPEC_AGENT_IDENTITY_HISTORY_PERSISTENCE_PROTOCOL_2026_08_16.md
+    // §3.3 — bundle.export_for_agent_with_history.
+
+    mod with_history_tests {
+        use super::*;
+        use crate::backend::history::adapter::{DiscoveredFile, HistoryAdapter, HistoryError, HistorySession, SessionMeta};
+        use crate::backend::history::index::SessionIndex;
+        use crate::backend::history::HistoryService;
+
+        /// Tags every discovered file with a fixed identity_id -- enough to
+        /// exercise the agent_id -> identity_id -> sessions chain without a
+        /// real filesystem scan.
+        struct MockAdapter {
+            files: Vec<DiscoveredFile>,
+            identity_id: String,
+        }
+        impl HistoryAdapter for MockAdapter {
+            fn provider(&self) -> &str {
+                "mock"
+            }
+            fn discover_files(&self) -> Result<Vec<DiscoveredFile>, HistoryError> {
+                Ok(self.files.iter().map(|f| DiscoveredFile { file_path: f.file_path.clone(), mtime_ms: f.mtime_ms }).collect())
+            }
+            fn extract_meta(&self, file_path: &str) -> Result<Option<SessionMeta>, HistoryError> {
+                let id = std::path::Path::new(file_path).file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+                Ok(Some(SessionMeta {
+                    session_id: id,
+                    file_path: file_path.to_string(),
+                    provider: "mock".to_string(),
+                    model: String::new(),
+                    slug: String::new(),
+                    working_directory: "/proj".to_string(),
+                    created_at: 0,
+                    modified_at: 0,
+                    message_count: 0,
+                    first_user_message: String::new(),
+                    file_size_bytes: 0,
+                    git_branch: String::new(),
+                    total_tokens: 0,
+                    subagent_count: 0,
+                    identity_id: self.identity_id.clone(),
+                }))
+            }
+            fn parse_file(&self, _: &str) -> Result<Option<HistorySession>, HistoryError> {
+                Ok(None)
+            }
+        }
+
+        fn link_agent_to_identity(state: &AppState, agent_id: &str, account_id: &str) {
+            state
+                .id_store
+                .identity_upsert(&crate::backend::storage::store::IdentityAccount {
+                    id: account_id.to_string(),
+                    name: format!("claude-{account_id}"),
+                    provider: "claude".to_string(),
+                    kind: "pat".to_string(),
+                    display_name: String::new(),
+                    secret_ref: crate::backend::storage::store::SecretRef::OAuthConfigDir { dir: String::new() },
+                    context: serde_json::json!({}),
+                    status: "unknown".to_string(),
+                    created_at: 0,
+                    updated_at: 0,
+                })
+                .unwrap();
+            state.id_store.agent_identity_link(agent_id, account_id, "claude").unwrap();
+        }
+
+        fn unzip_paths(zip_base64: &str) -> Vec<String> {
+            use base64::Engine as _;
+            let bytes = base64::engine::general_purpose::STANDARD.decode(zip_base64).unwrap();
+            let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+            (0..archive.len()).map(|i| archive.by_index(i).unwrap().name().to_string()).collect()
+        }
+
+        #[tokio::test]
+        async fn includes_the_agents_sessions_alongside_the_normal_bundle_files() {
+            let state = test_state();
+            let config_dir = tempfile::tempdir().unwrap();
+            make_agent(&state, "agent-1", "/work/proj", config_dir.path());
+            make_bundle(&state, "bundle-1", "Be helpful.");
+            link_agent_to_identity(&state, "agent-1", "acct-mine");
+
+            let session_dir = tempfile::tempdir().unwrap();
+            let session_path = session_dir.path().join("sess-1.jsonl");
+            std::fs::write(&session_path, "{\"role\":\"user\"}\n").unwrap();
+
+            let index = SessionIndex::with_isolated_roots(
+                vec![Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: session_path.to_string_lossy().into_owned(), mtime_ms: 1 }],
+                    identity_id: "acct-mine".to_string(),
+                })],
+                vec![session_dir.path().to_path_buf()],
+            );
+            let history_service = HistoryService::from_index(index);
+
+            let result = bundle_export_for_agent_with_history_impl(
+                &state.id_store,
+                &state.wstore,
+                &history_service,
+                ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(result["history_session_count"], 1);
+            let paths = unzip_paths(result["zip_base64"].as_str().unwrap());
+            assert!(paths.iter().any(|p| p.ends_with("instructions/AGENTS.md")), "base bundle files must still be present: {paths:?}");
+            assert!(paths.iter().any(|p| p.ends_with("history/mock/sess-1.jsonl")), "session must be included under history/: {paths:?}");
+        }
+
+        #[tokio::test]
+        async fn succeeds_with_zero_sessions_when_the_agent_has_no_linked_identity() {
+            let state = test_state();
+            let config_dir = tempfile::tempdir().unwrap();
+            make_agent(&state, "agent-1", "/work/proj", config_dir.path());
+            make_bundle(&state, "bundle-1", "Be helpful.");
+            // No link_agent_to_identity call -- agent has no bound account.
+
+            let history_service = HistoryService::from_index(SessionIndex::with_isolated_roots(vec![], vec![]));
+
+            let result = bundle_export_for_agent_with_history_impl(
+                &state.id_store,
+                &state.wstore,
+                &history_service,
+                ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(result["history_session_count"], 0);
+            let paths = unzip_paths(result["zip_base64"].as_str().unwrap());
+            assert!(!paths.iter().any(|p| p.contains("history/")), "no history/ entries when nothing is linked: {paths:?}");
+        }
+
+        #[tokio::test]
+        async fn warns_and_continues_when_a_transcript_file_cannot_be_read() {
+            let state = test_state();
+            let config_dir = tempfile::tempdir().unwrap();
+            make_agent(&state, "agent-1", "/work/proj", config_dir.path());
+            make_bundle(&state, "bundle-1", "Be helpful.");
+            link_agent_to_identity(&state, "agent-1", "acct-mine");
+
+            // Points at a file that will never exist on disk.
+            let missing_path = std::env::temp_dir().join("amx-nonexistent-session-xyz.jsonl");
+            let index = SessionIndex::with_isolated_roots(
+                vec![Box::new(MockAdapter {
+                    files: vec![DiscoveredFile { file_path: missing_path.to_string_lossy().into_owned(), mtime_ms: 1 }],
+                    identity_id: "acct-mine".to_string(),
+                })],
+                vec![],
+            );
+            // Note: refresh() would normally skip a file it can't stat via
+            // discover_files' own is_dir/exists checks in the real adapter,
+            // but MockAdapter unconditionally reports it as discovered so
+            // extract_meta -- and therefore the export's own read -- is what
+            // actually exercises the missing-file path here.
+            let history_service = HistoryService::from_index(index);
+
+            let result = bundle_export_for_agent_with_history_impl(
+                &state.id_store,
+                &state.wstore,
+                &history_service,
+                ExportForAgentWithHistoryReq { bundle_id: "bundle-1".to_string(), agent_id: "agent-1".to_string() },
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(result["history_session_count"], 0, "unreadable session must not count as included");
+            let warnings = result["warnings"].as_array().unwrap();
+            assert!(
+                warnings.iter().any(|w| w.as_str().unwrap_or("").contains("failed to read session")),
+                "must warn about the unreadable session: {warnings:?}"
+            );
+        }
     }
 }

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -295,6 +295,7 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "bundle.delete",
     "bundle.export",
     "bundle.export_for_agent",
+    "bundle.export_for_agent_with_history",
     "bundle.get",
     "bundle.import",
     "bundle.import_for_agent",


### PR DESCRIPTION
## Summary

Step 5 of #2603 (protocol §3.3). Deliberately a **separate, explicit** action from `bundle.export_for_agent` — a bundle is meant to be shared/reused across agents and machines, while conversation history is private, potentially large, and belongs to exactly one agent. Embedding it in the default export would conflate those two lifetimes/audiences.

Refactored `bundle_export_for_agent_impl`'s body into a shared `build_export_for_agent` helper (bundle+agent resolution, base export, native-memory splice) so the two export paths can't drift on that logic. The with-history variant additionally resolves the agent's sessions via `HistoryService::sessions_for_agent` (a typed core extracted from `list_for_agent`, from Step 4b — #2611, merged) and appends each readable transcript under `history/<provider>/<session_id>.jsonl` in the zip. Always zips (a multi-file, potentially large archive has no sensible inline-JSON shape). An unreadable transcript is warned about and skipped, never fails the whole export.

New RPC: `bundle.export_for_agent_with_history(bundle_id, agent_id)`.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2370 passed, 0 failed, 6 pre-existing ignores
- [x] `cargo check --workspace` — clean
- [x] All 42 pre-existing `bundle.rs` export/import tests still pass (confirms the `build_export_for_agent` refactor is behavior-preserving)
- [x] 3 new tests for the export-with-history path: includes sessions correctly, succeeds with zero sessions for an unlinked agent, warns-and-continues on an unreadable transcript

<!-- agentmux:agent_id=clamk -->