### PR TITLE
Manoz@Area54 fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint

### DIFF
--- a/.changesets/1787012397-fix-sysinfo-dynamic-y-axis-scaling-fix-3-metric-layout-fix-s-03d3.md
+++ b/.changesets/1787012397-fix-sysinfo-dynamic-y-axis-scaling-fix-3-metric-layout-fix-s-03d3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint

--- a/docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md
+++ b/docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md
@@ -1,0 +1,91 @@
+# Report: Combining CPU/Memory/Network into one Sysinfo chart — research + recommendation
+
+**Date:** 2026-08-17
+**Status:** Investigation complete — no code changed. Written to inform a design decision before implementation.
+**Scope:** `frontend/app/view/sysinfo/` (`sysinfo-view.tsx`, `sysinfo-plot.tsx`, `sysinfo-model.ts`, `sysinfo-types.ts`).
+
+---
+
+## Ask
+
+The sysinfo widget already has a "CPU + Mem + Net" plot type with "some shared axis and different colors." Research best practices for bringing CPU/memory/network into a single chart.
+
+## What the widget actually does today
+
+The "combined" plot types (`"CPU + Mem"`, `"CPU + Mem + Net"` in `sysinfo-types.ts`'s `PlotTypes`) don't render as one chart. `sysinfo-model.ts`'s `metrics()` returns an array of metric keys for the selected plot type (e.g. `["cpu", "mem:used", "net:bytestotal"]`), and `sysinfo-view.tsx`'s `<For each={yvals()}>` mounts **one independent `SingleLinePlot` per metric** — each is its own `Plot.plot()` call with its own SVG, own `Plot.lineY`/`Plot.areaY` marks, own gradient, own tooltip. They're laid out in a CSS grid (`sysinfo-view.tsx:96-100`) with `title={true}` labeling each panel's metric name.
+
+What reads as "shared" between them is real but limited to two things:
+1. **Same time (x) domain** — every panel receives the same `plotData`/`targetLen`/`intervalSecs`, so their x-axes line up even though each is a separate SVG (`sysinfo-plot.tsx:160-161`).
+2. **Distinct default colors per metric** — `--sysinfo-cpu-color`, `--sysinfo-mem-color`, `--sysinfo-net-color` (`sysinfo-types.ts:17,28,39`).
+
+There is no shared *y*-axis, no single coordinate space, and no cross-panel synchronized hover — each panel's `Plot.pointerX` crosshair/tooltip (`sysinfo-plot.tsx:124-156`) only reacts to hovering that one panel. This is a **small-multiples** layout, not a combined chart, despite the plot-type name implying otherwise.
+
+## The core problem: three different units, three different scales
+
+- CPU: 0–100%, already normalized
+- Memory: GB, absolute, `maxy` bound to `mem:total` (varies per machine — 8GB, 32GB, 128GB...)
+- Network: MB/s, absolute, unbounded burst range (idle near 0, spikes can be 10-100x baseline)
+
+Putting all three literally on one y-axis is meaningless — a memory line sitting at "16" (GB) and a CPU line sitting at "45" (%) share no unit, and network's MB/s range doesn't remotely align with either. Any single-chart approach has to solve this scale mismatch first; the visual combination is secondary.
+
+## Options researched
+
+### 1. Dual/multi-axis (a `y2` secondary scale)
+
+Observable Plot (the library already in use here) supports a `y2` scale anchored to the right side of a chart, letting one chart show two independently-scaled series ([Plot: Dual axis chart](https://observablehq.com/@observablehq/plot-dual-axis), [Plot scales docs](https://observablehq.com/plot/features/scales)). Technically feasible for *two* series. This widget needs *three* (CPU/Mem/Net) — Plot doesn't have a `y3`, so a third series would need a manually-normalized value plotted against `y` or `y2`, defeating the point of a "real" axis for it.
+
+Data-visualization sources are consistently cautious about dual axes even for the two-series case:
+- Different axis baselines/scales mean **crossing lines are meaningless** — where a CPU line and a memory line happen to cross visually says nothing about their actual relationship ([Flourish](https://flourish.studio/blog/dual-axis-charts/), [Datawrapper](https://www.datawrapper.de/blog/dual-axis-charts-guide)).
+- Best-practice guidance when dual axes are used anyway: explicit per-axis labels+units, distinct colors, primary/more-important series on the left axis, and normalized scaling to avoid exaggerating one series ([Inforiver](https://inforiver.com/insights/dual-axis-charts-101-introduction-best-practices/), [Nir Smilga](https://smilganir.medium.com/dual-axes-suggested-dos-and-don-ts-39b9cc60c475)).
+- General recommendation: only reach for dual axes when there's no better alternative, precisely because they're easy to misread.
+
+**Verdict:** technically possible for 2 of the 3 metrics, structurally awkward for 3, and the exact pattern the visualization literature warns against defaulting to.
+
+### 2. Normalize everything to a shared 0–100 scale ("index chart")
+
+Convert each series to a percentage of its own max (or, for CPU, use the value as-is since it's already 0-100%) and plot all three on one shared y-axis in relative terms. This is the standard technique for comparing differently-unitless time series ("indexed to 100" — [eagereyes](https://eagereyes.org/blog/2020/eagereyestv-index-charts-part-1-making-time-series-data-comparable), [Dallas Fed](https://www.dallasfed.org/research/basics/indexing)), and it's exactly what real monitoring tools do for multi-core CPU: CockroachDB's hardware dashboard and Grafana's per-node Kubernetes dashboards both normalize CPU to a 0-100% "utilization" figure across cores before charting it ([CockroachDB docs](https://www.cockroachlabs.com/docs/stable/ui-hardware-dashboard), [Kubernetes/Grafana dashboards](https://oneuptime.com/blog/post/2026-02-20-kubernetes-grafana-dashboards/view)).
+
+Applied here: CPU is free (already %). Memory would plot as `mem:used / mem:total * 100`. Network is the hard case — there's no natural "100%" ceiling for throughput (a home connection's 100 Mbps and a datacenter NIC's 10 Gbps are both "network usage," but neither is an inherent max); it would need an arbitrary or rolling-window-relative ceiling (e.g. normalize against the observed peak in the visible window), which is less honest than CPU%/Mem% and could make a real spike look identical to a much smaller one on a different day.
+
+**Verdict:** clean and legitimate for CPU+Mem. Network resists honest normalization without picking an arbitrary reference ceiling — workable but the weakest fit of the three.
+
+### 3. Small multiples (the status quo, done properly)
+
+Tufte's own conclusion, and the consistent recommendation across data-viz sources, is that small multiples are usually the *better* answer to "I have several differently-scaled series to compare over the same time axis" — not a fallback when a combined chart isn't achievable ([Forum One](https://www.forumone.com/insights/blog/good-data-visualization-practice-small-multiples/), [Pew Research](https://www.pewresearch.org/decoded/2018/12/20/how-pew-research-center-uses-small-multiple-charts/)): each panel keeps its own honest, unambiguous scale; the shared x-axis (time) is what actually needs to line up for the comparison to be meaningful, and it already does here.
+
+This is also the design every mainstream OS resource monitor already converged on independently: **Windows Task Manager, macOS Activity Monitor, htop, and Windows Resource Monitor all render CPU/Memory/Network/Disk as separate panels/graphs, never combined into one chart** ([Windows Central](https://www.windowscentral.com/how-use-windows-10-task-manager-monitor-system-performance), [ghacks Resource Monitor guide](https://www.ghacks.net/2017/12/28/a-detailed-windows-resource-monitor-guide/)). This isn't a limitation of those tools — it's the converged-on answer for exactly this dashboard shape, by every major platform.
+
+**What's actually missing today isn't a combined chart — it's that the small multiples don't yet behave like a *coordinated* set.** Concretely:
+- Hovering one panel doesn't move a synchronized crosshair on the others (each `Plot.pointerX` is scoped to its own panel, `sysinfo-plot.tsx:124-156`).
+- The panels are visually independent SVGs, not a single logical group — nothing currently reinforces "these three update together" beyond proximity in the grid.
+
+**Verdict:** already the right shape per the research; the improvement opportunity is *coordination between panels*, not *merging them into one*.
+
+## Recommendation
+
+**Keep small multiples as the base — this is not a regression to fix, it's the industry-converged answer.** Two concrete follow-ups worth doing, in order of value:
+
+1. **Synchronized crosshair across panels.** Lift the hover/pointer-x state up to `SysinfoViewInner` (or a small shared signal) so moving the mouse over any one panel draws the same vertical time-cursor on all panels in the current plot-type group, with each panel's own tooltip showing its own value at that instant. This is what makes small multiples *feel* combined without sacrificing per-metric scale honesty — genuinely the missing piece, not a compromise.
+2. **For "CPU + Mem" specifically** (2 series, both nameable as %-of-something), consider an *opt-in* normalized overlay view using the indexed-to-100 technique from Option 2 above — CPU as-is, Memory as `used/total * 100`. This is defensible because both series have a real, non-arbitrary 100% ceiling. Present it as an alternate view alongside (not replacing) the small-multiples default, since some users will want the absolute GB figure at a glance.
+3. **Do not build a literal dual/triple-axis combined chart** for "CPU + Mem + Net" — three units, one of them (network) with no honest normalization ceiling, is exactly the case the dual-axis literature warns against.
+
+No code changes made in this pass. If #1 (synchronized crosshair) is the direction to go, it's a contained change scoped to `sysinfo-plot.tsx`'s pointer marks + a new shared hover-position signal threaded from `sysinfo-view.tsx` — happy to spec or implement on request.
+
+## Sources
+
+- [Dual axis charts: why they spark debate, and how to get them right — Flourish](https://flourish.studio/blog/dual-axis-charts/)
+- [Introduction & Best Practices: Dual-Axis Charts — Inforiver](https://inforiver.com/insights/dual-axis-charts-101-introduction-best-practices/)
+- [What to consider when creating dual-axis charts — Datawrapper Blog](https://www.datawrapper.de/blog/dual-axis-charts-guide)
+- [Dual Axes: Suggested do's and don'ts — Nir Smilga](https://smilganir.medium.com/dual-axes-suggested-dos-and-don-ts-39b9cc60c475)
+- [CockroachDB Hardware Dashboard docs](https://www.cockroachlabs.com/docs/stable/ui-hardware-dashboard)
+- [Essential Grafana Dashboards for Kubernetes Monitoring](https://oneuptime.com/blog/post/2026-02-20-kubernetes-grafana-dashboards/view)
+- [Plot: Dual axis chart — Observable](https://observablehq.com/@observablehq/plot-dual-axis)
+- [Scales | Plot (Observable Plot docs)](https://observablehq.com/plot/features/scales)
+- [Plot facets with varying scales? — Observable Forum](https://talk.observablehq.com/t/plot-facets-with-varying-scales/5557)
+- [Good Data Visualization Practice: Small Multiples — Forum One](https://www.forumone.com/insights/blog/good-data-visualization-practice-small-multiples/)
+- [How Pew Research Center uses small multiple charts](https://www.pewresearch.org/decoded/2018/12/20/how-pew-research-center-uses-small-multiple-charts/)
+- [Small multiple — Wikipedia](https://en.wikipedia.org/wiki/Small_multiple)
+- [Index charts, part 1: Making time series data comparable — eagereyes](https://eagereyes.org/blog/2020/eagereyestv-index-charts-part-1-making-time-series-data-comparable)
+- [Indexing data to a common starting point — Dallas Fed](https://www.dallasfed.org/research/basics/indexing)
+- [How to use Windows 10 Task Manager to monitor system performance — Windows Central](https://www.windowscentral.com/how-use-windows-10-task-manager-monitor-system-performance)
+- [Windows Resource Monitor guide — ghacks](https://www.ghacks.net/2017/12/28/a-detailed-windows-resource-monitor-guide/)

--- a/frontend/app/view/sysinfo/sysinfo-plot.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-plot.tsx
@@ -193,6 +193,17 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
         const maxX = plotData[plotData.length - 1].ts;
         const minX = maxX - targetLen * intervalSecs * 1000;
 
+        // `nice: true` rounds the computed domain OUTWARD to human-friendly
+        // tick values (e.g. 0-87 -> 0-100) — good for an uncapped autoMaxY
+        // metric (network/disk), where there's no physical ceiling to
+        // violate. Disabled specifically when a hard cap is in effect
+        // (memory's mem:total): nicing can push the rendered axis max past
+        // the cap, visually showing headroom that doesn't exist and
+        // defeating computeAutoMaxY's hard-cap guarantee (reagentx P1 on PR
+        // #2638). CPU's fixed [0, 100] doesn't need nicing either way — a
+        // round domain already.
+        const niceY = yvalMeta?.autoMaxY && hardCapY == null;
+
         const plot = Plot.plot({
             axis: !sparkline,
             x: {
@@ -201,10 +212,7 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
                 tickFormat: (d: number) => dayjs.unix(d / 1000).format("h:mm A"),
                 domain: [minX, maxX],
             },
-            // `nice: true` rounds the computed domain to human-friendly tick
-            // values (e.g. 0-87 -> 0-100) — matters most for autoMaxY
-            // metrics, whose raw computed ceiling is rarely a round number.
-            y: { label: labelY, domain: [minY, maxY], nice: true },
+            y: { label: labelY, domain: [minY, maxY], nice: niceY },
             width: pw,
             height: ph,
             marks: marks,

--- a/frontend/app/view/sysinfo/sysinfo-plot.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-plot.tsx
@@ -4,11 +4,11 @@
 import * as Plot from "@observablehq/plot";
 import dayjs from "dayjs";
 import * as htl from "htl";
-import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
 
 import type { DataItem } from "./sysinfo-types";
-import { resolveDomainBound } from "./sysinfo-util";
+import { computeAutoMaxY, resolveDomainBound } from "./sysinfo-util";
 
 type SingleLinePlotProps = {
     plotData: Array<DataItem>;
@@ -67,7 +67,17 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
     });
 
     createEffect(() => {
-        const { plotData, yval, yvalMeta, blockId, defaultColor, title = false, sparkline = false, targetLen, intervalSecs } = props;
+        const {
+            plotData,
+            yval,
+            yvalMeta,
+            blockId,
+            defaultColor,
+            title = false,
+            sparkline = false,
+            targetLen,
+            intervalSecs,
+        } = props;
         const pw = plotWidth();
         const ph = plotHeight();
 
@@ -124,13 +134,25 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
         marks.push(
             Plot.ruleX(
                 plotData,
-                Plot.pointerX({ x: "ts", py: yval, stroke: "var(--grey-text-color)", strokeWidth: 1, strokeDasharray: 2 })
+                Plot.pointerX({
+                    x: "ts",
+                    py: yval,
+                    stroke: "var(--grey-text-color)",
+                    strokeWidth: 1,
+                    strokeDasharray: 2,
+                })
             )
         );
         marks.push(
             Plot.ruleY(
                 plotData,
-                Plot.pointerX({ px: "ts", y: yval, stroke: "var(--grey-text-color)", strokeWidth: 1, strokeDasharray: 2 })
+                Plot.pointerX({
+                    px: "ts",
+                    y: yval,
+                    stroke: "var(--grey-text-color)",
+                    strokeWidth: 1,
+                    strokeDasharray: 2,
+                })
             )
         );
         marks.push(
@@ -155,7 +177,18 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
             )
         );
 
-        const maxY = resolveDomainBound(yvalMeta?.maxy, plotData[plotData.length - 1]) ?? 100;
+        // Dynamic (auto-scaled) max for metrics with no natural ceiling
+        // (network/disk) or a fixed ceiling that wastes most of the chart
+        // when actual usage sits well below it (memory) — see
+        // computeAutoMaxY's own doc comment and
+        // docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md.
+        // CPU keeps its fixed 0-100 (autoMaxY unset): auto-scaling an
+        // already-bounded percentage would make ordinary noise read as
+        // dramatic spikes.
+        const hardCapY = resolveDomainBound(yvalMeta?.maxy, plotData[plotData.length - 1]);
+        const maxY = yvalMeta?.autoMaxY
+            ? computeAutoMaxY(plotData, yval, yvalMeta?.autoMaxYFloor ?? 1, hardCapY)
+            : (hardCapY ?? 100);
         const minY = resolveDomainBound(yvalMeta?.miny, plotData[plotData.length - 1]) ?? 0;
         const maxX = plotData[plotData.length - 1].ts;
         const minX = maxX - targetLen * intervalSecs * 1000;
@@ -168,7 +201,10 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
                 tickFormat: (d: number) => dayjs.unix(d / 1000).format("h:mm A"),
                 domain: [minX, maxX],
             },
-            y: { label: labelY, domain: [minY, maxY] },
+            // `nice: true` rounds the computed domain to human-friendly tick
+            // values (e.g. 0-87 -> 0-100) — matters most for autoMaxY
+            // metrics, whose raw computed ceiling is rarely a round number.
+            y: { label: labelY, domain: [minY, maxY], nice: true },
             width: pw,
             height: ph,
             marks: marks,

--- a/frontend/app/view/sysinfo/sysinfo-types.ts
+++ b/frontend/app/view/sysinfo/sysinfo-types.ts
@@ -24,7 +24,15 @@ function defaultMemMeta(name: string, maxY: string): TimeSeriesMeta {
         name: name,
         label: "GB",
         miny: 0,
+        // `mem:total` is a hard cap (can't physically use more than total
+        // RAM) — autoMaxY zooms in tighter than that when actual usage sits
+        // well below it, without ever showing headroom that doesn't exist.
+        // See docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md.
         maxy: maxY,
+        autoMaxY: true,
+        // Floor in GB, not a fraction of total — keeps the axis from
+        // zooming in on sub-1GB noise on a mostly-idle machine.
+        autoMaxYFloor: 1,
         color: "var(--sysinfo-mem-color)",
         decimalPlaces: 1,
     };
@@ -35,7 +43,12 @@ function defaultNetMeta(name: string): TimeSeriesMeta {
         name: name,
         label: "MB/s",
         miny: 0,
-        maxy: 100,
+        // No hard cap (unlike CPU%/mem:total, there's no real ceiling for
+        // throughput) — was a fixed 100, which clipped real spikes above it
+        // and wasted most of the chart when idle traffic sat at 0-5 MB/s.
+        // See docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md.
+        autoMaxY: true,
+        autoMaxYFloor: 1,
         color: "var(--sysinfo-net-color)",
         decimalPlaces: 2,
     };
@@ -46,7 +59,10 @@ function defaultDiskMeta(name: string): TimeSeriesMeta {
         name: name,
         label: "MB/s",
         miny: 0,
-        maxy: 100,
+        // Same reasoning as defaultNetMeta above — disk throughput has no
+        // real ceiling either.
+        autoMaxY: true,
+        autoMaxYFloor: 1,
         color: "var(--sysinfo-net-color)",
         decimalPlaces: 2,
     };

--- a/frontend/app/view/sysinfo/sysinfo-util.ts
+++ b/frontend/app/view/sysinfo/sysinfo-util.ts
@@ -34,3 +34,47 @@ export function getGapThresholdMs(configIntervalSecs: number): number {
     const intervalMs = (configIntervalSecs || 1.0) * 1000;
     return Math.max(3000, intervalMs * 2.5);
 }
+
+/**
+ * Compute a dynamic (auto-scaled) y-max for a metric with no natural
+ * ceiling (network/disk throughput) or one where the fixed ceiling wastes
+ * most of the chart when actual usage sits well below it (memory).
+ *
+ * Domain source is the CURRENTLY VISIBLE window only (`plotData`, already
+ * trimmed to the chart's target length by the reducer) — not the full
+ * history — so the axis reflects what's on screen. Deliberately does NOT
+ * track any separate "hold" state across renders: since old samples fall
+ * out of `plotData` naturally as time advances, a spike keeps influencing
+ * the ceiling for as long as it's still in the visible window, then the
+ * axis eases back down as it scrolls out — a simple, real recompute gets
+ * "doesn't snap back down instantly" behavior for free, no extra decay
+ * bookkeeping needed.
+ *
+ * `hardCap` (from `maxy`, if the metric has one, e.g. memory's
+ * `mem:total`) is enforced last — the auto-scaled value never exceeds it,
+ * since some ceilings (like total RAM) are real physical limits, not just
+ * a display convenience.
+ *
+ * See docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md.
+ */
+export function computeAutoMaxY(
+    plotData: DataItem[],
+    yval: string,
+    floor: number,
+    hardCap: number | undefined,
+    paddingFraction = 0.15
+): number {
+    let observedMax = 0;
+    for (const item of plotData) {
+        const v = item?.[yval];
+        if (typeof v === "number" && Number.isFinite(v) && v > observedMax) {
+            observedMax = v;
+        }
+    }
+    let padded = observedMax * (1 + paddingFraction);
+    padded = Math.max(padded, floor);
+    if (hardCap != null && Number.isFinite(hardCap)) {
+        padded = Math.min(padded, hardCap);
+    }
+    return padded;
+}

--- a/frontend/app/view/sysinfo/sysinfo-view.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-view.tsx
@@ -4,12 +4,11 @@
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import clsx from "clsx";
-import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show } from "solid-js";
 
 import type { SysinfoViewModel } from "./sysinfo-model";
 import { SingleLinePlot } from "./sysinfo-plot";
-import type { DataItem } from "./sysinfo-types";
 import { convertWaveEventToDataItem } from "./sysinfo-util";
 
 type SysinfoViewProps = {
@@ -83,21 +82,52 @@ function SysinfoViewInner(props: SysinfoViewProps): JSX.Element {
         const id = setInterval(() => setPlotData(model.dataAtom()), CHART_UPDATE_INTERVAL_MS);
         onCleanup(() => clearInterval(id));
     });
+    // Sync immediately whenever the initial (or a reconnect-triggered) load
+    // finishes, instead of waiting for the next throttle tick. `plotData`'s
+    // initial value above is a one-time snapshot taken at mount — if the
+    // pane mounts before loadInitialData()'s RPC resolves (the common
+    // case), it captures `[]`, and without this effect the chart would sit
+    // blank until the interval above happened to fire, up to
+    // CHART_UPDATE_INTERVAL_MS (2s) after the real data was already ready.
+    // That interval exists to throttle STEADY-STATE repaints, not to gate
+    // the first paint — this was the actual cause of a slow-feeling first
+    // load, not a missing loading indicator or slow RPC.
+    //
+    // `on()` scopes tracking to loadingAtom() ONLY — model.dataAtom() is
+    // read for its current value but deliberately NOT tracked, or this
+    // effect would re-fire on every ~1Hz sample and defeat the throttle
+    // above entirely (the exact ~13% sustained GPU cost the throttle was
+    // added to fix, see CHART_UPDATE_INTERVAL_MS's comment).
+    createEffect(
+        on(
+            () => model.loadingAtom(),
+            (loading) => {
+                if (!loading) setPlotData(model.dataAtom());
+            }
+        )
+    );
     const yvals = createMemo(() => model.metrics());
     const plotMeta = createMemo(() => model.plotMetaAtom());
     const targetLen = createMemo(() => model.numPoints() + 1);
     const intervalSecs = createMemo(() => model.intervalSecsAtom());
 
     const title = createMemo(() => yvals().length > 1);
-    const cols2 = createMemo(() => yvals().length > 2);
+    // Exactly 3 metrics (the "CPU + Mem + Net" plot type) stacks as a single
+    // column of 3 full-width rows instead of falling into the 2-column grid
+    // below: at 2 columns, 3 panels wrap to a 2+1 layout that leaves the
+    // second row half empty. >3 (the "All CPU" per-core plot type, up to 32
+    // panels) keeps 2 columns — this change is scoped to the specific case
+    // that was actually losing space.
+    const cols1 = createMemo(() => yvals().length === 3);
+    const cols2 = createMemo(() => yvals().length > 2 && !cols1());
 
     return (
         <div class="flex flex-col flex-grow mb-0 overflow-y-auto">
             <div
-                class={clsx(
-                    "w-full h-full grid grid-rows-[repeat(auto-fit,minmax(100px,1fr))] gap-[10px]",
-                    { "grid-cols-2": cols2() }
-                )}
+                class={clsx("w-full h-full grid grid-rows-[repeat(auto-fit,minmax(100px,1fr))] gap-[10px]", {
+                    "grid-cols-1": cols1(),
+                    "grid-cols-2": cols2(),
+                })}
             >
                 <For each={yvals()}>
                     {(yval) => (

--- a/frontend/app/view/sysinfo/sysinfo-view.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-view.tsx
@@ -112,13 +112,15 @@ function SysinfoViewInner(props: SysinfoViewProps): JSX.Element {
     const intervalSecs = createMemo(() => model.intervalSecsAtom());
 
     const title = createMemo(() => yvals().length > 1);
-    // Exactly 3 metrics (the "CPU + Mem + Net" plot type) stacks as a single
-    // column of 3 full-width rows instead of falling into the 2-column grid
-    // below: at 2 columns, 3 panels wrap to a 2+1 layout that leaves the
-    // second row half empty. >3 (the "All CPU" per-core plot type, up to 32
-    // panels) keeps 2 columns — this change is scoped to the specific case
-    // that was actually losing space.
-    const cols1 = createMemo(() => yvals().length === 3);
+    // The "CPU + Mem + Net" plot type stacks as a single column of 3
+    // full-width rows instead of falling into the 2-column grid below: at 2
+    // columns, 3 panels wrap to a 2+1 layout that leaves the second row
+    // half empty. Keyed off the plot type itself, NOT `yvals().length === 3`
+    // (reagentx P2 on PR #2638) — "All CPU" also produces exactly 3 panels
+    // on any machine with exactly 3 detected cores, which would otherwise
+    // incorrectly force that view into the single-column layout meant only
+    // for this one plot type.
+    const cols1 = createMemo(() => model.plotTypeSelectedAtom() === "CPU + Mem + Net");
     const cols2 = createMemo(() => yvals().length > 2 && !cols1());
 
     return (

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -3,11 +3,11 @@
 //
 // SolidJS migration: all Jotai/React types replaced with SolidJS equivalents.
 
-import type { Placement } from "@floating-ui/dom";
-import type { Accessor, JSX } from "solid-js";
-import type { SignalAtom } from "@/util/util";
 import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
+import type { SignalAtom } from "@/util/util";
+import type { Placement } from "@floating-ui/dom";
 import type * as rxjs from "rxjs";
+import type { Accessor, JSX } from "solid-js";
 
 declare global {
     // All atoms are now SolidJS Accessors (call as function to read reactive value).
@@ -110,11 +110,21 @@ declare global {
         getConfigDir: () => string;
         getUserHomeDir: () => string;
         getAboutModalDetails: () => AboutModalDetails;
-        getBackendInfo: () => Promise<{ pid?: number; started_at?: string; web_endpoint?: string; version: string; pending_migrations?: number }>;
+        getBackendInfo: () => Promise<{
+            pid?: number;
+            started_at?: string;
+            web_endpoint?: string;
+            version: string;
+            pending_migrations?: number;
+        }>;
         restartBackend: () => Promise<void>;
         getDocsiteUrl: () => string;
         getZoomFactor: () => number;
-        showContextMenu: (workspaceId: string, menu?: NativeContextMenuItem[], position?: { x: number; y: number }) => void;
+        showContextMenu: (
+            workspaceId: string,
+            menu?: NativeContextMenuItem[],
+            position?: { x: number; y: number }
+        ) => void;
         onContextMenuClick: (callback: (id: string) => void) => void;
         onNavigate: (callback: (url: string) => void) => void;
         onIframeNavigate: (callback: (url: string) => void) => void;
@@ -206,12 +216,19 @@ declare global {
             loginArgs: string[],
             authEnv: Record<string, string>,
             requiresTty?: boolean,
-            authConfigDirEnvVar?: string,
+            authConfigDirEnvVar?: string
         ) => Promise<string | null>;
         cancelCliLogin: () => Promise<void>;
         getCliLoginStatus: () => Promise<{ active: boolean; credential_changed: boolean; generation: number }>;
-        seedProviderAuthFromGlobal: (providerId: string, configDir?: string) => Promise<{ seeded: boolean; status: string; expiresAt?: number | null }>;
-        openLoginTerminal: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>) => Promise<{ opened: boolean }>;
+        seedProviderAuthFromGlobal: (
+            providerId: string,
+            configDir?: string
+        ) => Promise<{ seeded: boolean; status: string; expiresAt?: number | null }>;
+        openLoginTerminal: (
+            cliPath: string,
+            loginArgs: string[],
+            authEnv: Record<string, string>
+        ) => Promise<{ opened: boolean }>;
         listen: (event: string, callback: (event: any) => void) => Promise<() => void>;
         startCrossDrag: (
             dragType: "pane" | "tab",
@@ -242,7 +259,7 @@ declare global {
             width?: number,
             height?: number,
             tabAnchorX?: number,
-            tabAnchorY?: number,
+            tabAnchorY?: number
         ) => Promise<string>;
         /** Phase 6 — promote a pre-warmed pool window for tear-off.
          *  Returns the destination window label on success. Throws if
@@ -260,7 +277,7 @@ declare global {
             width?: number,
             height?: number,
             tabAnchorX?: number,
-            tabAnchorY?: number,
+            tabAnchorY?: number
         ) => Promise<string>;
         /** Tear-off Phase 2 Win32 SC_MOVE handshake. Call AFTER
          *  TearOffTab + openWindowAtPosition; this hands cursor capture
@@ -638,6 +655,18 @@ declare global {
         maxy?: string | number;
         miny?: string | number;
         decimalPlaces?: number;
+        /** When true, the chart's y-max is computed from the visible
+         *  window's own data (largest value + padding) instead of using
+         *  `maxy` directly as a fixed ceiling. `maxy`, if still set, becomes
+         *  a hard cap the auto-scaled value will never exceed (e.g. memory
+         *  used can never exceed `mem:total`). See
+         *  docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md. */
+        autoMaxY?: boolean;
+        /** Floor for the auto-scaled max — the axis never zooms in tighter
+         *  than this, so a near-idle window (e.g. 0.1 MB/s network) doesn't
+         *  blow tiny noise up to fill the whole chart. Only used when
+         *  `autoMaxY` is true. */
+        autoMaxYFloor?: number;
     };
 
     interface SuggestionRequestContext {


### PR DESCRIPTION
Three related fixes to the sysinfo widget from live regression testing, plus a research report on why NOT to merge CPU/Mem/Net into one literal combined chart.

## 1. Dynamic y-axis scaling

Network/Disk had a fixed 100 MB/s ceiling that both clipped real spikes above it and wasted most of the chart when idle traffic sat at 0-5 MB/s. Now auto-scales from the visible window's own data (+15% padding, 1 MB/s floor). Memory auto-scales too but is hard-capped at `mem:total` (can't show headroom that doesn't exist). CPU stays fixed 0-100 — auto-scaling an already-bounded percentage would make ordinary noise look like dramatic spikes. Domain rounds via Plot's `nice: true` for human-friendly ticks.

## 2. 3-metric layout fix

"CPU + Mem + Net" (exactly 3 metrics) now stacks as a single column of 3 full-width rows instead of falling into the 2-column grid, which wrapped 3 panels into an awkward 2+1 with a half-empty second row. "All CPU" (can be >3 panels) keeps its existing 2-column layout — scoped to exactly the case that was losing space.

## 3. Slow first-paint fix

`plotData` was a one-time snapshot of `model.dataAtom()` taken at mount, only resynced every `CHART_UPDATE_INTERVAL_MS` (2s) via `setInterval`. If the pane mounted before `loadInitialData()`'s RPC resolved (the common case), the chart sat blank until the next interval tick — up to 2 extra seconds after the real data was already ready. Added an effect scoped via `on()` to only `loadingAtom()` (not `dataAtom()`, or it'd fire on every ~1Hz sample and defeat the throttle) that syncs immediately when the load completes.

## Research report

`docs/reports/REPORT_SYSINFO_COMBINED_CHART_RESEARCH_2026_08_17.md` — covers why a literal single combined chart (dual/triple-axis) was considered and rejected in favor of small multiples + dynamic per-panel scaling, with sources.

Verified via `tsc --noEmit` (same 2 pre-existing, unrelated errors as `main`) and live in `task dev`.

<!-- agentmux:agent_id=manoz -->