### PR TITLE
feat(editor): word-wrap toggle + gutter/tab-strip visual polish

### DIFF
--- a/.changesets/1787036796-feat-editor-word-wrap-toggle-tighter-gutter-spacing-accent-c-c5ub.md
+++ b/.changesets/1787036796-feat-editor-word-wrap-toggle-tighter-gutter-spacing-accent-c-c5ub.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): word-wrap toggle, tighter gutter spacing, accent-colored line numbers, full-width tab strip border

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -45,6 +45,7 @@ const META_TREE_EXPANDED = "editor:tree_expanded";
 const META_SHOW_HIDDEN = "editor:show_hidden";
 const META_TREE_WIDTH = "editor:tree_width";
 const META_PREVIEW_HEIGHT = "editor:preview_height";
+const META_WORD_WRAP = "editor:word_wrap";
 const META_LEGACY_FILE = "file";
 // Reuse (SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md
 // Part 2): files pushed by reuse-and-not-yet-mounted OpenEditor calls.
@@ -155,6 +156,13 @@ export class EditorViewModel implements ViewModel {
 
     private _previewHeight = createSignal<number>(PREVIEW_HEIGHT_DEFAULT);
     previewHeightAtom: Accessor<number> = this._previewHeight[0];
+
+    // Word wrap defaults ON (matches the editor's long-standing hardcoded
+    // behavior before this setting existed — see editor-view.tsx's
+    // wordWrapCompartment) so existing panes see no behavior change until
+    // the user explicitly turns it off via the right-click menu.
+    private _wordWrap = createSignal<boolean>(true);
+    wordWrapAtom: Accessor<boolean> = this._wordWrap[0];
 
     // Per-tab editor mode: "preview" | "source" | "split".
     // Not persisted — tabs return to their language-appropriate default on reopen.
@@ -392,6 +400,9 @@ export class EditorViewModel implements ViewModel {
         const persistedPreviewH = meta?.[META_PREVIEW_HEIGHT];
         if (typeof persistedPreviewH === "number") {
             this._previewHeight[1](clampPreviewHeight(persistedPreviewH));
+        }
+        if (meta?.[META_WORD_WRAP] === false) {
+            this._wordWrap[1](false);
         }
 
         // Backwards-compat hydration: existing block meta uses `file` (the
@@ -1117,6 +1128,27 @@ export class EditorViewModel implements ViewModel {
         const next = !this._showHidden[0]();
         this._showHidden[1](next);
         await this.persistMeta({ [META_SHOW_HIDDEN]: next });
+    }
+
+    async toggleWordWrap(): Promise<void> {
+        const next = !this._wordWrap[0]();
+        this._wordWrap[1](next);
+        await this.persistMeta({ [META_WORD_WRAP]: next });
+    }
+
+    /** Right-click menu items for the editor's own body (the CodeMirror
+     *  area) — surfaced by blockframe.tsx's onBodyContextMenu ahead of the
+     *  generic pane actions (magnify/close). Context-specific to this view,
+     *  same extension point sysinfo/browser/agent use for their own toggles. */
+    getBodyContextMenuItems(): ContextMenuItem[] {
+        return [
+            {
+                label: "Word Wrap",
+                type: "checkbox",
+                checked: this.wordWrapAtom(),
+                click: () => void this.toggleWordWrap(),
+            },
+        ];
     }
 
     setTreeWidth(width: number): void {

--- a/frontend/app/view/editor/editor-theme.ts
+++ b/frontend/app/view/editor/editor-theme.ts
@@ -34,16 +34,21 @@ const editorChromeTheme = EditorView.theme(
                 backgroundColor: "var(--highlight-bg-color)",
             },
         ".cm-activeLine": {
-            backgroundColor: "rgba(255, 255, 255, 0.035)",
+            backgroundColor: "color-mix(in srgb, var(--accent-color) 10%, transparent)",
         },
         ".cm-gutters": {
             backgroundColor: "transparent",
-            color: "var(--secondary-text-color)",
+            // Muted accent shade — dimmer than the active line's number
+            // (below) so the current line's number visibly stands out
+            // instead of blending into every other line number.
+            color: "color-mix(in srgb, var(--accent-color) 55%, var(--secondary-text-color))",
             border: "none",
         },
         ".cm-activeLineGutter": {
-            backgroundColor: "rgba(255, 255, 255, 0.035)",
-            color: "var(--main-text-color)",
+            backgroundColor: "color-mix(in srgb, var(--accent-color) 10%, transparent)",
+            // Full-strength accent — the distinct, brighter shade for the
+            // current line's number.
+            color: "var(--accent-color)",
         },
         ".cm-foldPlaceholder": {
             backgroundColor: "transparent",

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -251,6 +251,18 @@
 // the editor-specific modifiers (applied via getTabClass in
 // editor-tab-strip.tsx) stay here.
 
+// Editor-only wrapper around <EditorTabStrip>. The shared .pane-tab-strip is
+// deliberately shrink-to-fit (see PaneTabStrip.scss — no trailing dead space
+// with few tabs open), so its own border-bottom only spans the tabs/+ button,
+// not the full pane width. This wrapper carries a full-width border-bottom
+// instead, sitting at the same y-position (identical height/border-color) so
+// it reads as one continuous line under the strip and then all the way to
+// the pane's right edge. Scoped to the editor only — not touching the shared
+// component, so agent/terminal tab strips are unaffected.
+.editor-tab-strip-row {
+    border-bottom: 1px solid var(--border-color);
+}
+
 // Preview tab — italic title (matches VS Code). At most one preview tab
 // per pane; tree single-click replaces its file in place, tree
 // double-click (or editing) pins it. Visual cue tells the user this tab
@@ -463,13 +475,28 @@
     // hidden. lintGutter() stays in the extension set because it backs the
     // inline diagnostic underlines — only its empty marker column is removed
     // here — so the only visible gutter is the line numbers.
+    //
+    // !important: @codemirror/lint's lintGutterTheme sets `.cm-gutter-lint {
+    // width: 1.4em }` via EditorView.baseTheme(), which style-mod mounts into
+    // its own runtime-injected <style> tag at equal selector specificity to
+    // this rule — on a specificity tie CSS falls back to DOM/source order,
+    // and CodeMirror's stylesheet mounts after this one loads, so it was
+    // winning the width (the visible ~18px gap between the line number and
+    // the code) even though `display: none` should have zeroed it out.
     .cm-foldGutter,
     .cm-gutter-lint {
-        display: none;
+        display: none !important;
     }
 
     .cm-lineNumbers .cm-gutterElement {
-        padding: 0 1px 0 6px;
+        padding: 0 4px 0 6px;
+    }
+
+    // CodeMirror's default .cm-line left padding (6px) is the actual
+    // gutter-to-text gap — the gutter element above only contributes its own
+    // 1px right padding. Tightened to sit closer to the line numbers.
+    .cm-line {
+        padding-left: 3px;
     }
 }
 

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -261,6 +261,15 @@
 // component, so agent/terminal tab strips are unaffected.
 .editor-tab-strip-row {
     border-bottom: 1px solid var(--border-color);
+
+    // This wrapper is now the single source of the line — without this, the
+    // strip's own unconditional border-bottom (PaneTabStrip.scss) would sit
+    // exactly under this one too, doubling border thickness under the tabs
+    // vs. the plain 1px extension past the last tab/+ button (reagent, PR
+    // #2649 review).
+    .pane-tab-strip {
+        border-bottom: none;
+    }
 }
 
 // Preview tab — italic title (matches VS Code). At most one preview tab

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -169,6 +169,12 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     let lspChangeDebounce: ReturnType<typeof setTimeout> | null = null;
     const [lspState, setLspState] = createSignal<LspState | null>(null);
     const lintCompartment = new Compartment();
+    // Word wrap toggle (right-click menu → editor-model.ts's
+    // getBodyContextMenuItems). Reconfigured live on toggle (see the
+    // createEffect below) and resynced on every tab switch — it's a
+    // pane-wide setting, not per-tab, so a stale per-tab CodeMirror-state
+    // snapshot (cmStates) must not be allowed to reintroduce an old value.
+    const wordWrapCompartment = new Compartment();
 
     const teardownLsp = async (): Promise<void> => {
         if (lspChangeDebounce) {
@@ -322,7 +328,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             // no debugger/breakpoint margin, so the numbers sit tight to code.
             lintGutter(),
             lintCompartment.of([]),
-            EditorView.lineWrapping,
+            wordWrapCompartment.of(model.wordWrapAtom() ? [EditorView.lineWrapping] : []),
             EditorView.updateListener.of((update) => {
                 if (update.docChanged) {
                     const content = update.state.doc.toString();
@@ -480,6 +486,13 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             const saved = cmStates.get(activeId);
             if (saved && cmView) {
                 cmView.setState(saved);
+                // Resync the pane-wide word-wrap setting — the restored state
+                // was snapshotted with whatever wrap value was active *at
+                // that time*, which may be stale if the user toggled it via
+                // another tab since.
+                cmView.dispatch({
+                    effects: wordWrapCompartment.reconfigure(model.wordWrapAtom() ? [EditorView.lineWrapping] : []),
+                });
                 setLiveDoc(saved.doc.toString()); // seed preview from restored doc
                 // Re-wire LSP for the now-active file's content.
                 void startLspIfSupported(path, lang, content);
@@ -490,6 +503,14 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 void startLspIfSupported(path, lang, content);
             });
         });
+    });
+
+    // Live-toggle word wrap (right-click menu → model.toggleWordWrap()) on
+    // whichever tab is currently showing, without rebuilding CodeMirror.
+    createEffect(() => {
+        const wrap = model.wordWrapAtom();
+        if (!cmView) return;
+        cmView.dispatch({ effects: wordWrapCompartment.reconfigure(wrap ? [EditorView.lineWrapping] : []) });
     });
 
     // Clear cached CodeMirror state when its tab closes, so re-opening
@@ -738,12 +759,14 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
 
             <div class="editor-main-column">
                 <Show when={model.tabsAtom().length > 0}>
-                    <EditorTabStrip
-                        model={model}
-                        saveAsTabId={saveAsTabId()}
-                        onSaveAsConfirm={(path) => void handleSaveAsConfirm(path)}
-                        onSaveAsCancel={() => setSaveAsTabId(null)}
-                    />
+                    <div class="editor-tab-strip-row">
+                        <EditorTabStrip
+                            model={model}
+                            saveAsTabId={saveAsTabId()}
+                            onSaveAsConfirm={(path) => void handleSaveAsConfirm(path)}
+                            onSaveAsCancel={() => setSaveAsTabId(null)}
+                        />
+                    </div>
                 </Show>
 
                 <Show when={isMarkdown() && model.tabsAtom().length > 0}>


### PR DESCRIPTION
## Summary
- Adds a Word Wrap toggle to the editor's right-click menu (`getBodyContextMenuItems`) — was previously hardcoded always-on with no way to turn it off. Persisted per-pane (`editor:word_wrap` block meta), reconfigured live via a CodeMirror `Compartment` (no rebuild needed), and resynced on tab switch since it's a pane-wide setting, not per-tab.
- Fixes a real gutter bug: `@codemirror/lint`'s `lintGutter()` ships a runtime-injected base theme (`.cm-gutter-lint { width: 1.4em }`) that was winning a CSS specificity tie against our existing `display: none` override, leaving a stray ~18px empty column between the line number and the code even though the lint gutter was supposed to be fully hidden.
- Tightens the line-number-to-text gap and gives the numbers a bit more horizontal breathing room on their own.
- Line numbers now use the theme's accent color instead of a flat secondary-text gray — dimmer for regular lines, full accent strength for the current line, so the active line visibly stands out. The active line's row background is now a light accent tint instead of a flat white tint.
- The tab strip's bottom border now runs the full width of the pane instead of stopping right after the last tab/`+` button. The strip itself stays intentionally shrink-to-fit (per `SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md`) — only a wrapping element around it picked up the full-width border, so agent/terminal tab strips (which share the same underlying `PaneTabStrip` component) are unaffected.

Iterated live against a `task dev` build with a human in the loop for every visual change in this PR.

## Test plan
- [x] Word Wrap: toggled on/off via right-click on the editor body, confirmed it applies immediately and survives a tab switch
- [x] Confirmed the gutter gap fix and remaining spacing/color changes visually against a running dev build
- [x] Confirmed the tab-strip border now reaches the pane's right edge
- [ ] Automated test coverage — none added yet for the new toggle; flagging for reviewer input on whether it's expected before merge

<!-- agentmux:agent_id=korp -->