### PR TITLE
fix(statusbar): popovers and tooltips paint over native browser-pane HWNDs

### DIFF
--- a/.changesets/1787009771-fix-statusbar-popovers-and-tooltips-paint-over-native-browse-jegz.md
+++ b/.changesets/1787009771-fix-statusbar-popovers-and-tooltips-paint-over-native-browse-jegz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): popovers and tooltips paint over native browser-pane HWNDs

--- a/docs/specs/SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md
+++ b/docs/specs/SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md
@@ -1,0 +1,174 @@
+# SPEC — Status bar popovers: fix native browser-pane airspace occlusion
+
+**Date:** 2026-08-17
+**Type:** Bug fix (root-caused, implementation-ready — no code shipped yet)
+**Status:** Draft
+**Scope:** `frontend/app/statusbar/HostPopover.tsx`, `frontend/app/statusbar/BackendStatus.tsx` (+ matching CSS in `StatusBar.scss`). No backend changes.
+
+## Problem
+
+When a browser pane occupies part of the window, two status-bar dropdowns —
+the host-info popover (click the hostname chip) and the backend-status
+popover (click the backend status dot / uptime) — render **behind** the
+pane's content instead of over it, if the popover's on-screen position
+overlaps the pane. Every other status-bar popover (CPU cores, disk volumes,
+token-usage breakdown, the version/instance panel) and the widget bar's
+"More ▾" dropdown paint correctly above the pane. Only these two are broken.
+
+## Root cause
+
+On Windows, a browser pane's content is a real native child HWND
+(`agentmux-cef`'s `CefBrowserView`), which Win32 composites **above the DOM
+regardless of CSS z-index** — the "airspace problem," fully diagnosed in
+`docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md`. Any DOM element that
+needs to visually sit above a pane must explicitly register its screen rect
+so the backend can punch a transparent hole through the pane's HWND
+(`SetWindowRgn`) at that rect. There is no way for CSS alone to win this —
+raising `z-index` does nothing, because the HWND isn't part of the DOM's
+paint order at all.
+
+The app already has a working, reusable fix for exactly this, used by
+**every other** status-bar popover:
+
+- `usePaneOverlay(() => rootRef)` (`frontend/app/platform/pane-overlay.ts:265-316`)
+  — call once per popover root; it measures the element's
+  `getBoundingClientRect()` on mount/resize/reposition and dispatches the
+  rect into the shared overlay-clip map, which flushes to the
+  `browser_panes_set_overlay_clip` IPC. This is the primitive that actually
+  makes the airspace transparent, and it works cross-platform (on
+  non-Windows the same dispatch drives the host's whole-pane-hide fallback,
+  `pane-overlay.ts:172-203`).
+- `data-pane-overlay` attribute on the popover's root element — belt-and-
+  suspenders auto-discovery via `pane-overlay-auto.ts`, which independently
+  re-measures on style/resize mutations. **This auto-service only starts on
+  Windows** (`pane-overlay-auto.ts:130`), so it is not a substitute for the
+  `usePaneOverlay()` hook call above on other platforms — both must be
+  present, matching every existing consumer.
+- Render via `<Portal>` (mount to `document.body`) instead of nesting the
+  popover inside the trigger's own DOM subtree, positioned with
+  `computeMenuPosition`/`autoUpdate` (floating-ui) anchored to the trigger's
+  rect.
+
+Confirmed consumers of this exact combination:
+`CpuCoresPopover.tsx:21,57` + `SystemStats.tsx:202-207` (Portal),
+`DiskVolumesPopover.tsx:18,39` + `SystemStats.tsx:269-275` (Portal),
+`TokenBreakdownPopover.tsx:16,54,127` + `TokenUsageIndicator.tsx:95-101`
+(Portal), `InstancePanel.tsx:23,50` (rendered via fixed positioning,
+`StatusBar.tsx:116-118`), and the widget bar's `PopoverMenu`
+(`frontend/app/element/popover-menu.tsx:5,52,95-106` — the mechanism behind
+"More ▾", which is why it already paints correctly). `CpuCoresPopover.tsx:15-16`'s
+own doc comment calls `TokenBreakdownPopover` "the canonical status-bar
+popover" for this pattern.
+
+**`HostPopover.tsx` and `BackendStatus.tsx` never adopted this pattern.**
+Both render their dropdown as a plain nested `<div class="status-bar-popover">`
+(`HostPopover.tsx:167`, `BackendStatus.tsx:169`) inside a
+`position: relative` wrapper (`HostPopover.tsx:144`, `BackendStatus.tsx:145`),
+positioned purely with CSS (`StatusBar.scss:286-299` —
+`position: absolute; bottom: calc(100% + 4px); left: 0;`). Neither calls
+`usePaneOverlay()`, neither sets `data-pane-overlay`, neither is rendered
+through a `Portal`. Their screen rect is never registered with
+`pane-overlay.ts`'s clip map, so the backend never punches a hole for them
+and the pane's HWND keeps painting over them uninterrupted — exactly the
+airspace bug the other five components above were already fixed for.
+
+`ConfigStatus.tsx`, `UpdateStatus.tsx`, and `GpuStatus.tsx` were checked and
+confirmed to render no popover of their own (`ConfigStatus` opens a modal via
+the existing `openModal`/`ModalLayer` machinery, which already handles this;
+`UpdateStatus`/`GpuStatus` have no dropdown at all) — they are out of scope,
+not overlooked.
+
+## Design
+
+Migrate `HostPopover.tsx` and `BackendStatus.tsx` to the same shape as
+`TokenUsageIndicator.tsx` + `TokenBreakdownPopover.tsx`, since both are a
+single trigger + single popover with an outside-click/Esc dismiss — the
+closest existing precedent, closer than the CPU/disk pair (which share a
+parent `SystemStats.tsx` for two triggers) or `InstancePanel` (which is
+driven by `StatusBar.tsx` itself).
+
+For each of the two components:
+
+1. **Split into trigger + portaled popover**, same shape as
+   `TokenUsageIndicator.tsx:74-104`: the trigger keeps its existing
+   `status-bar-item` markup; the popover moves into `<Show when={open()}><Portal><... /></Portal></Show>`.
+2. **Popover root calls `usePaneOverlay(() => rootRef)`** and sets
+   `data-pane-overlay` on its outermost element (mirrors
+   `TokenBreakdownPopover.tsx:54,127`).
+3. **Position via `computeMenuPosition` + `autoUpdate`**
+   (`TokenBreakdownPopover.tsx:74-107`), anchored to the trigger's
+   `getBoundingClientRect()` captured on open (already done —
+   `HostPopover.tsx` has no `anchorRect` state today and will need one,
+   `BackendStatus.tsx` likewise). Use placement `"top-start"` for both
+   (they're left-aligned status-bar-left items in `HostPopover`'s case, and
+   `BackendStatus` is also left-side) to preserve the current
+   `bottom: 100%; left: 0` visual alignment — contrast with
+   `TokenBreakdownPopover`'s `"top-end"`, which is right-aligned because
+   `TokenUsageIndicator` sits in `status-bar-right`
+   (`StatusBar.tsx:66-78`). Pass `avoidNativePanes: false` (the popover is
+   *meant* to sit over a pane now, not dodge it — same reasoning as
+   `TokenBreakdownPopover.tsx:104-106`'s comment on why
+   `assertMenuInPaintableArea` is intentionally omitted there).
+4. **Fix outside-click detection for the new dual-ref shape.** Both
+   components currently detect outside clicks by checking
+   `!popoverRef.contains(e.target)` where `popoverRef` is the *shared*
+   wrapper containing both the trigger and the popover
+   (`HostPopover.tsx:132-140`, `BackendStatus.tsx:132-141`). Once the
+   popover is portaled out of that wrapper, this check no longer includes
+   clicks inside the popover itself and would immediately self-dismiss on
+   any click inside it. Switch to the dual-ref pattern already used by
+   `TokenUsageIndicator.tsx:50-59`: keep separate `triggerRef`/`popoverRef`
+   and check `triggerRef?.contains(t) || popoverRef?.contains(t)`.
+5. **CSS**: the popover keeps its existing `.status-bar-popover` visual
+   styling (background/border/padding/rows) from `StatusBar.scss:286-320` —
+   only the *positioning* properties (`position`, `bottom`, `left`,
+   `z-index`) stop being needed on that class once floating-ui supplies
+   `position: fixed; left/top: ...px` inline via `computeMenuPosition`'s
+   returned style, same as `TokenBreakdownPopover`'s `floatingStyle()`
+   (`TokenBreakdownPopover.tsx:75-79,128`). No other visual change.
+
+No change to `HostPopover`'s QR-code canvas, LAN-toggle checkbox, or
+MuxBus sign-in controls, or to `BackendStatus`'s GPU/backend-death detail
+rows — all of that content is unaffected by where in the DOM tree the
+popover mounts.
+
+## Scope / non-goals
+
+- No visual/design change — same popover content, same rows, same
+  open/close triggers. This is purely a "make it paint in the right place"
+  fix.
+- Does not touch `pane-overlay.ts`/`pane-overlay-auto.ts` themselves — the
+  primitive is correct and already proven by five other consumers; this
+  spec only wires two stragglers onto it.
+- Does not address the browser-pane loading-indicator flicker — unrelated
+  bug, covered separately in
+  `docs/specs/SPEC_BROWSER_PANE_LOADING_INDICATOR_FLICKER_2026_08_17.md`.
+
+## Verification
+
+Manual repro (no automated test currently exercises native-pane airspace —
+consistent with how the CPU/disk/token popovers were verified per their own
+specs): open any browser pane (e.g. a messenger widget) so it covers the
+bottom-left/bottom-right corners of the window where these two chips live,
+then click the hostname chip and the backend-status dot in turn and confirm
+each popover is fully visible over the pane's content, not clipped behind
+it. Also confirm outside-click-to-close and Esc-to-close still work post-
+Portal (the dual-ref fix in step 4 above is what this specifically
+exercises). Repeat with the window resized/moved mid-open to confirm
+`autoUpdate` keeps the popover anchored (same behavior `TokenBreakdownPopover`
+already relies on).
+
+## References
+
+- `docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md` — origin of the
+  `data-pane-overlay` auto-discovery mechanism and the airspace problem
+  writeup.
+- `frontend/app/platform/pane-overlay.ts`, `pane-overlay-auto.ts` — the
+  primitive this spec reuses unmodified.
+- `frontend/app/statusbar/TokenUsageIndicator.tsx`,
+  `TokenBreakdownPopover.tsx` — the pattern being mirrored.
+- `frontend/app/statusbar/CpuCoresPopover.tsx`,
+  `DiskVolumesPopover.tsx`, `SystemStats.tsx` — a second working precedent
+  (two triggers sharing one parent).
+- `frontend/app/element/popover-menu.tsx` — the widget bar's "More ▾"
+  dropdown, the user's own reference point for "already works correctly."

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -6,7 +6,11 @@ import { setRestartInProgress } from "@/store/backendStatus";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import { getGpuInfo } from "@/util/gpuutil";
-import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { Accessor, createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import { autoUpdate } from "@floating-ui/dom";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { computeMenuPosition } from "@/app/util/menu-position";
 
 function pad2(n: number): string {
     return n < 10 ? `0${n}` : `${n}`;
@@ -33,10 +37,245 @@ function gpuColor(c: ReturnType<typeof getGpuInfo>["classification"]): string {
     }
 }
 
+type BackendInfo = {
+    pid?: number;
+    started_at?: string;
+    web_endpoint?: string;
+    version: string;
+    pending_migrations?: number;
+};
+
+interface BackendStatusPanelProps {
+    anchorRect: DOMRect | null;
+    onClose: () => void;
+    backendInfo: Accessor<BackendInfo | null>;
+    startedAt: Accessor<number | null>;
+    uptimeSecs: Accessor<number>;
+    restarting: Accessor<boolean>;
+    onRestart: () => void;
+    gpu: ReturnType<typeof getGpuInfo>;
+    ref?: (el: HTMLDivElement) => void;
+}
+
+/**
+ * The actual popover content, split out from `BackendStatus` so it mounts
+ * (and unmounts) only while open — `usePaneOverlay` and the floating-ui
+ * position registration both need to run against the popover's OWN mount
+ * lifecycle, not the always-mounted trigger's. Portaled to `document.body`
+ * and airspace-clipped so it paints over any browser-pane HWND the status
+ * bar overlaps, mirroring `TokenUsageIndicator` → `TokenBreakdownPopover`
+ * (the canonical status-bar popover pattern).
+ * Spec: SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md
+ */
+const BackendStatusPanel = (props: BackendStatusPanelProps): JSX.Element => {
+    let rootRef: HTMLDivElement | undefined;
+
+    // Airspace cut so the popover paints over any browser-pane HWND the
+    // status bar overlaps — same primitive as TokenBreakdownPopover.
+    usePaneOverlay(() => rootRef);
+
+    const backendStatus = atoms.backendStatusAtom;
+    const backendInfo = props.backendInfo;
+
+    const color = () => {
+        switch (backendStatus()) {
+            case "running": return "var(--accent-color)";
+            case "connecting": return "var(--warning-color)";
+            case "crashed": return "var(--error-color)";
+            default: return null;
+        }
+    };
+
+    // Positioning routes through the shared primitive (mirrors
+    // TokenBreakdownPopover): anchored to the status dot's rect, placement
+    // top-start so the popover opens upward and left-aligns to it —
+    // matches the pre-migration default `.status-bar-popover { left: 0 }`
+    // CSS this replaces (BackendStatus lives in status-bar-left).
+    const POPOVER_WIDTH = 260;
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
+    });
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerFloating = (el: HTMLDivElement) => {
+        rootRef = el;
+        props.ref?.(el);
+        requestAnimationFrame(() => {
+            const r = props.anchorRect;
+            if (!r || !(el instanceof Element)) return;
+            const update = async () => {
+                const cur = props.anchorRect;
+                if (!cur) return;
+                const pos = await computeMenuPosition(
+                    { anchor: cur, placement: "top-start", avoidNativePanes: false },
+                    el,
+                );
+                setFloatingStyle(pos.style);
+            };
+            cleanupAutoUpdate?.();
+            // anchorRect is a static DOMRect → virtual reference element.
+            cleanupAutoUpdate = autoUpdate(
+                { getBoundingClientRect: () => props.anchorRect ?? r },
+                el,
+                update,
+            );
+            // assertMenuInPaintableArea omitted: this popover uses usePaneOverlay
+            // (airspace transparency cut-out), so intentional native-pane overlap
+            // would produce a false-positive [menu-guard] warning.
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
+
+    return (
+        <div
+            ref={registerFloating}
+            class="status-bar-popover"
+            role="dialog"
+            aria-label="Backend status"
+            data-pane-overlay
+            style={{ ...floatingStyle(), width: `${POPOVER_WIDTH}px` }}
+        >
+            <div class="status-bar-popover-row">
+                <span class="status-bar-popover-label">Status</span>
+                <span style={{ color: color() }}>{backendStatus()}</span>
+            </div>
+            <Show when={backendInfo()?.pid}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">PID</span>
+                    <span>{backendInfo().pid}</span>
+                </div>
+            </Show>
+            <Show when={props.startedAt() != null}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Uptime</span>
+                    <span>{formatUptime(props.uptimeSecs())}</span>
+                </div>
+            </Show>
+            <Show when={backendInfo()?.web_endpoint}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Endpoint</span>
+                    <span class="status-bar-popover-mono">{backendInfo().web_endpoint}</span>
+                </div>
+            </Show>
+            <Show when={backendInfo()?.version}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Version</span>
+                    <span>{backendInfo().version}</span>
+                </div>
+            </Show>
+            <Show when={(backendInfo()?.pending_migrations ?? 0) > 0}>
+                <div class="status-bar-popover-divider" />
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label" style={{ color: "var(--warning-color)" }}>
+                        Migrations
+                    </span>
+                    <span style={{ color: "var(--warning-color)" }}>
+                        {backendInfo()!.pending_migrations} pending
+                    </span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <button
+                        type="button"
+                        class="status-bar-restart-btn"
+                        onClick={() => {
+                            props.onClose();
+                            window.dispatchEvent(new CustomEvent("agentmux:open-version-panel"));
+                        }}
+                    >
+                        Open Maintenance ↗
+                    </button>
+                </div>
+            </Show>
+            {/* GPU / WebGL rendering — enabled/disabled + driver info.
+                Surfaces the silent DOM-renderer fallback when the GPU
+                process is unavailable. */}
+            <div class="status-bar-popover-divider" />
+            <div class="status-bar-popover-section-title">GPU</div>
+            <div class="status-bar-popover-row">
+                <span class="status-bar-popover-label">Status</span>
+                <span style={{ color: gpuColor(props.gpu.classification) }}>
+                    {props.gpu.classification === "unavailable"
+                        ? "Disabled"
+                        : props.gpu.classification === "software"
+                            ? "Enabled (software)"
+                            : "Enabled (hardware)"}
+                </span>
+            </div>
+            <Show when={props.gpu.webgl}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">WebGL</span>
+                    <span>{props.gpu.webgl2 ? "2.0" : "1.0"}</span>
+                </div>
+            </Show>
+            <Show when={props.gpu.renderer}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Driver</span>
+                    <span class="status-bar-popover-mono">{props.gpu.renderer}</span>
+                </div>
+            </Show>
+            <Show when={props.gpu.vendor}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Vendor</span>
+                    <span class="status-bar-popover-mono">{props.gpu.vendor}</span>
+                </div>
+            </Show>
+            <Show when={termRendererAtom() != null}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Terminal</span>
+                    <span style={{ color: termRendererAtom() === "webgl" ? "var(--accent-color)" : "var(--warning-color)" }}>
+                        {termRendererAtom() === "webgl" ? "WebGL (GPU)" : "DOM (software)"}
+                    </span>
+                </div>
+            </Show>
+            <Show when={backendStatus() === "crashed" && backendDeathInfoAtom() != null}>
+                <div class="status-bar-popover-divider" />
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Died at</span>
+                    <span>{new Date(backendDeathInfoAtom()!.died_at).toLocaleTimeString()}</span>
+                </div>
+                <Show when={backendDeathInfoAtom()!.uptime_secs != null}>
+                    <div class="status-bar-popover-row">
+                        <span class="status-bar-popover-label">Was up</span>
+                        <span>{formatUptime(backendDeathInfoAtom()!.uptime_secs!)}</span>
+                    </div>
+                </Show>
+                <Show when={backendDeathInfoAtom()!.code != null}>
+                    <div class="status-bar-popover-row">
+                        <span class="status-bar-popover-label">Exit code</span>
+                        <span class="status-bar-popover-mono">{backendDeathInfoAtom()!.code}</span>
+                    </div>
+                </Show>
+                <Show when={backendDeathInfoAtom()!.signal != null}>
+                    <div class="status-bar-popover-row">
+                        <span class="status-bar-popover-label">Signal</span>
+                        <span class="status-bar-popover-mono">{backendDeathInfoAtom()!.signal}</span>
+                    </div>
+                </Show>
+                <div class="status-bar-popover-divider" />
+                <div class="status-bar-popover-row">
+                    <button
+                        class="status-bar-restart-btn"
+                        disabled={props.restarting()}
+                        onClick={props.onRestart}
+                    >
+                        {props.restarting() ? "Restarting…" : "Restart Backend"}
+                    </button>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+BackendStatusPanel.displayName = "BackendStatusPanel";
+
 const BackendStatus = (): JSX.Element => {
     const backendStatus = atoms.backendStatusAtom;
     const [popoverOpen, setPopoverOpen] = createSignal(false);
     const [restarting, setRestarting] = createSignal(false);
+    const [anchorRect, setAnchorRect] = createSignal<DOMRect | null>(null);
 
     const handleRestart = () => {
         setRestarting(true);
@@ -54,14 +293,9 @@ const BackendStatus = (): JSX.Element => {
 
     const [startedAt, setStartedAt] = createSignal<number | null>(null);
     const [uptimeSecs, setUptimeSecs] = createSignal(0);
-    const [backendInfo, setBackendInfo] = createSignal<{
-        pid?: number;
-        started_at?: string;
-        web_endpoint?: string;
-        version: string;
-        pending_migrations?: number;
-    } | null>(null);
-    let popoverRef!: HTMLDivElement;
+    const [backendInfo, setBackendInfo] = createSignal<BackendInfo | null>(null);
+    let triggerRef: HTMLDivElement | undefined;
+    let popoverRef: HTMLDivElement | undefined;
     const gpu = getGpuInfo(); // WebGL/GPU capability — static for the renderer process
 
     // Fetch started_at when backend becomes running
@@ -126,15 +360,21 @@ const BackendStatus = (): JSX.Element => {
         } catch {
             setBackendInfo(null);
         }
+        if (triggerRef) setAnchorRect(triggerRef.getBoundingClientRect());
         setPopoverOpen(true);
     };
 
+    // Close on outside click — ignores clicks on the trigger or inside the
+    // portaled popover. Dual-ref pattern (mirrors TokenUsageIndicator):
+    // now that the popover is portaled to document.body instead of nested
+    // under the trigger, a single containment check against the trigger
+    // alone would treat every click inside the popover as "outside."
     createEffect(() => {
         if (!popoverOpen()) return;
         const handleOutsideClick = (e: MouseEvent) => {
-            if (popoverRef && !popoverRef.contains(e.target as Node)) {
-                setPopoverOpen(false);
-            }
+            const t = e.target as Node;
+            if (triggerRef?.contains(t) || popoverRef?.contains(t)) return;
+            setPopoverOpen(false);
         };
         document.addEventListener("mousedown", handleOutsideClick);
         return () => document.removeEventListener("mousedown", handleOutsideClick);
@@ -142,161 +382,44 @@ const BackendStatus = (): JSX.Element => {
 
     return (
         <Show when={backendStatus() !== null && icon() !== null}>
-            <div style={{ position: "relative" }} ref={popoverRef}>
-                <div
-                    class="status-bar-item clickable"
-                    data-tip="Backend status, click for details"
-                    aria-label="Backend status"
-                    onClick={handleClick}
-                >
-                    <span class={`status-icon${iconSpin() ? " status-icon-spin" : ""}`} style={{ color: color() }}>
-                        {icon()}
-                    </span>
-                    <Show when={backendStatus() === "running" && startedAt() != null}>
-                        <span
-                            class="stat-mono stat-uptime"
-                            style={{ "min-width": uptimeSecs() < 3600 ? "5ch" : uptimeSecs() < 86400 ? "8ch" : "12ch" }}
-                        >{formatUptime(uptimeSecs())}</span>
-                    </Show>
-                    <Show when={backendStatus() === "connecting"}>
-                        <span style={{ color: color() }}>Connecting…</span>
-                    </Show>
-                    <Show when={backendStatus() === "crashed"}>
-                        <span style={{ color: color() }}>Offline</span>
-                    </Show>
-                </div>
-                <Show when={popoverOpen()}>
-                    <div class="status-bar-popover">
-                        <div class="status-bar-popover-row">
-                            <span class="status-bar-popover-label">Status</span>
-                            <span style={{ color: color() }}>{backendStatus()}</span>
-                        </div>
-                        <Show when={backendInfo()?.pid}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">PID</span>
-                                <span>{backendInfo().pid}</span>
-                            </div>
-                        </Show>
-                        <Show when={startedAt() != null}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Uptime</span>
-                                <span>{formatUptime(uptimeSecs())}</span>
-                            </div>
-                        </Show>
-                        <Show when={backendInfo()?.web_endpoint}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Endpoint</span>
-                                <span class="status-bar-popover-mono">{backendInfo().web_endpoint}</span>
-                            </div>
-                        </Show>
-                        <Show when={backendInfo()?.version}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Version</span>
-                                <span>{backendInfo().version}</span>
-                            </div>
-                        </Show>
-                        <Show when={(backendInfo()?.pending_migrations ?? 0) > 0}>
-                            <div class="status-bar-popover-divider" />
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label" style={{ color: "var(--warning-color)" }}>
-                                    Migrations
-                                </span>
-                                <span style={{ color: "var(--warning-color)" }}>
-                                    {backendInfo()!.pending_migrations} pending
-                                </span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <button
-                                    type="button"
-                                    class="status-bar-restart-btn"
-                                    onClick={() => {
-                                        setPopoverOpen(false);
-                                        window.dispatchEvent(new CustomEvent("agentmux:open-version-panel"));
-                                    }}
-                                >
-                                    Open Maintenance ↗
-                                </button>
-                            </div>
-                        </Show>
-                        {/* GPU / WebGL rendering — enabled/disabled + driver info.
-                            Surfaces the silent DOM-renderer fallback when the GPU
-                            process is unavailable. */}
-                        <div class="status-bar-popover-divider" />
-                        <div class="status-bar-popover-section-title">GPU</div>
-                        <div class="status-bar-popover-row">
-                            <span class="status-bar-popover-label">Status</span>
-                            <span style={{ color: gpuColor(gpu.classification) }}>
-                                {gpu.classification === "unavailable"
-                                    ? "Disabled"
-                                    : gpu.classification === "software"
-                                        ? "Enabled (software)"
-                                        : "Enabled (hardware)"}
-                            </span>
-                        </div>
-                        <Show when={gpu.webgl}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">WebGL</span>
-                                <span>{gpu.webgl2 ? "2.0" : "1.0"}</span>
-                            </div>
-                        </Show>
-                        <Show when={gpu.renderer}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Driver</span>
-                                <span class="status-bar-popover-mono">{gpu.renderer}</span>
-                            </div>
-                        </Show>
-                        <Show when={gpu.vendor}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Vendor</span>
-                                <span class="status-bar-popover-mono">{gpu.vendor}</span>
-                            </div>
-                        </Show>
-                        <Show when={termRendererAtom() != null}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Terminal</span>
-                                <span style={{ color: termRendererAtom() === "webgl" ? "var(--accent-color)" : "var(--warning-color)" }}>
-                                    {termRendererAtom() === "webgl" ? "WebGL (GPU)" : "DOM (software)"}
-                                </span>
-                            </div>
-                        </Show>
-                        <Show when={backendStatus() === "crashed" && backendDeathInfoAtom() != null}>
-                            <div class="status-bar-popover-divider" />
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Died at</span>
-                                <span>{new Date(backendDeathInfoAtom()!.died_at).toLocaleTimeString()}</span>
-                            </div>
-                            <Show when={backendDeathInfoAtom()!.uptime_secs != null}>
-                                <div class="status-bar-popover-row">
-                                    <span class="status-bar-popover-label">Was up</span>
-                                    <span>{formatUptime(backendDeathInfoAtom()!.uptime_secs!)}</span>
-                                </div>
-                            </Show>
-                            <Show when={backendDeathInfoAtom()!.code != null}>
-                                <div class="status-bar-popover-row">
-                                    <span class="status-bar-popover-label">Exit code</span>
-                                    <span class="status-bar-popover-mono">{backendDeathInfoAtom()!.code}</span>
-                                </div>
-                            </Show>
-                            <Show when={backendDeathInfoAtom()!.signal != null}>
-                                <div class="status-bar-popover-row">
-                                    <span class="status-bar-popover-label">Signal</span>
-                                    <span class="status-bar-popover-mono">{backendDeathInfoAtom()!.signal}</span>
-                                </div>
-                            </Show>
-                            <div class="status-bar-popover-divider" />
-                            <div class="status-bar-popover-row">
-                                <button
-                                    class="status-bar-restart-btn"
-                                    disabled={restarting()}
-                                    onClick={handleRestart}
-                                >
-                                    {restarting() ? "Restarting…" : "Restart Backend"}
-                                </button>
-                            </div>
-                        </Show>
-                    </div>
+            <div
+                ref={(el) => { triggerRef = el; }}
+                class="status-bar-item clickable"
+                data-tip="Backend status, click for details"
+                aria-label="Backend status"
+                onClick={handleClick}
+            >
+                <span class={`status-icon${iconSpin() ? " status-icon-spin" : ""}`} style={{ color: color() }}>
+                    {icon()}
+                </span>
+                <Show when={backendStatus() === "running" && startedAt() != null}>
+                    <span
+                        class="stat-mono stat-uptime"
+                        style={{ "min-width": uptimeSecs() < 3600 ? "5ch" : uptimeSecs() < 86400 ? "8ch" : "12ch" }}
+                    >{formatUptime(uptimeSecs())}</span>
+                </Show>
+                <Show when={backendStatus() === "connecting"}>
+                    <span style={{ color: color() }}>Connecting…</span>
+                </Show>
+                <Show when={backendStatus() === "crashed"}>
+                    <span style={{ color: color() }}>Offline</span>
                 </Show>
             </div>
+            <Show when={popoverOpen()}>
+                <Portal>
+                    <BackendStatusPanel
+                        anchorRect={anchorRect()}
+                        onClose={() => setPopoverOpen(false)}
+                        backendInfo={backendInfo}
+                        startedAt={startedAt}
+                        uptimeSecs={uptimeSecs}
+                        restarting={restarting}
+                        onRestart={handleRestart}
+                        gpu={gpu}
+                        ref={(el) => { popoverRef = el; }}
+                    />
+                </Portal>
+            </Show>
         </Show>
     );
 };

--- a/frontend/app/statusbar/HostPopover.tsx
+++ b/frontend/app/statusbar/HostPopover.tsx
@@ -5,8 +5,12 @@ import { getApi, lanInstancesAtom, lanDiscoveryErrorAtom, setLanDiscoveryErrorAt
 import { invokeCommand } from "@/app/platform/ipc";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
-import { useMuxBusStatus } from "@/app/view/accounts/AgentMuxConnectPanel";
+import { Accessor, createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import { autoUpdate } from "@floating-ui/dom";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { computeMenuPosition } from "@/app/util/menu-position";
+import { useMuxBusStatus, type MuxBusController } from "@/app/view/accounts/AgentMuxConnectPanel";
 import QRCode from "qrcode";
 
 type HostInfo = {
@@ -26,34 +30,41 @@ type HostInfo = {
     };
 };
 
-const HostPopover = (): JSX.Element => {
-    const hostname = getApi().getHostName();
-    const [popoverOpen, setPopoverOpen] = createSignal(false);
-    const [hostInfo, setHostInfo] = createSignal<HostInfo | null>(null);
-    let popoverRef!: HTMLDivElement;
-    const muxbus = useMuxBusStatus();
+interface HostPopoverPanelProps {
+    anchorRect: DOMRect | null;
+    onClose: () => void;
+    hostname: string;
+    hostInfo: Accessor<HostInfo | null>;
+    lanInstances: Accessor<LanInstance[]>;
+    lanCount: Accessor<number>;
+    lanDiscoveryEnabled: Accessor<boolean>;
+    lanDiscoveryError: Accessor<string | null>;
+    onLanToggle: (enabled: boolean) => void;
+    muxbus: MuxBusController;
+    ref?: (el: HTMLDivElement) => void;
+}
 
-    // Keep the trigger's muxbus dot current without requiring the popover
-    // to ever be opened — a dead session must be visible at a glance (the
-    // popover-only Sign in state let the 0.55.8 rollout sit with WAN jekt
-    // delivery silently dead for hours).
-    onMount(() => {
-        void muxbus.refresh();
-        const timer = window.setInterval(() => void muxbus.refresh(), 60_000);
-        onCleanup(() => window.clearInterval(timer));
-    });
-    const muxbusOk = () => {
-        const s = muxbus.status();
-        return !!s && s.connected && s.valid;
-    };
+/**
+ * The actual popover content, split out from `HostPopover` so it mounts
+ * (and unmounts) only while open — `usePaneOverlay` and the floating-ui
+ * position registration both need to run against the popover's OWN mount
+ * lifecycle, not the always-mounted trigger's. Portaled to `document.body`
+ * and airspace-clipped so it paints over any browser-pane HWND the status
+ * bar overlaps, mirroring `TokenUsageIndicator` → `TokenBreakdownPopover`
+ * (the canonical status-bar popover pattern).
+ * Spec: SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md
+ */
+const HostPopoverPanel = (props: HostPopoverPanelProps): JSX.Element => {
+    let rootRef: HTMLDivElement | undefined;
 
-    const lanInstances = lanInstancesAtom;
-    const lanCount = () => lanInstances().length;
-    const lanDiscoveryEnabled = () => !!settingsAtom()?.["network:lan_discovery"];
-    const lanDiscoveryError = lanDiscoveryErrorAtom;
+    // Airspace cut so the popover paints over any browser-pane HWND the
+    // status bar overlaps — same primitive as TokenBreakdownPopover.
+    usePaneOverlay(() => rootRef);
 
     // QR fallback for mobile pairing (Phase C). Off by default — only rendered
     // when the user explicitly clicks "Show QR code" while LAN discovery is on.
+    // Local to the panel: closing/reopening the popover remounts this
+    // component, which resets the signal for free — no manual reset needed.
     const [showQr, setShowQr] = createSignal(false);
     let qrCanvasRef: HTMLCanvasElement | undefined;
 
@@ -67,7 +78,7 @@ const HostPopover = (): JSX.Element => {
     // straight to the QR renderer below — it is never logged and never sent
     // anywhere else.
     const connectUri = (): string | null => {
-        const info = hostInfo();
+        const info = props.hostInfo();
         if (!info || !info.localIp || info.localIp === "127.0.0.1") return null;
         // Prefer the WS port (mobile's live connection); fall back to the web
         // port if WS somehow isn't available. Both endpoints are reported as
@@ -93,6 +104,273 @@ const HostPopover = (): JSX.Element => {
         });
     });
 
+    const muxbus = props.muxbus;
+    const muxbusOk = () => {
+        const s = muxbus.status();
+        return !!s && s.connected && s.valid;
+    };
+
+    // Positioning routes through the shared primitive (mirrors
+    // TokenBreakdownPopover): anchored to the hostname chip's rect,
+    // placement top-end so the popover opens upward and right-aligns to
+    // the chip — it lives in status-bar-right, near the window's right
+    // edge, matching the pre-migration `.status-bar-popover.host-popover
+    // { left: auto; right: 0; }` CSS override this replaces.
+    const POPOVER_WIDTH = 320;
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
+    });
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerFloating = (el: HTMLDivElement) => {
+        rootRef = el;
+        props.ref?.(el);
+        requestAnimationFrame(() => {
+            const r = props.anchorRect;
+            if (!r || !(el instanceof Element)) return;
+            const update = async () => {
+                const cur = props.anchorRect;
+                if (!cur) return;
+                const pos = await computeMenuPosition(
+                    { anchor: cur, placement: "top-end", avoidNativePanes: false },
+                    el,
+                );
+                setFloatingStyle(pos.style);
+            };
+            cleanupAutoUpdate?.();
+            // anchorRect is a static DOMRect → virtual reference element.
+            cleanupAutoUpdate = autoUpdate(
+                { getBoundingClientRect: () => props.anchorRect ?? r },
+                el,
+                update,
+            );
+            // assertMenuInPaintableArea omitted: this popover uses usePaneOverlay
+            // (airspace transparency cut-out), so intentional native-pane overlap
+            // would produce a false-positive [menu-guard] warning.
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
+
+    return (
+        <div
+            ref={registerFloating}
+            class="status-bar-popover host-popover"
+            role="dialog"
+            aria-label="Host info"
+            data-pane-overlay
+            style={{ ...floatingStyle(), width: `${POPOVER_WIDTH}px` }}
+        >
+            {/* Host Identity */}
+            <div class="status-bar-popover-row">
+                <span style={{ "font-weight": "bold", "font-size": "1.05em" }}>
+                    {props.hostInfo()?.hostname ?? props.hostname}
+                </span>
+            </div>
+            <Show when={props.hostInfo()}>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">OS</span>
+                    <span>{props.hostInfo()!.os}</span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">IP</span>
+                    <span class="status-bar-popover-mono">{props.hostInfo()!.localIp}</span>
+                </div>
+
+                {/* Instance Info */}
+                <div class="status-bar-popover-divider" />
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Instance</span>
+                    <span>{props.hostInfo()!.instanceId}</span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">PID</span>
+                    <span class="status-bar-popover-mono">{props.hostInfo()!.pid}</span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Data</span>
+                    <span class="status-bar-popover-mono" style={{ "font-size": "0.85em", "max-width": "220px", "overflow": "hidden", "text-overflow": "ellipsis" }}>
+                        {props.hostInfo()!.dataDir}
+                    </span>
+                </div>
+
+                {/* Network — LAN discovery toggle.
+                    Spec: specs/lan-discovery-toggle.md */}
+                <div class="status-bar-popover-divider" />
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">LAN discovery</span>
+                    <label
+                        class="status-bar-toggle"
+                        data-tip={props.lanDiscoveryEnabled() ? "Disable" : "Enable (may prompt Windows Firewall)"}
+                        style={{ "margin-left": "auto" }}
+                    >
+                        <input
+                            type="checkbox"
+                            checked={props.lanDiscoveryEnabled()}
+                            onChange={(e) =>
+                                props.onLanToggle((e.target as HTMLInputElement).checked)
+                            }
+                        />
+                    </label>
+                </div>
+                <Show when={props.lanDiscoveryError()}>
+                    <div
+                        class="status-bar-popover-row"
+                        style={{
+                            "padding-left": "12px",
+                            "font-size": "0.85em",
+                            color: "var(--warning-color, #d97706)",
+                        }}
+                    >
+                        <span>⚠ {props.lanDiscoveryError()}</span>
+                    </div>
+                </Show>
+                <Show when={props.lanDiscoveryEnabled() && props.lanCount() > 0}>
+                    <div class="status-bar-popover-row" style={{ "padding-left": "12px" }}>
+                        <span style={{ color: "var(--accent-color)" }}>◆</span>
+                        <span>{props.lanCount()} peer{props.lanCount() !== 1 ? "s" : ""}</span>
+                    </div>
+                    <For each={props.lanInstances()}>
+                        {(inst: LanInstance) => (
+                            <div class="status-bar-popover-row" style={{ "padding-left": "20px" }}>
+                                <span style={{ opacity: "0.7" }}>{inst.hostname || inst.instance_id}</span>
+                                <span class="status-bar-popover-mono" style={{ opacity: "0.5" }}>v{inst.version}</span>
+                            </div>
+                        )}
+                    </For>
+                </Show>
+                <Show when={props.lanDiscoveryEnabled() && props.lanCount() === 0 && !props.lanDiscoveryError()}>
+                    <div
+                        class="status-bar-popover-row"
+                        style={{ "padding-left": "12px", opacity: "0.5", "font-size": "0.85em" }}
+                    >
+                        <span>Searching for peers…</span>
+                    </div>
+                </Show>
+
+                {/* QR fallback for mobile pairing when mDNS discovery
+                    doesn't reach the phone (corporate/guest wifi,
+                    VPN, different subnet, etc). Encodes the same
+                    agentmux://connect deep link a peer would reach
+                    via mDNS. Spec: Phase C, LAN-discovery reliability. */}
+                <Show when={props.lanDiscoveryEnabled()}>
+                    <div class="status-bar-popover-row" style={{ "padding-left": "12px" }}>
+                        <button
+                            type="button"
+                            class="status-bar-qr-toggle-btn"
+                            onClick={() => setShowQr((v) => !v)}
+                        >
+                            {showQr() ? "Hide QR code" : "Show QR code"}
+                        </button>
+                    </div>
+                    <Show when={showQr()}>
+                        <div class="status-bar-qr-panel">
+                            <canvas ref={qrCanvasRef} class="status-bar-qr-canvas" />
+                            <div class="status-bar-qr-note">
+                                For pairing the AgentMux mobile app on this network only —
+                                don&apos;t share this code outside your local network.
+                            </div>
+                        </div>
+                    </Show>
+                </Show>
+
+                {/* MuxBus Cloud */}
+                <Show when={muxbus.isConfigured()}>
+                    <div class="status-bar-popover-divider" />
+                    <div class="status-bar-popover-row">
+                        <span class="status-bar-popover-label">MuxBus Cloud</span>
+                        <Show
+                            when={muxbus.status()?.connected && muxbus.status()?.valid}
+                            fallback={
+                                <button
+                                    type="button"
+                                    class="muxbus-login-chip muxbus-login-chip-signin"
+                                    style={{ "margin-left": "auto", height: "auto", padding: "1px 8px" }}
+                                    disabled={muxbus.loading()}
+                                    onClick={() => void muxbus.connect()}
+                                >
+                                    {muxbus.loading() ? "●···" : muxbus.status()?.connected ? "Expired — re-login" : "Sign in"}
+                                </button>
+                            }
+                        >
+                            <span class="status-bar-popover-mono" style={{ "font-size": "0.85em" }}>{muxbus.status()?.email}</span>
+                        </Show>
+                    </div>
+                    <Show when={muxbus.status()?.connected && muxbus.status()?.valid}>
+                        <div class="status-bar-popover-row" style={{ "justify-content": "flex-end" }}>
+                            <button
+                                type="button"
+                                class="muxbus-popover-disconnect-btn"
+                                disabled={muxbus.loading()}
+                                onClick={() => void muxbus.disconnect()}
+                            >
+                                {muxbus.loading() ? "Disconnecting…" : "Disconnect"}
+                            </button>
+                        </div>
+                    </Show>
+                    <Show when={muxbus.error()}>
+                        <div class="status-bar-popover-row" style={{ "font-size": "0.85em", color: "var(--warning-color, #d97706)" }}>
+                            <span>⚠ {muxbus.error()}</span>
+                        </div>
+                    </Show>
+                </Show>
+
+                <div class="status-bar-popover-divider" />
+
+                {/* Ports */}
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">IPC</span>
+                    <span class="status-bar-popover-mono">{props.hostInfo()!.ports.ipc}</span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">Backend</span>
+                    <span class="status-bar-popover-mono">{props.hostInfo()!.ports.web}</span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">WS</span>
+                    <span class="status-bar-popover-mono">{props.hostInfo()!.ports.ws}</span>
+                </div>
+                <div class="status-bar-popover-row">
+                    <span class="status-bar-popover-label">DevTools</span>
+                    <span class="status-bar-popover-mono">{props.hostInfo()!.ports.devtools}</span>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+HostPopoverPanel.displayName = "HostPopoverPanel";
+
+const HostPopover = (): JSX.Element => {
+    const hostname = getApi().getHostName();
+    const [popoverOpen, setPopoverOpen] = createSignal(false);
+    const [hostInfo, setHostInfo] = createSignal<HostInfo | null>(null);
+    const [anchorRect, setAnchorRect] = createSignal<DOMRect | null>(null);
+    let triggerRef: HTMLDivElement | undefined;
+    let popoverRef: HTMLDivElement | undefined;
+    const muxbus = useMuxBusStatus();
+
+    // Keep the trigger's muxbus dot current without requiring the popover
+    // to ever be opened — a dead session must be visible at a glance (the
+    // popover-only Sign in state let the 0.55.8 rollout sit with WAN jekt
+    // delivery silently dead for hours).
+    onMount(() => {
+        void muxbus.refresh();
+        const timer = window.setInterval(() => void muxbus.refresh(), 60_000);
+        onCleanup(() => window.clearInterval(timer));
+    });
+    const muxbusOk = () => {
+        const s = muxbus.status();
+        return !!s && s.connected && s.valid;
+    };
+
+    const lanInstances = lanInstancesAtom;
+    const lanCount = () => lanInstances().length;
+    const lanDiscoveryEnabled = () => !!settingsAtom()?.["network:lan_discovery"];
+    const lanDiscoveryError = lanDiscoveryErrorAtom;
+
     // Toggle the network:lan_discovery setting. The backend's setconfig handler
     // calls LanDiscoveryController.apply, which starts/stops the mDNS daemon
     // live — no restart. On Windows, the first enable triggers the firewall
@@ -113,7 +391,6 @@ const HostPopover = (): JSX.Element => {
     const handleClick = async () => {
         if (popoverOpen()) {
             setPopoverOpen(false);
-            setShowQr(false);
             return;
         }
         try {
@@ -124,16 +401,21 @@ const HostPopover = (): JSX.Element => {
             setHostInfo(null);
         }
         void muxbus.refresh();
+        if (triggerRef) setAnchorRect(triggerRef.getBoundingClientRect());
         setPopoverOpen(true);
     };
 
+    // Close on outside click — ignores clicks on the trigger or inside the
+    // portaled popover. Dual-ref pattern (mirrors TokenUsageIndicator):
+    // now that the popover is portaled to document.body instead of nested
+    // under the trigger, a single containment check against the trigger
+    // alone would treat every click inside the popover as "outside."
     createEffect(() => {
         if (!popoverOpen()) return;
         const handleOutsideClick = (e: MouseEvent) => {
-            if (popoverRef && !popoverRef.contains(e.target as Node)) {
-                setPopoverOpen(false);
-                setShowQr(false);
-            }
+            const t = e.target as Node;
+            if (triggerRef?.contains(t) || popoverRef?.contains(t)) return;
+            setPopoverOpen(false);
         };
         document.addEventListener("mousedown", handleOutsideClick);
         onCleanup(() => document.removeEventListener("mousedown", handleOutsideClick));
@@ -141,207 +423,45 @@ const HostPopover = (): JSX.Element => {
 
     return (
         <Show when={hostname && hostname !== "unknown"}>
-            <div style={{ position: "relative" }} ref={popoverRef}>
-                <div
-                    class="status-bar-item clickable"
-                    data-tip="Host info, click for details"
-                    aria-label="Host info"
-                    onClick={handleClick}
-                >
-                    <span class="status-hostname">
-                        {hostname}
-                    </span>
-                    <Show when={lanCount() > 0}>
-                        <span style={{ color: "var(--accent-color)", "margin-left": "4px" }}>{"◆"}</span>
-                    </Show>
-                    <Show when={muxbus.isConfigured() && muxbus.status() !== null}>
-                        <span
-                            class="status-muxbus-dot"
-                            classList={{ "status-muxbus-dot--ok": muxbusOk() }}
-                            data-tip={muxbusOk() ? "MuxBus connected" : "MuxBus not connected — click for details and sign in"}
-                            aria-label={muxbusOk() ? "MuxBus connected" : "MuxBus not connected"}
-                        />
-                    </Show>
-                </div>
-                <Show when={popoverOpen()}>
-                    <div class="status-bar-popover host-popover">
-                        {/* Host Identity */}
-                        <div class="status-bar-popover-row">
-                            <span style={{ "font-weight": "bold", "font-size": "1.05em" }}>
-                                {hostInfo()?.hostname ?? hostname}
-                            </span>
-                        </div>
-                        <Show when={hostInfo()}>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">OS</span>
-                                <span>{hostInfo()!.os}</span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">IP</span>
-                                <span class="status-bar-popover-mono">{hostInfo()!.localIp}</span>
-                            </div>
-
-                            {/* Instance Info */}
-                            <div class="status-bar-popover-divider" />
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Instance</span>
-                                <span>{hostInfo()!.instanceId}</span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">PID</span>
-                                <span class="status-bar-popover-mono">{hostInfo()!.pid}</span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Data</span>
-                                <span class="status-bar-popover-mono" style={{ "font-size": "0.85em", "max-width": "220px", "overflow": "hidden", "text-overflow": "ellipsis" }}>
-                                    {hostInfo()!.dataDir}
-                                </span>
-                            </div>
-
-                            {/* Network — LAN discovery toggle.
-                                Spec: specs/lan-discovery-toggle.md */}
-                            <div class="status-bar-popover-divider" />
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">LAN discovery</span>
-                                <label
-                                    class="status-bar-toggle"
-                                    data-tip={lanDiscoveryEnabled() ? "Disable" : "Enable (may prompt Windows Firewall)"}
-                                    style={{ "margin-left": "auto" }}
-                                >
-                                    <input
-                                        type="checkbox"
-                                        checked={lanDiscoveryEnabled()}
-                                        onChange={(e) =>
-                                            void handleLanToggle((e.target as HTMLInputElement).checked)
-                                        }
-                                    />
-                                </label>
-                            </div>
-                            <Show when={lanDiscoveryError()}>
-                                <div
-                                    class="status-bar-popover-row"
-                                    style={{
-                                        "padding-left": "12px",
-                                        "font-size": "0.85em",
-                                        color: "var(--warning-color, #d97706)",
-                                    }}
-                                >
-                                    <span>⚠ {lanDiscoveryError()}</span>
-                                </div>
-                            </Show>
-                            <Show when={lanDiscoveryEnabled() && lanCount() > 0}>
-                                <div class="status-bar-popover-row" style={{ "padding-left": "12px" }}>
-                                    <span style={{ color: "var(--accent-color)" }}>◆</span>
-                                    <span>{lanCount()} peer{lanCount() !== 1 ? "s" : ""}</span>
-                                </div>
-                                <For each={lanInstances()}>
-                                    {(inst: LanInstance) => (
-                                        <div class="status-bar-popover-row" style={{ "padding-left": "20px" }}>
-                                            <span style={{ opacity: "0.7" }}>{inst.hostname || inst.instance_id}</span>
-                                            <span class="status-bar-popover-mono" style={{ opacity: "0.5" }}>v{inst.version}</span>
-                                        </div>
-                                    )}
-                                </For>
-                            </Show>
-                            <Show when={lanDiscoveryEnabled() && lanCount() === 0 && !lanDiscoveryError()}>
-                                <div
-                                    class="status-bar-popover-row"
-                                    style={{ "padding-left": "12px", opacity: "0.5", "font-size": "0.85em" }}
-                                >
-                                    <span>Searching for peers…</span>
-                                </div>
-                            </Show>
-
-                            {/* QR fallback for mobile pairing when mDNS discovery
-                                doesn't reach the phone (corporate/guest wifi,
-                                VPN, different subnet, etc). Encodes the same
-                                agentmux://connect deep link a peer would reach
-                                via mDNS. Spec: Phase C, LAN-discovery reliability. */}
-                            <Show when={lanDiscoveryEnabled()}>
-                                <div class="status-bar-popover-row" style={{ "padding-left": "12px" }}>
-                                    <button
-                                        type="button"
-                                        class="status-bar-qr-toggle-btn"
-                                        onClick={() => setShowQr((v) => !v)}
-                                    >
-                                        {showQr() ? "Hide QR code" : "Show QR code"}
-                                    </button>
-                                </div>
-                                <Show when={showQr()}>
-                                    <div class="status-bar-qr-panel">
-                                        <canvas ref={qrCanvasRef} class="status-bar-qr-canvas" />
-                                        <div class="status-bar-qr-note">
-                                            For pairing the AgentMux mobile app on this network only —
-                                            don&apos;t share this code outside your local network.
-                                        </div>
-                                    </div>
-                                </Show>
-                            </Show>
-
-                            {/* MuxBus Cloud */}
-                            <Show when={muxbus.isConfigured()}>
-                                <div class="status-bar-popover-divider" />
-                                <div class="status-bar-popover-row">
-                                    <span class="status-bar-popover-label">MuxBus Cloud</span>
-                                    <Show
-                                        when={muxbus.status()?.connected && muxbus.status()?.valid}
-                                        fallback={
-                                            <button
-                                                type="button"
-                                                class="muxbus-login-chip muxbus-login-chip-signin"
-                                                style={{ "margin-left": "auto", height: "auto", padding: "1px 8px" }}
-                                                disabled={muxbus.loading()}
-                                                onClick={() => void muxbus.connect()}
-                                            >
-                                                {muxbus.loading() ? "●···" : muxbus.status()?.connected ? "Expired — re-login" : "Sign in"}
-                                            </button>
-                                        }
-                                    >
-                                        <span class="status-bar-popover-mono" style={{ "font-size": "0.85em" }}>{muxbus.status()?.email}</span>
-                                    </Show>
-                                </div>
-                                <Show when={muxbus.status()?.connected && muxbus.status()?.valid}>
-                                    <div class="status-bar-popover-row" style={{ "justify-content": "flex-end" }}>
-                                        <button
-                                            type="button"
-                                            class="muxbus-popover-disconnect-btn"
-                                            disabled={muxbus.loading()}
-                                            onClick={() => void muxbus.disconnect()}
-                                        >
-                                            {muxbus.loading() ? "Disconnecting…" : "Disconnect"}
-                                        </button>
-                                    </div>
-                                </Show>
-                                <Show when={muxbus.error()}>
-                                    <div class="status-bar-popover-row" style={{ "font-size": "0.85em", color: "var(--warning-color, #d97706)" }}>
-                                        <span>⚠ {muxbus.error()}</span>
-                                    </div>
-                                </Show>
-                            </Show>
-
-                            <div class="status-bar-popover-divider" />
-
-                            {/* Ports */}
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">IPC</span>
-                                <span class="status-bar-popover-mono">{hostInfo()!.ports.ipc}</span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">Backend</span>
-                                <span class="status-bar-popover-mono">{hostInfo()!.ports.web}</span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">WS</span>
-                                <span class="status-bar-popover-mono">{hostInfo()!.ports.ws}</span>
-                            </div>
-                            <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-label">DevTools</span>
-                                <span class="status-bar-popover-mono">{hostInfo()!.ports.devtools}</span>
-                            </div>
-                        </Show>
-                    </div>
+            <div
+                ref={(el) => { triggerRef = el; }}
+                class="status-bar-item clickable"
+                data-tip="Host info, click for details"
+                aria-label="Host info"
+                onClick={handleClick}
+            >
+                <span class="status-hostname">
+                    {hostname}
+                </span>
+                <Show when={lanCount() > 0}>
+                    <span style={{ color: "var(--accent-color)", "margin-left": "4px" }}>{"◆"}</span>
+                </Show>
+                <Show when={muxbus.isConfigured() && muxbus.status() !== null}>
+                    <span
+                        class="status-muxbus-dot"
+                        classList={{ "status-muxbus-dot--ok": muxbusOk() }}
+                        data-tip={muxbusOk() ? "MuxBus connected" : "MuxBus not connected — click for details and sign in"}
+                        aria-label={muxbusOk() ? "MuxBus connected" : "MuxBus not connected"}
+                    />
                 </Show>
             </div>
+            <Show when={popoverOpen()}>
+                <Portal>
+                    <HostPopoverPanel
+                        anchorRect={anchorRect()}
+                        onClose={() => setPopoverOpen(false)}
+                        hostname={hostname}
+                        hostInfo={hostInfo}
+                        lanInstances={lanInstances}
+                        lanCount={lanCount}
+                        lanDiscoveryEnabled={lanDiscoveryEnabled}
+                        lanDiscoveryError={lanDiscoveryError}
+                        onLanToggle={(enabled) => void handleLanToggle(enabled)}
+                        muxbus={muxbus}
+                        ref={(el) => { popoverRef = el; }}
+                    />
+                </Portal>
+            </Show>
         </Show>
     );
 };

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -147,66 +147,12 @@
         margin-right: 1px;
     }
 
-    // Instant CSS-only tooltip. Native `title` has a browser-controlled
-    // delay (~500 ms on Windows); users want these to pop immediately.
-    // Any status-bar child carrying `data-tip="…"` gets a hover balloon
-    // above it with no entry animation. Keep native `title` off these
-    // elements (causes double tooltips); `aria-label` covers screen-
-    // reader a11y.
-    [data-tip] {
-        position: relative;
-
-        &:hover::after,
-        &:focus-visible::after {
-            content: attr(data-tip);
-            position: absolute;
-            bottom: calc(100% + 4px);
-            // Default centered. Edge-anchored variants below override
-            // the horizontal anchor for items inside .status-bar-left
-            // and .status-bar-right so tooltips don't overflow the
-            // window's left or right edge.
-            left: 50%;
-            transform: translateX(-50%);
-            padding: var(--space-1) var(--space-1-5);
-            background: var(--modal-bg-color);
-            color: var(--main-text-color);
-            border: 1px solid var(--border-color);
-            border-radius: 0;
-            font-size: 11px;
-            // Size to content, but wrap (don't single-line overflow) once the
-            // tip exceeds max-width. `nowrap` + `max-width` contradicted: long
-            // tips (e.g. GFX's full GPU renderer string) spilled out of the
-            // balloon. `max-content` keeps short tips on one line; long ones
-            // wrap, and `overflow-wrap: anywhere` breaks unbreakable renderer
-            // strings instead of overflowing.
-            white-space: normal;
-            width: max-content;
-            max-width: 320px;
-            overflow-wrap: anywhere;
-            pointer-events: none;
-            z-index: calc(var(--zindex-modal-wrapper) + 10);
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
-        }
-    }
-
-    // Items in the LEFT group anchor their tooltip to the item's left
-    // edge (tooltip extends rightward). Prevents overflow off the
-    // window's left side for the very first item.
-    .status-bar-left [data-tip]:hover::after,
-    .status-bar-left [data-tip]:focus-visible::after {
-        left: 0;
-        transform: none;
-    }
-
-    // Items in the RIGHT group anchor to the item's right edge
-    // (tooltip extends leftward). Prevents overflow off the window's
-    // right side for the version + last-widget items.
-    .status-bar-right [data-tip]:hover::after,
-    .status-bar-right [data-tip]:focus-visible::after {
-        left: auto;
-        right: 0;
-        transform: none;
-    }
+    // `data-tip="…"` tooltips are rendered by the `StatusBarTip` component
+    // (StatusBarTip.tsx/.scss) — a real, Portal'd, airspace-clip-aware DOM
+    // element, not a CSS pseudo-element (which could never paint over a
+    // native browser-pane HWND). Keep native `title` off status-bar
+    // elements carrying `data-tip` (causes double tooltips); `aria-label`
+    // covers screen-reader a11y.
 
     .stat-separator {
         opacity: 0.2;
@@ -284,9 +230,10 @@
 }
 
 .status-bar-popover {
-    position: absolute;
-    bottom: calc(100% + 4px);
-    left: 0;
+    // Positioning (position/left/top) comes from computeMenuPosition's
+    // inline style — floating-ui anchors this to the trigger and keeps it
+    // in the paintable area, mirroring TokenBreakdownPopover. See
+    // SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md.
     background: var(--modal-bg-color);
     border: 1px solid var(--border-color);
     border-radius: 0;
@@ -375,11 +322,6 @@
             }
         }
     }
-}
-
-.status-bar-popover.host-popover {
-    left: auto;
-    right: 0;
 }
 
 // ── QR fallback for mobile pairing (LAN-discovery reliability, Phase C) ────

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -8,6 +8,7 @@ import { ConfigStatus } from "./ConfigStatus";
 import { GpuStatus } from "./GpuStatus";
 import { HostPopover } from "./HostPopover";
 import { InstancePanel } from "./InstancePanel";
+import { StatusBarTip } from "./StatusBarTip";
 import { SystemStats } from "./SystemStats";
 import { TokenUsageIndicator } from "./TokenUsageIndicator";
 import { UpdateStatus } from "./UpdateStatus";
@@ -116,6 +117,7 @@ const StatusBar = (): JSX.Element => {
             <Show when={panelOpen()}>
                 <InstancePanel anchorRect={anchorRect()} onClose={() => setPanelOpen(false)} />
             </Show>
+            <StatusBarTip />
         </div>
     );
 };

--- a/frontend/app/statusbar/StatusBarTip.scss
+++ b/frontend/app/statusbar/StatusBarTip.scss
@@ -1,0 +1,30 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Visual styling only — position/left/top come from computeMenuPosition's
+// inline style (floating-ui), which also handles keeping the balloon off
+// the window edges (replacing the old CSS's hand-rolled
+// .status-bar-left/.status-bar-right edge-anchor variants with flip/shift).
+// See StatusBarTip.tsx.
+.status-bar-tip-balloon {
+    padding: var(--space-1) var(--space-1-5);
+    background: var(--modal-bg-color);
+    color: var(--main-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    font-size: 11px;
+    zoom: var(--zoomfactor);
+    // Size to content, but wrap (don't single-line overflow) once the tip
+    // exceeds max-width. `nowrap` + `max-width` contradicted: long tips
+    // (e.g. GFX's full GPU renderer string) spilled out of the balloon.
+    // `max-content` keeps short tips on one line; long ones wrap, and
+    // `overflow-wrap: anywhere` breaks unbreakable renderer strings
+    // instead of overflowing.
+    white-space: normal;
+    width: max-content;
+    max-width: 320px;
+    overflow-wrap: anywhere;
+    pointer-events: none;
+    z-index: calc(var(--zindex-modal-wrapper) + 10);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}

--- a/frontend/app/statusbar/StatusBarTip.tsx
+++ b/frontend/app/statusbar/StatusBarTip.tsx
@@ -1,0 +1,161 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Replaces the status bar's pure-CSS `[data-tip]:hover::after` tooltip
+ * with a real, Portal'd DOM element that participates in the airspace-clip
+ * mechanism. A CSS `::after` pseudo-element is never a real DOM node —
+ * it can't be tagged `data-pane-overlay`, measured by a `ResizeObserver`,
+ * or registered with `usePaneOverlay()`, so it could never paint over a
+ * native browser-pane HWND (the same "airspace problem" the status-bar
+ * popovers had — SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md,
+ * SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md).
+ *
+ * Keeps the exact call-site API unchanged: any status-bar descendant with
+ * a `data-tip="…"` attribute still gets a hover/focus-visible balloon,
+ * with zero JSX changes needed at any of the existing call sites. A single
+ * delegated `mouseover`/`mouseout`/`focusin`/`focusout` listener on
+ * `document` (mirrors the existing delegated outside-click-to-close
+ * listeners already used throughout this directory) replaces the
+ * per-element `:hover`/`:focus-visible` CSS selectors — this mirrors how
+ * `pane-overlay-auto.ts` made the `data-pane-overlay` clip itself
+ * declarative instead of requiring a hook at every call site.
+ *
+ * Mount exactly once (in `StatusBar.tsx`).
+ */
+
+import { createSignal, onCleanup, Show, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import { autoUpdate } from "@floating-ui/dom";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { computeMenuPosition } from "@/app/util/menu-position";
+import "./StatusBarTip.scss";
+
+interface TipBalloonProps {
+    target: HTMLElement;
+    text: string;
+}
+
+/**
+ * The balloon itself, split out so `usePaneOverlay` and the floating-ui
+ * position registration run against ITS OWN mount lifecycle (only while a
+ * tip is showing) — same reasoning as `HostPopoverPanel`/
+ * `BackendStatusPanel`/`TokenBreakdownPopover`: calling `usePaneOverlay`
+ * in the always-mounted parent would read an undefined ref at the parent's
+ * mount time and never re-attach its observers once the ref is later set.
+ */
+const TipBalloon = (props: TipBalloonProps): JSX.Element => {
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
+    });
+    let cleanupAutoUpdate: (() => void) | null = null;
+    let rootRef: HTMLDivElement | undefined;
+
+    // Airspace cut so the balloon paints over any browser-pane HWND the
+    // status bar overlaps — same primitive as the status-bar popovers.
+    usePaneOverlay(() => rootRef);
+
+    const registerFloating = (el: HTMLDivElement) => {
+        rootRef = el;
+        requestAnimationFrame(() => {
+            if (!(el instanceof Element)) return;
+            const update = async () => {
+                const pos = await computeMenuPosition(
+                    { anchor: props.target.getBoundingClientRect(), placement: "top", avoidNativePanes: false },
+                    el,
+                );
+                setFloatingStyle(pos.style);
+            };
+            cleanupAutoUpdate?.();
+            cleanupAutoUpdate = autoUpdate(
+                { getBoundingClientRect: () => props.target.getBoundingClientRect() },
+                el,
+                update,
+            );
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
+
+    return (
+        <div
+            ref={registerFloating}
+            class="status-bar-tip-balloon"
+            data-pane-overlay
+            style={floatingStyle()}
+        >
+            {props.text}
+        </div>
+    );
+};
+
+TipBalloon.displayName = "TipBalloon";
+
+export const StatusBarTip = (): JSX.Element => {
+    const [activeEl, setActiveEl] = createSignal<HTMLElement | null>(null);
+
+    const findTipEl = (t: EventTarget | null): HTMLElement | null => {
+        if (!(t instanceof Element)) return null;
+        const el = t.closest<HTMLElement>("[data-tip]");
+        if (!el) return null;
+        // Scope to the status bar itself and its own portaled popovers
+        // (HostPopoverPanel/BackendStatusPanel render via <Portal> to
+        // document.body, so their content is no longer a DOM descendant of
+        // `.status-bar` — `.status-bar-popover` is the shared marker class
+        // both carry). Elsewhere in the app (e.g. the editor file-tree
+        // toolbar, editor-view.scss's own `[data-tip]:hover::after` copy)
+        // keeps its separate, untouched CSS tooltip — this listener is
+        // deliberately document-scoped for reach into the portaled
+        // popovers, not because it should own every `data-tip` in the app.
+        if (!el.closest(".status-bar, .status-bar-popover")) return null;
+        return el;
+    };
+
+    const onMouseOver = (e: MouseEvent) => {
+        const el = findTipEl(e.target);
+        if (el && el !== activeEl()) setActiveEl(el);
+    };
+    const onMouseOut = (e: MouseEvent) => {
+        const el = findTipEl(e.target);
+        if (!el || el !== activeEl()) return;
+        // Moving to a descendant of the same tip element isn't a real
+        // "leave" — mouseout/mouseover fire on every inner boundary
+        // crossing too (they bubble, unlike mouseenter/mouseleave).
+        const related = e.relatedTarget;
+        if (related instanceof Node && el.contains(related)) return;
+        setActiveEl(null);
+    };
+    // `:focus-visible` parity with the CSS this replaces — keyboard-tabbing
+    // onto a status-bar control shows its tip too, not just hover.
+    const onFocusIn = (e: FocusEvent) => {
+        const el = findTipEl(e.target);
+        if (el && el.matches(":focus-visible")) setActiveEl(el);
+    };
+    const onFocusOut = (e: FocusEvent) => {
+        const el = findTipEl(e.target);
+        if (el && el === activeEl()) setActiveEl(null);
+    };
+
+    document.addEventListener("mouseover", onMouseOver);
+    document.addEventListener("mouseout", onMouseOut);
+    document.addEventListener("focusin", onFocusIn);
+    document.addEventListener("focusout", onFocusOut);
+    onCleanup(() => {
+        document.removeEventListener("mouseover", onMouseOver);
+        document.removeEventListener("mouseout", onMouseOut);
+        document.removeEventListener("focusin", onFocusIn);
+        document.removeEventListener("focusout", onFocusOut);
+    });
+
+    return (
+        <Show when={activeEl()}>
+            <Portal>
+                <TipBalloon target={activeEl()!} text={activeEl()!.getAttribute("data-tip") ?? ""} />
+            </Portal>
+        </Show>
+    );
+};
+
+StatusBarTip.displayName = "StatusBarTip";


### PR DESCRIPTION
## Summary
- `HostPopover` and `BackendStatus` never adopted the `usePaneOverlay`/`data-pane-overlay`/`Portal` pattern every other status-bar popover already uses, so their dropdowns rendered behind a native browser pane's HWND (the airspace problem) instead of over it. Migrated both to the same Portal + floating-ui positioning pattern as `TokenUsageIndicator`/`TokenBreakdownPopover`, including a dual-ref fix for outside-click-to-close now that the popover content is portaled out of the trigger's own DOM subtree.
- The status bar's `data-tip="..."` hover tooltips had the identical root cause via a different mechanism: a pure-CSS `::after` pseudo-element can never be tagged `data-pane-overlay` or measured for the native-pane clip, since it isn't a real DOM node. Replaced it with `StatusBarTip`, a single delegated listener that renders a real, airspace-clip-aware balloon for any `data-tip` element in the status bar or its popovers — zero changes needed at the ~15 existing call sites, and scoped so it doesn't collide with the editor file-tree's own separate (untouched) copy of the same CSS pattern.

Spec: `docs/specs/SPEC_STATUS_BAR_POPOVER_AIRSPACE_CLIP_2026_08_17.md`

## Test plan
- [x] `npx tsc --noEmit` clean (only 2 pre-existing, unrelated errors in `armory-view.tsx`/`warden-view.tsx`)
- [x] `npx vitest run frontend/app/statusbar` passes (11/11)
- [x] Manually verified in `task dev`: backend-status popover and host-info popover now paint over a browser pane; hover tooltips (CPU/mem/disk stats, backend dot, host chip, LAN toggle) paint over a browser pane; outside-click-to-close still works for both popovers post-portal

<!-- agentmux:agent_id=agent2 -->