### PR TITLE
fix(agent): HOST/SANDBOX runtime tag reads as a small tag, not full-size text

### DIFF
--- a/.changesets/1786993300-fix-agent-host-sandbox-runtime-tag-reads-as-a-small-tag-not--0zn4.md
+++ b/.changesets/1786993300-fix-agent-host-sandbox-runtime-tag-reads-as-a-small-tag-not--0zn4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): HOST/SANDBOX runtime tag reads as a small tag, not full-size text

--- a/frontend/app/view/agent/components/RuntimeBadge.scss
+++ b/frontend/app/view/agent/components/RuntimeBadge.scss
@@ -24,7 +24,14 @@
     // selector. No border/icon; yellow HOST / plain-white SANDBOX per explicit
     // design spec (overrides &--container/&--host below via the compound
     // selectors, which win on specificity regardless of source order).
+    // Explicit font-size/padding — unlike &--sm/&--md above, this had none of
+    // its own, so it silently inherited the composer strip's ambient text
+    // size (~10-11px) instead of reading as a small tag. One step down from
+    // &--sm's 10px, matching this file's existing sm(10px)/md(11px) scale.
     &--tag {
+        font-size: 9px;
+        padding: 1px 4px;
+        line-height: 1.4;
         font-weight: 600;
         letter-spacing: 0.02em;
         border: none;

--- a/frontend/app/view/agent/components/RuntimeBadge.tsx
+++ b/frontend/app/view/agent/components/RuntimeBadge.tsx
@@ -7,7 +7,7 @@ import "./RuntimeBadge.scss";
 interface RuntimeBadgeProps {
     runtime: "host" | "container" | string;
     /** sm = card rows (10px); md = pane rows (11px); tag = minimal
-     *  icon-less text label (10px, HOST/SANDBOX wording) for the agent
+     *  icon-less text label (9px, HOST/SANDBOX wording) for the agent
      *  composer strip, next to the model selector — see
      *  docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md §3.2.
      *  Default: sm. */


### PR DESCRIPTION
## Summary

Follow-up to the earlier MyAgentsList/composer-strip HOST/SANDBOX consistency
fix — the `size="tag"` variant of `RuntimeBadge` never had its own
`font-size`/`padding`, unlike `--sm`/`--md`. It silently inherited whatever
text size surrounded it (composer strip / My Agents row), so it rendered as
normal-size text instead of the small, compact tag it's meant to be.

Gives `.runtime-badge--tag` an explicit `font-size: 9px; padding: 1px 4px;`
— one step below `--sm`'s existing 10px, following this file's own
sm(10px)/md(11px) scale downward for the more minimal tag variant.

## Test plan

- [x] `stylelint` on the touched file — 0 new violations (11 pre-existing,
      unrelated hex-color violations elsewhere in the same file).
- [x] Full `frontend/app/view/agent` suite: 94 files / 1199 tests passing.
- [ ] Not yet visually confirmed in a running instance.

<!-- agentmux:agent_id=agenty -->