### PR TITLE
Manoz@Area54 chore: release v0.55.11

### DIFF
--- a/.changesets/1786852838-fix-browser-pane-faster-connection-timeout-watchdog-and-huma-5gqf.md
+++ b/.changesets/1786852838-fix-browser-pane-faster-connection-timeout-watchdog-and-huma-5gqf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): faster connection-timeout watchdog and human-readable load-error pages

--- a/.changesets/1786855635-fix-agent-launch-modal-resolves-provider-through-the-bound-b-t2me.md
+++ b/.changesets/1786855635-fix-agent-launch-modal-resolves-provider-through-the-bound-b-t2me.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): launch modal resolves provider through the bound bundle, not the driftable agent column

--- a/.changesets/1786856032-fix-browser-pane-clicking-inside-a-pane-now-dismisses-open-m-ief5.md
+++ b/.changesets/1786856032-fix-browser-pane-clicking-inside-a-pane-now-dismisses-open-m-ief5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): clicking inside a pane now dismisses open menus/popovers

--- a/.changesets/1786856221-feat-browser-pane-unified-context-menu-replaces-chromium-s-n-ysgw.md
+++ b/.changesets/1786856221-feat-browser-pane-unified-context-menu-replaces-chromium-s-n-ysgw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser-pane): unified context menu replaces Chromium's native right-click menu

--- a/.changesets/1786881678-fix-drop-stop-an-unhandled-file-drop-from-navigating-the-who-tlo4.md
+++ b/.changesets/1786881678-fix-drop-stop-an-unhandled-file-drop-from-navigating-the-who-tlo4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(drop): stop an unhandled file drop from navigating the whole window away

--- a/.changesets/1786885082-fix-storage-correct-stale-db-agents-migration-phase-comments-5b0l.md
+++ b/.changesets/1786885082-fix-storage-correct-stale-db-agents-migration-phase-comments-5b0l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(storage): correct stale db_agents migration-phase comments, pin the read-side split with a test

--- a/.changesets/1786885126-docs-add-agent-identity-history-fragmentation-report-and-can-s1rz.md
+++ b/.changesets/1786885126-docs-add-agent-identity-history-fragmentation-report-and-can-s1rz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: add agent identity/history fragmentation report and canonical persistence protocol spec

--- a/.changesets/1786886693-fix-jekt-inject-host-lan-signing-keys-on-the-normal-launch-p-5ce3.md
+++ b/.changesets/1786886693-fix-jekt-inject-host-lan-signing-keys-on-the-normal-launch-p-5ce3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(jekt): inject host/LAN signing keys on the normal launch path, not just agent.open

--- a/.changesets/1786887880-fix-identity-keep-conversation-history-global-when-credentia-9wuk.md
+++ b/.changesets/1786887880-fix-identity-keep-conversation-history-global-when-credentia-9wuk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): keep conversation history global when credential isolation is on

--- a/.changesets/1786904766-fix-history-claudehistoryadapter-now-scans-per-channel-isola-543k.md
+++ b/.changesets/1786904766-fix-history-claudehistoryadapter-now-scans-per-channel-isola-543k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(history): ClaudeHistoryAdapter now scans per-channel isolated identity dirs too

--- a/.changesets/1786905565-fix-identity-resolve-provider-through-the-bound-bundle-at-th-y6jm.md
+++ b/.changesets/1786905565-fix-identity-resolve-provider-through-the-bound-bundle-at-th-y6jm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): resolve provider through the bound bundle at the three backend clone-sites

--- a/.changesets/1786924587-fix-identity-remove-the-post-creation-model-vendor-base-url--34n9.md
+++ b/.changesets/1786924587-fix-identity-remove-the-post-creation-model-vendor-base-url--34n9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): remove the post-creation model-vendor-base-url editor from AgentIdentityModal

--- a/.changesets/1786925818-fix-agent-agentpicker-resolves-provider-through-the-bound-bu-04jt.md
+++ b/.changesets/1786925818-fix-agent-agentpicker-resolves-provider-through-the-bound-bu-04jt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): AgentPicker resolves provider through the bound bundle for install-check, prereq-probe, and add-account

--- a/.changesets/1786926699-fix-agent-agentinstallmodal-installs-the-bound-bundle-s-prov-k2ij.md
+++ b/.changesets/1786926699-fix-agent-agentinstallmodal-installs-the-bound-bundle-s-prov-k2ij.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): AgentInstallModal installs the bound bundle's provider, not a drifted agent.provider

--- a/.changesets/1786927133-feat-history-fast-agent-id-keyed-conversation-history-lookup-g22r.md
+++ b/.changesets/1786927133-feat-history-fast-agent-id-keyed-conversation-history-lookup-g22r.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(history): fast agent_id-keyed Conversation History lookup

--- a/.changesets/1786927621-fix-identity-bind-to-agent-menu-and-connect-claude-cta-resol-6e84.md
+++ b/.changesets/1786927621-fix-identity-bind-to-agent-menu-and-connect-claude-cta-resol-6e84.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): bind-to-agent menu and Connect-Claude CTA resolve provider through the bound bundle

--- a/.changesets/1786927950-feat-armory-opt-in-bundle-export-for-agent-with-history-acti-1ayu.md
+++ b/.changesets/1786927950-feat-armory-opt-in-bundle-export-for-agent-with-history-acti-1ayu.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): opt-in bundle.export_for_agent_with_history action

--- a/.changesets/1786928135-docs-add-agent-data-scope-routing-pr-checklist-m3un.md
+++ b/.changesets/1786928135-docs-add-agent-data-scope-routing-pr-checklist-m3un.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: add agent data scope-routing PR checklist

--- a/.changesets/1786928533-fix-identity-exportagents-resolves-provider-through-the-boun-7mql.md
+++ b/.changesets/1786928533-fix-identity-exportagents-resolves-provider-through-the-boun-7mql.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): exportagents resolves provider through the bound bundle, not a drifted agent.provider

--- a/.changesets/1786948164-fix-deps-bump-nanoid-to-patch-ghsa-dos-a90882a0.md
+++ b/.changesets/1786948164-fix-deps-bump-nanoid-to-patch-ghsa-dos-a90882a0.md
@@ -1,8 +1,0 @@
----
-type: patch
----
-
-fix(deps): bump nanoid 3.3.16 -> 3.3.18 (GHSA, high severity DoS)
-
-Custom generators in nanoid < 3.3.18 can loop indefinitely when size is
-zero. Transitive-only (via postcss), no code changes needed.

--- a/.changesets/1786951148-fix-agent-pane-tab-strip-no-longer-overlaps-the-new-agent-pi-kgz8.md
+++ b/.changesets/1786951148-fix-agent-pane-tab-strip-no-longer-overlaps-the-new-agent-pi-kgz8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): pane tab-strip no longer overlaps the new-agent picker's top content

--- a/.changesets/1786951149-feat-agent-harness-then-model-creation-flow-pick-a-model-whe-7676.md
+++ b/.changesets/1786951149-feat-agent-harness-then-model-creation-flow-pick-a-model-whe-7676.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): harness-then-model creation flow — pick a model when creating from a template, explanatory copy for harness vs model

--- a/.changesets/1786951774-fix-agent-create-from-template-model-picker-reads-through-ge-bg0z.md
+++ b/.changesets/1786951774-fix-agent-create-from-template-model-picker-reads-through-ge-bg0z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): create-from-template model picker reads through getProvider, not the raw static catalog

--- a/.changesets/1786952323-docs-add-muxbus-free-account-abuse-hardening-spec-agentmux-c-fwm7.md
+++ b/.changesets/1786952323-docs-add-muxbus-free-account-abuse-hardening-spec-agentmux-c-fwm7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: add muxbus free-account abuse hardening spec (agentmux-cloud PR #50)

--- a/.changesets/1786952710-fix-agent-resolve-harness-model-picker-through-bound-bundle--yp0h.md
+++ b/.changesets/1786952710-fix-agent-resolve-harness-model-picker-through-bound-bundle--yp0h.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): resolve harness+model picker through bound bundle, gate model picker on --model launch support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.10"
+version = "0.55.11"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.10"
+version = "0.55.11"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.10"
+version = "0.55.11"
 dependencies = [
  "base64",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.10"
+version = "0.55.11"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.10"
+version = "0.55.11"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.10"
+version = "0.55.11"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.10"
+version = "0.55.11"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -28,7 +28,6 @@
 - docs: add muxbus free-account abuse hardening spec (agentmux-cloud PR #50)
 - fix(agent): resolve harness+model picker through bound bundle, gate model picker on --model launch support
 
-
 ## 0.55.10 — 2026-08-16
 
 - fix(bashwrap): exempt declared-background tasks from the idle-kill timeout

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,34 @@
 # AgentMux Version History
 
+## 0.55.11 — 2026-08-17
+
+- fix(browser-pane): faster connection-timeout watchdog and human-readable load-error pages
+- fix(agent): launch modal resolves provider through the bound bundle, not the driftable agent column
+- fix(browser-pane): clicking inside a pane now dismisses open menus/popovers
+- feat(browser-pane): unified context menu replaces Chromium's native right-click menu
+- fix(drop): stop an unhandled file drop from navigating the whole window away
+- fix(storage): correct stale db_agents migration-phase comments, pin the read-side split with a test
+- docs: add agent identity/history fragmentation report and canonical persistence protocol spec
+- fix(jekt): inject host/LAN signing keys on the normal launch path, not just agent.open
+- fix(identity): keep conversation history global when credential isolation is on
+- fix(history): ClaudeHistoryAdapter now scans per-channel isolated identity dirs too
+- fix(identity): resolve provider through the bound bundle at the three backend clone-sites
+- fix(identity): remove the post-creation model-vendor-base-url editor from AgentIdentityModal
+- fix(agent): AgentPicker resolves provider through the bound bundle for install-check, prereq-probe, and add-account
+- fix(agent): AgentInstallModal installs the bound bundle's provider, not a drifted agent.provider
+- feat(history): fast agent_id-keyed Conversation History lookup
+- fix(identity): bind-to-agent menu and Connect-Claude CTA resolve provider through the bound bundle
+- feat(armory): opt-in bundle.export_for_agent_with_history action
+- docs: add agent data scope-routing PR checklist
+- fix(identity): exportagents resolves provider through the bound bundle, not a drifted agent.provider
+- fix(deps): bump nanoid 3.3.16 -> 3.3.18 (GHSA, high severity DoS)
+- fix(agent): pane tab-strip no longer overlaps the new-agent picker's top content
+- feat(agent): harness-then-model creation flow — pick a model when creating from a template, explanatory copy for harness vs model
+- fix(agent): create-from-template model picker reads through getProvider, not the raw static catalog
+- docs: add muxbus free-account abuse hardening spec (agentmux-cloud PR #50)
+- fix(agent): resolve harness+model picker through bound bundle, gate model picker on --model launch support
+
+
 ## 0.55.10 — 2026-08-16
 
 - fix(bashwrap): exempt declared-background tasks from the idle-kill timeout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.10",
+  "version": "0.55.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.10",
+      "version": "0.55.11",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.10",
+  "version": "0.55.11",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes 25 pending changesets, forced to a **patch** release
(`task release -- --as patch`) rather than the computed minor — two
`feat`-type changesets ship under this patch:
- `feat(browser-pane)`: unified context menu replaces Chromium's native right-click menu
- `feat(history)`: fast agent_id-keyed Conversation History lookup

All five version-consistency-invariant locations agree at `0.55.11`:
`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`,
`package-lock.json`.

<!-- agentmux:agent_id=manoz -->