### PR TITLE
Manoz@Area54 fix(agent): eliminate Agent Picker loading flicker with a combined reveal gate

### DIFF
--- a/.changesets/1786998258-fix-agent-eliminate-agent-picker-loading-flicker-with-a-comb-1kiy.md
+++ b/.changesets/1786998258-fix-agent-eliminate-agent-picker-loading-flicker-with-a-comb-1kiy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): eliminate Agent Picker loading flicker with a combined reveal gate

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -186,7 +186,7 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     //    additional pills, deduped against the stack by blockId, so
     //    cross-pane fork-switching keeps working.
     const layoutModel = getLayoutModelForStaticTab();
-    const agentDefinitions = useAgentDefinitions();
+    const [agentDefinitions] = useAgentDefinitions();
     const [openDefinitions] = useOpenDefinitionMap();
     const forks = useForkSet({
         definitions: agentDefinitions,

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -30,39 +30,54 @@
  * and docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md (current).
  */
 
-import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { BrainSpinner } from "@/app/element/BrainSpinner";
+import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
+import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
+import { ContextMenuModel } from "@/app/store/contextmenu";
+import { atoms, refocusNode } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { ContextMenuModel } from "@/app/store/contextmenu";
 import { waveEventSubscribe } from "@/app/store/wps";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { useModalLayer, type LaunchFormStateWire } from "@/element/modal-layer";
 import { getPlatform } from "@/util/platformutil";
-import { refocusNode } from "@/app/store/global";
-import { getOpenDefinitionMap } from "@/app/store/agent-pane-state-store";
-import { subscribeToPaneLifecycle } from "@/app/store/agent-pane-registration";
-import type { AgentViewModel } from "../agent-model";
-import { getProvider } from "../providers";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { resolveEffectiveLaunchProvider } from "../agent-launch-env";
+import type { AgentViewModel } from "../agent-model";
 import { realAccountIdOrEmpty } from "../identity-carry-over";
-import { refreshAccountCache } from "@/app/view/identity/identity-model";
-import { AgentCard } from "./AgentCard";
+import { getProvider } from "../providers";
 import { AgentActionBar } from "./AgentActionBar";
+import { AgentCard } from "./AgentCard";
+import type { LaunchOverrides } from "./AgentLaunchModal";
 import { AgentPickerFilterBar } from "./AgentPickerFilterBar";
 import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
-import type { LaunchOverrides } from "./AgentLaunchModal";
 import { MyAgentsList } from "./MyAgentsList";
 
 // ── useAgentDefinitions hook ───────────────────────────────────────────────────────
 
 /**
- * Reactive accessor for the current agent-definition list. Subscribes to
- * `agents:changed` and refetches when that event fires.
+ * Reactive accessor for the current agent-definition list, plus whether the
+ * FIRST fetch is still in flight. Subscribes to `agents:changed` and
+ * refetches when that event fires.
+ *
+ * Returns a tuple `[agents, loading]` (matching `useOpenDefinitionMap`'s own
+ * convention below) rather than just the list accessor — `agents` starts as
+ * `[]` and stays indistinguishable from "genuinely zero definitions" without
+ * a separate loading flag, which is exactly what let AgentPicker's `<Show
+ * when={agents().length > 0}>` gate flash its "No definitions configured"
+ * empty state on every single mount for users who actually have agents,
+ * before the first `ListAgentDefinitionsCommand` response ever arrived (see
+ * AgentPicker's own render for the fix). `loading` only ever reflects the
+ * FIRST fetch — `agents:changed` refetches don't flip it back to true, so a
+ * background refresh never re-triggers whatever a caller gates on it.
  */
-export function useAgentDefinitions(): () => AgentDefinition[] {
+export function useAgentDefinitions(): [() => AgentDefinition[], () => boolean] {
     const [agents, setAgents] = createSignal<AgentDefinition[]>([]);
+    const [loading, setLoading] = createSignal(true);
 
     onMount(() => {
         let cancelled = false;
+        let firstLoad = true;
 
         async function load() {
             try {
@@ -70,6 +85,11 @@ export function useAgentDefinitions(): () => AgentDefinition[] {
                 if (!cancelled) setAgents(result ?? []);
             } catch {
                 // silently ignore
+            } finally {
+                if (!cancelled && firstLoad) {
+                    firstLoad = false;
+                    setLoading(false);
+                }
             }
         }
 
@@ -86,7 +106,7 @@ export function useAgentDefinitions(): () => AgentDefinition[] {
         });
     });
 
-    return agents;
+    return [agents, loading];
 }
 
 /**
@@ -126,8 +146,48 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // an *existing agent*, and a shared query risks the template grid
     // silently shrinking for an unrelated reason right next to it.
     const [filterQuery, setFilterQuery] = createSignal("");
-    const agents = useAgentDefinitions();
+    const [agents, definitionsLoading] = useAgentDefinitions();
     const modalLayer = useModalLayer();
+
+    // Combined "picker content is ready to reveal" gate — true once BOTH
+    // independent async sources feeding this view have resolved their
+    // FIRST load: the definitions list (definitionsLoading above) and
+    // MyAgentsList's own ListRecentSessionsCommand resource (reported back
+    // via onFirstLoad below, since MyAgentsList owns that resource
+    // internally). Neither alone was sufficient — gating only on
+    // definitionsLoading still let MyAgentsList's own empty `<ul>` flash
+    // before its rows arrived; gating only on MyAgentsList's load left the
+    // OUTER `<Show when={agents().length > 0}>` free to flash the "No
+    // definitions configured" empty state first for users who actually
+    // have agents, simply because `agents()` starts at `[]` and is
+    // indistinguishable from "genuinely zero" without definitionsLoading.
+    // One overlay, held until both are done, replaces two independent
+    // partial-content flashes with a single reveal — same principle as
+    // agent-view.tsx's pane-level loading overlay (one gate, one reveal),
+    // applied here across two sibling data sources instead of one.
+    const [myAgentsLoaded, setMyAgentsLoaded] = createSignal(false);
+    // A genuinely-empty definitions list never mounts MyAgentsList at all (it
+    // lives inside the `agents().length > 0` branch below) — so `loaded`
+    // must not wait on `myAgentsLoaded` in that case, or the overlay would
+    // spin forever for a user with zero agent definitions.
+    const pickerReady = createMemo(() => {
+        if (definitionsLoading()) return false;
+        if (agents().length === 0) return true;
+        return myAgentsLoaded();
+    });
+
+    // Hold-then-fade, same mechanics as agent-view.tsx's pane-level loading
+    // overlay (docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md):
+    // `pickerReady()` flips once, `showPickerOverlay` stays true for one
+    // more CSS fade duration so the overlay's own removal is never a pop.
+    const [showPickerOverlay, setShowPickerOverlay] = createSignal(true);
+    let pickerOverlayFadeTimeout: ReturnType<typeof setTimeout> | undefined;
+    onCleanup(() => clearTimeout(pickerOverlayFadeTimeout));
+    createEffect(() => {
+        if (pickerReady() && showPickerOverlay()) {
+            pickerOverlayFadeTimeout = setTimeout(() => setShowPickerOverlay(false), 220);
+        }
+    });
 
     // Reactive map of definition_id → blockId for panes currently open.
     const [openDefinitions, refreshOpenDefinitions] = useOpenDefinitionMap();
@@ -185,10 +245,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md; codex P2 on
     // round 7 expanded preservation from identity+memory only to the
     // full form.
-    const buildLaunchRequest = (
-        agent: AgentDefinition,
-        initialFormState?: Partial<LaunchFormStateWire>,
-    ) => ({
+    const buildLaunchRequest = (agent: AgentDefinition, initialFormState?: Partial<LaunchFormStateWire>) => ({
         kind: "launch-agent" as const,
         agent,
         originBlockId: props.model.blockId,
@@ -230,7 +287,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         buildLaunchRequest(agent, {
                             ...current,
                             accountId: id,
-                        }),
+                        })
                     );
                 },
                 onCancel: () => {
@@ -251,7 +308,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         buildLaunchRequest(agent, {
                             ...current,
                             memoryId: id,
-                        }),
+                        })
                     );
                 },
                 onCancel: () => {
@@ -286,9 +343,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             // a UX polish follow-up; for the cascade-recovery flow,
             // not crashing the picker is the priority.
             // eslint-disable-next-line no-console
-            console.warn(
-                `recent-session reattach: definition ${row.definition_id} not found`,
-            );
+            console.warn(`recent-session reattach: definition ${row.definition_id} not found`);
             return;
         }
         setLaunching(def.id);
@@ -310,7 +365,10 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 // non-UUID ("blank", "seed-*" — memory_bundles.rs/bundle.rs)
                 // rather than legacy garbage, so filtering it would silently
                 // drop a real carry-over (reagent P2 on this PR).
-                accountId: realAccountIdOrEmpty(row.identity_id, (await refreshAccountCache()).map((a) => a.id)),
+                accountId: realAccountIdOrEmpty(
+                    row.identity_id,
+                    (await refreshAccountCache()).map((a) => a.id)
+                ),
                 memoryId: row.memory_id,
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
@@ -344,7 +402,10 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 environment: forkedDef.agent_type === "container" ? "docker" : "local",
                 // #2463 Finding 1 — see handleReattach's comment above.
                 // memoryId intentionally unfiltered — same reasoning.
-                accountId: realAccountIdOrEmpty(row.identity_id, (await refreshAccountCache()).map((a) => a.id)),
+                accountId: realAccountIdOrEmpty(
+                    row.identity_id,
+                    (await refreshAccountCache()).map((a) => a.id)
+                ),
                 memoryId: row.memory_id,
             });
         } finally {
@@ -384,9 +445,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         // rather than the deprecated `window.navigator.platform` —
         // reagent P2 on PR #908.
         switch (getPlatform()) {
-            case "win32": return "windows";
-            case "darwin": return "macos";
-            default: return "linux";
+            case "win32":
+                return "windows";
+            case "darwin":
+                return "macos";
+            default:
+                return "linux";
         }
     };
     const probeMissingPrereqs = async (agent: AgentDefinition) => {
@@ -420,8 +484,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 tool: r.tool,
                 label: r.label ?? r.tool,
                 installUrl: r.installUrls[platform],
-                installLinkText:
-                    r.installLinkText?.[platform] ?? `Install ${r.label ?? r.tool}`,
+                installLinkText: r.installLinkText?.[platform] ?? `Install ${r.label ?? r.tool}`,
             }));
     };
 
@@ -446,12 +509,11 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             let accountId = "";
             let memoryId = "";
             try {
-                const rows = await RpcApi.ListNamedAgentsCommand(TabRpcClient, {
-                    definition_id: agent.id,
-                }) ?? [];
-                const mostRecent = [...rows].sort(
-                    (a, b) => (b.started_at ?? 0) - (a.started_at ?? 0),
-                )[0];
+                const rows =
+                    (await RpcApi.ListNamedAgentsCommand(TabRpcClient, {
+                        definition_id: agent.id,
+                    })) ?? [];
+                const mostRecent = [...rows].sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))[0];
                 if (mostRecent) {
                     // See identity-carry-over.ts's realAccountIdOrEmpty —
                     // cross-checks against a fresh account fetch (not the
@@ -465,7 +527,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     // handleReattach's comment above.
                     accountId = realAccountIdOrEmpty(
                         mostRecent.identity_id,
-                        (await refreshAccountCache()).map((a) => a.id),
+                        (await refreshAccountCache()).map((a) => a.id)
                     );
                     memoryId = mostRecent.memory_id;
                 }
@@ -579,10 +641,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // templates carry no session zone post-migration. On success it
     // hands off to `openCreateFromTemplateModal` instead of
     // `openLaunchModal`.
-    const handleTemplateSelect = async (
-        agent: AgentDefinition,
-        _evt?: MouseEvent | KeyboardEvent,
-    ) => {
+    const handleTemplateSelect = async (agent: AgentDefinition, _evt?: MouseEvent | KeyboardEvent) => {
         if (pendingSelect.has(agent.id)) return;
         pendingSelect.add(agent.id);
         try {
@@ -617,10 +676,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         openCreateFromTemplateModal(agent);
                     }
                 };
-                const openPrereqModal = (
-                    currentMissing: typeof missing,
-                    op: "open" | "replace",
-                ): void => {
+                const openPrereqModal = (currentMissing: typeof missing, op: "open" | "replace"): void => {
                     const refresh = async () => {
                         for (const m of currentMissing) prereqCache.delete(m.tool);
                         const fresh = await probeMissingPrereqs(agent);
@@ -684,8 +740,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             setInstallState((s) => {
                 const next = { ...s };
                 for (const a of agents()) {
-                    const aProviderId =
-                        a.id === agent.id ? canonical : (getProvider(a.provider)?.id ?? a.provider);
+                    const aProviderId = a.id === agent.id ? canonical : (getProvider(a.provider)?.id ?? a.provider);
                     if (aProviderId === canonical) {
                         next[a.id] = true;
                     }
@@ -718,10 +773,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // Only seeded templates get this context menu — user-owned rows
     // belong to `MyAgentsList`, which has its own affordances and
     // never funnels through this handler.
-    const handleTemplateContextMenu = (
-        agent: AgentDefinition,
-        evt: MouseEvent,
-    ) => {
+    const handleTemplateContextMenu = (agent: AgentDefinition, evt: MouseEvent) => {
         evt.preventDefault();
         const caption = agent.name || agent.slug || agent.id;
         ContextMenuModel.showContextMenu(
@@ -740,16 +792,13 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                                 // unreachable from this menu, but log
                                 // to muxlog if it ever fires.
                                 // eslint-disable-next-line no-console
-                                console.warn(
-                                    `agentdefhide failed for ${agent.id}:`,
-                                    err,
-                                );
+                                console.warn(`agentdefhide failed for ${agent.id}:`, err);
                             }
                         })();
                     },
                 },
             ],
-            evt,
+            evt
         );
     };
 
@@ -760,9 +809,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // implicitly handled by `MyAgentsList` (user-owned, surfaced as
     // recent sessions via `ListRecentSessionsCommand`). The card grid
     // below the My Agents list renders only the templates tier.
-    const templates = createMemo(() =>
-        agents().filter((a) => a.is_seeded === 1),
-    );
+    const templates = createMemo(() => agents().filter((a) => a.is_seeded === 1));
 
     // Refresh install state whenever the agent list changes.
     // Session-zone probes were removed in the Phase 1 cleanup
@@ -789,20 +836,42 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         return Math.max(0.5, Math.min(2.0, z));
     });
 
+    // Shared between both branches below (fallback and real-content) — see
+    // pickerReady/showPickerOverlay's own comments above for why a single
+    // combined overlay replaced each branch's previous independent partial
+    // reflow. Not a separate component (no reactive scope of its own
+    // needed) — just a render-time helper so the markup isn't duplicated.
+    const pickerOverlay = () => (
+        <Show when={showPickerOverlay()}>
+            <div
+                class="agent-pane-loading-overlay"
+                classList={{
+                    "is-fading": pickerReady(),
+                    "is-reduced-motion": atoms.prefersReducedMotionAtom(),
+                }}
+            >
+                <BrainSpinner fading={pickerReady()} />
+            </div>
+        </Show>
+    );
+
     return (
         <>
             <Show
                 when={agents().length > 0}
                 fallback={
                     <div class="agent-view" style={{ zoom: zoomFactor() }}>
-                        <div class="agent-picker-empty">
-                            <div class="agent-picker-empty-icon">{"\u2726"}</div>
-                            <div class="agent-picker-empty-title">No definitions configured</div>
-                            <div class="agent-picker-empty-desc">
-                                Use the ⚙ Agent settings to add your first definition.
+                        <Show when={!definitionsLoading()}>
+                            <div class="agent-picker-empty">
+                                <div class="agent-picker-empty-icon">{"\u2726"}</div>
+                                <div class="agent-picker-empty-title">No definitions configured</div>
+                                <div class="agent-picker-empty-desc">
+                                    Use the ⚙ Agent settings to add your first definition.
+                                </div>
                             </div>
-                        </div>
+                        </Show>
                         <AgentActionBar />
+                        {pickerOverlay()}
                     </div>
                 }
             >
@@ -826,13 +895,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                             openDefinitions={openDefinitions}
                             onFork={handleFork}
                             onSwitchToExisting={handleSwitchToExisting}
+                            onFirstLoad={() => setMyAgentsLoaded(true)}
                         />
                         <div class="agent-picker-templates-header" data-testid="agent-templates-header">
                             <span>+ New from template</span>
                         </div>
                         <p class="agent-picker-templates-hint" data-testid="agent-templates-hint">
-                            Each card is a <strong>harness</strong> (the CLI that runs the agent,
-                            e.g. Claude Code, Codex) — you'll pick which <strong>model</strong>
+                            Each card is a <strong>harness</strong> (the CLI that runs the agent, e.g. Claude Code,
+                            Codex) — you'll pick which <strong>model</strong>
                             it uses next.
                         </p>
                         <div class="agent-picker-list" data-testid="agent-templates-list">
@@ -889,6 +959,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         </Show>
                     </div>
                     <AgentActionBar />
+                    {pickerOverlay()}
                 </div>
             </Show>
         </>

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -36,6 +36,7 @@
  * new named session or switch focus to the existing pane.
  */
 
+import { useTick } from "@/app/hook/useTick";
 import {
     createEffect,
     createMemo,
@@ -47,21 +48,19 @@ import {
     type Accessor,
     type JSX,
 } from "solid-js";
-import { useTick } from "@/app/hook/useTick";
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { DualProviderLogo } from "@/element/DualProviderLogo";
-import { resolveEffectiveVendor } from "../providers/catalog";
-import { Logger } from "@/util/logger";
 import { formatTimeAgo } from "@/util/format-time";
+import { Logger } from "@/util/logger";
+import { resolveEffectiveVendor } from "../providers/catalog";
 import { RuntimeBadge } from "./RuntimeBadge";
 
 /** Empty-state copy varies based on whether an identity filter was
  * applied — surfaced so the integration test can match it. */
-export const EMPTY_GLOBAL =
-    "No agents yet — pick a template below to create your first one.";
+export const EMPTY_GLOBAL = "No agents yet — pick a template below to create your first one.";
 export const EMPTY_FILTERED = "No agents for this identity yet.";
 /** Shown when ListRecentSessionsCommand itself failed — distinct from
  * EMPTY_GLOBAL/EMPTY_FILTERED so a backend error never looks identical
@@ -69,8 +68,7 @@ export const EMPTY_FILTERED = "No agents for this identity yet.";
  * docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md §4/§9
  * rec 2 — this exact ambiguity is what let a real regression, PR #2296,
  * go unnoticed as "expected empty state" the first time it happened). */
-export const FETCH_ERROR =
-    "Couldn't load your agents — check the connection and try again.";
+export const FETCH_ERROR = "Couldn't load your agents — check the connection and try again.";
 /** Copy for "the fetch succeeded, but the name filter matched nothing" —
  * distinct from EMPTY_GLOBAL/EMPTY_FILTERED (both mean "there is nothing
  * to filter"), so a user narrowing a real, non-empty list to zero visible
@@ -116,11 +114,24 @@ export interface MyAgentsListProps {
      * prompt. Receives the blockId of the already-open pane.
      */
     onSwitchToExisting?: (blockId: string) => void;
+    /**
+     * Called exactly once, the first time this component's own
+     * ListRecentSessionsCommand resource resolves (success OR failure —
+     * `rows()` transitions away from `undefined` either way). Lets a parent
+     * that also has its own async gate (AgentPicker's `agents()` list) hold
+     * a single combined loading overlay until BOTH are ready, instead of
+     * this component's own empty-`<ul>`-while-loading state flashing
+     * separately underneath. Never re-fires on background refetches
+     * (visibility regain, agents:changed) — those correctly keep showing
+     * the already-loaded list via Solid's stale-while-revalidate and have
+     * nothing to do with "first load."
+     */
+    onFirstLoad?: () => void;
 }
 
 type ForkState =
     | { kind: "idle" }
-    | { kind: "prompt" }           // showing "Open new session / Switch" buttons
+    | { kind: "prompt" } // showing "Open new session / Switch" buttons
     | { kind: "naming"; label: string; loading: boolean; error: string | null }; // name input expanded
 
 export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
@@ -200,11 +211,10 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                 // is left alone here — those rows still render, just with
                 // the existing "(missing account)"-style fallback text.
                 if (result.rows.length === 0 && result.degraded.length > 0) {
-                    Logger.error(
-                        "agent",
-                        "MyAgentsList: listrecentsessions reported degraded sources with zero rows",
-                        { degraded: result.degraded, identityId: id },
-                    );
+                    Logger.error("agent", "MyAgentsList: listrecentsessions reported degraded sources with zero rows", {
+                        degraded: result.degraded,
+                        identityId: id,
+                    });
                     if (myGeneration === fetchGeneration) setFetchError(true);
                     return [];
                 }
@@ -216,14 +226,16 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                 // made a real regression here look like expected empty state.
                 // `Error` objects serialize to `{}` via structured/JSON clone
                 // (message/stack aren't own-enumerable) — pull them out explicitly.
-                const errInfo = e instanceof Error
-                    ? { name: e.name, message: e.message, stack: e.stack }
-                    : { value: String(e) };
-                Logger.error("agent", "MyAgentsList: ListRecentSessionsCommand failed", { error: errInfo, identityId: id });
+                const errInfo =
+                    e instanceof Error ? { name: e.name, message: e.message, stack: e.stack } : { value: String(e) };
+                Logger.error("agent", "MyAgentsList: ListRecentSessionsCommand failed", {
+                    error: errInfo,
+                    identityId: id,
+                });
                 if (myGeneration === fetchGeneration) setFetchError(true);
                 return [];
             }
-        },
+        }
     );
 
     // Re-poll on visibility regain so a session that just ended in
@@ -250,8 +262,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     // Fork prompt state per row (keyed by definition_id)
     const [forkStates, setForkStates] = createSignal<Map<string, ForkState>>(new Map());
 
-    const getForkState = (definitionId: string): ForkState =>
-        forkStates().get(definitionId) ?? { kind: "idle" };
+    const getForkState = (definitionId: string): ForkState => forkStates().get(definitionId) ?? { kind: "idle" };
 
     const setForkState = (definitionId: string, state: ForkState): void => {
         setForkStates((prev) => {
@@ -349,6 +360,19 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     const isLoading = () => rows.loading;
     const isEmpty = () => !isLoading() && !fetchError() && (rows() ?? []).length === 0;
 
+    // Report the first resolution up to the parent (see onFirstLoad's own
+    // doc comment on MyAgentsListProps). `once` guards against a stale
+    // closure re-firing `props.onFirstLoad` if it ever changed identity —
+    // not expected from AgentPicker's call site today, but cheap insurance
+    // since this must only ever fire once regardless.
+    let firstLoadReported = false;
+    createEffect(() => {
+        if (rows() !== undefined && !firstLoadReported) {
+            firstLoadReported = true;
+            props.onFirstLoad?.();
+        }
+    });
+
     // Client-side name filter over the already-fetched page (bumped to
     // SEARCH_LIMIT while searching — see resourceKey/fetcher above).
     // Matches instance_name first, falling back to definition_name for
@@ -362,8 +386,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     });
     // Distinct from `isEmpty()`: the fetch found real rows, but the
     // filter narrowed them all away — not "you have no agents."
-    const isNoMatch = () =>
-        !isLoading() && !fetchError() && (rows() ?? []).length > 0 && filteredRows().length === 0;
+    const isNoMatch = () => !isLoading() && !fetchError() && (rows() ?? []).length > 0 && filteredRows().length === 0;
 
     return (
         <div class="agent-recent-sessions" data-testid="agent-my-agents-list">
@@ -396,27 +419,18 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                             <Show
                                 when={isNoMatch()}
                                 fallback={
-                                    <div
-                                        class="agent-recent-sessions-empty"
-                                        data-testid="agent-my-agents-empty"
-                                    >
+                                    <div class="agent-recent-sessions-empty" data-testid="agent-my-agents-empty">
                                         {filterId() ? EMPTY_FILTERED : EMPTY_GLOBAL}
                                     </div>
                                 }
                             >
-                                <div
-                                    class="agent-recent-sessions-empty"
-                                    data-testid="agent-my-agents-no-match"
-                                >
+                                <div class="agent-recent-sessions-empty" data-testid="agent-my-agents-no-match">
                                     {noMatchText(rawQuery())}
                                 </div>
                             </Show>
                         }
                     >
-                        <div
-                            class="agent-recent-sessions-error"
-                            data-testid="agent-my-agents-error"
-                        >
+                        <div class="agent-recent-sessions-error" data-testid="agent-my-agents-error">
                             <span class="agent-recent-sessions-error-msg">{FETCH_ERROR}</span>
                             <button
                                 type="button"
@@ -433,8 +447,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                 <ul class="agent-recent-sessions-list">
                     <For each={filteredRows()}>
                         {(row) => {
-                            const isActive = () =>
-                                (props.openDefinitions?.() ?? new Map()).has(row.definition_id);
+                            const isActive = () => (props.openDefinitions?.() ?? new Map()).has(row.definition_id);
                             const forkState = () => getForkState(row.definition_id);
 
                             return (
@@ -464,7 +477,9 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                         aria-label="Active"
                                                     />
                                                 </Show>
-                                                <Show when={row.agent_type === "host" || row.agent_type === "container"}>
+                                                <Show
+                                                    when={row.agent_type === "host" || row.agent_type === "container"}
+                                                >
                                                     {/* size="tag" — same HOST/SANDBOX wording + white/
                                                         yellow styling as AgentComposerStrip's runtime
                                                         tag, so the badge reads as one consistent
@@ -486,9 +501,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                     </span>
                                                 }
                                             >
-                                                <span class="agent-recent-sessions-preview">
-                                                    {row.preview}
-                                                </span>
+                                                <span class="agent-recent-sessions-preview">{row.preview}</span>
                                             </Show>
                                             <Show when={row.node_count > 0}>
                                                 <span class="agent-recent-sessions-line3">
@@ -515,7 +528,13 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                         </span>
                                                     </span>
                                                 </Show>
-                                                <Show when={row.has_snapshot && row.started_at > 0 && row.last_active_at > row.started_at}>
+                                                <Show
+                                                    when={
+                                                        row.has_snapshot &&
+                                                        row.started_at > 0 &&
+                                                        row.last_active_at > row.started_at
+                                                    }
+                                                >
                                                     <span class="agent-recent-sessions-ts">
                                                         <span class="agent-recent-sessions-ts-label">Last Active</span>
                                                         <span class="agent-recent-sessions-ts-value">
@@ -531,7 +550,8 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                     <Show when={forkState().kind !== "idle"}>
                                         <div class="agent-fork-prompt" data-testid="agent-fork-prompt">
                                             <span class="agent-fork-prompt-msg">
-                                                <strong>{row.instance_name || row.definition_name}</strong> is already open in another pane.
+                                                <strong>{row.instance_name || row.definition_name}</strong> is already
+                                                open in another pane.
                                             </span>
                                             <Show when={forkState().kind === "prompt"}>
                                                 <div class="agent-fork-prompt-actions">
@@ -561,7 +581,13 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                     </button>
                                                 </div>
                                             </Show>
-                                            <Show when={forkState().kind === "naming" ? (forkState() as Extract<ForkState, { kind: "naming" }>) : null}>
+                                            <Show
+                                                when={
+                                                    forkState().kind === "naming"
+                                                        ? (forkState() as Extract<ForkState, { kind: "naming" }>)
+                                                        : null
+                                                }
+                                            >
                                                 {(ns) => (
                                                     <div class="agent-fork-naming">
                                                         <label class="agent-fork-label">Name for new session:</label>
@@ -583,9 +609,14 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                                 }
                                                                 onKeyDown={(e) => {
                                                                     if (e.key === "Enter") void handleForkStart(row);
-                                                                    if (e.key === "Escape") handleForkCancel(row.definition_id);
+                                                                    if (e.key === "Escape")
+                                                                        handleForkCancel(row.definition_id);
                                                                 }}
-                                                                ref={(el) => { createEffect(() => { if (!ns().loading) el.focus(); }); }}
+                                                                ref={(el) => {
+                                                                    createEffect(() => {
+                                                                        if (!ns().loading) el.focus();
+                                                                    });
+                                                                }}
                                                             />
                                                             <button
                                                                 type="button"

--- a/frontend/app/view/bundle-summary.test.tsx
+++ b/frontend/app/view/bundle-summary.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/app/store/global", () => ({
     openOrFocusPaneByView: vi.fn(),
 }));
 vi.mock("@/app/view/agent/components/AgentPicker", () => ({
-    useAgentDefinitions: () => () => agentsList,
+    useAgentDefinitions: () => [() => agentsList, () => false],
 }));
 
 import { BundleSummaryPanel } from "./bundle-summary";

--- a/frontend/app/view/bundle-summary.tsx
+++ b/frontend/app/view/bundle-summary.tsx
@@ -59,7 +59,7 @@ interface BundleSummaryPanelProps {
 }
 
 export const BundleSummaryPanel = (props: BundleSummaryPanelProps): JSX.Element => {
-    const agents = useAgentDefinitions();
+    const [agents] = useAgentDefinitions();
     const boundBundleId = createMemo(() => {
         const id = props.agentId;
         if (!id) return undefined;

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -31,13 +31,16 @@ vi.mock("@/app/store/wps", () => ({
     waveEventSubscribe: vi.fn(() => () => {}),
 }));
 vi.mock("@/app/view/agent/components/AgentPicker", () => ({
-    useAgentDefinitions: () => () => [
-        { id: "agent-1", name: "Agent One", provider: "claude" },
-        { id: "agent-2", name: "Agent Two", provider: "claude" },
-        { id: "agent-3", name: "Agent Three (codex)", provider: "codex" },
-        // #2594 drift fixtures — column vs. bound bundle disagree.
-        { id: "agent-4", name: "Agent Four (drifted to claude)", provider: "codex", memory_id: "mem-4" },
-        { id: "agent-5", name: "Agent Five (drifted away from claude)", provider: "claude", memory_id: "mem-5" },
+    useAgentDefinitions: () => [
+        () => [
+            { id: "agent-1", name: "Agent One", provider: "claude" },
+            { id: "agent-2", name: "Agent Two", provider: "claude" },
+            { id: "agent-3", name: "Agent Three (codex)", provider: "codex" },
+            // #2594 drift fixtures — column vs. bound bundle disagree.
+            { id: "agent-4", name: "Agent Four (drifted to claude)", provider: "codex", memory_id: "mem-4" },
+            { id: "agent-5", name: "Agent Five (drifted away from claude)", provider: "claude", memory_id: "mem-5" },
+        ],
+        () => false,
     ],
 }));
 vi.mock("./identity-model", () => ({

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -47,7 +47,7 @@ interface AgentIdentityLinksPanelProps {
 }
 
 export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JSX.Element => {
-    const agents = useAgentDefinitions();
+    const [agents] = useAgentDefinitions();
 
     const [allLinks, setAllLinks] = createSignal<AgentDefinitionIdentity[]>([]);
     const [accounts, setAccounts] = createSignal<Account[]>(loadAccounts());

--- a/frontend/app/view/identity/identity-accounts-tab.tsx
+++ b/frontend/app/view/identity/identity-accounts-tab.tsx
@@ -26,7 +26,7 @@ const STATUS_DOT: Record<string, string> = {
 
 export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Element {
     const groups = () => model.accountsByProvider();
-    const agents = useAgentDefinitions();
+    const [agents] = useAgentDefinitions();
 
     // Right-click an account row → "Bind to Agent" submenu + Copy account ID
     // (SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md). Menu contents
@@ -167,7 +167,7 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
     // pre-delete warning never fire for exactly the agents that matter
     // (reagent P1, PR #2161 round 1). The legacy index is kept as a union
     // for agents that predate direct links.
-    const agents = useAgentDefinitions();
+    const [agents] = useAgentDefinitions();
     const [linkedAgentIds, setLinkedAgentIds] = createSignal<string[]>([]);
     RpcApi.ListAllAgentIdentitiesCommand(TabRpcClient)
         .then((links) => {


### PR DESCRIPTION
## Problem

Opening a new agent pane (the picker view) had a visible flicker/layout-shift: bottom content painted first, then top content arrived and pushed it down.

## Root cause

Two independent, uncoordinated async data sources fed `AgentPicker`:
1. `useAgentDefinitions()` — no loading/empty distinction. `agents()` starts at `[]`, indistinguishable from "genuinely zero definitions" — so `<Show when={agents().length > 0}>` flashed the "No definitions configured" empty state on *every* picker mount for users who actually have agents, before the first RPC response arrived.
2. `MyAgentsList`'s own `ListRecentSessionsCommand` fetch — rendered an empty `<ul>` with no loading indicator while in flight, and was nested *inside* gate #1 so it couldn't even start until that one resolved.

Each reflowed independently — the reported flicker.

## Fix

- `useAgentDefinitions()` now returns `[agents, loading]` instead of just the accessor. Updated all 5 other call sites (`agent-view.tsx`, `bundle-summary.tsx`, `agent-identity-links-panel.tsx`, `identity-accounts-tab.tsx` ×2) + 2 test mocks that broke from the signature change — verified via `tsc --noEmit` (only 2 pre-existing, unrelated errors remain, confirmed present on `main` too).
- `AgentPicker` combines `definitionsLoading` with a new `onFirstLoad` callback from `MyAgentsList` into one `pickerReady` gate, held behind a single `BrainSpinner` overlay — same hold-then-fade pattern already used by `agent-view.tsx`'s pane-level loading overlay. One reveal, no partial states.

Manually verified live via `task dev` — flicker is gone.

<!-- agentmux:agent_id=manoz -->