### PR TITLE
Fix macOS Keychain password prompt on every app launch

### DIFF
--- a/.changesets/1787062243-fix-model-catalog-stop-the-automatic-startup-model-catalog-r-sfyx.md
+++ b/.changesets/1787062243-fix-model-catalog-stop-the-automatic-startup-model-catalog-r-sfyx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(model-catalog): stop the automatic startup model-catalog refresh from prompting for the macOS Keychain password

--- a/agentmux-srv/src/backend/model_catalog.rs
+++ b/agentmux-srv/src/backend/model_catalog.rs
@@ -96,37 +96,44 @@ pub fn read_oauth_access_token(config_dir: &Path) -> Option<String> {
 /// Callers should use this instead of calling [`read_oauth_access_token`]
 /// directly. Never logs the token.
 ///
-/// `allow_keychain_fallback` gates steps 2/3 — both hit the OS keychain (via
-/// `identity::secret_store`), which wraps blocking `keyring` syscalls that
-/// can trigger an interactive macOS "App wants to use your confidential
-/// information" password prompt whenever a previously-stored entry exists
-/// under a code signature the OS doesn't already trust (e.g. a rebuilt local
-/// dev binary). That's fine for a flow the user explicitly triggered, but
-/// this function's only caller today (`providers.models`) is a silent,
-/// fire-and-forget background refresh fired on every app launch
-/// (`frontend/app-init.ts`) — a keychain prompt appearing unprompted at
-/// startup, for a purely cosmetic model-label refresh, is not acceptable.
-/// Pass `false` from any automatic/background caller; steps 2/3 (and the
-/// `spawn_blocking` they'd run on) are skipped entirely in that case, so
-/// there is no keychain interaction at all — matching the pre-existing,
-/// already-documented "macOS Keychain → empty → static fallback" contract.
-/// Only pass `true` from a path the user explicitly initiated.
+/// `allow_keychain_fallback` gates the two operations in steps 2/3 that
+/// actually touch the OS keychain (via `identity::secret_store`, which
+/// wraps blocking `keyring` syscalls): *persisting* a freshly-read env-var
+/// token, and reading back a *previously-persisted* one. Either can trigger
+/// an interactive macOS "App wants to use your confidential information"
+/// password prompt whenever a stored entry exists under a code signature
+/// the OS doesn't already trust (e.g. a rebuilt local dev binary). That's
+/// fine for a flow the user explicitly triggered, but this function's only
+/// caller today (`providers.models`) is a silent, fire-and-forget background
+/// refresh fired on every app launch (`frontend/app-init.ts`) — a keychain
+/// prompt appearing unprompted at startup, for a purely cosmetic
+/// model-label refresh, is not acceptable.
+///
+/// Reading the `CLAUDE_CODE_OAUTH_TOKEN` env var itself is a plain
+/// process-env read with no keychain interaction, so it's always
+/// attempted regardless of this flag (Codex P2, PR #2654) — only the
+/// persist-on-find and read-the-stored-copy operations are skipped when
+/// `false`. Pass `false` from any automatic/background caller; pass `true`
+/// only from a path the user explicitly initiated.
 pub async fn resolve_access_token(config_dir: &Path, allow_keychain_fallback: bool) -> Option<String> {
     if let Some(token) = read_oauth_access_token(config_dir) {
         return Some(token);
     }
-    if !allow_keychain_fallback {
-        return None;
-    }
-    tokio::task::spawn_blocking(|| {
+    tokio::task::spawn_blocking(move || {
         resolve_fallback_access_token(
             || std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok(),
             |token| {
+                if !allow_keychain_fallback {
+                    return;
+                }
                 if let Err(e) = secret_store::put(CLAUDE_OAUTH_TOKEN_ACCOUNT, token) {
                     tracing::warn!("model catalog: failed to persist CLAUDE_CODE_OAUTH_TOKEN: {e}");
                 }
             },
             || {
+                if !allow_keychain_fallback {
+                    return None;
+                }
                 secret_store::get(CLAUDE_OAUTH_TOKEN_ACCOUNT)
                     .ok()
                     .map(|z| z.to_string())
@@ -220,19 +227,56 @@ mod tests {
     #[tokio::test]
     async fn resolve_access_token_never_touches_keychain_when_fallback_disallowed() {
         // The fix for the app-launch keychain-prompt regression: when
-        // `allow_keychain_fallback` is false and no `.credentials.json`
-        // exists (the macOS case), this must return None without ever
-        // entering the env-var/keychain fallback branch at all — not just
-        // "return the same result," but structurally skip it, since even a
-        // *read* of a stale keychain entry can trigger an OS prompt. This
-        // test can't observe "no syscall happened" directly, but a real
-        // keychain entry under CLAUDE_OAUTH_TOKEN_ACCOUNT existing on the
-        // machine this test runs on would make the old (pre-fix) code path
-        // return Some(..) — so None here is a meaningful assertion, not a
-        // vacuous one, whenever such an entry happens to be present.
+        // `allow_keychain_fallback` is false, no `.credentials.json` exists
+        // (the macOS case), and the env var isn't set either, this must
+        // return None without ever entering the keychain-touching persist/
+        // read-back branch — not just "return the same result," but
+        // structurally skip it, since even a *read* of a stale keychain
+        // entry can trigger an OS prompt. This test can't observe "no
+        // syscall happened" directly, but a real keychain entry under
+        // CLAUDE_OAUTH_TOKEN_ACCOUNT existing on the machine this test runs
+        // on would make the old (pre-fix) code path return Some(..) — so
+        // None here is a meaningful assertion, not a vacuous one, whenever
+        // such an entry happens to be present.
+        let _lock = crate::test_support::ISOLATED_AUTH_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let had_env = std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok();
+        std::env::remove_var("CLAUDE_CODE_OAUTH_TOKEN");
+
         let tmp = tempfile::tempdir().unwrap();
         let got = resolve_access_token(tmp.path(), false).await;
+
+        if let Some(v) = had_env {
+            std::env::set_var("CLAUDE_CODE_OAUTH_TOKEN", v);
+        }
         assert_eq!(got, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_access_token_still_honors_env_var_when_fallback_disallowed() {
+        // Codex P2, PR #2654: reading CLAUDE_CODE_OAUTH_TOKEN is a plain
+        // process-env read with no keychain interaction, so it must still
+        // resolve even with `allow_keychain_fallback: false` — only
+        // persisting it (or reading a previously-persisted copy) is
+        // keychain-touching and gated. Before this fix, disallowing
+        // keychain fallback also silently dropped this env var, making the
+        // only real caller (providers.models) always return an empty
+        // catalog for exactly the users this env var exists for.
+        let _lock = crate::test_support::ISOLATED_AUTH_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let had_env = std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok();
+        std::env::set_var("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test-token");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let got = resolve_access_token(tmp.path(), false).await;
+
+        match had_env {
+            Some(v) => std::env::set_var("CLAUDE_CODE_OAUTH_TOKEN", v),
+            None => std::env::remove_var("CLAUDE_CODE_OAUTH_TOKEN"),
+        }
+        assert_eq!(got.as_deref(), Some("sk-ant-oat-test-token"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/model_catalog.rs
+++ b/agentmux-srv/src/backend/model_catalog.rs
@@ -96,15 +96,27 @@ pub fn read_oauth_access_token(config_dir: &Path) -> Option<String> {
 /// Callers should use this instead of calling [`read_oauth_access_token`]
 /// directly. Never logs the token.
 ///
-/// Steps 2/3 hit the OS keychain (via `identity::secret_store`), which wraps
-/// blocking `keyring` syscalls (can even trigger a macOS permission prompt on
-/// first access) — run on a `spawn_blocking` thread, matching the established
-/// pattern for the same calls in `app_api/mod.rs`'s
-/// `identity_account_validate_stored_impl`, so this never blocks an async
-/// runtime worker thread.
-pub async fn resolve_access_token(config_dir: &Path) -> Option<String> {
+/// `allow_keychain_fallback` gates steps 2/3 — both hit the OS keychain (via
+/// `identity::secret_store`), which wraps blocking `keyring` syscalls that
+/// can trigger an interactive macOS "App wants to use your confidential
+/// information" password prompt whenever a previously-stored entry exists
+/// under a code signature the OS doesn't already trust (e.g. a rebuilt local
+/// dev binary). That's fine for a flow the user explicitly triggered, but
+/// this function's only caller today (`providers.models`) is a silent,
+/// fire-and-forget background refresh fired on every app launch
+/// (`frontend/app-init.ts`) — a keychain prompt appearing unprompted at
+/// startup, for a purely cosmetic model-label refresh, is not acceptable.
+/// Pass `false` from any automatic/background caller; steps 2/3 (and the
+/// `spawn_blocking` they'd run on) are skipped entirely in that case, so
+/// there is no keychain interaction at all — matching the pre-existing,
+/// already-documented "macOS Keychain → empty → static fallback" contract.
+/// Only pass `true` from a path the user explicitly initiated.
+pub async fn resolve_access_token(config_dir: &Path, allow_keychain_fallback: bool) -> Option<String> {
     if let Some(token) = read_oauth_access_token(config_dir) {
         return Some(token);
+    }
+    if !allow_keychain_fallback {
+        return None;
     }
     tokio::task::spawn_blocking(|| {
         resolve_fallback_access_token(
@@ -204,6 +216,24 @@ pub async fn fetch_model_catalog(access_token: &str) -> Option<Vec<CatalogModel>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn resolve_access_token_never_touches_keychain_when_fallback_disallowed() {
+        // The fix for the app-launch keychain-prompt regression: when
+        // `allow_keychain_fallback` is false and no `.credentials.json`
+        // exists (the macOS case), this must return None without ever
+        // entering the env-var/keychain fallback branch at all — not just
+        // "return the same result," but structurally skip it, since even a
+        // *read* of a stale keychain entry can trigger an OS prompt. This
+        // test can't observe "no syscall happened" directly, but a real
+        // keychain entry under CLAUDE_OAUTH_TOKEN_ACCOUNT existing on the
+        // machine this test runs on would make the old (pre-fix) code path
+        // return Some(..) — so None here is a meaningful assertion, not a
+        // vacuous one, whenever such an entry happens to be present.
+        let tmp = tempfile::tempdir().unwrap();
+        let got = resolve_access_token(tmp.path(), false).await;
+        assert_eq!(got, None);
+    }
 
     #[test]
     fn parses_models_and_falls_back_display_name_to_id() {

--- a/agentmux-srv/src/server/providers_handlers.rs
+++ b/agentmux-srv/src/server/providers_handlers.rs
@@ -64,13 +64,21 @@ pub fn register_providers_handlers(engine: &Arc<WshRpcEngine>, _state: &AppState
                     None => return empty_result(),
                 };
                 let dir = paths.provider_auth_dir(provider.auth_dir_name);
-                let token = match resolve_access_token(&dir).await {
+                // `allow_keychain_fallback: false` — this RPC is fired
+                // automatically, unprompted, on every app launch
+                // (`frontend/app-init.ts`'s init wave). The env-var/keychain
+                // fallback (model_catalog.rs's steps 2/3) can trigger an
+                // interactive macOS Keychain password prompt; a background
+                // model-label refresh must never surface one. This means the
+                // catalog silently stays on the file-based source only
+                // (Linux/Windows) — macOS keeps its static bundled fallback,
+                // per the module's own documented contract.
+                let token = match resolve_access_token(&dir, false).await {
                     Some(t) => t,
-                    // No token from the `.credentials.json` file, the
-                    // CLAUDE_CODE_OAUTH_TOKEN env var, or a previously
-                    // persisted copy of it (e.g. logged out, or macOS
-                    // Keychain with no `claude setup-token` token exported)
-                    // → empty → frontend keeps its static fallback.
+                    // No token from the `.credentials.json` file (logged
+                    // out, or macOS Keychain — the only source this
+                    // background call is allowed to use) → empty → frontend
+                    // keeps its static fallback.
                     None => return empty_result(),
                 };
 

--- a/agentmux-srv/src/server/providers_handlers.rs
+++ b/agentmux-srv/src/server/providers_handlers.rs
@@ -77,10 +77,12 @@ pub fn register_providers_handlers(engine: &Arc<WshRpcEngine>, _state: &AppState
                 // catalog only when that env var isn't set for this process.
                 let token = match resolve_access_token(&dir, false).await {
                     Some(t) => t,
-                    // No token from the `.credentials.json` file (logged
-                    // out, or macOS Keychain — the only source this
-                    // background call is allowed to use) → empty → frontend
-                    // keeps its static fallback.
+                    // No token from the `.credentials.json` file or the
+                    // CLAUDE_CODE_OAUTH_TOKEN env var — the two sources this
+                    // background call is allowed to use (see the comment
+                    // above; the keychain-backed fallback is deliberately
+                    // excluded) → empty → frontend keeps its static
+                    // fallback.
                     None => return empty_result(),
                 };
 

--- a/agentmux-srv/src/server/providers_handlers.rs
+++ b/agentmux-srv/src/server/providers_handlers.rs
@@ -66,13 +66,15 @@ pub fn register_providers_handlers(engine: &Arc<WshRpcEngine>, _state: &AppState
                 let dir = paths.provider_auth_dir(provider.auth_dir_name);
                 // `allow_keychain_fallback: false` — this RPC is fired
                 // automatically, unprompted, on every app launch
-                // (`frontend/app-init.ts`'s init wave). The env-var/keychain
-                // fallback (model_catalog.rs's steps 2/3) can trigger an
-                // interactive macOS Keychain password prompt; a background
-                // model-label refresh must never surface one. This means the
-                // catalog silently stays on the file-based source only
-                // (Linux/Windows) — macOS keeps its static bundled fallback,
-                // per the module's own documented contract.
+                // (`frontend/app-init.ts`'s init wave). Persisting or reading
+                // back a stored fallback token (model_catalog.rs's steps 2/3)
+                // can trigger an interactive macOS Keychain password prompt;
+                // a background model-label refresh must never surface one.
+                // The `CLAUDE_CODE_OAUTH_TOKEN` env var itself is still
+                // honored either way (a plain process-env read, no keychain
+                // involved) — only the keychain-touching persist/read-back
+                // is skipped, so macOS falls back to its static bundled
+                // catalog only when that env var isn't set for this process.
                 let token = match resolve_access_token(&dir, false).await {
                     Some(t) => t,
                     // No token from the `.credentials.json` file (logged

--- a/docs/retro/retro-startup-keychain-prompt-model-catalog-2026-08-18.md
+++ b/docs/retro/retro-startup-keychain-prompt-model-catalog-2026-08-18.md
@@ -1,0 +1,83 @@
+# Retro: opening AgentMux on macOS prompted for the Keychain password
+
+**Date:** 2026-08-18
+**Area:** `agentmux-srv/src/backend/model_catalog.rs`, `agentmux-srv/src/server/providers_handlers.rs`, `frontend/app-init.ts`
+
+---
+
+## 1. Symptom (as reported)
+
+A freshly built v0.55.13 `.dmg`, opened for the first time: macOS immediately
+prompted for the Keychain password. Reported as unacceptable — "we cannot
+have that prompt."
+
+## 2. Investigation
+
+- Grepped for AgentMux's own direct OS-Keychain usage (separate from the
+  Claude Code CLI's own Keychain use, which is the subject of
+  [retro-macos-keychain-credential-isolation-gap-2026-08-17.md](retro-macos-keychain-credential-isolation-gap-2026-08-17.md)
+  and out of AgentMux's control). Found `identity/secret_store.rs`, a thin
+  wrapper around the `keyring` crate under a fixed service name (`"agentmux"`)
+  — this is a real, first-party Keychain touch, not the Claude CLI's.
+- Traced every caller of that module. Most are gated behind explicit user
+  actions (connecting/deleting an Armory account, MuxBus token storage). One
+  wasn't: `backend/model_catalog.rs`'s `resolve_access_token`, used by the
+  `providers.models` RPC (`server/providers_handlers.rs`) — a "fetch the
+  authoritative Claude model list for the dropdown" feature.
+- `resolve_access_token`'s own doc comment already flagged the risk before
+  this investigation: "can even trigger a macOS permission prompt on first
+  access" — the mechanism was known; what wasn't caught was where it's
+  called from.
+- `frontend/app-init.ts:1108` calls `providers.models` **fire-and-forget, on
+  every app launch**, unconditionally, as part of the main init wave — not
+  gated behind opening the model dropdown or any other user action.
+
+## 3. Root cause
+
+`resolve_access_token` tries three sources in order: (1) the isolated
+`.credentials.json` file (Linux/Windows — no Keychain involved), (2) the
+`CLAUDE_CODE_OAUTH_TOKEN` env var (if set, persisted into AgentMux's own
+Keychain entry for reuse across relaunches), (3) that same persisted
+Keychain entry, read back unconditionally whenever step 2's env var isn't
+present.
+
+On macOS, step 1 always fails — Claude Code never writes `.credentials.json`
+there (the same root cause as the 2026-08-17 retro). So on every macOS
+launch, this automatic background call falls straight to step 3: an
+unconditional read of AgentMux's own `"agentmux"` Keychain entry. If that
+entry already contains something (e.g. from an earlier session where
+`CLAUDE_CODE_OAUTH_TOKEN` was exported once), macOS's Keychain ACL requires
+approval from any code signature it doesn't already trust — which, for a
+locally rebuilt dev binary, is every fresh build. The result: a password
+prompt at app open, for a purely cosmetic feature (fresher model-name
+labels in a dropdown) the user never asked to trigger.
+
+## 4. Fix
+
+Added `allow_keychain_fallback: bool` to `resolve_access_token`. The
+automatic startup RPC (`providers.models`) now passes `false`, skipping
+steps 2/3 (and the `spawn_blocking` they ran on) entirely — no Keychain
+interaction from that path, ever. The underlying capability isn't deleted
+(steps 2/3 still exist in the function, callable with `true`), since it's a
+real, documented, intentional feature for users who explicitly export
+`CLAUDE_CODE_OAUTH_TOKEN` — it's just no longer reachable from a silent,
+unprompted background call. No caller passes `true` today; that's left for
+a future explicit-user-action trigger if one is ever built, not implemented
+speculatively here.
+
+## 5. Why this wasn't caught earlier
+
+The risk was documented in the function's own doc comment when the
+Keychain-fallback feature was added, but the audit stopped at "this can
+prompt" without asking "is this call site the kind where a prompt is
+acceptable?" The feature's own doc comments correctly frame it as
+best-effort/cosmetic ("Best-effort — returns \[\] with no token"), which
+made it easy to reason about failure modes (falls back to static list) while
+missing the different question of side effects on success — the OS-level
+interaction has a UX cost even when the read eventually succeeds.
+
+## 6. Follow-up
+
+None planned. If a future explicit "refresh model catalog" user action is
+ever built, it can pass `allow_keychain_fallback: true` — do not wire the
+automatic/background path back to it without re-reading this retro.


### PR DESCRIPTION
## Summary
- `frontend/app-init.ts` fires the `providers.models` RPC unconditionally on every app launch (fire-and-forget, to refresh the Claude model dropdown's labels).
- On macOS, where Claude Code never writes `.credentials.json`, that RPC fell through to an unconditional read of AgentMux's own Keychain-backed fallback-token store (`identity/secret_store.rs`, `keyring` crate under service `"agentmux"`).
- If that Keychain entry already had something in it (e.g. from an earlier session where `CLAUDE_CODE_OAUTH_TOKEN` was exported once), macOS's Keychain ACL requires approval from any code signature it doesn't already trust — for a locally rebuilt dev binary, that's every fresh build. Result: an interactive password prompt at app open, for a purely cosmetic feature.
- Fix: `resolve_access_token` now takes `allow_keychain_fallback: bool`. The automatic startup call passes `false`, skipping the Keychain-touching fallback steps entirely — no Keychain interaction from that path, ever. The capability itself isn't deleted (still callable with `true` from a future explicit user action); it's just no longer reachable from a silent background call.
- Adds a retro (`docs/retro/retro-startup-keychain-prompt-model-catalog-2026-08-18.md`) documenting the investigation.

## Test plan
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv model_catalog::` — 8 passed, including a new test locking "flag off + no file → None, never enters the keychain-fallback branch"
- [x] Root cause confirmed by code tracing (`app-init.ts` → `providers.models` RPC → `resolve_access_token` → `secret_store::get`, unconditional on every launch when `.credentials.json` is absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)