### PR TITLE
fix(editor): + button now always opens a new tab

### DIFF
--- a/.changesets/1787041527-fix-editor-button-now-always-opens-a-new-tab-instead-of-re-a-2lod.md
+++ b/.changesets/1787041527-fix-editor-button-now-always-opens-a-new-tab-instead-of-re-a-2lod.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): + button now always opens a new tab instead of re-activating an existing scratch tab

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -790,13 +790,20 @@ export class EditorViewModel implements ViewModel {
     // ── Scratch buffer ──────────────────────────────────────────────────
 
     /** Open (or focus) a scratch buffer. Called from the constructor when
-     *  editor:scratch is true and no other file is open. */
-    async openScratch(): Promise<void> {
-        // Reuse an existing scratch tab if one is already open in this pane.
-        const existing = snapshot(this.blockId)?.tabs.find((t) => t.isScratch);
-        if (existing) {
-            dispatch(this.blockId, { type: "SwitchTab", tabId: existing.id, source: "system" });
-            return;
+     *  editor:scratch is true and no other file is open (`reuseExisting`
+     *  true — idempotency guard, in case that path ever fires twice), and
+     *  from the "+" button (`reuseExisting` false — a user clicking "+"
+     *  always wants a genuinely new tab, same as any other tabbed UI;
+     *  silently re-activating the pane's existing scratch tab there reads
+     *  as "+ does nothing" when that tab is already the active one). */
+    async openScratch(reuseExisting: boolean = true): Promise<void> {
+        if (reuseExisting) {
+            // Reuse an existing scratch tab if one is already open in this pane.
+            const existing = snapshot(this.blockId)?.tabs.find((t) => t.isScratch);
+            if (existing) {
+                dispatch(this.blockId, { type: "SwitchTab", tabId: existing.id, source: "system" });
+                return;
+            }
         }
         try {
             // Exclude scratch files already open in any editor pane so that

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -86,7 +86,7 @@ export function EditorTabStrip(props: Props): JSX.Element {
                     <span class="pane-tab-label">{basenameOf(tab)}</span>
                 )
             }
-            onAdd={() => void props.model.openScratch()}
+            onAdd={() => void props.model.openScratch(false)}
             addTitle="New scratch buffer"
         />
     );


### PR DESCRIPTION
## Summary
Follow-up to #2649 (merged before this commit made it in). `openScratch()` reused an existing scratch tab whenever one was already open in the pane — correct for the constructor's idempotency-guarded default-open call, but wrong for the "+" button: since a fresh editor pane opens with a default scratch tab, clicking "+" just silently re-activated that same already-active tab. Indistinguishable from broken.

- Added a `reuseExisting` param to `openScratch()` (default `true`, preserving the constructor's dedup behavior).
- The "+" button now calls `openScratch(false)`, so it always creates a genuinely new tab, matching ordinary tabbed-UI expectations (VS Code's Untitled-1/2/3, etc.).

## Test plan
- [x] Verified live against a `task dev` build: pane opens with its default scratch tab, clicking "+" now opens a second, genuinely new blank tab instead of no-op'ing
- [ ] No automated test coverage added — flagging for reviewer input on whether it's expected before merge

<!-- agentmux:agent_id=korp -->