### PR TITLE
chore: release v0.55.13

### DIFF
--- a/.changesets/1786997803-feat-agent-pane-answered-questions-render-as-user-input-user-msvr.md
+++ b/.changesets/1786997803-feat-agent-pane-answered-questions-render-as-user-input-user-msvr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): answered questions render as user input; user-input surface inverted per theme

--- a/.changesets/1786998258-fix-agent-eliminate-agent-picker-loading-flicker-with-a-comb-1kiy.md
+++ b/.changesets/1786998258-fix-agent-eliminate-agent-picker-loading-flicker-with-a-comb-1kiy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): eliminate Agent Picker loading flicker with a combined reveal gate

--- a/.changesets/1786998817-fix-launcher-stop-inherited-msys-stdio-from-breaking-cef-hos-195k.md
+++ b/.changesets/1786998817-fix-launcher-stop-inherited-msys-stdio-from-breaking-cef-hos-195k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher): stop inherited MSYS stdio from breaking CEF host CREATE_SUSPENDED spawn

--- a/.changesets/1786998957-fix-identity-agent-account-links-survive-a-version-channel-s-3vvn.md
+++ b/.changesets/1786998957-fix-identity-agent-account-links-survive-a-version-channel-s-3vvn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(identity): agent-account links survive a version/channel switch — new permanently-global identity store

--- a/.changesets/1786999034-feat-widgets-parent-widgets-with-grouped-submenus-messengers-jpel.md
+++ b/.changesets/1786999034-feat-widgets-parent-widgets-with-grouped-submenus-messengers-jpel.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(widgets): parent widgets with grouped submenus — Messengers

--- a/.changesets/1787008507-fix-ui-distinct-icon-for-anthropic-vendor-badge-no-longer-id-tmtp.md
+++ b/.changesets/1787008507-fix-ui-distinct-icon-for-anthropic-vendor-badge-no-longer-id-tmtp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): distinct icon for Anthropic vendor badge, no longer identical to the Claude harness icon

--- a/.changesets/1787009424-feat-reactive-expose-post-agentmux-reactive-ensure-signing-k-f2se.md
+++ b/.changesets/1787009424-feat-reactive-expose-post-agentmux-reactive-ensure-signing-k-f2se.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(reactive): expose POST /agentmux/reactive/ensure-signing-key for host-tier jekt signing tests

--- a/.changesets/1787009771-fix-statusbar-popovers-and-tooltips-paint-over-native-browse-jegz.md
+++ b/.changesets/1787009771-fix-statusbar-popovers-and-tooltips-paint-over-native-browse-jegz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): popovers and tooltips paint over native browser-pane HWNDs

--- a/.changesets/1787010094-fix-agent-remove-agent-definitions-import-export-toolbar-fro-iftz.md
+++ b/.changesets/1787010094-fix-agent-remove-agent-definitions-import-export-toolbar-fro-iftz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove agent-definitions Import/Export toolbar from the Agent Picker

--- a/.changesets/1787013019-fix-reactive-don-t-evict-cross-channel-jekt-registry-entries-mi9o.md
+++ b/.changesets/1787013019-fix-reactive-don-t-evict-cross-channel-jekt-registry-entries-mi9o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(reactive): don't evict cross-channel jekt registry entries whose owning process is still alive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.12"
+version = "0.55.13"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.12"
+version = "0.55.13"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.12"
+version = "0.55.13"
 dependencies = [
  "base64",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.12"
+version = "0.55.13"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.12"
+version = "0.55.13"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.12"
+version = "0.55.13"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.12"
+version = "0.55.13"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,19 @@
 # AgentMux Version History
 
+## 0.55.13 — 2026-08-17
+
+- feat(agent-pane): answered questions render as user input; user-input surface inverted per theme
+- fix(agent): eliminate Agent Picker loading flicker with a combined reveal gate
+- fix(launcher): stop inherited MSYS stdio from breaking CEF host CREATE_SUSPENDED spawn
+- fix(identity): agent-account links survive a version/channel switch — new permanently-global identity store
+- feat(widgets): parent widgets with grouped submenus — Messengers
+- fix(ui): distinct icon for Anthropic vendor badge, no longer identical to the Claude harness icon
+- feat(reactive): expose POST /agentmux/reactive/ensure-signing-key for host-tier jekt signing tests
+- fix(statusbar): popovers and tooltips paint over native browser-pane HWNDs
+- fix(agent): remove agent-definitions Import/Export toolbar from the Agent Picker
+- fix(reactive): don't evict cross-channel jekt registry entries whose owning process is still alive
+
+
 ## 0.55.12 — 2026-08-17
 
 - docs: add CI completion notifications spec (agentmux-cloud PR #48)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.12",
+  "version": "0.55.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.12",
+      "version": "0.55.13",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.12",
+  "version": "0.55.13",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release v0.55.13, consuming 10 pending changesets.

**Forced patch bump (`--as patch` override)**: 4 of the 10 changesets were `feat`-typed, which would normally compute a `minor` bump. Per explicit request, overrode to `patch` — those feature-level changes ship under 0.55.13 rather than a minor version. `scripts/release.sh` prints its standard warning for this case (forcing a bump lower than the changesets request).

Notably includes PR #2640 (`fix(reactive): don't evict live cross-channel jekt registry entries`), merged just before this release — a 4-round reagent-reviewed fix for cross-channel jekt registry entries being wrongly/permanently evicted, plus a new re-registration heartbeat so the fix's grace-period logic is meaningful past an agent's first minute of life. See `docs/retro/retro-cross-channel-jekt-eviction-2026-08-17.md`.

## Test plan

- [x] All 5 version locations agree at 0.55.13 (`package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`, `VERSION_HISTORY.md`) — verified directly, matches the release-consistency invariant this repo's own CI/reagent gate checks
- [x] `scripts/release.sh` completed cleanly (changesets consumed, lockfiles regenerated)

<!-- agentmux:agent_id=loap -->