### PR TITLE
fix(agent-pane): preserve cache-read/cache-creation token breakdown instead of collapsing it

### DIFF
--- a/.changesets/1787102240-fix-agent-pane-preserve-cache-read-cache-creation-token-brea-xzy9.md
+++ b/.changesets/1787102240-fix-agent-pane-preserve-cache-read-cache-creation-token-brea-xzy9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): preserve cache-read/cache-creation token breakdown instead of collapsing it into input_tokens

--- a/docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md
+++ b/docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md
@@ -1,0 +1,191 @@
+# Token Accounting & Compaction Control — Current State, Gaps, and a Path Forward
+
+**Date:** 2026-08-18
+**Scope:** How AgentMux tracks token usage today, why the numbers look the way they do, whether compaction can be user-triggered, and what a more reliable accounting layer should look like.
+**Builds on:** `docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md`, `docs/analysis/TOKEN_TAX_FOLLOWUP_2026_07_04.md` (prior empirical work on the same subsystem — this report doesn't repeat their findings, it extends them toward the accounting/compaction-control questions those docs flagged but didn't resolve).
+
+---
+
+## 0. TL;DR
+
+- **Yes, Claude's API always separates input and output tokens** (plus two more fields — see §1). AgentMux's frontend *receives* all four fields off the wire but **collapses three of them into one number in two separate places** before anything is stored. That's the single biggest fixable gap.
+- **"600 down but 100k up" is not a bug — it's the Messages API's stateless design working as intended.** Every turn resends the *entire* conversation as input; only the new reply is output. See §1 for the mechanics and §1.1 for why the *bigger* question is whether that 100k was billed at full price or served from cache.
+- **Compaction today is 100% passive.** AgentMux detects and displays a compaction Claude Code's CLI decided to run on its own — it has no way to request one. The existing architecture doc that ruled this out (`SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md`) predates the persistent-controller work that may make it feasible now. See §3.
+- **No historical token telemetry exists anywhere.** `docs/analysis/TOKEN_TAX_FOLLOWUP_2026_07_04.md` already flagged this in July; it's still true in August. Everything described below is live-only, in-memory, gone on reload.
+- There are currently **two parallel, drifting implementations** of token accounting in this codebase — a collapsed 2-field one driving the UI, and a correct 4-field one (`agentmux-srv/src/agents/types.rs`) that isn't wired to the interactive pane. Reconciling these is the highest-leverage structural fix (§5.1).
+
+---
+
+## 1. How the Claude Messages API actually accounts for tokens
+
+Every response from `POST /v1/messages` carries a `usage` object with **four distinct fields**, not two:
+
+| Field | Meaning | Relative cost |
+|---|---|---|
+| `input_tokens` | Fresh, uncached prompt tokens processed this request | 1x (full price) |
+| `cache_creation_input_tokens` | Tokens newly written into the prompt cache this request | ~1.25x (5min TTL) or ~2x (1hr TTL) |
+| `cache_read_input_tokens` | Tokens served from a previously-written cache entry | ~0.1x |
+| `output_tokens` | Tokens the model generated this turn | 1x (usually a higher per-token rate than input) |
+
+`input_tokens + cache_creation_input_tokens + cache_read_input_tokens` is the *real* size of everything sent to the model this turn — call that "prompt size." `output_tokens` is unrelated to prompt size; it's just how much the model chose to write back.
+
+### 1.1 Why "600 down but 100,000 up" is completely normal — and what to actually check
+
+The Messages API is **stateless**. There is no server-side conversation object — every single request resends the full transcript (system prompt, tool definitions, every prior user/assistant/tool_result turn) as the prompt, then the model appends one more turn. That means:
+
+- **The "up" number grows monotonically with conversation length**, almost independent of what happened this turn. By turn 50 of a long agentic session, the prompt legitimately *is* ~100k tokens of accumulated history — that's not a leak or a bug, that's the transcript.
+- **The "down" number reflects only the newest reply** — often a short tool call, a one-line status update, or a terse answer. 600 output tokens for a single turn is completely ordinary.
+
+So the asymmetry itself is expected and correct. **The question worth asking isn't "why is up so much bigger than down" — it's "was that 100k of up tokens actually expensive, or was it a cache read?"** A 100k-token prompt that's 95k `cache_read_input_tokens` and 5k fresh `input_tokens` costs roughly what a 10k-token prompt would cost at full price. The same 100k number with `cache_read_input_tokens: 0` is genuinely expensive, and if it *should* have been cached, that's a real problem (usually a silent cache invalidator — see the invalidator list in `TOKEN_TAX_FOLLOWUP §4b`: soul/agentmd/memory edits, a skill added/removed, a fresh (non-`--resume`) session, or a changed working directory).
+
+This repo already has direct empirical proof this mechanism works as described: `TOKEN_TAX_FOLLOWUP_2026_07_04.md §2` measured a *first-ever* session showing `cache_read_input_tokens: 44661` against `cache_creation_input_tokens: 6212` — tens of thousands of tokens served from cache before the session had even done anything, because Anthropic's own system-prompt-plus-tools baseline (~27–32K tokens) is cached by content hash and shared account-wide, not per-session.
+
+**Practical takeaway for anyone staring at a "100k up" number in the UI today: there is currently no way to tell, after the fact, whether that was mostly cache reads or mostly full-price fresh tokens.** That distinction is parsed off the wire and then thrown away before it's stored (§2.2). This is the single most actionable finding in this report.
+
+---
+
+## 2. How AgentMux currently tracks token usage
+
+### 2.1 Data flow
+
+AgentMux makes **zero direct calls to the Anthropic API**. It spawns the real `claude` binary as a subprocess (`-p --output-format stream-json`, `agentmux-srv/src/backend/blockcontroller/subprocess/argv.rs:148-154`) and reads its NDJSON stdout — through a persistent, long-lived process for the interactive pane (`agentmux-srv/src/backend/blockcontroller/persistent.rs`) or a one-shot invocation for background/subagent task runs (`agentmux-srv/src/agents/runner.rs:176-211`). This bounds what AgentMux can ever directly control: it can change what it *writes into* the prompt (CLAUDE.md content), CLI launch flags, and session lifecycle (fresh vs. `--resume`) — it can never place its own `cache_control` breakpoints, because it never builds the request.
+
+For the interactive pane, the raw JSON reaches the frontend close to verbatim. Two places independently parse the same usage fields off the wire:
+
+- `frontend/app/view/agent/providers/claude-translator.ts:106-123`
+- `frontend/app/view/agent/useAgentStream.ts:483-515`
+
+From there: `reducer.ts` (`frontend/app/store/agent-pane-state/reducer.ts:688-757`) updates a live `turnTokens` value; `useTurnLifecycle.ts`'s `finalizeTurn` (`:73-127`) merges the terminal `result` event's totals (preferred, since it's authoritative) or the live value (fallback) into `SessionStats` on turn end, dispatches a `TurnEnd` that the reducer sums into a lifetime `sessionTotals` (`reducer.ts:1317-1357`), and separately calls `recordTurn()` into `frontend/app/store/token-usage.ts` — a third, app-session-wide, per-provider running total that only the status-bar `TokenUsageIndicator`/`TokenBreakdownPopover` read from.
+
+A second, more structured implementation also exists: `agentmux-srv/src/agents/{runner.rs, translator/claude.rs, types.rs}` parses the same raw usage into a proper 4-field `TokenCounts` struct (`types.rs:138`) and emits `AgentEvent::Cost{cost_usd, tokens}`. Per its own module doc (`agents/mod.rs:4-12`), **this is explicitly not yet wired to the interactive agent pane** — it currently only drives the headless drone Agent block executor. So the more-correct implementation exists in the codebase today; it's just not the one users see.
+
+### 2.2 The collapsing problem
+
+Both frontend parse sites take all three prompt-related fields off the wire and immediately sum them into one "input" number:
+
+```
+// claude-translator.ts:110-111 and useAgentStream.ts:489-496 — identical comment in both:
+// "input_tokens is only the uncached prompt; cache_creation/cache_read carry the rest of the real prompt size"
+```
+
+The code is *aware* the distinction matters — it says so in a comment — and then discards it anyway. Every stored value downstream (`turnTokens`, `SessionStats`, `sessionTotals`, the `token-usage.ts` store, and the `↑` number in the status bar) is this same undifferentiated sum. There is no code path today, live or historical, that can answer "what fraction of this session's input tokens were cache reads?" — despite the raw data briefly existing in memory to answer exactly that.
+
+### 2.3 What the UI shows today
+
+- **`TokenUsageIndicator.tsx`** — a status-bar button: `↑{compact(input)} ↓{compact(output)}`, tooltip "Total tokens this session." Cumulative, app-session-wide, all providers combined by default.
+- **`TokenBreakdownPopover.tsx`** — opens on click: per-provider `↑input ↓output` rows, a total row, a "Reset counter" button (explicitly resets only this running display, not the actual conversation).
+- **`AgentFooter.tsx` / `AgentComposerStrip.tsx`** — per-pane "Worked" line (tokens + elapsed time for the last/live turn), and a context-fill meter: `"Context window: X / Y tokens (Z%) ... Auto-compacts around N tokens."`
+
+None of these three surfaces distinguish cache-read from fresh tokens. None persist history — everything resets on app reload.
+
+### 2.4 Known accuracy gaps (already documented in code)
+
+- **Multi-call-turn undercounting**: the live `turnTokens` value is *overwritten*, not accumulated, on each `message_start`/`message_delta` — `reducer.ts:1317-1320` explicitly notes this undercounts a turn that made multiple API calls. Mitigated (not fixed) by preferring the terminal `result` event's total when one is available.
+- **Empty boundary markers**: Claude's persistent-mode controller emits an empty `session_end` (`stats: {}`) as a mere turn-boundary marker after every plain-text turn, while the real usage-bearing `result` only fires at process teardown — `parseHistoryLines.ts:18-34` has to specifically track "the last `session_end` that actually carried usage" so a later empty marker doesn't clobber real historical stats on history replay.
+- **No historical persistence at all**: confirmed independently by this investigation and by `TOKEN_TAX_FOLLOWUP §4`/`§5` — `agentmux-srv/src/backend/storage/` has no table or column for `cache_read_input_tokens` / `cache_creation_input_tokens`, or for any per-turn usage record. "Is caching actually working for this session" is answerable only live, in the moment, by reading the UI before it resets.
+
+---
+
+## 3. How compaction currently works
+
+**Fully passive.** AgentMux detects and renders a compaction that Claude Code's own CLI already decided to run — it never requests, triggers, or influences one. This is Claude Code CLI's own internal auto-compact mechanism, unrelated to the Anthropic API's separate server-side "compaction" beta feature (AgentMux doesn't use the API directly, so that beta is irrelevant here).
+
+- **Trigger**: purely the CLI's own logic. The CLI reports which of its own two triggers fired — `Auto` (its context-fill heuristic) or `Manual` (someone typed `/compact` *inside the CLI session itself*, not through AgentMux) — via `CompactionTrigger` (`agentmux-srv/src/agents/types.rs:117-134`). AgentMux only *reads* the threshold for display (`compactionThreshold(window) = window - 33,000`, `context-window.ts:26`) — it never sets it.
+- **`agentmux-bashwrap/src/precompact.rs`** is a Claude Code `PreCompact` hook, auto-registered into the CLI's `settings.json`, invoked the instant compaction *begins* (before it's known to have finished). It publishes a live-only `compaction_started` event so the UI can show "Compacting…" — it has no power to cause or block compaction, and always exits 0 with no stdout.
+- **No RPC, button, or stub exists to trigger one manually.** `frontend/app/store/rpc-api/agent.ts` has nothing compaction-related. The relevant slash-command architecture spec (`SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md`, appendix) explicitly marked `/compact` **"✗ — Requires live CLI session; offer 'start new pane' instead"** and left open the question "does `/compact` have any meaningful representation in stream-json mode?" — **that spec predates the persistent pane controller** (`blockcontroller/persistent.rs`), which *does* keep one long-running `claude` process alive with piped stdin for the entire conversation. The premise the spec rejected on ("no live session to send it to") may no longer hold. See §6.
+- **What the user sees**: the actual compaction UI lives in `DocumentRow.tsx:266-311` — a divider reading `"context compacted — you ran /compact"` or `"— auto-compacted"`, with `"Earlier history summarized · {before} → {after} tokens · took {N}s"` when real CLI-reported numbers are available (falls back to a heuristic-detected boundary, no duration/trigger, for non-Claude providers). (Note: `components/CompactResult.tsx` is a same-named-but-unrelated component that collapses tool-call *results* like Grep/Glob output — not conversation compaction. Don't confuse the two when reading the code.)
+- **Effect on tracked totals**: compaction *corrects* the running context estimate rather than resetting or double-counting — `reducer.ts`'s `CompactionBoundary` case (~lines 1147-1215) reconciles `lastContextTokens` to the CLI-reported `postTokens`, with a race guard against a stale/delayed boundary event clobbering a newer one. A parallel heuristic (≥50% token-count drop from a >10k baseline) remains the only detection path for Codex/Gemini/Copilot, which have no structured compaction signal, and is suppressed for a window after a real boundary fires so the two don't double-trigger.
+
+---
+
+## 4. Should we track "up" and "down" tokens?
+
+**Yes — but as four buckets, not two.** "Up"/"down" (input/output) is already the coarsest possible view, and the API gives strictly more information for free. The recommendation is specifically:
+
+```
+input_tokens              — fresh prompt tokens, full price
+cache_creation_input_tokens — fresh tokens written to cache, elevated price
+cache_read_input_tokens   — served from cache, ~0.1x price
+output_tokens              — model's reply, full price
+```
+
+This isn't new plumbing — **the raw data already flows through both frontend parse sites today** (§2.2) and is discarded immediately after. Preserving it through `TurnTokens` → `SessionStats` → `sessionTotals` → `token-usage.ts` is a matter of not collapsing three numbers into one at the point of parsing, not building a new data pipeline. The properly-typed 4-field struct already exists server-side (`agents/types.rs`); it just isn't the one feeding the UI (§5.1).
+
+---
+
+## 5. Getting a more reliable picture of token usage — recommendations
+
+### 5.1 Consolidate the two parallel implementations (highest leverage)
+
+Right now a correct, 4-field `TokenCounts` implementation exists in the Rust unified agent runner and an incorrect, 2-field, twice-duplicated implementation exists in the frontend and drives everything users actually see. Two implementations of the same concept in one codebase, one of which is already known-better, is a standing invitation for the two to drift further apart. The recommendation is to finish wiring the interactive pane onto the unified runner's event stream (the module doc already anticipates this as "PR 1") rather than fixing the frontend's collapsing bug in place — fixing it in two files that will need to be deleted anyway is wasted work.
+
+### 5.2 Preserve the 4-field breakdown end-to-end
+
+If full consolidation isn't scheduled soon, the smaller fix is: stop summing `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` at the point of parsing in `claude-translator.ts` and `useAgentStream.ts`. Carry all four fields through every downstream type (`TurnTokens`, `SessionStats`, `sessionTotals`, the `token-usage.ts` store). Collapse to a single number only at display time, in views that genuinely need brevity (e.g. `AgentFooter`'s compact "Worked" line) — never earlier.
+
+### 5.3 Surface cache-hit rate as a first-class metric
+
+Once §5.2 lands, expose `cache_read / (input + cache_creation + cache_read)` per turn and per session. This is the single most actionable number for the "why is this session expensive" question (§1.1) and is currently invisible anywhere in the product. A sudden drop in cache-hit rate mid-session is also a good automatic signal that something silently invalidated the cache (per the trigger list in `TOKEN_TAX_FOLLOWUP §4b`) — worth a subtle UI nudge rather than requiring a manual investigation each time.
+
+### 5.4 Fix per-turn accumulation properly
+
+Replace the "overwrite live value, prefer terminal `result` event, fall back to live value" pattern (§2.4) with a live running accumulator that sums every `message_start`/`message_delta` usage delta within a turn, still reconciled against the terminal event's authoritative total when one arrives (rather than only used as a fallback). This closes the multi-call-turn undercounting gap without waiting on the terminal event to correct it.
+
+### 5.5 Compute real dollar cost, not a flat multiplier
+
+Once the 4-field breakdown is preserved, cost can be computed correctly per the current per-model pricing table (input/output/cache-write/cache-read all have different per-token rates) instead of the flat guess a 2-bucket view would force. This is a natural pairing with §5.3 — "N tokens, $X, Y% cache hit rate" is a materially more useful status-bar tooltip than the current raw arrow-counts.
+
+### 5.6 Persist history, not just live counters
+
+`TOKEN_TAX_FOLLOWUP §5` flagged this in July and it's still true: nothing survives a reload. Persisting per-turn usage records (even just the four raw numbers + timestamp + provider + session id) turns "is caching actually working" from a one-off manual experiment into a query, and is the prerequisite for any trend view, cost dashboard, or regression alert. This doesn't need to be a new table from scratch — the drone Agent block executor already computes `AgentEvent::Cost` records that could be the seed of a shared storage schema.
+
+### 5.7 Note the context-window-size limitation honestly
+
+`context-window.ts` guesses the model's context window from a model-id string pattern match and learns upward from observed usage, because — per its own header comment — the CLI never reports the effective window directly. This is a real accuracy ceiling on the "% of context used" meter specifically, but it's a CLI limitation AgentMux is working around reasonably, not a bug to "fix" outright. Worth documenting as a known limitation rather than silently trusting the percentage as exact.
+
+---
+
+## 6. Giving users a manual "compact now" option
+
+**Feasibility has changed since the architecture was last assessed, and it's worth re-testing rather than treating as settled.** The spec that ruled this out (`SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md`) reasoned from the one-shot `--print` invocation model, where there's no live process to send anything to after the fact. The persistent pane controller built since then (`blockcontroller/persistent.rs`) keeps exactly the thing that was missing: one long-running `claude` process with a piped, still-open stdin for the whole conversation, and an existing control-protocol channel already used for `AskUserQuestion` and permission-prompt round-trips.
+
+**Recommended path:**
+
+1. **Verify empirically first** (cheap, ~an hour): with a live persistent-controller session, send `/compact` as a plain user-turn text message over the existing piped stdin, the same way any other user message is sent. Claude Code CLI's stream-json stdin protocol may or may not treat an in-band `/compact` string as the command rather than literal text — this is unconfirmed in the codebase and is the actual open question, not a re-litigation of "is a live session available" (it now is).
+2. **If step 1 works**: wiring a "Compact now" button becomes a straightforward RPC that reuses the existing send-user-message path — no new protocol needed. Compaction feedback already renders correctly via the existing `context_compacted`/`compaction_started` UI nodes (§3), since those don't distinguish auto- from user-triggered compaction except by the `trigger` label already piped through.
+3. **If step 1 fails** (CLI needs a distinct control-protocol frame, not a text command): the addition point is the same place `AskUserQuestion`/permission handling already lives in the persistent controller (`blockcontroller/persistent.rs`, control-protocol section) — a new outbound control frame requesting compaction, if the CLI's control protocol exposes one. This needs checking against the current Claude Code CLI's control-protocol surface, which is out of scope for a code-only investigation of this repo.
+
+Either way, the "start a new pane instead" advice in the 2026-04-14 spec was a reasonable conclusion for the constraints that existed *then* — flag it as worth revisiting rather than assuming it's still the last word, since the persistent controller changes the premise it was based on.
+
+---
+
+## 7. Best-practice infrastructure for accounting — summary design
+
+Pulling the above into one target architecture:
+
+1. **One source of truth.** Retire the frontend's duplicate parsing once the unified Rust runner drives the interactive pane (§5.1) — two independently-maintained parsers of the same wire format is the root cause of the current collapsing bug and a standing risk of future drift.
+2. **Never collapse at ingestion.** Store all four raw `usage` fields as far downstream as possible; collapse to a display-friendly number only in the specific view that needs it, and even then prefer showing the breakdown when space allows.
+3. **Track three time scales, not one.** Per-turn (diagnosing a single expensive exchange), per-session (the current running total), and lifetime/historical (trend and regression detection) are different questions and should be different rollups, not one counter overwritten in place.
+4. **Prefer authoritative terminal totals over accumulated live deltas, but don't drop the live signal.** Keep reconciling against the CLI's own `result`/`session_end` totals when they arrive (already the right instinct in the current code) — but accumulate properly in between so a mid-turn or dropped-terminal-event case doesn't silently undercount.
+5. **Make cache health a visible, first-class number**, not something recoverable only by re-deriving it from raw fields nobody currently sees together (§5.3).
+6. **Persist, don't just display.** A live-only counter answers "what's happening right now"; a persisted per-turn log is what turns "is our caching strategy working" from an occasional manual experiment (as in `TOKEN_TAX_FOLLOWUP`) into an ongoing, queryable fact.
+7. **Compute real cost from the real per-field pricing table**, not a flat rate — this is only possible once #2 is in place, and it's the number users actually care about more than raw token counts.
+8. **Be honest about the ceilings AgentMux can't move.** The subprocess-only integration model (§2.1) means no direct `cache_control` placement and no server-reported context-window size — these are architectural facts, not bugs, and the accounting layer should present numbers with that caveat rather than implying more precision than the underlying CLI actually provides.
+
+---
+
+## 8. Suggested priority order
+
+1. §5.2 (stop collapsing the 4 fields) — small, self-contained, unblocks everything else.
+2. §5.3 (surface cache-hit rate) — immediate user value, depends only on #1.
+3. §6 step 1 (empirically test `/compact` over the persistent controller's stdin) — cheap to test, answers the "can we even do this" question before any UI work is committed.
+4. §5.1 (consolidate onto the unified Rust runner) — larger, but prevents #1–3 from being built twice.
+5. §5.6 (persist per-turn usage history) — the prerequisite for any longer-term cost/trend tooling, and directly closes the gap `TOKEN_TAX_FOLLOWUP` already flagged twice.
+
+---
+
+## Sources
+
+- `docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md`, `docs/analysis/TOKEN_TAX_FOLLOWUP_2026_07_04.md` — prior empirical investigation of this same subsystem; this report extends rather than repeats their findings.
+- Code investigation (this report): `frontend/app/statusbar/{TokenUsageIndicator,TokenBreakdownPopover}.tsx`, `frontend/app/store/agent-pane-state/{reducer,context-window,types}.ts`, `frontend/app/store/token-usage.ts`, `frontend/app/view/agent/hooks/useTurnLifecycle.ts`, `frontend/app/view/agent/parseHistoryLines.ts`, `frontend/app/view/agent/providers/claude-translator.ts`, `frontend/app/view/agent/useAgentStream.ts`, `frontend/app/view/agent/compact-boundary.ts`, `frontend/app/view/agent/virtualization/DocumentRow.tsx`, `agentmux-bashwrap/src/precompact.rs`, `agentmux-srv/src/agents/{runner.rs,types.rs,translator/claude.rs}`, `agentmux-srv/src/backend/blockcontroller/persistent.rs`, `docs/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md`.
+- Anthropic Messages API `usage` schema and prompt-caching pricing/mechanics (input/output/cache-creation/cache-read token separation, cache TTL economics, stateless-request behavior).

--- a/frontend/app/statusbar/TokenBreakdownPopover.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.tsx
@@ -20,6 +20,7 @@ import { getCliCatalogEntry } from "@/app/view/agent/defaults/cli-catalog";
 import { formatCompactNumber } from "@/util/format-count";
 import {
     getBreakdown,
+    getCacheHitRate,
     getSessionStartAt,
     getTotal,
     resetSession,
@@ -64,6 +65,13 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
     const total = createMemo(() => {
         void tokenUsageState.byService;
         return getTotal();
+    });
+    // null until at least one turn has reported a cache breakdown (see
+    // getCacheHitRate's doc comment) — render nothing rather than a
+    // misleading "0%" in that window.
+    const cacheHitRate = createMemo(() => {
+        void tokenUsageState.byService;
+        return getCacheHitRate();
     });
 
     // Positioning routes through the shared primitive (Phase 3): anchored to
@@ -168,6 +176,14 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
                                 {formatCompactNumber(total().output)}
                             </span>
                         </div>
+                        <Show when={cacheHitRate() != null}>
+                            <div
+                                class="token-usage-breakdown-cache-rate"
+                                title="Share of input tokens served from Claude's prompt cache this session (~0.1x the cost of a fresh token). Only available for providers that report a cache breakdown."
+                            >
+                                {Math.round((cacheHitRate() as number) * 100)}% of input served from cache
+                            </div>
+                        </Show>
                     </div>
                 </Show>
                 <div class="token-usage-breakdown-footer">

--- a/frontend/app/statusbar/_token-usage.scss
+++ b/frontend/app/statusbar/_token-usage.scss
@@ -128,6 +128,13 @@
         color: var(--main-text-color);
     }
 
+    .token-usage-breakdown-cache-rate {
+        padding: 2px var(--space-3) 0;
+        color: var(--secondary-text-color);
+        font-size: 10px;
+        text-align: right;
+    }
+
     .token-usage-breakdown-empty {
         padding: var(--space-3) var(--space-3);
         color: var(--secondary-text-color);

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -689,6 +689,9 @@ export function update(
             const next = {
                 input: command.input,
                 output: state.turnTokens?.output ?? 0,
+                freshInput: command.freshInput,
+                cacheCreation: command.cacheCreation,
+                cacheRead: command.cacheRead,
             };
             // Learn the context window from the resolved model + observed fill
             // (seed-then-high-water-upgrade); null until a recognised model is
@@ -747,6 +750,11 @@ export function update(
             const next = {
                 input: state.turnTokens?.input ?? 0,
                 output: command.output,
+                // Preserve the breakdown from the last TokensIn — TokensOut
+                // never carries its own, only replaces `output`.
+                freshInput: state.turnTokens?.freshInput,
+                cacheCreation: state.turnTokens?.cacheCreation,
+                cacheRead: state.turnTokens?.cacheRead,
             };
             const nextState = bumpEvent(
                 { ...state, turnTokens: next },
@@ -1330,10 +1338,22 @@ function mergeStats(
             ...stats,
             input_tokens: stats.input_tokens || tokens?.input,
             output_tokens: stats.output_tokens || tokens?.output,
+            // Same fallback logic as input_tokens/output_tokens above,
+            // applied to the cache breakdown — prefer the result event's
+            // own breakdown, fall back to the live turn-tokens' breakdown.
+            fresh_input_tokens: stats.fresh_input_tokens ?? tokens?.freshInput,
+            cache_creation_input_tokens: stats.cache_creation_input_tokens ?? tokens?.cacheCreation,
+            cache_read_input_tokens: stats.cache_read_input_tokens ?? tokens?.cacheRead,
         };
     }
     if (tokens) {
-        return { input_tokens: tokens.input, output_tokens: tokens.output };
+        return {
+            input_tokens: tokens.input,
+            output_tokens: tokens.output,
+            fresh_input_tokens: tokens.freshInput,
+            cache_creation_input_tokens: tokens.cacheCreation,
+            cache_read_input_tokens: tokens.cacheRead,
+        };
     }
     return null;
 }
@@ -1355,6 +1375,13 @@ function accumulateStats(
         duration_ms: (totals?.duration_ms ?? 0) + (merged.duration_ms ?? 0),
         input_tokens: (totals?.input_tokens ?? 0) + (merged.input_tokens ?? 0),
         output_tokens: (totals?.output_tokens ?? 0) + (merged.output_tokens ?? 0),
+        // Same accumulate-not-replace treatment as input_tokens/output_tokens
+        // above, for the cache breakdown. See fresh_input_tokens' doc comment
+        // in view/agent/types.ts for why this split matters.
+        fresh_input_tokens: (totals?.fresh_input_tokens ?? 0) + (merged.fresh_input_tokens ?? 0),
+        cache_creation_input_tokens:
+            (totals?.cache_creation_input_tokens ?? 0) + (merged.cache_creation_input_tokens ?? 0),
+        cache_read_input_tokens: (totals?.cache_read_input_tokens ?? 0) + (merged.cache_read_input_tokens ?? 0),
         num_turns: (totals?.num_turns ?? 0) + (merged.num_turns ?? 1),
     };
 }

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -504,7 +504,11 @@ export type AgentPaneCommand =
     | { type: "ToolStart"; name: string; arg?: string }
     | { type: "ToolEnd" }
 
-    | { type: "TokensIn"; input: number; model?: string }
+    // freshInput/cacheCreation/cacheRead: optional breakdown of `input` by
+    // cache status (fresh + cacheCreation + cacheRead === input). See
+    // TurnTokens'/SessionStats' matching doc comments in view/agent/types.ts —
+    // this is the same split, just on the dispatched command.
+    | { type: "TokensIn"; input: number; model?: string; freshInput?: number; cacheCreation?: number; cacheRead?: number }
     | { type: "TokensOut"; output: number }
 
     /** User pressed Esc / clicked Stop. */

--- a/frontend/app/store/token-usage.test.ts
+++ b/frontend/app/store/token-usage.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { getCacheHitRate, getTotal, recordTurn, resetSession } from "./token-usage";
+
+describe("token-usage store — cache-hit-rate normalization", () => {
+    beforeEach(() => {
+        resetSession();
+    });
+
+    it("computes the hit rate correctly for our own shape (input = freshInput + cacheCreation + cacheRead)", () => {
+        // claude-translator.ts / useAgentStream.ts shape: `input` is the
+        // collapsed total, `freshInput` carries the fresh-only portion.
+        recordTurn("claude", { input: 1000, output: 50, freshInput: 100, cacheCreation: 300, cacheRead: 600 });
+        expect(getCacheHitRate()).toBeCloseTo(0.6, 5); // 600 / (100 + 300 + 600)
+    });
+
+    it("reagentx/codex P2 on PR #2658 — normalizes the backend TokenCounts shape (input = fresh only, no freshInput field)", () => {
+        // gotypes.d.ts's TokenCounts shape, as passed by
+        // useNextPromptSuggestion/useAgentActivitySummary/ActivityDock/
+        // swarm-view's ambient `result.tokens` — `input` means fresh-only
+        // here, and there is no separate `freshInput` field at all.
+        recordTurn("ambient:next_prompt_suggestion", { input: 100, output: 5, cacheCreation: 300, cacheRead: 600 });
+        // Before the fix this read 1.0 (600 / (300 + 600), silently
+        // dropping the 100 fresh tokens from the denominator because they
+        // never appear under a `freshInput` key). Correct answer treats
+        // `input` as the fresh contribution: 600 / (100 + 300 + 600).
+        expect(getCacheHitRate()).toBeCloseTo(0.6, 5);
+    });
+
+    it("mixes both shapes across services without corrupting either one's contribution", () => {
+        recordTurn("claude", { input: 1000, output: 0, freshInput: 100, cacheCreation: 300, cacheRead: 600 });
+        recordTurn("ambient:next_prompt_suggestion", { input: 50, output: 0, cacheCreation: 0, cacheRead: 450 });
+        // fresh: 100 + 50 = 150; cacheCreation: 300 + 0 = 300; cacheRead: 600 + 450 = 1050
+        // total prompt: 150 + 300 + 1050 = 1500; hit rate: 1050 / 1500 = 0.7
+        expect(getCacheHitRate()).toBeCloseTo(0.7, 5);
+    });
+
+    it("returns null when no service has reported a cache breakdown yet", () => {
+        recordTurn("codex", { input: 500, output: 20 });
+        expect(getCacheHitRate()).toBeNull();
+    });
+
+    it("getTotal still sums the plain input/output regardless of breakdown shape", () => {
+        recordTurn("claude", { input: 1000, output: 50, freshInput: 100, cacheCreation: 300, cacheRead: 600 });
+        recordTurn("ambient:next_prompt_suggestion", { input: 50, output: 5, cacheCreation: 0, cacheRead: 450 });
+        const total = getTotal();
+        expect(total.input).toBe(1050);
+        expect(total.output).toBe(55);
+    });
+});

--- a/frontend/app/store/token-usage.ts
+++ b/frontend/app/store/token-usage.ts
@@ -66,11 +66,32 @@ export function recordTurn(provider: string, tokens: ServiceUsage | null | undef
     // service, the running total is exact from that point on.
     const hasBreakdown =
         tokens.freshInput != null || tokens.cacheCreation != null || tokens.cacheRead != null;
+    // reagentx/codex P2 on PR #2658: two incompatible wire shapes reach
+    // this function under the same field names. claude-translator.ts /
+    // useAgentStream.ts (via useTurnLifecycle.ts) pass `input` as the
+    // COLLAPSED total (freshInput + cacheCreation + cacheRead) with a
+    // separate `freshInput` for the fresh-only count. The backend
+    // TokenCounts shape — gotypes.d.ts's `{input, output, cacheCreation,
+    // cacheRead}`, no `freshInput` field at all, reaching recordTurn via
+    // useNextPromptSuggestion/useAgentActivitySummary/ActivityDock/
+    // swarm-view's ambient `result.tokens` — uses `input` to mean
+    // fresh-only directly. Without this normalization, getCacheHitRate's
+    // denominator silently drops that caller's fresh tokens (cacheCreation/
+    // cacheRead are present, freshInput isn't), inflating the reported
+    // hit rate — e.g. 100 fresh + 900 cache-read reads as 100%, not 90%.
+    // Distinguishing rule: our own path always sets freshInput whenever it
+    // sets cacheCreation/cacheRead (see useAgentStream.ts/reducer.ts — all
+    // three are sourced together or not at all), so "cache fields present,
+    // freshInput absent" unambiguously means the TokenCounts shape, where
+    // `input` IS the fresh count.
+    const freshContribution =
+        tokens.freshInput
+        ?? ((tokens.cacheCreation != null || tokens.cacheRead != null) ? input : undefined);
     setState("byService", id, {
         input: current.input + input,
         output: current.output + output,
         freshInput: hasBreakdown
-            ? (current.freshInput ?? 0) + (tokens.freshInput ?? 0)
+            ? (current.freshInput ?? 0) + (freshContribution ?? 0)
             : current.freshInput,
         cacheCreation: hasBreakdown
             ? (current.cacheCreation ?? 0) + (tokens.cacheCreation ?? 0)

--- a/frontend/app/store/token-usage.ts
+++ b/frontend/app/store/token-usage.ts
@@ -21,6 +21,20 @@ import { createStore } from "solid-js/store";
 export interface ServiceUsage {
     input: number;
     output: number;
+    /**
+     * Breakdown of `input` by cache status (fresh + cacheCreation + cacheRead
+     * === input). Optional — providers without a structured cache signal
+     * (codex/gemini/copilot) never set these, so consumers must treat them
+     * as "unknown," not "zero." See TurnTokens'/SessionStats' doc comments
+     * in view/agent/types.ts for the source of this split, and
+     * docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md
+     * §2.2/§5.2/§5.3 for why it's tracked (cache_read tokens cost ~0.1x a
+     * fresh token — the breakdown is what actually explains cost, the raw
+     * input number alone doesn't).
+     */
+    freshInput?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
 }
 
 interface TokenUsageState {
@@ -44,9 +58,26 @@ export function recordTurn(provider: string, tokens: ServiceUsage | null | undef
     if (input === 0 && output === 0) return;
     const id = provider.toLowerCase();
     const current = state.byService[id] ?? { input: 0, output: 0 };
+    // Breakdown fields accumulate only when provided — `?? 0` on the
+    // current side (not the incoming side) so a provider that has never
+    // reported a breakdown keeps reading as `undefined` (unknown) rather
+    // than silently becoming `0` (known-zero) the moment ANY turn for it
+    // omits the fields. Once any turn does supply the fields for this
+    // service, the running total is exact from that point on.
+    const hasBreakdown =
+        tokens.freshInput != null || tokens.cacheCreation != null || tokens.cacheRead != null;
     setState("byService", id, {
         input: current.input + input,
         output: current.output + output,
+        freshInput: hasBreakdown
+            ? (current.freshInput ?? 0) + (tokens.freshInput ?? 0)
+            : current.freshInput,
+        cacheCreation: hasBreakdown
+            ? (current.cacheCreation ?? 0) + (tokens.cacheCreation ?? 0)
+            : current.cacheCreation,
+        cacheRead: hasBreakdown
+            ? (current.cacheRead ?? 0) + (tokens.cacheRead ?? 0)
+            : current.cacheRead,
     });
 }
 
@@ -58,11 +89,40 @@ export function getTotal(): ServiceUsage {
     const services = state.byService;
     let input = 0;
     let output = 0;
+    let cacheRead = 0;
+    let hasBreakdown = false;
     for (const id in services) {
         input += services[id].input;
         output += services[id].output;
+        if (services[id].cacheRead != null) {
+            hasBreakdown = true;
+            cacheRead += services[id].cacheRead ?? 0;
+        }
     }
-    return { input, output };
+    return { input, output, cacheRead: hasBreakdown ? cacheRead : undefined };
+}
+
+/**
+ * Fraction of total prompt tokens (input + cacheCreation + cacheRead) served
+ * from cache this session, across every service. `null` when no service has
+ * reported a cache breakdown yet (e.g. session just started, or every active
+ * provider is one that never reports cache fields) — render as "—", not "0%".
+ * See docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md §5.3.
+ */
+export function getCacheHitRate(): number | null {
+    const services = state.byService;
+    let promptTotal = 0;
+    let cacheRead = 0;
+    let hasBreakdown = false;
+    for (const id in services) {
+        const u = services[id];
+        if (u.freshInput == null && u.cacheCreation == null && u.cacheRead == null) continue;
+        hasBreakdown = true;
+        promptTotal += (u.freshInput ?? 0) + (u.cacheCreation ?? 0) + (u.cacheRead ?? 0);
+        cacheRead += u.cacheRead ?? 0;
+    }
+    if (!hasBreakdown || promptTotal === 0) return null;
+    return cacheRead / promptTotal;
 }
 
 /**
@@ -73,6 +133,9 @@ export interface ServiceRow {
     id: string;
     input: number;
     output: number;
+    freshInput?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
 }
 
 export function getBreakdown(): ServiceRow[] {
@@ -80,6 +143,9 @@ export function getBreakdown(): ServiceRow[] {
         id,
         input: u.input,
         output: u.output,
+        freshInput: u.freshInput,
+        cacheCreation: u.cacheCreation,
+        cacheRead: u.cacheRead,
     }));
     rows.sort((a, b) => {
         const aTotal = a.input + a.output;

--- a/frontend/app/view/agent/hooks/useTurnLifecycle.ts
+++ b/frontend/app/view/agent/hooks/useTurnLifecycle.ts
@@ -90,7 +90,15 @@ export function useTurnLifecycle(opts: UseTurnLifecycleOptions): UseTurnLifecycl
         const liveTokens = paneSnapshot(opts.blockId)?.turnTokens ?? null;
         const statsTokens =
             stats && (stats.input_tokens != null || stats.output_tokens != null)
-                ? { input: stats.input_tokens ?? 0, output: stats.output_tokens ?? 0 }
+                ? {
+                    input: stats.input_tokens ?? 0,
+                    output: stats.output_tokens ?? 0,
+                    // Same breakdown carried alongside input/output — see
+                    // TurnTokens'/SessionStats' doc comments in ../types.ts.
+                    freshInput: stats.fresh_input_tokens,
+                    cacheCreation: stats.cache_creation_input_tokens,
+                    cacheRead: stats.cache_read_input_tokens,
+                }
                 : null;
         const tokens = statsTokens ?? liveTokens;
         // Aggregate the completed turn's tokens into the global

--- a/frontend/app/view/agent/providers/claude-translator.test.ts
+++ b/frontend/app/view/agent/providers/claude-translator.test.ts
@@ -322,7 +322,7 @@ describe("ClaudeTranslator", () => {
             });
         });
 
-        it("carries token usage — input sums uncached + cache_creation + cache_read", () => {
+        it("carries token usage — input sums uncached + cache_creation + cache_read, and preserves the split", () => {
             const t = new ClaudeTranslator();
             const events = t.translate({
                 type: "result",
@@ -334,10 +334,17 @@ describe("ClaudeTranslator", () => {
                     output_tokens: 512,
                 },
             });
+            // input_tokens stays the combined total (back-compat for existing
+            // consumers); fresh/cache_creation/cache_read carry the split
+            // that was previously discarded — see
+            // docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md §5.2.
             expect((events[0] as any).stats).toEqual({
                 duration_ms: 1000,
                 input_tokens: 2 + 49164 + 20685,
                 output_tokens: 512,
+                fresh_input_tokens: 2,
+                cache_creation_input_tokens: 49164,
+                cache_read_input_tokens: 20685,
             });
         });
 

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -108,15 +108,21 @@ export class ClaudeTranslator implements OutputTranslator {
             if (typeof rawEvent.duration_ms === "number") stats.duration_ms = rawEvent.duration_ms;
             if (typeof rawEvent.num_turns === "number") stats.num_turns = rawEvent.num_turns;
             // input_tokens is only the uncached prompt; cache_creation/cache_read
-            // carry the rest of the real prompt size.
+            // carry the rest of the real prompt size. Preserve the split (not
+            // just the sum) — see SessionStats' fresh_input_tokens doc comment.
             const usage = rawEvent.usage;
             if (usage && typeof usage === "object") {
-                const input =
-                    (usage.input_tokens ?? 0) +
-                    (usage.cache_creation_input_tokens ?? 0) +
-                    (usage.cache_read_input_tokens ?? 0);
+                const freshInput = usage.input_tokens ?? 0;
+                const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+                const cacheRead = usage.cache_read_input_tokens ?? 0;
+                const input = freshInput + cacheCreation + cacheRead;
                 const output = usage.output_tokens ?? 0;
-                if (input > 0) stats.input_tokens = input;
+                if (input > 0) {
+                    stats.input_tokens = input;
+                    stats.fresh_input_tokens = freshInput;
+                    stats.cache_creation_input_tokens = cacheCreation;
+                    stats.cache_read_input_tokens = cacheRead;
+                }
                 if (output > 0) stats.output_tokens = output;
             }
             events.push({ type: "session_end", stats });

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -523,16 +523,36 @@ export interface SessionStats {
     input_tokens?: number;
     /** Snapshot of TurnTokens.output at finalizeTurn (see above). */
     output_tokens?: number;
+    /**
+     * Breakdown of input_tokens by cache status:
+     * fresh_input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+     * == input_tokens. These previously reached this codebase off the wire
+     * and were summed into input_tokens at parse time, discarding the split —
+     * cache_read tokens cost ~0.1x a fresh token, so the breakdown is what
+     * actually explains whether a given turn's input size was cheap or
+     * expensive. See docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md
+     * §2.2/§5.2. Optional because older/other providers (codex/gemini) never
+     * report a cache split at all.
+     */
+    fresh_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
 }
 
 /**
  * Live token counts accumulated during the current turn.
  * input is set from message_start.message.usage.input_tokens.
  * output accumulates from message_delta.usage.output_tokens.
+ * freshInput/cacheCreation/cacheRead: see SessionStats' matching fields —
+ * same breakdown, carried on the live per-turn signal instead of the
+ * finalized one.
  */
 export interface TurnTokens {
     input: number;
     output: number;
+    freshInput?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -487,20 +487,31 @@ export function useAgentStream({
                     const inner = rawEvent.type === "stream_event" ? rawEvent.event : rawEvent;
                     if (inner?.type === "message_start") {
                         // input_tokens is only the uncached prompt; cache_creation/
-                        // cache_read carry the rest of the real prompt size.
+                        // cache_read carry the rest of the real prompt size. Keep
+                        // the split (not just the sum) so downstream state can
+                        // tell a cheap cache-served turn from an expensive fresh
+                        // one — see TurnTokens' doc comment in ../types.ts.
                         const u = inner.message?.usage;
+                        const freshInput = u?.input_tokens as number | undefined;
+                        const cacheCreation = u?.cache_creation_input_tokens as number | undefined;
+                        const cacheRead = u?.cache_read_input_tokens as number | undefined;
                         const inputTok =
-                            u?.input_tokens != null
-                                ? (u.input_tokens as number)
-                                  + ((u.cache_creation_input_tokens as number | undefined) ?? 0)
-                                  + ((u.cache_read_input_tokens as number | undefined) ?? 0)
+                            freshInput != null
+                                ? freshInput + (cacheCreation ?? 0) + (cacheRead ?? 0)
                                 : undefined;
                         if (inputTok != null) {
                             // message.model is the resolved model id (e.g.
                             // "claude-opus-4-8") — used to seed the context-window
                             // meter per model (Opus/Sonnet 1M, Haiku 200K).
                             const modelId = inner.message?.model as string | undefined;
-                            const paneEvents = model.dispatchPane({ type: "TokensIn", input: inputTok, model: modelId });
+                            const paneEvents = model.dispatchPane({
+                                type: "TokensIn",
+                                input: inputTok,
+                                model: modelId,
+                                freshInput,
+                                cacheCreation: cacheCreation ?? 0,
+                                cacheRead: cacheRead ?? 0,
+                            });
                             // Detect context compaction from the reducer's event output.
                             // Primary signal for Claude is the real CompactionBoundary
                             // path above; this heuristic (≥50% token drop from a >10k


### PR DESCRIPTION
## Summary

Both frontend token-usage parse sites (`claude-translator.ts`'s `result` handler and `useAgentStream.ts`'s `message_start` handler) summed Anthropic's four usage fields — `input_tokens` + `cache_creation_input_tokens` + `cache_read_input_tokens` — into one number before anything was stored, discarding the split despite a code comment noting it mattered. That made it impossible to tell after the fact whether a session's input-token total was mostly cheap cache reads (~0.1x cost) or expensive fresh tokens.

- Extends `TurnTokens` / `SessionStats` / the `TokensIn` command / `ServiceUsage` with optional `freshInput` / `cacheCreation` / `cacheRead` (snake_case equivalents on `SessionStats`), threaded additively through both parse sites → the reducer's `TokensIn`/`TokensOut`/`mergeStats`/`accumulateStats` → `useTurnLifecycle`'s `finalizeTurn` → the `token-usage.ts` session store.
- The existing collapsed `input` / `input_tokens` total is unchanged, so every existing consumer keeps working as-is — this is additive only.
- Surfaces a "N% of input served from cache" line in the token breakdown popover once at least one turn has reported the split.
- Full write-up, including compaction's current passive-only architecture and a proposed path to a manual-trigger option (not addressed by this PR): `docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md`.

## Test plan

- [x] `npx vitest run` on the three touched suites (`claude-translator.test.ts`, `reducer.test.ts`, `parseHistoryLines.test.ts`) — 249/249 pass
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] Updated `claude-translator.test.ts`'s exact-equality assertion to include the new breakdown fields
- [ ] Manual verification of the new "N% served from cache" popover line in a live pane (not done — no live Claude session run as part of this PR)

<!-- agentmux:agent_id=agenta -->