### PR TITLE
Manoz@Area54 fix(tabs): remove automatic tab color assignment

### DIFF
--- a/.changesets/1787014873-fix-tabs-remove-automatic-tab-color-assignment-0zbo.md
+++ b/.changesets/1787014873-fix-tabs-remove-automatic-tab-color-assignment-0zbo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): remove automatic tab color assignment

--- a/docs/reports/REPORT_REMOVE_AUTO_TAB_COLOR_2026_08_18.md
+++ b/docs/reports/REPORT_REMOVE_AUTO_TAB_COLOR_2026_08_18.md
@@ -1,0 +1,59 @@
+# Report: Remove automatic tab-color assignment (random + startup default)
+
+**Date:** 2026-08-18
+**Status:** Analysis complete — no code changed. Written to inform implementation.
+**Scope:** `frontend/app/store/tab-actions.ts`, `frontend/app/tab/tabbar.tsx`.
+
+## Ask
+
+Default tabs and new tabs currently get an automatically-assigned color. Remove that — all tabs (default and new) should start with no color ("clear"). Users can still set a color manually afterward via the existing right-click color picker.
+
+## Current behavior — two separate auto-assignment mechanisms
+
+### 1. Random color on every new tab
+
+`frontend/app/store/tab-actions.ts:22-32`, in `createTab()`:
+
+```ts
+function randomNewTabColor(): string {
+    return TAB_COLORS[Math.floor(Math.random() * TAB_COLORS.length)].hex;
+}
+```
+
+Called immediately after `WorkspaceService.CreateTab(...)`, via `ObjectService.UpdateObjectMeta(oref, { "tab:color": randomNewTabColor() })` (`tab-actions.ts:50-54`). Every tab created through this path — `Ctrl+T`, the "+" button, the command palette's "New Tab" — gets a random hex from the 14-entry `TAB_COLORS` palette (`tab.tsx:28-43`), no user input involved.
+
+### 2. Fixed "Blue" on the startup (first) tab
+
+`frontend/app/tab/tabbar.tsx:99-128`, an `onMount` effect: if the workspace has exactly one tab and it has no `tab:color` set yet (and hasn't been backfilled before, per the `tab:color-initialized` guard), it applies `#2562c5` ("Blue" in `TAB_COLORS`) unconditionally. This exists because the backend-created startup tab doesn't get a color meta at creation time, so without this, the very first tab a user ever sees would look different (neutral) from every subsequently-created tab (vibrant) — the backfill was added specifically to make the *first* tab consistent with the *random* behavior of every tab after it, not as an independent feature.
+
+**These two are coupled**, not independent: #2 exists to paper over the inconsistency #1 creates. Removing #1 without #2 would leave the startup tab colored and every new tab neutral — the opposite of today's problem. Removing #1 makes #2 pointless (nothing left for it to stay "consistent" with), so both need to go together, which is what's proposed below.
+
+## Why the random-color feature exists (for context)
+
+The code comment states the rationale directly: "so successive tabs read as visually distinct at a glance instead of all defaulting to the same hue." This is a real, legitimate UX goal — in a multi-tab workspace, color is a fast visual anchor for "which tab am I looking at" without reading labels. Worth naming honestly, since removing the feature does give up that automatic behavior.
+
+## Why removing it is reasonable anyway
+
+- **Unpredictability, not choice.** A *random* color isn't really helping the user express intent — it's assigning them a color they didn't pick and may not want, which they then have to actively override if it clashes with how they'd have organized things themselves (e.g., a user who *does* want color-coding by project/purpose gets a color they now have to change before applying their own scheme).
+- **Manual color-coding is already fully supported and low-friction** — right-click a tab → 14-swatch picker → done (`tab.tsx:80-100`, `ColorSwatchPalette`). Nothing about "distinguish tabs visually" is lost as a *capability*; only the *default-on* behavior goes away. A user who wants the "glanceable" benefit still gets it — they just author it instead of receiving it randomly.
+- **A neutral default is not a broken/undefined state.** `tab.tsx:129,259,261` already treats an absent `tab:color` as a clean, fully-supported render path (`"tab-colored": !!tabColor()` only applies the colored-background class when a color is actually set — no color reads as the tab's plain default style, not as an error state or a visual gap). There's also already an explicit "✕ Clear color" action in the picker (`color-swatch-palette.tsx:46-50`, `showClear` defaults to `true`), confirming "no color" is a first-class, already-designed-for state in this UI — this change just makes it the *starting* state instead of something a user has to opt into via Clear.
+- **Consistency with "start neutral, personalize deliberately"** is arguably the more common pattern elsewhere in the app already (e.g. agent panes don't get a random border color either — `AGENT_COLOR_PALETTE` auto-assignment is scoped to something else per `SPEC_TAB_COLOR_DESATURATION_2026_08_13.md`'s own note that the two palettes were deliberately forked to stay independent).
+
+## What's explicitly NOT affected
+
+- **Tabs that already have a `tab:color` set** — whether from a prior random assignment, the startup backfill, or a manual pick — are untouched. This removes only the *going-forward* auto-assignment on tab creation/first-mount; it is not a migration and does not clear existing colors. (Same non-migration posture the desaturation spec already established for this exact meta field — `tab:color` stores a literal hex, there's no "was this auto-assigned or user-chosen" flag to distinguish retroactively, and there's no reason to guess.)
+- **The manual color picker itself** — `TAB_COLORS`, `ColorSwatchPalette`, the right-click menu, `onColorSelect` — none of this changes. Users pick colors exactly as they do today.
+
+## Proposed implementation
+
+1. **`tab-actions.ts`** — in `createTab()`, delete the `ObjectService.UpdateObjectMeta(..., { "tab:color": randomNewTabColor() })` call entirely (not replace it with a null-set — simply never write `tab:color` for a freshly created tab, so it's absent, same as any other never-touched meta key). Delete the now-unused `randomNewTabColor()` function and, if nothing else in the file still needs it, the `TAB_COLORS` import.
+2. **`tabbar.tsx`** — delete the entire startup-tab-color `onMount` effect (lines 99-128), including the `tab:color-initialized` guard write — with #1 gone, there's no "every other tab is colored" inconsistency left to backfill against, so the guard has nothing left to protect.
+3. No backend/RPC changes needed — both mechanisms are frontend-only meta writes on top of the existing generic `tab:color` field; the field itself, its type, and every read path stay exactly as-is.
+
+## Verification plan
+
+- Open a fresh workspace (or one with a single default tab) — confirm the startup tab renders with no color (no `.tab-colored` class, default tab background).
+- Create several new tabs (`Ctrl+T`, "+", command palette) — confirm none get an automatic color.
+- Manually pick a color on a tab via right-click → swatch — confirm it still applies and persists normally (this path is unchanged).
+- Manually clear a color via "✕ Clear color" — confirm it goes back to the same neutral default new tabs now start with (should already work, since this is the same code path `tabColor()` already treats as the falsy/no-color case).
+- Confirm no leftover references to `randomNewTabColor` or the startup-backfill's `tab:color-initialized` meta key elsewhere in the codebase after removal (a quick grep, not expected to find anything given the search already done for this report).

--- a/frontend/app/store/tab-actions.ts
+++ b/frontend/app/store/tab-actions.ts
@@ -13,45 +13,30 @@
 
 import { markEnd, markStart } from "@/perf";
 import { fireAndForget } from "@/util/util";
-import { TAB_COLORS } from "@/app/tab/tab";
-import { activeTabId, workspace } from "./window-identity";
-import { ObjectService, WorkspaceService } from "./services";
+import { WorkspaceService } from "./services";
 import { holdRevealGate, scheduleRevealLift } from "./tab-reveal";
-import * as WOS from "./wos";
-
-/**
- * Picks a random color for a newly-created tab, so successive tabs read
- * as visually distinct at a glance instead of all defaulting to the same
- * hue. The first (startup) tab is unaffected — it keeps its fixed "Blue"
- * standard color, applied separately by the startup-tab backfill in
- * tabbar.tsx. Users can still change the colour per-tab via the
- * right-click menu after creation.
- */
-function randomNewTabColor(): string {
-    return TAB_COLORS[Math.floor(Math.random() * TAB_COLORS.length)].hex;
-}
+import { activeTabId, workspace } from "./window-identity";
 
 export function createTab() {
     const ws = workspace();
     if (ws == null) return;
     fireAndForget(async () => {
-        // Pin the gate while CreateTab + UpdateObjectMeta + preset import
-        // + applyTabPreset run. Calling scheduleRevealLift here would let
-        // the 80ms SETTLE window elapse during the (longtask-free) RPCs
-        // and layout-model polling inside applyTabPreset, so the gate
-        // would lift before the agent/sysinfo/swarm blocks have mounted
-        // and the user would still see the piecemeal cascade. The
-        // detector is started in `finally` once the preset apply has
-        // returned (or failed) — at that point SETTLE / MAX_GATE measure
-        // the actual mount window. See issue #774 /
-        // SPEC_TAB_CONTENT_REVEAL_GATE.md.
+        // Pin the gate while CreateTab + preset import + applyTabPreset
+        // run. Calling scheduleRevealLift here would let the 80ms SETTLE
+        // window elapse during the (longtask-free) RPCs and layout-model
+        // polling inside applyTabPreset, so the gate would lift before the
+        // agent/sysinfo/swarm blocks have mounted and the user would still
+        // see the piecemeal cascade. The detector is started in `finally`
+        // once the preset apply has returned (or failed) — at that point
+        // SETTLE / MAX_GATE measure the actual mount window. See issue
+        // #774 / SPEC_TAB_CONTENT_REVEAL_GATE.md.
         holdRevealGate();
         try {
             const tabId = await WorkspaceService.CreateTab(ws.oid, "", true, false);
-            await ObjectService.UpdateObjectMeta(
-                WOS.makeORef("tab", tabId),
-                { "tab:color": randomNewTabColor() } as MetaType,
-            );
+            // New tabs intentionally start with no `tab:color` — see
+            // docs/reports/REPORT_REMOVE_AUTO_TAB_COLOR_2026_08_18.md. Users
+            // still pick one manually via the right-click swatch picker
+            // (tab.tsx); this used to auto-assign a random hex here.
             // Default-layout preset (agent + sysinfo + swarm). Lives in
             // a single central module so any future tab-creation path
             // (duplicate, tear-off destination, startup-tab backfill)

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -1,27 +1,26 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, setActiveTab } from "@/store/global";
-import { settingsAtom } from "@/store/config-signals";
-import { fireAndForget } from "@/util/util";
-import { isMacOS } from "@/util/platformutil";
-import { HamburgerMenu } from "@/app/window/hamburger-menu";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
-import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
-import { Portal } from "solid-js/web";
-import type { JSX } from "solid-js";
-import { ObjectService, WorkspaceService } from "../store/services";
+import { HamburgerMenu } from "@/app/window/hamburger-menu";
+import { deleteLayoutModelForTab } from "@/layout/index";
+import { settingsAtom } from "@/store/config-signals";
+import { atoms, setActiveTab } from "@/store/global";
 import { RpcApi } from "@/store/rpc-api";
 import { TabRpcClient } from "@/store/rpc-util";
-import { makeORef, getObjectValue } from "../store/wos";
-import { registerTabCloseRequestHandler } from "./tab-close-request";
-import { deleteLayoutModelForTab } from "@/layout/index";
+import { isMacOS } from "@/util/platformutil";
+import { fireAndForget } from "@/util/util";
+import type { JSX } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { WorkspaceService } from "../store/services";
 import { DroppableTab } from "./droppable-tab";
 import { TabCloseConfirmModal } from "./tab-close-confirm-modal";
-import { createTearOffTabAtRelease } from "./tab-tearoff-rpc";
-import { useTabTearOffEvents } from "./tab-tearoff-events";
-import { useTabDragAndDrop } from "./tab-reorder";
+import { registerTabCloseRequestHandler } from "./tab-close-request";
 import { useActiveTabColorLine } from "./tab-color-line";
+import { useTabDragAndDrop } from "./tab-reorder";
+import { useTabTearOffEvents } from "./tab-tearoff-events";
+import { createTearOffTabAtRelease } from "./tab-tearoff-rpc";
 import "./tabbar.scss";
 
 interface TabBarProps {
@@ -96,57 +95,32 @@ function TabBar(props: TabBarProps): JSX.Element {
         }
     });
 
-    // Startup-tab color: if the workspace has exactly one tab and it has no
-    // tab:color set, apply the theme Blue from TAB_COLORS. The backend-created
-    // startup tab doesn't get a color meta, so without this the first tab
-    // stays neutral while every user-created tab is vibrant.
-    onMount(() => {
-        const ws = props.workspace;
-        if (!ws) return;
-        const ids = [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])];
-        if (ids.length !== 1) return;
-        const firstId = ids[0];
-        const tab = getObjectValue<Tab>(makeORef("tab", firstId));
-        if (!tab) return;
-        if (tab.meta?.["tab:color"]) return;
-        // Skip if the default-color backfill has already run once for this
-        // tab. Without this guard, a user who clears the color on a single-
-        // tab workspace would have it silently restored on the next mount.
-        if (tab.meta?.["tab:color-initialized"]) return;
-        // #2562c5 is the "Blue" entry in TAB_COLORS — same as the color
-        // picker's blue swatch, so stays consistent with user-chosen blue.
-        fireAndForget(async () => {
-            try {
-                await ObjectService.UpdateObjectMeta(
-                    makeORef("tab", firstId),
-                    { "tab:color": "#2562c5", "tab:color-initialized": true } as MetaType,
-                );
-            } catch (e) {
-                console.error("[tabbar] startup-tab color apply failed:", e);
-            }
-        });
-    });
+    // The startup tab intentionally has no `tab:color` — see
+    // docs/reports/REPORT_REMOVE_AUTO_TAB_COLOR_2026_08_18.md. This used to
+    // backfill a fixed "Blue" here so the first tab wouldn't look different
+    // from every (then-randomly-colored) subsequent tab; now that new tabs
+    // no longer auto-assign a color either (tab-actions.ts's createTab()),
+    // there's no inconsistency left to paper over.
 
     // Commit-on-release tab tear-off. Fired from the drag monitor's onDrop
     // (useTabDragAndDrop, tab-reorder.ts) when the tab is released below
     // the strip. See tab-tearoff-rpc.ts for the full derivation.
     const tearOffTabAtRelease = createTearOffTabAtRelease(
         () => props.workspace,
-        () => tabBarScrollRef,
+        () => tabBarScrollRef
     );
 
     // In-strip reorder DnD + pane-drag-over-strip cleanup + Windows
     // tear-off-cursor workaround + wheel-scroll.
-    useTabDragAndDrop(
-        { tabBarScrollRef: () => tabBarScrollRef },
-        () => props.workspace,
-        tabIds,
-        tearOffTabAtRelease,
-    );
+    useTabDragAndDrop({ tabBarScrollRef: () => tabBarScrollRef }, () => props.workspace, tabIds, tearOffTabAtRelease);
 
     // Phase 4/5 — cross-window tear-off event listeners (hover/merge/
     // standalone/cancel-back).
-    useTabTearOffEvents(() => props.workspace, () => tabBarScrollRef, tabIds);
+    useTabTearOffEvents(
+        () => props.workspace,
+        () => tabBarScrollRef,
+        tabIds
+    );
 
     if (!props.workspace) return null;
 
@@ -158,7 +132,7 @@ function TabBar(props: TabBarProps): JSX.Element {
             tabBarScrollRef: () => tabBarScrollRef,
             tabBarFillRef: () => tabBarFillRef,
         },
-        tabIds,
+        tabIds
     );
 
     return (
@@ -225,19 +199,19 @@ function TabBar(props: TabBarProps): JSX.Element {
                     end tab strip can still position that edge past what's
                     currently visible. */}
                 <Portal mount={document.body}>
-                <div
-                    class="active-tab-color-line"
-                    aria-hidden="true"
-                    style={{
-                        position: "fixed",
-                        left: `${lineLeft()}px`,
-                        width: `${lineWidth()}px`,
-                        bottom: `${lineBottom()}px`,
-                        height: "3px",
-                        background: activeTabColor()!,
-                        "pointer-events": "none",
-                    }}
-                />
+                    <div
+                        class="active-tab-color-line"
+                        aria-hidden="true"
+                        style={{
+                            position: "fixed",
+                            left: `${lineLeft()}px`,
+                            width: `${lineWidth()}px`,
+                            bottom: `${lineBottom()}px`,
+                            height: "3px",
+                            background: activeTabColor()!,
+                            "pointer-events": "none",
+                        }}
+                    />
                 </Portal>
             </Show>
             <Show when={pendingCloseTabId() !== null}>
@@ -247,7 +221,9 @@ function TabBar(props: TabBarProps): JSX.Element {
                         const tabId = pendingCloseTabId()!;
                         setPendingCloseTabId(null);
                         if (skipFuture) {
-                            fireAndForget(() => RpcApi.SetConfigCommand(TabRpcClient, { "tab:skipcloseconfirm": true } as any));
+                            fireAndForget(() =>
+                                RpcApi.SetConfigCommand(TabRpcClient, { "tab:skipcloseconfirm": true } as any)
+                            );
                         }
                         handleClose(tabId);
                     }}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1391,7 +1391,6 @@ declare global {
         // Tab accent color (frontend/app/tab/tab.tsx, tabbar.tsx). Was missing
         // here despite being a real, actively-set meta key — #859.
         "tab:color"?: string | null;
-        "tab:color-initialized"?: boolean;
         "cmd:*"?: boolean;
         cmd?: string;
         "cmd:interactive"?: boolean;


### PR DESCRIPTION
Removes two coupled auto-assignment mechanisms so all tabs (default and new) start with no color — users still set one manually via the existing right-click swatch picker, unchanged.

1. `createTab()` (`tab-actions.ts`) assigned a random hex from `TAB_COLORS` to every newly-created tab. Removed `randomNewTabColor()` and its call site.
2. `tabbar.tsx` backfilled a fixed "Blue" onto the startup tab — this existed ONLY to paper over the inconsistency #1 created (first tab neutral, every tab after it randomly colored). With #1 gone there's nothing left to stay consistent with, so removed too, along with the now-dead `tab:color-initialized` guard meta key (`gotypes.d.ts`).

"No color" was already a fully-supported, intentional state before this change — `tab.tsx` already renders gracefully with no `tab:color` set, and the picker already has an explicit "Clear color" action. This just makes that the starting state instead of something a user opts into.

Existing tabs that already have a color (random, backfilled, or manually chosen) are untouched — this only stops future auto-assignment, not a migration.

See `docs/reports/REPORT_REMOVE_AUTO_TAB_COLOR_2026_08_18.md` for the full analysis.

Verified via `tsc --noEmit` (same 2 pre-existing, unrelated errors as `main`) and live in `task dev`.

<!-- agentmux:agent_id=manoz -->