### PR TITLE
fix(agent-pane): hold brain-spinner overlay until launch-flow auth check resolves

### DIFF
--- a/.changesets/1786985201-fix-agent-pane-hold-the-brain-spinner-overlay-until-launch-f-ax7f.md
+++ b/.changesets/1786985201-fix-agent-pane-hold-the-brain-spinner-overlay-until-launch-f-ax7f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): hold the brain-spinner overlay until launch-flow's auth check resolves, not just history paint

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -797,6 +797,12 @@ const AgentPresentationView = ({
     // an invisible-but-present pointer-events:none div forever.
     const [historyLoaded, setHistoryLoaded] = createSignal(false);
     const [showLoadingOverlay, setShowLoadingOverlay] = createSignal(true);
+    // Separate from `historyLoaded` below: this only means "the transcript
+    // has actually painted" — the effect after `status` is defined (further
+    // down) decides whether that's enough to start the fade, or whether the
+    // auth-panel pop-in flicker fix also needs to hold the overlay a bit
+    // longer.
+    const [historyPainted, setHistoryPainted] = createSignal(false);
     let cancelSettleWait: (() => void) | undefined;
     let loadingOverlayFadeTimeout: ReturnType<typeof setTimeout> | undefined;
     // Two extra rAFs between "settle detected" and actually starting the
@@ -844,8 +850,7 @@ const AgentPresentationView = ({
                 // queued as of the first one's frame has been painted.
                 settlePaintRaf1 = requestAnimationFrame(() => {
                     settlePaintRaf2 = requestAnimationFrame(() => {
-                        setHistoryLoaded(true);
-                        loadingOverlayFadeTimeout = setTimeout(() => setShowLoadingOverlay(false), 220);
+                        setHistoryPainted(true);
                     });
                 });
             });
@@ -1094,6 +1099,41 @@ const AgentPresentationView = ({
         onControllerStatus: (rts) => {
             reconcileTurnActive(!!rts.turn_active);
         },
+    });
+
+    // Brain-spinner loading overlay, part 2 (part 1 is the historyPainted/
+    // scheduleOnSettle chain above `status`'s own definition — this has to
+    // live down here since it reads `status.launchPhase()`). A fresh
+    // agent's mount-time launch-flow.ts runs Phase 1 (resolving-cli) then
+    // Phase 2 (checking-auth) before AgentAuthPanel's authUrl/authNotice can
+    // ever become non-null; when they do, that panel pops into normal flex
+    // flow between the scroll region and the composer strip/AgentFooter,
+    // pushing both down with no warning — often well after historyPainted
+    // already flipped true for a brand-new, empty-history agent (live-
+    // reported flicker, 2026-08-17: "bottom paints first, then gets pushed
+    // down"). Hold the fade until the launch flow has moved past the two
+    // phases that can still cause that pop-in, so it happens hidden behind
+    // the mask instead — same principle as the historyPainted rAF-pair fix
+    // above, just gating on a different async source. Bounded by a 3s
+    // safety timeout so a launch path that never calls setLaunchPhase (a
+    // future code path, a test double) can't leave the pane stuck behind
+    // the spinner forever — worse than the flicker this exists to fix.
+    const [authPhaseTimedOut, setAuthPhaseTimedOut] = createSignal(false);
+    let authPhaseSafetyTimeout: ReturnType<typeof setTimeout> | undefined;
+    onMount(() => {
+        authPhaseSafetyTimeout = setTimeout(() => setAuthPhaseTimedOut(true), 3000);
+    });
+    onCleanup(() => clearTimeout(authPhaseSafetyTimeout));
+    const authPhaseSettled = createMemo(() => {
+        if (authPhaseTimedOut()) return true;
+        const phase = status.launchPhase();
+        return phase !== null && phase.kind !== "resolving-cli" && phase.kind !== "checking-auth";
+    });
+    createEffect(() => {
+        if (historyPainted() && authPhaseSettled() && !historyLoaded()) {
+            setHistoryLoaded(true);
+            loadingOverlayFadeTimeout = setTimeout(() => setShowLoadingOverlay(false), 220);
+        }
     });
 
     // status.isLoading() is `flowRunning() || !agentReady()` — it never


### PR DESCRIPTION
## Summary

Live-reported flicker: opening a new agent pane, the bottom (composer
strip/footer) painted first, then got visibly pushed down.

Root cause (traced via an Explore pass over `agent-view.tsx` +
`launch-flow.ts`, ranked and confirmed against the code): `AgentAuthPanel`
renders as a normal flex-flow sibling between `.agent-document-scroll-
region` and the composer strip. It's empty at first paint (`authUrl`/
`authNotice` start `null`) and only pops a real bordered card in once
`launch-flow.ts`'s Phase 2 auth check resolves — an async RPC round-trip
that, for a brand-new agent with empty history, routinely finishes *after*
the brain-spinner loading overlay has already faded (the existing
`historyLoaded` signal fires almost immediately when there's no history to
replay), so the pop-in happens unmasked.

Fix: split the existing `historyLoaded` signal into `historyPainted`
(unchanged timing — the existing `scheduleOnSettle` + double-rAF chain)
and a new `authPhaseSettled` memo derived from `status.launchPhase()`,
gated past the two phases (`resolving-cli`, `checking-auth`) that can
still precede an auth-panel pop-in. The overlay's fade now only starts
once both are true, so the pop-in happens hidden behind the mask —
same principle as the existing 2026-08-11 tab-switch double-rAF fix,
applied to the launch-flow side of the same overlay instead of the
history-replay side. A 3s safety timeout bounds the added wait so a
launch path that never reports a phase can't leave the pane stuck behind
the spinner forever (worse than the flicker this fixes).

Diff: `frontend/app/view/agent/agent-view.tsx` only — ~45 lines.

## Test plan

- [x] Traced the full mount → auth-check → composer render sequence by
      reading `agent-view.tsx`, `AgentDocumentView.tsx`'s `AgentAuthPanel`,
      `launch-flow.ts`, and `launch-phase.ts` directly (not guessing).
- [x] `npx tsc --noEmit` — zero new errors (2 pre-existing, unrelated
      errors elsewhere in the repo).
- [x] Full `frontend/app/view/agent` suite: 94 files / 1185 tests passing,
      no regressions.
- [ ] Not yet manually verified in a running instance (visual/timing
      behavior, no existing test scaffold for this file to extend safely —
      `agent-view.tsx` has no dedicated test file at all, it's an
      RPC/store-heavy orchestration component). Flagging this explicitly
      rather than claiming visual confirmation I don't have.

<!-- agentmux:agent_id=agenty -->