### PR TITLE
test: PR notification routing probe (do not merge)

### DIFF
--- a/docs/_test_pr_notification_probe.md
+++ b/docs/_test_pr_notification_probe.md
@@ -1,0 +1,10 @@
+# Test PR — notification routing probe
+
+This is a throwaway file created solely to test that GitHub PR review
+notifications route back to the correct agent (`Lark`) when the PR was
+pushed via the shared `GenericAgentX-asaf` fallback account (no dedicated
+PAT registered on this host) and the `<!-- agentmux:agent_id=lark -->` tag
+is present in the PR body, per `CLAUDE.md`'s MuxBus Identity section.
+
+This PR will be closed without merging once the notification is confirmed.
+Safe to delete.


### PR DESCRIPTION
## Summary
Throwaway test PR to confirm GitHub review notifications route back to the
correct agent when pushed via the shared `GenericAgentX-asaf` fallback
account (no dedicated PAT registered on this host) and the agent_id tag is
present. Will be closed without merging once confirmed.

<!-- agentmux:agent_id=lark -->