### PR TITLE
chore: release v0.55.14

### DIFF
--- a/.changesets/1787012397-fix-sysinfo-dynamic-y-axis-scaling-fix-3-metric-layout-fix-s-03d3.md
+++ b/.changesets/1787012397-fix-sysinfo-dynamic-y-axis-scaling-fix-3-metric-layout-fix-s-03d3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint

--- a/.changesets/1787013667-feat-agent-pane-pane-title-tracks-the-session-s-overall-goal-h9tx.md
+++ b/.changesets/1787013667-feat-agent-pane-pane-title-tracks-the-session-s-overall-goal-h9tx.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): pane title tracks the session's overall goal, not per-turn micro-steps

--- a/.changesets/1787014443-fix-browser-pane-stop-loading-brain-flicker-on-repeated-load-v0wy.md
+++ b/.changesets/1787014443-fix-browser-pane-stop-loading-brain-flicker-on-repeated-load-v0wy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): stop loading-brain flicker on repeated load-state flips

--- a/.changesets/1787014873-fix-tabs-remove-automatic-tab-color-assignment-0zbo.md
+++ b/.changesets/1787014873-fix-tabs-remove-automatic-tab-color-assignment-0zbo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): remove automatic tab color assignment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "base64",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.13"
+version = "0.55.14"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.13"
+version = "0.55.14"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.55.14 — 2026-08-18
+
+- fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint
+- feat(agent-pane): pane title tracks the session's overall goal, not per-turn micro-steps
+- fix(browser-pane): stop loading-brain flicker on repeated load-state flips
+- fix(tabs): remove automatic tab color assignment
+
+
 ## 0.55.13 — 2026-08-17
 
 - feat(agent-pane): answered questions render as user input; user-input surface inverted per theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.13",
+  "version": "0.55.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.13",
+      "version": "0.55.14",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.13",
+  "version": "0.55.14",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR consuming 4 pending changesets. Forced `--as patch` (overriding the computed `minor` bump) per explicit request — one queued changeset was `feat`-tagged, so it ships under this patch version rather than triggering a minor bump.

- fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint
- feat(agent-pane): pane title tracks the session's overall goal, not per-turn micro-steps
- fix(browser-pane): stop loading-brain flicker on repeated load-state flips
- fix(tabs): remove automatic tab color assignment

`0.55.13` → `0.55.14`

## Test plan
- [x] `task release -- --as patch` reported all 5 version locations (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) agree at `0.55.14`
- [x] `git diff --staged` reviewed before commit — only changeset deletions + version-location bumps + `VERSION_HISTORY.md` entry

<!-- agentmux:agent_id=agent2 -->