### PR TITLE
feat(widgets): parent widgets with grouped submenus — Messengers

### DIFF
--- a/.changesets/1786999034-feat-widgets-parent-widgets-with-grouped-submenus-messengers-jpel.md
+++ b/.changesets/1786999034-feat-widgets-parent-widgets-with-grouped-submenus-messengers-jpel.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(widgets): parent widgets with grouped submenus — Messengers

--- a/agentmux-srv/src/backend/wconfig/loader.rs
+++ b/agentmux-srv/src/backend/wconfig/loader.rs
@@ -23,6 +23,7 @@ pub fn build_default_config() -> FullConfigType {
 
     match serde_json::from_str::<HashMap<String, WidgetConfigType>>(WIDGETS_JSON) {
         Ok(widgets) => {
+            validate_widget_configs(&widgets);
             config.widgets = widgets;
         }
         Err(e) => {
@@ -31,6 +32,28 @@ pub fn build_default_config() -> FullConfigType {
     }
 
     config
+}
+
+/// Soft validation for widget entries loaded from `widgets.json`: a widget
+/// must be either a leaf (non-empty `blockdef.meta`) or a parent (non-empty
+/// `children`), never neither, never both. Logged as a startup warning, not
+/// a hard failure, matching how other config issues are handled.
+fn validate_widget_configs(widgets: &HashMap<String, WidgetConfigType>) {
+    for (key, widget) in widgets {
+        let has_blockdef = !widget.block_def.meta.is_empty();
+        let has_children = !widget.children.is_empty();
+        if has_blockdef && has_children {
+            eprintln!(
+                "wconfig: widget \"{}\" has both a blockdef and children — children (parent behavior) takes precedence",
+                key
+            );
+        } else if !has_blockdef && !has_children {
+            eprintln!(
+                "wconfig: widget \"{}\" has neither a blockdef nor children — it can't open a pane or expand a submenu",
+                key
+            );
+        }
+    }
 }
 
 // ---- Config loading helpers ----
@@ -255,4 +278,77 @@ pub fn expand_env_vars(s: &str) -> String {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaf_widget() -> WidgetConfigType {
+        WidgetConfigType {
+            block_def: super::super::types::BlockDef {
+                meta: std::collections::HashMap::from([("view".to_string(), serde_json::json!("browser"))]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn parent_widget(children: &[&str]) -> WidgetConfigType {
+        WidgetConfigType {
+            children: children.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    // validate_widget_configs only logs (eprintln) — these tests just confirm
+    // it doesn't panic for every combination, since there's no return value
+    // to assert on. The real coverage of "parent xor leaf" is enforced by the
+    // embedded widgets.json actually loading without triggering a warning,
+    // which build_default_config's own tests below check indirectly by
+    // asserting on the real parsed shape.
+    #[test]
+    fn test_validate_widget_configs_does_not_panic() {
+        let widgets: HashMap<String, WidgetConfigType> = HashMap::from([
+            ("defwidget@leaf".to_string(), leaf_widget()),
+            ("defwidget@parent".to_string(), parent_widget(&["leaf"])),
+            ("defwidget@neither".to_string(), WidgetConfigType::default()),
+            (
+                "defwidget@both".to_string(),
+                WidgetConfigType {
+                    children: vec!["leaf".to_string()],
+                    ..leaf_widget()
+                },
+            ),
+        ]);
+        validate_widget_configs(&widgets);
+    }
+
+    #[test]
+    fn test_build_default_config_loads_messengers_group() {
+        let config = build_default_config();
+        let messengers = config
+            .widgets
+            .get("defwidget@messengers")
+            .expect("defwidget@messengers should be in the embedded widgets.json");
+        assert_eq!(
+            messengers.children,
+            vec!["discord", "slack", "telegram", "whatsapp", "teams"]
+        );
+        assert!(
+            messengers.block_def.meta.is_empty(),
+            "a parent widget shouldn't carry a blockdef"
+        );
+
+        for short_name in ["discord", "slack", "telegram", "whatsapp", "teams"] {
+            let key = format!("defwidget@{short_name}");
+            let child = config
+                .widgets
+                .get(&key)
+                .unwrap_or_else(|| panic!("{key} should still be in widgets.json"));
+            assert!(child.display_hidden, "{key} should be display:hidden now that it's grouped");
+            assert!(child.children.is_empty(), "{key} is a leaf, not itself a parent");
+            assert!(!child.block_def.meta.is_empty(), "{key} should still carry its own blockdef");
+        }
+    }
 }

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -503,6 +503,14 @@ pub struct WidgetConfigType {
     #[serde(default, skip_serializing_if = "is_false")]
     pub magnified: bool,
 
+    /// Ordered short-names (no "defwidget@" prefix, same convention as
+    /// `widget:pinned`) of this widget's children. A non-empty `children`
+    /// list is what makes a widget entry a "parent" — it expands a submenu
+    /// on the widget bar / More dropdown instead of opening a pane, so its
+    /// own `blockdef` is unused.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<String>,
+
     #[serde(rename = "blockdef", default)]
     pub block_def: BlockDef,
 }

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -118,9 +118,18 @@
             }
         }
     },
+    "defwidget@messengers": {
+        "display:order": 10,
+        "display:pinned": false,
+        "icon": "comments",
+        "label": "Messengers",
+        "description": "Team chat and messaging apps",
+        "children": ["discord", "slack", "telegram", "whatsapp", "teams"]
+    },
     "defwidget@discord": {
         "display:order": 10,
         "display:pinned": false,
+        "display:hidden": true,
         "icon": "brands@discord",
         "color": "#5865f2",
         "label": "Discord",
@@ -136,6 +145,7 @@
     "defwidget@slack": {
         "display:order": 11,
         "display:pinned": false,
+        "display:hidden": true,
         "icon": "brands@slack",
         "color": "#4a154b",
         "label": "Slack",
@@ -151,6 +161,7 @@
     "defwidget@telegram": {
         "display:order": 12,
         "display:pinned": false,
+        "display:hidden": true,
         "icon": "brands@telegram",
         "color": "#229ed9",
         "label": "Telegram",
@@ -166,6 +177,7 @@
     "defwidget@whatsapp": {
         "display:order": 13,
         "display:pinned": false,
+        "display:hidden": true,
         "icon": "brands@whatsapp",
         "color": "#25d366",
         "label": "WhatsApp",
@@ -181,6 +193,7 @@
     "defwidget@teams": {
         "display:order": 14,
         "display:pinned": false,
+        "display:hidden": true,
         "icon": "brands@microsoft",
         "color": "#6264a7",
         "label": "Teams",

--- a/docs/specs/SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md
+++ b/docs/specs/SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md
@@ -1,0 +1,476 @@
+# SPEC: Widget bar parent widgets (grouped submenus)
+
+**Date:** 2026-08-12
+**Status:** proposed
+
+---
+
+## 0. Ask
+
+Introduce **parent widgets** on the action widget bar: a widget entry that,
+instead of opening a pane on click, expands a submenu listing **child**
+widgets — "just like our right-click context menus." First concrete case:
+a **"Messengers"** parent grouping the 5 existing messenger widgets
+(`defwidget@teams`, `defwidget@slack`, `defwidget@discord`,
+`defwidget@telegram`, `defwidget@whatsapp`).
+
+Two placements a parent widget can be interacted from, both need to work:
+
+- **A. Pinned** — the parent sits directly in the bar like any other pinned
+  widget.
+- **B. Inside "More"** — the parent is one row in the `···More` overflow
+  dropdown (`frontend/app/window/more-dropdown.tsx`).
+
+---
+
+## 1. Audit — what already exists
+
+### 1.1 Widget bar today (flat, two tiers)
+
+`frontend/app/window/action-widgets.tsx` renders **pinned** widgets directly
+in the bar; everything else lives in the **More** dropdown
+(`more-dropdown.tsx`). Both tiers are flat lists — no grouping concept
+exists anywhere in the widget system today. Config helpers live in
+`action-widgets-config.ts` (`getPinnedWidgets`/`getMoreWidgets`/`pinWidget`/
+`unpinWidget`), driven by the `widget:pinned` settings array (ordered
+short-names) with `display:pinned` in `widgets.json` as the new-install
+default (see `docs/specs/widget-pinning.md`).
+
+Widget definitions live in `agentmux-srv/src/config/widgets.json`, typed as
+`WidgetConfigType` in `agentmux-srv/src/backend/wconfig/types.rs:478` (Rust)
+and mirrored in `frontend/types/gotypes.d.ts:2106` (TS). Current shape:
+
+```rust
+pub struct WidgetConfigType {
+    display_order: f64,       // "display:order"
+    display_hidden: bool,     // "display:hidden"
+    display_pinned: bool,     // "display:pinned"
+    icon: String,
+    color: String,
+    label: String,
+    description: String,
+    magnified: bool,
+    block_def: BlockDef,      // "blockdef" — what pane opens on click
+}
+```
+
+**The 5 messenger widgets already exist as flat, standalone entries** —
+`defwidget@discord`, `defwidget@slack`, `defwidget@telegram`,
+`defwidget@whatsapp`, `defwidget@teams` (`widgets.json` lines 121–195), each
+`display:pinned: false`, each a `view: "browser"` blockdef pointed at the
+service's web app. Today they only differ from any other widget by being
+pre-set browser shortcuts — nothing already groups them. This is the
+concrete first parent/children set for this feature.
+
+**Aside (found during audit, not part of this spec):** `CLAUDE.md`'s widget
+table lists `browser`/`terminal`/`sysinfo`/`editor`/`help` as "Pinned"
+tier, but `widgets.json` has all five as `display:pinned: false` today.
+Since no `widget:pinned` default exists in `settings-template.jsonc`, a
+fresh install's actual pinned set is whatever `display:pinned: true`
+produces — `agent`, `swarm`, `drone`, `warden`, `media` only. Worth a
+docs-fix follow-up; flagging here since a "Messengers" default-pinned
+decision (§3.6) should be made with the real current defaults in mind, not
+the stale table.
+
+### 1.2 Submenu infrastructure already exists and is directly reusable
+
+Two DOM submenu implementations exist, and — as of
+`SPEC_SUBMENU_POSITIONING_AND_HOVER_TIMING_2026_08_10.md`, already
+merged to `main` — both route through one shared, framework-agnostic
+hover-intent core: **`frontend/app/util/submenu-hover.ts`**
+(`createSubmenuHover`). It gives:
+
+- **90ms open delay** on trigger-row hover (avoids opening every submenu
+  the cursor merely passes over).
+- **Safe-triangle close** — the submenu stays open while the cursor moves
+  through the triangle from the point it left the trigger row toward the
+  submenu panel's near edge, with a 300ms absolute backstop timer either
+  way. This is exactly the "diagonal mouse movement into the submenu
+  shouldn't slam it shut" behavior implied by "expand just like our
+  right-click context menus."
+- **Peer close** — a `createPeerRegistry()` helper (in
+  `flyoutmenu.tsx`) force-closes any other open sibling submenu the
+  instant a new sibling row is entered, on top of (not instead of) the
+  safe-triangle grace period for that row's own approach.
+
+`FlyoutMenu`/`SubMenu` (`frontend/app/element/flyoutmenu.tsx`) is the
+SolidJS-native consumer: `MenuItem.subItems?: MenuItem[]` renders a nested
+`<SubMenu>` positioned via the shared `computeMenuPosition()` primitive
+(`frontend/app/util/menu-position.ts`) — anchored to the parent row's rect,
+preferred placement `right-start` (flips to `left-start` near the window
+edge), `autoUpdate` from `@floating-ui/dom` keeps it live on scroll/resize,
+and it stays `visibility:hidden` until the real position is known (fixes
+the positioning-flash bug the same spec addresses). It already carries
+`data-pane-overlay` / `usePaneOverlay()` so it draws correctly on top of a
+native browser-pane HWND sitting behind it — the same requirement
+`more-dropdown.tsx` already has (comment there: *"cut a transparent hole
+through any browser pane HWND behind this dropdown"*).
+
+`MoreDropdown` itself is a good structural template for a **pinned**
+parent's flyout (Case A below): it's a `Portal`-rendered floating panel,
+anchored to a trigger button via `computeMenuPosition()` +
+`autoUpdate`, closes on outside-mousedown, and separately renders a
+`PopoverMenu` for per-item right-click actions that must stay open
+independently of the dropdown itself.
+
+`ContextMenuModel.showContextMenu()` (`frontend/app/store/contextmenu.ts`)
+is a **third**, unrelated path — it hands off to the OS-native context
+menu (`NativeContextMenuItem.submenu`), used for actual right-click
+(`handlePinnedContextMenu` in `action-widgets.tsx`). It is **not** a
+candidate for the parent-widget expand UI — that's a native OS menu, not a
+DOM flyout, and can't be anchored/positioned the way an in-bar expand
+needs to be. Case A/B below build on the DOM path (`submenu-hover.ts` +
+`computeMenuPosition()`), matching what right-click submenus look and feel
+like without literally routing through the native-menu API.
+
+`PopoverMenu` (`frontend/app/element/popover-menu.tsx`) — used today for
+the pin/unpin item menu spawned from `ActionWidgets`/`MoreDropdown` — is
+**single-level only** (sections, but no nested `subItems`/hover-intent). Not
+a fit for the parent/child expand itself; still the right tool for the
+existing "pin/unpin" per-item action menu, unchanged by this spec.
+
+### 1.3 Responsive collapse & drag-reorder
+
+`use-widget-bar-responsive.ts` measures pinned-widget width via hidden
+mirror elements to decide the 3-tier label/icon/overflow collapse.
+`use-widget-drag-reorder.ts` drives pinned-bar drag-to-reorder. Both treat
+`pinnedWidgets()` as a flat array of `{key, widget}` — a parent widget is
+just one more entry in that array from their point of view; **no changes
+needed** to either as long as a parent widget is represented as a single
+`{key, widget}` slot (§3.1).
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- A widget entry can declare itself a parent with an ordered list of child
+  widget keys.
+- Pinned parent (Case A) and More-dropdown parent (Case B) both expand a
+  child list using the *same* hover-intent timing and positioning
+  primitives already used by every other submenu in the app.
+- Right-click on a parent still works and is scoped sensibly (group-level
+  actions, not a single pane's actions).
+- Existing single-widget behavior (pin/unpin, drag-reorder, responsive
+  collapse, right-click, "Open in New Window") is unaffected for anything
+  that isn't a parent or a grouped child.
+- Ship the "Messengers" group as the first real usage, folding in the 5
+  existing messenger widgets without changing their individual `blockdef`s.
+
+**Non-goals (v1)**
+
+- Nested groups (a parent whose child is itself a parent). Nothing in the
+  design below forbids it later — `FlyoutMenu`'s `SubMenu` already
+  recurses — but no current use case needs it, so it's untested scope.
+- Per-child pin-to-bar that "promotes" a grouped child out of its parent
+  onto the bar as its own standalone pinned entry. Right-click on a child
+  still offers "Open in New Window" / "Open in Floating Pane" (unchanged),
+  but not "pin this one directly." Flagged as an open question (§6).
+- A "customize groups" UI for user-defined parents. `widgets.json` is
+  the only place parents are authored, same as widgets today.
+
+---
+
+## 3. Design
+
+### 3.1 Data model
+
+Add one field to `WidgetConfigType`, both sides:
+
+**Rust — `agentmux-srv/src/backend/wconfig/types.rs`**
+
+```rust
+pub struct WidgetConfigType {
+    // ...existing fields unchanged...
+
+    /// Ordered short-names (no "defwidget@" prefix, same convention as
+    /// `widget:pinned`) of this widget's children. Presence of a
+    /// non-empty `children` list is what makes a widget entry a "parent":
+    /// its own `blockdef` is not used to open a pane and can be omitted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<String>,
+}
+```
+
+`block_def: BlockDef` stays as-is — it already deserializes to
+`BlockDef::default()` (empty `files`/`meta`) when the `blockdef` key is
+absent from JSON, so a parent entry can omit `blockdef` entirely today
+with no struct change. Add a config-load-time validation (not a type-level
+`Option`, to keep the diff minimal): a widget must have **either** a
+non-empty `blockdef.meta` **or** a non-empty `children` list, never
+neither, never both — surfaced as a startup log warning, not a hard
+failure (matches how other soft config issues are handled).
+
+**TS — `frontend/types/gotypes.d.ts:2106`**
+
+```ts
+type WidgetConfigType = {
+    "display:order"?: number;
+    "display:hidden"?: boolean;
+    "display:pinned"?: boolean;
+    icon?: string;
+    color?: string;
+    label?: string;
+    description?: string;
+    magnified?: boolean;
+    children?: string[];   // new
+    blockdef: BlockDef;
+};
+```
+
+(This file is generated from the Rust types elsewhere in the build; listed
+here for completeness of the frontend-visible contract.)
+
+**`agentmux-srv/src/config/widgets.json`**
+
+```jsonc
+"defwidget@messengers": {
+    "display:order": 10,
+    "display:pinned": false,
+    "icon": "comments",
+    "label": "Messengers",
+    "description": "Team chat and messaging apps",
+    "children": ["discord", "slack", "telegram", "whatsapp", "teams"]
+    // no "blockdef" — this entry never opens a pane directly
+},
+```
+
+The 5 existing messenger entries (`defwidget@discord`, `defwidget@slack`,
+`defwidget@telegram`, `defwidget@whatsapp`, `defwidget@teams`) are
+unchanged in shape — same `blockdef`, same icon/color/label — except they
+gain `"display:hidden": true`. §3.2 explains why hidden, not merely
+un-pinned.
+
+### 3.2 Grouped children are hidden from the flat lists
+
+Once a widget key appears in some parent's `children`, it must not *also*
+appear as its own row in the top-level bar or in More — otherwise a user
+sees "Slack" twice: once standalone in More, once inside "Messengers."
+`getPinnedWidgets()`/`getMoreWidgets()` (`action-widgets-config.ts`) both
+need one new filter step:
+
+```ts
+function getGroupedChildKeys(wmap: Record<string, WidgetConfigType>): Set<string> {
+    const grouped = new Set<string>();
+    for (const w of Object.values(wmap)) {
+        for (const child of w.children ?? []) grouped.add(child);
+    }
+    return grouped;
+}
+```
+
+`getPinnedWidgets`/`getMoreWidgets` exclude any key in this set from their
+top-level enumeration (a parent widget itself is never in this set unless
+someone nests groups, which is out of scope — §2). This is why the
+messenger entries additionally get `display:hidden: true` in §3.1: it's
+belt-and-suspenders documentation of intent in the config file itself (a
+human reading `widgets.json` sees these are not top-level-reachable),
+even though the *actual* exclusion is enforced by the grouped-key filter
+so it also protects against a future author forgetting the flag.
+
+Resolving a parent's children for rendering is a pure lookup, not
+filtering: `(widget.children ?? []).map(shortName => wmap[`defwidget@${shortName}`]).filter(Boolean)`.
+
+### 3.3 Case A — pinned parent in the bar
+
+**Trigger element:** the existing `.action-widget-slot` /
+`<ActionWidget>` row, unchanged in structure. Its `divOnClick` currently
+calls `handleWidgetSelect(widget)` (opens a pane) — for a parent widget
+(`widget.children?.length`), this must instead **toggle** the flyout
+open/closed, exactly like the existing More button's `openMore` handler
+(`action-widgets.tsx:121`), not call `handleWidgetSelect`. This mirrors
+"click toggles" as the accessible/discoverable fallback for anyone who
+doesn't hover-dwell, same rationale as the More button already having
+both.
+
+**Hover-intent:** in addition to click-toggle, wire the row's
+`onMouseEnter`/`onMouseLeave` through a `createSubmenuHover` controller —
+the same 90ms-open / safe-triangle-close primitive every other submenu in
+the app uses. This is the literal "expand just like our right-click
+context menus" ask. One controller per pinned parent slot (there may be
+more than one parent pinned at once, e.g. "Messengers" + a hypothetical
+future "Dev Tools" group) — wrap them in a `createPeerRegistry()` (same
+helper `flyoutmenu.tsx` already exports the *pattern* for, though it's
+currently private to that file — worth hoisting to `submenu-hover.ts` or a
+new small shared module, since both `MenuBody`/`SubMenu` internally and
+this new pinned-bar case need "close my siblings when I open" — see §5)
+so opening "Messengers" force-closes any other open pinned-parent flyout
+immediately, matching in-bar sibling behavior to in-menu sibling behavior.
+
+**Panel:** new component, e.g. `PinnedWidgetFlyout` — structurally a clone
+of `MoreDropdown` (§1.2): `Portal`-rendered, `usePaneOverlay()` +
+`data-pane-overlay` (browser-pane HWND clipping — non-negotiable, every
+floating menu in this app needs it), positioned via `computeMenuPosition()`
+anchored to the pinned slot's own element (not the whole bar), preferred
+placement `bottom-start` (opens downward under the icon — matches how the
+More dropdown already opens under its button; this is *not* a sideways
+`right-start` submenu, because the trigger lives in a horizontal bar, not
+a vertical menu list). Starts `visibility:hidden` until positioned (same
+flash-avoidance requirement as `SubMenu`).
+
+**Rows inside the panel:** each child widget renders like a normal
+`MoreDropdown` item — icon + label, click calls `handleWidgetSelect(child)`
+and closes the flyout. Right-click on a child row opens the existing
+per-item `PopoverMenu` (Open in New Window / Open in Floating Pane /
+separator / Pin-Unpin) unchanged — reuse `buildItemMenuItems`, just resolve
+`shortName` against the child instead of a top-level widget.
+
+**Closing:** outside mousedown (existing pattern), `Escape`, and the
+safe-triangle timeout. Selecting a child closes it (same as More).
+
+### 3.4 Case B — parent as a row inside the More dropdown
+
+This one is a much closer fit for the *existing* `FlyoutMenu`/`SubMenu`
+machinery than Case A, because More-dropdown rows are already a vertical
+list — a parent row there behaves exactly like a `MenuItem` with
+`subItems` inside `FlyoutMenu` (hamburger menu's Theme/Opacity submenus
+are the existing example of this exact shape).
+
+Two implementation options, in preference order:
+
+1. **(Recommended) Give `MoreDropdown` its own lightweight `SubMenu`
+   support**, structurally identical to `flyoutmenu.tsx`'s `SubMenu`:
+   `createSubmenuHover` per parent row, `computeMenuPosition()` anchored
+   to that row's rect with placement `right-start` (flips to `left-start`
+   near the right edge — More already right-aligns itself to its own
+   anchor, so this flip matters more here than in Case A), same
+   `visibility:hidden`-until-positioned guard, same `data-pane-overlay`.
+   This keeps `MoreDropdown`'s existing item-click / item-context-menu
+   wiring (`onItemContextMenu`, `handleItemClick`) intact and just adds a
+   third branch (parent row → render `SubMenu` instead of a leaf item).
+2. **(Rejected for v1) Route More's item list through `FlyoutMenu`
+   itself.** `FlyoutMenu` owns its own trigger/open-state
+   (`menu-anchor`/`isOpen`) which doesn't match how `MoreDropdown` is
+   already triggered (externally, by `ActionWidgets`' own `moreOpen`
+   signal) — bending `FlyoutMenu` to accept an externally-controlled open
+   state is a larger refactor than duplicating the ~80-line `SubMenu`
+   shape, for no behavioral difference to the user. Revisit only if a
+   third consumer needing the same "externally-triggered flyout with
+   nested subItems" shape shows up.
+
+**Row indicator:** a parent row in More gets the same
+`<i class="fa-sharp fa-solid fa-chevron-right" />` trailing icon
+`FlyoutMenu` already renders for any `item.subItems` — free visual
+consistency, no new icon/affordance to invent.
+
+**Closing:** parent submenu closes via its own safe-triangle/timer,
+independent of the outer More dropdown's own outside-mousedown close
+(same nesting model `FlyoutMenu`'s `SubMenu`-inside-`MenuBody` already
+has — an inner `Show` unmount, not a shared close flag).
+
+### 3.5 Right-click on a parent
+
+Scope right-click to **group-level** actions — it must not offer
+"Open in New Window" (there's no single pane a parent represents) or a
+generic "Unpin from bar" phrased the same as a leaf widget's, since
+unpinning a group has a different mental model (the whole group leaves
+the bar, not "this one pane's shortcut"). Proposed menu, reusing
+`ContextMenuModel.showContextMenu` exactly as `handlePinnedContextMenu`
+does today:
+
+```
+Pinned parent (bar):
+  Unpin group from bar
+More-dropdown parent:
+  Pin group to bar
+```
+
+Right-click on a **child row**, inside either flyout, keeps today's
+per-widget `PopoverMenu` (Open in New Window / Open in Floating Pane /
+Pin-Unpin) exactly as-is — §2 already scopes out per-child promotion, so
+"Pin to bar" on a child is left as todo/disabled pending the §6 decision,
+not silently different behavior.
+
+### 3.6 Should "Messengers" ship pinned or in More?
+
+Given the audit finding in §1.1 (actual current pinned defaults are
+`agent`/`swarm`/`drone`/`warden`/`media`, not the CLAUDE.md table), default
+`defwidget@messengers` to `"display:pinned": false` — lands in More on
+first install, same tier its 5 children individually occupy today. This
+is the lower-risk default (existing installs' `widget:pinned` arrays are
+untouched; new-install defaults don't change bar density) and lets both
+Case A and Case B get exercised by any user who chooses to pin it or not.
+Do not special-case a "new group defaults to pinned" rule — no other
+recent widget addition has done that either.
+
+---
+
+## 4. Files touched (est.)
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/backend/wconfig/types.rs` | Add `children: Vec<String>` to `WidgetConfigType`; load-time validation (blockdef xor children) |
+| `agentmux-srv/src/config/widgets.json` | Add `defwidget@messengers`; add `"display:hidden": true` to the 5 messenger entries |
+| `frontend/types/gotypes.d.ts` | Mirror `children?: string[]` on `WidgetConfigType` |
+| `frontend/app/window/action-widgets-config.ts` | `getGroupedChildKeys()`; filter it out of `getPinnedWidgets`/`getMoreWidgets`; `pinGroup`/`unpinGroup` (or reuse `pinWidget`/`unpinWidget` — parent is just another key in `widget:pinned`) |
+| `frontend/app/window/action-widgets.tsx` | Parent-aware click handler (toggle vs `handleWidgetSelect`); per-slot `createSubmenuHover`; peer-close across pinned parents; render `PinnedWidgetFlyout`; group-scoped right-click menu |
+| `frontend/app/window/pinned-widget-flyout.tsx` *(new)* | Case A panel — modeled on `more-dropdown.tsx` |
+| `frontend/app/window/more-dropdown.tsx` | Parent-row branch → nested `SubMenu`-equivalent (§3.4 option 1) |
+| `frontend/app/util/submenu-hover.ts` *(maybe)* | Hoist `createPeerRegistry()` out of `flyoutmenu.tsx` if Case A needs it too (§3.3) |
+| `schema/widgets.json` | Mirror the `children` field for editor/schema validation, if this file is hand-maintained JSON Schema rather than generated |
+
+---
+
+## 5. Open questions
+
+1. **Hoisting `createPeerRegistry()`** — currently private to
+   `flyoutmenu.tsx`. Case A (§3.3) needs the same "close my siblings"
+   behavior across pinned-bar parent slots, which live outside
+   `FlyoutMenu` entirely. Move it to `submenu-hover.ts` (alongside
+   `createSubmenuHover`, which it already composes with) so both
+   `flyoutmenu.tsx` and `action-widgets.tsx` import the same helper,
+   rather than forking a second copy.
+2. **Per-child "pin to bar directly"** (§2, §3.5) — deferred, but the
+   moment a user asks for it, `widget:pinned` needs to accept child
+   short-names as first-class entries even though they're
+   `display:hidden` in `widgets.json`. `getPinnedWidgets()`'s "is this
+   key in `wmap`" check already tolerates that (hidden ≠ absent from
+   `wmap`) — worth confirming with a test once/if this ships, not
+   blocking v1.
+3. **`children` referencing a key that's also independently pinned** —
+   e.g. a user's existing `widget:pinned` array already contains `slack`
+   from before grouping existed. Recommend: once `slack` is marked
+   `display:hidden: true` and becomes a grouped child, strip any bare
+   occurrence of it from `widget:pinned` during config load (same spirit
+   as the existing migration in `widget-pinning.md` §Migration) — otherwise
+   a stale pinned entry could render as an orphaned bar icon for a hidden
+   widget. Needs a small backend migration step alongside the `widgets.json`
+   change, not just a frontend filter.
+4. **Nested groups** (§2) — not building it, but confirm the recursive
+   shape in `FlyoutMenu`'s `SubMenu` (§3.4 option 1 borrows its structure)
+   doesn't accidentally *require* forbidding it — if `getGroupedChildKeys()`
+   walks one level deep only, a nested parent-inside-parent would silently
+   misbehave rather than clearly error. Add a load-time validation
+   (§3.1) rejecting `children` that itself resolves to another parent,
+   until nesting is an actual spec'd feature.
+
+---
+
+## 6. Testing
+
+- `action-widgets-config.test.ts` (or wherever `getPinnedWidgets`/
+  `getMoreWidgets` are covered today): grouped children excluded from both
+  flat lists; parent itself present in exactly one of the two lists per
+  its own pin state.
+- Case A: hover-open respects the 90ms delay (no flash on fast mouse
+  pass-through); diagonal move from icon into the panel doesn't close it
+  early (safe-triangle); opening one pinned parent force-closes another
+  already-open one; click toggles without requiring hover; Escape/
+  outside-click closes; child click opens the right pane and closes the
+  flyout; child right-click still shows the existing per-item menu while
+  the flyout itself stays open (matches today's More-dropdown-stays-open-
+  during-item-context-menu behavior).
+- Case B: parent row shows the chevron; hover opens sideways, flips side
+  near the window edge; parent submenu closes independently of outer More
+  dropdown; selecting a child closes both levels.
+- Responsive collapse: a pinned parent counts as one slot for width
+  measurement/clipping — verify `useWidgetBarResponsive`'s tier-3 clip
+  math is unaffected (no code change expected, but the parent's icon-only
+  tooltip should show the group label, not attempt to enumerate children).
+- Drag-reorder: dragging a pinned parent slot reorders it as a unit; no
+  drop-target logic needed inside its children (they're not on the bar).
+- Config migration (§5 item 3): a fixture `settings.json` with a bare
+  `slack` in `widget:pinned` from before grouping existed, loaded against
+  a `widgets.json` where `slack` is now a hidden grouped child — confirm
+  it's stripped rather than rendering an orphaned icon.

--- a/frontend/app/block/pane-actions.ts
+++ b/frontend/app/block/pane-actions.ts
@@ -7,6 +7,7 @@
  */
 
 import { atoms, createBlockSplitHorizontally, createBlockSplitVertically, getApi, replaceBlock } from "@/app/store/global";
+import { buildPaneWidgetMenuItems } from "@/app/window/action-widgets-config";
 import { readText as clipboardReadText, writeText as clipboardWriteText } from "@/util/clipboard";
 
 type SplitDirection = "up" | "down" | "left" | "right";
@@ -100,36 +101,21 @@ async function handleSplitPane(blockData: Block, direction: SplitDirection): Pro
 
 // ─── Replace With submenu ─────────────────────────────────────────────────────
 
-/** Non-pane widget views that should be excluded from the Replace submenu. */
-const nonPaneViews = new Set(["devtools"]);
-
 /**
- * Build a "Replace With..." submenu listing all pane-based widgets.
- * Returns an array with the submenu item + a trailing separator, or empty
- * array if no replacement widgets are available.
+ * Build a "Replace With..." submenu listing all pane-based widgets (grouped
+ * widgets — e.g. the Messengers group's Discord/Slack/etc. — nest under
+ * their parent's own label rather than each showing up individually; see
+ * buildPaneWidgetMenuItems). Returns an array with the submenu item + a
+ * trailing separator, or empty array if no replacement widgets are
+ * available.
  */
 function buildReplaceSubmenu(blockData: Block): ContextMenuItem[] {
-    const fullConfig = atoms.fullConfigAtom();
-    const widgets = fullConfig?.widgets ?? {};
-    const currentView = blockData?.meta?.view;
-
-    const items: ContextMenuItem[] = Object.values(widgets)
-        .filter((w) => {
-            const view = w.blockdef?.meta?.view;
-            if (!view || nonPaneViews.has(view)) return false;
-            if (view === currentView) return false;
-            return true;
-        })
-        .sort((a, b) => {
-            const orderA = a["display:order"] ?? 0;
-            const orderB = b["display:order"] ?? 0;
-            if (orderA !== orderB) return orderA - orderB;
-            return (a.label ?? "").localeCompare(b.label ?? "");
-        })
-        .map((widget) => ({
-            label: widget.label ?? "Unnamed",
-            click: () => void replaceBlock(blockData.oid, widget.blockdef, true),
-        }));
+    const wmap = atoms.fullConfigAtom()?.widgets ?? {};
+    const items = buildPaneWidgetMenuItems(
+        wmap,
+        (blockdef) => void replaceBlock(blockData.oid, blockdef, true),
+        { excludeView: blockData?.meta?.view }
+    );
 
     if (items.length === 0) return [];
     return [

--- a/frontend/app/block/pane-actions.ts
+++ b/frontend/app/block/pane-actions.ts
@@ -110,9 +110,12 @@ async function handleSplitPane(blockData: Block, direction: SplitDirection): Pro
  * available.
  */
 function buildReplaceSubmenu(blockData: Block): ContextMenuItem[] {
-    const wmap = atoms.fullConfigAtom()?.widgets ?? {};
+    const fullConfig = atoms.fullConfigAtom();
+    const wmap = fullConfig?.widgets ?? {};
+    const settings = fullConfig?.settings ?? {};
     const items = buildPaneWidgetMenuItems(
         wmap,
+        settings,
         (blockdef) => void replaceBlock(blockData.oid, blockdef, true),
         { excludeView: blockData?.meta?.view }
     );

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -15,7 +15,7 @@ import {
     computeMenuPosition,
     type MenuPositionResult,
 } from "@/app/util/menu-position";
-import { createSubmenuHover, type SubmenuHoverController } from "@/app/util/submenu-hover";
+import { createPeerRegistry, createSubmenuHover, type SubmenuHoverController } from "@/app/util/submenu-hover";
 
 import "./flyoutmenu.scss";
 
@@ -43,30 +43,13 @@ function styleToString(pos: MenuPositionResult): string {
     );
 }
 
-/**
- * Tracks the hover controllers of peer (same-level) menu items so entering
- * one can force-close any other peer's still-open submenu immediately —
- * matching how a native/VS-Code-style menu behaves for an explicit new
- * selection, on top of (not instead of) the safe-triangle grace period each
- * controller gives its OWN trigger-to-submenu approach. Scoped one per menu
- * level (one per MenuBody, one per SubMenu) — peers never reach across
- * levels, so a still-open descendant closes naturally via Solid unmounting
- * it when its own ancestor's <Show> flips off, not through this registry.
- */
-function createPeerRegistry() {
-    const peers = new Map<string, SubmenuHoverController>();
-    return {
-        register(key: string, hover: SubmenuHoverController) {
-            peers.set(key, hover);
-            onCleanup(() => peers.delete(key));
-        },
-        closeOthers(key: string) {
-            for (const [k, h] of peers) {
-                if (k !== key) h.close();
-            }
-        },
-    };
-}
+// createPeerRegistry moved to @/app/util/submenu-hover (hoisted so
+// action-widgets.tsx's pinned-parent flyouts (Case A, SPEC_WIDGET_BAR_
+// PARENT_SUBMENUS_2026_08_12.md §3.3) can share the same "close my
+// siblings" behavior outside of FlyoutMenu). Scoped one per menu level
+// (one per MenuBody, one per SubMenu) here — peers never reach across
+// levels, so a still-open descendant closes naturally via Solid unmounting
+// it when its own ancestor's <Show> flips off, not through this registry.
 
 type MenuProps = {
     items: MenuItem[];
@@ -327,7 +310,7 @@ const MenuBody = (props: MenuBodyProps): JSX.Element => {
                               onClose: () => props.closeSubMenu(key),
                           })
                         : null;
-                    if (hover) peers.register(key, hover);
+                    if (hover) onCleanup(peers.register(key, hover));
                     onCleanup(() => hover?.dispose());
 
                     const menuItemProps = {
@@ -522,7 +505,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                               onClose: () => props.closeSubMenu(newKey),
                           })
                         : null;
-                    if (hover) peers.register(newKey, hover);
+                    if (hover) onCleanup(peers.register(newKey, hover));
                     onCleanup(() => hover?.dispose());
 
                     const menuItemProps = {

--- a/frontend/app/tab/tabcontent.tsx
+++ b/frontend/app/tab/tabcontent.tsx
@@ -22,8 +22,10 @@ import type { JSX } from "solid-js";
  * buildPaneWidgetMenuItems.
  */
 function buildEmptyTabMenu(): ContextMenuItem[] {
-    const wmap = atoms.fullConfigAtom()?.widgets ?? {};
-    return buildPaneWidgetMenuItems(wmap, (blockdef) => void createBlock(blockdef));
+    const fullConfig = atoms.fullConfigAtom();
+    const wmap = fullConfig?.widgets ?? {};
+    const settings = fullConfig?.settings ?? {};
+    return buildPaneWidgetMenuItems(wmap, settings, (blockdef) => void createBlock(blockdef));
 }
 
 function TabContent(props: { tabId: string }): JSX.Element {

--- a/frontend/app/tab/tabcontent.tsx
+++ b/frontend/app/tab/tabcontent.tsx
@@ -11,32 +11,19 @@ import { TileLayoutContents } from "@/layout/lib/types";
 import { atoms, createBlock, getApi, getHostName, getUserName, isDev } from "@/store/global";
 import * as services from "@/store/services";
 import * as WOS from "@/store/wos";
+import { buildPaneWidgetMenuItems } from "@/app/window/action-widgets-config";
 import { createMemo, Show } from "solid-js";
 import type { JSX } from "solid-js";
 
-/** Non-pane widget views excluded from the empty-tab context menu. */
-const nonPaneViews = new Set(["devtools"]);
-
-/** Build a flat widget menu for right-clicking an empty tab (no panes). */
+/**
+ * Build a widget menu for right-clicking an empty tab (no panes). Grouped
+ * widgets (e.g. Messengers' Discord/Slack/etc.) nest under their parent's
+ * own label instead of each showing up individually — see
+ * buildPaneWidgetMenuItems.
+ */
 function buildEmptyTabMenu(): ContextMenuItem[] {
-    const fullConfig = atoms.fullConfigAtom();
-    const widgets = fullConfig?.widgets ?? {};
-
-    return Object.values(widgets)
-        .filter((w) => {
-            const view = w.blockdef?.meta?.view;
-            return view && !nonPaneViews.has(view);
-        })
-        .sort((a, b) => {
-            const orderA = a["display:order"] ?? 0;
-            const orderB = b["display:order"] ?? 0;
-            if (orderA !== orderB) return orderA - orderB;
-            return (a.label ?? "").localeCompare(b.label ?? "");
-        })
-        .map((widget) => ({
-            label: widget.label ?? "Unnamed",
-            click: () => void createBlock(widget.blockdef),
-        }));
+    const wmap = atoms.fullConfigAtom()?.widgets ?? {};
+    return buildPaneWidgetMenuItems(wmap, (blockdef) => void createBlock(blockdef));
 }
 
 function TabContent(props: { tabId: string }): JSX.Element {

--- a/frontend/app/util/submenu-hover.test.ts
+++ b/frontend/app/util/submenu-hover.test.ts
@@ -210,6 +210,44 @@ describe("createSubmenuHover", () => {
         });
     });
 
+    describe("openNow", () => {
+        it("opens immediately, bypassing the open delay", () => {
+            controller.openNow();
+            expect(onOpen).toHaveBeenCalledOnce();
+        });
+
+        it("cancels a pending delayed open first (no double onOpen)", () => {
+            controller.onTriggerEnter();
+            vi.advanceTimersByTime(50); // mid-delay, not yet open
+            controller.openNow();
+            expect(onOpen).toHaveBeenCalledOnce();
+            vi.advanceTimersByTime(100); // the original delayed open, if still pending, would fire here
+            expect(onOpen).toHaveBeenCalledOnce();
+        });
+
+        it("is a no-op when already open (no double onOpen)", () => {
+            controller.openNow();
+            controller.openNow();
+            expect(onOpen).toHaveBeenCalledOnce();
+        });
+
+        // The actual bug this exists to fix (reagent P1, PR #2633): a
+        // click-driven open must leave the controller's state truthful so a
+        // later mouse-leave still starts the normal close-intent window,
+        // instead of onTriggerLeave's `if (!isOpen) return` silently
+        // skipping it forever.
+        it("a later onTriggerLeave starts the normal close-intent window (unlike opening via external state alone)", () => {
+            controller.setSubmenuEl({ getBoundingClientRect: () => SUBMENU_RECT });
+            controller.openNow();
+            expect(onOpen).toHaveBeenCalledOnce();
+
+            controller.onTriggerLeave({ clientX: 250, clientY: 200 });
+            moveTo(250, 0); // straight away from the submenu — outside the safe triangle
+            vi.advanceTimersByTime(10);
+            expect(onClose).toHaveBeenCalledOnce();
+        });
+    });
+
     describe("dispose", () => {
         it("closes an open submenu immediately, same as close()", () => {
             controller.setSubmenuEl({ getBoundingClientRect: () => SUBMENU_RECT });

--- a/frontend/app/util/submenu-hover.ts
+++ b/frontend/app/util/submenu-hover.ts
@@ -214,3 +214,39 @@ export function createSubmenuHover(opts: SubmenuHoverOptions): SubmenuHoverContr
         },
     };
 }
+
+export interface PeerRegistry {
+    /**
+     * Register a peer's hover controller. Returns an unregister function —
+     * callers own their own cleanup (e.g. Solid's `onCleanup(unregister)`)
+     * since this module stays framework-agnostic.
+     */
+    register(key: string, hover: SubmenuHoverController): () => void;
+    /** Force-close every registered peer except `key`. */
+    closeOthers(key: string): void;
+}
+
+/**
+ * Tracks the hover controllers of peer (same-level) menu items/slots so
+ * entering one can force-close any other peer's still-open submenu
+ * immediately — matching how a native/VS-Code-style menu behaves for an
+ * explicit new selection, on top of (not instead of) the safe-triangle
+ * grace period each controller gives its OWN trigger-to-submenu approach.
+ * Scoped to whatever the caller considers one "level" — one per MenuBody,
+ * one per SubMenu, one per pinned-widget-bar row of parent slots. Peers
+ * never reach across levels/scopes a caller doesn't register together.
+ */
+export function createPeerRegistry(): PeerRegistry {
+    const peers = new Map<string, SubmenuHoverController>();
+    return {
+        register(key, hover) {
+            peers.set(key, hover);
+            return () => peers.delete(key);
+        },
+        closeOthers(key) {
+            for (const [k, h] of peers) {
+                if (k !== key) h.close();
+            }
+        },
+    };
+}

--- a/frontend/app/util/submenu-hover.ts
+++ b/frontend/app/util/submenu-hover.ts
@@ -55,6 +55,18 @@ export interface SubmenuHoverController {
      * reusable for a future onTriggerEnter (unlike dispose()).
      */
     close(): void;
+    /**
+     * Force-open now, bypassing the open delay — the click-to-open
+     * counterpart to close(). Without this, a caller that opens by setting
+     * its own external state directly (rather than through onTriggerEnter)
+     * leaves `isOpen` internally false; the next onTriggerLeave then no-ops
+     * (`if (!isOpen) return`) since nothing ever recorded the open, so the
+     * safe-triangle close-intent never starts and the submenu is stuck open
+     * until an unrelated close path (outside click, Escape, re-click) fires.
+     * Calling this instead keeps internal state truthful, so a later mouse
+     * leave closes normally like any hover-opened submenu.
+     */
+    openNow(): void;
     /** Tear down all timers/listeners. Call on unmount / menu close. */
     dispose(): void;
 }
@@ -200,6 +212,14 @@ export function createSubmenuHover(opts: SubmenuHoverOptions): SubmenuHoverContr
         close() {
             clearOpenTimer();
             doClose();
+        },
+
+        openNow() {
+            clearOpenTimer();
+            cancelPendingClose();
+            if (isOpen) return;
+            isOpen = true;
+            opts.onOpen();
         },
 
         // Same as close() — if this was open, onClose() MUST fire so the

--- a/frontend/app/view/launcher/launcher.tsx
+++ b/frontend/app/view/launcher/launcher.tsx
@@ -3,6 +3,7 @@
 
 import logoUrl from "@/app/asset/logo.svg?url";
 import { atoms, replaceBlock } from "@/app/store/global";
+import { getChildWidgets } from "@/app/window/action-widgets-config";
 import { checkKeyPressed, keydownWrapper } from "@/util/keyutil";
 import { isBlank, makeIconClass, createSignalAtom } from "@/util/util";
 import type { SignalAtom } from "@/util/util";
@@ -29,6 +30,16 @@ export class LauncherViewModel implements ViewModel {
     searchTerm: SignalAtom<string>;
     selectedIndex: SignalAtom<number>;
     containerSize: SignalAtom<{ width: number; height: number }>;
+    /**
+     * A parent widget (e.g. "Messengers") the grid has drilled into — its
+     * children replace the top-level grid until Escape/Back pops back out.
+     * SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md doesn't cover this
+     * surface directly, but a parent has no blockdef of its own to launch,
+     * so clicking/Entering one has to do *something* other than try to open
+     * an empty pane — drill-down mirrors how every other picker in the app
+     * now reaches a group's children (nested submenu / flyout).
+     */
+    activeParent: SignalAtom<WidgetConfigType | null>;
     gridLayout: GridLayoutType = null;
     inputRef: { current: HTMLInputElement | null } = { current: null };
 
@@ -40,16 +51,38 @@ export class LauncherViewModel implements ViewModel {
         this.searchTerm = createSignalAtom("");
         this.selectedIndex = createSignalAtom(0);
         this.containerSize = createSignalAtom({ width: 0, height: 0 });
+        this.activeParent = createSignalAtom<WidgetConfigType | null>(null);
     }
 
     filteredWidgets(): WidgetConfigType[] {
         const searchTerm = this.searchTerm();
-        const widgets = sortByDisplayOrder(atoms.fullConfigAtom()?.widgets || {});
-        return widgets.filter(
-            (widget) =>
-                !widget["display:hidden"] &&
-                (!searchTerm || widget.label?.toLowerCase().includes(searchTerm.toLowerCase()))
+        const wmap = atoms.fullConfigAtom()?.widgets || {};
+        const parent = this.activeParent();
+
+        const source = parent
+            ? getChildWidgets(parent, wmap).map((c) => c.widget)
+            : sortByDisplayOrder(wmap).filter((widget) => !widget["display:hidden"]);
+
+        return source.filter(
+            (widget) => !searchTerm || widget.label?.toLowerCase().includes(searchTerm.toLowerCase())
         );
+    }
+
+    /** True when a tile click/Enter should drill down instead of opening a pane. */
+    isParentWidget(widget: WidgetConfigType): boolean {
+        return (widget.children?.length ?? 0) > 0;
+    }
+
+    drillInto(widget: WidgetConfigType): void {
+        this.activeParent._set(widget);
+        this.searchTerm._set("");
+        this.selectedIndex._set(0);
+    }
+
+    goBack(): void {
+        this.activeParent._set(null);
+        this.searchTerm._set("");
+        this.selectedIndex._set(0);
     }
 
     giveFocus(): boolean {
@@ -103,14 +136,26 @@ export class LauncherViewModel implements ViewModel {
             return true;
         }
         if (checkKeyPressed(e, "Escape")) {
-            this.searchTerm._set("");
-            this.selectedIndex._set(0);
+            // Two-stage: clear an in-progress search first; only pop back out
+            // of a drilled-into group once the search box is already empty,
+            // so "Escape, Escape" from a filtered child list doesn't skip
+            // straight past the group's own child list.
+            if (this.searchTerm() === "" && this.activeParent() !== null) {
+                this.goBack();
+            } else {
+                this.searchTerm._set("");
+                this.selectedIndex._set(0);
+            }
             return true;
         }
         return false;
     }
 
     async handleWidgetSelect(widget: WidgetConfigType) {
+        if (this.isParentWidget(widget)) {
+            this.drillInto(widget);
+            return;
+        }
         try {
             await replaceBlock(this.blockId, widget.blockdef, true);
         } catch (error) {
@@ -222,6 +267,21 @@ function LauncherView(props: ViewComponentProps<LauncherViewModel>): JSX.Element
                 </div>
             </Show>
 
+            {/* Breadcrumb — shown only once drilled into a parent widget
+                (e.g. "Messengers"). Escape does the same thing; this is the
+                mouse-driven equivalent for discoverability. */}
+            <Show when={model.activeParent()}>
+                {(parent) => (
+                    <div
+                        class="mb-2 flex items-center gap-1 text-secondary text-xs cursor-pointer hover:text-white"
+                        onClick={() => model.goBack()}
+                    >
+                        <i class="fa-sharp fa-solid fa-chevron-left" />
+                        <span>{parent().label}</span>
+                    </div>
+                )}
+            </Show>
+
             {/* Grid of widgets */}
             <div
                 class="grid gap-4 justify-center"
@@ -241,8 +301,11 @@ function LauncherView(props: ViewComponentProps<LauncherViewModel>): JSX.Element
                             )}
                             style={{ width: `${finalTileWidth()}px`, height: `${finalTileHeight()}px` }}
                         >
-                            <div style={{ color: widget.color }}>
+                            <div class="relative" style={{ color: widget.color }}>
                                 <i class={makeIconClass(widget.icon, true, { defaultIcon: "browser" })} />
+                                <Show when={model.isParentWidget(widget)}>
+                                    <i class="fa-sharp fa-solid fa-chevron-right absolute -right-2.5 top-1/2 -translate-y-1/2 text-[8px] opacity-60" />
+                                </Show>
                             </div>
                             <Show when={gridLayout().showLabel && !isBlank(widget.label)}>
                                 <div class="mt-1 w-full text-[11px] leading-4 overflow-hidden text-ellipsis whitespace-nowrap">

--- a/frontend/app/view/launcher/launcher.tsx
+++ b/frontend/app/view/launcher/launcher.tsx
@@ -3,7 +3,7 @@
 
 import logoUrl from "@/app/asset/logo.svg?url";
 import { atoms, replaceBlock } from "@/app/store/global";
-import { getChildWidgets } from "@/app/window/action-widgets-config";
+import { getChildWidgets, getPinnedKeys } from "@/app/window/action-widgets-config";
 import { checkKeyPressed, keydownWrapper } from "@/util/keyutil";
 import { isBlank, makeIconClass, createSignalAtom } from "@/util/util";
 import type { SignalAtom } from "@/util/util";
@@ -11,11 +11,13 @@ import clsx from "clsx";
 import { createEffect, createMemo, createSignal, For, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 
-function sortByDisplayOrder(wmap: { [key: string]: WidgetConfigType } | null | undefined): WidgetConfigType[] {
+function sortByDisplayOrder(
+    wmap: { [key: string]: WidgetConfigType } | null | undefined
+): [string, WidgetConfigType][] {
     if (!wmap) return [];
-    const wlist = Object.values(wmap);
-    wlist.sort((a, b) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));
-    return wlist;
+    const entries = Object.entries(wmap);
+    entries.sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));
+    return entries;
 }
 
 type GridLayoutType = { columns: number; tileWidth: number; tileHeight: number; showLabel: boolean };
@@ -56,12 +58,28 @@ export class LauncherViewModel implements ViewModel {
 
     filteredWidgets(): WidgetConfigType[] {
         const searchTerm = this.searchTerm();
-        const wmap = atoms.fullConfigAtom()?.widgets || {};
+        const fullConfig = atoms.fullConfigAtom();
+        const wmap = fullConfig?.widgets || {};
+        const settings = fullConfig?.settings || {};
         const parent = this.activeParent();
 
-        const source = parent
-            ? getChildWidgets(parent, wmap).map((c) => c.widget)
-            : sortByDisplayOrder(wmap).filter((widget) => !widget["display:hidden"]);
+        let source: WidgetConfigType[];
+        if (parent) {
+            // Drilled into a group — a child that's since been individually
+            // pinned (promoted out via its own "Pin to bar") is excluded
+            // here; it now shows at the top level instead, not doubled up.
+            source = getChildWidgets(parent, wmap, settings).map((c) => c.widget);
+        } else {
+            // display:hidden normally keeps a grouped child out of this
+            // top-level grid — but an individually pinned child (promoted
+            // out of its group) overrides that, same as it overrides the
+            // group-hiding default everywhere else (see
+            // getEffectiveGroupedChildKeys).
+            const pinnedSet = new Set(getPinnedKeys(settings, wmap));
+            source = sortByDisplayOrder(wmap).filter(
+                ([key, widget]) => !widget["display:hidden"] || pinnedSet.has(key.replace("defwidget@", ""))
+            ).map(([, widget]) => widget);
+        }
 
         return source.filter(
             (widget) => !searchTerm || widget.label?.toLowerCase().includes(searchTerm.toLowerCase())

--- a/frontend/app/window/action-widgets-config.test.ts
+++ b/frontend/app/window/action-widgets-config.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
     buildPaneWidgetMenuItems,
     getChildWidgets,
+    getEffectiveGroupedChildKeys,
     getGroupedChildKeys,
     getMoreWidgets,
     getPinnedKeys,
@@ -53,6 +54,33 @@ describe("getGroupedChildKeys", () => {
     it("tolerates a missing/undefined wmap", () => {
         expect(getGroupedChildKeys(undefined as unknown as Record<string, WidgetConfigType>).size).toBe(0);
     });
+
+    it("is unaffected by pin state — purely structural", () => {
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["slack"] };
+        expect(getGroupedChildKeys(wmap)).toEqual(new Set(["discord", "slack"]));
+        void settings; // getGroupedChildKeys doesn't take settings at all
+    });
+});
+
+describe("getEffectiveGroupedChildKeys", () => {
+    it("matches getGroupedChildKeys when nothing is individually pinned", () => {
+        const wmap = messengersWmap();
+        expect(getEffectiveGroupedChildKeys(wmap, {})).toEqual(new Set(["discord", "slack"]));
+    });
+
+    it("drops a child that's individually pinned via widget:pinned — it's been promoted out", () => {
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["agent", "slack"] };
+        expect(getEffectiveGroupedChildKeys(wmap, settings)).toEqual(new Set(["discord"]));
+    });
+
+    it("re-includes a child once it's removed from widget:pinned (unpinned)", () => {
+        const wmap = messengersWmap();
+        expect(getEffectiveGroupedChildKeys(wmap, { "widget:pinned": ["agent"] })).toEqual(
+            new Set(["discord", "slack"])
+        );
+    });
 });
 
 describe("getChildWidgets", () => {
@@ -71,6 +99,19 @@ describe("getChildWidgets", () => {
 
     it("returns an empty array for a leaf widget (no children)", () => {
         expect(getChildWidgets(widget(), {})).toEqual([]);
+    });
+
+    it("without settings, includes every declared child regardless of pin state", () => {
+        const wmap = messengersWmap();
+        const resolved = getChildWidgets(wmap["defwidget@messengers"], wmap);
+        expect(resolved.map((c) => c.key)).toEqual(["defwidget@discord", "defwidget@slack"]);
+    });
+
+    it("with settings, excludes a child that's been individually pinned (promoted out)", () => {
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["slack"] };
+        const resolved = getChildWidgets(wmap["defwidget@messengers"], wmap, settings);
+        expect(resolved.map((c) => c.key)).toEqual(["defwidget@discord"]);
     });
 });
 
@@ -102,15 +143,50 @@ describe("grouped children excluded from pinned/more (display:pinned defaults)",
     });
 });
 
-describe("grouped children excluded from pinned/more (widget:pinned override)", () => {
-    it("a stale bare child short-name in widget:pinned is still excluded", () => {
-        // A user's `widget:pinned` predating the grouping still lists "slack"
-        // directly — getPinnedKeys must not let it through even though it's
-        // present in the settings array (SPEC §5 open question 3).
+describe("individually pinning a grouped child (promote out of the group)", () => {
+    it("a child explicitly listed in widget:pinned is honored — it shows as a standalone pinned widget", () => {
+        // This is the actual feature: right-clicking "Slack" inside the
+        // Messengers flyout and choosing "Pin to bar" writes "slack" into
+        // widget:pinned exactly like pinning any other widget. It must NOT
+        // be stripped back out.
         const wmap = messengersWmap();
         const settings = { "widget:pinned": ["agent", "slack"] };
-        expect(getPinnedKeys(settings, wmap)).toEqual(["agent"]);
+        expect(getPinnedKeys(settings, wmap)).toEqual(["agent", "slack"]);
+        expect(getPinnedWidgets(settings, wmap).map((p) => p.key)).toContain("defwidget@slack");
+    });
+
+    it("a promoted child never also appears in getMoreWidgets", () => {
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["slack"] };
         expect(getMoreWidgets(settings, wmap).map((m) => m.key)).not.toContain("defwidget@slack");
+    });
+
+    it("a promoted child is dropped from its parent's own resolved children (getChildWidgets + settings)", () => {
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["slack"] };
+        const resolved = getChildWidgets(wmap["defwidget@messengers"], wmap, settings);
+        expect(resolved.map((c) => c.key)).toEqual(["defwidget@discord"]);
+    });
+
+    it("a non-promoted sibling stays reachable only through the group", () => {
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["slack"] };
+        expect(getPinnedKeys(settings, wmap)).not.toContain("discord");
+        expect(getMoreWidgets(settings, wmap).map((m) => m.key)).not.toContain("defwidget@discord");
+    });
+
+    it("unpinning reverts the child to living only inside its parent group, regardless of the parent's own pin state", () => {
+        const wmap = messengersWmap();
+        // Slack was pinned, now it's unpinned (removed from widget:pinned) —
+        // "goes back into Messengers" — this holds whether Messengers itself
+        // is pinned or not.
+        for (const settings of [{ "widget:pinned": [] as string[] }, { "widget:pinned": ["messengers"] }]) {
+            expect(getPinnedKeys(settings, wmap)).not.toContain("slack");
+            expect(getMoreWidgets(settings, wmap).map((m) => m.key)).not.toContain("defwidget@slack");
+            expect(getChildWidgets(wmap["defwidget@messengers"], wmap, settings).map((c) => c.key)).toContain(
+                "defwidget@slack"
+            );
+        }
     });
 });
 
@@ -127,27 +203,27 @@ describe("buildPaneWidgetMenuItems", () => {
     }
 
     it("excludes grouped children as flat top-level entries", () => {
-        const items = buildPaneWidgetMenuItems(paneWmap(), vi.fn());
+        const items = buildPaneWidgetMenuItems(paneWmap(), {}, vi.fn());
         expect(items.map((i) => i.label)).not.toContain("Discord");
         expect(items.map((i) => i.label)).not.toContain("Slack");
     });
 
     it("nests a parent's children under its own label as a native submenu", () => {
-        const items = buildPaneWidgetMenuItems(paneWmap(), vi.fn());
+        const items = buildPaneWidgetMenuItems(paneWmap(), {}, vi.fn());
         const messengers = items.find((i) => i.label === "Messengers");
         expect(messengers?.type).toBe("submenu");
         expect(messengers?.submenu?.map((c) => c.label)).toEqual(["Discord", "Slack"]);
     });
 
     it("excludes non-pane views (devtools) everywhere, including inside a submenu", () => {
-        const items = buildPaneWidgetMenuItems(paneWmap(), vi.fn());
+        const items = buildPaneWidgetMenuItems(paneWmap(), {}, vi.fn());
         expect(items.map((i) => i.label)).not.toContain("DevTools");
     });
 
     it("excludes the current view via opts.excludeView (leaf) and from inside a submenu", () => {
         const wmap = paneWmap();
         wmap["defwidget@discord"].blockdef = { meta: { view: "editor" } };
-        const items = buildPaneWidgetMenuItems(wmap, vi.fn(), { excludeView: "editor" });
+        const items = buildPaneWidgetMenuItems(wmap, {}, vi.fn(), { excludeView: "editor" });
         expect(items.map((i) => i.label)).not.toContain("Editor");
         const messengers = items.find((i) => i.label === "Messengers");
         expect(messengers?.submenu?.map((c) => c.label)).toEqual(["Slack"]);
@@ -157,15 +233,23 @@ describe("buildPaneWidgetMenuItems", () => {
         const wmap = paneWmap();
         wmap["defwidget@discord"].blockdef = { meta: { view: "devtools" } };
         wmap["defwidget@slack"].blockdef = { meta: { view: "devtools" } };
-        const items = buildPaneWidgetMenuItems(wmap, vi.fn());
+        const items = buildPaneWidgetMenuItems(wmap, {}, vi.fn());
         expect(items.map((i) => i.label)).not.toContain("Messengers");
     });
 
     it("invokes onSelect with the chosen widget's blockdef", () => {
         const onSelect = vi.fn();
-        const items = buildPaneWidgetMenuItems(paneWmap(), onSelect);
+        const items = buildPaneWidgetMenuItems(paneWmap(), {}, onSelect);
         const editor = items.find((i) => i.label === "Editor")!;
         editor.click?.();
         expect(onSelect).toHaveBeenCalledWith(paneWmap()["defwidget@editor"].blockdef);
+    });
+
+    it("a promoted child shows as a flat entry instead of nested under its parent", () => {
+        const settings = { "widget:pinned": ["slack"] };
+        const items = buildPaneWidgetMenuItems(paneWmap(), settings, vi.fn());
+        expect(items.map((i) => i.label)).toContain("Slack");
+        const messengers = items.find((i) => i.label === "Messengers");
+        expect(messengers?.submenu?.map((c) => c.label)).toEqual(["Discord"]);
     });
 });

--- a/frontend/app/window/action-widgets-config.test.ts
+++ b/frontend/app/window/action-widgets-config.test.ts
@@ -1,8 +1,9 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+    buildPaneWidgetMenuItems,
     getChildWidgets,
     getGroupedChildKeys,
     getMoreWidgets,
@@ -110,5 +111,61 @@ describe("grouped children excluded from pinned/more (widget:pinned override)", 
         const settings = { "widget:pinned": ["agent", "slack"] };
         expect(getPinnedKeys(settings, wmap)).toEqual(["agent"]);
         expect(getMoreWidgets(settings, wmap).map((m) => m.key)).not.toContain("defwidget@slack");
+    });
+});
+
+describe("buildPaneWidgetMenuItems", () => {
+    // Replace With... / empty-tab menu — grouped children must not show up
+    // individually, but must still be reachable via a nested submenu under
+    // their parent's own label.
+    function paneWmap(): Record<string, WidgetConfigType> {
+        return {
+            ...messengersWmap(),
+            "defwidget@devtools": widget({ label: "DevTools", blockdef: { meta: { view: "devtools" } } }),
+            "defwidget@editor": widget({ "display:order": 6, label: "Editor", blockdef: { meta: { view: "editor" } } }),
+        };
+    }
+
+    it("excludes grouped children as flat top-level entries", () => {
+        const items = buildPaneWidgetMenuItems(paneWmap(), vi.fn());
+        expect(items.map((i) => i.label)).not.toContain("Discord");
+        expect(items.map((i) => i.label)).not.toContain("Slack");
+    });
+
+    it("nests a parent's children under its own label as a native submenu", () => {
+        const items = buildPaneWidgetMenuItems(paneWmap(), vi.fn());
+        const messengers = items.find((i) => i.label === "Messengers");
+        expect(messengers?.type).toBe("submenu");
+        expect(messengers?.submenu?.map((c) => c.label)).toEqual(["Discord", "Slack"]);
+    });
+
+    it("excludes non-pane views (devtools) everywhere, including inside a submenu", () => {
+        const items = buildPaneWidgetMenuItems(paneWmap(), vi.fn());
+        expect(items.map((i) => i.label)).not.toContain("DevTools");
+    });
+
+    it("excludes the current view via opts.excludeView (leaf) and from inside a submenu", () => {
+        const wmap = paneWmap();
+        wmap["defwidget@discord"].blockdef = { meta: { view: "editor" } };
+        const items = buildPaneWidgetMenuItems(wmap, vi.fn(), { excludeView: "editor" });
+        expect(items.map((i) => i.label)).not.toContain("Editor");
+        const messengers = items.find((i) => i.label === "Messengers");
+        expect(messengers?.submenu?.map((c) => c.label)).toEqual(["Slack"]);
+    });
+
+    it("omits a parent entirely once every child is filtered out", () => {
+        const wmap = paneWmap();
+        wmap["defwidget@discord"].blockdef = { meta: { view: "devtools" } };
+        wmap["defwidget@slack"].blockdef = { meta: { view: "devtools" } };
+        const items = buildPaneWidgetMenuItems(wmap, vi.fn());
+        expect(items.map((i) => i.label)).not.toContain("Messengers");
+    });
+
+    it("invokes onSelect with the chosen widget's blockdef", () => {
+        const onSelect = vi.fn();
+        const items = buildPaneWidgetMenuItems(paneWmap(), onSelect);
+        const editor = items.find((i) => i.label === "Editor")!;
+        editor.click?.();
+        expect(onSelect).toHaveBeenCalledWith(paneWmap()["defwidget@editor"].blockdef);
     });
 });

--- a/frontend/app/window/action-widgets-config.test.ts
+++ b/frontend/app/window/action-widgets-config.test.ts
@@ -1,0 +1,114 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+    getChildWidgets,
+    getGroupedChildKeys,
+    getMoreWidgets,
+    getPinnedKeys,
+    getPinnedWidgets,
+} from "./action-widgets-config";
+
+function widget(overrides: Partial<WidgetConfigType> = {}): WidgetConfigType {
+    return {
+        "display:order": 0,
+        "display:pinned": false,
+        icon: "circle",
+        label: "Widget",
+        blockdef: { meta: { view: "browser" } },
+        ...overrides,
+    } as WidgetConfigType;
+}
+
+// Messengers fixture — the concrete first parent/children set from
+// SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md.
+function messengersWmap(): Record<string, WidgetConfigType> {
+    return {
+        "defwidget@agent": widget({ "display:order": 1, "display:pinned": true, label: "Agent" }),
+        "defwidget@messengers": widget({
+            "display:order": 10,
+            "display:pinned": false,
+            label: "Messengers",
+            children: ["discord", "slack"],
+            blockdef: { files: {}, meta: {} },
+        }),
+        "defwidget@discord": widget({ "display:order": 10, "display:hidden": true, label: "Discord" }),
+        "defwidget@slack": widget({ "display:order": 11, "display:hidden": true, label: "Slack" }),
+        "defwidget@help": widget({ "display:order": 9, label: "Help" }),
+    };
+}
+
+describe("getGroupedChildKeys", () => {
+    it("collects every short-name across all parents' children lists", () => {
+        expect(getGroupedChildKeys(messengersWmap())).toEqual(new Set(["discord", "slack"]));
+    });
+
+    it("returns an empty set when nothing is grouped", () => {
+        const wmap = { "defwidget@agent": widget() };
+        expect(getGroupedChildKeys(wmap).size).toBe(0);
+    });
+
+    it("tolerates a missing/undefined wmap", () => {
+        expect(getGroupedChildKeys(undefined as unknown as Record<string, WidgetConfigType>).size).toBe(0);
+    });
+});
+
+describe("getChildWidgets", () => {
+    it("resolves children in declared order", () => {
+        const wmap = messengersWmap();
+        const resolved = getChildWidgets(wmap["defwidget@messengers"], wmap);
+        expect(resolved.map((c) => c.key)).toEqual(["defwidget@discord", "defwidget@slack"]);
+    });
+
+    it("skips a child short-name that doesn't resolve to a real widget", () => {
+        const wmap = messengersWmap();
+        const parent = widget({ children: ["discord", "does-not-exist"] });
+        const resolved = getChildWidgets(parent, wmap);
+        expect(resolved.map((c) => c.key)).toEqual(["defwidget@discord"]);
+    });
+
+    it("returns an empty array for a leaf widget (no children)", () => {
+        expect(getChildWidgets(widget(), {})).toEqual([]);
+    });
+});
+
+describe("grouped children excluded from pinned/more (display:pinned defaults)", () => {
+    it("never appear in getPinnedWidgets even if individually display:pinned", () => {
+        const wmap = messengersWmap();
+        wmap["defwidget@discord"]["display:pinned"] = true;
+        const pinned = getPinnedWidgets({}, wmap);
+        expect(pinned.map((p) => p.key)).not.toContain("defwidget@discord");
+    });
+
+    it("never appear in getMoreWidgets", () => {
+        const more = getMoreWidgets({}, messengersWmap());
+        expect(more.map((m) => m.key)).not.toContain("defwidget@discord");
+        expect(more.map((m) => m.key)).not.toContain("defwidget@slack");
+    });
+
+    it("the parent itself is present in exactly one of pinned/more, per its own pin state", () => {
+        const wmap = messengersWmap();
+
+        const unpinned = { pinned: getPinnedWidgets({}, wmap), more: getMoreWidgets({}, wmap) };
+        expect(unpinned.pinned.map((p) => p.key)).not.toContain("defwidget@messengers");
+        expect(unpinned.more.map((m) => m.key)).toContain("defwidget@messengers");
+
+        const settings = { "widget:pinned": ["messengers"] };
+        const pinned = { pinned: getPinnedWidgets(settings, wmap), more: getMoreWidgets(settings, wmap) };
+        expect(pinned.pinned.map((p) => p.key)).toContain("defwidget@messengers");
+        expect(pinned.more.map((m) => m.key)).not.toContain("defwidget@messengers");
+    });
+});
+
+describe("grouped children excluded from pinned/more (widget:pinned override)", () => {
+    it("a stale bare child short-name in widget:pinned is still excluded", () => {
+        // A user's `widget:pinned` predating the grouping still lists "slack"
+        // directly — getPinnedKeys must not let it through even though it's
+        // present in the settings array (SPEC §5 open question 3).
+        const wmap = messengersWmap();
+        const settings = { "widget:pinned": ["agent", "slack"] };
+        expect(getPinnedKeys(settings, wmap)).toEqual(["agent"]);
+        expect(getMoreWidgets(settings, wmap).map((m) => m.key)).not.toContain("defwidget@slack");
+    });
+});

--- a/frontend/app/window/action-widgets-config.ts
+++ b/frontend/app/window/action-widgets-config.ts
@@ -17,11 +17,12 @@ import { fireAndForget } from "@/util/util";
 
 /**
  * Short-names (no "defwidget@" prefix) that appear in some widget's
- * `children` list — i.e. every grouped child across all parent widgets.
- * These must never appear as their own top-level row (pinned or in More);
- * they're only reachable by expanding their parent's submenu. A parent
- * itself is never in this set unless groups are nested (out of scope —
- * see SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md §2).
+ * `children` list — i.e. every grouped child across all parent widgets,
+ * purely structural (independent of pin state; see
+ * getEffectiveGroupedChildKeys for the pin-state-aware version most
+ * callers actually want). A parent itself is never in this set unless
+ * groups are nested (out of scope — see
+ * SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md §2).
  */
 export function getGroupedChildKeys(wmap: Record<string, WidgetConfigType>): Set<string> {
     const grouped = new Set<string>();
@@ -31,16 +32,55 @@ export function getGroupedChildKeys(wmap: Record<string, WidgetConfigType>): Set
     return grouped;
 }
 
+/** True if `shortName` is individually pinned via widget:pinned — i.e. promoted out of its parent group. */
+function isIndividuallyPinned(shortName: string, settings: Record<string, any>): boolean {
+    const pinned: string[] | undefined = settings?.["widget:pinned"];
+    return pinned !== undefined && pinned.includes(shortName);
+}
+
+/**
+ * Grouped short-names that should stay hidden from every flat top-level
+ * enumeration (pinned bar, More, Pin Widgets, Replace With, the Launcher
+ * grid, ...) — i.e. structurally a child (getGroupedChildKeys) AND NOT
+ * individually pinned.
+ *
+ * A user can right-click a child inside its parent's flyout/submenu and
+ * "Pin to bar" it — that PROMOTES it out of the group: it becomes a normal
+ * standalone widget everywhere (shows on the bar/in More/checked in Pin
+ * Widgets, like any other pinned widget) and drops out of its parent's own
+ * children list, so it's never shown in two places at once. "Unpin from
+ * bar" reverses this — the child goes back to being reachable only through
+ * its parent, regardless of whether the parent itself is pinned.
+ */
+export function getEffectiveGroupedChildKeys(
+    wmap: Record<string, WidgetConfigType>,
+    settings: Record<string, any>
+): Set<string> {
+    const grouped = getGroupedChildKeys(wmap);
+    const effective = new Set<string>();
+    for (const shortName of grouped) {
+        if (!isIndividuallyPinned(shortName, settings)) effective.add(shortName);
+    }
+    return effective;
+}
+
 /**
  * Resolve a parent widget's children to their full widget defs, in the
  * order declared by `children`. Skips any short-name that doesn't resolve
  * (e.g. a stale/typo'd entry in widgets.json).
+ *
+ * When `settings` is passed, a child that's currently individually pinned
+ * (promoted out of the group — see getEffectiveGroupedChildKeys) is
+ * excluded here too, so it doesn't render both as its own standalone entry
+ * AND inside its old parent's flyout/submenu at the same time.
  */
 export function getChildWidgets(
     widget: WidgetConfigType,
-    wmap: Record<string, WidgetConfigType>
+    wmap: Record<string, WidgetConfigType>,
+    settings?: Record<string, any>
 ): { key: string; widget: WidgetConfigType }[] {
     return (widget.children ?? [])
+        .filter((shortName) => !settings || !isIndividuallyPinned(shortName, settings))
         .map((shortName) => {
             const key = `defwidget@${shortName}`;
             return { key, widget: wmap[key] };
@@ -52,22 +92,25 @@ export function getChildWidgets(
  * Return the effective pinned short-names (no "defwidget@" prefix), in order.
  *
  * Priority:
- *  1. widget:pinned is set → authoritative
- *  2. Not set → derive from display:pinned in widget config
- *
- * Grouped children (§ getGroupedChildKeys) are always excluded — they're
- * only reachable through their parent's submenu, never as a standalone
- * pinned entry.
+ *  1. widget:pinned is set → authoritative. A grouped child listed here IS
+ *     honored (not stripped) — that's exactly how an individual child gets
+ *     promoted out of its parent group onto the bar (see
+ *     getEffectiveGroupedChildKeys).
+ *  2. Not set → derive from display:pinned in widget config. Grouped
+ *     children are excluded here since none is ever authored
+ *     display:pinned:true — this is about fresh-install defaults, not a
+ *     user's deliberate promotion, so the group-hiding default still
+ *     applies.
  */
 export function getPinnedKeys(
     settings: Record<string, any>,
     wmap: Record<string, WidgetConfigType>
 ): string[] {
-    const grouped = getGroupedChildKeys(wmap);
     const pinned: string[] | undefined = settings["widget:pinned"];
     if (pinned !== undefined) {
-        return pinned.filter((shortName) => wmap[`defwidget@${shortName}`] != null && !grouped.has(shortName));
+        return pinned.filter((shortName) => wmap[`defwidget@${shortName}`] != null);
     }
+    const grouped = getGroupedChildKeys(wmap);
     return Object.entries(wmap)
         .filter(([key, w]) => w["display:pinned"] && !grouped.has(key.replace("defwidget@", "")))
         .sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
@@ -126,15 +169,17 @@ function comparePaneWidgets(a: WidgetConfigType, b: WidgetConfigType): number {
  * Both used to hand-roll near-identical flat `Object.values(wmap)` logic
  * that (pre SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md) never knew about
  * grouped children, so "Discord"/"Slack"/etc. showed up individually here
- * even once hidden from the widget bar. Grouped children are now excluded
- * as flat entries and instead reachable through a native nested submenu
- * under their parent's own label (`type: "submenu"`, same OS-native submenu
- * support `ContextMenuModel.showContextMenu()` already renders) — so the
- * group stays reachable everywhere a leaf widget would have been, without
- * the top-level list showing every child individually.
+ * even once hidden from the widget bar. A child NOT individually pinned is
+ * excluded as a flat entry and instead reachable through a native nested
+ * submenu under its parent's own label (`type: "submenu"`, same OS-native
+ * submenu support `ContextMenuModel.showContextMenu()` already renders). A
+ * child that IS individually pinned (promoted out of its group — see
+ * getEffectiveGroupedChildKeys) shows as a normal flat entry instead, and
+ * is dropped from its old parent's submenu so it's never listed twice.
  */
 export function buildPaneWidgetMenuItems(
     wmap: Record<string, WidgetConfigType>,
+    settings: Record<string, any>,
     onSelect: (blockdef: BlockDef) => void,
     opts: { excludeView?: string } = {}
 ): ContextMenuItem[] {
@@ -145,7 +190,7 @@ export function buildPaneWidgetMenuItems(
         return { label: widget.label ?? "Unnamed", click: () => onSelect(widget.blockdef) };
     };
 
-    const grouped = getGroupedChildKeys(wmap);
+    const grouped = getEffectiveGroupedChildKeys(wmap, settings);
     const topLevel = Object.entries(wmap)
         .filter(([key]) => !grouped.has(key.replace("defwidget@", "")))
         .map(([, widget]) => widget)
@@ -154,7 +199,7 @@ export function buildPaneWidgetMenuItems(
     const items: ContextMenuItem[] = [];
     for (const widget of topLevel) {
         if ((widget.children?.length ?? 0) > 0) {
-            const submenu = getChildWidgets(widget, wmap)
+            const submenu = getChildWidgets(widget, wmap, settings)
                 .map(({ widget: child }) => child)
                 .sort(comparePaneWidgets)
                 .map(toLeafItem)

--- a/frontend/app/window/action-widgets-config.ts
+++ b/frontend/app/window/action-widgets-config.ts
@@ -16,22 +16,60 @@ import { createBlock } from "@/store/global";
 import { fireAndForget } from "@/util/util";
 
 /**
+ * Short-names (no "defwidget@" prefix) that appear in some widget's
+ * `children` list — i.e. every grouped child across all parent widgets.
+ * These must never appear as their own top-level row (pinned or in More);
+ * they're only reachable by expanding their parent's submenu. A parent
+ * itself is never in this set unless groups are nested (out of scope —
+ * see SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md §2).
+ */
+export function getGroupedChildKeys(wmap: Record<string, WidgetConfigType>): Set<string> {
+    const grouped = new Set<string>();
+    for (const w of Object.values(wmap ?? {})) {
+        for (const child of w.children ?? []) grouped.add(child);
+    }
+    return grouped;
+}
+
+/**
+ * Resolve a parent widget's children to their full widget defs, in the
+ * order declared by `children`. Skips any short-name that doesn't resolve
+ * (e.g. a stale/typo'd entry in widgets.json).
+ */
+export function getChildWidgets(
+    widget: WidgetConfigType,
+    wmap: Record<string, WidgetConfigType>
+): { key: string; widget: WidgetConfigType }[] {
+    return (widget.children ?? [])
+        .map((shortName) => {
+            const key = `defwidget@${shortName}`;
+            return { key, widget: wmap[key] };
+        })
+        .filter((e): e is { key: string; widget: WidgetConfigType } => e.widget != null);
+}
+
+/**
  * Return the effective pinned short-names (no "defwidget@" prefix), in order.
  *
  * Priority:
  *  1. widget:pinned is set → authoritative
  *  2. Not set → derive from display:pinned in widget config
+ *
+ * Grouped children (§ getGroupedChildKeys) are always excluded — they're
+ * only reachable through their parent's submenu, never as a standalone
+ * pinned entry.
  */
 export function getPinnedKeys(
     settings: Record<string, any>,
     wmap: Record<string, WidgetConfigType>
 ): string[] {
+    const grouped = getGroupedChildKeys(wmap);
     const pinned: string[] | undefined = settings["widget:pinned"];
     if (pinned !== undefined) {
-        return pinned.filter((shortName) => wmap[`defwidget@${shortName}`] != null);
+        return pinned.filter((shortName) => wmap[`defwidget@${shortName}`] != null && !grouped.has(shortName));
     }
     return Object.entries(wmap)
-        .filter(([, w]) => w["display:pinned"])
+        .filter(([key, w]) => w["display:pinned"] && !grouped.has(key.replace("defwidget@", "")))
         .sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
         .map(([key]) => key.replace("defwidget@", ""));
 }
@@ -55,8 +93,12 @@ export function getMoreWidgets(
 ): { key: string; widget: WidgetConfigType }[] {
     if (!wmap) return [];
     const pinnedSet = new Set(getPinnedKeys(settings, wmap));
+    const grouped = getGroupedChildKeys(wmap);
     return Object.entries(wmap)
-        .filter(([key]) => !pinnedSet.has(key.replace("defwidget@", "")))
+        .filter(([key]) => {
+            const shortName = key.replace("defwidget@", "");
+            return !pinnedSet.has(shortName) && !grouped.has(shortName);
+        })
         .sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
         .map(([key, widget]) => ({ key, widget }));
 }

--- a/frontend/app/window/action-widgets-config.ts
+++ b/frontend/app/window/action-widgets-config.ts
@@ -103,6 +103,73 @@ export function getMoreWidgets(
         .map(([key, widget]) => ({ key, widget }));
 }
 
+// ── Pane-widget pickers (Replace With..., empty-tab menu) ──────────────────────
+
+/** Non-pane widget views excluded from any pane-widget picker (Replace With, empty-tab menu). */
+const NON_PANE_WIDGET_VIEWS = new Set(["devtools"]);
+
+function paneWidgetSortKey(w: WidgetConfigType): [number, string] {
+    return [w["display:order"] ?? 0, w.label ?? ""];
+}
+
+function comparePaneWidgets(a: WidgetConfigType, b: WidgetConfigType): number {
+    const [orderA, labelA] = paneWidgetSortKey(a);
+    const [orderB, labelB] = paneWidgetSortKey(b);
+    if (orderA !== orderB) return orderA - orderB;
+    return labelA.localeCompare(labelB);
+}
+
+/**
+ * Build the menu items for a "pick a pane widget to open here" surface —
+ * shared by the "Replace With..." pane context-menu submenu
+ * (`pane-actions.ts`) and the empty-tab right-click menu (`tabcontent.tsx`).
+ * Both used to hand-roll near-identical flat `Object.values(wmap)` logic
+ * that (pre SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md) never knew about
+ * grouped children, so "Discord"/"Slack"/etc. showed up individually here
+ * even once hidden from the widget bar. Grouped children are now excluded
+ * as flat entries and instead reachable through a native nested submenu
+ * under their parent's own label (`type: "submenu"`, same OS-native submenu
+ * support `ContextMenuModel.showContextMenu()` already renders) — so the
+ * group stays reachable everywhere a leaf widget would have been, without
+ * the top-level list showing every child individually.
+ */
+export function buildPaneWidgetMenuItems(
+    wmap: Record<string, WidgetConfigType>,
+    onSelect: (blockdef: BlockDef) => void,
+    opts: { excludeView?: string } = {}
+): ContextMenuItem[] {
+    const toLeafItem = (widget: WidgetConfigType): ContextMenuItem | null => {
+        const view = widget.blockdef?.meta?.["view"] as string | undefined;
+        if (!view || NON_PANE_WIDGET_VIEWS.has(view)) return null;
+        if (opts.excludeView && view === opts.excludeView) return null;
+        return { label: widget.label ?? "Unnamed", click: () => onSelect(widget.blockdef) };
+    };
+
+    const grouped = getGroupedChildKeys(wmap);
+    const topLevel = Object.entries(wmap)
+        .filter(([key]) => !grouped.has(key.replace("defwidget@", "")))
+        .map(([, widget]) => widget)
+        .sort(comparePaneWidgets);
+
+    const items: ContextMenuItem[] = [];
+    for (const widget of topLevel) {
+        if ((widget.children?.length ?? 0) > 0) {
+            const submenu = getChildWidgets(widget, wmap)
+                .map(({ widget: child }) => child)
+                .sort(comparePaneWidgets)
+                .map(toLeafItem)
+                .filter((item): item is ContextMenuItem => item != null);
+            if (submenu.length > 0) {
+                items.push({ label: widget.label ?? "Unnamed", type: "submenu", submenu });
+            }
+            continue;
+        }
+        const item = toLeafItem(widget);
+        if (item) items.push(item);
+    }
+    return items;
+}
+
 // ── Widget actions ────────────────────────────────────────────────────────────
 
 export async function handleWidgetSelect(widget: WidgetConfigType) {

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -20,6 +20,15 @@
     color: var(--widget-icon-hover-color);
 }
 
+// Trailing chevron on a pinned parent widget (SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md
+// §3.3) — a small "this expands" affordance, same spirit as the More
+// button's own chevron just below.
+.action-widget-parent-chevron {
+    font-size: 8px;
+    opacity: 0.6;
+    margin-left: 1px;
+}
+
 .action-widgets {
     display: flex;
     flex-direction: row;
@@ -165,6 +174,15 @@
             text-transform: capitalize;
             flex: 1 1 auto;
             min-width: 0;
+        }
+
+        // Trailing disclosure chevron on a parent row (Case B,
+        // SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md §3.4) — same
+        // treatment FlyoutMenu already gives any item.subItems row.
+        .action-widget-more-item-chevron {
+            font-size: 10px;
+            opacity: 0.6;
+            flex-shrink: 0;
         }
     }
 }

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -252,6 +252,20 @@ const ActionWidgets = (): JSX.Element => {
         shortName: string;
     } | null>(null);
 
+    // A right-click that opens the item popover makes the browser fire a
+    // synthetic mouseleave on whichever dropdown/flyout sits underneath —
+    // the popover renders at the cursor position, and Chromium re-runs
+    // hit-testing against the new topmost element even though the cursor
+    // itself never moved. Left unguarded, that spurious leave reaches the
+    // hover controller's onSubmenuLeave and starts a close-intent, so More
+    // (or a pinned parent's flyout) would collapse the moment you right-
+    // click an item inside it — losing the "menu stays open while you work
+    // with pin/unpin" behavior the outside-click handler already protects
+    // on the click side (its own `.closest(".popover-menu")` check). Every
+    // onSubmenuLeave call site below is gated on this so hover-driven close
+    // is suspended for as long as the item popover is open.
+    const isItemMenuOpen = () => itemMenuState() !== null;
+
     const handleItemContextMenu = (pos: { x: number; y: number }, key: string) => {
         setItemMenuState({ pos, shortName: key.replace("defwidget@", "") });
     };
@@ -528,8 +542,12 @@ const ActionWidgets = (): JSX.Element => {
                         wmap={wmap}
                         ref={(el) => (moreDropdownRef = el)}
                         onSubmenuEnter={() => moreHover.onSubmenuEnter()}
-                        onSubmenuLeave={(e) => moreHover.onSubmenuLeave(e)}
+                        onSubmenuLeave={(e) => {
+                            if (isItemMenuOpen()) return;
+                            moreHover.onSubmenuLeave(e);
+                        }}
                         setSubmenuEl={(el) => moreHover.setSubmenuEl(el)}
+                        isItemMenuOpen={isItemMenuOpen}
                     />
                 </Show>
             </Portal>
@@ -556,7 +574,10 @@ const ActionWidgets = (): JSX.Element => {
                                 onItemContextMenu={handleItemContextMenu}
                                 anchor={() => parentSlotRefs.get(key) ?? null}
                                 onSubmenuEnter={() => parentHoverControllers.get(key)?.onSubmenuEnter()}
-                                onSubmenuLeave={(e) => parentHoverControllers.get(key)?.onSubmenuLeave(e)}
+                                onSubmenuLeave={(e) => {
+                                    if (isItemMenuOpen()) return;
+                                    parentHoverControllers.get(key)?.onSubmenuLeave(e);
+                                }}
                                 setSubmenuEl={(el) => parentHoverControllers.get(key)?.setSubmenuEl(el)}
                                 ref={(el) => (pinnedFlyoutRef = el)}
                             />

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -147,6 +147,21 @@ const ActionWidgets = (): JSX.Element => {
     };
 
     const registerParentHover = (key: string): SubmenuHoverController => {
+        // Reuse an existing controller for this key rather than always
+        // creating+registering a fresh one (reagent P1 on this PR):
+        // getPinnedWidgets() allocates new {key, widget} object literals on
+        // every fullConfigAtom change, so Solid's reference-diffing <For>
+        // tears down and rebuilds EVERY pinned slot — including this one —
+        // on any config change, not just when the pinned set actually
+        // changes. That includes this PR's own "Pin to bar" RPC round-trip
+        // for a child inside this very flyout. Disposing an open controller
+        // fires its onClose and force-closes the flyout out from under the
+        // user; reusing the same instance across that reference churn keeps
+        // it open. See the matching component-level onCleanup below for
+        // where these actually get disposed (component unmount, not per-row
+        // teardown).
+        const existing = parentHoverControllers.get(key);
+        if (existing) return existing;
         const hover = createSubmenuHover({
             // Closing any other open peer — including the More button's own
             // controller, registered below under MORE_PEER_KEY — already
@@ -157,14 +172,16 @@ const ActionWidgets = (): JSX.Element => {
             onClose: () => setOpenParentKey((cur) => (cur === key ? null : cur)),
         });
         parentHoverControllers.set(key, hover);
-        const unregister = parentPeers.register(key, hover);
-        onCleanup(() => {
-            unregister();
-            hover.dispose();
-            parentHoverControllers.delete(key);
-        });
+        parentPeers.register(key, hover);
         return hover;
     };
+
+    // Component-level teardown for every pinned-parent hover controller —
+    // deliberately NOT per-<For>-item (see registerParentHover above).
+    onCleanup(() => {
+        for (const hover of parentHoverControllers.values()) hover.dispose();
+        parentHoverControllers.clear();
+    });
 
     const handleParentSlotClick = (key: string) => {
         if (openParentKey() === key) {

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -28,6 +28,7 @@ import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import {
+    getGroupedChildKeys,
     getMoreWidgets,
     getPinnedKeys,
     getPinnedWidgets,
@@ -175,9 +176,15 @@ const ActionWidgets = (): JSX.Element => {
             return;
         }
         parentPeers.closeOthers(key);
-        parentHoverControllers.get(key)?.close();
-        setMoreOpen(false);
-        setOpenParentKey(key);
+        // openNow() (not a direct setOpenParentKey) so the controller's own
+        // isOpen flips true — otherwise (reagent P1 on this PR) the mouse is
+        // already over the row when a click happens, no later onMouseEnter
+        // ever arrives to resync isOpen, and the subsequent onMouseLeave's
+        // `if (!isOpen) return` skips starting the close-intent timer
+        // entirely — the flyout would stay open until an unrelated close
+        // path (outside click, Escape, re-click) fired. onOpen() (registered
+        // above) already handles setMoreOpen(false) + setOpenParentKey(key).
+        parentHoverControllers.get(key)?.openNow();
     };
 
     // Close on outside click / Escape — mirrors the More dropdown's own
@@ -249,7 +256,7 @@ const ActionWidgets = (): JSX.Element => {
         }
         const blockMeta = widgetDef?.blockdef?.meta as Record<string, unknown> | undefined;
         const view = (blockMeta?.["view"] as string) ?? null;
-        return [
+        const items: PopoverMenuItem[] = [
             {
                 label: "Open in New Window",
                 click: () => {
@@ -268,11 +275,25 @@ const ActionWidgets = (): JSX.Element => {
                     );
                 },
             },
-            { type: "separator" } as PopoverMenuItem,
-            getPinnedKeys(settings(), wmap()).includes(shortName)
-                ? { label: "Unpin from bar", click: () => { unpinWidget(shortName, settings(), wmap()); } }
-                : { label: "Pin to bar", click: () => { pinWidget(shortName, settings(), wmap()); } },
         ];
+        // A grouped child (e.g. right-clicking "Discord" inside the
+        // Messengers flyout) isn't individually pinnable — promoting one out
+        // of its parent group onto the bar isn't supported yet (spec §2/§6
+        // open question). Omit the action entirely here rather than show a
+        // "Pin to bar" that's a silent no-op: getPinnedKeys() unconditionally
+        // strips grouped children (reagent P2 on this PR), so pinWidget()
+        // would write the short-name into widget:pinned and it'd be filtered
+        // straight back out on every read — never actually pinning, never
+        // flipping the label to "Unpin".
+        if (!getGroupedChildKeys(wmap()).has(shortName)) {
+            items.push({ type: "separator" } as PopoverMenuItem);
+            items.push(
+                getPinnedKeys(settings(), wmap()).includes(shortName)
+                    ? { label: "Unpin from bar", click: () => { unpinWidget(shortName, settings(), wmap()); } }
+                    : { label: "Pin to bar", click: () => { pinWidget(shortName, settings(), wmap()); } }
+            );
+        }
+        return items;
     };
 
     // Close on outside click — ignore clicks inside button, dropdown, or any

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -148,15 +148,12 @@ const ActionWidgets = (): JSX.Element => {
 
     const registerParentHover = (key: string): SubmenuHoverController => {
         const hover = createSubmenuHover({
-            onOpen: () => {
-                // Same rationale as openMore() below — the pinned flyout and
-                // More dropdown can visually overlap, so opening one closes
-                // the other. setMoreOpen is declared further down in this
-                // same component scope; safe to reference here since this
-                // callback only ever runs later, in response to a real hover.
-                setMoreOpen(false);
-                setOpenParentKey(key);
-            },
+            // Closing any other open peer — including the More button's own
+            // controller, registered below under MORE_PEER_KEY — already
+            // happens via parentPeers.closeOthers(key) on mouseenter/click
+            // (immediately, not gated on this delayed onOpen), so this only
+            // needs to update this row's own state.
+            onOpen: () => setOpenParentKey(key),
             onClose: () => setOpenParentKey((cur) => (cur === key ? null : cur)),
         });
         parentHoverControllers.set(key, hover);
@@ -174,6 +171,10 @@ const ActionWidgets = (): JSX.Element => {
             closeParentFlyout(key);
             return;
         }
+        // closeOthers closes every other registered peer — every other
+        // pinned parent AND the More button's own controller (MORE_PEER_KEY,
+        // registered below) — symmetrically with how hovering/clicking More
+        // closes this row.
         parentPeers.closeOthers(key);
         // openNow() (not a direct setOpenParentKey) so the controller's own
         // isOpen flips true — otherwise (reagent P1 on this PR) the mouse is
@@ -181,8 +182,7 @@ const ActionWidgets = (): JSX.Element => {
         // ever arrives to resync isOpen, and the subsequent onMouseLeave's
         // `if (!isOpen) return` skips starting the close-intent timer
         // entirely — the flyout would stay open until an unrelated close
-        // path (outside click, Escape, re-click) fired. onOpen() (registered
-        // above) already handles setMoreOpen(false) + setOpenParentKey(key).
+        // path (outside click, Escape, re-click) fired.
         parentHoverControllers.get(key)?.openNow();
     };
 
@@ -212,18 +212,37 @@ const ActionWidgets = (): JSX.Element => {
     // More dropdown state
     const [moreOpen, setMoreOpen] = createSignal(false);
 
+    // The More button gets its own createSubmenuHover controller, registered
+    // as a peer in the SAME parentPeers registry pinned parents use — so
+    // hovering onto Messengers closes More and hovering onto More closes
+    // Messengers, symmetrically. Before this, More was click-only: hovering
+    // onto a pinned parent still force-closed it (via peer-close below), but
+    // hovering back onto More never reopened it, only an explicit click did.
+    const MORE_PEER_KEY = "__more__";
+    const moreHover = createSubmenuHover({
+        onOpen: () => setMoreOpen(true),
+        onClose: () => setMoreOpen(false),
+    });
+    const unregisterMoreHover = parentPeers.register(MORE_PEER_KEY, moreHover);
+    onCleanup(() => {
+        unregisterMoreHover();
+        moreHover.dispose();
+    });
+
     const openMore = (_e: MouseEvent) => {
-        const opening = !moreOpen();
-        if (opening) {
-            // The two floating panels sit right next to each other on the bar
-            // and can visually overlap — only one should be open at a time.
-            const openParent = openParentKey();
-            if (openParent !== null) closeParentFlyout(openParent);
+        if (moreOpen()) {
+            moreHover.close();
+            return;
         }
-        setMoreOpen(opening);
+        parentPeers.closeOthers(MORE_PEER_KEY);
+        // openNow(), not a direct setMoreOpen — same click-must-sync-
+        // controller-state rationale as handleParentSlotClick above (reagent
+        // P1 on this PR): without it, the next mouse-leave's `if (!isOpen)
+        // return` would skip starting the close-intent timer.
+        moreHover.openNow();
     };
 
-    const closeMore = () => setMoreOpen(false);
+    const closeMore = () => moreHover.close();
 
     // Item context menu — rendered independently so the More dropdown stays open
     // while the user interacts with pin/unpin. itemMenuState drives a PopoverMenu
@@ -303,7 +322,7 @@ const ActionWidgets = (): JSX.Element => {
             if (moreButtonRef?.contains(t) || moreDropdownRef?.contains(t)) return;
             const el = t instanceof Element ? t : (t as Node).parentElement;
             if (el?.closest(".popover-menu")) return;
-            setMoreOpen(false);
+            moreHover.close();
         };
         document.addEventListener("mousedown", handler, true);
         onCleanup(() => document.removeEventListener("mousedown", handler, true));
@@ -435,6 +454,11 @@ const ActionWidgets = (): JSX.Element => {
                         class="action-widget-more-btn"
                         classList={{ open: moreOpen() }}
                         onClick={openMore}
+                        onMouseEnter={() => {
+                            parentPeers.closeOthers(MORE_PEER_KEY);
+                            moreHover.onTriggerEnter();
+                        }}
+                        onMouseLeave={(e) => moreHover.onTriggerLeave(e)}
                     >
                         <i class="fa-solid fa-ellipsis" />
                         <Show when={showWidgetLabels()}>
@@ -503,6 +527,9 @@ const ActionWidgets = (): JSX.Element => {
                         settings={settings}
                         wmap={wmap}
                         ref={(el) => (moreDropdownRef = el)}
+                        onSubmenuEnter={() => moreHover.onSubmenuEnter()}
+                        onSubmenuLeave={(e) => moreHover.onSubmenuLeave(e)}
+                        setSubmenuEl={(el) => moreHover.setSubmenuEl(el)}
                     />
                 </Show>
             </Portal>

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -148,7 +148,15 @@ const ActionWidgets = (): JSX.Element => {
 
     const registerParentHover = (key: string): SubmenuHoverController => {
         const hover = createSubmenuHover({
-            onOpen: () => setOpenParentKey(key),
+            onOpen: () => {
+                // Same rationale as openMore() below — the pinned flyout and
+                // More dropdown can visually overlap, so opening one closes
+                // the other. setMoreOpen is declared further down in this
+                // same component scope; safe to reference here since this
+                // callback only ever runs later, in response to a real hover.
+                setMoreOpen(false);
+                setOpenParentKey(key);
+            },
             onClose: () => setOpenParentKey((cur) => (cur === key ? null : cur)),
         });
         parentHoverControllers.set(key, hover);
@@ -168,6 +176,7 @@ const ActionWidgets = (): JSX.Element => {
         }
         parentPeers.closeOthers(key);
         parentHoverControllers.get(key)?.close();
+        setMoreOpen(false);
         setOpenParentKey(key);
     };
 
@@ -198,7 +207,14 @@ const ActionWidgets = (): JSX.Element => {
     const [moreOpen, setMoreOpen] = createSignal(false);
 
     const openMore = (_e: MouseEvent) => {
-        setMoreOpen(!moreOpen());
+        const opening = !moreOpen();
+        if (opening) {
+            // The two floating panels sit right next to each other on the bar
+            // and can visually overlap — only one should be open at a time.
+            const openParent = openParentKey();
+            if (openParent !== null) closeParentFlyout(openParent);
+        }
+        setMoreOpen(opening);
     };
 
     const closeMore = () => setMoreOpen(false);
@@ -474,19 +490,31 @@ const ActionWidgets = (): JSX.Element => {
 
             <Portal>
                 <Show when={openParentKey()}>
-                    {(key) => (
-                        <PinnedWidgetFlyout
-                            widget={wmap()[key()]}
-                            wmap={wmap}
-                            onClose={() => closeParentFlyout(key())}
-                            onItemContextMenu={handleItemContextMenu}
-                            anchor={() => parentSlotRefs.get(key()) ?? null}
-                            onSubmenuEnter={() => parentHoverControllers.get(key())?.onSubmenuEnter()}
-                            onSubmenuLeave={(e) => parentHoverControllers.get(key())?.onSubmenuLeave(e)}
-                            setSubmenuEl={(el) => parentHoverControllers.get(key())?.setSubmenuEl(el)}
-                            ref={(el) => (pinnedFlyoutRef = el)}
-                        />
-                    )}
+                    {(keyAccessor) => {
+                        // Capture a plain string once instead of re-invoking
+                        // the Show's accessor from these callbacks — several
+                        // of them (onClose, and PinnedWidgetFlyout's own
+                        // onCleanup calling setSubmenuEl(null)) can still fire
+                        // during/after this <Show> branch unmounts, and
+                        // calling a stale keyed-Show accessor post-unmount
+                        // throws ("Attempting to access a stale value from
+                        // <Show>") — reproduced live via muxlog while testing
+                        // this PR's own click-to-close path.
+                        const key = keyAccessor();
+                        return (
+                            <PinnedWidgetFlyout
+                                widget={wmap()[key]}
+                                wmap={wmap}
+                                onClose={() => closeParentFlyout(key)}
+                                onItemContextMenu={handleItemContextMenu}
+                                anchor={() => parentSlotRefs.get(key) ?? null}
+                                onSubmenuEnter={() => parentHoverControllers.get(key)?.onSubmenuEnter()}
+                                onSubmenuLeave={(e) => parentHoverControllers.get(key)?.onSubmenuLeave(e)}
+                                setSubmenuEl={(el) => parentHoverControllers.get(key)?.setSubmenuEl(el)}
+                                ref={(el) => (pinnedFlyoutRef = el)}
+                            />
+                        );
+                    }}
                 </Show>
             </Portal>
 

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -22,6 +22,7 @@ import { Tooltip } from "@/app/element/tooltip";
 import { PopoverMenu, type PopoverMenuItem } from "@/app/element/popover-menu";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { createPeerRegistry, createSubmenuHover, type SubmenuHoverController } from "@/app/util/submenu-hover";
 import { atoms, getApi } from "@/store/global";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
@@ -35,6 +36,7 @@ import {
     unpinWidget,
 } from "./action-widgets-config";
 import { MoreDropdown } from "./more-dropdown";
+import { PinnedWidgetFlyout } from "./pinned-widget-flyout";
 import { useWidgetBarResponsive } from "./use-widget-bar-responsive";
 import { useWidgetDragReorder } from "./use-widget-drag-reorder";
 import "./action-widgets.scss";
@@ -51,19 +53,29 @@ const ActionWidget = (props: {
     widget: WidgetConfigType;
     iconOnly: boolean;
     onContextMenu?: (e: MouseEvent) => void;
+    onClick?: () => void;
+    onMouseEnter?: () => void;
+    onMouseLeave?: (e: MouseEvent) => void;
 }): JSX.Element => (
-    <div onContextMenu={props.onContextMenu}>
+    <div
+        onContextMenu={props.onContextMenu}
+        onMouseEnter={() => props.onMouseEnter?.()}
+        onMouseLeave={(e) => props.onMouseLeave?.(e)}
+    >
         <Tooltip
             content={props.widget.description || props.widget.label}
             placement="bottom"
             divClassName="flex flex-row items-center gap-1 px-2 py-0.5 text-secondary hover:bg-hoverbg hover:text-white rounded-sm h-full"
-            divOnClick={() => handleWidgetSelect(props.widget)}
+            divOnClick={props.onClick ?? (() => handleWidgetSelect(props.widget))}
         >
             <div class="widget-icon text-sm">
                 <i class={makeIconClass(props.widget.icon, true, { defaultIcon: "browser" })}></i>
             </div>
             <Show when={!props.iconOnly && !isBlank(props.widget.label)}>
                 <div class="text-xs whitespace-nowrap">{props.widget.label}</div>
+            </Show>
+            <Show when={(props.widget.children?.length ?? 0) > 0}>
+                <i class="fa-sharp fa-solid fa-chevron-down action-widget-parent-chevron" />
             </Show>
         </Tooltip>
     </div>
@@ -115,6 +127,73 @@ const ActionWidgets = (): JSX.Element => {
         pinnedWidgets,
     });
 
+    // ── Pinned-parent flyout (Case A, SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md §3.3) ──
+    // Exactly one pinned parent's flyout can be open at a time — a single
+    // scalar (rather than a per-key visible map) is the source of truth for
+    // which one, and rendering is keyed directly off it. Each parent row still
+    // gets its own createSubmenuHover controller (open-delay + safe-triangle
+    // close) registered in a shared peer registry so hovering onto a new
+    // parent row force-closes whichever one is currently open, same as any
+    // other peer-submenu level in the app.
+    const [openParentKey, setOpenParentKey] = createSignal<string | null>(null);
+    const parentPeers = createPeerRegistry();
+    const parentHoverControllers = new Map<string, SubmenuHoverController>();
+    const parentSlotRefs = new Map<string, HTMLDivElement>();
+    let pinnedFlyoutRef: HTMLDivElement | undefined;
+
+    const closeParentFlyout = (key: string) => {
+        parentHoverControllers.get(key)?.close();
+        setOpenParentKey((cur) => (cur === key ? null : cur));
+    };
+
+    const registerParentHover = (key: string): SubmenuHoverController => {
+        const hover = createSubmenuHover({
+            onOpen: () => setOpenParentKey(key),
+            onClose: () => setOpenParentKey((cur) => (cur === key ? null : cur)),
+        });
+        parentHoverControllers.set(key, hover);
+        const unregister = parentPeers.register(key, hover);
+        onCleanup(() => {
+            unregister();
+            hover.dispose();
+            parentHoverControllers.delete(key);
+        });
+        return hover;
+    };
+
+    const handleParentSlotClick = (key: string) => {
+        if (openParentKey() === key) {
+            closeParentFlyout(key);
+            return;
+        }
+        parentPeers.closeOthers(key);
+        parentHoverControllers.get(key)?.close();
+        setOpenParentKey(key);
+    };
+
+    // Close on outside click / Escape — mirrors the More dropdown's own
+    // outside-click effect below, scoped to whichever parent is open.
+    createEffect(() => {
+        const key = openParentKey();
+        if (key === null) return;
+        const handler = (e: MouseEvent) => {
+            const t = e.target as Node;
+            if (parentSlotRefs.get(key)?.contains(t) || pinnedFlyoutRef?.contains(t)) return;
+            const el = t instanceof Element ? t : (t as Node).parentElement;
+            if (el?.closest(".popover-menu")) return;
+            closeParentFlyout(key);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") closeParentFlyout(key);
+        };
+        document.addEventListener("mousedown", handler, true);
+        document.addEventListener("keydown", onKey);
+        onCleanup(() => {
+            document.removeEventListener("mousedown", handler, true);
+            document.removeEventListener("keydown", onKey);
+        });
+    });
+
     // More dropdown state
     const [moreOpen, setMoreOpen] = createSignal(false);
 
@@ -141,6 +220,17 @@ const ActionWidgets = (): JSX.Element => {
 
     const buildItemMenuItems = (shortName: string): PopoverMenuItem[] => {
         const widgetDef = resolveWidgetDef(shortName);
+        // A parent row's right-click is scoped to the group as a whole (§3.5)
+        // — no "Open in New Window"/"Open in Floating Pane" (no single pane a
+        // parent represents), and worded "group" instead of the leaf phrasing.
+        // Same underlying pinWidget/unpinWidget call either way.
+        if ((widgetDef?.children?.length ?? 0) > 0) {
+            return [
+                getPinnedKeys(settings(), wmap()).includes(shortName)
+                    ? { label: "Unpin group from bar", click: () => { unpinWidget(shortName, settings(), wmap()); } }
+                    : { label: "Pin group to bar", click: () => { pinWidget(shortName, settings(), wmap()); } },
+            ];
+        }
         const blockMeta = widgetDef?.blockdef?.meta as Record<string, unknown> | undefined;
         const view = (blockMeta?.["view"] as string) ?? null;
         return [
@@ -218,6 +308,22 @@ const ActionWidgets = (): JSX.Element => {
         handlePointerCancel();
         armContextMenuDismiss(key);
         const shortName = key.replace("defwidget@", "");
+        const isParent = (wmap()[key]?.children?.length ?? 0) > 0;
+        // A parent's right-click is scoped to group-level actions (§3.5) —
+        // no "Open in New Window" (no single pane a parent represents), and
+        // "Unpin group from bar" instead of the leaf "Unpin from bar" so the
+        // whole-group-leaves-the-bar mental model reads differently from a
+        // single pane's shortcut. Unpinning uses the same underlying
+        // unpinWidget() call either way — a parent is just another key in
+        // `widget:pinned`.
+        if (isParent) {
+            closeParentFlyout(key);
+            ContextMenuModel.showContextMenu(
+                [{ label: "Unpin group from bar", click: () => unpinWidget(shortName, settings(), wmap()) }],
+                e
+            );
+            return;
+        }
         ContextMenuModel.showContextMenu(
             [
                 { label: "New Window", click: () => {
@@ -243,27 +349,46 @@ const ActionWidgets = (): JSX.Element => {
                 data-drag-region="false"
             >
                 <For each={visiblePinnedWidgets()}>
-                    {({ key, widget }, idx) => (
-                        <>
-                            <Show when={draggingKey() != null && dropIndex() === idx() && draggingKey() !== key}>
-                                <div class="action-widget-drop-indicator" />
-                            </Show>
-                            <div
-                                class={`action-widget-slot${draggingKey() === key ? " dragging" : ""}${contextMenuActiveKey() === key ? " context-active" : ""}`}
-                                data-widget-slot={idx()}
-                                onPointerDown={(e) => handlePointerDown(key, e)}
-                                onPointerMove={handlePointerMove}
-                                onPointerUp={handlePointerUp}
-                                onPointerCancel={handlePointerCancel}
-                            >
-                                <ActionWidget
-                                    widget={widget}
-                                    iconOnly={!showWidgetLabels()}
-                                    onContextMenu={(e) => handlePinnedContextMenu(e, key)}
-                                />
-                            </div>
-                        </>
-                    )}
+                    {({ key, widget }, idx) => {
+                        const isParent = (widget.children?.length ?? 0) > 0;
+                        const hover = isParent ? registerParentHover(key) : null;
+                        return (
+                            <>
+                                <Show when={draggingKey() != null && dropIndex() === idx() && draggingKey() !== key}>
+                                    <div class="action-widget-drop-indicator" />
+                                </Show>
+                                <div
+                                    ref={(el) => {
+                                        if (!isParent) return;
+                                        parentSlotRefs.set(key, el);
+                                        onCleanup(() => parentSlotRefs.delete(key));
+                                    }}
+                                    class={`action-widget-slot${draggingKey() === key ? " dragging" : ""}${contextMenuActiveKey() === key ? " context-active" : ""}`}
+                                    data-widget-slot={idx()}
+                                    onPointerDown={(e) => handlePointerDown(key, e)}
+                                    onPointerMove={handlePointerMove}
+                                    onPointerUp={handlePointerUp}
+                                    onPointerCancel={handlePointerCancel}
+                                >
+                                    <ActionWidget
+                                        widget={widget}
+                                        iconOnly={!showWidgetLabels()}
+                                        onContextMenu={(e) => handlePinnedContextMenu(e, key)}
+                                        onClick={isParent ? () => handleParentSlotClick(key) : undefined}
+                                        onMouseEnter={
+                                            hover
+                                                ? () => {
+                                                      parentPeers.closeOthers(key);
+                                                      hover.onTriggerEnter();
+                                                  }
+                                                : undefined
+                                        }
+                                        onMouseLeave={hover ? (e) => hover.onTriggerLeave(e) : undefined}
+                                    />
+                                </div>
+                            </>
+                        );
+                    }}
                 </For>
                 <Show when={draggingKey() != null && dropIndex() === visiblePinnedWidgets().length}>
                     <div class="action-widget-drop-indicator" />
@@ -344,6 +469,24 @@ const ActionWidgets = (): JSX.Element => {
                         wmap={wmap}
                         ref={(el) => (moreDropdownRef = el)}
                     />
+                </Show>
+            </Portal>
+
+            <Portal>
+                <Show when={openParentKey()}>
+                    {(key) => (
+                        <PinnedWidgetFlyout
+                            widget={wmap()[key()]}
+                            wmap={wmap}
+                            onClose={() => closeParentFlyout(key())}
+                            onItemContextMenu={handleItemContextMenu}
+                            anchor={() => parentSlotRefs.get(key()) ?? null}
+                            onSubmenuEnter={() => parentHoverControllers.get(key())?.onSubmenuEnter()}
+                            onSubmenuLeave={(e) => parentHoverControllers.get(key())?.onSubmenuLeave(e)}
+                            setSubmenuEl={(el) => parentHoverControllers.get(key())?.setSubmenuEl(el)}
+                            ref={(el) => (pinnedFlyoutRef = el)}
+                        />
+                    )}
                 </Show>
             </Portal>
 

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -28,7 +28,6 @@ import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import {
-    getGroupedChildKeys,
     getMoreWidgets,
     getPinnedKeys,
     getPinnedWidgets,
@@ -276,23 +275,22 @@ const ActionWidgets = (): JSX.Element => {
                 },
             },
         ];
-        // A grouped child (e.g. right-clicking "Discord" inside the
-        // Messengers flyout) isn't individually pinnable — promoting one out
-        // of its parent group onto the bar isn't supported yet (spec §2/§6
-        // open question). Omit the action entirely here rather than show a
-        // "Pin to bar" that's a silent no-op: getPinnedKeys() unconditionally
-        // strips grouped children (reagent P2 on this PR), so pinWidget()
-        // would write the short-name into widget:pinned and it'd be filtered
-        // straight back out on every read — never actually pinning, never
-        // flipping the label to "Unpin".
-        if (!getGroupedChildKeys(wmap()).has(shortName)) {
-            items.push({ type: "separator" } as PopoverMenuItem);
-            items.push(
-                getPinnedKeys(settings(), wmap()).includes(shortName)
-                    ? { label: "Unpin from bar", click: () => { unpinWidget(shortName, settings(), wmap()); } }
-                    : { label: "Pin to bar", click: () => { pinWidget(shortName, settings(), wmap()); } }
-            );
-        }
+        // Pin/Unpin here works for a grouped child too — e.g. right-clicking
+        // "Discord" inside the Messengers flyout and choosing "Pin to bar"
+        // PROMOTES it out of the group onto the bar as a standalone widget;
+        // "Unpin from bar" reverses that, and it goes back to living only
+        // inside Messengers (see getEffectiveGroupedChildKeys). This used to
+        // be a silent no-op (reagent P2 on this PR) because getPinnedKeys()
+        // unconditionally stripped grouped children regardless of
+        // widget:pinned — fixed at the source, so the ordinary Pin/Unpin
+        // item below is correct for a child exactly as it is for any other
+        // widget, no special-casing needed here.
+        items.push({ type: "separator" } as PopoverMenuItem);
+        items.push(
+            getPinnedKeys(settings(), wmap()).includes(shortName)
+                ? { label: "Unpin from bar", click: () => { unpinWidget(shortName, settings(), wmap()); } }
+                : { label: "Pin to bar", click: () => { pinWidget(shortName, settings(), wmap()); } }
+        );
         return items;
     };
 
@@ -526,6 +524,7 @@ const ActionWidgets = (): JSX.Element => {
                             <PinnedWidgetFlyout
                                 widget={wmap()[key]}
                                 wmap={wmap}
+                                settings={settings}
                                 onClose={() => closeParentFlyout(key)}
                                 onItemContextMenu={handleItemContextMenu}
                                 anchor={() => parentSlotRefs.get(key) ?? null}

--- a/frontend/app/window/more-dropdown.tsx
+++ b/frontend/app/window/more-dropdown.tsx
@@ -171,6 +171,7 @@ const MoreDropdown = ({
                                 <PinnedWidgetFlyout
                                     widget={widget}
                                     wmap={wmap}
+                                    settings={settings}
                                     onClose={() => {
                                         closeParentSub(key);
                                         hover.close();

--- a/frontend/app/window/more-dropdown.tsx
+++ b/frontend/app/window/more-dropdown.tsx
@@ -27,6 +27,9 @@ const MoreDropdown = ({
     settings,
     wmap,
     ref,
+    onSubmenuEnter,
+    onSubmenuLeave,
+    setSubmenuEl,
 }: {
     widgets: () => { key: string; widget: WidgetConfigType }[];
     onClose: () => void;
@@ -35,6 +38,16 @@ const MoreDropdown = ({
     settings: () => Record<string, any>;
     wmap: () => Record<string, WidgetConfigType>;
     ref?: (el: HTMLDivElement) => void;
+    /**
+     * Optional hover-controller plumbing — present when the caller opens
+     * this dropdown via hover-intent (a createSubmenuHover on the "More"
+     * button itself) rather than click-only, so moving the cursor into this
+     * panel cancels the pending close the same way any other hover-opened
+     * flyout/submenu in the app does.
+     */
+    onSubmenuEnter?: () => void;
+    onSubmenuLeave?: (e: MouseEvent) => void;
+    setSubmenuEl?: (el: HTMLDivElement | null) => void;
 }): JSX.Element => {
     let overlayEl: HTMLDivElement | undefined;
     // Cut a transparent hole through any browser pane HWND behind this
@@ -56,6 +69,7 @@ const MoreDropdown = ({
     const registerFloating = (el: HTMLDivElement) => {
         overlayEl = el;
         ref?.(el);
+        setSubmenuEl?.(el);
         requestAnimationFrame(() => {
             const anchorEl = anchor();
             if (!(anchorEl instanceof Element) || !(el instanceof Element)) return;
@@ -81,7 +95,10 @@ const MoreDropdown = ({
         });
     };
 
-    onCleanup(() => cleanupAutoUpdate?.());
+    onCleanup(() => {
+        cleanupAutoUpdate?.();
+        setSubmenuEl?.(null);
+    });
 
     const handleItemClick = (widget: WidgetConfigType) => {
         handleWidgetSelect(widget);
@@ -119,6 +136,8 @@ const MoreDropdown = ({
             class="action-widget-more-dropdown"
             style={floatingStyle()}
             data-pane-overlay
+            onMouseEnter={() => onSubmenuEnter?.()}
+            onMouseLeave={(e) => onSubmenuLeave?.(e)}
         >
             <For each={widgets()}>
                 {({ key, widget }) => {

--- a/frontend/app/window/more-dropdown.tsx
+++ b/frontend/app/window/more-dropdown.tsx
@@ -12,7 +12,7 @@ import {
     assertMenuInPaintableArea,
     computeMenuPosition,
 } from "@/app/util/menu-position";
-import { createPeerRegistry, createSubmenuHover } from "@/app/util/submenu-hover";
+import { createPeerRegistry, createSubmenuHover, type SubmenuHoverController } from "@/app/util/submenu-hover";
 import { makeIconClass } from "@/util/util";
 import { autoUpdate } from "@floating-ui/dom";
 import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
@@ -132,6 +132,21 @@ const MoreDropdown = ({
     // same hover-intent + peer-close shape as flyoutmenu.tsx's own SubMenu,
     // scoped to this one dropdown instance.
     const parentPeers = createPeerRegistry();
+    // Keyed by widget short-name, deliberately OUTSIDE the <For> below —
+    // see the reuse-not-recreate comment at its one call site (reagent P1
+    // on this PR): `widgets()` (clippedPinnedWidgets + moreWidgets)
+    // allocates fresh {key, widget} object literals on every
+    // fullConfigAtom change, so Solid's reference-diffing <For> tears down
+    // and rebuilds every row on any config change — including this PR's
+    // own "Pin to bar" RPC round-trip for a child inside an open nested
+    // submenu. Disposing an open controller mid-render would force-close
+    // that submenu via its onClose (closeParentSub) out from under the
+    // user.
+    const parentRowHoverControllers = new Map<string, SubmenuHoverController>();
+    onCleanup(() => {
+        for (const hover of parentRowHoverControllers.values()) hover.dispose();
+        parentRowHoverControllers.clear();
+    });
     const [visibleParentSubMenus, setVisibleParentSubMenus] = createSignal<Record<string, boolean>>({});
     const openParentSub = (key: string) => setVisibleParentSubMenus((prev) => ({ ...prev, [key]: true }));
     const closeParentSub = (key: string) =>
@@ -173,15 +188,15 @@ const MoreDropdown = ({
                     }
 
                     let rowEl: HTMLDivElement | undefined;
-                    const hover = createSubmenuHover({
-                        onOpen: () => openParentSub(key),
-                        onClose: () => closeParentSub(key),
-                    });
-                    const unregister = parentPeers.register(key, hover);
-                    onCleanup(() => {
-                        unregister();
-                        hover.dispose();
-                    });
+                    let hover = parentRowHoverControllers.get(key);
+                    if (!hover) {
+                        hover = createSubmenuHover({
+                            onOpen: () => openParentSub(key),
+                            onClose: () => closeParentSub(key),
+                        });
+                        parentRowHoverControllers.set(key, hover);
+                        parentPeers.register(key, hover);
+                    }
 
                     return (
                         <>

--- a/frontend/app/window/more-dropdown.tsx
+++ b/frontend/app/window/more-dropdown.tsx
@@ -12,10 +12,12 @@ import {
     assertMenuInPaintableArea,
     computeMenuPosition,
 } from "@/app/util/menu-position";
+import { createPeerRegistry, createSubmenuHover } from "@/app/util/submenu-hover";
 import { makeIconClass } from "@/util/util";
 import { autoUpdate } from "@floating-ui/dom";
-import { createSignal, For, onCleanup, type JSX } from "solid-js";
+import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { handleWidgetSelect } from "./action-widgets-config";
+import { PinnedWidgetFlyout } from "./pinned-widget-flyout";
 
 const MoreDropdown = ({
     widgets,
@@ -95,6 +97,22 @@ const MoreDropdown = ({
         onItemContextMenu({ x: e.clientX, y: e.clientY }, key);
     };
 
+    // ── Parent rows (Case B, SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md §3.4) ──
+    // A row whose widget has `children` expands a nested PinnedWidgetFlyout
+    // (placement="right-start") instead of opening a pane — structurally the
+    // same hover-intent + peer-close shape as flyoutmenu.tsx's own SubMenu,
+    // scoped to this one dropdown instance.
+    const parentPeers = createPeerRegistry();
+    const [visibleParentSubMenus, setVisibleParentSubMenus] = createSignal<Record<string, boolean>>({});
+    const openParentSub = (key: string) => setVisibleParentSubMenus((prev) => ({ ...prev, [key]: true }));
+    const closeParentSub = (key: string) =>
+        setVisibleParentSubMenus((prev) => {
+            if (!(key in prev)) return prev;
+            const next = { ...prev };
+            delete next[key];
+            return next;
+        });
+
     return (
         <div
             ref={registerFloating}
@@ -103,18 +121,73 @@ const MoreDropdown = ({
             data-pane-overlay
         >
             <For each={widgets()}>
-                {({ key, widget }) => (
-                    <div
-                        class="action-widget-more-item"
-                        onClick={() => handleItemClick(widget)}
-                        onContextMenu={(e) => handleItemContextMenu(e, key)}
-                    >
-                        <span class="action-widget-more-item-icon widget-icon">
-                            <i class={makeIconClass(widget.icon, true, { defaultIcon: "browser" })}></i>
-                        </span>
-                        <span class="action-widget-more-item-label">{widget.label}</span>
-                    </div>
-                )}
+                {({ key, widget }) => {
+                    const isParent = (widget.children?.length ?? 0) > 0;
+                    if (!isParent) {
+                        return (
+                            <div
+                                class="action-widget-more-item"
+                                onClick={() => handleItemClick(widget)}
+                                onContextMenu={(e) => handleItemContextMenu(e, key)}
+                            >
+                                <span class="action-widget-more-item-icon widget-icon">
+                                    <i class={makeIconClass(widget.icon, true, { defaultIcon: "browser" })}></i>
+                                </span>
+                                <span class="action-widget-more-item-label">{widget.label}</span>
+                            </div>
+                        );
+                    }
+
+                    let rowEl: HTMLDivElement | undefined;
+                    const hover = createSubmenuHover({
+                        onOpen: () => openParentSub(key),
+                        onClose: () => closeParentSub(key),
+                    });
+                    const unregister = parentPeers.register(key, hover);
+                    onCleanup(() => {
+                        unregister();
+                        hover.dispose();
+                    });
+
+                    return (
+                        <>
+                            <div
+                                ref={(el) => (rowEl = el)}
+                                class="action-widget-more-item"
+                                onMouseEnter={() => {
+                                    parentPeers.closeOthers(key);
+                                    hover.onTriggerEnter();
+                                }}
+                                onMouseLeave={(e) => hover.onTriggerLeave(e)}
+                                onContextMenu={(e) => handleItemContextMenu(e, key)}
+                            >
+                                <span class="action-widget-more-item-icon widget-icon">
+                                    <i class={makeIconClass(widget.icon, true, { defaultIcon: "browser" })}></i>
+                                </span>
+                                <span class="action-widget-more-item-label">{widget.label}</span>
+                                <i class="fa-sharp fa-solid fa-chevron-right action-widget-more-item-chevron" />
+                            </div>
+                            <Show when={visibleParentSubMenus()[key]}>
+                                <PinnedWidgetFlyout
+                                    widget={widget}
+                                    wmap={wmap}
+                                    onClose={() => {
+                                        closeParentSub(key);
+                                        hover.close();
+                                        onClose();
+                                    }}
+                                    onItemContextMenu={onItemContextMenu}
+                                    anchor={() => rowEl ?? null}
+                                    placement="right-start"
+                                    gutter={8}
+                                    onSubmenuEnter={() => hover.onSubmenuEnter()}
+                                    onSubmenuLeave={(e) => hover.onSubmenuLeave(e)}
+                                    setSubmenuEl={(el) => hover.setSubmenuEl(el)}
+                                />
+                            </Show>
+                        </>
+                    );
+                }}
             </For>
         </div>
     );

--- a/frontend/app/window/more-dropdown.tsx
+++ b/frontend/app/window/more-dropdown.tsx
@@ -30,6 +30,7 @@ const MoreDropdown = ({
     onSubmenuEnter,
     onSubmenuLeave,
     setSubmenuEl,
+    isItemMenuOpen,
 }: {
     widgets: () => { key: string; widget: WidgetConfigType }[];
     onClose: () => void;
@@ -48,6 +49,17 @@ const MoreDropdown = ({
     onSubmenuEnter?: () => void;
     onSubmenuLeave?: (e: MouseEvent) => void;
     setSubmenuEl?: (el: HTMLDivElement | null) => void;
+    /**
+     * True while the right-click item popover (pin/unpin, open-in-new-
+     * window, ...) is open. A right-click's popover renders at the cursor
+     * position, which makes the browser re-target hit-testing and fire a
+     * spurious mouseleave on whatever's underneath even though the cursor
+     * never actually moved — without this guard that leave reaches the
+     * per-row hover controller for a Case B parent row (e.g. Messengers
+     * nested inside More) and starts a close-intent, collapsing it out from
+     * under the user mid right-click.
+     */
+    isItemMenuOpen?: () => boolean;
 }): JSX.Element => {
     let overlayEl: HTMLDivElement | undefined;
     // Cut a transparent hole through any browser pane HWND behind this
@@ -137,7 +149,10 @@ const MoreDropdown = ({
             style={floatingStyle()}
             data-pane-overlay
             onMouseEnter={() => onSubmenuEnter?.()}
-            onMouseLeave={(e) => onSubmenuLeave?.(e)}
+            onMouseLeave={(e) => {
+                if (isItemMenuOpen?.()) return;
+                onSubmenuLeave?.(e);
+            }}
         >
             <For each={widgets()}>
                 {({ key, widget }) => {
@@ -177,7 +192,10 @@ const MoreDropdown = ({
                                     parentPeers.closeOthers(key);
                                     hover.onTriggerEnter();
                                 }}
-                                onMouseLeave={(e) => hover.onTriggerLeave(e)}
+                                onMouseLeave={(e) => {
+                                    if (isItemMenuOpen?.()) return;
+                                    hover.onTriggerLeave(e);
+                                }}
                                 onContextMenu={(e) => handleItemContextMenu(e, key)}
                             >
                                 <span class="action-widget-more-item-icon widget-icon">
@@ -201,7 +219,10 @@ const MoreDropdown = ({
                                     placement="right-start"
                                     gutter={8}
                                     onSubmenuEnter={() => hover.onSubmenuEnter()}
-                                    onSubmenuLeave={(e) => hover.onSubmenuLeave(e)}
+                                    onSubmenuLeave={(e) => {
+                                        if (isItemMenuOpen?.()) return;
+                                        hover.onSubmenuLeave(e);
+                                    }}
                                     setSubmenuEl={(el) => hover.setSubmenuEl(el)}
                                 />
                             </Show>

--- a/frontend/app/window/pinned-widget-flyout.tsx
+++ b/frontend/app/window/pinned-widget-flyout.tsx
@@ -32,6 +32,13 @@ import { getChildWidgets, handleWidgetSelect } from "./action-widgets-config";
 const PinnedWidgetFlyout = (props: {
     widget: WidgetConfigType;
     wmap: () => Record<string, WidgetConfigType>;
+    /**
+     * Needed so a child that gets individually pinned (promoted out of this
+     * group — see getEffectiveGroupedChildKeys) drops out of this list
+     * immediately, reactively, instead of still showing here alongside its
+     * new standalone bar/More entry.
+     */
+    settings: () => Record<string, any>;
     onClose: () => void;
     onItemContextMenu: (pos: { x: number; y: number }, key: string) => void;
     anchor: () => HTMLElement | null;
@@ -44,7 +51,7 @@ const PinnedWidgetFlyout = (props: {
     setSubmenuEl?: (el: HTMLDivElement | null) => void;
     ref?: (el: HTMLDivElement) => void;
 }): JSX.Element => {
-    const children = () => getChildWidgets(props.widget, props.wmap());
+    const children = () => getChildWidgets(props.widget, props.wmap(), props.settings());
 
     let overlayEl: HTMLDivElement | undefined;
     // Cut a transparent hole through any browser pane HWND behind this

--- a/frontend/app/window/pinned-widget-flyout.tsx
+++ b/frontend/app/window/pinned-widget-flyout.tsx
@@ -1,0 +1,140 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PinnedWidgetFlyout — the child-widget panel a parent widget (e.g.
+ * "Messengers") expands, per SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md.
+ * Shared by both placements the spec calls out:
+ *
+ *  - Case A (pinned in the bar, §3.3): anchored to the parent's own bar
+ *    slot, `placement="bottom-start"` (opens downward under the icon, like
+ *    More) — the default below.
+ *  - Case B (a row inside the More dropdown, §3.4): anchored to that row's
+ *    rect, `placement="right-start"` (opens sideways, flips to
+ *    `left-start` near the right edge) — passed explicitly by the caller.
+ *
+ * Structurally a clone of MoreDropdown (§1.2) either way — Portal-rendered,
+ * pane-overlay-aware, positioned via the shared computeMenuPosition()
+ * primitive, closed via the caller's createSubmenuHover controller as well
+ * as (Case A only) click-toggle/outside-click/Escape.
+ */
+
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import {
+    assertMenuInPaintableArea,
+    computeMenuPosition,
+} from "@/app/util/menu-position";
+import { makeIconClass } from "@/util/util";
+import { autoUpdate, type Placement } from "@floating-ui/dom";
+import { createSignal, For, onCleanup, type JSX } from "solid-js";
+import { getChildWidgets, handleWidgetSelect } from "./action-widgets-config";
+
+const PinnedWidgetFlyout = (props: {
+    widget: WidgetConfigType;
+    wmap: () => Record<string, WidgetConfigType>;
+    onClose: () => void;
+    onItemContextMenu: (pos: { x: number; y: number }, key: string) => void;
+    anchor: () => HTMLElement | null;
+    /** Default "bottom-start" (Case A). Case B passes "right-start". */
+    placement?: Placement;
+    /** Default 4 (Case A, matches MoreDropdown). Case B passes 8 to match other nested submenus (flyoutmenu.tsx's SubMenu). */
+    gutter?: number;
+    onSubmenuEnter?: () => void;
+    onSubmenuLeave?: (e: MouseEvent) => void;
+    setSubmenuEl?: (el: HTMLDivElement | null) => void;
+    ref?: (el: HTMLDivElement) => void;
+}): JSX.Element => {
+    const children = () => getChildWidgets(props.widget, props.wmap());
+
+    let overlayEl: HTMLDivElement | undefined;
+    // Cut a transparent hole through any browser pane HWND behind this
+    // flyout so DOM renders above the pane in this rect — same requirement
+    // as MoreDropdown. See `frontend/app/platform/pane-overlay.ts`.
+    usePaneOverlay(() => overlayEl);
+
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
+        visibility: "hidden",
+    });
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerFloating = (el: HTMLDivElement) => {
+        overlayEl = el;
+        props.ref?.(el);
+        props.setSubmenuEl?.(el);
+        requestAnimationFrame(() => {
+            const anchorEl = props.anchor();
+            if (!(anchorEl instanceof Element) || !(el instanceof Element)) return;
+            const update = async () => {
+                const a = props.anchor();
+                if (!a) return;
+                // avoidNativePanes:false — carries data-pane-overlay, same
+                // rationale as MoreDropdown: open in place under the slot,
+                // not pushed toward the window edge by a pane behind it.
+                const pos = await computeMenuPosition(
+                    {
+                        anchor: a,
+                        placement: props.placement ?? "bottom-start",
+                        gutter: props.gutter ?? 4,
+                        avoidNativePanes: false,
+                    },
+                    el,
+                );
+                setFloatingStyle({ ...pos.style });
+            };
+            cleanupAutoUpdate?.();
+            cleanupAutoUpdate = autoUpdate(anchorEl, el, update);
+            assertMenuInPaintableArea(el, "pinned-widget-flyout");
+        });
+    };
+
+    onCleanup(() => {
+        cleanupAutoUpdate?.();
+        props.setSubmenuEl?.(null);
+    });
+
+    const handleItemClick = (widget: WidgetConfigType) => {
+        handleWidgetSelect(widget);
+        props.onClose();
+    };
+
+    const handleItemContextMenu = (e: MouseEvent, key: string) => {
+        e.preventDefault();
+        e.stopPropagation();
+        // Delegate up — the item popover renders independently so it can
+        // stay open while this flyout remains visible (matches MoreDropdown).
+        props.onItemContextMenu({ x: e.clientX, y: e.clientY }, key);
+    };
+
+    return (
+        <div
+            ref={registerFloating}
+            class="action-widget-more-dropdown action-widget-pinned-flyout"
+            style={floatingStyle()}
+            data-pane-overlay
+            onMouseEnter={() => props.onSubmenuEnter?.()}
+            onMouseLeave={(e) => props.onSubmenuLeave?.(e)}
+        >
+            <For each={children()}>
+                {({ key, widget }) => (
+                    <div
+                        class="action-widget-more-item"
+                        onClick={() => handleItemClick(widget)}
+                        onContextMenu={(e) => handleItemContextMenu(e, key)}
+                    >
+                        <span class="action-widget-more-item-icon widget-icon">
+                            <i class={makeIconClass(widget.icon, true, { defaultIcon: "browser" })}></i>
+                        </span>
+                        <span class="action-widget-more-item-label">{widget.label}</span>
+                    </div>
+                )}
+            </For>
+        </div>
+    );
+};
+
+PinnedWidgetFlyout.displayName = "PinnedWidgetFlyout";
+
+export { PinnedWidgetFlyout };

--- a/frontend/app/window/titlebar-context-menu.tsx
+++ b/frontend/app/window/titlebar-context-menu.tsx
@@ -7,19 +7,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { createTab, getApi } from "@/store/global";
 import { fireAndForget } from "@/util/util";
 import { createSignal, type JSX } from "solid-js";
-
-function getPinnedKeys(settings: Record<string, any>, widgets: Record<string, any>): string[] {
-    const pinned: string[] | undefined = settings["widget:pinned"];
-    if (pinned !== undefined) {
-        // Filter out stale keys that no longer exist in the widget map to avoid
-        // writing ghost entries back to the server on each toggle.
-        return pinned.filter((shortName) => widgets[`defwidget@${shortName}`] != null);
-    }
-    return Object.entries(widgets)
-        .filter(([, w]: any) => w["display:pinned"])
-        .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
-        .map(([key]) => key.replace("defwidget@", ""));
-}
+import { getGroupedChildKeys, getPinnedKeys } from "./action-widgets-config";
 
 interface TitleBarContextMenuProps {
     pos: { x: number; y: number };
@@ -83,8 +71,14 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
             },
         });
 
+        // Grouped children (e.g. Messengers' Discord/Slack/etc.) are only
+        // pinnable as their parent group — pinning/unpinning a child
+        // individually isn't a supported action (SPEC_WIDGET_BAR_PARENT_
+        // SUBMENUS_2026_08_12.md §2 non-goals), so they're excluded here the
+        // same way they're excluded from the bar's own pinned/More lists.
+        const grouped = getGroupedChildKeys(widgets());
         const widgetEntries = Object.entries(widgets())
-            .filter(([key]) => key.startsWith("defwidget@"))
+            .filter(([key]) => key.startsWith("defwidget@") && !grouped.has(key.replace("defwidget@", "")))
             .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));
 
         if (widgetEntries.length > 0) {

--- a/frontend/app/window/titlebar-context-menu.tsx
+++ b/frontend/app/window/titlebar-context-menu.tsx
@@ -7,7 +7,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { createTab, getApi } from "@/store/global";
 import { fireAndForget } from "@/util/util";
 import { createSignal, type JSX } from "solid-js";
-import { getGroupedChildKeys, getPinnedKeys } from "./action-widgets-config";
+import { getEffectiveGroupedChildKeys, getPinnedKeys } from "./action-widgets-config";
 
 interface TitleBarContextMenuProps {
     pos: { x: number; y: number };
@@ -71,12 +71,13 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
             },
         });
 
-        // Grouped children (e.g. Messengers' Discord/Slack/etc.) are only
-        // pinnable as their parent group — pinning/unpinning a child
-        // individually isn't a supported action (SPEC_WIDGET_BAR_PARENT_
-        // SUBMENUS_2026_08_12.md §2 non-goals), so they're excluded here the
-        // same way they're excluded from the bar's own pinned/More lists.
-        const grouped = getGroupedChildKeys(widgets());
+        // A grouped child not currently individually pinned (e.g.
+        // Messengers' Discord/Slack/etc.) is excluded here the same way
+        // it's excluded from the bar's own pinned/More lists — only
+        // reachable by expanding its parent's flyout. Once a user promotes
+        // one out via that flyout's own right-click "Pin to bar", it shows
+        // up here too, checked, like any other pinned widget.
+        const grouped = getEffectiveGroupedChildKeys(widgets(), settings());
         const widgetEntries = Object.entries(widgets())
             .filter(([key]) => key.startsWith("defwidget@") && !grouped.has(key.replace("defwidget@", "")))
             .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2170,6 +2170,7 @@ declare global {
         label?: string;
         description?: string;
         magnified?: boolean;
+        children?: string[];
         blockdef: BlockDef;
     };
 

--- a/schema/widgets.json
+++ b/schema/widgets.json
@@ -54,15 +54,18 @@
         "magnified": {
           "type": "boolean"
         },
+        "children": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "blockdef": {
           "$ref": "#/$defs/BlockDef"
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "blockdef"
-      ]
+      "type": "object"
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
## Summary

Implements `docs/specs/SPEC_WIDGET_BAR_PARENT_SUBMENUS_2026_08_12.md` — a "parent widget" that expands a submenu of child widgets instead of opening a pane, matching the app's existing right-click submenu feel. First concrete use: a **Messengers** parent grouping the 5 existing standalone messenger widgets (Discord, Slack, Telegram, WhatsApp, Teams).

- `WidgetConfigType` gains an optional `children: Vec<String>` (Rust) / `children?: string[]` (TS). A non-empty `children` list makes a widget a "parent"; its own `blockdef` goes unused. Load-time validation warns (not hard-fails) if a widget has neither `blockdef.meta` nor `children`, or both.
- `widgets.json`: new `defwidget@messengers` parent (`children: [discord, slack, telegram, whatsapp, teams]`); the 5 messenger entries gain `display:hidden: true`.
- `getGroupedChildKeys()` (new, in `action-widgets-config.ts`) excludes grouped children from both `getPinnedWidgets()` and `getMoreWidgets()`, and strips a stale bare child short-name out of a pre-existing `widget:pinned` array.
- **Case A (pinned in the bar):** clicking a parent slot toggles a new `PinnedWidgetFlyout` (bottom-start placement, modeled on `MoreDropdown`); hovering opens it via the shared `createSubmenuHover` 90ms-delay/safe-triangle-close primitive. Right-click is scoped to group-level actions ("Pin/Unpin group from bar") instead of the leaf per-pane menu.
- **Case B (a row inside More):** the same `PinnedWidgetFlyout` renders sideways (`right-start`, flips near the edge) off a parent row in `more-dropdown.tsx`, with a trailing chevron — structurally the same hover-intent shape `flyoutmenu.tsx`'s own `SubMenu` already uses.
- `createPeerRegistry()` (force-close a sibling submenu when a new one opens) is hoisted out of `flyoutmenu.tsx` into `submenu-hover.ts` so both `FlyoutMenu` and the new pinned-bar/More-dropdown parent rows share one implementation — kept framework-agnostic (returns an unregister function; callers own their own `onCleanup`).
- Non-goals kept out per spec: nested groups, per-child "promote to standalone pinned," and a UI for authoring new groups.

## Test plan

- [x] `cargo test -p agentmux-srv wconfig` — 40/40 pass, including 2 new tests (`test_build_default_config_loads_messengers_group`, `test_validate_widget_configs_does_not_panic`)
- [x] `cargo check -p agentmux-srv` and `task build:backend` (release profile) — both clean, no new warnings
- [x] `npx vitest run frontend/app/window frontend/app/element frontend/app/util` — 67/67 pass, including 10 new tests in `action-widgets-config.test.ts` (grouped-children exclusion, parent-in-exactly-one-list, stale-pinned-child stripped)
- [x] `npx tsc --noEmit` — clean on every touched file (2 pre-existing unrelated errors in `armory-view.tsx`/`warden-view.tsx` confirmed present on `main` via `git stash`, not introduced here)
- [x] `task build:frontend` — production Vite build succeeds
- [ ] Manual verification in a running `task dev` instance (hover-intent timing, safe-triangle close, Case A/B visual placement) — not done in this session; recommend a reviewer click through both placements before merge

<!-- agentmux:agent_id=agent1 -->