### PR TITLE
fix(reactive): don't evict live cross-channel jekt registry entries

### DIFF
--- a/.changesets/1787013019-fix-reactive-don-t-evict-cross-channel-jekt-registry-entries-mi9o.md
+++ b/.changesets/1787013019-fix-reactive-don-t-evict-cross-channel-jekt-registry-entries-mi9o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(reactive): don't evict cross-channel jekt registry entries whose owning process is still alive

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -302,20 +302,47 @@ fn pid_alive(pid: u32) -> bool {
     sys.process(target).is_some()
 }
 
-/// Public entry point for callers outside this module (`server/reactive.rs`'s
-/// evict-on-forward-failure sites) that need to distinguish "the owning
-/// process is genuinely gone" (safe to evict permanently) from "the process
-/// is alive but this one forward attempt failed" (a transient hiccup — e.g.
-/// the target channel's srv is up but the specific agent hadn't finished its
-/// own registration yet, a momentary lock/timing race, ...). Before this,
-/// `remove_shared`/`remove` were called unconditionally on any `success:false`
-/// response, which is correct for a truly-dead channel but destroys a live
-/// channel's only path to being found again — nothing re-writes the shared
-/// entry except the agent's own one-time registration event, so an evicted
-/// live entry stays unreachable until that agent's controller restarts. See
-/// docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
-pub fn is_pid_alive(pid: u32) -> bool {
-    pid_alive(pid)
+/// Grace period during which a forward failure against a live-process entry
+/// is presumed transient rather than proof the specific agent is gone — see
+/// [`should_evict_on_forward_failure`].
+const FORWARD_FAILURE_GRACE_MS: u64 = 60_000;
+
+/// Should `server/reactive.rs`'s evict-on-forward-failure sites remove this
+/// entry after a failed forward (`success:false` or a connection error)?
+///
+/// `entry.pid` identifies the OWNING SRV PROCESS (`AgentEntry::pid`'s own
+/// doc comment: "OS PID of the owning agentmux-srv process"), not the
+/// individual agent — every agent registered under the same channel/srv
+/// shares one `pid` value. A first version of this function (PR #2640,
+/// reagent P1 round 2) checked ONLY `pid_alive(entry.pid)`: alive process ⇒
+/// never evict. That over-corrects — it can only ever prove "the whole
+/// process died," never "this ONE agent's controller died while its srv
+/// process kept running for other agents," which is at least as common a
+/// failure mode as a whole-process death on a host running multiple agents
+/// under one shared srv (the default topology — see the retro). Under that
+/// version, a genuinely-dead individual agent's entry would linger in the
+/// shared registry forever as long as ANY other agent kept that same srv
+/// process alive, with no self-healing path short of a full srv restart —
+/// strictly worse than the pre-PR-2640 behavior (unconditional eviction) for
+/// that case.
+///
+/// Evict when EITHER signal indicates death:
+/// - the owning process is confirmed dead (definitive), OR
+/// - the entry is older than [`FORWARD_FAILURE_GRACE_MS`] — a fresh entry
+///   gets one grace window to account for the specific race PR #2640 fixes
+///   (the registering agent's controller hasn't finished its own
+///   registration yet, even though its srv process and this file both
+///   already exist); anything older that still fails a forward is presumed
+///   genuinely gone, matching pre-PR-2640 behavior for everything but a
+///   just-registered entry.
+///
+/// See docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+pub fn should_evict_on_forward_failure(entry: &AgentEntry) -> bool {
+    if !pid_alive(entry.pid) {
+        return true;
+    }
+    let age_ms = now_unix_millis().saturating_sub(entry.updated_at);
+    age_ms > FORWARD_FAILURE_GRACE_MS
 }
 
 /// Write (create or update) this channel's entry for `agent_id` in the
@@ -813,5 +840,48 @@ mod shared_tests {
     #[test]
     fn pid_alive_false_for_max_pid() {
         assert!(!pid_alive(u32::MAX));
+    }
+
+    fn entry_with(pid: u32, updated_at: u64) -> AgentEntry {
+        AgentEntry {
+            agent_id: "agentx".to_string(),
+            local_url: "http://127.0.0.1:9001".to_string(),
+            block_id: "block1".to_string(),
+            pid,
+            updated_at,
+            auth_key: String::new(),
+            channel: "dev-a".to_string(),
+            registration_nonce: 0,
+        }
+    }
+
+    #[test]
+    fn should_evict_on_forward_failure_true_for_dead_pid_even_when_fresh() {
+        // Dead process is definitive regardless of age — the original,
+        // pre-PR-2640 case this whole mechanism exists for.
+        let entry = entry_with(u32::MAX, now_unix_millis());
+        assert!(should_evict_on_forward_failure(&entry));
+    }
+
+    #[test]
+    fn should_evict_on_forward_failure_false_for_alive_pid_and_fresh_entry() {
+        // The race PR #2640 actually fixes: owning srv process is alive, the
+        // entry was JUST written (this agent's own registration is still
+        // settling) — a forward failure right now is presumed transient.
+        let entry = entry_with(std::process::id(), now_unix_millis());
+        assert!(!should_evict_on_forward_failure(&entry));
+    }
+
+    #[test]
+    fn should_evict_on_forward_failure_true_for_alive_pid_but_old_entry() {
+        // reagent P1 round 2 on PR #2640: a genuinely-dead INDIVIDUAL agent
+        // whose srv process stays alive for other agents (the shared-srv
+        // topology this host actually runs) must still be evictable once
+        // the entry is old enough that a startup race is no longer a
+        // plausible explanation — pid-liveness alone would wrongly protect
+        // this forever.
+        let stale_updated_at = now_unix_millis().saturating_sub(FORWARD_FAILURE_GRACE_MS + 1_000);
+        let entry = entry_with(std::process::id(), stale_updated_at);
+        assert!(should_evict_on_forward_failure(&entry));
     }
 }

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -302,6 +302,22 @@ fn pid_alive(pid: u32) -> bool {
     sys.process(target).is_some()
 }
 
+/// Public entry point for callers outside this module (`server/reactive.rs`'s
+/// evict-on-forward-failure sites) that need to distinguish "the owning
+/// process is genuinely gone" (safe to evict permanently) from "the process
+/// is alive but this one forward attempt failed" (a transient hiccup — e.g.
+/// the target channel's srv is up but the specific agent hadn't finished its
+/// own registration yet, a momentary lock/timing race, ...). Before this,
+/// `remove_shared`/`remove` were called unconditionally on any `success:false`
+/// response, which is correct for a truly-dead channel but destroys a live
+/// channel's only path to being found again — nothing re-writes the shared
+/// entry except the agent's own one-time registration event, so an evicted
+/// live entry stays unreachable until that agent's controller restarts. See
+/// docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+pub fn is_pid_alive(pid: u32) -> bool {
+    pid_alive(pid)
+}
+
 /// Write (create or update) this channel's entry for `agent_id` in the
 /// host-global shared registry. Writes only this channel's own file
 /// (`shared_channel_path`) — never touches another channel's file, so

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1298,16 +1298,26 @@ pub async fn bind_listeners_and_network(
                 interval.tick().await;
                 let data_dir = base::get_wave_data_dir();
                 for reg in reactive::get_global_handler().list_agents() {
-                    backend::reactive::registry::write(
+                    // _with_nonce, not the plain write/write_shared_from_env
+                    // — those hardcode registration_nonce: 0, which would
+                    // silently break remove_if_nonce/
+                    // remove_shared_from_env_if_nonce's compare-and-remove
+                    // on this agent's own clean-exit cleanup (reagent P1
+                    // round 4 on PR #2640: every 20s heartbeat tick would
+                    // zero out the real nonce already recorded in
+                    // `reg.registration_nonce`).
+                    backend::reactive::registry::write_with_nonce(
                         &data_dir,
                         &reg.agent_id,
                         &local_web_url,
                         &reg.block_id,
+                        reg.registration_nonce,
                     );
-                    backend::reactive::registry::write_shared_from_env(
+                    backend::reactive::registry::write_shared_from_env_with_nonce(
                         &reg.agent_id,
                         &local_web_url,
                         &reg.block_id,
+                        reg.registration_nonce,
                     );
                 }
             }

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1268,6 +1268,52 @@ pub async fn bind_listeners_and_network(
         backend::reactive::registry::cleanup_stale_shared(&shared_dir, 4 * 60 * 60 * 1000);
     }
 
+    // Periodic re-registration heartbeat for every LOCALLY-registered agent's
+    // Tier 2 (per-channel) and Tier 2b (host-global shared) registry
+    // entries. Without this, an entry's `updated_at` is stamped once at
+    // registration and never refreshed — so `should_evict_on_forward_failure`
+    // (registry.rs)'s grace-period check is only ever true in the ~60s right
+    // after an agent registers, useless for any steady-state agent (i.e.
+    // most of them). reagent P1 round 3 on PR #2640: the PID+age eviction
+    // guard from the earlier commits on that PR doesn't actually protect a
+    // live, long-running agent from a single transient forward failure,
+    // reproducing the exact bug the PR claims to fix. This heartbeat closes
+    // that gap: `reactive::get_global_handler().list_agents()` is the
+    // in-memory Tier-1 registry, updated synchronously on every
+    // register/unregister — so it's always accurate, with no staleness
+    // window of its own. Re-writing from it keeps a live agent's on-disk
+    // entries fresh indefinitely; a genuinely-dead agent simply stops
+    // appearing in `list_agents()` (its own register/unregister lifecycle
+    // already handles that), so its entries age past the grace period and
+    // become evictable again within one heartbeat interval. The interval is
+    // well under `FORWARD_FAILURE_GRACE_MS` so a live entry's age never
+    // approaches the grace threshold between heartbeats. See
+    // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+    {
+        let local_web_url = local_web_url.clone();
+        tokio::spawn(async move {
+            const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+            let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+            loop {
+                interval.tick().await;
+                let data_dir = base::get_wave_data_dir();
+                for reg in reactive::get_global_handler().list_agents() {
+                    backend::reactive::registry::write(
+                        &data_dir,
+                        &reg.agent_id,
+                        &local_web_url,
+                        &reg.block_id,
+                    );
+                    backend::reactive::registry::write_shared_from_env(
+                        &reg.agent_id,
+                        &local_web_url,
+                        &reg.block_id,
+                    );
+                }
+            }
+        });
+    }
+
     // Tracks agent-spawned OS processes per block. Registered trackers
     // live as long as their agent pane; the background poller emits
     // delta events (`agent:process-added`/`-exited`) to the frontend.

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -487,30 +487,35 @@ pub(super) async fn handle_reactive_inject(
                             // shutdown) OR that the owning process is alive
                             // but hasn't (yet) registered this specific agent
                             // — e.g. right after that channel's srv came up.
-                            // Only evict if the owning PID is confirmed gone;
-                            // otherwise a single transient miss permanently
-                            // destroys the only path back to a live channel,
-                            // since nothing re-writes this entry except that
-                            // agent's own one-time registration event. See
+                            // should_evict_on_forward_failure combines
+                            // PID-liveness with the entry's age: a dead
+                            // process always evicts; a live process only
+                            // protects a FRESH entry (the actual startup
+                            // race), not an old one — an old entry whose
+                            // process happens to still be alive for OTHER
+                            // agents is presumed to be its own genuinely-dead
+                            // agent (reagent P1 round 2 on #2640: PID alone
+                            // over-protects, since it identifies the whole
+                            // srv process, not this one agent). See
                             // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
                             // Falls through to Tier 2b/3 either way (reagent
                             // P1 on #2350 — this previously returned
                             // unconditionally whenever the body parsed,
                             // regardless of success, so a stale same-channel
                             // entry never fell through to any later tier).
-                            if agent_registry::is_pid_alive(entry.pid) {
+                            if agent_registry::should_evict_on_forward_failure(&entry) {
                                 tracing::warn!(
                                     target = %req.target_agent,
                                     pid = entry.pid,
-                                    "cross-instance forward: success=false but owning process is alive — NOT evicting, falling through"
+                                    "cross-instance forward: success=false, entry presumed dead — evicting and falling through"
                                 );
+                                agent_registry::remove(&data_dir, &req.target_agent);
                             } else {
                                 tracing::warn!(
                                     target = %req.target_agent,
                                     pid = entry.pid,
-                                    "cross-instance forward: success=false, owning process is gone — evicting and falling through"
+                                    "cross-instance forward: success=false but entry is fresh and owning process is alive — NOT evicting, falling through"
                                 );
-                                agent_registry::remove(&data_dir, &req.target_agent);
                             }
                         }
                     }
@@ -526,29 +531,29 @@ pub(super) async fn handle_reactive_inject(
                         // Connection-level failure (e.g. target port not
                         // listening yet) is at least as plausible a transient
                         // trigger as a parsed success:false body — same
-                        // liveness guard as that branch above (reagent P1 on
-                        // this PR: this Err(e) arm still evicted
-                        // unconditionally, inconsistent with the fix just
-                        // applied a few lines up for the same underlying bug
-                        // class). See
+                        // should_evict_on_forward_failure guard as that
+                        // branch above (reagent P1 on this PR, both rounds:
+                        // this Err(e) arm originally evicted unconditionally,
+                        // then a PID-only guard over-protected an old entry
+                        // whose process stayed alive for other agents). See
                         // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
-                        if agent_registry::is_pid_alive(entry.pid) {
+                        if agent_registry::should_evict_on_forward_failure(&entry) {
                             tracing::warn!(
                                 target = %req.target_agent,
                                 error = %e,
                                 url = %forward_url,
                                 pid = entry.pid,
-                                "cross-instance forward failed but owning process is alive — NOT evicting"
+                                "cross-instance forward failed, entry presumed dead — removing registry entry"
                             );
+                            agent_registry::remove(&data_dir, &req.target_agent);
                         } else {
                             tracing::warn!(
                                 target = %req.target_agent,
                                 error = %e,
                                 url = %forward_url,
                                 pid = entry.pid,
-                                "cross-instance forward failed, owning process is gone — removing registry entry"
+                                "cross-instance forward failed but entry is fresh and owning process is alive — NOT evicting"
                             );
-                            agent_registry::remove(&data_dir, &req.target_agent);
                         }
                     }
                 }
@@ -607,30 +612,28 @@ pub(super) async fn handle_reactive_inject(
                                 );
                                 return Json(body);
                             }
-                            // success:false — same ambiguity as Tier 2a above:
-                            // could be a genuinely stale entry, or a live
-                            // channel whose srv is up but hadn't (yet)
-                            // registered this specific agent. Only evict on a
-                            // confirmed-dead PID; a live-but-momentarily-
-                            // not-found process just falls through to the
-                            // next candidate without losing its registry
-                            // entry. See
+                            // success:false — same ambiguity as Tier 2a above,
+                            // same should_evict_on_forward_failure policy
+                            // (PID-liveness alone over-protects an old,
+                            // genuinely-dead individual agent whose srv
+                            // process another agent keeps alive — reagent P1
+                            // round 2 on #2640). See
                             // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
-                            if agent_registry::is_pid_alive(entry.pid) {
+                            if agent_registry::should_evict_on_forward_failure(&entry) {
                                 tracing::warn!(
                                     target = %req.target_agent,
                                     channel = %entry.channel,
                                     pid = entry.pid,
-                                    "cross-channel forward: success=false but owning process is alive — NOT evicting, trying next candidate"
+                                    "cross-channel forward: success=false, entry presumed dead — evicting and trying next candidate"
                                 );
+                                agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
                             } else {
                                 tracing::warn!(
                                     target = %req.target_agent,
                                     channel = %entry.channel,
                                     pid = entry.pid,
-                                    "cross-channel forward: success=false, owning process is gone — evicting and trying next candidate"
+                                    "cross-channel forward: success=false but entry is fresh and owning process is alive — NOT evicting, trying next candidate"
                                 );
-                                agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
                             }
                         }
                     }
@@ -644,22 +647,23 @@ pub(super) async fn handle_reactive_inject(
                         );
                     }
                     Err(e) => {
-                        // Same liveness guard as the success:false branch
-                        // above — a connection failure can be the exact same
-                        // startup-race transient (target channel's srv not
-                        // listening yet), not proof the process is dead.
-                        // reagent P1 on this PR: this arm still evicted
-                        // unconditionally. See
+                        // Same should_evict_on_forward_failure policy as the
+                        // success:false branch above — a connection failure
+                        // can be the exact same startup-race transient
+                        // (target channel's srv not listening yet), not
+                        // proof the specific agent is dead. reagent P1 on
+                        // this PR, both rounds. See
                         // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
-                        if agent_registry::is_pid_alive(entry.pid) {
+                        if agent_registry::should_evict_on_forward_failure(&entry) {
                             tracing::warn!(
                                 target = %req.target_agent,
                                 channel = %entry.channel,
                                 error = %e,
                                 url = %forward_url,
                                 pid = entry.pid,
-                                "cross-channel forward failed but owning process is alive — NOT evicting"
+                                "cross-channel forward failed, entry presumed dead — evicting entry"
                             );
+                            agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
                         } else {
                             tracing::warn!(
                                 target = %req.target_agent,
@@ -667,9 +671,8 @@ pub(super) async fn handle_reactive_inject(
                                 error = %e,
                                 url = %forward_url,
                                 pid = entry.pid,
-                                "cross-channel forward failed, owning process is gone — evicting entry"
+                                "cross-channel forward failed but entry is fresh and owning process is alive — NOT evicting"
                             );
-                            agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
                         }
                     }
                 }

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -523,13 +523,33 @@ pub(super) async fn handle_reactive_inject(
                         );
                     }
                     Err(e) => {
-                        tracing::warn!(
-                            target = %req.target_agent,
-                            error = %e,
-                            url = %forward_url,
-                            "cross-instance forward failed — removing stale registry entry"
-                        );
-                        agent_registry::remove(&data_dir, &req.target_agent);
+                        // Connection-level failure (e.g. target port not
+                        // listening yet) is at least as plausible a transient
+                        // trigger as a parsed success:false body — same
+                        // liveness guard as that branch above (reagent P1 on
+                        // this PR: this Err(e) arm still evicted
+                        // unconditionally, inconsistent with the fix just
+                        // applied a few lines up for the same underlying bug
+                        // class). See
+                        // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+                        if agent_registry::is_pid_alive(entry.pid) {
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                error = %e,
+                                url = %forward_url,
+                                pid = entry.pid,
+                                "cross-instance forward failed but owning process is alive — NOT evicting"
+                            );
+                        } else {
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                error = %e,
+                                url = %forward_url,
+                                pid = entry.pid,
+                                "cross-instance forward failed, owning process is gone — removing registry entry"
+                            );
+                            agent_registry::remove(&data_dir, &req.target_agent);
+                        }
                     }
                 }
             }
@@ -624,14 +644,33 @@ pub(super) async fn handle_reactive_inject(
                         );
                     }
                     Err(e) => {
-                        tracing::warn!(
-                            target = %req.target_agent,
-                            channel = %entry.channel,
-                            error = %e,
-                            url = %forward_url,
-                            "cross-channel forward failed — evicting stale entry"
-                        );
-                        agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
+                        // Same liveness guard as the success:false branch
+                        // above — a connection failure can be the exact same
+                        // startup-race transient (target channel's srv not
+                        // listening yet), not proof the process is dead.
+                        // reagent P1 on this PR: this arm still evicted
+                        // unconditionally. See
+                        // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+                        if agent_registry::is_pid_alive(entry.pid) {
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                channel = %entry.channel,
+                                error = %e,
+                                url = %forward_url,
+                                pid = entry.pid,
+                                "cross-channel forward failed but owning process is alive — NOT evicting"
+                            );
+                        } else {
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                channel = %entry.channel,
+                                error = %e,
+                                url = %forward_url,
+                                pid = entry.pid,
+                                "cross-channel forward failed, owning process is gone — evicting entry"
+                            );
+                            agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
+                        }
                     }
                 }
             }

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -482,19 +482,36 @@ pub(super) async fn handle_reactive_inject(
                                 );
                                 return Json(body);
                             }
-                            // success:false — this entry is stale (e.g. agent
-                            // unregistered without a clean shutdown); evict
-                            // and fall through to Tier 2b/3 instead of
-                            // returning the failure (reagent P1 on #2350 —
-                            // this previously returned unconditionally
-                            // whenever the body parsed, regardless of
-                            // success, so a stale same-channel entry never
-                            // fell through to any later tier).
-                            tracing::warn!(
-                                target = %req.target_agent,
-                                "cross-instance forward: success=false — evicting and falling through"
-                            );
-                            agent_registry::remove(&data_dir, &req.target_agent);
+                            // success:false — could mean this entry is stale
+                            // (e.g. agent unregistered without a clean
+                            // shutdown) OR that the owning process is alive
+                            // but hasn't (yet) registered this specific agent
+                            // — e.g. right after that channel's srv came up.
+                            // Only evict if the owning PID is confirmed gone;
+                            // otherwise a single transient miss permanently
+                            // destroys the only path back to a live channel,
+                            // since nothing re-writes this entry except that
+                            // agent's own one-time registration event. See
+                            // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+                            // Falls through to Tier 2b/3 either way (reagent
+                            // P1 on #2350 — this previously returned
+                            // unconditionally whenever the body parsed,
+                            // regardless of success, so a stale same-channel
+                            // entry never fell through to any later tier).
+                            if agent_registry::is_pid_alive(entry.pid) {
+                                tracing::warn!(
+                                    target = %req.target_agent,
+                                    pid = entry.pid,
+                                    "cross-instance forward: success=false but owning process is alive — NOT evicting, falling through"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    target = %req.target_agent,
+                                    pid = entry.pid,
+                                    "cross-instance forward: success=false, owning process is gone — evicting and falling through"
+                                );
+                                agent_registry::remove(&data_dir, &req.target_agent);
+                            }
                         }
                     }
                     Ok(r) => {
@@ -570,15 +587,31 @@ pub(super) async fn handle_reactive_inject(
                                 );
                                 return Json(body);
                             }
-                            // success:false — this channel's entry is stale
-                            // (e.g. agent unregistered without a clean
-                            // shutdown); evict and try the next candidate.
-                            tracing::warn!(
-                                target = %req.target_agent,
-                                channel = %entry.channel,
-                                "cross-channel forward: success=false — evicting and trying next candidate"
-                            );
-                            agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
+                            // success:false — same ambiguity as Tier 2a above:
+                            // could be a genuinely stale entry, or a live
+                            // channel whose srv is up but hadn't (yet)
+                            // registered this specific agent. Only evict on a
+                            // confirmed-dead PID; a live-but-momentarily-
+                            // not-found process just falls through to the
+                            // next candidate without losing its registry
+                            // entry. See
+                            // docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md.
+                            if agent_registry::is_pid_alive(entry.pid) {
+                                tracing::warn!(
+                                    target = %req.target_agent,
+                                    channel = %entry.channel,
+                                    pid = entry.pid,
+                                    "cross-channel forward: success=false but owning process is alive — NOT evicting, trying next candidate"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    target = %req.target_agent,
+                                    channel = %entry.channel,
+                                    pid = entry.pid,
+                                    "cross-channel forward: success=false, owning process is gone — evicting and trying next candidate"
+                                );
+                                agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
+                            }
                         }
                     }
                     Ok(r) => {

--- a/docs/analysis/ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md
+++ b/docs/analysis/ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md
@@ -1,0 +1,430 @@
+# Analysis: agent-pane scroll "spins backward" during tool-call streaming
+
+**Date:** 2026-08-17
+**Status:** Root-cause analysis from direct code inspection + prior internal
+docs. No code changed. One question (§6) needs a live repro this agent
+cannot drive (no GUI automation available in this environment — same
+limitation `PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md` §7 hit).
+
+## Addendum 2026-08-17 (same day) — corrections from a first implementation pass, plus diagnostic instrumentation shipped
+
+Two corrections to §2 below, found while attempting to implement a fix, both
+important enough to flag before anyone acts on the original text:
+
+1. **`ToolBlock.tsx`'s summary-row swap (§2, "Source A", `ToolBlock.tsx`
+   half) does NOT affect vertical scroll at all.** Confirmed by reading
+   `_document-nodes.scss:229-233`: `.agent-tool-summary` is
+   `white-space: nowrap; overflow: hidden` — a forced single-line row. The
+   live-tail ↔ result-pill swap changes horizontal content only; the row's
+   height is fixed regardless of which child is present. This was wrong in
+   the original analysis and should not be treated as a fix target for the
+   symptom in this doc.
+2. **A "shrink-aware eased `scrollToTrueBottom()`" fix (the initially
+   proposed remediation) cannot work as stated**, for a specific physical
+   reason: the browser clamps `scrollTop` down to the new
+   `scrollHeight - clientHeight` **synchronously, as part of the same
+   layout pass that produces the shrink** — before any application code
+   (effects, `ResizeObserver` callbacks) runs. By the time our code
+   observes the shrink, the visible jump has already happened; there is
+   nothing left to animate. This is the same fact
+   `PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md` §2 ("H1") established
+   for the grow case, just not carried through to the shrink case
+   originally. The technique that DOES work is the one already partially
+   implemented in `ToolOverlayLog.tsx` (`flipHeight()`, PR #1975): freeze
+   the shrinking element at its old height BEFORE the browser paints the
+   smaller layout, then ease it down via CSS transition — so the native
+   `scrollTop` clamp happens in many imperceptible per-frame steps instead
+   of one visible jump. Fixing the outer scroll's *symptom* requires
+   preventing shrinks at the *content* layer, not intercepting the scroll
+   position after the fact.
+
+Re-tracing `createSpinnerCollapser` (`output-cap.ts`) more carefully after
+(1): the "retroactive reclassification" it documents can only ever affect
+the single most-recent, not-yet-committed chunk (the code's own comment
+confirms at most one chunk is ever "pending" at a time) — so in practice it
+swaps at most one rendered line for another line of the same count. §3's
+original framing ("lower-confidence... 1-line-for-1-line") was already
+appropriately hedged and doesn't need correction, but is reiterated here:
+this is not a "large block ↔ small block" mechanism on its own.
+
+What's left standing from the original analysis, unweakened: the
+`ToolOverlayLog.tsx` `<Switch>` branch-swap (§2, the `ToolOverlayLog.tsx`
+half of "Source A") is still the most credible source of a genuinely large
+vertical delta — but tracing `ToolBlock.tsx`'s `autoExpanded()` /
+`isFailTerminal()` logic shows the existing FLIP mitigation should already
+engage correctly for the common case (a `success`/`failed` tool holds its
+panel open — not `content-visibility: hidden` — straight through the
+`running` → terminal transition, so `heightStale` should read `false` at
+exactly the moment it matters). The `heightStale` bypass appears to be
+real but narrower than originally implied — it reliably fires only for
+`denied`/`canceled` tools, whose panel collapses in the same synchronous
+tick as the branch change (`isFailTerminal()` skips the held-open hold).
+**This means the dominant real-world cause is not yet pinned down with
+confidence** — static tracing has been pushed about as far as it usefully
+goes; the two corrections above are both things that only became clear by
+tracing actual CSS/timing rather than by reasoning about the component
+code alone, which argues for live data over a third round of the same.
+
+**Shipped this pass (no behavior change, diagnostic only):**
+`AgentDocumentVirtualList.tsx`'s `scrollToTrueBottom()` now logs
+`[wave-scroll-shrink] pane=<id> scrollHeight <old>px -> <new>px
+(delta=<n>px)` via `console.info` whenever it's invoked (from any of the
+three pin mechanisms, or `jumpToBottom`) and the container's `scrollHeight`
+has decreased since the last such call. This is the single choke point all
+three pin mechanisms already funnel through, so it catches a shrink from
+*any* source (branch swap, spinner reclassification, markdown re-highlight,
+or something not yet identified) without needing per-source instrumentation.
+Reachable live via `muxlog fe grep wave-scroll-shrink` against a running
+instance — see the branch `loap/fix-tool-call-scroll-shrink-oscillation`.
+121/121 existing tests in `frontend/app/view/agent/virtualization` still
+pass (no logic changed, only a diagnostic branch added inside an existing
+function).
+
+**Recommended next step:** run a `task dev` build from this branch, drive a
+real repro (a chatty tool call, ideally including at least one
+`denied`/`canceled` completion to isolate the `heightStale` hypothesis),
+and correlate `wave-scroll-shrink` log lines against what's visually
+observed. Only implement a content-layer fix (FLIP-style freeze-then-ease,
+scoped to whichever element the log identifies) once that correlation is
+in hand — guessing a third time without it has a track record now (twice
+in this same session).
+
+---
+
+## 0. Symptom, as reported
+
+> Sometimes it appears like the scrolling is going backward, during the
+> expansion of tool calls — it spins back as it's outputting. A large block
+> comes out, then it's replaced with a small block causing the scroll to go
+> backward, then replaced again by a large block. Ideally there should be no
+> scrollback behavior — a continuous one-direction flow.
+
+This is a **repeating oscillation** observed while tool calls are actively
+streaming/expanding, not a single one-shot glitch. That framing matters —
+see §4.
+
+## 1. This is not one bug — it's three independent DOM-shape-swap
+mechanisms, all missing a "never shrink visibly" guarantee, sitting under
+scroll-pin machinery that only ever *snaps*, never eases
+
+The agent pane (`frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx`)
+keeps `viewState.stickToBottom()` pinned to true bottom via three
+independent triggers — verified directly in the current file:
+
+- **Itemized `createEffect`** (`AgentDocumentVirtualList.tsx:464-483`) — re-pins on `nodes().length` / `layoutView().totalSize` / `workingRowHeight()` changes, via `queueMicrotask`.
+- **RO #1 — viewport resize** (`:505-525`) — re-pins on `scrollRef.clientHeight` change (sibling panels, pane resize).
+- **RO #2 — content resize** (`:556-565`) — re-pins on `virtualContainerRef`/`streamingBufferRef` box-size change (this one exists specifically to catch late reflow the other two miss; added per `REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md` §4's recommendation).
+
+All three call the same `scrollToTrueBottom()` (`:167-171`):
+
+```ts
+function scrollToTrueBottom(): void {
+    if (!scrollRef) return;
+    pendingProgrammaticScroll = true;
+    scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+}
+```
+
+`behavior: "auto"` is an **instant** jump, by design (§3.4 of the 07-30
+report explicitly recommends "auto" over "smooth" during streaming, to
+avoid a laggy eased-scroll fighting a fast-arriving stream — a reasonable
+call for the *growing* case). But it means the pin has exactly one gear:
+teleport to `scrollHeight - clientHeight`. There is no code path anywhere in
+this component that *eases* a scroll-position correction.
+
+That's fine as long as `scrollHeight` only ever **grows** while pinned — a
+teleport-to-bottom during monotonic growth is invisible (you're already
+where the teleport lands, modulo the pin *lag* bugs the 07-24/07-27/07-30/
+08-05 docs chased). It stops being invisible the moment `scrollHeight`
+**shrinks** while pinned:
+
+1. The browser's own layout step auto-clamps `scrollTop` down to the new,
+   smaller `scrollHeight - clientHeight` the instant the shrink lays out —
+   this is unconditional native behavior, confirmed in
+   `PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md` §2 ("H1" analysis: "the
+   browser's auto-clamp always sets `scrollTop` to *exactly* the new max").
+2. That clamp is a **discrete jump**, not a transition — nothing animates a
+   `scrollTop` correction in this codebase.
+3. Any of the three pin mechanisms above then fires and calls
+   `scrollToTrueBottom()` again — a no-op (already at the new max), but
+   irrelevant: the visible jump already happened in step 1.
+
+**So the actual bug is not "the pin doesn't work" — the pin works exactly
+as designed. The bug is that something legitimately shrinks the rendered
+content while streaming, and a shrink-then-regrow cycle is visually
+indistinguishable from "the scrollbar spun backward."** Three confirmed,
+independent sources of that shrink:
+
+## 2. Source A (primary suspect) — the running→terminal DOM-shape swap, only half-mitigated
+
+`mergeReplacement()` (`frontend/app/store/agent-document/reducer.ts:906-926`)
+flips a tool's `status` out of `"running"` **and** force-clears
+`log.open` to `false` in the same reducer tick when a `tool_result` lands:
+
+```ts
+const terminal =
+    replacement.status === "success" ||
+    replacement.status === "failed" ||
+    replacement.status === "denied";
+const mergedLog: ToolStreamingLog = {
+    chunks: existingLog.chunks,
+    open: terminal ? false : existingLog.open,
+};
+```
+
+Two UI surfaces key off exactly those two signals and both swap DOM shape
+on that same tick:
+
+- **`ToolOverlayLog.tsx:310-323`** — an exclusive `<Switch>` that unmounts
+  `ChunkList` (raw streamed lines — can be dozens of `<pre>` rows for a
+  chatty command) and mounts `ToolOverlayResult` (a compact, structured
+  view — `BashOutputViewer`, `DiffViewer`, etc.). These are genuinely
+  different component trees with different natural heights; a long-running
+  `npm install`'s live tail is routinely much taller than its terminal
+  `exit 0` summary.
+- **`ToolBlock.tsx`'s summary row** (`:390-434`) — the live-tail/elapsed
+  span (`.agent-tool-live-tail`, gated on `log?.open === true`) disappears
+  the same instant the result pill (`.agent-tool-result-pill`, gated on
+  `resultPill() != null`) appears. Confirmed by direct read: these are two
+  independent sibling `<Show>` blocks with **no shared box, no cross-fade,
+  no height reservation** — the row's own height can change too.
+
+**This was diagnosed once already** (`docs/analysis/ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md`)
+and **partially fixed** in PR #1975 (`fix(agent): smooth the running ->
+completed tool-preview transition`): `ToolOverlayLog.tsx:238-289` now runs a
+FLIP-style height transition (`flipHeight()`, `:342-363`, 150ms
+`cubic-bezier`) whenever the rendered `<Switch>` branch changes, so the
+*panel body's* height eases across the swap instead of jump-cutting.
+
+**But the fix is narrower than the bug in three ways, all confirmed by
+direct read of the current file:**
+
+1. **It only covers `ToolOverlayLog`'s own box.** `ToolBlock.tsx`'s summary
+   row (the live-tail ↔ result-pill swap, part of *every* tool call, not
+   just ones with an open panel) has no equivalent treatment — still an
+   instant content-shape swap today, exactly as the 07-05 analysis
+   described it, unchanged since.
+2. **The FLIP itself is skipped — jump-cut instead — whenever the panel was
+   `content-visibility: hidden` at the moment of transition** (`heightStale`,
+   set at `:226-235, 252-253, 257-266`; gated at `:273-280`). A tool that
+   auto-collapses immediately on leaving `running` (any `denied`/`canceled`
+   tool, per `ToolBlock.tsx`'s `isFailTerminal()`), or one whose panel is
+   simply scrolled out of the measurable viewport, commonly hits exactly
+   this branch — the case the mitigation exists for is also the case most
+   likely to disable it.
+3. **Easing the *content's* height does not ease the *outer scroll
+   container's* `scrollTop`.** Even where the 150ms FLIP is active, it
+   changes `ToolOverlayLog`'s box size on every animation frame — and RO #2
+   (§1) fires on every one of those frames and re-teleports `scrollTop` to
+   the instantaneous new bottom, since `scrollToTrueBottom()` has no eased
+   variant. The content glides; the viewport's read of "true bottom" still
+   jumps in discrete per-frame steps chasing it. Whether that reads as
+   smooth or juddery to the user depends on frame timing that hasn't been
+   measured live (§6).
+
+## 3. Source B — retroactive spinner-run reclassification (real, continuous, lower-confidence as the *dominant* cause here)
+
+`frontend/app/view/agent/components/output-cap.ts`'s `createSpinnerCollapser()`
+(`:362-433`) folds consecutive terminal redraw frames (progress bars,
+spinners) into a single updating DOM node, to avoid one `<pre>` per frame.
+Its own doc comment (`:349-360`) states the mechanism explicitly:
+
+> "sometimes retroactively groups a previously-standalone trailing chunk
+> into a new run" — a chunk rendered on one call as its own committed
+> `display` entry can, on the *next* chunk, be pulled back out and folded
+> into `spinnerSlot` instead, once a second frame arrives that makes the
+> first one *look* like the start of a redraw run in hindsight
+> (`startsRun`/`continuesRun`, `:280-292`; the ambiguity is inherent — you
+> can't know a chunk starts an animation run until you see the chunk that
+> follows it).
+
+Traced through the algorithm (`:372-432`), a single reclassification event
+is usually a 1-line-for-1-line swap (a tentative `display` entry becomes an
+identical-length `spinnerSlot` entry), so on its own it's a weaker fit for
+"large block ↔ small block" than Source A. It's flagged here because it:
+
+- Fires **continuously while a tool is actively streaming** (matches "as
+  it's outputting" more literally than A, which is a one-shot event per
+  tool call), and
+- Compounds with A — a chatty tool with progress-bar output hits both the
+  per-chunk reclassification *and* the running→terminal swap when it
+  finishes, and
+- Is the kind of mechanism worth a live check (`REDRAW_SIMILARITY_THRESHOLD`
+  false-positive/negative behavior, `:186-188`) specifically for whatever
+  tool the user was watching when they saw this — output-cap.ts has its own
+  documented history of false-positive tuning (PR #2330, referenced inline
+  at `:184-188`), so a tool whose real output looks progress-bar-ish is a
+  plausible amplifier even if it isn't the root cause.
+
+## 4. Source C — MarkdownBlock's throttled highlight re-render (documented, unfixed, still live)
+
+`frontend/app/view/agent/components/MarkdownBlock.tsx:64-80` — confirmed by
+direct read, unchanged since `REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md`
+§2.1 flagged it (no commits to this file touch this logic since; `git log`
+confirms). During streaming, markdown re-parses render a cheap intermediate
+(`highlight: !streaming`); ~90ms after the last token in a burst, a trailing
+`setTimeout` commits `highlight: true` — a full syntax-highlighted
+re-render that "routinely reflow[s] to a different height than the
+plain-text intermediate" (the report's own words). This is a text/thinking
+block mechanism, not tool-call-specific, but it's the same *family* of bug
+(a throttled/delayed re-render silently swapping DOM shape) and fires on
+the same cadence ("during normal streaming... not just at turn boundaries")
+the user describes. **Unlike Source A, this one is not mitigated at all** —
+no FLIP, no cross-fade; RO #2 (§1) should now at least *catch* the resulting
+resize and re-pin (it didn't exist yet when the 07-30 report called this
+out — it was the report's own recommended fix, landed since), but "caught
+and re-pinned" still means "a hard snap," not "no visible motion" — see §1.
+
+## 5. Why this reads as an "oscillation" specifically during tool-call expansion
+
+None of A/B/C individually oscillates forever — each is a shrink (or grow)
+event tied to a state transition. The *sequence* is what produces the
+described spinning:
+
+- A running tool streams output → content is large (raw `ChunkList` /
+  live-tail).
+- It completes → Source A fires → content shrinks (compact result) →
+  scroll snaps backward (§1).
+- The **next** tool call in the same turn starts running → its own
+  `ChunkList` starts accumulating → content grows again → scroll (already
+  pinned) rides the growth forward, back toward where it was.
+- That tool completes → shrinks again → snaps backward again.
+
+For a turn that chains several tool calls (a very common shape — read
+several files, run a few greps, edit, run tests), this reproduces exactly
+the reported "large block, small block, large block" cycle, once per tool
+boundary, for the duration of "the expansion of tool calls." Source B adds
+a faster, smaller-amplitude version of the same thing *within* a single
+still-running tool's output if it looks progress-bar-like.
+
+## 6. What isn't confirmed yet (needs a live repro, not static analysis)
+
+Following the same discipline `PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md`
+used (that plan explicitly refused to ship a fix without a live repro, and
+correctly disproved its own leading hypothesis by testing rather than
+reasoning alone):
+
+1. **Relative magnitude of A vs. B vs. C** in the user's actual repro —
+   the code confirms all three are real and live, but not which one
+   dominates the specific session that prompted this. The existing
+   `[wave-scroll]` console channel (`AgentDocumentVirtualList.tsx:666-676`
+   per the 08-05 plan's citation) already logs engage/disengage decisions
+   with `scrollTop`/`scrollHeight`/`clientHeight`/gap on every pin
+   decision — filtering that during a repro, cross-referenced with which
+   tool was active at each backward jump, would disambiguate directly
+   without new instrumentation.
+2. **Whether RO #2's per-frame re-teleport during an active FLIP (§2 point
+   3) is itself visually smooth or adds its own micro-judder** — a
+   plausible *additional* contributor on top of A/B/C, not yet measured.
+3. Whether the specific tool(s) in the user's repro have progress-bar-style
+   output (implicates B) or are simple one-shot commands (points to A/C).
+
+## 7. Why this is an architecture question, not just "add another special case"
+
+The repo's own history already reached this conclusion once, for a related
+but distinct symptom (pin *lag*, not shrink-triggered *reversal*) —
+`REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md` §2 states it
+plainly: *"This is the third documented pass at this bug class, and each
+pass added one more named dependency or observer rather than a structural
+fix... The pattern itself is the root cause."* That report's own fix (RO #2)
+has since landed — and the shrink-side problem analyzed here is the same
+architectural gap wearing a different face:
+
+**There is no single place in this codebase where "a node's rendered DOM
+shape is about to change" is a first-class event.** Instead there are, by
+current count, at least **six independent mechanisms**, each independently
+deciding whether/how to react to a height change, none aware of the others:
+
+| # | Mechanism | File | Reacts to |
+|---|---|---|---|
+| 1 | Itemized pin effect | `AgentDocumentVirtualList.tsx:464-483` | node count / layout total / working-row height |
+| 2 | RO #1 (viewport) | `AgentDocumentVirtualList.tsx:505-525` | `scrollRef.clientHeight` |
+| 3 | RO #2 (content) | `AgentDocumentVirtualList.tsx:556-565` | `virtualContainerRef`/streaming-buffer box size |
+| 4 | Local FLIP | `ToolOverlayLog.tsx:238-289` | its own `<Switch>` branch changing |
+| 5 | Local auto-scroll-within-panel | `ToolOverlayLog.tsx:179-200` | `chunks()` / `panelHidden()`, scoped to the panel's own internal scroll, not the outer pane |
+| 6 | Throttled re-render timers | `MarkdownBlock.tsx:64-80`, `createSpinnerCollapser` (`output-cap.ts:362-433`) | their own internal timers/heuristics, invisible to 1-5 entirely |
+
+Each was added in response to a specific reported symptom (the 07-24 →
+07-27 → 07-30 → 08-05 → this-doc chain, plus #1975/#2330 on the content
+side) rather than from a shared contract. The result is what you'd expect
+from six uncoordinated systems layered over two build cycles: individually
+reasonable, collectively unable to guarantee the one property the user
+actually wants — **monotonic, one-directional visual flow while pinned to
+bottom** — because no component in the stack owns that guarantee end to
+end. `scrollToTrueBottom()` is correct *arithmetic* (always lands exactly
+at true bottom) but provides zero *visual continuity* guarantee, and
+nothing upstream of it prevents the content it's chasing from legitimately
+getting shorter mid-stream.
+
+### Two different depths of fix, worth weighing separately
+
+**A. Contain the symptom (bounded, incremental, consistent with how every
+prior pass in this file's history has shipped):**
+- Extend the existing FLIP pattern from `ToolOverlayLog`'s body to
+  `ToolBlock`'s summary row (§2, point 1) — reserve a fixed-height slot and
+  cross-fade live-tail ↔ result-pill instead of an instant swap, per the
+  07-05 analysis's own unimplemented recommendation (§"A viable fix shape").
+- Fix the `heightStale` jump-cut gap (§2, point 2) — even a short, cheap
+  fallback animation (or simply not skipping the FLIP for the common
+  `denied`/`canceled` auto-collapse case) removes the largest share of
+  cases where the existing mitigation silently doesn't apply.
+- Give `scrollToTrueBottom()` a **shrink-aware eased variant**: when the new
+  true-bottom target is *less* than the current `scrollTop` (a shrink, not a
+  grow), ease over ~120-150ms instead of teleporting: this is the single
+  highest-leverage change, because it fixes the *visible* symptom
+  regardless of which of A/B/C caused the shrink, without having to track
+  down and individually FLIP every current and future source of content
+  shrinkage. Growth-case teleporting can stay instant (already correct,
+  already relied on for streaming responsiveness per the 07-30 report's own
+  §4 rule 4).
+
+**B. Fix the structural gap (larger, matches what the repo's own audit
+already called for on the lag side):** give DOM-shape-changing nodes (tool
+completion, spinner-run reclassification, markdown highlight commit, and
+whatever the next one turns out to be) a single shared "content is about to
+resize" contract — e.g. every such site reports a from/to height (or simply
+relies on one, generalized, outer-scoped ResizeObserver + FLIP helper
+instead of five bespoke local ones) — so that "don't let visual height
+changes jump-cut while pinned" is a property of the framework layer, not
+something each new component has to remember to opt into. This is the
+"stop whack-a-moling, fix the pattern" move the 07-30 report explicitly
+called for and only partially delivered (it unified the *pin-lag* side via
+RO #2; the *pin-direction/shrink* side analyzed here was out of that
+report's scope and remains exactly as fragmented as the lag side was before
+RO #2 landed).
+
+Recommend (B) NOT be scoped as one big rewrite — the six mechanisms in the
+table above are individually well-tested and several have their own
+regression suites (`AgentDocumentVirtualList.resize.test.tsx`, `anchor.test.ts`,
+`state.test.ts`). A safer sequencing: ship the shrink-aware eased scroll
+(A, third bullet) first since it's the one change that structurally
+subsumes the others' symptoms without touching five files, verify it live
+against §6, then decide whether the remaining jump-cut/FLIP gaps (A, first
+two bullets) are still worth closing individually or whether the eased
+scroll alone already reads as "no scrollback" to a user.
+
+## Files referenced (all read directly)
+
+| File | Role |
+|---|---|
+| `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx:167-171, 464-565` | The three pin mechanisms + the un-eased `scrollToTrueBottom()` |
+| `frontend/app/store/agent-document/reducer.ts:906-926` | `mergeReplacement()` — couples `status` + `log.open` on one tick |
+| `frontend/app/view/agent/components/ToolOverlayLog.tsx:91-108, 202-289, 310-323, 328-363` | The `<Switch>` DOM-shape swap + its partial FLIP mitigation + the `heightStale` bypass |
+| `frontend/app/view/agent/components/ToolBlock.tsx:227-279, 390-434` | `resultPill()` / live-tail — unmitigated sibling-swap in the summary row |
+| `frontend/app/view/agent/components/output-cap.ts:343-433` | `createSpinnerCollapser` — retroactive reclassification |
+| `frontend/app/view/agent/components/MarkdownBlock.tsx:32, 64-80` | Throttled streaming re-parse/highlight commit |
+| `frontend/app/view/agent/virtualization/anchor.ts:66-85` | `isNearBottom` / `STICK_TO_BOTTOM_THRESHOLD_PX = 200` |
+
+## Related prior docs (read in full, not just referenced)
+
+| Path | Relevance |
+|---|---|
+| `docs/analysis/ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md` | Diagnosed Source A originally; its recommended FLIP fix landed (#1975) but only for `ToolOverlayLog`'s body, not `ToolBlock`'s summary row |
+| `docs/specs/REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md` | Diagnosed the *lag* half of this bug class (content grows, pin doesn't follow) and correctly identified "itemized dependency whack-a-mole" as the root pattern; its RO #2 recommendation has since landed and is confirmed present in the current file |
+| `docs/specs/PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md` | Same bug class, splitter-resize trigger; methodology model for this doc (disproved its own leading hypothesis via a real-component test rather than reasoning alone) — its H4 (overlay-lag) and the general "no visible motion should ever come from a hard snap" theme are adjacent to §7 here |
+
+No prior doc connects the running→terminal shrink (Source A), the spinner
+reclassification (Source B), and the markdown re-highlight (Source C) as
+one shared "un-eased shrink" symptom class, or names the un-eased
+`scrollToTrueBottom()` itself as the common amplifier — that synthesis is
+new in this document.

--- a/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
+++ b/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
@@ -121,18 +121,17 @@ Verified: `cargo check -p agentmux-srv` clean; existing
 2. **This fix prevents *future* wrongful evictions — it does not restore
    `ScrollPinTest-host-7c31`'s entry, already deleted before the fix
    landed.** Nothing re-writes a channel's shared registry entry except
-   that agent's own one-time registration event; recovering reachability
-   for that specific agent requires it to go through that event again (in
-   practice, a restart/respawn of that agent/pane). This is itself evidence
-   for a second, independent improvement worth considering separately: a
-   periodic re-write (heartbeat) of the shared registry entry for as long
-   as an agent is alive, so a wrongful eviction (from any future bug, not
-   just this one) self-heals within one heartbeat interval instead of
-   requiring a restart. Not implemented here — deliberately scoped this
-   pass to "stop the bleeding" (don't evict live entries) rather than also
-   adding new always-on background work per agent, which touches more
-   call sites (every controller type that currently calls
-   `write_shared_from_env` once) and deserves its own review.
+   that agent's own one-time registration event (or, as of Addendum 2, the
+   new heartbeat — but only once a build containing it is running);
+   recovering reachability for that specific agent requires it to go
+   through a fresh registration event (in practice, a restart/respawn of
+   that agent/pane).
+   ~~This is itself evidence for a second, independent improvement worth
+   considering separately: a periodic re-write (heartbeat)... Not
+   implemented here.~~ **Superseded by Addendum 2 — the heartbeat turned out
+   to be required for THIS fix to work at all past an agent's first minute
+   of life, not just a nice-to-have for faster self-healing. Implemented in
+   `bootstrap.rs`.**
 3. **The fix has not yet taken effect on any running instance.** It's a
    Rust (`agentmux-srv`) change — unlike the frontend TypeScript fix on this
    same branch, it needs `task build:backend` + an srv restart to take
@@ -168,6 +167,45 @@ for everything except a just-registered entry. Added three unit tests
 (`should_evict_on_forward_failure_{true_for_dead_pid_even_when_fresh,
 false_for_alive_pid_and_fresh_entry, true_for_alive_pid_but_old_entry}`) —
 the third directly encodes the regression reagent found.
+
+## Addendum 2 — reagent's third review: the age-grace fix was hollow without a heartbeat
+
+reagent caught, again correctly, that `should_evict_on_forward_failure`'s
+age check keys off `entry.updated_at` — which, as this retro's own root
+cause section already documented, is stamped **once at registration and
+never refreshed** (no heartbeat existed anywhere in the codebase at that
+point). That means the 60s grace window only ever covers an agent's first
+minute of life. Every steady-state agent — including this retro's own
+`ScrollPinTest-host-7c31`, already up "a few minutes" when the original
+failure hit — sits well outside that window permanently, so a single
+transient forward failure against a long-running agent still evicted it
+immediately, reproducing the exact bug this PR claims to fix. The "known
+gap" this retro's original text flagged ("a periodic re-write (heartbeat)
+of the shared registry entry... not implemented here — deliberately scoped
+this pass to 'stop the bleeding'") turned out not to be an optional
+follow-up — it's load-bearing for the fix to do anything at all past the
+first minute of an agent's life.
+
+Fix: added a periodic heartbeat (`bootstrap.rs`, 20s interval, well under
+the 60s grace window) that re-writes every locally-registered agent's Tier
+2 (per-channel) and Tier 2b (host-global shared) registry entries, driven
+from `reactive::get_global_handler().list_agents()` — the in-memory Tier-1
+registry, which is authoritative and always current (updated synchronously
+on register/unregister, no staleness window of its own). A live agent's
+on-disk entries now stay fresh indefinitely; a genuinely-dead agent simply
+stops appearing in `list_agents()` (already handled by its own
+register/unregister lifecycle) and its entries age past the grace period
+and become evictable again within one heartbeat interval.
+
+This is the third round of reagent review on this PR, each catching a
+progressively subtler gap in the same mechanism: (1) no guard at all, (2)
+PID-only guard with wrong granularity (process vs. individual agent), (3)
+age-only guard with no heartbeat to make age meaningful. Worth naming as a
+pattern for next time: an eviction/staleness policy that reads a field
+("is this fresh," "is this alive") is only as good as the mechanism that
+keeps that field truthful — reviewing the READ side without checking
+whether anything WRITES to keep it current is an easy gap to miss, and was
+missed twice in a row here before reagent's third pass caught it.
 
 ## Timeline
 

--- a/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
+++ b/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
@@ -207,6 +207,35 @@ keeps that field truthful — reviewing the READ side without checking
 whether anything WRITES to keep it current is an easy gap to miss, and was
 missed twice in a row here before reagent's third pass caught it.
 
+## Addendum 3 — reagent's fourth review: the heartbeat itself zeroed a field it didn't know about
+
+The heartbeat added in Addendum 2 called the plain `registry::write` /
+`registry::write_shared_from_env`, both of which hardcode
+`registration_nonce: 0`. Every 20s tick then overwrote each live agent's
+*real* nonce (already sitting right there on `AgentRegistration`, just
+unused) with 0. `remove_if_nonce`/`remove_shared_from_env_if_nonce`
+(`persistent.rs`) — the compare-and-remove a controller's own exit-handler
+uses so it only ever deletes the entry IT registered, not a fallback
+respawn's fresher one (issue #2363) — require `entry.registration_nonce ==
+expected_nonce`. Zeroed by the heartbeat, that comparison would fail
+silently on every clean exit, and the entry would linger until the 4-hour
+TTL sweep instead of being cleaned up immediately as designed — the
+heartbeat, in fixing Addendum 2's gap, quietly broke a different, already-
+correct cleanup path it didn't know it was touching.
+
+Fix: switched to `write_with_nonce` / `write_shared_from_env_with_nonce`,
+threading `reg.registration_nonce` through on every heartbeat tick instead
+of dropping it.
+
+Fourth round, fourth distinct bug in the same ~15 lines: (1) no guard, (2)
+wrong-granularity guard (process vs. agent), (3) guard with no heartbeat to
+back it, (4) heartbeat that broke an unrelated invariant it didn't
+preserve. Each fix so far touched code adjacent to the previous fix without
+re-deriving the full set of invariants that code already depended on —
+worth remembering next time a "small" fix touches a shared write path: check
+every OTHER reader of the fields being written, not just the one that
+motivated the change.
+
 ## Timeline
 
 - Loap's `SendMessage` to `ScrollPinTest-host-7c31` fails: `agent not found`.

--- a/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
+++ b/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
@@ -1,0 +1,157 @@
+# Retro: cross-channel jekt to a live agent silently and permanently failed
+
+**Date:** 2026-08-17
+**Reporter:** repo owner, live in an agent session
+**Investigator:** Loap
+
+## Summary
+
+While testing a scroll-pin fix, I (Loap) tried to `SendMessage` (jekt) a
+teammate agent, `ScrollPinTest-host-7c31`, running in a different `task dev`
+channel (`dev-loap-fix-tool-call-scroll-shrink-oscillation-415610cb303ae11d`)
+on the same machine. The send failed with `agent not found`, and the agent
+disappeared from `DiscoverAgents`' cross-channel listing entirely after the
+attempt — even though the repo owner confirmed directly that the agent was,
+in fact, alive and running the whole time. A second attempt a few minutes
+later, after confirming the target's `task dev` build had finished, still
+failed the same way and the agent still didn't reappear in discovery.
+
+## Root cause
+
+Cross-channel jekt delivery (Tier 2b in `server/reactive.rs`) works off a
+host-global, file-based registry (`backend/reactive/registry.rs`): each
+`(agent_id, channel)` pair gets one JSON file, written **once**, at specific
+one-time lifecycle events (agent controller registration, PTY/persistent
+controller spawn — `write_shared_from_env` call sites in
+`server/reactive.rs:784`, `server/agent_handlers/input.rs:521`,
+`backend/blockcontroller/persistent.rs:2339`,
+`backend/blockcontroller/shell/lifecycle.rs:498`). **There is no periodic
+heartbeat that re-writes this entry** — nothing keeps it fresh once the
+one-time write happens.
+
+Meanwhile, the forward path treated a single `success:false` response from
+the target channel as sufficient grounds to permanently delete that entry
+(`reactive.rs`, both the Tier 2a same-channel path and the Tier 2b
+cross-channel path): "success:false — evicting and trying next candidate,"
+unconditionally.
+
+Combine those two facts and the failure mode is structural, not incidental:
+**a single transient miss (the target channel's srv is up, but the specific
+agent hadn't finished registering yet, or some other momentary race)
+permanently destroys the only record of how to reach that agent going
+forward** — because nothing will ever re-write it except that agent's own
+one-time registration event happening again (i.e., a restart). This is a
+liveness bug dressed up as a staleness cleanup: the eviction logic was
+written for "the process is gone and never unregistered cleanly" (a real,
+common case worth cleaning up — see `cleanup_stale_shared`'s PID-liveness
+check, run at startup), but it fires on *any* `success:false`, including
+ones that have nothing to do with the owning process being dead.
+
+Notably, the codebase already has the right primitive to distinguish these
+two cases — `cleanup_stale_shared` (`registry.rs:467`) checks **PID
+liveness** (via `sysinfo`) before evicting, specifically because "the shared
+registry is always same-host by construction... PID-liveness is an
+authoritative staleness signal, not just a heuristic" (its own doc comment).
+That check exists at the *startup sweep* call site
+(`bootstrap.rs:1267-1269`) but was never applied at the *evict-on-forward-
+failure* call sites in `server/reactive.rs` — the two code paths solving the
+same problem (is this entry actually dead?) diverged, and only one of them
+used the authoritative signal.
+
+## Why this was hard to see live
+
+- `DiscoverAgents`/`SendMessage` give no signal that a *previously
+  reachable* agent just became unreachable *because of the send attempt
+  itself* — the eviction is silent from the caller's point of view; the only
+  visible symptom is "not found," identical to the target having never
+  existed.
+- The evidence trail only exists in `agentmux-srv`'s own log
+  (`tracing::warn!("cross-channel forward: success=false — evicting and
+  trying next candidate")`) — not surfaced anywhere in the agent-facing
+  tool results. Debugging this required `muxlog srv grep` to find it after
+  the fact.
+- My own first-pass theory (before finding this) was that the eviction was
+  *correct* — a leftover stale entry from an earlier dead process on the
+  same branch. That was a reasonable read of the code as written (the
+  comments describe exactly that case), and it took the repo owner's direct,
+  first-hand confirmation that the agent was genuinely alive to establish
+  the eviction was wrong in this instance — a good example of why "the code
+  comment's stated intent" and "what the code actually does on every input"
+  can quietly diverge.
+
+## Fix
+
+Reuse the existing `pid_alive` check (already used by the startup sweep) at
+both evict-on-forward-failure call sites in `server/reactive.rs`. Exposed as
+a new `pub fn is_pid_alive(pid: u32)` in `registry.rs` (thin wrapper — kept
+`pid_alive` itself private, matching the module's existing visibility
+style).
+
+Before evicting on a `success:false` response, check whether the entry's
+recorded `pid` (the owning process, always same-host by construction for
+this registry) is still alive:
+- **PID confirmed dead** → evict, exactly as before. This is the case the
+  original code was actually designed for.
+- **PID alive** → do NOT evict. Log a distinct warning
+  (`"success=false but owning process is alive — NOT evicting"`) and fall
+  through to the next tier/candidate, same as before, just without
+  destroying the registry entry. The next send attempt (or the target
+  agent's own eventual registration) gets a real chance to succeed instead
+  of the entry being gone forever.
+
+Changed: `agentmux-srv/src/backend/reactive/registry.rs` (new
+`is_pid_alive` wrapper), `agentmux-srv/src/server/reactive.rs` (both evict
+sites — Tier 2a same-channel, Tier 2b cross-channel).
+
+Verified: `cargo check -p agentmux-srv` clean; existing
+`backend::reactive::registry` unit test suite (17 tests) passes unchanged.
+
+## Known gaps / follow-ups (not done in this pass)
+
+1. **No integration-level regression test added yet** for the new
+   PID-alive-guard branch in `server/reactive.rs` itself (only the
+   underlying `is_pid_alive`/`pid_alive` primitive has direct unit coverage,
+   pre-existing). `server/tests.rs` already has a `test_router()` harness
+   used for `/agentmux/reactive/inject` tests
+   (`lan_key_is_accepted_on_reactive_inject`, etc.) that could be extended
+   with a second in-process router standing in for the "downstream channel"
+   and asserting the shared entry survives a `success:false` from a live
+   PID but is removed for a dead one. Left as a follow-up given this pass's
+   scope.
+2. **This fix prevents *future* wrongful evictions — it does not restore
+   `ScrollPinTest-host-7c31`'s entry, already deleted before the fix
+   landed.** Nothing re-writes a channel's shared registry entry except
+   that agent's own one-time registration event; recovering reachability
+   for that specific agent requires it to go through that event again (in
+   practice, a restart/respawn of that agent/pane). This is itself evidence
+   for a second, independent improvement worth considering separately: a
+   periodic re-write (heartbeat) of the shared registry entry for as long
+   as an agent is alive, so a wrongful eviction (from any future bug, not
+   just this one) self-heals within one heartbeat interval instead of
+   requiring a restart. Not implemented here — deliberately scoped this
+   pass to "stop the bleeding" (don't evict live entries) rather than also
+   adding new always-on background work per agent, which touches more
+   call sites (every controller type that currently calls
+   `write_shared_from_env` once) and deserves its own review.
+3. **The fix has not yet taken effect on any running instance.** It's a
+   Rust (`agentmux-srv`) change — unlike the frontend TypeScript fix on this
+   same branch, it needs `task build:backend` + an srv restart to take
+   effect, and the `srv` process on this host is currently **shared** across
+   multiple active agents (Lark, Korp, Agent1, Agent2, Loap all show up
+   under the same `host.addressable` list in `DiscoverAgents`). Restarting
+   it would interrupt everyone's in-flight sessions, so this was left for a
+   deliberate, coordinated restart rather than done unilaterally mid-session.
+
+## Timeline
+
+- Loap's `SendMessage` to `ScrollPinTest-host-7c31` fails: `agent not found`.
+- `muxlog srv errors` surfaces `23:35:03 WARN srv:reactive cross-channel
+  forward: success=false — evicting and trying next candidate`.
+- Follow-up `DiscoverAgents` calls confirm the entry never reappears.
+- Repo owner confirms directly, live, that the agent is real and running on
+  the exact channel named.
+- Root cause traced to `server/reactive.rs`'s unconditional eviction on
+  `success:false`, missing the PID-liveness check `cleanup_stale_shared`
+  already uses elsewhere in the same file's problem space.
+- Fix applied, compiled, and unit-tested; live verification and the
+  heartbeat follow-up left open pending a coordinated srv restart.

--- a/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
+++ b/docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md
@@ -142,6 +142,33 @@ Verified: `cargo check -p agentmux-srv` clean; existing
    it would interrupt everyone's in-flight sessions, so this was left for a
    deliberate, coordinated restart rather than done unilaterally mid-session.
 
+## Addendum — reagent's second review caught a real granularity bug in the first fix
+
+The first version of this fix (`is_pid_alive`) checked only whether the
+*owning srv process* was alive before evicting. reagent caught, correctly,
+that `AgentEntry.pid` is stamped with the **srv process's** PID
+(`std::process::id()`), shared by every agent registered under that same
+channel/srv — not a per-agent PID. So a PID-only guard can only prove "the
+whole process died," never "this one agent's controller died while its srv
+process stayed up for other agents" — and on a host running multiple agents
+under one shared `srv` (the default topology here — see the incident this
+retro is about), that's at least as common a failure mode as a whole-process
+death. Under the PID-only guard, a genuinely-dead individual agent's entry
+would linger in the shared registry **forever**, strictly worse than the
+pre-this-PR behavior (unconditional eviction) for that specific case.
+
+Fix: `should_evict_on_forward_failure` (replacing `is_pid_alive` as the
+call sites' policy function) evicts when *either* signal indicates death —
+the owning process is confirmed dead (definitive), **or** the entry is
+older than a 60s grace period. A fresh entry with a live owning process gets
+the benefit of the doubt (the actual race this PR fixes); an old entry that
+still fails is presumed genuinely gone, regardless of whether its process
+happens to still be alive for other agents — matching pre-this-PR behavior
+for everything except a just-registered entry. Added three unit tests
+(`should_evict_on_forward_failure_{true_for_dead_pid_even_when_fresh,
+false_for_alive_pid_and_fresh_entry, true_for_alive_pid_but_old_entry}`) —
+the third directly encodes the regression reagent found.
+
 ## Timeline
 
 - Loap's `SendMessage` to `ScrollPinTest-host-7c31` fails: `agent not found`.

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -164,8 +164,34 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // — this is the "input-gating race" both prior passes deferred pending
     // live reports continuing, which they did.
     let pendingProgrammaticScroll = false;
+    // Last scrollHeight observed at a pin-correction call — diagnostic only,
+    // see docs/analysis/ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md.
+    // A shrink between two consecutive calls means content that was already
+    // laid out at true bottom got shorter while pinned (a tool-call
+    // running->terminal swap, a spinner-run reclassification, a markdown
+    // re-highlight reflow, ...). By the time THIS function runs, the
+    // browser's own scrollTop auto-clamp for that shrink has already
+    // happened synchronously as part of the layout pass that produced it —
+    // there is nothing left here to animate away (confirmed against
+    // PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md §2's "H1" math, which
+    // established the same clamp-is-already-synchronous fact for the grow
+    // case). This log exists purely so a live repro
+    // (`muxlog fe grep wave-scroll-shrink`) can identify WHICH content
+    // change produced a given visible "scroll went backward" report — the
+    // real fix has to happen upstream, at whatever DOM swap caused the
+    // shrink (e.g. a FLIP-style freeze-then-ease on that element), not here.
+    let lastKnownScrollHeight = 0;
     function scrollToTrueBottom(): void {
         if (!scrollRef) return;
+        const h = scrollRef.scrollHeight;
+        if (lastKnownScrollHeight > 0 && h < lastKnownScrollHeight - 1) {
+            console.info(
+                "[wave-scroll-shrink]",
+                `pane=${props.blockId?.slice(0, 7) ?? "?"}`,
+                `scrollHeight ${lastKnownScrollHeight}px -> ${h}px (delta=${lastKnownScrollHeight - h}px)`,
+            );
+        }
+        lastKnownScrollHeight = h;
         pendingProgrammaticScroll = true;
         scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
     }


### PR DESCRIPTION
## Summary

- **Root cause fix**: cross-channel jekt forwarding (`server/reactive.rs`) permanently deleted a channel's shared registry entry on any `success:false` response — including transient ones (target channel up, but the specific agent hadn't finished registering yet). Nothing re-writes the entry except that agent's own one-time registration event, so a single hiccup made the agent unreachable via cross-channel jekt until a restart. Reuses the PID-liveness check `cleanup_stale_shared` already applies at startup (`registry.rs`'s new `is_pid_alive`) at both evict-on-forward-failure call sites (Tier 2a same-channel, Tier 2b cross-channel): only evict when the owning process is confirmed dead.
- Also includes the tool-call-streaming scroll-pin diagnostic instrumentation (`[wave-scroll-shrink]` log) and analysis this branch started with — see the linked docs.

Full writeups:
- `docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md`
- `docs/analysis/ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md`

## Test plan

- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv reactive::registry` — 17/17 pass, no regressions
- [x] `npx vitest run frontend/app/view/agent/virtualization` — 121/121 pass, no regressions
- [ ] Live cross-channel jekt repro against a currently-unreachable agent, post-restart (needs a coordinated `srv` rebuild/restart — the shared `srv` on this host currently serves multiple live agents, so this wasn't done unilaterally; see retro §"Known gaps")
- [ ] Integration-level regression test for the new PID-alive-guard branch in `server/reactive.rs` (only the underlying `is_pid_alive` primitive has direct unit coverage today) — flagged as a follow-up in the retro

<!-- agentmux:agent_id=loap -->