### PR TITLE
fix(layout): shift-drag group resize — correct border direction, raise min pane size to 128px

### DIFF
--- a/.changesets/1786983766-fix-layout-shift-drag-group-resize-no-longer-moves-borders-o-rx2n.md
+++ b/.changesets/1786983766-fix-layout-shift-drag-group-resize-no-longer-moves-borders-o-rx2n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): shift-drag group resize no longer moves borders opposite the drag direction

--- a/.changesets/1786985909-fix-layout-raise-minimum-pane-size-from-40px-to-128px-m1i3.md
+++ b/.changesets/1786985909-fix-layout-raise-minimum-pane-size-from-40px-to-128px-m1i3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): raise minimum pane size from 40px to 128px

--- a/docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md
+++ b/docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md
@@ -208,6 +208,40 @@ Degenerate cases:
   runtime in this sandbox); `task dev` started so the requester can verify
   directly.
 
+## 6.1 Follow-on bug found via live use: premature stop before the floor
+
+User report, same session, after raising `MinNodeSizePx` to 128: "if I
+shift+drag a pane, it stops resizing before the 128px, why is that?"
+
+Root cause: `computeGroupResizeSizes` computed
+`clampedDesired = Math.max(drivenDesiredSize, minNodeSize)` and derived
+`totalDelta` from that **clamped** value, before the block split. That was
+correct under the pre-4.x single-node model, where driven's own final size
+*was* `clampedDesired` directly. Under the two-block model, driven's real
+final size is only its **proportional share** of `afterBlock`'s total
+change — generally larger than `clampedDesired` whenever `afterBlock` has
+other members. Pre-clamping the raw desired value to the floor freezes
+`totalDelta` the instant the *unshared* cursor-implied position crosses
+128, which happens long before the block's true combined headroom is
+exhausted — so the pane being watched stalls above 128 and further
+dragging does nothing.
+
+Fix: compute `totalDelta` from the **unclamped** `drivenDesiredSize`
+always. Floor enforcement is already handled correctly, per member, inside
+`shrinkBlockBy` — the upfront clamp was redundant for the main two-block
+path and actively wrong. The clamp is still needed (and correct) for the
+degenerate `beforeBlock.length === 0` fallback, where driven genuinely has
+no block to share with and its final size really is the directly-floored
+value — that branch keeps the `Math.max` clamp, now scoped to only that
+case.
+
+Added a regression test (`layoutResize.test.ts`) with a driven pane sharing
+`afterBlock` with one other sibling: dragging to a raw desired size far
+below the floor must still land driven exactly at 128 (using the block's
+real combined headroom), not stall wherever it was when the raw,
+unshared position first crossed 128 — and dragging further past that still
+holds at the correct floor rather than moving at all.
+
 ## 7. Out of scope
 
 - Scope A vs. Scope B (cross-branch pixel-alignment resize) — unchanged

--- a/docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md
+++ b/docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md
@@ -1,0 +1,216 @@
+# SPEC: Shift+drag group resize — fix borders that move opposite the drag direction
+
+**Date:** 2026-08-17
+**Status:** implemented (this branch)
+**Author:** Clamk (agent)
+**Tracking discussion:** user report, this session — "if I shift+drag any pane
+to the right, all the pane borders should move to the right... currently,
+sometimes if I shift+drag a pane border in one direction, some of the panes
+along that direction move in the opposite direction — is that a design flaw
+or intentional?"
+
+Builds directly on `SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md` (PR #2401,
+merged `6dba4bc51`) — read that first for the feature's original scope
+decisions (Scope A: resize confined to the dragged handle's own parent,
+Shift as the modifier). Nothing here revisits those; this only fixes the
+distribution math within Scope A.
+
+---
+
+## 1. Verdict: design flaw, not intentional
+
+Confirmed by reading `computeGroupResizeSizes`
+(`frontend/layout/lib/layoutResize.ts`) and its spec: the reversed-direction
+border movement is a real, unconsidered gap, not a deliberate tradeoff.
+
+- The original spec's §5.2 algorithm distributes the complementary delta
+  across **every other sibling under the parent, weighted only by current
+  size** — with no regard for whether a sibling sits before or after the
+  driven pane in the parent's child order.
+- §3's prior-art survey does flag the tmux/i3/sway "T-junction" ambiguity,
+  but only to justify confining the feature to one parent's children
+  (Scope A vs. Scope B) — it never revisits per-border directionality
+  *within* Scope A.
+- The 8 shipped unit tests (`frontend/layout/tests/layoutResize.test.ts`)
+  only assert total-size conservation and min-size floor clamping. None of
+  them construct a case where the driven pane has siblings on *both* sides
+  of it — the exact precondition needed to observe the bug — so the
+  behavior below was never exercised or asserted on.
+
+---
+
+## 2. Root cause, with a worked example
+
+Row of 4 panes, all under one parent: `A(100) B(100) C(100) D(100)`
+(sum 400). User Shift-drags the `B|C` handle to the right by an amount that
+shrinks `C` (the driven pane, i.e. `afterNode`) by 40.
+
+Current algorithm: `others = [A, B, D]` (every sibling except the driven
+one, regardless of position), each absorbing a share of the 40 proportional
+to its own size — 100/300 each ⇒ +13.33 apiece:
+
+| Pane | Before | After |
+|------|--------|-------|
+| A | 100 | 113.33 |
+| B | 100 | 113.33 |
+| C (driven) | 100 | 60 |
+| D | 100 | 113.33 |
+
+Border positions (cumulative sum from the left):
+
+| Border | Before | After | Δ | Direction |
+|--------|--------|-------|---|-----------|
+| A\|B | 100 | 113.33 | +13.33 | right — matches drag |
+| B\|C (the dragged handle) | 200 | 226.67 | +26.67 | right — matches drag |
+| C\|D | 300 | 286.67 | **−13.33** | **left — opposite the drag** |
+
+`D` sits on the far side of the driven pane `C`. Because `D` is entitled to
+the same size-proportional share of `C`'s shrinkage as `A` and `B` are, `D`
+grows too — and since `D` is *after* `C`, growing `D` pulls the shared
+`C|D` border **toward** `C`, i.e. left, even though the user is dragging
+right. This happens on any handle that isn't the outermost one in the
+group — i.e. whenever the driven pane has siblings on both sides of it.
+The more siblings past the driven pane, the more of the give-up they
+absorb, and the more visible the reversal is.
+
+---
+
+## 3. Why "exclude the far side" isn't the right fix
+
+The obvious quick fix — only redistribute to siblings positioned before the
+driven pane, leave everyone past it untouched — does eliminate the reversed
+border, but at a real cost: it silently narrows the feature from "every
+sibling in the row moves together" (the original ask and spec's stated
+goal, §1 of the original spec) down to "only the near side moves," with no
+indication to the user why panes past their cursor stopped participating.
+Rejected for that reason — see `docs/retro`-style reasoning below rather
+than shipping the narrower behavior silently.
+
+## 4. Fix: two-block proportional scaling, split at the handle
+
+Reframe the redistribution as **two independently-scaling blocks** meeting
+exactly at the dragged handle, instead of "one driven node vs. an
+undifferentiated pool of others":
+
+- **`beforeBlock`** — every sibling positioned *before* the driven pane in
+  the parent's child order (i.e. before the handle).
+- **`afterBlock`** — the driven pane itself plus every sibling *after* it
+  (i.e. at-or-after the handle).
+
+The same aggregate transfer amount `Δ` the existing code already computes
+(`clampedDesired - driven.size`) is applied to the **blocks' totals**, not
+to the driven node individually:
+
+- `beforeBlock`'s total changes by `-Δ` (shrinks when the driven pane
+  grows, grows when the driven pane shrinks) — exactly mirroring the plain
+  2-node baseline's `beforeNode`/`afterNode` relationship, just scaled up
+  from one node to a block of them.
+- `afterBlock`'s total changes by `+Δ`.
+- Within each block, the change is distributed **proportionally to each
+  member's own current size** — i.e. each block scales uniformly as a
+  unit. The block that's shrinking uses the existing iterative
+  floor-clamp-and-redistribute logic (a member clamped to `minNodeSize`
+  drops out of that block's pool and its shortfall re-spreads across the
+  rest of the same block); the growing block is unconstrained, as today.
+- If the shrinking block's combined floor headroom is less than `Δ`, the
+  growing block's actual change is capped to whatever was actually
+  redistributable — same conservation-safety principle as today, just
+  scoped to a block instead of "all others."
+
+### 4.1 Why this fixes the bug
+
+For any block of siblings that all scale by the same proportional factor
+(uniform scaling — the definition of how each block redistributes above),
+every border *internal* to that block moves in the same direction as the
+block's own boundary that's tied to the drag. Sketch: if a block's total
+changes by `Δ` and each member `i` changes by `Δ · size_i / blockTotal`,
+then the position of any internal border (a partial cumulative sum within
+the block) changes by `Δ · (blockTotal − offset) / blockTotal ≥ 0` when
+`Δ ≥ 0` — i.e. it never has the opposite sign from the block's own
+boundary shift, regardless of how many members are in the block or how
+they're sized. Applying this to both `beforeBlock` and `afterBlock`
+independently means **every border in the whole group moves in the same
+direction as the drag, or doesn't move at all — never backward.**
+
+Re-running the §2 example under this model: `beforeBlock = [A, B]` grows by
+the full 40 (not shared with `D`) ⇒ `A=120, B=120`; `afterBlock = [C, D]`
+shrinks by 40, split proportionally between `C` and `D` (100:100) ⇒
+`C=80, D=80`.
+
+| Border | Before | After | Δ | Direction |
+|--------|--------|-------|---|-----------|
+| A\|B | 100 | 120 | +20 | right |
+| B\|C (handle) | 200 | 240 | +40 | right — tracks the cursor exactly |
+| C\|D | 300 | 320 | **+20** | **right — now matches the drag** |
+
+### 4.2 Trade-off: the driven pane's own size is no longer pixel-exact
+
+Under the old model, the driven pane's size always equaled the raw
+pixel-computed desired value exactly (it alone absorbed the delta). Under
+this fix, the driven pane shares `afterBlock`'s change with whatever
+siblings sit past it, so its own size generally lands somewhere other than
+the raw pixel value (here, `C=80` rather than the naively-implied `60`).
+
+This is judged the correct trade to make: the invariant that actually
+matters for a drag interaction is that **the border under the pointer
+tracks the pointer exactly** (verified above — `B|C` moves by the full 40,
+matching the cursor 1:1, in every case tested including the floor-clamp
+ones). The driven pane's own individual width was never something the spec
+called out as needing 1:1 pixel tracking in the group case — only the
+handle itself needs that — so giving it up to gain full-row participation
+with correct directionality is a net improvement, not a regression against
+anything the original spec promised.
+
+### 4.3 Minimize-locked siblings
+
+Unaffected by this change — they're already filtered out of
+`groupSiblingStartSizes` before reaching `computeGroupResizeSizes`
+(`layoutResize.ts`'s `onResizeMove`, per the original spec's §5.3). A
+locked sibling simply isn't a member of either block.
+
+---
+
+## 5. Implementation
+
+Confined entirely to `computeGroupResizeSizes` in
+`frontend/layout/lib/layoutResize.ts` — same exported signature
+(`siblings`, `drivenNodeId`, `drivenDesiredSize`, `minNodeSize`), so
+`onResizeMove`'s call site is unchanged. `drivenNodeId` is now used only to
+locate the split point between the two blocks (`siblings.findIndex(...)`);
+it no longer identifies a single node that's treated specially in the
+distribution math.
+
+Degenerate cases:
+- `beforeBlock` empty (driven pane has no siblings before it) — cannot
+  happen via `onResizeMove` in production (the driven pane is always
+  `afterNode`, which by construction always has a `beforeNode` ahead of
+  it), but the pure function falls back to leaving everything but the
+  driven pane untouched, matching the original function's "no other
+  siblings" fallback.
+- `afterBlock` of size 1 (driven pane is the last sibling) — degenerates
+  to exactly the original 2-node transfer (`beforeBlock` absorbs the full
+  `Δ`, the sole `afterBlock` member gets the full `Δ` too) — this is the
+  existing "two siblings" baseline case and is unchanged.
+
+## 6. Testing plan
+
+- Rewrote/added unit tests in `frontend/layout/tests/layoutResize.test.ts`
+  for the two-block model, including cases with siblings on *both* sides
+  of the driven pane, asserting **border positions** (cumulative sums), not
+  just individual sizes — this is what actually encodes the regression
+  test for the reported bug (a magnitude-only assertion can't tell a
+  correct-direction move from a reversed one).
+- Retained floor-clamp and conservation-safety-cap coverage, rescoped to
+  operate on a block instead of "all others."
+- Live verification (drag a 4+ pane row with Shift held, confirm no border
+  moves opposite the cursor) — flagged as a follow-up in this environment
+  for the same reason as the original PR (no interactive display/CEF
+  runtime in this sandbox); `task dev` started so the requester can verify
+  directly.
+
+## 7. Out of scope
+
+- Scope A vs. Scope B (cross-branch pixel-alignment resize) — unchanged
+  from the original spec; not revisited here.
+- Visual affordance for which panes participate — still an open item from
+  the original spec (§7), untouched by this fix.

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -39,70 +39,23 @@ export const DefaultGapSizePx = 3;
 const MinNodeSizePx = 40;
 
 /**
- * Computes new sizes for every sibling in `siblings` when the one pane whose
- * edge is actually under the pointer (`drivenNodeId`) is resized to
- * `drivenDesiredSize`. The rest of `siblings` absorb the complementary delta
- * proportional to each one's *current* size (a pane holding more of the row
- * gives up more, one holding less gives up less) — not an equal split, and
- * not "snap everyone to the same value" (that's a different, selection-driven
- * model that doesn't fit a live drag; see SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §3).
- *
- * Each sibling is floored at `minNodeSize`. If the combined floor headroom
- * across the other siblings is less than the drag calls for, `drivenNodeId`'s
- * own growth is capped to whatever was actually redistributable — this is
- * the same conservation-safety principle the plain 2-node resize already
- * applies to its one neighbor, generalized to N-1 neighbors instead of 1.
- * Shrinking `drivenNodeId` (giving size back to its siblings) has no such
- * cap: there's no max-size concept in this layout model, so growth is always
- * unconstrained. Pure function — no DOM/model dependency — so the
- * distribution math is directly unit-testable.
- *
- * SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §5.2-§5.3.
+ * Shrinks `block` by `amount` in total, distributed proportionally to each
+ * member's own current size (bigger members give up more), floored at
+ * `minNodeSize`. A member clamped to its floor drops out of the pool and
+ * its shortfall re-spreads across whichever members are still above the
+ * floor — terminates within `block.length` rounds (each round either fully
+ * satisfies `remaining` or permanently removes at least one member).
+ * Mutates `result` in place; returns the amount actually shrunk (may be
+ * less than `amount` if the block's combined floor headroom is smaller).
  */
-export function computeGroupResizeSizes(
-    siblings: ResizeNodeOperation[],
-    drivenNodeId: string,
-    drivenDesiredSize: number,
-    minNodeSize: number
-): Map<string, number> {
-    const result = new Map<string, number>(siblings.map((s) => [s.nodeId, s.size]));
-    const driven = siblings.find((s) => s.nodeId === drivenNodeId);
-    const others = siblings.filter((s) => s.nodeId !== drivenNodeId);
-    if (!driven) return result;
-
-    const clampedDesired = Math.max(drivenDesiredSize, minNodeSize);
-    const totalDelta = clampedDesired - driven.size; // + = driven grows (others must shrink); - = driven shrinks (others grow)
-
-    if (others.length === 0 || totalDelta === 0) {
-        result.set(drivenNodeId, clampedDesired);
-        return result;
-    }
-
-    if (totalDelta < 0) {
-        // Driven shrinks; the space it gives up is unconstrained growth for
-        // the others (no max-size floor to violate), so one proportional
-        // pass is sufficient.
-        const othersStartSum = others.reduce((sum, s) => sum + s.size, 0);
-        const growTotal = -totalDelta;
-        if (othersStartSum > 0) {
-            for (const s of others) {
-                result.set(s.nodeId, s.size + growTotal * (s.size / othersStartSum));
-            }
-        }
-        result.set(drivenNodeId, clampedDesired);
-        return result;
-    }
-
-    // Driven grows; the others must give up `totalDelta` combined, each
-    // floored at `minNodeSize`. Iterative proportional shrink: a sibling
-    // clamped to its floor drops out of the pool and its shortfall is
-    // re-spread across whichever siblings are still above the floor. Each
-    // round either fully satisfies the remaining delta (nobody clamps, the
-    // while-loop exits on the next check) or permanently removes at least
-    // one sibling from the pool — so this always terminates within
-    // `others.length` rounds.
-    let pool = others.map((s) => ({ id: s.nodeId, size: s.size }));
-    let remaining = totalDelta;
+function shrinkBlockBy(
+    block: ResizeNodeOperation[],
+    amount: number,
+    minNodeSize: number,
+    result: Map<string, number>
+): number {
+    let pool = block.map((s) => ({ id: s.nodeId, size: s.size }));
+    let remaining = amount;
     while (remaining > 1e-6 && pool.length > 0) {
         const poolSum = pool.reduce((sum, p) => sum + result.get(p.id)!, 0);
         if (poolSum <= 0) break;
@@ -124,8 +77,107 @@ export function computeGroupResizeSizes(
         remaining -= takenThisRound;
         pool = nextPool;
     }
-    const actualDelta = totalDelta - Math.max(remaining, 0);
-    result.set(drivenNodeId, driven.size + actualDelta);
+    return amount - Math.max(remaining, 0);
+}
+
+/**
+ * Grows `block` by `amount` in total, distributed proportionally to each
+ * member's own *starting* size (using `block`'s own sizes, not any prior
+ * mutation of `result` in this call — matches how `shrinkBlockBy` computes
+ * its pool). No floor/cap: there's no max-size concept in this layout
+ * model. Mutates `result` in place.
+ */
+function growBlockBy(block: ResizeNodeOperation[], amount: number, result: Map<string, number>): void {
+    if (amount <= 0 || block.length === 0) return;
+    const blockSum = block.reduce((sum, s) => sum + s.size, 0);
+    if (blockSum <= 0) {
+        result.set(block[0].nodeId, block[0].size + amount);
+        return;
+    }
+    for (const s of block) {
+        result.set(s.nodeId, s.size + amount * (s.size / blockSum));
+    }
+}
+
+/**
+ * Computes new sizes for every sibling in `siblings` (in their parent's
+ * child order) when the pane whose edge is actually under the pointer
+ * (`drivenNodeId`) is dragged toward `drivenDesiredSize`.
+ *
+ * Modeled as two blocks meeting exactly at the dragged handle —
+ * `beforeBlock` (every sibling ahead of `drivenNodeId`) and `afterBlock`
+ * (`drivenNodeId` itself plus everyone after it) — rather than "one driven
+ * node vs. an undifferentiated pool of others". The same aggregate transfer
+ * amount `Δ` the raw pixel delta implies (`drivenDesiredSize - driven.size`)
+ * is applied to the *blocks'* totals: `beforeBlock` changes by `-Δ`,
+ * `afterBlock` by `+Δ`, exactly mirroring the plain 2-node baseline's
+ * `beforeNode`/`afterNode` relationship, generalized from one node per side
+ * to a block of them. Within each block, the change is distributed
+ * proportionally to each member's own current size (uniform scaling) — not
+ * an equal split, and not "snap everyone to the same value" (see
+ * SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §3).
+ *
+ * This guarantees the handle border (the boundary between the two blocks)
+ * always tracks the pointer exactly, and — critically — that every OTHER
+ * border in the group moves in the same direction as the drag, never
+ * backward: for any block that scales uniformly, every border internal to
+ * it shifts the same direction as the block's own boundary tied to the
+ * drag. The prior "one driven node vs. every other sibling regardless of
+ * position" model didn't have this property — a sibling positioned past
+ * the driven node could get a growth share that pulled its shared border
+ * *toward* the driven node, i.e. opposite the drag. See
+ * SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md for the full
+ * worked example and the geometric argument.
+ *
+ * The trade-off: the driven pane's own size is no longer pixel-exact when
+ * `afterBlock` has more than one member — it shares the block's change
+ * with whatever sits past it. Only the handle border itself is guaranteed
+ * to track the cursor 1:1; that's the invariant that actually matters for
+ * a drag interaction.
+ *
+ * Each block is floored at `minNodeSize` when shrinking (unconstrained
+ * when growing — no max-size concept exists). If the shrinking block's
+ * combined floor headroom is less than `Δ` calls for, the growing block's
+ * actual change is capped to whatever was actually redistributable — same
+ * conservation-safety principle the plain 2-node resize already applies,
+ * scoped to a block instead of a single neighbor. Pure function — no
+ * DOM/model dependency — so the distribution math is directly
+ * unit-testable.
+ *
+ * SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §5.2-§5.3;
+ * SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md §4.
+ */
+export function computeGroupResizeSizes(
+    siblings: ResizeNodeOperation[],
+    drivenNodeId: string,
+    drivenDesiredSize: number,
+    minNodeSize: number
+): Map<string, number> {
+    const result = new Map<string, number>(siblings.map((s) => [s.nodeId, s.size]));
+    const drivenIndex = siblings.findIndex((s) => s.nodeId === drivenNodeId);
+    if (drivenIndex === -1) return result;
+    const driven = siblings[drivenIndex];
+
+    const clampedDesired = Math.max(drivenDesiredSize, minNodeSize);
+    const totalDelta = clampedDesired - driven.size; // + = afterBlock grows / beforeBlock shrinks; - = afterBlock shrinks / beforeBlock grows
+
+    const beforeBlock = siblings.slice(0, drivenIndex);
+    const afterBlock = siblings.slice(drivenIndex); // includes driven itself
+
+    if (beforeBlock.length === 0 || totalDelta === 0) {
+        result.set(drivenNodeId, clampedDesired);
+        return result;
+    }
+
+    if (totalDelta < 0) {
+        // afterBlock (incl. driven) shrinks in total by -totalDelta; beforeBlock absorbs it as unconstrained growth.
+        const actualDelta = shrinkBlockBy(afterBlock, -totalDelta, minNodeSize, result);
+        growBlockBy(beforeBlock, actualDelta, result);
+    } else {
+        // beforeBlock shrinks in total by totalDelta, floored; afterBlock (incl. driven) grows by whatever was actually redistributable.
+        const actualDelta = shrinkBlockBy(beforeBlock, totalDelta, minNodeSize, result);
+        growBlockBy(afterBlock, actualDelta, result);
+    }
     return result;
 }
 

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -161,14 +161,28 @@ export function computeGroupResizeSizes(
     if (drivenIndex === -1) return result;
     const driven = siblings[drivenIndex];
 
-    const clampedDesired = Math.max(drivenDesiredSize, minNodeSize);
-    const totalDelta = clampedDesired - driven.size; // + = afterBlock grows / beforeBlock shrinks; - = afterBlock shrinks / beforeBlock grows
-
     const beforeBlock = siblings.slice(0, drivenIndex);
     const afterBlock = siblings.slice(drivenIndex); // includes driven itself
 
-    if (beforeBlock.length === 0 || totalDelta === 0) {
-        result.set(drivenNodeId, clampedDesired);
+    if (beforeBlock.length === 0) {
+        // No block to redistribute with — driven alone is floored directly (degenerate
+        // fallback; cannot happen via onResizeMove in production, see the doc comment above).
+        result.set(drivenNodeId, Math.max(drivenDesiredSize, minNodeSize));
+        return result;
+    }
+
+    // Deliberately UNCLAMPED: floor enforcement happens per-member inside shrinkBlockBy,
+    // scoped to whichever block actually shrinks. Pre-clamping drivenDesiredSize to
+    // minNodeSize here (as the prior single-node model correctly did, since driven's
+    // final size WAS this value directly) would freeze totalDelta the instant the raw
+    // cursor position implies driven should go below the floor — even though driven's
+    // REAL final size, once shared proportionally across afterBlock, generally lands
+    // well above the floor when afterBlock has other members. That stops the drag from
+    // ever reaching the block's true (larger) headroom: the pane you're watching stalls
+    // above minNodeSize and further dragging does nothing. See
+    // SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md §5 for the worked example.
+    const totalDelta = drivenDesiredSize - driven.size; // + = afterBlock grows / beforeBlock shrinks; - = afterBlock shrinks / beforeBlock grows
+    if (totalDelta === 0) {
         return result;
     }
 

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -57,7 +57,19 @@ function shrinkBlockBy(
     minNodeSize: number,
     result: Map<string, number>
 ): number {
-    let pool = block.map((s) => ({ id: s.nodeId, size: s.size }));
+    // A member already at/under the floor has zero shrink headroom to give up.
+    // Exclude it from the pool up front rather than discovering that inside the
+    // loop: `cur - minNodeSize` for such a member is <= 0, which would otherwise
+    // ENLARGE it up to minNodeSize (the opposite of "shrinking" this block) and
+    // feed a non-positive amount into `takenThisRound`, breaking conservation
+    // (the block could net *grow* instead of shrink, with the complementary
+    // block never told to compensate). Already-undersized panes are a real,
+    // reachable state here — split, minimize-restore, and window-shrink reflow
+    // don't enforce minNodeSize, only this interactive drag path does (see
+    // SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md). Excluded
+    // members are simply left at their current (possibly already-undersized)
+    // size, never touched.
+    let pool = block.filter((s) => s.size > minNodeSize).map((s) => ({ id: s.nodeId, size: s.size }));
     let remaining = amount;
     while (remaining > 1e-6 && pool.length > 0) {
         const poolSum = pool.reduce((sum, p) => sum + result.get(p.id)!, 0);

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -36,7 +36,10 @@ export interface ResizeContext {
 }
 
 export const DefaultGapSizePx = 3;
-const MinNodeSizePx = 40;
+// 128px minimum in both directions — this same constant floors both Row (width)
+// and Column (height) drags, since minNodeSize is derived generically from
+// whichever parent's pixelToSizeRatio is active (see onResizeMove below).
+const MinNodeSizePx = 128;
 
 /**
  * Shrinks `block` by `amount` in total, distributed proportionally to each

--- a/frontend/layout/tests/layoutResize.test.ts
+++ b/frontend/layout/tests/layoutResize.test.ts
@@ -13,6 +13,11 @@ function sum(values: number[]): number {
     return values.reduce((a, b) => a + b, 0);
 }
 
+/** Cumulative border position after `ids[0..index]`, in `ids`' own left-to-right order. */
+function borderAfter(result: Map<string, number>, ids: string[], index: number): number {
+    return sum(sizesOf(result, ids.slice(0, index + 1)));
+}
+
 test("computeGroupResizeSizes - two siblings degenerates to a plain transfer (matches the baseline 2-node math)", () => {
     const siblings: ResizeNodeOperation[] = [
         { nodeId: "a", size: 50 },
@@ -24,48 +29,106 @@ test("computeGroupResizeSizes - two siblings degenerates to a plain transfer (ma
     assert.equal(sum(sizesOf(result, ["a", "b"])), 100, "total size must be conserved");
 });
 
-test("computeGroupResizeSizes - growing the driven pane shrinks every other sibling proportional to its own size", () => {
-    // a=10, b=20, c=70 (sum 100). Driven pane d grows from 0 (not present —
-    // use a 4th sibling) to keep this simple: shrink c (the big one) via a's growth.
+test("computeGroupResizeSizes - driven shrinks: no border moves opposite the drag direction (regression for the reversed-border bug)", () => {
+    // A(100) B(100) C(100) D(100), dragging the B|C handle so C (driven)
+    // shrinks by 40. Under the old "driven vs. undifferentiated others"
+    // model, D (past the driven pane) got a growth share too, which pulled
+    // the C|D border LEFT — opposite the drag. The two-block model must
+    // keep every border moving right (or unmoved), never left.
+    const ids = ["a", "b", "c", "d"];
+    const siblings: ResizeNodeOperation[] = [
+        { nodeId: "a", size: 100 },
+        { nodeId: "b", size: 100 },
+        { nodeId: "c", size: 100 },
+        { nodeId: "d", size: 100 },
+    ];
+    const result = computeGroupResizeSizes(siblings, "c", 60, 10);
+
+    // beforeBlock [a, b] absorbs the full 40 (proportional 100:100 -> +20 each).
+    assert.approximately(result.get("a")!, 120, 1e-6);
+    assert.approximately(result.get("b")!, 120, 1e-6);
+    // afterBlock [c, d] gives up 40 total, proportional 100:100 -> -20 each.
+    assert.approximately(result.get("c")!, 80, 1e-6);
+    assert.approximately(result.get("d")!, 80, 1e-6);
+    assert.approximately(sum(sizesOf(result, ids)), 400, 1e-6, "total size must be conserved");
+
+    const oldBorders = [100, 200, 300]; // a|b, b|c, c|d before the drag
+    const newBorders = [0, 1, 2].map((i) => borderAfter(result, ids, i));
+    assert.approximately(newBorders[0], 120, 1e-6, "a|b must move right, matching the drag");
+    assert.approximately(newBorders[1], 240, 1e-6, "b|c (the dragged handle) must track the cursor exactly");
+    assert.approximately(newBorders[2], 320, 1e-6, "c|d must move right too, not opposite the drag");
+    for (let i = 0; i < oldBorders.length; i++) {
+        assert.isAtLeast(newBorders[i], oldBorders[i] - 1e-6, `border ${i} must never move opposite the drag direction`);
+    }
+});
+
+test("computeGroupResizeSizes - driven grows: mirror case, no border moves opposite the drag direction", () => {
+    const ids = ["a", "b", "c", "d"];
+    const siblings: ResizeNodeOperation[] = [
+        { nodeId: "a", size: 100 },
+        { nodeId: "b", size: 100 },
+        { nodeId: "c", size: 100 },
+        { nodeId: "d", size: 100 },
+    ];
+    const result = computeGroupResizeSizes(siblings, "c", 140, 10);
+
+    assert.approximately(result.get("a")!, 80, 1e-6);
+    assert.approximately(result.get("b")!, 80, 1e-6);
+    assert.approximately(result.get("c")!, 120, 1e-6);
+    assert.approximately(result.get("d")!, 120, 1e-6);
+    assert.approximately(sum(sizesOf(result, ids)), 400, 1e-6, "total size must be conserved");
+
+    const oldBorders = [100, 200, 300];
+    const newBorders = [0, 1, 2].map((i) => borderAfter(result, ids, i));
+    assert.approximately(newBorders[1], 160, 1e-6, "b|c (the dragged handle) must track the cursor exactly");
+    for (let i = 0; i < oldBorders.length; i++) {
+        assert.isAtMost(newBorders[i], oldBorders[i] + 1e-6, `border ${i} must never move opposite the drag direction`);
+    }
+});
+
+test("computeGroupResizeSizes - beforeBlock absorbs proportional to its own sizes when afterBlock shrinks", () => {
     const siblings: ResizeNodeOperation[] = [
         { nodeId: "a", size: 10 },
         { nodeId: "b", size: 20 },
-        { nodeId: "c", size: 70 },
+        { nodeId: "driven", size: 70 },
     ];
-    // a grows by 10 (10 -> 20); b and c must give up 10 combined, proportional
-    // to their own sizes (20:70, i.e. b gives up 10*20/90=2.222, c gives up 10*70/90=7.778).
-    const result = computeGroupResizeSizes(siblings, "a", 20, 5);
-    assert.equal(result.get("a"), 20);
-    assert.approximately(result.get("b")!, 20 - (10 * 20) / 90, 1e-6);
-    assert.approximately(result.get("c")!, 70 - (10 * 70) / 90, 1e-6);
-    assert.approximately(sum(sizesOf(result, ["a", "b", "c"])), 100, 1e-6, "total size must be conserved");
+    // driven shrinks from 70 to 30 (afterBlock = [driven] alone, so it absorbs the full shrink);
+    // beforeBlock [a, b] splits the 40 it gains proportional to their own sizes (10:20).
+    const result = computeGroupResizeSizes(siblings, "driven", 30, 5);
+    assert.equal(result.get("driven"), 30);
+    assert.approximately(result.get("a")!, 10 + (40 * 10) / 30, 1e-6);
+    assert.approximately(result.get("b")!, 20 + (40 * 20) / 30, 1e-6);
+    assert.approximately(sum(sizesOf(result, ["a", "b", "driven"])), 100, 1e-6, "total size must be conserved");
 });
 
-test("computeGroupResizeSizes - shrinking the driven pane grows every other sibling proportionally", () => {
+test("computeGroupResizeSizes - afterBlock absorbs growth proportionally, so driven's own size no longer matches its raw desired value (documented trade-off)", () => {
     const siblings: ResizeNodeOperation[] = [
-        { nodeId: "a", size: 50 },
-        { nodeId: "b", size: 20 },
-        { nodeId: "c", size: 30 },
+        { nodeId: "x", size: 30 },
+        { nodeId: "driven", size: 20 },
+        { nodeId: "a", size: 20 },
+        { nodeId: "b", size: 30 },
     ];
-    // a shrinks by 20 (50 -> 30); b and c split the 20 proportional to their
-    // own sizes (20:30).
-    const result = computeGroupResizeSizes(siblings, "a", 30, 5);
-    assert.equal(result.get("a"), 30);
-    assert.approximately(result.get("b")!, 20 + (20 * 20) / 50, 1e-6);
-    assert.approximately(result.get("c")!, 30 + (20 * 30) / 50, 1e-6);
-    assert.approximately(sum(sizesOf(result, ["a", "b", "c"])), 100, 1e-6, "total size must be conserved");
+    // beforeBlock = [x] shrinks by the full 10 (driven's raw desired growth) to feed
+    // afterBlock = [driven, a, b], which grows by that same 10 split proportional to
+    // their own sizes (20:20:30) — driven only gets its own share, not the full 10.
+    const result = computeGroupResizeSizes(siblings, "driven", 30, 5);
+    assert.approximately(result.get("x")!, 20, 1e-6, "beforeBlock absorbs the full pixel-implied delta — the handle tracks the cursor exactly");
+    assert.approximately(result.get("driven")!, 20 + (10 * 20) / 70, 1e-6);
+    assert.notEqual(result.get("driven"), 30, "driven's own size intentionally no longer matches its raw desired value once afterBlock has other members");
+    assert.approximately(result.get("a")!, 20 + (10 * 20) / 70, 1e-6);
+    assert.approximately(result.get("b")!, 30 + (10 * 30) / 70, 1e-6);
+    assert.approximately(sum(sizesOf(result, ["x", "driven", "a", "b"])), 100, 1e-6, "total size must be conserved");
 });
 
-test("computeGroupResizeSizes - a sibling clamped to the floor drops out, and the shortfall re-spreads across the rest", () => {
-    // a is tiny (already near the floor); b and c hold the rest. Driving a
-    // large growth on d should push a to its floor and take the remainder
-    // from b/c only, not evenly split with a.
+test("computeGroupResizeSizes - a beforeBlock member clamped to the floor drops out, and the shortfall re-spreads across the rest", () => {
+    // beforeBlock = [a (near floor), b, c] must shrink to feed driven's growth.
+    // a clamps almost immediately; the remainder comes from b/c only.
     const minNodeSize = 10;
     const siblings: ResizeNodeOperation[] = [
-        { nodeId: "driven", size: 10 },
         { nodeId: "a", size: 12 }, // barely above the floor — should clamp almost immediately
         { nodeId: "b", size: 39 },
         { nodeId: "c", size: 39 },
+        { nodeId: "driven", size: 10 },
     ];
     const result = computeGroupResizeSizes(siblings, "driven", 50, minNodeSize);
     assert.equal(result.get("driven"), 50, "driven should get its full requested growth — plenty of headroom exists in b/c");
@@ -73,26 +136,26 @@ test("computeGroupResizeSizes - a sibling clamped to the floor drops out, and th
     assert.isAtLeast(result.get("b")!, minNodeSize - 1e-6);
     assert.isAtLeast(result.get("c")!, minNodeSize - 1e-6);
     assert.approximately(
-        sum(sizesOf(result, ["driven", "a", "b", "c"])),
+        sum(sizesOf(result, ["a", "b", "c", "driven"])),
         100,
         1e-6,
         "total size must be conserved even when a sibling clamps"
     );
 });
 
-test("computeGroupResizeSizes - driven growth is capped when every other sibling is already at the floor (conservation safety)", () => {
+test("computeGroupResizeSizes - driven growth is capped when beforeBlock is already entirely at the floor (conservation safety)", () => {
     const minNodeSize = 10;
     const siblings: ResizeNodeOperation[] = [
-        { nodeId: "driven", size: 20 },
         { nodeId: "a", size: 10 }, // already at the floor
         { nodeId: "b", size: 10 }, // already at the floor
+        { nodeId: "driven", size: 20 },
     ];
-    // Ask for a huge growth (driven -> 200) that vastly exceeds what a/b can give up (0 combined).
+    // Ask for a huge growth (driven -> 200) that vastly exceeds what beforeBlock can give up (0 combined).
     const result = computeGroupResizeSizes(siblings, "driven", 200, minNodeSize);
-    assert.equal(result.get("driven"), 20, "no headroom exists anywhere, so driven cannot actually grow");
+    assert.equal(result.get("driven"), 20, "no headroom exists in beforeBlock, so driven cannot actually grow");
     assert.equal(result.get("a"), minNodeSize);
     assert.equal(result.get("b"), minNodeSize);
-    assert.approximately(sum(sizesOf(result, ["driven", "a", "b"])), 40, 1e-6, "total size must be conserved, not exceeded");
+    assert.approximately(sum(sizesOf(result, ["a", "b", "driven"])), 40, 1e-6, "total size must be conserved, not exceeded");
 });
 
 test("computeGroupResizeSizes - driven node not found in siblings is a no-op", () => {
@@ -117,8 +180,12 @@ test("computeGroupResizeSizes - zero delta is a no-op", () => {
     assert.equal(result.get("c"), 34);
 });
 
-test("computeGroupResizeSizes - driven with no other siblings just applies the clamped desired size", () => {
-    const siblings: ResizeNodeOperation[] = [{ nodeId: "solo", size: 100 }];
+test("computeGroupResizeSizes - driven with no siblings before it (degenerate: cannot happen via onResizeMove, driven is always afterNode) leaves everyone else untouched", () => {
+    const siblings: ResizeNodeOperation[] = [
+        { nodeId: "solo", size: 100 },
+        { nodeId: "untouched", size: 50 },
+    ];
     const result = computeGroupResizeSizes(siblings, "solo", 5, 10);
     assert.equal(result.get("solo"), 10, "clamped to the floor since desired (5) is below minNodeSize (10)");
+    assert.equal(result.get("untouched"), 50, "no beforeBlock exists to redistribute with, so afterBlock's other members are untouched");
 });

--- a/frontend/layout/tests/layoutResize.test.ts
+++ b/frontend/layout/tests/layoutResize.test.ts
@@ -62,6 +62,41 @@ test("computeGroupResizeSizes - driven shrinks: no border moves opposite the dra
     }
 });
 
+test("computeGroupResizeSizes - driven reaches the true floor even when the raw cursor position implies it should go far below minNodeSize (regression: totalDelta must not be pre-clamped on driven's own raw desired size)", () => {
+    // afterBlock = [driven, far], both starting at 200 with a floor of 128 (headroom 72 each,
+    // 144 combined). beforeBlock = [x] has effectively unlimited headroom (only grows here).
+    // Dragging far enough that the RAW cursor-implied desired size for driven alone (50) is
+    // already below the floor must still let driven and far share the block's full 144 of
+    // real headroom — landing driven exactly at 128, not stalled wherever it happened to be
+    // when the raw desired first crossed the floor (the bug: pre-clamping drivenDesiredSize
+    // to minNodeSize before computing totalDelta freezes the aggregate delta the instant the
+    // UNSHARED raw position crosses the floor, even though driven's REAL size — shared
+    // proportionally with `far` — hasn't gotten there yet).
+    const minNodeSize = 128;
+    const siblings: ResizeNodeOperation[] = [
+        { nodeId: "x", size: 1000 },
+        { nodeId: "driven", size: 200 },
+        { nodeId: "far", size: 200 },
+    ];
+    const result = computeGroupResizeSizes(siblings, "driven", 50, minNodeSize);
+    assert.approximately(result.get("driven")!, 128, 1e-6, "driven must reach the actual floor, not stall above it");
+    assert.approximately(result.get("far")!, 128, 1e-6, "far shares the same block and floor headroom as driven");
+    assert.approximately(result.get("x")!, 1144, 1e-6, "beforeBlock absorbs the full 144 of real headroom the block could give up");
+    assert.approximately(
+        sum(sizesOf(result, ["x", "driven", "far"])),
+        1400,
+        1e-6,
+        "total size must be conserved"
+    );
+
+    // Dragging even further past the floor (raw desired well below 50) must not change the
+    // outcome — the block is already fully floored, this just re-confirms the cap holds.
+    const resultFurther = computeGroupResizeSizes(siblings, "driven", -1000, minNodeSize);
+    assert.approximately(resultFurther.get("driven")!, 128, 1e-6);
+    assert.approximately(resultFurther.get("far")!, 128, 1e-6);
+    assert.approximately(resultFurther.get("x")!, 1144, 1e-6);
+});
+
 test("computeGroupResizeSizes - driven grows: mirror case, no border moves opposite the drag direction", () => {
     const ids = ["a", "b", "c", "d"];
     const siblings: ResizeNodeOperation[] = [

--- a/frontend/layout/tests/layoutResize.test.ts
+++ b/frontend/layout/tests/layoutResize.test.ts
@@ -18,6 +18,43 @@ function borderAfter(result: Map<string, number>, ids: string[], index: number):
     return sum(sizesOf(result, ids.slice(0, index + 1)));
 }
 
+test("computeGroupResizeSizes - a block member already below minNodeSize is left untouched, never enlarged, when its block shrinks (regression: Codex review on PR #2624)", () => {
+    // Split/minimize-restore/window-shrink reflow don't enforce minNodeSize — only
+    // this interactive drag path does — so a pane can genuinely already be smaller
+    // than the floor when a Shift-drag starts. Shrinking a block containing one
+    // must not "fix" it by enlarging it up to the floor (that's growth, the
+    // opposite of what this helper does, and it broke total-size conservation).
+    // tiny and other share beforeBlock; driven grows, so beforeBlock is the one
+    // asked to shrink (this is where tiny's stale undersized state matters).
+    const minNodeSize = 128;
+    const siblings: ResizeNodeOperation[] = [
+        { nodeId: "tiny", size: 20 }, // already below the floor before the drag starts
+        { nodeId: "other", size: 200 },
+        { nodeId: "driven", size: 200 },
+    ];
+    // Modest growth request (driven -> 250, beforeBlock must give up 50) — other alone
+    // has plenty of headroom (72) to cover it without ever touching tiny.
+    const modest = computeGroupResizeSizes(siblings, "driven", 250, minNodeSize);
+    assert.equal(modest.get("tiny"), 20, "already-undersized sibling must be left exactly as-is, not enlarged");
+    assert.approximately(modest.get("other")!, 150, 1e-6);
+    assert.approximately(modest.get("driven")!, 250, 1e-6, "driven gets its full requested growth — plenty of real headroom exists in other");
+    assert.approximately(sum(sizesOf(modest, ["tiny", "other", "driven"])), 420, 1e-6, "total size must be conserved");
+
+    // Larger growth request that exceeds other's real headroom (72, down to its own
+    // floor) — must cap at that real headroom, not "find" extra room by enlarging tiny,
+    // and must never let the block's total size grow while it's being asked to shrink.
+    const large = computeGroupResizeSizes(siblings, "driven", 300, minNodeSize);
+    assert.equal(large.get("tiny"), 20, "still untouched even when the request would otherwise exceed available headroom");
+    assert.approximately(large.get("other")!, 128, 1e-6, "other capped at its own real floor headroom");
+    assert.approximately(large.get("driven")!, 272, 1e-6, "driven only grows by the real 72 of headroom that existed, not the full 100 requested");
+    assert.approximately(
+        sum(sizesOf(large, ["tiny", "other", "driven"])),
+        420,
+        1e-6,
+        "total size must be conserved — the block must never net-grow while being asked to shrink"
+    );
+});
+
 test("computeGroupResizeSizes - two siblings degenerates to a plain transfer (matches the baseline 2-node math)", () => {
     const siblings: ResizeNodeOperation[] = [
         { nodeId: "a", size: 50 },


### PR DESCRIPTION
## Summary

Three related fixes to Shift+drag group pane resize (PR #2401), found and
fixed live in this session per a user report ("if I shift+drag a pane
border in one direction, some panes along that direction move in the
opposite direction — is that a design flaw or intentional?"):

- **Border-direction bug (design flaw, not intentional).** `computeGroupResizeSizes`
  previously redistributed the resize delta across every sibling in the
  parent regardless of position. A sibling positioned *past* the driven
  pane could get a growth share that pulled its own shared border *toward*
  the driven pane — i.e. opposite the drag — whenever the driven pane had
  siblings on both sides of it. Rewrote the algorithm as two blocks meeting
  exactly at the dragged handle (`beforeBlock`/`afterBlock`), each scaling
  proportionally as a unit. This guarantees the handle border always
  tracks the cursor exactly, and — the actual fix — that every other
  border in the group moves the same direction as the drag, never
  backward. Trade-off: the driven pane's own size is no longer pixel-exact
  once `afterBlock` has more than one member (documented; the invariant
  that matters is the handle border, not the driven node's individual
  width).
- **Minimum pane size raised from 40px to 128px** (`MinNodeSizePx` in
  `layoutResize.ts`) — scoped to the interactive drag path only (plain and
  Shift-group resize, both row and column share the one constant). Several
  other paths that can also produce a pane's on-screen size — split,
  the resize reducer's own flex-weight range check, moveNode,
  minimize-restore, and window-shrink reflow — do not enforce any pixel
  floor today and were deliberately left alone (confirmed via a full-repo
  scan); scope decision made explicitly with the requester rather than
  silently expanding this PR.
- **Follow-on stall bug**, found via live use immediately after raising the
  floor to 128px ("it stops resizing before the 128px, why is that?"):
  `computeGroupResizeSizes` pre-clamped the raw cursor-implied desired size
  to `minNodeSize` before computing the aggregate transfer delta — correct
  under the old single-node model (driven's final size *was* that clamped
  value), but wrong under the new two-block model, where driven only gets
  a *proportional share* of `afterBlock`'s total change. Pre-clamping
  froze the aggregate delta the instant the raw, unshared cursor position
  crossed the floor, well before the block's true combined headroom was
  exhausted — so the pane being dragged stalled above 128px and further
  dragging did nothing. Fixed by deriving the delta from the unclamped
  desired size always; floor enforcement already happens correctly
  per-member inside the block-shrink helper.

Full write-up, worked numeric examples, and the geometric argument for why
the two-block model is direction-safe:
`docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md`.

## Test plan

- [x] `npx vitest run frontend/layout frontend/app/element` — 169/169 pass
      (12 files), including 3 new/rewritten regression tests: one asserting
      **border positions** (not just sizes) never move opposite the drag
      direction, one exercising the documented driven-size-vs-desired-value
      trade-off, and one specifically for the pre-clamp stall bug (driven
      reaches the true floor even when the raw cursor position implies it
      should go far below it, and stays there on further dragging).
- [x] `npx tsc --noEmit` — clean (2 pre-existing, unrelated errors in
      `armory-view.tsx`/`warden-view.tsx`, untouched by this change).
- [x] Live verification in a real `task dev` window this session: confirmed
      the border-direction fix, then live-caught and fixed the stall bug
      via direct interactive dragging — not just a code read.

<!-- agentmux:agent_id=clamk -->