### PR TITLE
feat(bundle): Bundle editor MCP Servers/Skills sections (composable model v2)

### DIFF
--- a/.changesets/1787034731-feat-bundle-bundle-editor-mcp-servers-skills-sections-compos-djrk.md
+++ b/.changesets/1787034731-feat-bundle-bundle-editor-mcp-servers-skills-sections-compos-djrk.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(bundle): Bundle editor MCP Servers/Skills sections (composable model v2)

--- a/frontend/app/view/memory/BundleMcpSection.test.tsx
+++ b/frontend/app/view/memory/BundleMcpSection.test.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * reagentx P1 on PR #2647: a failed "add private server" must not silently
+ * discard the name/config the user just typed — `addPrivate` never rejects
+ * (errors go to errorAtom, same convention as bind/unbind), so a naive
+ * `.then(() => clearForm())` ran unconditionally regardless of success.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/app/store/wps", () => ({ waveEventSubscribe: vi.fn(() => () => {}) }));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        McpCatalogListForBundleCommand: vi.fn(),
+        McpCatalogBindToBundleCommand: vi.fn(),
+        McpCatalogUnbindFromBundleCommand: vi.fn(),
+        McpCatalogUpsertForBundleCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { BundleMcpSection } from "./BundleMcpSection";
+
+afterEach(() => cleanup());
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+});
+
+function getInputs() {
+    return {
+        name: screen.getByPlaceholderText("Server name") as HTMLInputElement,
+        config: screen.getByPlaceholderText(/my-tool/) as HTMLTextAreaElement,
+        submit: screen.getByRole("button", { name: /Add private server/ }) as HTMLButtonElement,
+    };
+}
+
+describe("BundleMcpSection — add-private form", () => {
+    test("a failed add does NOT clear the typed name/config", async () => {
+        vi.mocked(RpcApi.McpCatalogUpsertForBundleCommand).mockRejectedValue(
+            new Error("server name 'X' already bound to this bundle"),
+        );
+        render(() => <BundleMcpSection bundleId="bundle-1" />);
+        const user = userEvent.setup();
+        const { name, config, submit } = getInputs();
+
+        await user.type(name, "My Tool");
+        await user.clear(config);
+        await user.click(config);
+        await user.paste('{"command":"my-tool"}');
+        await user.click(submit);
+
+        await screen.findByText(/Add failed/);
+        expect(name.value).toBe("My Tool");
+        expect(config.value).toBe('{"command":"my-tool"}');
+    });
+
+    test("a successful add DOES clear the form", async () => {
+        vi.mocked(RpcApi.McpCatalogUpsertForBundleCommand).mockResolvedValue({
+            id: "new-1", name: "My Tool", transport: "stdio", config: "{}",
+            is_global: false, created_at: 0, updated_at: 0,
+        } as any);
+        render(() => <BundleMcpSection bundleId="bundle-1" />);
+        const user = userEvent.setup();
+        const { name, config, submit } = getInputs();
+
+        await user.type(name, "My Tool");
+        await user.click(submit);
+
+        await vi.waitFor(() => expect(name.value).toBe(""));
+        expect(config.value).toBe("{}");
+    });
+});

--- a/frontend/app/view/memory/BundleMcpSection.tsx
+++ b/frontend/app/view/memory/BundleMcpSection.tsx
@@ -1,0 +1,130 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleMcpSection — the "MCP Servers" section of the Bundle editor's
+ * detail view (memory-manager.tsx). Composable model v2,
+ * docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md, GH issue #2024
+ * item 3.
+ *
+ * Two distinct actions, both surfaced here:
+ *   - Bind/unbind an EXISTING global server. Offered for parity with the
+ *     agent-scoped AgentMcpModal and because it's harmless, but has NO
+ *     effect on a spawned agent — a global server already reaches every
+ *     agent unconditionally regardless of bundle binding (see
+ *     BundleMcpModel's doc comment). The caveat text below says so.
+ *   - Add a brand-new PRIVATE server scoped to this bundle. This is the
+ *     actually-functional path: every agent bound to this bundle gets it.
+ *
+ * Deliberately a flat inline list, not a nested PrimitiveListDetail — this
+ * section already lives inside the bundle's own detail pane (itself one
+ * side of MemoryManagerBody's list/detail split), and a second full-height
+ * single-pane swap nested inside that would fight for the same space.
+ */
+
+import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
+import { BundleMcpModel } from "./bundle-mcp-model";
+import "./BundlePrimitiveSection.scss";
+
+interface BundleMcpSectionProps {
+    bundleId: string;
+}
+
+export const BundleMcpSection = (props: BundleMcpSectionProps): JSX.Element => {
+    const model = new BundleMcpModel(props.bundleId);
+    onCleanup(() => model.dispose());
+
+    const [newName, setNewName] = createSignal("");
+    const [newConfig, setNewConfig] = createSignal("{}");
+
+    const handleAdd = (e: Event) => {
+        e.preventDefault();
+        const name = newName().trim();
+        if (!name) return;
+        void model.addPrivate(name, newConfig()).then(() => {
+            setNewName("");
+            setNewConfig("{}");
+        });
+    };
+
+    return (
+        <div class="bundle-primitive-section">
+            <h4 class="bundle-primitive-section-title">MCP Servers</h4>
+            <Show when={model.errorAtom()}>
+                <div class="bundle-primitive-section-error">{model.errorAtom()}</div>
+            </Show>
+            <Show
+                when={model.serversAtom().length > 0}
+                fallback={<p class="bundle-primitive-section-empty">No MCP servers yet</p>}
+            >
+                <ul class="bundle-primitive-section-list">
+                    <For each={model.serversAtom()}>
+                        {(server) => (
+                            <li class="bundle-primitive-section-item">
+                                <span class="bundle-primitive-section-item-name">{server.name}</span>
+                                <Show when={!server.is_global}>
+                                    <span class="bundle-primitive-section-item-badge is-private">private</span>
+                                </Show>
+                                <Show
+                                    when={server.bound_to_bundle}
+                                    fallback={
+                                        <Show when={server.is_global}>
+                                            <button
+                                                type="button"
+                                                class="bundle-primitive-section-btn"
+                                                onClick={() => void model.bind(server.id)}
+                                            >
+                                                Bind
+                                            </button>
+                                        </Show>
+                                    }
+                                >
+                                    <button
+                                        type="button"
+                                        class="bundle-primitive-section-btn"
+                                        onClick={() => void model.unbind(server.id)}
+                                    >
+                                        {server.is_global ? "Unbind" : "Remove"}
+                                    </button>
+                                </Show>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+            </Show>
+            <p class="bundle-primitive-section-caveat">
+                Binding an existing global server here has no effect on a spawned agent
+                — it's already applied to every agent regardless of bundle binding. Add a
+                new private server below to give this bundle its own tool.
+            </p>
+            <form class="bundle-primitive-section-add" onSubmit={handleAdd}>
+                <input
+                    type="text"
+                    class="bundle-primitive-section-add-input"
+                    placeholder="Server name"
+                    value={newName()}
+                    onInput={(e) => setNewName(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
+                />
+                <textarea
+                    class="bundle-primitive-section-add-textarea"
+                    placeholder='{"command": "my-tool"}'
+                    rows={3}
+                    value={newConfig()}
+                    onInput={(e) => setNewConfig(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
+                />
+                <button
+                    type="submit"
+                    class="bundle-primitive-section-add-btn"
+                    disabled={model.addingAtom() || !newName().trim()}
+                >
+                    {model.addingAtom() ? "Adding…" : "+ Add private server"}
+                </button>
+            </form>
+        </div>
+    );
+};
+
+BundleMcpSection.displayName = "BundleMcpSection";

--- a/frontend/app/view/memory/BundleMcpSection.tsx
+++ b/frontend/app/view/memory/BundleMcpSection.tsx
@@ -42,7 +42,12 @@ export const BundleMcpSection = (props: BundleMcpSectionProps): JSX.Element => {
         e.preventDefault();
         const name = newName().trim();
         if (!name) return;
-        void model.addPrivate(name, newConfig()).then(() => {
+        // addPrivate never rejects (errors go to errorAtom, same convention
+        // as bind/unbind) — only clear the form on the reported success,
+        // otherwise a failed add (duplicate name, invalid JSON, FORBIDDEN)
+        // would silently wipe what the user typed. reagentx P1 on PR #2647.
+        void model.addPrivate(name, newConfig()).then((ok) => {
+            if (!ok) return;
             setNewName("");
             setNewConfig("{}");
         });

--- a/frontend/app/view/memory/BundlePrimitiveSection.scss
+++ b/frontend/app/view/memory/BundlePrimitiveSection.scss
@@ -1,0 +1,149 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared styles for BundleMcpSection.tsx / BundleSkillsSection.tsx — the
+// inline MCP Servers / Skills sections inside the Bundle editor's detail
+// view (memory-manager.tsx). Composable model v2,
+// docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md. Deliberately its
+// own compact, flat-list layout rather than reusing AgentPrimitiveModal.scss
+// wholesale — this content sits inside memory-view-detail, not a
+// full-height PrimitiveListDetail pane.
+
+.bundle-primitive-section {
+    margin-top: var(--space-3);
+    padding-top: var(--space-2);
+    border-top: 1px solid var(--border-color);
+}
+
+.bundle-primitive-section-title {
+    margin: 0 0 var(--space-1-5) 0;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--main-text-color);
+}
+
+.bundle-primitive-section-error {
+    margin-bottom: var(--space-1-5);
+    padding: var(--space-1) var(--space-1-5);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 30%, transparent);
+    color: var(--error-color);
+    font-size: var(--text-xs);
+}
+
+.bundle-primitive-section-empty {
+    margin: 0 0 var(--space-1-5) 0;
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+    font-style: italic;
+}
+
+.bundle-primitive-section-list {
+    list-style: none;
+    margin: 0 0 var(--space-1-5) 0;
+    padding: 0;
+}
+
+.bundle-primitive-section-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) 0;
+    border-bottom: 1px solid var(--border-color);
+    font-size: var(--text-sm);
+
+    &:last-child {
+        border-bottom: none;
+    }
+}
+
+.bundle-primitive-section-item-name {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--main-text-color);
+}
+
+.bundle-primitive-section-item-badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 1px 5px;
+
+    &.is-private {
+        color: var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+    }
+}
+
+.bundle-primitive-section-btn {
+    flex-shrink: 0;
+    padding: 2px var(--space-1-5);
+    font-size: var(--text-xs);
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+}
+
+.bundle-primitive-section-caveat {
+    margin: 0 0 var(--space-1-5) 0;
+    padding: var(--space-1) var(--space-1-5);
+    background: color-mix(in srgb, var(--warning-color) 15%, transparent);
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+}
+
+.bundle-primitive-section-add {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.bundle-primitive-section-add-input,
+.bundle-primitive-section-add-textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: var(--space-1) var(--space-1-5);
+    border: 1px solid var(--border-color);
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    font-size: var(--text-sm);
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}
+
+.bundle-primitive-section-add-textarea {
+    font-family: var(--fixed-font, monospace);
+    resize: vertical;
+}
+
+.bundle-primitive-section-add-btn {
+    align-self: flex-start;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-sm);
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--accent-color);
+    cursor: default;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+}

--- a/frontend/app/view/memory/BundleSkillsSection.test.tsx
+++ b/frontend/app/view/memory/BundleSkillsSection.test.tsx
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// reagentx P1 on PR #2647 — see BundleMcpSection.test.tsx's identical
+// doc comment, mirrored here for skills.
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/app/store/wps", () => ({ waveEventSubscribe: vi.fn(() => () => {}) }));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        SkillCatalogListForBundleCommand: vi.fn(),
+        SkillCatalogBindToBundleCommand: vi.fn(),
+        SkillCatalogUnbindFromBundleCommand: vi.fn(),
+        SkillCatalogUpsertForBundleCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { BundleSkillsSection } from "./BundleSkillsSection";
+
+afterEach(() => cleanup());
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+});
+
+function getInputs() {
+    return {
+        name: screen.getByPlaceholderText("Skill name") as HTMLInputElement,
+        content: screen.getByPlaceholderText(/Skill content/) as HTMLTextAreaElement,
+        submit: screen.getByRole("button", { name: /Add private skill/ }) as HTMLButtonElement,
+    };
+}
+
+describe("BundleSkillsSection — add-private form", () => {
+    test("a failed add does NOT clear the typed name/content", async () => {
+        vi.mocked(RpcApi.SkillCatalogUpsertForBundleCommand).mockRejectedValue(
+            new Error("skill name 'X' already bound to this bundle"),
+        );
+        render(() => <BundleSkillsSection bundleId="bundle-1" />);
+        const user = userEvent.setup();
+        const { name, content, submit } = getInputs();
+
+        await user.type(name, "My Skill");
+        await user.type(content, "Do the thing");
+        await user.click(submit);
+
+        await screen.findByText(/Add failed/);
+        expect(name.value).toBe("My Skill");
+        expect(content.value).toBe("Do the thing");
+    });
+
+    test("a successful add DOES clear the form", async () => {
+        vi.mocked(RpcApi.SkillCatalogUpsertForBundleCommand).mockResolvedValue({
+            id: "new-1", name: "My Skill", trigger: "", skill_type: "prompt",
+            description: "", content: "Do the thing", is_global: false, created_at: 0, updated_at: 0,
+        } as any);
+        render(() => <BundleSkillsSection bundleId="bundle-1" />);
+        const user = userEvent.setup();
+        const { name, content, submit } = getInputs();
+
+        await user.type(name, "My Skill");
+        await user.click(submit);
+
+        await vi.waitFor(() => expect(name.value).toBe(""));
+        expect(content.value).toBe("");
+    });
+});

--- a/frontend/app/view/memory/BundleSkillsSection.tsx
+++ b/frontend/app/view/memory/BundleSkillsSection.tsx
@@ -1,0 +1,116 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleSkillsSection — the "Skills" section of the Bundle editor's detail
+ * view. Mirrors BundleMcpSection.tsx — see its doc comment for the
+ * bind/unbind-has-no-effect-vs-addPrivate-is-functional reasoning and the
+ * flat-list-not-nested-PrimitiveListDetail layout choice.
+ */
+
+import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
+import { BundleSkillModel } from "./bundle-skill-model";
+import "./BundlePrimitiveSection.scss";
+
+interface BundleSkillsSectionProps {
+    bundleId: string;
+}
+
+export const BundleSkillsSection = (props: BundleSkillsSectionProps): JSX.Element => {
+    const model = new BundleSkillModel(props.bundleId);
+    onCleanup(() => model.dispose());
+
+    const [newName, setNewName] = createSignal("");
+    const [newContent, setNewContent] = createSignal("");
+
+    const handleAdd = (e: Event) => {
+        e.preventDefault();
+        const name = newName().trim();
+        if (!name) return;
+        void model.addPrivate(name, newContent()).then(() => {
+            setNewName("");
+            setNewContent("");
+        });
+    };
+
+    return (
+        <div class="bundle-primitive-section">
+            <h4 class="bundle-primitive-section-title">Skills</h4>
+            <Show when={model.errorAtom()}>
+                <div class="bundle-primitive-section-error">{model.errorAtom()}</div>
+            </Show>
+            <Show
+                when={model.skillsAtom().length > 0}
+                fallback={<p class="bundle-primitive-section-empty">No skills yet</p>}
+            >
+                <ul class="bundle-primitive-section-list">
+                    <For each={model.skillsAtom()}>
+                        {(skill) => (
+                            <li class="bundle-primitive-section-item">
+                                <span class="bundle-primitive-section-item-name">{skill.name}</span>
+                                <Show when={!skill.is_global}>
+                                    <span class="bundle-primitive-section-item-badge is-private">private</span>
+                                </Show>
+                                <Show
+                                    when={skill.bound_to_bundle}
+                                    fallback={
+                                        <Show when={skill.is_global}>
+                                            <button
+                                                type="button"
+                                                class="bundle-primitive-section-btn"
+                                                onClick={() => void model.bind(skill.id)}
+                                            >
+                                                Bind
+                                            </button>
+                                        </Show>
+                                    }
+                                >
+                                    <button
+                                        type="button"
+                                        class="bundle-primitive-section-btn"
+                                        onClick={() => void model.unbind(skill.id)}
+                                    >
+                                        {skill.is_global ? "Unbind" : "Remove"}
+                                    </button>
+                                </Show>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+            </Show>
+            <p class="bundle-primitive-section-caveat">
+                Binding an existing global skill here has no effect on a spawned agent
+                — it's already applied to every agent regardless of bundle binding. Add a
+                new private skill below to give this bundle its own skill.
+            </p>
+            <form class="bundle-primitive-section-add" onSubmit={handleAdd}>
+                <input
+                    type="text"
+                    class="bundle-primitive-section-add-input"
+                    placeholder="Skill name"
+                    value={newName()}
+                    onInput={(e) => setNewName(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
+                />
+                <textarea
+                    class="bundle-primitive-section-add-textarea"
+                    placeholder="Skill content / prompt"
+                    rows={3}
+                    value={newContent()}
+                    onInput={(e) => setNewContent(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
+                />
+                <button
+                    type="submit"
+                    class="bundle-primitive-section-add-btn"
+                    disabled={model.addingAtom() || !newName().trim()}
+                >
+                    {model.addingAtom() ? "Adding…" : "+ Add private skill"}
+                </button>
+            </form>
+        </div>
+    );
+};
+
+BundleSkillsSection.displayName = "BundleSkillsSection";

--- a/frontend/app/view/memory/BundleSkillsSection.tsx
+++ b/frontend/app/view/memory/BundleSkillsSection.tsx
@@ -28,7 +28,11 @@ export const BundleSkillsSection = (props: BundleSkillsSectionProps): JSX.Elemen
         e.preventDefault();
         const name = newName().trim();
         if (!name) return;
-        void model.addPrivate(name, newContent()).then(() => {
+        // See BundleMcpSection.tsx's identical comment — addPrivate never
+        // rejects, only clear the form on reported success. reagentx P1 on
+        // PR #2647.
+        void model.addPrivate(name, newContent()).then((ok) => {
+            if (!ok) return;
             setNewName("");
             setNewContent("");
         });

--- a/frontend/app/view/memory/bundle-mcp-model.test.ts
+++ b/frontend/app/view/memory/bundle-mcp-model.test.ts
@@ -137,8 +137,9 @@ describe("BundleMcpModel", () => {
             server("new-1", { is_global: false, bound_to_bundle: true }),
         ]);
 
-        await model.addPrivate("My Tool", '{"command":"my-tool"}');
+        const ok = await model.addPrivate("My Tool", '{"command":"my-tool"}');
 
+        expect(ok).toBe(true);
         expect(RpcApi.McpCatalogUpsertForBundleCommand).toHaveBeenCalledWith(
             {},
             { bundle_id: "bundle-1", name: "My Tool", config: '{"command":"my-tool"}' },
@@ -171,8 +172,9 @@ describe("BundleMcpModel", () => {
         const model = makeModel();
         await model.refresh();
 
-        await model.addPrivate("X", "{}");
+        const ok = await model.addPrivate("X", "{}");
 
+        expect(ok).toBe(false);
         expect(model.errorAtom()).toContain("already bound to this bundle");
         expect(model.addingAtom()).toBe(false);
     });

--- a/frontend/app/view/memory/bundle-mcp-model.test.ts
+++ b/frontend/app/view/memory/bundle-mcp-model.test.ts
@@ -1,0 +1,205 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for BundleMcpModel — the bundle-scoped MCP Servers view model
+// (composable model v2, docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md).
+
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+}));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        hub.handlers.set(sub.eventType, sub.handler);
+        return () => hub.handlers.delete(sub.eventType);
+    }),
+}));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        McpCatalogListForBundleCommand: vi.fn(),
+        McpCatalogBindToBundleCommand: vi.fn(),
+        McpCatalogUnbindFromBundleCommand: vi.fn(),
+        McpCatalogUpsertForBundleCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { BundleMcpModel } from "./bundle-mcp-model";
+
+const server = (id: string, overrides: Partial<McpServerBundleListItem> = {}): McpServerBundleListItem => ({
+    id,
+    name: `srv-${id}`,
+    transport: "stdio",
+    config: "{}",
+    is_global: true,
+    created_at: 0,
+    updated_at: 0,
+    bound_to_bundle: false,
+    ...overrides,
+});
+
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    hub.handlers.clear();
+});
+
+afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+});
+
+function makeModel(bundleId = "bundle-1"): BundleMcpModel {
+    let model!: BundleMcpModel;
+    createRoot((d) => {
+        dispose = d;
+        model = new BundleMcpModel(bundleId);
+    });
+    return model;
+}
+
+describe("BundleMcpModel", () => {
+    test("refresh loads the bundle-scoped list on construction", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([server("s1")]);
+        const model = makeModel("bundle-1");
+        await model.refresh();
+
+        expect(RpcApi.McpCatalogListForBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1" },
+        );
+        expect(model.serversAtom()).toHaveLength(1);
+    });
+
+    test("a refresh failure surfaces via errorAtom, not a thrown exception", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockRejectedValue(new Error("boom"));
+        const model = makeModel();
+        await model.refresh();
+
+        expect(model.errorAtom()).toContain("boom");
+        expect(model.serversAtom()).toEqual([]);
+    });
+
+    test("bind calls McpCatalogBindToBundleCommand with the bundle_id, then refreshes", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.McpCatalogBindToBundleCommand).mockResolvedValue({ bound: true });
+        const model = makeModel("bundle-1");
+        await model.refresh();
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([server("s1", { bound_to_bundle: true })]);
+
+        await model.bind("s1");
+
+        expect(RpcApi.McpCatalogBindToBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1", mcp_id: "s1" },
+        );
+        expect(model.serversAtom()[0]?.bound_to_bundle).toBe(true);
+    });
+
+    test("unbind calls McpCatalogUnbindFromBundleCommand with the bundle_id", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.McpCatalogUnbindFromBundleCommand).mockResolvedValue({ unbound: true });
+        const model = makeModel("bundle-1");
+        await model.refresh();
+
+        await model.unbind("s1");
+
+        expect(RpcApi.McpCatalogUnbindFromBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1", mcp_id: "s1" },
+        );
+    });
+
+    test("a bind failure surfaces via errorAtom instead of throwing", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.McpCatalogBindToBundleCommand).mockRejectedValue(new Error("FORBIDDEN"));
+        const model = makeModel();
+        await model.refresh();
+
+        await model.bind("s1");
+
+        expect(model.errorAtom()).toContain("FORBIDDEN");
+    });
+
+    test("addPrivate creates a new server scoped to this bundle, then refreshes", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.McpCatalogUpsertForBundleCommand).mockResolvedValue(
+            server("new-1", { is_global: false, bound_to_bundle: true }) as any,
+        );
+        const model = makeModel("bundle-1");
+        await model.refresh();
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([
+            server("new-1", { is_global: false, bound_to_bundle: true }),
+        ]);
+
+        await model.addPrivate("My Tool", '{"command":"my-tool"}');
+
+        expect(RpcApi.McpCatalogUpsertForBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1", name: "My Tool", config: '{"command":"my-tool"}' },
+        );
+        expect(model.addingAtom()).toBe(false);
+        expect(model.serversAtom()).toHaveLength(1);
+    });
+
+    test("addPrivate sets addingAtom while the call is in flight", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        let resolveUpsert!: (v: McpServer) => void;
+        vi.mocked(RpcApi.McpCatalogUpsertForBundleCommand).mockReturnValue(
+            new Promise((resolve) => { resolveUpsert = resolve; }) as any,
+        );
+        const model = makeModel();
+        await model.refresh();
+
+        const promise = model.addPrivate("name", "{}");
+        expect(model.addingAtom()).toBe(true);
+        resolveUpsert(server("x") as any);
+        await promise;
+        expect(model.addingAtom()).toBe(false);
+    });
+
+    test("a duplicate-name addPrivate failure surfaces via errorAtom and clears addingAtom", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.McpCatalogUpsertForBundleCommand).mockRejectedValue(
+            new Error("server name 'X' already bound to this bundle"),
+        );
+        const model = makeModel();
+        await model.refresh();
+
+        await model.addPrivate("X", "{}");
+
+        expect(model.errorAtom()).toContain("already bound to this bundle");
+        expect(model.addingAtom()).toBe(false);
+    });
+
+    test("selectedAtom resolves the currently selected server by id", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([server("s1"), server("s2")]);
+        const model = makeModel();
+        await model.refresh();
+
+        model.handleSelect(model.serversAtom()[1]!);
+        expect(model.selectedAtom()?.id).toBe("s2");
+    });
+
+    test("an mcp:changed event fired elsewhere triggers a refresh", async () => {
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([]);
+        const model = makeModel("bundle-1");
+        await model.refresh();
+        vi.mocked(RpcApi.McpCatalogListForBundleCommand).mockResolvedValue([server("s1")]);
+
+        hub.handlers.get("mcp:changed")?.({});
+        await vi.waitFor(() => expect(model.serversAtom()).toHaveLength(1));
+    });
+
+    test("dispose unsubscribes from mcp:changed", () => {
+        const model = makeModel();
+        expect(hub.handlers.has("mcp:changed")).toBe(true);
+        model.dispose();
+        expect(hub.handlers.has("mcp:changed")).toBe(false);
+    });
+});

--- a/frontend/app/view/memory/bundle-mcp-model.ts
+++ b/frontend/app/view/memory/bundle-mcp-model.ts
@@ -100,8 +100,16 @@ export class BundleMcpModel {
 
     /** Creates a NEW, PRIVATE server scoped directly to this bundle —
      *  the actually-functional "give this bundle its own tool" path. See
-     *  this class's own doc comment. */
-    async addPrivate(name: string, config: string): Promise<void> {
+     *  this class's own doc comment.
+     *
+     *  Returns whether it succeeded (never throws — same "log to errorAtom,
+     *  don't reject" convention as bind/unbind) so the caller can decide
+     *  whether it's safe to clear its own form state. reagentx P1 on
+     *  PR #2647: since this never rejected, `BundleMcpSection`'s
+     *  `.then(() => clearForm())` used to run unconditionally, silently
+     *  discarding the user's typed name/config on a failed add (duplicate
+     *  name, invalid JSON, FORBIDDEN) even though the error banner showed. */
+    async addPrivate(name: string, config: string): Promise<boolean> {
         this.setError(null);
         this.setAdding(true);
         try {
@@ -111,8 +119,10 @@ export class BundleMcpModel {
                 config,
             });
             await this.refresh();
+            return true;
         } catch (e) {
             this.setError(`Add failed: ${(e as Error).message ?? e}`);
+            return false;
         } finally {
             this.setAdding(false);
         }

--- a/frontend/app/view/memory/bundle-mcp-model.ts
+++ b/frontend/app/view/memory/bundle-mcp-model.ts
@@ -1,0 +1,124 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleMcpModel — view model for a bundle's MCP Servers section (part of
+ * the Bundle editor, memory-manager.tsx). Same shape as AgentMcpModel
+ * (agent-mcp-model.ts) — see its doc comment for the is_global /
+ * no-check_s1 details, which apply identically here, just keyed by
+ * bundle_id instead of agent_id.
+ *
+ * One real difference from the agent-scoped model: binding an existing
+ * GLOBAL server here has no effect on a spawned agent (globals already
+ * reach every agent unconditionally, bundle-bound or not — composable
+ * model v2, docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md). The
+ * actually-functional path is `addPrivate`, which creates a BRAND-NEW
+ * private server scoped to this bundle (mcp.catalog.upsert_for_bundle) —
+ * that's what makes a bundle's own tool show up for every agent bound to
+ * it. Bind/unbind of existing globals is still offered for parity with the
+ * agent-scoped modal and because it's harmless, just not load-bearing.
+ */
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
+
+export class BundleMcpModel {
+    readonly bundleId: string;
+
+    private _servers = createSignal<McpServerBundleListItem[]>([]);
+    serversAtom: Accessor<McpServerBundleListItem[]> = this._servers[0];
+    private setServers = this._servers[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    private _adding = createSignal<boolean>(false);
+    addingAtom: Accessor<boolean> = this._adding[0];
+    setAdding = this._adding[1];
+
+    selectedAtom: Accessor<McpServerBundleListItem | null>;
+
+    // Cross-window reactivity — a bind/unbind, add, or Armory catalog edit
+    // made elsewhere refreshes this view without a manual reopen.
+    private unsubChanged: () => void;
+
+    constructor(bundleId: string) {
+        this.bundleId = bundleId;
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.serversAtom().find((s) => s.id === id) ?? null;
+        });
+        void this.refresh();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "mcp:changed",
+            handler: () => void this.refresh(),
+        });
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.McpCatalogListForBundleCommand(TabRpcClient, { bundle_id: this.bundleId });
+            this.setServers(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load MCP servers: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    handleSelect(server: McpServerBundleListItem): void {
+        this.setError(null);
+        this.setSelectedId(server.id);
+    }
+
+    async bind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.McpCatalogBindToBundleCommand(TabRpcClient, { bundle_id: this.bundleId, mcp_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Bind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    async unbind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.McpCatalogUnbindFromBundleCommand(TabRpcClient, { bundle_id: this.bundleId, mcp_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Unbind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Creates a NEW, PRIVATE server scoped directly to this bundle —
+     *  the actually-functional "give this bundle its own tool" path. See
+     *  this class's own doc comment. */
+    async addPrivate(name: string, config: string): Promise<void> {
+        this.setError(null);
+        this.setAdding(true);
+        try {
+            await RpcApi.McpCatalogUpsertForBundleCommand(TabRpcClient, {
+                bundle_id: this.bundleId,
+                name,
+                config,
+            });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Add failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setAdding(false);
+        }
+    }
+
+    dispose(): void {
+        this.unsubChanged();
+    }
+}

--- a/frontend/app/view/memory/bundle-skill-model.test.ts
+++ b/frontend/app/view/memory/bundle-skill-model.test.ts
@@ -1,0 +1,208 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for BundleSkillModel — the bundle-scoped Skills view model
+// (composable model v2, docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md).
+// Mirrors bundle-mcp-model.test.ts.
+
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+}));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        hub.handlers.set(sub.eventType, sub.handler);
+        return () => hub.handlers.delete(sub.eventType);
+    }),
+}));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        SkillCatalogListForBundleCommand: vi.fn(),
+        SkillCatalogBindToBundleCommand: vi.fn(),
+        SkillCatalogUnbindFromBundleCommand: vi.fn(),
+        SkillCatalogUpsertForBundleCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { BundleSkillModel } from "./bundle-skill-model";
+
+const skill = (id: string, overrides: Partial<SkillBundleListItem> = {}): SkillBundleListItem => ({
+    id,
+    name: `skill-${id}`,
+    trigger: "",
+    skill_type: "prompt",
+    description: "",
+    content: "content",
+    is_global: true,
+    created_at: 0,
+    updated_at: 0,
+    bound_to_bundle: false,
+    ...overrides,
+});
+
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    hub.handlers.clear();
+});
+
+afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+});
+
+function makeModel(bundleId = "bundle-1"): BundleSkillModel {
+    let model!: BundleSkillModel;
+    createRoot((d) => {
+        dispose = d;
+        model = new BundleSkillModel(bundleId);
+    });
+    return model;
+}
+
+describe("BundleSkillModel", () => {
+    test("refresh loads the bundle-scoped list on construction", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([skill("s1")]);
+        const model = makeModel("bundle-1");
+        await model.refresh();
+
+        expect(RpcApi.SkillCatalogListForBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1" },
+        );
+        expect(model.skillsAtom()).toHaveLength(1);
+    });
+
+    test("a refresh failure surfaces via errorAtom, not a thrown exception", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockRejectedValue(new Error("boom"));
+        const model = makeModel();
+        await model.refresh();
+
+        expect(model.errorAtom()).toContain("boom");
+        expect(model.skillsAtom()).toEqual([]);
+    });
+
+    test("bind calls SkillCatalogBindToBundleCommand with the bundle_id, then refreshes", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.SkillCatalogBindToBundleCommand).mockResolvedValue({ bound: true });
+        const model = makeModel("bundle-1");
+        await model.refresh();
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([skill("s1", { bound_to_bundle: true })]);
+
+        await model.bind("s1");
+
+        expect(RpcApi.SkillCatalogBindToBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1", skill_id: "s1" },
+        );
+        expect(model.skillsAtom()[0]?.bound_to_bundle).toBe(true);
+    });
+
+    test("unbind calls SkillCatalogUnbindFromBundleCommand with the bundle_id", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.SkillCatalogUnbindFromBundleCommand).mockResolvedValue({ unbound: true });
+        const model = makeModel("bundle-1");
+        await model.refresh();
+
+        await model.unbind("s1");
+
+        expect(RpcApi.SkillCatalogUnbindFromBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1", skill_id: "s1" },
+        );
+    });
+
+    test("a bind failure surfaces via errorAtom instead of throwing", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.SkillCatalogBindToBundleCommand).mockRejectedValue(new Error("FORBIDDEN"));
+        const model = makeModel();
+        await model.refresh();
+
+        await model.bind("s1");
+
+        expect(model.errorAtom()).toContain("FORBIDDEN");
+    });
+
+    test("addPrivate creates a new skill scoped to this bundle, then refreshes", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.SkillCatalogUpsertForBundleCommand).mockResolvedValue(
+            skill("new-1", { is_global: false, bound_to_bundle: true }) as any,
+        );
+        const model = makeModel("bundle-1");
+        await model.refresh();
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([
+            skill("new-1", { is_global: false, bound_to_bundle: true }),
+        ]);
+
+        await model.addPrivate("My Skill", "Do the thing");
+
+        expect(RpcApi.SkillCatalogUpsertForBundleCommand).toHaveBeenCalledWith(
+            {},
+            { bundle_id: "bundle-1", name: "My Skill", content: "Do the thing" },
+        );
+        expect(model.addingAtom()).toBe(false);
+        expect(model.skillsAtom()).toHaveLength(1);
+    });
+
+    test("addPrivate sets addingAtom while the call is in flight", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        let resolveUpsert!: (v: Skill) => void;
+        vi.mocked(RpcApi.SkillCatalogUpsertForBundleCommand).mockReturnValue(
+            new Promise((resolve) => { resolveUpsert = resolve; }) as any,
+        );
+        const model = makeModel();
+        await model.refresh();
+
+        const promise = model.addPrivate("name", "content");
+        expect(model.addingAtom()).toBe(true);
+        resolveUpsert(skill("x") as any);
+        await promise;
+        expect(model.addingAtom()).toBe(false);
+    });
+
+    test("a duplicate-name addPrivate failure surfaces via errorAtom and clears addingAtom", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.SkillCatalogUpsertForBundleCommand).mockRejectedValue(
+            new Error("skill name 'X' already bound to this bundle"),
+        );
+        const model = makeModel();
+        await model.refresh();
+
+        await model.addPrivate("X", "content");
+
+        expect(model.errorAtom()).toContain("already bound to this bundle");
+        expect(model.addingAtom()).toBe(false);
+    });
+
+    test("selectedAtom resolves the currently selected skill by id", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([skill("s1"), skill("s2")]);
+        const model = makeModel();
+        await model.refresh();
+
+        model.handleSelect(model.skillsAtom()[1]!);
+        expect(model.selectedAtom()?.id).toBe("s2");
+    });
+
+    test("a skills:changed event fired elsewhere triggers a refresh", async () => {
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([]);
+        const model = makeModel("bundle-1");
+        await model.refresh();
+        vi.mocked(RpcApi.SkillCatalogListForBundleCommand).mockResolvedValue([skill("s1")]);
+
+        hub.handlers.get("skills:changed")?.({});
+        await vi.waitFor(() => expect(model.skillsAtom()).toHaveLength(1));
+    });
+
+    test("dispose unsubscribes from skills:changed", () => {
+        const model = makeModel();
+        expect(hub.handlers.has("skills:changed")).toBe(true);
+        model.dispose();
+        expect(hub.handlers.has("skills:changed")).toBe(false);
+    });
+});

--- a/frontend/app/view/memory/bundle-skill-model.test.ts
+++ b/frontend/app/view/memory/bundle-skill-model.test.ts
@@ -140,8 +140,9 @@ describe("BundleSkillModel", () => {
             skill("new-1", { is_global: false, bound_to_bundle: true }),
         ]);
 
-        await model.addPrivate("My Skill", "Do the thing");
+        const ok = await model.addPrivate("My Skill", "Do the thing");
 
+        expect(ok).toBe(true);
         expect(RpcApi.SkillCatalogUpsertForBundleCommand).toHaveBeenCalledWith(
             {},
             { bundle_id: "bundle-1", name: "My Skill", content: "Do the thing" },
@@ -174,8 +175,9 @@ describe("BundleSkillModel", () => {
         const model = makeModel();
         await model.refresh();
 
-        await model.addPrivate("X", "content");
+        const ok = await model.addPrivate("X", "content");
 
+        expect(ok).toBe(false);
         expect(model.errorAtom()).toContain("already bound to this bundle");
         expect(model.addingAtom()).toBe(false);
     });

--- a/frontend/app/view/memory/bundle-skill-model.ts
+++ b/frontend/app/view/memory/bundle-skill-model.ts
@@ -87,8 +87,10 @@ export class BundleSkillModel {
     }
 
     /** Creates a NEW, PRIVATE skill scoped directly to this bundle — see
-     *  BundleMcpModel.addPrivate's identical doc comment. */
-    async addPrivate(name: string, content: string): Promise<void> {
+     *  BundleMcpModel.addPrivate's identical doc comment, including why
+     *  this returns a success boolean instead of Promise<void> (reagentx
+     *  P1 on PR #2647). */
+    async addPrivate(name: string, content: string): Promise<boolean> {
         this.setError(null);
         this.setAdding(true);
         try {
@@ -98,8 +100,10 @@ export class BundleSkillModel {
                 content,
             });
             await this.refresh();
+            return true;
         } catch (e) {
             this.setError(`Add failed: ${(e as Error).message ?? e}`);
+            return false;
         } finally {
             this.setAdding(false);
         }

--- a/frontend/app/view/memory/bundle-skill-model.ts
+++ b/frontend/app/view/memory/bundle-skill-model.ts
@@ -1,0 +1,111 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleSkillModel — view model for a bundle's Skills section (part of the
+ * Bundle editor, memory-manager.tsx). Same shape as AgentSkillModel
+ * (agent-skill-model.ts) and BundleMcpModel (bundle-mcp-model.ts) — see
+ * BundleMcpModel's doc comment for why `addPrivate` is the actually-
+ * functional path, not bind/unbind of existing globals.
+ */
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
+
+export class BundleSkillModel {
+    readonly bundleId: string;
+
+    private _skills = createSignal<SkillBundleListItem[]>([]);
+    skillsAtom: Accessor<SkillBundleListItem[]> = this._skills[0];
+    private setSkills = this._skills[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    private _adding = createSignal<boolean>(false);
+    addingAtom: Accessor<boolean> = this._adding[0];
+    setAdding = this._adding[1];
+
+    selectedAtom: Accessor<SkillBundleListItem | null>;
+
+    private unsubChanged: () => void;
+
+    constructor(bundleId: string) {
+        this.bundleId = bundleId;
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.skillsAtom().find((s) => s.id === id) ?? null;
+        });
+        void this.refresh();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "skills:changed",
+            handler: () => void this.refresh(),
+        });
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.SkillCatalogListForBundleCommand(TabRpcClient, { bundle_id: this.bundleId });
+            this.setSkills(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load skills: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    handleSelect(skill: SkillBundleListItem): void {
+        this.setError(null);
+        this.setSelectedId(skill.id);
+    }
+
+    async bind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.SkillCatalogBindToBundleCommand(TabRpcClient, { bundle_id: this.bundleId, skill_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Bind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    async unbind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.SkillCatalogUnbindFromBundleCommand(TabRpcClient, { bundle_id: this.bundleId, skill_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Unbind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Creates a NEW, PRIVATE skill scoped directly to this bundle — see
+     *  BundleMcpModel.addPrivate's identical doc comment. */
+    async addPrivate(name: string, content: string): Promise<void> {
+        this.setError(null);
+        this.setAdding(true);
+        try {
+            await RpcApi.SkillCatalogUpsertForBundleCommand(TabRpcClient, {
+                bundle_id: this.bundleId,
+                name,
+                content,
+            });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Add failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setAdding(false);
+        }
+    }
+
+    dispose(): void {
+        this.unsubChanged();
+    }
+}

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -25,6 +25,8 @@ import { useModalLayer } from "@/app/element/modal-layer";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { PROVIDERS } from "@/app/view/agent/providers/catalog";
 import { type MemoryDraft, MemoryViewModel } from "./memory-model";
+import { BundleMcpSection } from "./BundleMcpSection";
+import { BundleSkillsSection } from "./BundleSkillsSection";
 
 import "./memory-view.scss";
 
@@ -240,6 +242,15 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                                             Delete
                                         </button>
                                     </div>
+                                    {/* MCP servers / skills are managed live via
+                                        their own bind/unbind + upsert-for-bundle
+                                        RPCs, independent of the edit-draft flow
+                                        above — same reason AgentMcpModal/
+                                        AgentSkillsModal sit outside the agent's
+                                        own edit form. Composable model v2,
+                                        docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md. */}
+                                    <BundleMcpSection bundleId={memory().id} />
+                                    <BundleSkillsSection bundleId={memory().id} />
                                 </Show>
                             </div>
                         )}
@@ -465,13 +476,13 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                             </Show>
 
                             <p class="memory-view-form-hint">
-                                This bundle's other Armory Bundle Format (ABF) components — context files,
-                                MCP servers, and skills — will be editable here in a follow-up. For now they're
-                                persisted as JSON and round-trip cleanly through the form; use{" "}
+                                MCP servers and skills are managed on the bundle's own detail
+                                view (Cancel to get back there), not in this edit form — they
+                                take effect live and don't need a Save. Context files are still
+                                persisted as JSON and round-trip cleanly through this form; use{" "}
                                 <strong>Validate</strong> above to catch unsafe paths or malformed JSON in
                                 them. To bring in an existing <code>.abf</code> archive's components directly,
-                                use <strong>Import Bundle</strong> from the bundle list (Cancel to get back
-                                there).
+                                use <strong>Import Bundle</strong> from the bundle list.
                             </p>
                         </form>
                     )}


### PR DESCRIPTION
## Summary

Delivery-plan step 4 (final) of `docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md`, GH issue #2024 item 3 — frontend follow-up to the backend PR #2639 (schema/RPCs/launch-time wiring). Before this, `memory-manager.tsx`'s bundle-editor form still said MCP servers and skills "will be editable here in a follow-up" — this is that follow-up.

- **`BundleMcpModel`/`BundleSkillModel`** (`bundle-mcp-model.ts`, `bundle-skill-model.ts`): view models mirroring the existing `AgentMcpModel`/`AgentSkillModel`, keyed by `bundle_id` instead of `agent_id`, plus `addPrivate()` — the actually-functional path (creates a brand-new bundle-owned private server/skill via `mcp.catalog.upsert_for_bundle`/`skill.catalog.upsert_for_bundle`). Binding an existing global item is offered for parity with the agent-scoped modal, but the UI carries a caveat that it has no effect on a spawned agent — globals already reach every agent unconditionally regardless of bundle binding.
- **`BundleMcpSection`/`BundleSkillsSection`**: compact inline list + bind/unbind + "add private" form, mounted directly in the bundle's readonly detail view. Deliberately a flat list, not a nested `PrimitiveListDetail` — this content already sits inside one side of `MemoryManagerBody`'s own list/detail split, and a second full-height single-pane swap nested inside that would fight for the same space.
- Updated the stale "will be editable here in a follow-up" hint text in the bundle edit form to point at the new sections.

## Test plan

- [x] 22 new model tests (bind/unbind/addPrivate success + failure, `addingAtom` in-flight state, cross-window `mcp:changed`/`skills:changed` reactivity, dispose) — spot-verified meaningful by breaking the `addPrivate` bundle_id wiring and confirming the test catches it before trusting it.
- [x] Full frontend suite: 2759 passed, 0 failed.
- [x] `tsc --noEmit`: no new errors (2 pre-existing, unrelated, in `armory-view.tsx`/`warden-view.tsx`).
- [x] Changeset added (`minor`).
- [x] Branch created fresh off latest `main` (just fast-forwarded from PR #2639) — no staleness to merge.
- [ ] **Not visually verified in a running app** — this requires the full Rust backend + CEF desktop host, which isn't practical to launch interactively in this environment. Noting this explicitly rather than claiming visual verification; recommend a manual pass before merge if UI correctness matters beyond what the model tests + typecheck cover.

<!-- agentmux:agent_id=agenty -->