### PR TITLE
fix(identity): exportagents resolves provider through the bound bundle, not a drifted agent.provider

### DIFF
--- a/.changesets/1786928533-fix-identity-exportagents-resolves-provider-through-the-boun-7mql.md
+++ b/.changesets/1786928533-fix-identity-exportagents-resolves-provider-through-the-boun-7mql.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): exportagents resolves provider through the bound bundle, not a drifted agent.provider

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -672,10 +672,12 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
     // exportagents — export all agent definitions with content and skills
     let wstore_efa = state.wstore.clone();
+    let id_store_efa = state.id_store.clone();
     engine.register_handler(
         COMMAND_EXPORT_AGENTS,
         Box::new(move |_data, _ctx| {
             let wstore = wstore_efa.clone();
+            let id_store = id_store_efa.clone();
             Box::pin(async move {
                 let agents = wstore.agent_def_list()
                     .map_err(|e| format!("exportagents: list: {e}"))?;
@@ -701,12 +703,22 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         })
                         .collect::<Vec<_>>();
 
+                    // Resolve through the agent's bound bundle rather than
+                    // the possibly-drifted `agent.provider` column directly
+                    // — #2594, same "gate vs. actual launch can disagree"
+                    // risk class #2592/#2596/#2607/#2609/#2610/#2612 fixed.
+                    // `importagents` round-trips whatever this exports
+                    // straight into a NEW definition+bundle
+                    // (agent_def_provision_and_bind_bundle), so an already-
+                    // drifted export would seed the imported agent's bundle
+                    // with the WRONG provider from the start.
+                    let effective_provider = id_store.resolve_effective_provider_id(&agent);
                     agent_exports.push(AgentDefinitionExport {
                         id: agent.slug.clone(),
                         name: agent.name,
                         icon: agent.icon,
                         description: agent.description,
-                        provider: agent.provider,
+                        provider: effective_provider,
                         shell: agent.shell,
                         working_directory: agent.working_directory,
                         agent_bus_id: agent.agent_bus_id,
@@ -731,4 +743,110 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::rpc_types::RpcMessage;
+    use crate::backend::storage::Memory;
+    use crate::server::tests::test_state;
+
+    fn seed_bundle(state: &AppState, id: &str, provider: &str) {
+        let bundle = Memory {
+            id: id.to_string(),
+            name: "Bundle".to_string(),
+            description: String::new(),
+            is_blank: false,
+            is_global: false,
+            provider: provider.to_string(),
+            model: String::new(),
+            instructions: String::new(),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: 0,
+            created_at: 0,
+            updated_at: 0,
+        };
+        state.id_store.bundle_memory_upsert(&bundle).unwrap();
+    }
+
+    // Template's own `.provider` column says "codex" (drifted/stale —
+    // simulates the same drift class #2592 fixed: some definition-time
+    // write path changed this column after the bundle was already
+    // provisioned/immutable), but its bound bundle's REAL provider is
+    // "claude". A correct export must carry "claude", not "codex" —
+    // #2594: `importagents` round-trips whatever this exports straight
+    // into a new definition+bundle, so an already-drifted export would
+    // seed the imported agent's bundle with the wrong provider.
+    fn seed_drifted_agent(state: &AppState, def_id: &str, bundle_id: &str) {
+        let mut def = AgentDefinition {
+            id: def_id.to_string(),
+            slug: def_id.to_string(),
+            name: "Drifted Agent".to_string(),
+            icon: String::new(),
+            provider: "codex".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: bundle_id.to_string(),
+        };
+        state.wstore.agent_def_insert(&mut def).unwrap();
+    }
+
+    #[tokio::test]
+    async fn exportagents_resolves_provider_through_the_agents_bundle_not_the_drifted_column() {
+        let state = test_state();
+        seed_bundle(&state, "bundle-claude", "claude");
+        seed_drifted_agent(&state, "agent-drift", "bundle-claude");
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+
+        engine.handle_message(RpcMessage {
+            command: COMMAND_EXPORT_AGENTS.to_string(),
+            reqid: "req-1".to_string(),
+            data: Some(serde_json::json!({})),
+            ..Default::default()
+        });
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: ExportAgentDefinitionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+
+        let exported = result
+            .agents
+            .iter()
+            .find(|a| a.id == "agent-drift")
+            .expect("exported agent should be present");
+        assert_eq!(
+            exported.provider, "claude",
+            "export must carry the agent's REAL (bundle-resolved) provider, not the drifted `codex` column"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Delivery-plan item 7 of #2594 (harness/model decoupling & ABF portability) — the **last remaining item**: `agent_handlers/core.rs:709` (`exportagents`), "weaker case; round-trips a possibly-drifted value through `importagents` into a new definition+bundle." Same "gate vs. actual launch can disagree" risk class #2592/#2596/#2607/#2609/#2610/#2612 fixed.

`exportagents` read `agent.provider` directly for every exported definition. `importagents` (verified while investigating this fix) is internally consistent on its own — it writes the imported value onto the new definition and immediately provisions that same new definition's bundle from it, so there's no separate drift bug on the import side. But if the SOURCE export itself already carried a drifted value, importing it would seed the newly-created agent's bundle with the wrong provider from the very start — the export is the only place this needed fixing.

## Fix

`id_store.resolve_effective_provider_id(&agent)` (already used by #2592/#2607/#2612) replaces the direct `agent.provider` read.

## Test plan

- [x] Regression test seeds an agent with a drifted `.provider` (`"codex"`) against a bundle with the real provider (`"claude"`) and asserts the exported entry carries `"claude"`.
- [x] Verified it fails against the pre-fix code (temporarily reverted the fix inline, ran the test — `left: "codex", right: "claude"` — then restored it).
- [x] `cargo check -p agentmux-srv` — clean, no new warnings/errors.
- [x] `cargo test -p agentmux-srv --bin agentmux-srv server::agent_handlers::` — 31/31 pass, including the new test.
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::storage::` — 282/282 pass.
- [x] Branch was not stale — `main` had not moved since branching, no merge needed before push.

This is the **last unchecked item** on issue #2594's delivery plan — once this merges, the whole harness/model decoupling & ABF portability plan is complete.

<!-- agentmux:agent_id=agenty -->