### PR TITLE
fix(ui): distinct icon for Anthropic vendor badge vs Claude harness icon

### DIFF
--- a/.changesets/1787008507-fix-ui-distinct-icon-for-anthropic-vendor-badge-no-longer-id-tmtp.md
+++ b/.changesets/1787008507-fix-ui-distinct-icon-for-anthropic-vendor-badge-no-longer-id-tmtp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): distinct icon for Anthropic vendor badge, no longer identical to the Claude harness icon

--- a/frontend/app/element/DualProviderLogo.test.tsx
+++ b/frontend/app/element/DualProviderLogo.test.tsx
@@ -32,4 +32,18 @@ describe("DualProviderLogo", () => {
         const el = container.querySelector(".dual-provider-logo") as HTMLElement;
         expect(el.title).toBe("Claude Code harness");
     });
+
+    it("renders a visually distinct icon for the Anthropic vendor badge than the Claude harness icon", () => {
+        // Regression: ProviderLogo used to map both "claude" and "anthropic"
+        // to the identical claude-color.svg asset, so a claude-harness agent
+        // running on the anthropic vendor showed the same icon twice — the
+        // badge existed but was visually redundant, defeating the point of
+        // the harness-vs-vendor split this component exists to communicate.
+        const { container } = render(() => <DualProviderLogo harness="claude" vendor="anthropic" />);
+        const harnessIcon = container.querySelector(".dual-provider-logo > .provider-logo") as HTMLElement;
+        const vendorIcon = container.querySelector(".dual-provider-logo-badge .provider-logo") as HTMLElement;
+        expect(harnessIcon).not.toBeNull();
+        expect(vendorIcon).not.toBeNull();
+        expect(vendorIcon.innerHTML).not.toBe(harnessIcon.innerHTML);
+    });
 });

--- a/frontend/app/element/ProviderLogo.tsx
+++ b/frontend/app/element/ProviderLogo.tsx
@@ -8,6 +8,7 @@
 // the theme.
 
 import claudeColorSvg from "@lobehub/icons-static-svg/icons/claude-color.svg?raw";
+import anthropicSvg from "@lobehub/icons-static-svg/icons/anthropic.svg?raw";
 import codexColorSvg from "@lobehub/icons-static-svg/icons/codex-color.svg?raw";
 import geminiColorSvg from "@lobehub/icons-static-svg/icons/gemini-color.svg?raw";
 import copilotColorSvg from "@lobehub/icons-static-svg/icons/copilot-color.svg?raw";
@@ -79,7 +80,13 @@ export const ProviderLogo = (props: ProviderLogoProps): JSX.Element => {
     const inner = (): { html?: string; png?: string; jsx?: JSX.Element } => {
         const p = (props.provider ?? "").toLowerCase();
 
-        if (p === "anthropic" || p === "claude") return { html: claudeColorSvg };
+        // Distinct icons on purpose: "claude" is the harness (Claude Code,
+        // the CLI), "anthropic" is the model vendor serving responses. Using
+        // the same icon for both would defeat the point of DualProviderLogo,
+        // which exists specifically to show harness and vendor as separate
+        // things.
+        if (p === "claude") return { html: claudeColorSvg };
+        if (p === "anthropic") return { html: anthropicSvg };
         if (p === "codex") return { html: codexColorSvg };
         if (p === "openai") return { html: openaiSvg };
         if (p === "gemini" || p === "antigravity" || p === "agy") return { html: geminiColorSvg };


### PR DESCRIPTION
## Summary

- `ProviderLogo` mapped both `"claude"` (the harness id) and `"anthropic"` (the model vendor id) to the identical `claude-color.svg` asset. `DualProviderLogo`'s vendor badge exists specifically to distinguish harness from vendor (per #2594's harness/model decoupling work), but for the most common case — a Claude Code agent running on the Anthropic API — the badge rendered the exact same Claude icon on top of itself, defeating the purpose.
- Added a distinct `anthropic.svg` (mono brand mark, same treatment as the other single-color vendor badges like OpenAI/GitHub/Moonshot) for the `"anthropic"` vendor id. The harness icon (`"claude"` → `claude-color.svg`) is untouched.

## Test plan

- [x] Added a regression test in `DualProviderLogo.test.tsx` asserting the harness icon and vendor badge render different SVG content for `harness="claude" vendor="anthropic"` — verified it fails against the unfixed code (both icons byte-identical) before trusting it passes against the fix.
- [x] Full `DualProviderLogo`/`HiddenTemplatesSection`/`MyAgentsList` test files (all `ProviderLogo`/`DualProviderLogo` consumers with test coverage): 35 passed.
- [x] `tsc --noEmit`: no new errors (2 pre-existing, unrelated errors in `armory-view.tsx`/`warden-view.tsx`).
- [x] Changeset added (`patch`).
- [x] Branch created fresh off latest `main` — no staleness to merge.

<!-- agentmux:agent_id=agenty -->