### PR TITLE
Fix macOS false-positive needs_reauth for Keychain-backed Claude accounts

### DIFF
--- a/.changesets/1787037196-fix-identity-stop-mislabeling-macos-keychain-backed-claude-a-xi4o.md
+++ b/.changesets/1787037196-fix-identity-stop-mislabeling-macos-keychain-backed-claude-a-xi4o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): stop mislabeling macOS Keychain-backed Claude accounts as needs_reauth

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -1938,6 +1938,14 @@ mod tests {
         // bundle dir with NO token file → the probe surfaces
         // `needs_reauth` and the resolver upserts the account row
         // with the new status. Spec §4.4.
+        //
+        // Uses "codex", not "claude": the macOS Keychain carve-out added
+        // in oauth_probe.rs (retro-macos-keychain-credential-isolation-gap-
+        // 2026-08-17.md) makes a missing token file for "claude" return
+        // `None` (no status change) on macOS specifically, since Claude
+        // Code never writes `.credentials.json` there regardless of the
+        // config dir. "codex" isn't covered by that carve-out, so it keeps
+        // this test's original, platform-independent needs_reauth signal.
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
@@ -1945,7 +1953,7 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            provider: "codex".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1978,10 +1986,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let bundle_dir = tmp.path().to_str().unwrap().to_string();
 
-        let claude = IdentityAccount {
-            id: "acct-claude".to_string(),
-            name: "claude-acct-claude".to_string(),
-            provider: "claude".to_string(),
+        let codex_acct = IdentityAccount {
+            id: "acct-codex".to_string(),
+            name: "codex-acct-codex".to_string(),
+            provider: "codex".to_string(),
             kind: "oauth".to_string(),
             display_name: String::new(),
             secret_ref: SecretRef::OAuthConfigDir { dir: bundle_dir },
@@ -1992,9 +2000,9 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         };
-        store.identity_upsert(&claude).unwrap();
+        store.identity_upsert(&codex_acct).unwrap();
         store
-            .agent_identity_link("def-1", "acct-claude", "claude")
+            .agent_identity_link("def-1", "acct-codex", "codex")
             .unwrap();
 
         insert_block_for_agent(&store, "block-probe", "def-1");
@@ -2007,10 +2015,10 @@ mod tests {
         // Env injection still happened (resolver doesn't block on
         // probe outcome — the CLI launches with the dir env var set
         // and will trigger OAuth itself when it sees no tokens).
-        assert!(env.get("CLAUDE_CONFIG_DIR").is_some());
+        assert!(env.get("CODEX_HOME").is_some());
 
         // Status row was UPDATED to needs_reauth.
-        let after = store.identity_get("acct-claude").unwrap().unwrap();
+        let after = store.identity_get("acct-codex").unwrap().unwrap();
         assert_eq!(after.status, oauth_status::NEEDS_REAUTH);
     }
 
@@ -2024,6 +2032,14 @@ mod tests {
         // silently never refreshing that account's status. Same fixture
         // as inject_oauth_class_probes_and_flips_status_to_needs_reauth
         // above, but bound under the alias instead of the canonical id.
+        //
+        // Uses "codex-cli" → "codex", not "claude-code" → "claude": the
+        // macOS Keychain carve-out (oauth_probe.rs) means a missing token
+        // file for "claude" returns `None` on macOS regardless of whether
+        // canonicalization ran, which would make this test unable to
+        // distinguish "canonicalization is broken" from "hit the carve-out"
+        // on that platform. "codex" isn't covered by the carve-out, so it
+        // keeps the original, platform-independent needs_reauth signal.
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
@@ -2031,7 +2047,7 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            provider: "codex".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -2062,10 +2078,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let bundle_dir = tmp.path().to_str().unwrap().to_string();
 
-        let claude = IdentityAccount {
+        let codex_acct = IdentityAccount {
             id: "acct-alias".to_string(),
-            name: "claude-code-acct-alias".to_string(),
-            provider: "claude-code".to_string(),
+            name: "codex-cli-acct-alias".to_string(),
+            provider: "codex-cli".to_string(),
             kind: "oauth".to_string(),
             display_name: String::new(),
             secret_ref: SecretRef::OAuthConfigDir { dir: bundle_dir },
@@ -2074,10 +2090,10 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         };
-        store.identity_upsert(&claude).unwrap();
-        // Bound under the alias, not the canonical "claude".
+        store.identity_upsert(&codex_acct).unwrap();
+        // Bound under the alias, not the canonical "codex".
         store
-            .agent_identity_link("def-1", "acct-alias", "claude-code")
+            .agent_identity_link("def-1", "acct-alias", "codex-cli")
             .unwrap();
 
         insert_block_for_agent(&store, "block-probe-alias", "def-1");
@@ -2087,7 +2103,7 @@ mod tests {
         let mut env: HashMap<String, String> = HashMap::new();
         inject_identity_env(store.clone(), store.clone(), store.clone(), "block-probe-alias", &mut env).unwrap();
 
-        assert!(env.get("CLAUDE_CONFIG_DIR").is_some());
+        assert!(env.get("CODEX_HOME").is_some());
         // Status row was UPDATED to needs_reauth — proves the probe ran
         // with the canonicalized provider id, not the raw alias (which
         // would have returned None and left status untouched at "valid").

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -26,7 +26,7 @@ use crate::backend::storage::StoreError;
 use crate::backend::wps::{Broker, WaveEvent};
 
 use super::errors::SpawnGateError;
-use super::oauth_probe::probe_oauth_status;
+use super::oauth_probe::{oauth_status, probe_oauth_status};
 use super::provider::{provider_class, ProviderClass};
 use super::secret::resolve_secret;
 
@@ -572,8 +572,35 @@ pub fn inject_identity_env_with_broker(
                 // strings — passing a raw alias like "claude-code" always
                 // returned None, silently never refreshing an alias-bound
                 // account's status or publishing identityaccounts:changed.
-                if let Some(probed) = probe_oauth_status(resolve_provider_alias(&binding.provider), &dir, now_ms) {
-                    let new_status = probed.as_str();
+                let canonical_provider = resolve_provider_alias(&binding.provider);
+                let probed = probe_oauth_status(canonical_provider, &dir, now_ms);
+                // Self-heal a stale false-positive (Codex P1, PR #2645): the
+                // macOS Keychain carve-out in oauth_probe.rs makes a missing
+                // token file return `None` for `claude` on macOS instead of
+                // `needs_reauth` — but an account probed BEFORE that
+                // carve-out existed may already have `needs_reauth`
+                // persisted from the old, buggy behavior. A `None` probe
+                // never upserts anything, so without this, an already-
+                // mislabeled account would stay stuck showing "reconnect"
+                // forever, even though this fix landed specifically to stop
+                // that. Correcting to "unknown" rather than "valid" — the
+                // probe genuinely can't tell on macOS, and a false "valid"
+                // would be exactly as dishonest as the "needs_reauth" this
+                // is fixing. Scoped tightly to the exact carve-out
+                // condition (not "any None"), so an unsupported provider's
+                // genuinely-earned needs_reauth (set by some other path)
+                // is never touched by this.
+                let new_status: Option<&'static str> = match probed {
+                    Some(p) => Some(p.as_str()),
+                    None if canonical_provider == "claude"
+                        && cfg!(target_os = "macos")
+                        && account.status == oauth_status::NEEDS_REAUTH =>
+                    {
+                        Some("unknown")
+                    }
+                    None => None,
+                };
+                if let Some(new_status) = new_status {
                     if account.status != new_status {
                         let mut updated = account.clone();
                         updated.status = new_status.to_string();
@@ -2020,6 +2047,60 @@ mod tests {
         // Status row was UPDATED to needs_reauth.
         let after = store.identity_get("acct-codex").unwrap().unwrap();
         assert_eq!(after.status, oauth_status::NEEDS_REAUTH);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[cfg(debug_assertions)]
+    #[test]
+    fn inject_oauth_class_self_heals_stale_needs_reauth_for_claude_on_macos() {
+        // Codex P1 on PR #2645: an account probed BEFORE the macOS
+        // Keychain carve-out existed may already have `needs_reauth`
+        // persisted from the old, buggy behavior. Without a self-heal,
+        // that account stays stuck showing "reconnect" forever, since a
+        // `None` probe never upserts anything — this proves the resolver
+        // corrects it back to "unknown" (not a fabricated "valid") the
+        // next time the agent spawns.
+        let store = make_store();
+
+        // gate_def's own provider is already "claude" — see its doc comment.
+        let mut def = gate_def(0);
+        store.agent_def_insert(&mut def).unwrap();
+
+        // Bundle dir intentionally empty, same as the pre-fix broken case —
+        // but the account already carries the stale needs_reauth status
+        // the old probe would have written.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = tmp.path().to_str().unwrap().to_string();
+
+        let stale = IdentityAccount {
+            id: "acct-stale".to_string(),
+            name: "claude-acct-stale".to_string(),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir { dir: bundle_dir },
+            context: serde_json::json!({}),
+            status: oauth_status::NEEDS_REAUTH.to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.identity_upsert(&stale).unwrap();
+        store
+            .agent_identity_link("def-1", "acct-stale", "claude")
+            .unwrap();
+
+        insert_block_for_agent(&store, "block-self-heal", "def-1");
+        let inst = make_instance("block-self-heal", "id-self-heal");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store.clone(), store.clone(), store.clone(), "block-self-heal", &mut env).unwrap();
+
+        let after = store.identity_get("acct-stale").unwrap().unwrap();
+        assert_eq!(
+            after.status, "unknown",
+            "a stale pre-carve-out needs_reauth must self-heal to unknown, not stay stuck"
+        );
     }
 
     #[cfg(debug_assertions)]

--- a/agentmux-srv/src/identity/resolver/oauth_probe.rs
+++ b/agentmux-srv/src/identity/resolver/oauth_probe.rs
@@ -72,6 +72,23 @@ impl OAuthProbeStatus {
 /// isn't supported for the provider (so the caller skips status
 /// updates rather than mis-writing `needs_reauth` for a provider whose
 /// file we just don't know how to parse yet).
+///
+/// **macOS caveat (`claude` only):** the Claude Code CLI stores OAuth
+/// credentials in the encrypted macOS Keychain, never in
+/// `<dir>/.credentials.json` — confirmed against Claude Code's own docs
+/// and empirically on a real per-identity bundle dir on this machine (zero
+/// `.credentials.json` present despite a working session). Unlike Linux
+/// and Windows, this is true regardless of `CLAUDE_CONFIG_DIR` — see
+/// `docs/retro/retro-macos-keychain-credential-isolation-gap-2026-08-17.md`.
+/// So on macOS, a missing `claude` token file is not evidence the account
+/// needs reauth — it's the expected, permanent shape, and reporting
+/// `NeedsReauth` here would be a standing false positive on every working
+/// macOS Claude account. `None` is returned instead (status left alone) —
+/// see the `None` variant's doc above for why that's the honest answer
+/// when this probe genuinely can't tell. `codex`/`openclaw` are not
+/// covered by this carve-out: their macOS credential-storage behavior
+/// hasn't been verified, so their existing file-probe semantics are
+/// unchanged.
 pub fn probe_oauth_status(
     provider: &str,
     dir: &str,
@@ -94,6 +111,18 @@ pub fn probe_oauth_status(
     let contents = match std::fs::read_to_string(&probe_path) {
         Ok(s) => s,
         Err(e) => {
+            if provider == "claude" && cfg!(target_os = "macos") {
+                tracing::debug!(
+                    target: "identity",
+                    provider,
+                    path = %probe_path.display(),
+                    error = %e,
+                    "oauth probe: token file unreadable on macOS — Claude Code stores \
+                     credentials in Keychain here, not this file, so this is not evidence \
+                     of needs_reauth; leaving status unchanged"
+                );
+                return None;
+            }
             tracing::debug!(
                 target: "identity",
                 provider,
@@ -212,7 +241,35 @@ mod tests {
     }
 
     #[test]
-    fn probe_oauth_status_missing_dir_is_needs_reauth() {
+    fn probe_oauth_status_missing_dir_is_needs_reauth_for_codex() {
+        // codex isn't covered by the macOS carve-out (its macOS
+        // credential-storage behavior hasn't been verified the way
+        // Claude Code's has) — a missing file is still a definitive
+        // needs_reauth signal for it, on every platform.
+        let r = probe_oauth_status("codex", "/definitely/does/not/exist-xyz-9q", 0);
+        assert_eq!(r, Some(OAuthProbeStatus::NeedsReauth));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn probe_oauth_status_missing_dir_is_none_for_claude_on_macos() {
+        // Claude Code stores OAuth credentials in the macOS Keychain, not
+        // `<dir>/.credentials.json`, regardless of CLAUDE_CONFIG_DIR — a
+        // missing file here is the expected, permanent shape on macOS, not
+        // evidence of needs_reauth. See
+        // docs/retro/retro-macos-keychain-credential-isolation-gap-2026-08-17.md.
+        // Asserting `None` (not `NeedsReauth`) is what stops this probe
+        // from mislabeling every working macOS Claude account as needing
+        // reauth.
+        let r = probe_oauth_status("claude", "/definitely/does/not/exist-xyz-9q", 0);
+        assert_eq!(r, None);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn probe_oauth_status_missing_dir_is_needs_reauth_for_claude_off_macos() {
+        // On Linux/Windows, CLAUDE_CONFIG_DIR genuinely relocates
+        // `.credentials.json` — a missing file there is a real signal.
         let r = probe_oauth_status("claude", "/definitely/does/not/exist-xyz-9q", 0);
         assert_eq!(r, Some(OAuthProbeStatus::NeedsReauth));
     }

--- a/docs/retro/retro-macos-keychain-credential-isolation-gap-2026-08-17.md
+++ b/docs/retro/retro-macos-keychain-credential-isolation-gap-2026-08-17.md
@@ -1,0 +1,162 @@
+# Retro: macOS Claude Code sessions authenticate with zero linked identity accounts
+
+**Date:** 2026-08-17
+**Area:** `agentmux-srv/src/identity/resolver/inject.rs`, `agentmux-cef/src/commands/platform.rs`, macOS Keychain credential storage in the upstream Claude Code CLI
+
+---
+
+## 1. Symptom (as reported)
+
+Inspecting a live, running AgentMux agent instance on macOS: the `IdentityAccounts`
+MCP tool returns `{"accounts": []}` — no identity account is bound to this agent in
+`db_agent_identity_links` — yet the agent is running normally with full Claude
+access. The user's framing: "that would be impossible on Windows."
+
+## 2. Investigation
+
+- Confirmed `db_agent_identity_links` genuinely has no row for this agent
+  (`IdentityAccounts` result), ruling out a stale-cache or query bug.
+- Read `agentmux-srv/src/identity/resolver/inject.rs`
+  (`inject_identity_env_with_broker`, the "layer 3 spawn gate") in full.
+  **Correction to an earlier working theory in this investigation:** the
+  `use_ambient_login` escape hatch this function's doc comments still
+  describe was fully retired — per the "Superseded same-day" note in
+  `docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md` §7
+  (2026-07-22 correction), a missing bound oauth account now blocks the
+  spawn *unconditionally*; the flag is read only for a log line and has no
+  effect on the outcome (`spawn_still_blocked_when_bound_oauth_account_missing_and_flag_true`
+  pins this directly). So the flag is not what let this agent run — two
+  things actually explain it, and neither depends on that flag:
+  1. This gate's Step 1 (`instance_get_active_for_block`) returns `Ok(())`
+     immediately, with **no gating and no injection at all**, whenever the
+     block has no `AgentInstance` row — the function's own comment: "Block
+     has no agent instance row — nothing to inject, and no gating either:
+     quick-launch panes that never went through the launch modal are
+     outside the managed-credentials contract." A pane spawned outside the
+     launch-modal flow never reaches the gate in the first place.
+  2. Independent of whether the gate fires, the srv-side identity system
+     isn't what supplies this agent's credentials anyway — see the next
+     bullet. The CEF-host-side shared-provider default (`ensureAuthDir` /
+     `ensure_auth_dir`) is a separate, earlier-in-the-pipeline mechanism
+     that resolves `CLAUDE_CONFIG_DIR` before/independent of the srv gate,
+     confirmed live via 5 current frontend call sites (`agent-model.ts:257,489`,
+     `PreLaunchAuthPanel.tsx:429`, `useAgentControllerStatus.ts:256`,
+     `ClaudeLoginPanel.tsx:173`) — this is not legacy/dead code, it's the
+     active default path today.
+- The agent process's actual `CLAUDE_CONFIG_DIR` env var points not at a
+  per-identity bundle but at the **legacy shared-provider default path**,
+  `~/.agentmux/shared/providers/claude/` — a structurally separate, older
+  mechanism documented in `agentmux-cef/src/commands/platform.rs`
+  (`ensure_auth_dir`) as the account-wide, version/channel-independent
+  default, put in place as the fix for
+  `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`. The
+  layer-3 gate in `inject.rs` only resolves `db_agent_identity_links`
+  bindings — it has no knowledge of, and does not gate, this shared-provider
+  path at all.
+- That shared-provider directory has **no `.credentials.json` file on
+  disk.** Checked the macOS Keychain directly (`security dump-keychain` /
+  `security find-generic-password`) and found the running session's OAuth
+  credential live there instead, under service name `"Claude
+  Code-credentials"` (plus several hash-suffixed variants of unclear origin —
+  see §5).
+- Fetched Claude Code's own authentication docs
+  (`code.claude.com/docs/en/authentication`) to get the canonical behavior:
+  > - On macOS, credentials are stored in the encrypted macOS Keychain.
+  > - On Linux, credentials are stored in `~/.claude/.credentials.json`
+  >   (mode `0600`).
+  > - On Windows, credentials are stored in
+  >   `%USERPROFILE%\.claude\.credentials.json`, ACL-restricted to the user
+  >   profile.
+  > - **If you've set `CLAUDE_CONFIG_DIR` on Linux or Windows, the
+  >   `.credentials.json` file lives under that directory instead.**
+
+  The docs explicitly scope the `CLAUDE_CONFIG_DIR`-relocation behavior to
+  Linux and Windows only. macOS is not listed — Keychain storage is not
+  redirected by `CLAUDE_CONFIG_DIR` at all.
+- Cross-checked against GitHub issue
+  [anthropics/claude-code#9403](https://github.com/anthropics/claude-code/issues/9403)
+  (a *different* macOS Keychain bug — a service-name read/write mismatch —
+  but it incidentally confirms the scoping): "Credentials are **machine-wide**
+  in the macOS Keychain (`~/Library/Keychains/login.keychain-db`), stored
+  under the user account (`-a "$USER"`)." No per-directory or per-profile
+  scoping exists.
+
+## 3. Root cause
+
+AgentMux's whole per-agent/per-identity credential-isolation strategy — for
+both the new identity-account system and the legacy shared-provider default —
+is built on setting `CLAUDE_CONFIG_DIR` to point each spawned Claude Code
+process at a distinct directory. On Linux and Windows this genuinely works,
+because the underlying CLI relocates its credential *file* under that
+directory. **On macOS it's silently a no-op for credential storage**, because
+the CLI's macOS credential storage never consults `CLAUDE_CONFIG_DIR` — it
+always reads/writes one Keychain entry (`"Claude Code-credentials"`), scoped
+only to the OS user account, machine-wide, regardless of which config
+directory the process was launched with.
+
+So on this machine: whatever `CLAUDE_CONFIG_DIR` value happens to be set
+(shared-provider default, in this case — but a per-identity bundle dir would
+behave identically), the CLI ignores it for auth purposes and transparently
+falls through to the single OS-Keychain-resident login that's already
+present from some prior `/login` on this Mac. That's why the agent "just
+works" with an empty `db_agent_identity_links` binding and no
+`.credentials.json` on disk anywhere in its assigned config dir: it was
+never actually using its assigned config dir for auth. It's riding the
+ambient, account-wide Keychain login.
+
+This also compounds with a documented ACL weakness in how the CLI writes
+that Keychain entry: a third-party security disclosure (Silverfort,
+"Skipping the lock: A Claude Code CLI weakness lets any macOS process read
+stored credentials") found the entry is written via
+`/usr/bin/security add-generic-password` without an explicit access-control
+list, so its default ACL only names `/usr/bin/security` itself as a trusted
+reader — meaning *any* process running as the same OS user, not just Claude
+Code, can read the full OAuth token bundle with a single
+`security find-generic-password -s "Claude Code-credentials" -w` call, no
+prompt. Anthropic's stated position (per that disclosure) is that this is an
+accepted design tradeoff, not a vulnerability, since they consider all
+same-user processes trusted; they're reportedly tracking a future ACL
+tightening as a hardening improvement, not a fix. That "same-user processes
+are trusted" assumption doesn't hold inside AgentMux, where separate
+identity-scoped agents are supposed to be mutually untrusted with respect to
+each other's credentials.
+
+## 4. Why this can't happen the same way on Windows
+
+On Windows, `CLAUDE_CONFIG_DIR` genuinely relocates `.credentials.json`
+(confirmed above, official docs). An agent with no identity binding and a
+config dir containing no credentials file would have no readable credential
+at all — the CLI has nowhere else to silently fall back to. It would either
+prompt to log in or fail outright, consistent with the user's "would be
+impossible on Windows" framing, and presumably also what the layer-3 spawn
+gate in `inject.rs` was designed assuming would happen everywhere. macOS
+breaks that assumption at the OS-integration layer, below anything
+AgentMux's own gate can see or control.
+
+## 5. Open questions / not fully explained
+
+- The multiple hash-suffixed Keychain service-name variants observed on this
+  machine (`Claude Code-credentials-<hash>`, e.g. `-0b9a1af6`, `-4d6f0fa0`,
+  ...) aren't accounted for by either the official docs or issue #9403, which
+  both describe a single plain `"Claude Code-credentials"` entry. Possible
+  explanations not yet confirmed: leftover entries from multiple installed
+  CLI versions, a third-party multi-account switcher tool that scopes
+  entries itself, or per-app-instance Keychain access-group hashing by
+  macOS. Worth a follow-up if it matters for the fix design in the plan doc.
+- **Resolved during follow-up investigation:** yes, the newer
+  `db_agent_identity_links`-bound path is equally exposed, and for a more
+  fundamental reason than "spot-check whether it behaves differently." The
+  root cause (§3) is that macOS Keychain storage in the CLI never consults
+  `CLAUDE_CONFIG_DIR` at all, regardless of which AgentMux subsystem set
+  that env var or why. Whether the value came from the srv-side identity
+  gate's `SecretRef::OAuthConfigDir` injection or the CEF-side
+  `ensureAuthDir` shared-provider default, the CLI ignores it identically on
+  macOS. The identity-account path is not a separate case to verify — it's
+  covered by the same mechanism. (Separately, confirmed the srv-side layer-3
+  gate's `use_ambient_login` bypass no longer exists as live code — see §2 —
+  so it's not a factor for either path.)
+
+## 6. Follow-up
+
+Remediation options are written up separately:
+[PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17.md](../specs/PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17.md).

--- a/docs/specs/PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17.md
+++ b/docs/specs/PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17.md
@@ -1,0 +1,205 @@
+# Plan — enforce the same per-agent Claude auth isolation on macOS that already holds on Windows
+
+**Date:** 2026-08-17
+**Status:** proposed, not yet implemented. First slice of 3d shipped
+2026-08-17 (see §7) — the rest is intentionally on hold, see §7.
+**Context:** follow-up to
+[retro-macos-keychain-credential-isolation-gap-2026-08-17.md](../retro/retro-macos-keychain-credential-isolation-gap-2026-08-17.md),
+which found that AgentMux's `CLAUDE_CONFIG_DIR`-based per-agent credential
+isolation is a silent no-op on macOS, because the Claude Code CLI's macOS
+credential storage (OS Keychain) ignores `CLAUDE_CONFIG_DIR` entirely and
+always resolves to one machine-wide, OS-user-scoped Keychain entry — a
+behavior that only exists on macOS; Linux and Windows both genuinely
+relocate the credential file under `CLAUDE_CONFIG_DIR`.
+
+## 1. Problem restated
+
+AgentMux's identity-isolation model (both the current
+`db_agent_identity_links` system and the older shared-provider default)
+assumes that setting `CLAUDE_CONFIG_DIR` per spawned process controls which
+credential that process can see. That assumption is false on macOS.
+Concretely, on macOS today:
+
+- An agent with **no** identity-account binding and **no**
+  `use_ambient_login` flag can still run fully authenticated, because it
+  transparently inherits whatever OAuth session is sitting in the
+  machine-wide Keychain entry — not because of any AgentMux-side bypass, but
+  because the underlying CLI never consulted AgentMux's config dir in the
+  first place.
+- Two AgentMux-spawned agents given *different* `CLAUDE_CONFIG_DIR` values,
+  intended to be different accounts, will silently authenticate as the
+  **same** account on macOS if a Keychain login already exists — there's no
+  way today to detect this from inside AgentMux, since every layer only
+  checks its own `db_agent_identity_links` bookkeeping, not what credential
+  the CLI actually resolved.
+- Any other process on the machine running as the same OS user can read that
+  Keychain entry outright (documented ACL weakness, retro §3), which is a
+  second, compounding isolation gap beyond AgentMux's own control.
+
+The goal: make macOS behave like Windows/Linux — an agent with no valid
+binding should have no usable credential, and different identity-bound
+agents should not be able to silently share one Keychain login.
+
+## 2. Constraints
+
+- The macOS Keychain behavior is upstream Claude Code CLI behavior, not
+  something AgentMux controls directly. Any fix has to work *around* it
+  (force a different credential-supply mechanism) rather than *through* it —
+  there's no documented `CLAUDE_CONFIG_DIR`-equivalent flag for macOS
+  Keychain scoping.
+- Whatever mechanism is chosen must not break the documented, sanctioned
+  `use_ambient_login = 1` path, which is *supposed* to fall through to
+  whatever's ambiently available.
+- Must not regress the existing Linux/Windows isolation, which already works
+  correctly via `CLAUDE_CONFIG_DIR`.
+
+## 3. Candidate fixes, ranked
+
+**Recommended: 3a as the primary fix, landed together with 3d's
+detection/fail-closed check as a safety net. Hold 3b/3c as documented but
+not pursued unless 3a proves insufficient.**
+
+**3a. Force file-based credential storage on macOS the same way Linux does,
+by supplying each agent's credential through `apiKeyHelper` instead of
+letting the CLI touch Keychain at all.**
+The CLI's authentication precedence (confirmed via the official docs,
+"Authentication precedence" section) checks several sources before falling
+through to the stored `/login` OAuth credential — notably `apiKeyHelper`
+(precedence source 4) ranks *above* the OAuth/Keychain credential (source
+7). AgentMux could point `apiKeyHelper` at a small per-agent script that
+reads a token from the agent's own isolated `CLAUDE_CONFIG_DIR`-scoped file,
+achieving real filesystem-level isolation identical in spirit to the Linux
+path, without touching Keychain at all. This requires AgentMux to
+independently manage OAuth token refresh (since it's bypassing the CLI's own
+Keychain-backed refresh flow) — the main implementation cost.
+*Tradeoff:* most work, but the only option that gives macOS the same
+filesystem-scoped guarantee Linux/Windows already have, and doesn't depend
+on any undocumented or fragile Keychain behavior.
+
+**3b. Use `CLAUDE_CODE_OAUTH_TOKEN` per spawned process, sourced from an
+AgentMux-managed per-identity token store.**
+This env var is documented (precedence source 5) to bypass Keychain reads.
+Simpler than 3a since it doesn't require an `apiKeyHelper` script.
+**Rejected as primary fix** — GitHub issue #37512 documents that setting
+this variable causes the CLI to silently *delete* the machine's shared
+Keychain entry on process exit, which would destroy the ambient login other
+non-AgentMux-managed `use_ambient_login=1` sessions (or a developer's own
+interactive `claude` session on the same Mac) depend on. Usable only if
+AgentMux can guarantee no other process on the machine still needs the plain
+Keychain entry — too fragile an assumption to rely on by default.
+
+**3c. Request Keychain ACL hardening / a `CLAUDE_CONFIG_DIR`-scoped Keychain
+service name from Anthropic upstream.**
+The root cause is entirely inside the CLI's macOS storage code. The cleanest
+long-term fix is upstream: either honor `CLAUDE_CONFIG_DIR` for Keychain
+service-name scoping on macOS the same way it's honored for the file path on
+Linux/Windows, or at minimum tighten the ACL per the Silverfort disclosure.
+Worth filing/tracking, but not something AgentMux can land on its own
+timeline — listed for completeness, not as something this plan can execute
+directly.
+
+**3d. Fail-closed detection: after spawn, verify the *actual* resolved
+credential matches the intended identity, not just that the gate ran.**
+Independent of which of 3a-3c is chosen, add a runtime check (e.g., shell
+out to the CLI's own credential-source introspection immediately after
+spawn, or before allowing the first request) that confirms the
+account/session AgentMux *expects* to be active is the one actually in use —
+rather than trusting that setting `CLAUDE_CONFIG_DIR` was sufficient. This
+directly closes the blind spot found in this investigation: today nothing in
+AgentMux ever checks what credential a spawned process actually ended up
+using. Cheap relative to 3a/3b, and valuable as a safety net even after 3a
+lands, since it would catch any future regression of this class immediately
+instead of requiring another manual Keychain-dump investigation.
+
+## 4. Non-goals
+
+- Not attempting to patch or vendor a fork of the Claude Code CLI to change
+  its Keychain behavior directly — out of scope and a maintenance burden;
+  prefer working through documented credential-precedence hooks (3a) or
+  upstream engagement (3c).
+- Not proposing 3b as shipped default behavior, given the confirmed
+  data-loss bug (#37512) — only worth revisiting if that upstream bug is
+  fixed.
+- Not scoping this plan to Linux, which is unaffected (already file-based
+  and correctly relocated by `CLAUDE_CONFIG_DIR`).
+
+## 5. Open questions (carried from the retro)
+
+- **Resolved:** both the `db_agent_identity_links`-bound path and the legacy
+  shared-provider default fall through to ambient Keychain on macOS
+  identically — the root cause is in the CLI's OS-level credential storage,
+  which doesn't distinguish which AgentMux subsystem set `CLAUDE_CONFIG_DIR`
+  (see retro §5). This *simplifies* 3a's scope: every call site that
+  currently relies on `CLAUDE_CONFIG_DIR` for isolation needs the
+  `apiKeyHelper` treatment on macOS, with no special-casing between the two
+  systems. Full call-site list: `agentmux-srv/src/backend/providers.rs:60`,
+  `native_memory_handlers.rs:46,69`, `cli_handlers.rs:305`,
+  `app_api/agent_open.rs:309`, `subagent_watcher/parse.rs:487`,
+  `agentmux-cef/src/commands/providers.rs:393-491`, plus the CEF-side
+  `ensure_auth_dir` (`agentmux-cef/src/commands/platform.rs:79`) and its 5
+  frontend callers (`agent-model.ts`, `PreLaunchAuthPanel.tsx`,
+  `useAgentControllerStatus.ts`, `ClaudeLoginPanel.tsx`).
+- The unexplained hash-suffixed Keychain entries (retro §5) — worth
+  understanding before 3a ships, in case they indicate an existing,
+  undocumented partial mitigation already in place (e.g., from a prior CLI
+  version) that 3a would need to account for or clean up.
+- Whether 3a's `apiKeyHelper`-managed token refresh can reuse the CLI's own
+  refresh-token exchange logic or needs an independent reimplementation —
+  not yet investigated, and likely the single biggest cost driver for 3a.
+
+## 6. Suggested implementation order
+
+1. Spot-check the open question in §5 (identity-account path vs. legacy
+   shared path) — cheap, and changes 3a's scope.
+2. Prototype 3d (fail-closed detection) first — it's the cheapest of the
+   four options, ships independent value immediately (turns a silent
+   isolation gap into a loud, actionable failure), and gives a concrete test
+   harness to validate 3a against once it's built.
+3. Build 3a (`apiKeyHelper`-backed per-agent file credential) behind the
+   detection check from step 2, so a regression during development is
+   caught by the same mechanism rather than requiring another manual
+   Keychain investigation.
+4. File the upstream ask (3c) in parallel — long lead time, doesn't block
+   1-3.
+
+## 7. Progress (2026-08-17)
+
+**Step 1 (§5's open question) done** — resolved by re-reading
+`inject_identity_env_with_broker` in full: both credential paths are
+affected identically, and are affected regardless of the srv-side identity
+gate's own policy history (its `use_ambient_login` bypass, referenced in
+the original retro draft, turned out to already be fully retired — see the
+retro's §2 correction). See retro §5.
+
+**A bounded first slice of 3d shipped**, narrower than the full "verify the
+actual resolved credential matches the intended identity" detector
+originally scoped: while investigating, found that the *existing*
+`probe_oauth_status()` (`agentmux-srv/src/identity/resolver/oauth_probe.rs`)
+already treats a missing `<dir>/.credentials.json` as a definitive
+`needs_reauth` signal — which, given §3's root cause, means every
+Keychain-backed macOS Claude account was almost certainly being mislabeled
+`needs_reauth` even while genuinely working. Verified empirically against a
+real per-identity bundle dir on the dev machine (zero `.credentials.json`
+present). Fixed: on macOS, a missing token file for `claude` now returns
+`None` (status left alone) instead of asserting a false `needs_reauth` —
+see the function's updated doc comment for the full reasoning, and its test
+module for the platform-gated coverage (`#[cfg(target_os = "macos")]` /
+`#[cfg(not(target_os = "macos"))]`). Two pre-existing integration tests in
+`inject.rs` that exercised this exact scenario under provider `"claude"`
+were repointed to `"codex"` (unaffected by the carve-out) so they keep
+testing the general probe→upsert plumbing rather than colliding with the
+new macOS-specific behavior.
+
+This is real, shipped value (removes a standing false-positive), but it is
+**not** the full 3d design (an active post-spawn check that fails loudly on
+a genuine cross-account mix-up) — it's a correctness fix to a signal 3d
+would have needed anyway. The full active-detection design is still open.
+
+**Decision (2026-08-17): stop here for now.** 3a (`apiKeyHelper`-backed
+credential storage, requiring AgentMux to independently manage OAuth token
+refresh against Anthropic's undocumented endpoint) is explicitly *not*
+being started — the risk/cost this plan already flagged in §5's last bullet
+held up under scrutiny, and it's being left as a scoped follow-up rather
+than started blind. Filing the upstream ask (3c) is also being held pending
+a separate go-ahead, since it's a public action (a GitHub issue on
+`anthropics/claude-code`) that shouldn't be taken without explicit sign-off.


### PR DESCRIPTION
## Summary
- Root cause (documented in the new retro): Claude Code CLI stores OAuth credentials in the macOS Keychain, never in `<dir>/.credentials.json`, regardless of `CLAUDE_CONFIG_DIR` — unlike Linux/Windows, where `CLAUDE_CONFIG_DIR` genuinely relocates the credential file. This makes AgentMux's per-agent credential isolation strategy a silent no-op on macOS.
- Concrete bug found and fixed while investigating: `probe_oauth_status()` treated a missing token file as a definitive `needs_reauth` signal, which — given the root cause above — meant every working, Keychain-backed macOS Claude account was almost certainly being mislabeled `needs_reauth`. Verified empirically against a real per-identity bundle dir on the dev machine (working session, zero `.credentials.json`).
- Fix: on macOS, a missing token file for `claude` now returns `None` (status left alone) instead of asserting a false `needs_reauth`. `codex`/`openclaw` are untouched (their macOS credential-storage behavior hasn't been verified).
- Two pre-existing `inject.rs` integration tests that exercised this exact scenario under `"claude"` were repointed to `"codex"` so they keep testing the general probe→upsert plumbing rather than colliding with the new macOS-specific carve-out.
- Adds a plan for the broader isolation gap (`PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17.md`). The riskier remaining item — independently managing OAuth token refresh outside the CLI's own Keychain-backed flow — is intentionally deferred, not started in this PR.

## Test plan
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv identity::` — 89 passed, 0 failed
- [x] New tests added: platform-gated coverage in `oauth_probe.rs` (`#[cfg(target_os = "macos")]` / `#[cfg(not(target_os = "macos"))]`) proving the carve-out only applies to `claude` on macOS
- [x] Verified the underlying claim empirically against a real per-identity bundle dir on this machine (no `.credentials.json`, working session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)