### PR TITLE
chore: release v0.55.15

### DIFF
--- a/.changesets/1787041732-fix-agent-pane-stop-the-cli-s-own-tool-result-echo-from-clob-7j6h.md
+++ b/.changesets/1787041732-fix-agent-pane-stop-the-cli-s-own-tool-result-echo-from-clob-7j6h.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): stop the CLI's own tool_result echo from clobbering an answered AskUserQuestion's answerText

--- a/.changesets/1787061206-feat-muxlog-add-muxlog-phases-merged-turn-phase-timeline-for-jtia.md
+++ b/.changesets/1787061206-feat-muxlog-add-muxlog-phases-merged-turn-phase-timeline-for-jtia.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxlog): add muxlog phases — merged turn-phase timeline for one agent pane

--- a/.changesets/1787062243-fix-model-catalog-stop-the-automatic-startup-model-catalog-r-sfyx.md
+++ b/.changesets/1787062243-fix-model-catalog-stop-the-automatic-startup-model-catalog-r-sfyx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(model-catalog): stop the automatic startup model-catalog refresh from prompting for the macOS Keychain password

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.14"
+version = "0.55.15"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.14"
+version = "0.55.15"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.14"
+version = "0.55.15"
 dependencies = [
  "base64",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.14"
+version = "0.55.15"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.14"
+version = "0.55.15"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.14"
+version = "0.55.15"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.14"
+version = "0.55.15"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -6,7 +6,6 @@
 - feat(muxlog): add muxlog phases — merged turn-phase timeline for one agent pane
 - fix(model-catalog): stop the automatic startup model-catalog refresh from prompting for the macOS Keychain password
 
-
 ## 0.55.14 — 2026-08-18
 
 - fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,12 @@
 # AgentMux Version History
 
+## 0.55.15 — 2026-08-18
+
+- fix(agent-pane): stop the CLI's own tool_result echo from clobbering an answered AskUserQuestion's answerText
+- feat(muxlog): add muxlog phases — merged turn-phase timeline for one agent pane
+- fix(model-catalog): stop the automatic startup model-catalog refresh from prompting for the macOS Keychain password
+
+
 ## 0.55.14 — 2026-08-18
 
 - fix(sysinfo): dynamic y-axis scaling, fix 3-metric layout, fix slow first paint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.14",
+  "version": "0.55.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.14",
+      "version": "0.55.15",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.14",
+  "version": "0.55.15",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR consuming 3 pending changesets. Forced `--as patch` (overriding the computed `minor` bump) per explicit request — one queued changeset was `minor`-tagged (muxlog phases), so it ships under this patch version rather than triggering a minor bump.

- fix(agent-pane): stop the CLI's own tool_result echo from clobbering an answered AskUserQuestion's answerText
- feat(muxlog): add muxlog phases — merged turn-phase timeline for one agent pane
- fix(model-catalog): stop the automatic startup model-catalog refresh from prompting for the macOS Keychain password

`0.55.14` → `0.55.15`

## Test plan
- [x] Verified `main` was fully up to date (`git fetch` + `git log HEAD..origin/main` empty) immediately before branching AND again immediately before opening this PR — the previous release PR (#2655) raced a concurrent release from stale main and had to be closed; confirmed no repeat this time.
- [x] `task release -- --as patch` reported all 5 version locations (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) agree at `0.55.15`
- [x] `git diff --staged` reviewed before commit — only changeset deletions + version-location bumps + `VERSION_HISTORY.md` entry

<!-- agentmux:agent_id=agent2 -->