### PR TITLE
fix(deps): bump nanoid 3.3.16 -> 3.3.18 (GHSA, high severity DoS)

### DIFF
--- a/.changesets/1786948164-fix-deps-bump-nanoid-to-patch-ghsa-dos-a90882a0.md
+++ b/.changesets/1786948164-fix-deps-bump-nanoid-to-patch-ghsa-dos-a90882a0.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+fix(deps): bump nanoid 3.3.16 -> 3.3.18 (GHSA, high severity DoS)
+
+Custom generators in nanoid < 3.3.18 can loop indefinitely when size is
+zero. Transitive-only (via postcss), no code changes needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8749,9 +8749,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Addresses the open Dependabot alert (1 high) on the default branch: [nanoid: custom generators can loop indefinitely when size is zero](https://github.com/agentmuxai/agentmux/security/dependabot/13).

`nanoid` isn't a direct dependency — it's pulled in transitively via `postcss` (whose `^3.3.16` range already permits `3.3.18`, so no `package.json` change needed). Hand-edited the single `node_modules/nanoid` lockfile entry directly, verified against the real registry `dist.integrity`/`dist.tarball`, rather than running `npm update` (which touches ~190 unrelated lines of npm-version-driven `devOptional`/`peer` metadata churn across the rest of the lockfile — same noise class already seen and reverted in a couple of other recent PRs on this repo).

No code changes — nanoid isn't referenced anywhere in this codebase directly.

## Test plan

- [x] `npm ls nanoid` confirms resolution: `postcss@8.5.25 -> nanoid@3.3.18`.
- [x] `npm audit` reports 0 vulnerabilities post-bump.
- [x] Lockfile validated as parseable JSON.
- [x] `tsc --noEmit` clean except the 2 pre-existing, unrelated errors in `armory-view.tsx`/`warden-view.tsx` (present on main before this change).

<!-- agentmux:agent_id=manoz -->