### PR TITLE
fix(types): add missing armory:section/warden:section to MetaType

### DIFF
--- a/.changesets/1787034601-fix-types-add-missing-armory-section-warden-section-to-metat-a3gk.md
+++ b/.changesets/1787034601-fix-types-add-missing-armory-section-warden-section-to-metat-a3gk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(types): add missing armory:section/warden:section to MetaType

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1500,6 +1500,10 @@ declare global {
         "subagent:slug"?: string;
         "subagent:parent"?: string;
         "subagent:session"?: string;
+        // Selected rail section, meta-backed so it survives a block remount
+        // and the view model can react to it (armory-model.ts/warden-model.ts).
+        "armory:section"?: "accounts" | "memory" | "skills" | "mcp" | "bundles";
+        "warden:section"?: "host" | "lan" | "internet" | "audit" | "supervisor";
     };
 
     // tsgenmeta.MethodMeta


### PR DESCRIPTION
## Summary
- `frontend/types/gotypes.d.ts`'s `MetaType` is a hand-maintained mirror of the backend's meta-key surface (no codegen — the old Go generator was removed). `armory:section` and `warden:section` are real, actively-used meta keys (`armory-model.ts`/`warden-model.ts`, both view components, both test suites) that were simply never added to this mirror — a pure compile-time gap, not a runtime bug.
- Added both keys, typed as the same literal unions their respective models already declare (`ArmorySection`/`WardenSection`), matching this file's existing convention for other section-style keys (e.g. `"agent:resume_strategy"`).

## Test plan
- [x] `npx tsc --noEmit` — clean, zero errors (previously 2)
- [x] `armory-view.test.tsx` + `warden-view.test.tsx` — 28/28 passing, unchanged (confirms this was purely compile-time)
- [x] `cargo check --workspace` — clean

<!-- agentmux:agent_id=lark -->