### PR TITLE
fix(agent-pane): stop tool_result echo from clobbering an answered AskUserQuestion

### DIFF
--- a/.changesets/1787041732-fix-agent-pane-stop-the-cli-s-own-tool-result-echo-from-clob-7j6h.md
+++ b/.changesets/1787041732-fix-agent-pane-stop-the-cli-s-own-tool-result-echo-from-clob-7j6h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): stop the CLI's own tool_result echo from clobbering an answered AskUserQuestion's answerText

--- a/docs/retro/RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md
+++ b/docs/retro/RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md
@@ -1,0 +1,146 @@
+# Retro: Answered `AskUserQuestion` silently reverted to the old collapsed row (PR #2630 follow-up)
+
+**Date:** 2026-08-18
+**Owner:** AgentA
+**Area:** `frontend/app/store/agent-document/reducer.ts` (`mergeReplacement`), `frontend/app/view/agent/hooks/useAgentQuestions.ts`, `frontend/app/view/agent/components/AnsweredQuestionMessage.tsx`
+
+---
+
+## 1. Symptom
+
+PR #2630 shipped "answered questions render as user input" — an answered
+`AskUserQuestion` should show the same `.agent-user-message` treatment as
+typed input once it scrolls into history, instead of the generic collapsed
+tool row. Asked to verify it live: `task dev`, answer a fresh question —
+it rendered exactly like it always had, the plain collapsed row. Not a
+stale-build or wrong-window issue (checked both); reproduced on a fresh
+`task dev` launch built directly from latest `main`.
+
+## 2. Investigation false start
+
+The initial ask was framed as "we had work that was supposed to do X, find
+out why it was skipped, write a retro." That framing was wrong and cost the
+first round of investigation: `git log`/`gh pr list` showed PR #2630
+merged hours earlier, fully implemented, 33/33 + 27/27 tests passing, spec
+marked `Status: Implemented`. Nothing was skipped — the feature had
+shipped and was live. The real defect only surfaced once the actual running
+app was exercised end-to-end rather than trusting the merged PR's own
+description and test-plan checkboxes.
+
+**Lesson:** "it merged, tests pass, spec says Implemented" is not the same
+claim as "it works when you actually use it." The PR's own test plan had an
+honest unchecked box — `[ ] Visual check in task dev across a few themes` —
+that turned out to be exactly the gap that mattered.
+
+## 3. Root cause
+
+`AskUserQuestion` is a **real tool call** from the CLI's perspective, not a
+pane-only construct. The flow:
+
+1. User answers → `useAgentQuestions.ts`'s `handleAnswer` optimistically
+   sets `status: "success"`, `answerText`, `timeoutNote` on the node and
+   dispatches it via `StreamFlush`. This is a frontend-only annotation —
+   nothing else in the codebase writes these fields.
+2. The answer is delivered to the CLI (control protocol or follow-up
+   message) and the agent's turn resumes.
+3. Because `AskUserQuestion` really is a tool call, the underlying CLI
+   stream **still emits its own `tool_result` event** for that same
+   `tool_use_id` once the turn resumes — that's how the answer re-enters
+   the model's own context. `claude-translator.ts`'s `buildToolResults`
+   has no special-casing for `AskUserQuestion`; it treats it exactly like
+   `Read`/`Bash`/anything else.
+4. That event flows through `stream-parser.ts`'s `toolResultToNode()`,
+   which builds a **fresh, generic** `ToolNode` — no concept of
+   `answerText`/`timeoutNote` at all, since those aren't part of the raw
+   event shape.
+5. Since the node id already exists, `useAgentStream.ts` routes it as an
+   *update*, not a new node. The reducer's `mergeReplacement()`
+   (`reducer.ts`) had exactly one carry-over case — a streaming `log`
+   buffer — and `AskUserQuestion` never streams one. With nothing to
+   carry over, it fell through to a **wholesale replace**: the fresh,
+   generic node from step 4 completely overwrote the optimistically
+   answered one, silently dropping `answerText` back to `undefined`.
+6. `ToolBlock.tsx`'s render gate is `answerText != null` — once that field
+   is gone, the node falls straight back to the pre-#2630 collapsed-row
+   rendering. By the time a human looks at the pane, this has already
+   happened; the new styling was visible for at most one animation frame.
+
+This happens on essentially **every** live answer to a persistent-agent
+question — not a rare race, a guaranteed sequence — which is exactly why it
+looked identical to the pre-PR behavior every time it was tested.
+
+## 4. Why this wasn't caught earlier
+
+PR #2630's own tests construct fixed `ToolNode` fixtures directly in the
+"already answered" state and assert on the render output — they never
+simulate the follow-on `tool_result` echo that the live CLI always sends.
+The optimistic-update path and the event-stream path were tested
+independently and each looked correct in isolation; the bug only exists at
+the seam between them, which no test exercised. The PR's own test plan
+called this out honestly (`[ ] Visual check in task dev` left unchecked)
+but that step was never actually run before merge.
+
+## 5. Fix
+
+`mergeReplacement()` now special-cases an already-answered `AskUserQuestion`
+(`toolName === "AskUserQuestion" && answerText != null`): instead of the
+wholesale replace, it keeps the fresh replacement's other fields but
+preserves `answerText`/`timeoutNote`/`questionText`/`summary` from the
+existing node. The CLI's own `tool_result` echo still lands and updates
+whatever else it legitimately owns (status, duration, params) — it just
+can't clobber the frontend-only annotation fields it never carried in the
+first place.
+
+Added a reducer regression test that reproduces the exact sequence (answer
+→ generic echo for the same id) and confirmed it fails without the fix
+(`answerText` → `undefined`) before confirming it passes with it.
+
+## 6. Follow-up UX changes (same PR, direct feedback after live-verifying the fix)
+
+Once the clobbering bug was fixed and the feature was actually visible for
+the first time, two follow-up requests came from watching it live rather
+than reading the spec:
+
+- **Size reverted.** #2630 deliberately enlarged the answer text
+  (`--answered-question` SCSS modifier, `font-size: 1.25em`) as its
+  original ask. Seeing it live, the request was to match ordinary input
+  size instead — removed the modifier entirely.
+- **The question now prints too.** #2630 only ever rendered the answer
+  half — `question` is cleared to `undefined` on answer (needed so the
+  question panel stops treating the node as pending) and nothing captured
+  what it had said. Added a `questionText` field, flattened from
+  `question.questions[].question` in `handleAnswer` *before* `question` is
+  cleared, and `AnsweredQuestionMessage` now renders it as plain agent text
+  (the same `.agent-markdown-block`/`Markdown` treatment a normal assistant
+  message gets) directly above the answer. The resolved node now reads as
+  an ordinary question-then-answer exchange instead of only ever showing
+  half of it. `questionText` needed the same clobber-protection as
+  `answerText` in `mergeReplacement()` for the same reason.
+
+## 7. What went well
+
+- Didn't stop at "PR merged, tests green" — insisted on driving the actual
+  running app before accepting the feature as done, which is what
+  surfaced the real bug.
+- Traced the full event path (optimistic update → control-protocol
+  delivery → CLI's own tool_result echo → parser → reducer → render gate)
+  from code alone before touching anything, and confirmed the hypothesis
+  with a regression test that fails on the un-fixed code, not just green
+  tests on the fixed code.
+- Caught mid-flight that "use a long-running-process method" meant the
+  established Bash-heartbeat pattern already documented in agent memory
+  for this repo, not the newer `mcp__agentmux__Shell` tool — the latter's
+  Windows launch path hits a separate, already-documented PATH gap (Gap
+  B in this repo's own CLAUDE.md) that looks identical to a real failure
+  (`exit_code: 200`, ~53 lines) if you don't know to check for it.
+
+## 8. Follow-up
+
+None identified — `mergeReplacement`'s guard is scoped narrowly to
+`AskUserQuestion`'s specific annotation fields and doesn't change behavior
+for any other tool. If a future feature adds another frontend-only
+optimistic field to `ToolNode`, the same clobbering risk applies whenever
+that tool also has a real terminal event of its own arriving after the
+optimistic update — worth a shared pattern (e.g. an explicit "preserved
+fields" allowlist per tool) if a third case shows up, but not worth
+generalizing for one instance today.

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -283,6 +283,46 @@ describe("agent document reducer", () => {
                 updateDropped: 1,
             });
         });
+
+        it("preserves an answered AskUserQuestion's answerText/timeoutNote/summary against the CLI's own trailing tool_result echo", () => {
+            // Regression: AskUserQuestion is a real tool call, so once the
+            // answer resumes the turn, the CLI's own tool_result for the
+            // same tool_use_id still arrives and gets parsed into a fresh,
+            // generic ToolNode (stream-parser.ts's toolResultToNode — no
+            // concept of answerText/timeoutNote). Without mergeReplacement's
+            // AskUserQuestion guard, that update wholesale-replaces the
+            // answered node (no log buffer to preserve otherwise) and
+            // silently reverts the collapsed-row rendering right after the
+            // user answers. See
+            // docs/retro/RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md.
+            const answered = tool("q1", {
+                toolName: "AskUserQuestion",
+                status: "success",
+                summary: "❓ Answered — Red",
+                answerText: "Red",
+                questionText: "Which color do you like?",
+            });
+            const s0 = seed([answered]);
+
+            // The CLI's own tool_result echo: a fresh, generic node for the
+            // same id, built the way toolResultToNode() actually builds it —
+            // no answerText/timeoutNote, and a plain completed-tool summary.
+            const echo = tool("q1", {
+                toolName: "AskUserQuestion",
+                status: "success",
+                summary: "✓ AskUserQuestion",
+            });
+            const r = update(s0, {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: [echo],
+            });
+
+            const result = r.state.nodes[0] as ToolNode;
+            expect(result.answerText).toBe("Red");
+            expect(result.summary).toBe("❓ Answered — Red");
+            expect(result.questionText).toBe("Which color do you like?");
+        });
     });
 
     describe("StreamTruncate suppression", () => {

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -902,10 +902,37 @@ function isDuplicate(
  * `log.chunks` across the replacement and flip `log.open = false`
  * since the tool has terminated. For non-tool nodes the behavior is
  * the same as the prior unconditional replacement.
+ *
+ * Also preserves an already-answered AskUserQuestion's `answerText`/
+ * `timeoutNote`/`questionText`/`summary` across a same-id replacement —
+ * those are frontend-only optimistic fields the parser's fresh-built
+ * replacement never carries, and AskUserQuestion's own `tool_result` echo
+ * (which always eventually arrives once the answer resumes the turn) would
+ * otherwise wholesale-clobber them since the tool has no log buffer.
  */
 function mergeReplacement(existing: DocumentNode, replacement: DocumentNode): DocumentNode {
     if (existing.type !== "tool" || replacement.type !== "tool") {
         return replacement;
+    }
+    // An answered AskUserQuestion's `answerText`/`timeoutNote` are set only
+    // by useAgentQuestions.ts's optimistic handleAnswer — they never come
+    // from the event stream. But AskUserQuestion IS a real tool call, so
+    // once the answer resumes the turn, the CLI's own `tool_result` for the
+    // same tool_use_id still arrives and gets parsed into a fresh, generic
+    // ToolNode via stream-parser.ts's toolResultToNode() (no concept of
+    // these fields). Without this guard that update lands here and wins
+    // the wholesale-replace path below, silently reverting the node to the
+    // pre-answered-styling collapsed-row rendering shortly after the user
+    // answers. See docs/retro/RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md.
+    const existingTool = existing as ToolNode;
+    if (existingTool.toolName === "AskUserQuestion" && existingTool.answerText != null) {
+        return {
+            ...(replacement as ToolNode),
+            summary: existingTool.summary,
+            answerText: existingTool.answerText,
+            timeoutNote: existingTool.timeoutNote,
+            questionText: existingTool.questionText,
+        };
     }
     const existingLog = (existing as ToolNode).log;
     if (!existingLog || existingLog.chunks.length === 0) {

--- a/frontend/app/view/agent/components/AnsweredQuestionMessage.tsx
+++ b/frontend/app/view/agent/components/AnsweredQuestionMessage.tsx
@@ -3,11 +3,16 @@
 
 /**
  * AnsweredQuestionMessage — renders a resolved `AskUserQuestion` tool node
- * using the same visual treatment as a typed user message (the
- * `.agent-user-message` family of classes from `_document-nodes.scss`),
- * rather than the generic collapsed tool row every other finished tool
- * gets. Once a question is answered it IS user input substantively, so it
- * should read that way once it scrolls into history.
+ * as an ordinary back-and-forth exchange rather than the generic collapsed
+ * tool row every other finished tool gets: the original question prints as
+ * plain agent text (the same `.agent-markdown-block` treatment a normal
+ * assistant message gets), followed by the answer using the same visual
+ * treatment as a typed user message (the `.agent-user-message` family of
+ * classes from `_document-nodes.scss`, at the SAME size as ordinary typed
+ * input — no enlarged-text variant). Once a question is answered it IS a
+ * normal conversational exchange substantively — the agent asked, the user
+ * answered — so it should read that way once it scrolls into history, as if
+ * both sides had simply typed their half normally.
  *
  * No tool icon, no collapse/pin/peek chrome, no elapsed ticker — those are
  * live tool-call affordances that don't apply to a terminal, already-
@@ -16,10 +21,14 @@
  * node.answerText != null` — see that guard for why `answerText` (not just
  * tool+status) gates this: legacy transcripts answered before this field
  * existed keep the old collapsed-row rendering instead of showing empty.
+ * `questionText` is a separate, independently-optional field added after
+ * `answerText` — a transcript answered between the two shows the answer
+ * alone, same as it always could before this component existed.
  *
  * See docs/specs/SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md.
  */
 
+import { Markdown } from "@/app/element/markdown";
 import { LinkifiedText } from "@/app/element/linkified-text";
 import { Show, type JSX } from "solid-js";
 import type { ToolNode } from "../types";
@@ -30,21 +39,30 @@ interface AnsweredQuestionMessageProps {
 
 export const AnsweredQuestionMessage = (props: AnsweredQuestionMessageProps): JSX.Element => {
     return (
-        <div class="agent-user-message agent-user-message--answered-question">
-            <div class="agent-user-message-content agent-user-message-content--flow">
-                {/* node.timeoutNote is computed in useAgentQuestions.ts from
-                    AnswerOutcome's numeric counts, not parsed back out of a
-                    decorated string here — the free-text answer can legally
-                    contain " — ", which broke two prior string-split
-                    attempts (reagent P1 x2 on PR #2630). */}
-                <Show when={props.node.timeoutNote}>
-                    {(note) => <div class="agent-user-message-timeout-note">{note()}</div>}
-                </Show>
-                <pre>
-                    <LinkifiedText text={props.node.answerText ?? ""} />
-                </pre>
+        <>
+            <Show when={props.node.questionText}>
+                {(text) => (
+                    <div class="agent-markdown-block">
+                        <Markdown text={text()} highlight scrollable={false} />
+                    </div>
+                )}
+            </Show>
+            <div class="agent-user-message">
+                <div class="agent-user-message-content agent-user-message-content--flow">
+                    {/* node.timeoutNote is computed in useAgentQuestions.ts from
+                        AnswerOutcome's numeric counts, not parsed back out of a
+                        decorated string here — the free-text answer can legally
+                        contain " — ", which broke two prior string-split
+                        attempts (reagent P1 x2 on PR #2630). */}
+                    <Show when={props.node.timeoutNote}>
+                        {(note) => <div class="agent-user-message-timeout-note">{note()}</div>}
+                    </Show>
+                    <pre>
+                        <LinkifiedText text={props.node.answerText ?? ""} />
+                    </pre>
+                </div>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -431,11 +431,39 @@ describe("ToolBlock — answered AskUserQuestion renders as a user message", () 
         expect(container.querySelector(".agent-user-message-content pre")?.textContent).toBe("Yes");
     });
 
-    it("gets the `--answered-question` modifier class (drives the larger-text treatment)", () => {
+    it("renders the answer at normal size — no enlarged-text modifier", () => {
+        // Reverted per direct user feedback after the larger-text variant
+        // shipped: the answer should read at the SAME size as ordinary
+        // typed input, not enlarged.
         const { container } = render(() => (
             <ToolBlock node={answeredQuestion} pinned={false} onTogglePin={() => {}} />
         ));
-        expect(container.querySelector(".agent-user-message--answered-question")).not.toBeNull();
+        expect(container.querySelector(".agent-user-message--answered-question")).toBeNull();
+    });
+
+    it("prints the original question as agent text before the answer", () => {
+        const withQuestion: ToolNode = {
+            ...answeredQuestion,
+            questionText: "Which color do you like?",
+        };
+        const { container } = render(() => (
+            <ToolBlock node={withQuestion} pinned={false} onTogglePin={() => {}} />
+        ));
+        const markdown = container.querySelector(".agent-markdown-block");
+        expect(markdown?.textContent).toContain("Which color do you like?");
+        const userMessage = container.querySelector(".agent-user-message");
+        expect(userMessage?.textContent).toBe("Yes");
+        // Question reads before the answer in document order.
+        const position = markdown!.compareDocumentPosition(userMessage!);
+        expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("omits the question block when questionText is absent (answered before that field existed)", () => {
+        const { container } = render(() => (
+            <ToolBlock node={answeredQuestion} pinned={false} onTogglePin={() => {}} />
+        ));
+        expect(container.querySelector(".agent-markdown-block")).toBeNull();
+        expect(container.querySelector(".agent-user-message-content pre")?.textContent).toBe("Yes");
     });
 
     it("shows the muted timeout note verbatim from node.timeoutNote — no parsing involved", () => {

--- a/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
@@ -133,6 +133,31 @@ describe("useAgentQuestions — handleAnswer fallback", () => {
         dispose();
     });
 
+    // AnsweredQuestionMessage re-prints the original prompt as agent text
+    // above the answer — flattened from `question.questions[].question`
+    // BEFORE `question` itself is cleared on answer, since `question` is
+    // what drives whether the panel still treats the node as pending.
+    it("sets questionText from the original prompt(s), joined with a blank line for multiple questions", async () => {
+        hub.agentAnswer.mockResolvedValue(undefined);
+        const sendMessage = vi.fn().mockResolvedValue(undefined);
+        const { handleAnswer, dispose } = setup(sendMessage);
+
+        handleAnswer({
+            tool_use_id: TOOL_USE_ID,
+            answers: [],
+            answers_map: { "Pick one": "a" },
+            answer_text: "Pick one: a",
+            autoFilledCount: 0,
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const node = updatedNodeFromDispatch();
+        expect(node?.questionText).toBe("Pick one");
+        expect(node?.question).toBeUndefined();
+        dispose();
+    });
+
     // reagent P1 x2 on PR #2630: timeoutNote used to be parsed back out of
     // the decorated `summary` string at render time, which broke twice —
     // once because the "partly auto-answered" format embeds its own " — "

--- a/frontend/app/view/agent/hooks/useAgentQuestions.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.ts
@@ -141,6 +141,13 @@ export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuest
             if (n.type !== "tool" || n.status !== "awaiting_answer") continue;
             if (n.question?.tool_use_id !== outcome.tool_use_id) continue;
             originals.push(n);
+            // Flatten the original prompt(s) to plain text BEFORE `question`
+            // is cleared below — AnsweredQuestionMessage re-prints this as
+            // ordinary agent text so the resolved node reads as a real
+            // question-then-answer exchange, not just the answer half.
+            // Header/options are the interactive panel's own affordance and
+            // don't belong in a read-back of "what the agent said."
+            const questionText = n.question?.questions.map((q) => q.question).join("\n\n");
             updated.push({
                 ...n,
                 status: "success",
@@ -152,6 +159,7 @@ export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuest
                 // line. See SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md.
                 answerText: outcome.answer_text,
                 timeoutNote,
+                questionText,
             });
         }
         const applyDoc = (nodes: ToolNode[]) => {

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1199,18 +1199,6 @@
             border-left-width: 4px;
         }
 
-        // Answered AskUserQuestion (AnsweredQuestionMessage.tsx) — the
-        // ORIGINAL ask behind this whole feature (before it grew the
-        // inverted-surface half): the answer should read as larger,
-        // expanded text, not just same-size-as-everything-else user
-        // input. em-relative (not a fixed --text-* token) so it scales
-        // with the pane's own zoom (--termfontsize) instead of fighting
-        // it. Scoped to this variant only — regular typed input keeps
-        // its normal size.
-        &--answered-question .agent-user-message-content pre {
-            font-size: 1.25em;
-            line-height: 1.4;
-        }
     }
 
     // === Section Headings ===

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -288,6 +288,14 @@ export interface ToolNode {
      *  which broke two prior string-split attempts (reagent P1 x2 on PR
      *  #2630). Undefined for a manually-answered question. */
     timeoutNote?: string;
+    /** Set alongside `answerText` when an AskUserQuestion is answered — the
+     *  original question prompt(s) (`question.questions[].question`),
+     *  flattened to plain text before `question` itself is cleared. Lets
+     *  the resolved node re-print the exchange as an ordinary back-and-
+     *  forth (question read as agent text, answer read as user text)
+     *  instead of only ever showing the answer half. Undefined for a
+     *  legacy transcript answered before this field existed. */
+    questionText?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to #2630 — addresses a bug found while manually verifying that PR live: an answered `AskUserQuestion` briefly rendered with the new user-message styling, then reverted to the old collapsed tool row.

- **Root cause:** `AskUserQuestion` is a real tool call, so once `handleAnswer`'s optimistic update sets `answerText`/`timeoutNote` and delivers the answer, the CLI's own `tool_result` for the same `tool_use_id` still arrives once the answer resumes the turn (`claude-translator.ts` has no special-casing for it). That event gets parsed into a fresh, generic `ToolNode` via `stream-parser.ts`'s `toolResultToNode()` (no concept of these fields), and `mergeReplacement`'s wholesale-replace path (AskUserQuestion has no log buffer to otherwise gate on) silently wiped `answerText` back to `undefined` — reverting the resolved question to the old collapsed-row rendering shortly after the user answered.
- **Fix:** `mergeReplacement` now preserves `answerText`/`timeoutNote`/`questionText`/`summary` across that echo when the existing node is an already-answered `AskUserQuestion`.

Also, per direct follow-up feedback after #2630 shipped:
- Reverted the enlarged-text treatment for the answer (`--answered-question` SCSS modifier) — it now renders at the same size as ordinary typed input.
- The original question now prints too, as plain agent text (the same treatment `MarkdownBlock` gives a normal assistant message) directly above the answer — flattened into a new `questionText` field in `handleAnswer` before `question` is cleared. The resolved node now reads as an ordinary question-then-answer exchange instead of only ever showing the answer half.

## Test plan
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx stylelint` on the changed SCSS — no new errors (31 pre-existing, unrelated — same baseline #2630 reported)
- [x] Full suite: `npx vitest run` — 2741 passed, 3 skipped (2 e2e, no build dir)
- [x] Added a reducer regression test that reproduces the exact clobbering scenario; confirmed it fails without the fix (`answerText` → `undefined`) and passes with it
- [x] Verified live in `task dev`: answered a fresh question, confirmed it now renders normal-size with the question printed as agent text above the answer, and stays that way (no revert)

<!-- agentmux:agent_id=agenta -->