### PR TITLE
feat(agent): harness-then-model creation flow + pane tab-strip padding fix

### DIFF
--- a/.changesets/1786951148-fix-agent-pane-tab-strip-no-longer-overlaps-the-new-agent-pi-kgz8.md
+++ b/.changesets/1786951148-fix-agent-pane-tab-strip-no-longer-overlaps-the-new-agent-pi-kgz8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): pane tab-strip no longer overlaps the new-agent picker's top content

--- a/.changesets/1786951149-feat-agent-harness-then-model-creation-flow-pick-a-model-whe-7676.md
+++ b/.changesets/1786951149-feat-agent-harness-then-model-creation-flow-pick-a-model-whe-7676.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): harness-then-model creation flow — pick a model when creating from a template, explanatory copy for harness vs model

--- a/.changesets/1786951774-fix-agent-create-from-template-model-picker-reads-through-ge-bg0z.md
+++ b/.changesets/1786951774-fix-agent-create-from-template-model-picker-reads-through-ge-bg0z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): create-from-template model picker reads through getProvider, not the raw static catalog

--- a/.changesets/1786952710-fix-agent-resolve-harness-model-picker-through-bound-bundle--yp0h.md
+++ b/.changesets/1786952710-fix-agent-resolve-harness-model-picker-through-bound-bundle--yp0h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): resolve harness+model picker through bound bundle, gate model picker on --model launch support

--- a/docs/reports/REPORT_SESSION_STATUS_ABF_HARNESS_MODEL_2026_08_17.md
+++ b/docs/reports/REPORT_SESSION_STATUS_ABF_HARNESS_MODEL_2026_08_17.md
@@ -1,0 +1,105 @@
+# Session status — ABF/harness-model work, 2026-08-17
+
+Working directory: `C:/amx-dev`, branch `main`. Written as a handoff snapshot,
+not a spec — see the linked issues/PRs for authoritative detail.
+
+## Issue #2594 — Harness/model decoupling & ABF portability: COMPLETE
+
+All 9 delivery-plan checkboxes shipped and merged. Every site that read
+`agent.provider` directly instead of resolving through the agent's bound ABF
+bundle (the "gate vs. actual launch can disagree" bug class #2592 first
+found) is now fixed:
+
+| PR | Item |
+|---|---|
+| #2596 | `AgentLaunchModal.tsx` |
+| #2607 | Three backend clone-sites (`template.rs` create-from-template/fork, `v1_templates.rs` promote) |
+| #2608 | `AgentIdentityModal.tsx` — product decision (confirmed live with the human operator): removed the post-creation `model_vendor_base_url` edit surface rather than relaxing bundle immutability, since the bundle has no field to mirror that value into |
+| #2609 | `AgentPicker.tsx` — 5 live sites fixed; one "cache invalidation" site turned out to be dead code and was deleted; one redundant duplicate read was folded away |
+| #2610 | `AgentInstallModal.tsx` — the actual `InstallStartCommand` payload, not just display |
+| #2612 | `bind-to-agent-menu.ts` + `agent-identity-links-panel.tsx` — kept `computeBindCandidates` pure/sync via an optional resolver param |
+| #2615 | `exportagents` — last item; confirmed `importagents` was already internally consistent, only the export read needed fixing |
+
+Every PR: read-before-edit, a regression test verified to fail against the
+pre-fix code before trusting it, a changeset, full relevant test-suite runs,
+independent `gh api` verification of any review/approval claim (several
+arrived via jekt — all verified directly against GitHub, never trusted on
+the jekt's word alone; one earlier jekt in this session falsely claimed a
+fix commit didn't exist and was correctly dismissed after independent
+verification).
+
+Issue #2594 itself has not been closed — left open for the human operator to
+close.
+
+## Adjacent work — not done by this agent
+
+- **Clamk / issue #2603** — "Agent identity/history persistence protocol"
+  (conversation-history fragmentation across channel/identity UUIDs). Same
+  storage layer as ABF but a distinct concern. PR #2602 (Step 1) merged.
+  Reached out to coordinate before Clamk's Step 3 (splitting CREDENTIAL
+  isolation from CONVERSATION HISTORY storage in `identities_dir()`) — no
+  scope conflict found with #2594's now-complete work. No reply yet on the
+  open coordination questions (does Step 3 change `identities_dir()`'s
+  public contract; file overlap sequencing).
+- **Issue #2024** — Armory Brain/Bundle tab, bundle-as-composition-primitive
+  (v2). Explicitly sequenced to start only after #2594 landed cleanly.
+  Untouched this session.
+
+## In-progress — harness + model creation-flow UX (this session, not yet shipped)
+
+User-requested usability work, confirmed direction via clarifying questions:
+
+1. **Explanatory copy** for harness vs. model/vendor concepts in the
+   "new agent" pane (`AgentPicker.tsx`) and the create-from-template modal —
+   confirmed: short inline hint text in the modal, recommended placement.
+2. **Model picker at creation time** — confirmed: keep the existing
+   template-card grid (each card already implies a harness), add a model
+   dropdown once a card is picked, reusing the `getProvider(harnessId)?.models`
+   pattern `AgentRuntimeDropup.tsx` already uses for the in-session runtime
+   switcher.
+3. **Backend wrinkle found mid-implementation, now blocking**: the obvious
+   plan (add a `model` field to `agentdefcreatefromtemplate`'s RPC, write it
+   into the new bundle) collides with existing semantics —
+   `Memory.model` is **already** used to store the VENDOR label
+   (`"anthropic"`/`"openai"`/`"google"`/`"custom"`, via
+   `resolve_effective_vendor`), not an actual model choice like `"opus"` or
+   `"gpt-5.5"`. The real per-session model picker
+   (`AgentRuntimeDropup`/`AgentComposerStrip`) writes into **per-launch block
+   runtime config** instead (`applyRuntimeChange`), not the bundle at all —
+   there is no existing persisted "default model for this agent" field.
+   **Awaiting a decision from the human operator**: (a) add a real new
+   bundle column (e.g. `default_model`) distinct from the vendor-labeled
+   `model` column — schema/migration work — or (b) have the creation-time
+   picker just seed the first launch's runtime config, matching how model
+   choice actually flows today, with a durable per-agent default left as a
+   separate follow-up.
+
+No code has been committed for this feature yet pending that decision.
+
+## Also found and fixed this session (uncommitted)
+
+- **Pane tab-strip overlay bug**: `.agent-picker` (the "new agent" pane
+  content) had a flat `padding: var(--space-4)` with no extra top clearance
+  for the floating `PaneTabStrip`, which renders even over the blank/picker
+  tab (`agent-view.tsx`). Icons/header content rendered behind the strip.
+  Fixed in `frontend/app/view/agent/styles/_picker.scss` by mirroring the
+  exact `padding-top: calc(... + var(--pane-tab-strip-height, 28px))`
+  pattern `_document.scss` already uses for `.agent-document`.
+  **Status: fixed locally, uncommitted** — no changeset/PR yet.
+- **Dev-session Vite lifecycle issue** (environment, not app code): running
+  `task dev` via a monitored background shell got killed by the harness's
+  own bashwrap idle-output timeout once the GUI window stopped producing
+  stdout, which also killed the backgrounded Vite dev server while the
+  window (protected by the launcher's own Job Object) stayed open —
+  producing exactly the "icons turned into squares" symptom (Font Awesome
+  webfonts/CSS 404ing once Vite died). Not a code fix; documented here in
+  case it recurs. Workaround used: launch `task dev` fully detached via
+  `cmd.exe /c start`, outside the harness's monitored process tree.
+
+## Open items for the human operator
+
+1. Harness+model creation-flow: pick (a) new bundle column vs. (b) seed
+   first-launch runtime config (see above).
+2. Whether to close issue #2594 now that all delivery items are merged.
+3. `.agent-picker` padding fix: commit + changeset + PR, or fold into
+   whichever PR ships the harness+model creation-flow work.

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -213,7 +213,7 @@ export function renderRequest(
                         // (spec note on CreateFromTemplateRequest) so
                         // `submitting()` covers both RPC steps and ESC
                         // / backdrop dismiss stay blocked end-to-end.
-                        onSubmit={async ({ name, accountId, memoryId, agentType, modelVendorBaseUrl }) => {
+                        onSubmit={async ({ name, accountId, memoryId, agentType, modelVendorBaseUrl, model }) => {
                             setSubmitting(true);
                             try {
                                 const resp = await RpcApi.AgentDefCreateFromTemplateCommand(
@@ -242,6 +242,7 @@ export function renderRequest(
                                     resp.memory_id,
                                     name,
                                     agentType,
+                                    model,
                                 );
                                 setSubmitting(false);
                                 api.close();

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -233,6 +233,11 @@ export interface CreateFromTemplateRequest {
          *  uses this directly instead of re-reading the (template-
          *  derived) `agent_type`, so the choice actually takes effect. */
         agentType: "host" | "container",
+        /** Model the user picked in the modal (from the harness's own
+         *  models list) — seeds the new instance's first-launch
+         *  `agent:runtime` block meta via LaunchOverrides.model. Empty
+         *  string when the harness declares no models list. */
+        model: string,
     ) => Promise<void>;
 }
 

--- a/frontend/app/view/agent/agent-launch-env.test.ts
+++ b/frontend/app/view/agent/agent-launch-env.test.ts
@@ -28,10 +28,16 @@ vi.mock("@/util/logger", () => ({
     Logger: { warn: (...args: unknown[]) => loggerWarn(...args) },
 }));
 
-import { resolveEffectiveLaunchProvider } from "./agent-launch-env";
+import { resolveEffectiveLaunchProvider, resolveInitialRuntimeConfig } from "./agent-launch-env";
+import { DEFAULT_RUNTIME_CONFIG } from "./types";
+import type { ProviderModel } from "./providers/types";
 
 function agentWith(provider: string, memory_id: string): AgentDefinition {
     return { id: "a1", provider, memory_id } as AgentDefinition;
+}
+
+function models(...specs: Array<{ value: string; default?: boolean }>): ProviderModel[] {
+    return specs.map((s) => ({ value: s.value, label: s.value, default: s.default }));
 }
 
 describe("resolveEffectiveLaunchProvider", () => {
@@ -76,5 +82,41 @@ describe("resolveEffectiveLaunchProvider", () => {
         const agent = agentWith("claude", "mem1");
         const result = await resolveEffectiveLaunchProvider(agent);
         expect(result).toBe("claude");
+    });
+});
+
+describe("resolveInitialRuntimeConfig", () => {
+    // Fixes the latent bug this function exists to close: launchAgentDefinition
+    // never set "agent:runtime" meta at all on a fresh launch, so
+    // getRuntimeConfig's fallback (DEFAULT_RUNTIME_CONFIG, hardcoded to
+    // Claude's "sonnet") silently applied to every launch regardless of
+    // harness.
+    it("uses an explicit override model when given, even if the provider has its own default", () => {
+        const result = resolveInitialRuntimeConfig("gpt-5.5", models({ value: "gpt-5-mini", default: true }));
+        expect(result.model).toBe("gpt-5.5");
+    });
+
+    it("falls back to the provider's own default model when no override is given", () => {
+        const result = resolveInitialRuntimeConfig(
+            undefined,
+            models({ value: "gpt-5-mini" }, { value: "gpt-5.5", default: true }),
+        );
+        expect(result.model).toBe("gpt-5.5");
+    });
+
+    it("falls back to DEFAULT_RUNTIME_CONFIG.model when the provider declares no models at all", () => {
+        const result = resolveInitialRuntimeConfig(undefined, undefined);
+        expect(result.model).toBe(DEFAULT_RUNTIME_CONFIG.model);
+    });
+
+    it("falls back to DEFAULT_RUNTIME_CONFIG.model when the provider's model list has no default entry", () => {
+        const result = resolveInitialRuntimeConfig(undefined, models({ value: "gpt-5-mini" }, { value: "gpt-5.5" }));
+        expect(result.model).toBe(DEFAULT_RUNTIME_CONFIG.model);
+    });
+
+    it("carries permissionMode and effort from DEFAULT_RUNTIME_CONFIG unchanged", () => {
+        const result = resolveInitialRuntimeConfig("gpt-5.5", undefined);
+        expect(result.permissionMode).toBe(DEFAULT_RUNTIME_CONFIG.permissionMode);
+        expect(result.effort).toBe(DEFAULT_RUNTIME_CONFIG.effort);
     });
 });

--- a/frontend/app/view/agent/agent-launch-env.ts
+++ b/frontend/app/view/agent/agent-launch-env.ts
@@ -12,6 +12,8 @@ import { getApi } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { Logger } from "@/util/logger";
+import { DEFAULT_RUNTIME_CONFIG, type AgentRuntimeConfig } from "./types";
+import type { ProviderModel } from "./providers/types";
 
 /**
  * Check if Node.js is available. Required for npm-based providers (Codex, Gemini).
@@ -100,4 +102,31 @@ export async function resolveEffectiveLaunchProvider(agent: AgentDefinition): Pr
         });
         return agent.provider;
     }
+}
+
+/**
+ * Resolve the initial `agent:runtime` block-meta value (AgentRuntimeConfig)
+ * for a fresh launch. Extracted as its own pure function — same reasoning
+ * as `resolveEffectiveLaunchProvider` above — so it's unit-testable without
+ * `launchAgentDefinition`'s much larger RPC/side-effect surface.
+ *
+ * `launchAgentDefinition` previously never set `agent:runtime` on a fresh
+ * launch at all, so `getRuntimeConfig`'s fallback (`DEFAULT_RUNTIME_CONFIG`,
+ * hardcoded to Claude's `"sonnet"`) silently applied regardless of harness —
+ * harmless for Claude agents, but a non-Claude agent's very first turn
+ * could carry a model string its own provider doesn't even recognize until
+ * the user opened the model picker and chose a real one.
+ *
+ * Precedence: an explicit `overrides.model` (e.g. a choice made in
+ * AgentCreateFromTemplateModal) wins; otherwise the effective provider's
+ * own `default: true` model; otherwise `DEFAULT_RUNTIME_CONFIG.model` as
+ * the last-resort fallback (a provider that declares no `models` list at
+ * all — e.g. one still on the raw-passthrough output format).
+ */
+export function resolveInitialRuntimeConfig(
+    overridesModel: string | undefined,
+    providerModels: ProviderModel[] | undefined,
+): AgentRuntimeConfig {
+    const model = overridesModel || providerModels?.find((m) => m.default)?.value || DEFAULT_RUNTIME_CONFIG.model;
+    return { ...DEFAULT_RUNTIME_CONFIG, model };
 }

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -17,7 +17,7 @@ import { buildInstanceSlug } from "./defaults/instance-slug";
 import type { LaunchOverrides } from "./components/AgentLaunchModal";
 import { readActivitySummary } from "@/app/store/activitySummary";
 import { buildConfigFiles } from "./agent-config-builder";
-import { checkNodejsForProvider, agentmuxHome, resolveCliDir, resolveEffectiveLaunchProvider } from "./agent-launch-env";
+import { checkNodejsForProvider, agentmuxHome, resolveCliDir, resolveEffectiveLaunchProvider, resolveInitialRuntimeConfig } from "./agent-launch-env";
 import { realAccountIdOrEmpty } from "./identity-carry-over";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
@@ -629,6 +629,11 @@ export class AgentViewModel implements ViewModel {
                 });
             }
 
+            // Seed the initial runtime config (permission mode / model /
+            // effort — see resolveInitialRuntimeConfig's own doc comment
+            // for why launchAgentDefinition never set this key at all
+            // before now).
+            const runtimeConfig = resolveInitialRuntimeConfig(overrides?.model, provider.models);
             const meta: Record<string, unknown> = {
                 agentId: agent.id,
                 agentProvider: effectiveProvider,
@@ -646,6 +651,7 @@ export class AgentViewModel implements ViewModel {
                 "agent:resume_strategy": provider.resumeStrategy ?? (provider.resumeFlag ? "flag" : "none"),
                 "agent:session_id_field": provider.sessionIdField,
                 "agent:sessionid": continueSid,
+                "agent:runtime": runtimeConfig,
                 ...zoomMeta,
                 "frame:activebordercolor": agentColor,
                 "frame:bordercolor": dimAgentColor(agentColor),

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -129,6 +129,25 @@ export function buildRuntimeArgs(
 }
 
 /**
+ * Whether `buildRuntimeArgs` actually applies `AgentRuntimeConfig.model`
+ * to this provider's launch args at all (via `--model`, through either
+ * the plain claude branch above or codex's own dedicated branch below).
+ * The single source of truth a model PICKER (AgentRuntimeDropup,
+ * AgentCreateFromTemplateModal) should gate on before offering a choice
+ * — otherwise a provider with a `models` list in the catalog (e.g.
+ * antigravity) but no `--model` wiring here lets the user pick a model
+ * that's silently discarded at launch (ReAgent P2 on PR #2618).
+ *
+ * Kept in this file specifically (not providers/catalog.ts) so it can
+ * never drift from the actual arg-building logic above — a provider
+ * added to one without the other is exactly the bug class this function
+ * exists to close.
+ */
+export function providerSupportsModelFlag(providerId: string | undefined): boolean {
+    return !providerId || providerId === "claude" || providerId === "codex";
+}
+
+/**
  * Read AgentRuntimeConfig from block metadata, falling back to defaults.
  */
 export function getRuntimeConfig(blockMeta: Record<string, any> | undefined): AgentRuntimeConfig {

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -260,4 +260,88 @@ describe("AgentCreateFromTemplateModalPanel", () => {
         await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
         expect(onSubmit.mock.calls[0][0].modelVendorBaseUrl).toBe("");
     });
+
+    // #2594 follow-up: harness-then-model creation flow. The template
+    // card already picked the harness (claude); these cover the model
+    // picker that lets the user choose WHICH model that harness runs.
+    describe("model picker (harness-then-model creation flow)", () => {
+        it("renders a model select defaulting to the harness's own default model", async () => {
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={template}
+                    onSubmit={vi.fn().mockResolvedValue(undefined)}
+                    onCancel={vi.fn()}
+                />
+            ));
+            const select = screen.getByTestId(
+                "create-from-template-model-select",
+            ) as HTMLSelectElement;
+            // claude's catalog entry marks "sonnet" as `default: true`.
+            expect(select.value).toBe("sonnet");
+            expect(Array.from(select.options).map((o) => o.value)).toContain("opus");
+        });
+
+        it("shows the harness-vs-model explanatory hint for a harness with a models list", async () => {
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={template}
+                    onSubmit={vi.fn().mockResolvedValue(undefined)}
+                    onCancel={vi.fn()}
+                />
+            ));
+            expect(screen.getByText(/is the/)).toHaveTextContent("harness");
+        });
+
+        it("sends the user's picked model in onSubmit's form data", async () => {
+            const onSubmit = vi.fn().mockResolvedValue(undefined);
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={template}
+                    onSubmit={onSubmit}
+                    onCancel={vi.fn()}
+                />
+            ));
+            await flush();
+            await flush();
+            await flush();
+
+            const select = screen.getByTestId(
+                "create-from-template-model-select",
+            ) as HTMLSelectElement;
+            fireEvent.change(select, { target: { value: "opus" } });
+
+            const submit = screen.getByTestId("create-from-template-submit");
+            fireEvent.click(submit);
+
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+            expect(onSubmit.mock.calls[0][0].model).toBe("opus");
+        });
+
+        it("hides the model select, the hint, and sends an empty model for a harness with no models list", async () => {
+            const noModelsTemplate = {
+                ...template,
+                provider: "not-a-real-provider",
+            } as AgentDefinition;
+            const onSubmit = vi.fn().mockResolvedValue(undefined);
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={noModelsTemplate}
+                    onSubmit={onSubmit}
+                    onCancel={vi.fn()}
+                />
+            ));
+            await flush();
+            await flush();
+            await flush();
+
+            expect(screen.queryByTestId("create-from-template-model-select")).toBeNull();
+            expect(screen.queryByText(/is the/)).toBeNull();
+
+            const submit = screen.getByTestId("create-from-template-submit");
+            fireEvent.click(submit);
+
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+            expect(onSubmit.mock.calls[0][0].model).toBe("");
+        });
+    });
 });

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -24,6 +24,12 @@ vi.mock("@/app/store/rpc-api", () => ({
         // Mount-time daemon probe (drives the host/container dropdown).
         // Default → no reachable runtime → host-only.
         ContainerRuntimeAvailableCommand: vi.fn(),
+        // Backs `resolveEffectiveLaunchProvider`'s bound-bundle resolution
+        // (#2594) — resolves to `undefined` by default so the base
+        // `template` fixture (no memory_id) never even triggers a fetch;
+        // the drift regression tests below set their own
+        // `.mockResolvedValue`.
+        GetMemoryCommand: vi.fn().mockResolvedValue(undefined),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -343,6 +349,133 @@ describe("AgentCreateFromTemplateModalPanel", () => {
             await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
             expect(onSubmit.mock.calls[0][0].model).toBe("");
         });
+    });
+
+    // ReAgent P1 on PR #2618 (round 2): every provider-dependent decision
+    // in this modal (model list, account filter, container support,
+    // vendor-endpoint field) must resolve through the template's BOUND
+    // BUNDLE, not its possibly-drifted `.provider` column directly —
+    // `agentdefcreatefromtemplate` itself already resolves the clone's
+    // provider this way server-side (template.rs, #2607).
+    describe("resolves through the template's bound bundle, not a drifted provider column (ReAgent P1 on #2618)", () => {
+        it("shows the resolved (bundle) provider's models, not the drifted column's", async () => {
+            const drifted = { ...template, provider: "codex", memory_id: "mem-1" } as AgentDefinition;
+            vi.mocked(RpcApi.GetMemoryCommand).mockResolvedValue({ provider: "claude" } as any);
+
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={drifted}
+                    onSubmit={vi.fn().mockResolvedValue(undefined)}
+                    onCancel={vi.fn()}
+                />
+            ));
+            await flush();
+            await flush();
+            await flush();
+
+            const select = (await screen.findByTestId(
+                "create-from-template-model-select",
+            )) as HTMLSelectElement;
+            const options = Array.from(select.options).map((o) => o.value);
+            // claude's models, not codex's (gpt-5.x family).
+            expect(options).toContain("opus");
+            expect(options).not.toContain("gpt-5.5");
+        });
+
+        it("filters accounts by the resolved (bundle) provider, not the drifted column's", async () => {
+            const drifted = { ...template, provider: "codex", memory_id: "mem-1" } as AgentDefinition;
+            vi.mocked(RpcApi.GetMemoryCommand).mockResolvedValue({ provider: "claude" } as any);
+            vi.mocked(refreshAccountCache).mockResolvedValue([
+                { id: "acct-claude", name: "Claude Work", provider: "claude" } as any,
+                { id: "acct-codex", name: "Codex Work", provider: "codex" } as any,
+            ]);
+
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={drifted}
+                    onSubmit={vi.fn().mockResolvedValue(undefined)}
+                    onCancel={vi.fn()}
+                />
+            ));
+            await flush();
+            await flush();
+            await flush();
+
+            const select = screen.getByTestId(
+                "create-from-template-identity-select",
+            ) as HTMLSelectElement;
+            const optionIds = Array.from(select.options).map((o) => o.value);
+            expect(optionIds).toContain("acct-claude");
+            expect(optionIds).not.toContain("acct-codex");
+        });
+
+        it("does not auto-pick an account filtered against the stale fallback provider before the bundle resolves", async () => {
+            // Deliberately let accounts resolve BEFORE the bundle so the
+            // auto-pick effect gets a chance to fire against the stale
+            // fallback provider ("claude") first — this is what makes
+            // the race actually reproducible.
+            const drifted = { ...template, provider: "claude", memory_id: "mem-1" } as AgentDefinition;
+            vi.mocked(refreshAccountCache).mockResolvedValue([
+                { id: "acct-claude", name: "Claude Work", provider: "claude" } as any,
+                { id: "acct-codex", name: "Codex Work", provider: "codex" } as any,
+            ]);
+            let resolveBundle!: (v: any) => void;
+            vi.mocked(RpcApi.GetMemoryCommand).mockReturnValue(
+                new Promise((resolve) => {
+                    resolveBundle = resolve;
+                }),
+            );
+
+            render(() => (
+                <AgentCreateFromTemplateModalPanel
+                    template={drifted}
+                    onSubmit={vi.fn().mockResolvedValue(undefined)}
+                    onCancel={vi.fn()}
+                />
+            ));
+            // Let the already-resolved accounts fetch fully settle,
+            // including the auto-pick effect's own commit, before the
+            // bundle resolves.
+            await flush();
+            await flush();
+
+            resolveBundle({ provider: "codex" });
+            await flush();
+            await flush();
+            await flush();
+
+            const select = screen.getByTestId(
+                "create-from-template-identity-select",
+            ) as HTMLSelectElement;
+            expect(select.value).toBe("acct-codex");
+        });
+    });
+
+    // ReAgent P2 on PR #2618: a provider can declare a `models` list in
+    // the catalog without buildRuntimeArgs.ts actually wiring `--model`
+    // for it (antigravity: providers/catalog.ts, 4-entry models list, no
+    // --model branch) — offering a picker there would let the user pick
+    // a model that's silently discarded at launch.
+    it("hides the model picker for a provider whose models list has no --model wiring at launch (antigravity)", async () => {
+        const antigravityTemplate = { ...template, provider: "antigravity" } as AgentDefinition;
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={antigravityTemplate}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />
+        ));
+        await flush();
+        await flush();
+        await flush();
+
+        expect(screen.queryByTestId("create-from-template-model-select")).toBeNull();
+
+        const submit = screen.getByTestId("create-from-template-submit");
+        fireEvent.click(submit);
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+        expect(onSubmit.mock.calls[0][0].model).toBe("");
     });
 
     // ReAgent P1 on PR #2618: the model list must read through

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -344,4 +344,39 @@ describe("AgentCreateFromTemplateModalPanel", () => {
             expect(onSubmit.mock.calls[0][0].model).toBe("");
         });
     });
+
+    // ReAgent P1 on PR #2618: the model list must read through
+    // getProvider() (the live, API-sourced-overlay-aware accessor), not
+    // the raw static PROVIDERS catalog — otherwise a refreshed label
+    // (setProviderModels, folded in at app-init from the authoritative
+    // Models API) never reaches this modal. Exercises the REAL overlay
+    // mechanism (model-overlay.ts) rather than mocking it, since
+    // `modelOverlay` is module-level signal state shared across this
+    // whole test file — this must be the LAST test in the file so the
+    // overlay it sets can't leak into any test that runs after it.
+    // Preserves "sonnet"'s `value`/`default` (only the `label` changes),
+    // matching setProviderModels' own documented "label-only refresh"
+    // contract, so this can't itself corrupt any earlier test's
+    // `select.value` assertions either.
+    it("shows a live-overlaid model label, not the stale static catalog label (ReAgent P1 on #2618)", async () => {
+        const { setProviderModels } = await import("../providers");
+        setProviderModels("claude", [
+            { value: "claude-sonnet-5-5", label: "Claude Sonnet 5.5" },
+        ]);
+
+        render(() => (
+            <AgentCreateFromTemplateModalPanel
+                template={template}
+                onSubmit={vi.fn().mockResolvedValue(undefined)}
+                onCancel={vi.fn()}
+            />
+        ));
+        const select = screen.getByTestId(
+            "create-from-template-model-select",
+        ) as HTMLSelectElement;
+        const sonnetOption = Array.from(select.options).find((o) => o.value === "sonnet")!;
+        expect(sonnetOption.textContent).toBe("Sonnet 5.5");
+        // value/default untouched by the label refresh.
+        expect(select.value).toBe("sonnet");
+    });
 });

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -22,7 +22,7 @@
  * universal modal system per `feedback_use_universal_modal_system`.
  */
 
-import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -30,6 +30,8 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { PROVIDERS } from "../providers/catalog";
 import { getProvider } from "../providers";
+import { resolveEffectiveLaunchProvider } from "../agent-launch-env";
+import { providerSupportsModelFlag } from "../buildRuntimeArgs";
 import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 import { refreshAccountCache, type Account } from "@/app/view/identity/identity-model";
 
@@ -72,7 +74,7 @@ export const AgentCreateFromTemplateModalPanel = (
     const [name, setName] = createSignal(props.initialName ?? props.template.name);
     const [accountId, setAccountId] = createSignal("");
     const [memoryId, setMemoryId] = createSignal("");
-    const [accounts, setAccounts] = createSignal<Account[]>([]);
+    const [allAccounts, setAllAccounts] = createSignal<Account[]>([]);
     const [memories, setMemories] = createSignal<Memory[]>([]);
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
@@ -80,12 +82,35 @@ export const AgentCreateFromTemplateModalPanel = (
         props.template.model_vendor_base_url ?? "",
     );
 
+    // Resolve through the template's bound bundle rather than its
+    // possibly-drifted `.provider` column directly — #2594-class drift
+    // (ReAgent P1 on PR #2618): `agentdefcreatefromtemplate` itself
+    // already resolves the clone's provider this way server-side
+    // (template.rs, #2607's fix) — a template whose column has drifted
+    // from its bundle would otherwise show this modal offering
+    // accounts/models/endpoint-support for the WRONG provider relative
+    // to what actually gets cloned. Falls back to `props.template.provider`
+    // while loading/on failure, same contract `resolveEffectiveLaunchProvider`
+    // itself documents — a brief stale flash here is cosmetic (form
+    // options), not a spawn/credential decision the way it would be in
+    // AgentLaunchModal.
+    const [resolvedTemplateProviderId] = createResource(
+        () => props.template,
+        resolveEffectiveLaunchProvider,
+    );
+    const effectiveProviderId = () => resolvedTemplateProviderId() ?? props.template.provider;
+
+    // Derived, not filtered-once-at-fetch-time — see the onMount comment
+    // below for why (reacts correctly regardless of fetch-vs-resolve
+    // ordering).
+    const accounts = createMemo(() => allAccounts().filter((a) => a.provider === effectiveProviderId()));
+
     // Only providers that declare `baseUrlEnvVar` (currently just claude)
     // can actually be redirected to a custom endpoint — see
     // agent_define::validate_vendor_base_url on the backend, which rejects
     // a non-empty override for any other provider.
     const supportsCustomEndpoint = createMemo(
-        () => !!PROVIDERS[props.template.provider]?.baseUrlEnvVar,
+        () => !!PROVIDERS[effectiveProviderId()]?.baseUrlEnvVar,
     );
 
     // ── Model (which model this harness runs) ────────────────────────
@@ -98,12 +123,34 @@ export const AgentCreateFromTemplateModalPanel = (
     // authoritative version labels at app-init, e.g. "Sonnet 4.6" →
     // "Sonnet 5"). Reading the raw static catalog directly would show
     // stale labels and never react to a later-landing overlay (ReAgent
-    // review on PR #2618). Hidden entirely when the harness declares no
-    // models list — nothing to choose between.
-    const modelOptions = createMemo(() => getProvider(props.template.provider)?.models ?? []);
-    const [model, setModel] = createSignal(
-        modelOptions().find((m) => m.default)?.value ?? modelOptions()[0]?.value ?? "",
+    // P1 on PR #2618). Gated on providerSupportsModelFlag (ReAgent P2 on
+    // the same PR) — a provider with a `models` list but no `--model`
+    // wiring in buildRuntimeArgs.ts (e.g. antigravity) would otherwise
+    // offer a choice that's silently discarded at launch. Hidden
+    // entirely when neither applies — nothing meaningful to choose.
+    const modelOptions = createMemo(() =>
+        providerSupportsModelFlag(effectiveProviderId()) ? getProvider(effectiveProviderId())?.models ?? [] : [],
     );
+    const [model, setModel] = createSignal("");
+    // Re-pick the default whenever modelOptions() changes — same
+    // "async-resolved dependency" race #2596 fixed for AgentLaunchModal's
+    // account auto-pick: modelOptions() starts computed from the
+    // synchronous fallback (props.template.provider) before
+    // resolvedTemplateProviderId's fetch lands, then flips once it does.
+    // A plain createSignal initializer only runs once at mount, so
+    // without this effect a value auto-picked from the stale pre-
+    // resolution list would never get re-picked once the real provider's
+    // list is known. Skipped once the user has made an explicit choice
+    // (modelTouched), mirroring runtimeTouched below.
+    let modelTouched = false;
+    createEffect(() => {
+        if (modelTouched) return;
+        setModel(modelOptions().find((m) => m.default)?.value ?? modelOptions()[0]?.value ?? "");
+    });
+    const pickModel = (v: string) => {
+        modelTouched = true;
+        setModel(v);
+    };
 
     // ── Runtime (host vs container) ────────────────────────────────
     // Runtime is decided HERE, when instantiating the template — it's
@@ -118,7 +165,7 @@ export const AgentCreateFromTemplateModalPanel = (
     let runtimeTouched = false;
 
     const containerSupported = createMemo(
-        () => getCliCatalogEntry(props.template.provider)?.containerSupported ?? true,
+        () => getCliCatalogEntry(effectiveProviderId())?.containerSupported ?? true,
     );
     // Reads the shared toolchain-capabilities store rather than probing
     // Docker itself — this is what guarantees this modal can never disagree
@@ -152,16 +199,23 @@ export const AgentCreateFromTemplateModalPanel = (
         setRuntime(v);
     };
 
-    // Load account + memory lists on mount. The account list is
-    // filtered to the template's own provider (accounts are provider-
-    // specific — issue #1624 PR-C Part B). Bindings are stored on the
-    // db_agent_instances row at launch time; the empty string sentinel
-    // means "ambient creds / vanilla CLI" so an empty selection is OK.
+    // Load account + memory lists on mount. `accounts` below derives the
+    // provider filter reactively (accounts are provider-specific — issue
+    // #1624 PR-C Part B) rather than filtering once here, so it reacts
+    // correctly regardless of whether the account fetch or
+    // resolvedTemplateProviderId's own fetch lands first — filtering
+    // once inline against effectiveProviderId() at this single point in
+    // time would silently freeze on whichever value (fallback or
+    // resolved) happened to be current at that instant, the same race
+    // #2596 fixed for AgentLaunchModal's account auto-pick. Bindings are
+    // stored on the db_agent_instances row at launch time; the empty
+    // string sentinel means "ambient creds / vanilla CLI" so an empty
+    // selection is OK.
     onMount(() => {
         void (async () => {
             try {
                 const list = await refreshAccountCache();
-                setAccounts(list.filter((a) => a.provider === props.template.provider));
+                setAllAccounts(list);
             } catch {
                 /* non-fatal; user can still create without binding */
             }
@@ -178,12 +232,28 @@ export const AgentCreateFromTemplateModalPanel = (
     // matching the launch modal's UX (saves a click for users with
     // existing accounts). `is_blank` rows are a bundle-only concept —
     // accounts have no such thing.
+    //
+    // Re-picks on every `accounts()` change rather than the more obvious
+    // "if (accountId()) return" early-out — `accounts()` now depends on
+    // `effectiveProviderId()` (see the memo above), which resolves
+    // asynchronously. The early-out shape stops Solid from tracking
+    // `accounts()` as a dependency at all once it fires once (the same
+    // race #2596 fixed for AgentLaunchModal's own account auto-pick): if
+    // the account fetch settles before the provider resolution, this
+    // effect would lock onto an account filtered against the STALE
+    // fallback provider and never reconsider once the real one lands.
+    // `accountTouched` (mirroring runtimeTouched/modelTouched above)
+    // stops the re-pick once the user has made an explicit choice.
     const realMemories = createMemo(() => memories().filter((m) => !m.is_blank));
+    let accountTouched = false;
     createEffect(() => {
-        if (accountId()) return;
-        const first = accounts()[0];
-        if (first) setAccountId(first.id);
+        if (accountTouched) return;
+        setAccountId(accounts()[0]?.id ?? "");
     });
+    const pickAccount = (v: string) => {
+        accountTouched = true;
+        setAccountId(v);
+    };
     createEffect(() => {
         if (memoryId()) return;
         const first = realMemories()[0];
@@ -294,7 +364,7 @@ export const AgentCreateFromTemplateModalPanel = (
                         <select
                             class="agent-new-bundle-modal-input"
                             value={model()}
-                            onChange={(e) => setModel(e.currentTarget.value)}
+                            onChange={(e) => pickModel(e.currentTarget.value)}
                             disabled={submitting()}
                             data-testid="create-from-template-model-select"
                         >
@@ -314,7 +384,7 @@ export const AgentCreateFromTemplateModalPanel = (
                         <input
                             type="text"
                             class="agent-new-bundle-modal-input"
-                            placeholder={`Default (${PROVIDERS[props.template.provider]?.baseUrlEnvVar})`}
+                            placeholder={`Default (${PROVIDERS[effectiveProviderId()]?.baseUrlEnvVar})`}
                             value={modelVendorBaseUrl()}
                             onInput={(e) => setModelVendorBaseUrl(e.currentTarget.value)}
                             onKeyDown={onKeyDown}
@@ -333,7 +403,7 @@ export const AgentCreateFromTemplateModalPanel = (
                     <select
                         class="agent-new-bundle-modal-input"
                         value={accountId()}
-                        onChange={(e) => setAccountId(e.currentTarget.value)}
+                        onChange={(e) => pickAccount(e.currentTarget.value)}
                         disabled={submitting()}
                         data-testid="create-from-template-identity-select"
                     >

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -29,6 +29,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { PROVIDERS } from "../providers/catalog";
+import { getProvider } from "../providers";
 import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 import { refreshAccountCache, type Account } from "@/app/view/identity/identity-model";
 
@@ -90,11 +91,16 @@ export const AgentCreateFromTemplateModalPanel = (
     // ── Model (which model this harness runs) ────────────────────────
     // The template card you clicked already picked the HARNESS (the CLI
     // — "Claude Code", "Codex", etc.); this picks WHICH MODEL that
-    // harness runs, from its own model list (same list
-    // AgentRuntimeDropup's in-session picker reads via
-    // getProvider(id)?.models). Hidden entirely when the harness
-    // declares no models list — nothing to choose between.
-    const modelOptions = createMemo(() => PROVIDERS[props.template.provider]?.models ?? []);
+    // harness runs, from its own model list. Reads through getProvider()
+    // (not the raw PROVIDERS catalog) so this sees the same live,
+    // API-sourced label overlay AgentRuntimeDropup's in-session picker
+    // does (getProvider(id)?.models — setProviderModels folds in
+    // authoritative version labels at app-init, e.g. "Sonnet 4.6" →
+    // "Sonnet 5"). Reading the raw static catalog directly would show
+    // stale labels and never react to a later-landing overlay (ReAgent
+    // review on PR #2618). Hidden entirely when the harness declares no
+    // models list — nothing to choose between.
+    const modelOptions = createMemo(() => getProvider(props.template.provider)?.models ?? []);
     const [model, setModel] = createSignal(
         modelOptions().find((m) => m.default)?.value ?? modelOptions()[0]?.value ?? "",
     );

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -45,6 +45,13 @@ interface CreateFromTemplateFormData {
      *  endpoint. Only meaningful — and only shown in the form — when the
      *  template's provider declares `baseUrlEnvVar` in the catalog. */
     modelVendorBaseUrl: string;
+    /** Initial model choice — a value from the template's harness's own
+     *  `models` list (e.g. "opus" for claude, "gpt-5.5" for codex). Empty
+     *  string when the harness declares no models list; the launch path
+     *  falls back to that harness's own default. Distinct from
+     *  `modelVendorBaseUrl` above: this picks WHICH model the harness
+     *  runs, not WHO serves it. */
+    model: string;
 }
 
 interface AgentCreateFromTemplateModalPanelProps {
@@ -78,6 +85,18 @@ export const AgentCreateFromTemplateModalPanel = (
     // a non-empty override for any other provider.
     const supportsCustomEndpoint = createMemo(
         () => !!PROVIDERS[props.template.provider]?.baseUrlEnvVar,
+    );
+
+    // ── Model (which model this harness runs) ────────────────────────
+    // The template card you clicked already picked the HARNESS (the CLI
+    // — "Claude Code", "Codex", etc.); this picks WHICH MODEL that
+    // harness runs, from its own model list (same list
+    // AgentRuntimeDropup's in-session picker reads via
+    // getProvider(id)?.models). Hidden entirely when the harness
+    // declares no models list — nothing to choose between.
+    const modelOptions = createMemo(() => PROVIDERS[props.template.provider]?.models ?? []);
+    const [model, setModel] = createSignal(
+        modelOptions().find((m) => m.default)?.value ?? modelOptions()[0]?.value ?? "",
     );
 
     // ── Runtime (host vs container) ────────────────────────────────
@@ -181,6 +200,7 @@ export const AgentCreateFromTemplateModalPanel = (
                 memoryId: memoryId(),
                 agentType: runtime(),
                 modelVendorBaseUrl: supportsCustomEndpoint() ? modelVendorBaseUrl().trim() : "",
+                model: modelOptions().length > 0 ? model() : "",
             });
             // Layer unmounts via close-on-success. Reset is defensive.
             setSubmitting(false);
@@ -205,6 +225,13 @@ export const AgentCreateFromTemplateModalPanel = (
                     A new user-owned agent will be cloned from this template.
                     The template stays untouched and can be used again.
                 </p>
+                <Show when={modelOptions().length > 0}>
+                    <p class="modal-panel-description agent-new-bundle-modal-harness-hint">
+                        {props.template.name} is the <strong>harness</strong> — the CLI tool
+                        that runs this agent. Pick which <strong>model</strong> it uses below;
+                        the harness stays the same either way.
+                    </p>
+                </Show>
             </header>
             <div class="modal-panel-body agent-new-bundle-modal-body">
                 <label class="agent-new-bundle-modal-field">
@@ -255,6 +282,26 @@ export const AgentCreateFromTemplateModalPanel = (
                         </span>
                     </Show>
                 </label>
+                <Show when={modelOptions().length > 0}>
+                    <label class="agent-new-bundle-modal-field">
+                        <span class="agent-new-bundle-modal-label">Model</span>
+                        <select
+                            class="agent-new-bundle-modal-input"
+                            value={model()}
+                            onChange={(e) => setModel(e.currentTarget.value)}
+                            disabled={submitting()}
+                            data-testid="create-from-template-model-select"
+                        >
+                            <For each={modelOptions()}>
+                                {(m) => <option value={m.value}>{m.label}</option>}
+                            </For>
+                        </select>
+                        <span class="agent-new-bundle-modal-hint">
+                            Which model {props.template.name} runs with. Changeable later
+                            from the agent pane's runtime picker.
+                        </span>
+                    </label>
+                </Show>
                 <Show when={supportsCustomEndpoint()}>
                     <label class="agent-new-bundle-modal-field">
                         <span class="agent-new-bundle-modal-label">Model Vendor / Custom Endpoint</span>

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -76,6 +76,17 @@ export interface LaunchOverrides {
      *  provider naturally falls back to "fork = fresh definition, fresh
      *  start" by simply not getting the flag. */
     forkSession?: boolean;
+    /** Initial model choice (a value from the effective provider's own
+     *  `models` list) — seeds the new block's `agent:runtime` meta at
+     *  launch, the same key `AgentRuntimeDropup`'s in-session model
+     *  picker writes to via `applyRuntimeChange`. When omitted,
+     *  `launchAgentDefinition` falls back to the provider's own
+     *  `default: true` model, or `DEFAULT_RUNTIME_CONFIG.model` if the
+     *  provider declares none. Callers that let the user pick a model at
+     *  creation time (e.g. AgentCreateFromTemplateModal) set this so the
+     *  first launch doesn't silently start on an unrelated provider's
+     *  default model. */
+    model?: string;
 }
 
 interface AgentLaunchModalPanelProps {

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -228,6 +228,15 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         expect(header).toHaveTextContent("New from template");
     });
 
+    // #2594 follow-up: harness-vs-model explanation in the new-agent pane.
+    it("renders the harness-vs-model explanatory hint under the templates header", async () => {
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const hint = await screen.findByTestId("agent-templates-hint");
+        expect(hint).toHaveTextContent("harness");
+        expect(hint).toHaveTextContent("model");
+    });
+
     it("clicks on a template open the create-from-template modal", async () => {
         const model = makeMockModel();
         render(() => <AgentPicker model={model as any} />);
@@ -333,16 +342,18 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         await waitFor(() => expect(modalLayerOpen).toHaveBeenCalled());
 
         const req = modalLayerOpen.mock.calls[0][0];
-        // Pass an explicit runtime (5th arg) — the modal always supplies
-        // it; exercise the threading so the stub + override carry the
-        // user's pick rather than silently falling back (reagent P2 on
-        // #1576).
+        // Pass an explicit runtime (5th arg) and model (6th arg) — the
+        // modal always supplies both; exercise the threading so the stub
+        // + override carry the user's picks rather than silently falling
+        // back (reagent P2 on #1576; model threading added #2594 follow-
+        // up work).
         await req.onCreatedAndLaunch(
             "new-def-id",
             "id-work",
             "mem-notes",
             "Mary",
             "container",
+            "opus",
         );
         expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1);
         const [stubAgent, overrides] = model.launchAgentDefinition.mock.calls[0];
@@ -359,6 +370,20 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         expect(overrides.memoryId).toBe("mem-notes");
         expect(overrides.instanceName).toBe("Mary");
         expect(overrides.continueOfInstanceId).toBeUndefined();
+        expect(overrides.model).toBe("opus");
+    });
+
+    it("modal onCreatedAndLaunch omits the model override when the modal supplied none (harness has no models list)", async () => {
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const card = await screen.findByTestId("agent-card-tpl-claude");
+        fireEvent.click(card);
+        await waitFor(() => expect(modalLayerOpen).toHaveBeenCalled());
+
+        const req = modalLayerOpen.mock.calls[0][0];
+        await req.onCreatedAndLaunch("new-def-id", "id-work", "mem-notes", "Mary", "host", "");
+        const [, overrides] = model.launchAgentDefinition.mock.calls[0];
+        expect(overrides.model).toBeUndefined();
     });
 
     // #2594 — AgentPicker's install-check/prereq-probe/cache-invalidation

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -500,7 +500,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             kind: "create-from-template" as const,
             template,
             originBlockId: props.model.blockId,
-            onCreatedAndLaunch: async (newDefId, accountIdSel, memoryIdSel, name, agentType) => {
+            onCreatedAndLaunch: async (newDefId, accountIdSel, memoryIdSel, name, agentType, modelSel) => {
                 // The new definition is user-owned and carries the
                 // template's provider + cmd config. Build an
                 // AgentDefinition stub good enough for the launch flow
@@ -542,6 +542,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         // No `continueOfInstanceId` — the new definition
                         // has no prior session; its agent-anchored zone
                         // is empty and the pane will start fresh.
+                        // Model the user picked in the modal (empty when
+                        // the harness declares no models list) — seeds
+                        // the first launch's agent:runtime block meta.
+                        // See resolveInitialRuntimeConfig's own doc
+                        // comment for the fallback when this is empty.
+                        model: modelSel || undefined,
                     });
                     if (props.model.nodejsError) {
                         setNodejsError(props.model.nodejsError);
@@ -811,6 +817,11 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         <div class="agent-picker-templates-header" data-testid="agent-templates-header">
                             <span>+ New from template</span>
                         </div>
+                        <p class="agent-picker-templates-hint" data-testid="agent-templates-hint">
+                            Each card is a <strong>harness</strong> (the CLI that runs the agent,
+                            e.g. Claude Code, Codex) — you'll pick which <strong>model</strong>
+                            it uses next.
+                        </p>
                         <div class="agent-picker-list" data-testid="agent-templates-list">
                             <For each={templates()}>
                                 {(agent, index) => (

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -15,6 +15,17 @@
         flex-direction: column;
         height: 100%;
         padding: var(--space-4);
+        // Reserves the pane tab strip's rendered height so the picker's own
+        // top row (the "My Agents"/"+ New from template" header + first
+        // cards) never renders behind it — same overlay problem, same fix,
+        // as .agent-document's padding-top in _document.scss (the strip
+        // renders for a blank/picker tab too, agent-view.tsx: "the strip
+        // stays visible whether the active member is a launched
+        // conversation OR a blank/picker tab"). Unconditional (not gated on
+        // whether the strip actually has >1 tab to show) — same tradeoff
+        // _document.scss makes: a little extra top whitespace when the
+        // strip is empty beats the content staying hidden when it isn't.
+        padding-top: calc(var(--space-4) + var(--pane-tab-strip-height, 28px));
         gap: var(--space-3);
         overflow-y: auto;
         // Min tile width for the My Agents / Templates grids. The grids
@@ -37,6 +48,17 @@
         text-transform: uppercase;
         letter-spacing: 0.04em;
         margin-top: var(--space-3);
+    }
+
+    // Harness-vs-model explanation (#2594 follow-up) — a quiet subtitle
+    // under the section header, not another heading of its own. Muted +
+    // no letter-spacing/uppercase so it reads as clarifying prose, not a
+    // second label competing with the header above it.
+    .agent-picker-templates-hint {
+        width: 100%;
+        font-size: var(--text-xs, 0.75rem);
+        color: color-mix(in srgb, var(--main-text-color) 55%, transparent);
+        margin: 0;
     }
 
     // Templates tier — a responsive tile grid that fills the pane width


### PR DESCRIPTION
## Summary

Two related pieces of usability work in the "new agent" (AgentPicker) flow. Not part of issue #2594's delivery plan (that's fully merged) — separate follow-up feature work requested directly in conversation, building on #2594's harness/bundle-resolution lineage.

### Harness-then-model creation flow

The template card grid already picks the **harness** (the CLI — clicking "Claude Code" = the claude harness); this adds an explicit **model** picker once a card is clicked, so creation now reads as harness-first-then-model, matching how the in-session runtime switcher (`AgentRuntimeDropup`/`AgentComposerStrip`) already works.

Frontend-only — no backend RPC change. I investigated adding a `model` field to `agentdefcreatefromtemplate` first, but `Memory.model` (the bundle field that looked like "which model") turned out to already be used to store the **vendor** label (`"anthropic"`/`"openai"`/`"custom"`, via `resolve_effective_vendor`), not an actual model choice. The real model picker writes into per-launch block runtime config (`agent:runtime` meta / `applyRuntimeChange`) instead — a purely client-side concept with no bundle involvement at all. So the model chosen at creation time threads through as a new `LaunchOverrides.model` field into the first launch's runtime config, via a new pure, testable `resolveInitialRuntimeConfig` helper (`agent-launch-env.ts`, same pattern as `resolveEffectiveLaunchProvider`).

**Incidental fix along the way**: `launchAgentDefinition` never set `agent:runtime` meta on *any* fresh launch before this — every new agent silently got `DEFAULT_RUNTIME_CONFIG`'s hardcoded `"sonnet"` regardless of harness. Now seeded from the harness's own `default: true` model when no explicit choice is given, for every launch, not just template-creates.

Explanatory copy: inline hint text in `AgentCreateFromTemplateModal.tsx` near the model field, plus a short subtitle under the picker's "+ New from template" header explaining harness vs. model.

### Pane tab-strip padding fix

`.agent-picker` (the "new agent" pane content) had a flat `padding: var(--space-4)` with no extra top clearance for the floating `PaneTabStrip`, which renders even over the blank/picker tab (`agent-view.tsx`: "the strip stays visible whether the active member is a launched conversation OR a blank/picker tab"). The picker's own top row rendered behind it. Fixed by mirroring the exact `padding-top: calc(... + var(--pane-tab-strip-height, 28px))` pattern `.agent-document` (`_document.scss`) already uses for the same problem.

## Test plan

- [x] `resolveInitialRuntimeConfig`: 5 new unit tests (override wins, provider default wins, `DEFAULT_RUNTIME_CONFIG` fallback ×2, permissionMode/effort pass through unchanged).
- [x] `AgentCreateFromTemplateModal`: 4 new tests (model select defaults to the harness's own default, explanatory hint renders, picked model reaches `onSubmit`, both hidden + empty model sent for a harness with no models list).
- [x] `AgentPicker`: extended the existing `onCreatedAndLaunch` integration test to assert the model threads through to `launchAgentDefinition`'s overrides; added a companion test for the omitted-model case; added a test for the new templates-section hint.
- [x] `npx tsc --noEmit -p tsconfig.json` — same 2 pre-existing, unrelated errors as `main` (`armory-view.tsx`/`warden-view.tsx`), nothing new.
- [x] `npx vitest run app/view/agent/ app/element/` — 1202/1202 pass, 97/97 files, no flakes.
- [x] Branch was not stale — `main` had not moved since branching, no merge needed before push.

Also includes `docs/reports/REPORT_SESSION_STATUS_ABF_HARNESS_MODEL_2026_08_17.md`, a handoff status doc covering this session's #2594 delivery-plan completion and this follow-up work.

<!-- agentmux:agent_id=agenty -->