### PR TITLE
chore: release v0.55.14 (patch override)

### DIFF
--- a/.changesets/1787012397-fix-sysinfo-dynamic-y-axis-scaling-fix-3-metric-layout-fix-s-03d3.md
+++ b/.changesets/1787012397-fix-sysinfo-dynamic-y-axis-scaling-fix-3-metric-layout-fix-s-03d3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint

--- a/.changesets/1787012701-feat-bundle-bundle-level-mcp-server-and-skill-references-com-103s.md
+++ b/.changesets/1787012701-feat-bundle-bundle-level-mcp-server-and-skill-references-com-103s.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(bundle): Bundle-level MCP Server and Skill references (composable model v2)

--- a/.changesets/1787013553-fix-bundle-a-bundle-referenced-private-skill-server-no-longe-0jbu.md
+++ b/.changesets/1787013553-fix-bundle-a-bundle-referenced-private-skill-server-no-longe-0jbu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bundle): a bundle-referenced private skill/server no longer discards agent-level legacy config

--- a/.changesets/1787013667-feat-agent-pane-pane-title-tracks-the-session-s-overall-goal-h9tx.md
+++ b/.changesets/1787013667-feat-agent-pane-pane-title-tracks-the-session-s-overall-goal-h9tx.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): pane title tracks the session's overall goal, not per-turn micro-steps

--- a/.changesets/1787014443-fix-browser-pane-stop-loading-brain-flicker-on-repeated-load-v0wy.md
+++ b/.changesets/1787014443-fix-browser-pane-stop-loading-brain-flicker-on-repeated-load-v0wy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): stop loading-brain flicker on repeated load-state flips

--- a/.changesets/1787014873-fix-tabs-remove-automatic-tab-color-assignment-0zbo.md
+++ b/.changesets/1787014873-fix-tabs-remove-automatic-tab-color-assignment-0zbo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): remove automatic tab color assignment

--- a/.changesets/1787034601-fix-types-add-missing-armory-section-warden-section-to-metat-a3gk.md
+++ b/.changesets/1787034601-fix-types-add-missing-armory-section-warden-section-to-metat-a3gk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(types): add missing armory:section/warden:section to MetaType

--- a/.changesets/1787034731-feat-bundle-bundle-editor-mcp-servers-skills-sections-compos-djrk.md
+++ b/.changesets/1787034731-feat-bundle-bundle-editor-mcp-servers-skills-sections-compos-djrk.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(bundle): Bundle editor MCP Servers/Skills sections (composable model v2)

--- a/.changesets/1787036796-feat-editor-word-wrap-toggle-tighter-gutter-spacing-accent-c-c5ub.md
+++ b/.changesets/1787036796-feat-editor-word-wrap-toggle-tighter-gutter-spacing-accent-c-c5ub.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): word-wrap toggle, tighter gutter spacing, accent-colored line numbers, full-width tab strip border

--- a/.changesets/1787037196-fix-identity-stop-mislabeling-macos-keychain-backed-claude-a-xi4o.md
+++ b/.changesets/1787037196-fix-identity-stop-mislabeling-macos-keychain-backed-claude-a-xi4o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): stop mislabeling macOS Keychain-backed Claude accounts as needs_reauth

--- a/.changesets/1787041527-fix-editor-button-now-always-opens-a-new-tab-instead-of-re-a-2lod.md
+++ b/.changesets/1787041527-fix-editor-button-now-always-opens-a-new-tab-instead-of-re-a-2lod.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): + button now always opens a new tab instead of re-activating an existing scratch tab

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "base64",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.13"
+version = "0.55.14"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,7 +14,6 @@
 - fix(identity): stop mislabeling macOS Keychain-backed Claude accounts as needs_reauth
 - fix(editor): + button now always opens a new tab instead of re-activating an existing scratch tab
 
-
 ## 0.55.13 — 2026-08-17
 
 - feat(agent-pane): answered questions render as user input; user-input surface inverted per theme

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.55.14 — 2026-08-18
+
+- fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint
+- feat(bundle): Bundle-level MCP Server and Skill references (composable model v2)
+- fix(bundle): a bundle-referenced private skill/server no longer discards agent-level legacy config
+- feat(agent-pane): pane title tracks the session's overall goal, not per-turn micro-steps
+- fix(browser-pane): stop loading-brain flicker on repeated load-state flips
+- fix(tabs): remove automatic tab color assignment
+- fix(types): add missing armory:section/warden:section to MetaType
+- feat(bundle): Bundle editor MCP Servers/Skills sections (composable model v2)
+- feat(editor): word-wrap toggle, tighter gutter spacing, accent-colored line numbers, full-width tab strip border
+- fix(identity): stop mislabeling macOS Keychain-backed Claude accounts as needs_reauth
+- fix(editor): + button now always opens a new tab instead of re-activating an existing scratch tab
+
+
 ## 0.55.13 — 2026-08-17
 
 - feat(agent-pane): answered questions render as user input; user-input surface inverted per theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.13",
+  "version": "0.55.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.13",
+      "version": "0.55.14",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.13",
+  "version": "0.55.14",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Patch-override release, consuming all 11 currently pending changesets: `0.55.13 -> 0.55.14`.

**Note:** the computed bump from the pending changesets was `minor` (4 of the 11 are `type: minor` — the two bundle MCP/Skills composable-model changes, agent-pane title tracking, and the editor word-wrap toggle). This release forces `patch` via `task release -- --as patch` per explicit direction — those minor-level changes ship under a patch version.

Changesets consumed:
- fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint
- feat(bundle): Bundle-level MCP Server and Skill references (composable model v2)
- fix(bundle): a bundle-referenced private skill/server no longer discards agent-level legacy config
- feat(agent-pane): pane title tracks the session's overall goal, not per-turn micro-steps
- fix(browser-pane): stop loading-brain flicker on repeated load-state flips
- fix(tabs): remove automatic tab color assignment
- fix(types): add missing armory:section/warden:section to MetaType
- feat(bundle): Bundle editor MCP Servers/Skills sections (composable model v2)
- feat(editor): word-wrap toggle, tighter gutter spacing, accent-colored line numbers, full-width tab strip border
- fix(identity): stop mislabeling macOS Keychain-backed Claude accounts as needs_reauth
- fix(editor): + button now always opens a new tab instead of re-activating an existing scratch tab

All 5 version locations verified in agreement at 0.55.14 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md).

## Test plan
- [x] `task release -- --as patch` ran clean, staged diff reviewed before commit
- [x] All 5 version-location invariant checked and consistent

<!-- agentmux:agent_id=korp -->