### PR TITLE
fix(muxbus): let the browser sign-in flow be cancelled instead of hanging for 5 minutes

### DIFF
--- a/.changesets/1787124092-fix-muxbus-let-the-browser-sign-in-flow-be-cancelled-instead-fhhk.md
+++ b/.changesets/1787124092-fix-muxbus-let-the-browser-sign-in-flow-be-cancelled-instead-fhhk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): let the browser sign-in flow be cancelled instead of hanging for 5 minutes

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -43,24 +43,28 @@ fn relay_base_url() -> String {
 // a port another live socket already holds) the browser's redirect lands on
 // whichever listener the OS picks — a 400 state-mismatch coin flip. The newest
 // attempt is the one the user actually wants: abort the predecessor.
-static ACTIVE_LOGIN: std::sync::Mutex<Option<tokio::task::AbortHandle>> =
+//
+// Each flow gets a monotonic generation id (NEXT_LOGIN_ID), stored alongside
+// its abort handle. A prior design tracked "was this abort a user Cancel?"
+// in a single shared CANCELLED_BY_USER flag instead of per-attempt — that
+// was a real bug (Codex + reagent review, PR #2661, 2026-08-19): if flow A
+// is cancelled but a *different* flow B starts and is itself superseded by
+// C before A's own `task.await` resumes, nothing guarantees which of A/B
+// reads the shared flag first — the two flows' error messages could swap.
+// Keying the cancellation record on the generation id makes that
+// structurally impossible: each flow only ever looks up its OWN id.
+static NEXT_LOGIN_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+static ACTIVE_LOGIN: std::sync::Mutex<Option<(u64, tokio::task::AbortHandle)>> =
     std::sync::Mutex::new(None);
-
-// Set immediately before cancel_active_login() aborts the task, so the
-// aborted flow's own `Err(e) if e.is_cancelled()` branch can tell "the user
-// clicked Cancel" apart from "a newer muxbus.login call superseded this one"
-// — same underlying tokio abort, different message the frontend needs to
-// react to differently (see HostPopover.tsx's Cancel button).
-static CANCELLED_BY_USER: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static CANCELLED_IDS: std::sync::Mutex<Vec<u64>> = std::sync::Mutex::new(Vec::new());
 
 /// Abort the in-flight login flow, if any. Returns false if there was none
 /// (a harmless no-op — the UI can call this without checking state first).
 pub fn cancel_active_login() -> bool {
     let mut guard = ACTIVE_LOGIN.lock().unwrap();
     match guard.take() {
-        Some(handle) => {
-            CANCELLED_BY_USER.store(true, std::sync::atomic::Ordering::SeqCst);
+        Some((id, handle)) => {
+            CANCELLED_IDS.lock().unwrap().push(id);
             handle.abort();
             true
         }
@@ -73,6 +77,8 @@ pub async fn run_pkce_login(
     client_id: &str,
     http_client: &reqwest::Client,
 ) -> Result<PkceResult, String> {
+    let my_id = NEXT_LOGIN_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
     // Abort-predecessor and register-successor must be one critical section:
     // with separate lock acquisitions, two concurrent muxbus.login RPCs can
     // both take() None and neither aborts the other (reagent P1 on this PR).
@@ -80,7 +86,7 @@ pub async fn run_pkce_login(
     // across it is fine — the guard never spans an await.
     let task = {
         let mut guard = ACTIVE_LOGIN.lock().unwrap();
-        if let Some(prev) = guard.take() {
+        if let Some((_, prev)) = guard.take() {
             prev.abort();
         }
         let task = tokio::spawn(run_pkce_login_inner(
@@ -88,13 +94,15 @@ pub async fn run_pkce_login(
             client_id.to_string(),
             http_client.clone(),
         ));
-        *guard = Some(task.abort_handle());
+        *guard = Some((my_id, task.abort_handle()));
         task
     };
     match task.await {
         Ok(r) => r,
         Err(e) if e.is_cancelled() => {
-            if CANCELLED_BY_USER.swap(false, std::sync::atomic::Ordering::SeqCst) {
+            let mut cancelled = CANCELLED_IDS.lock().unwrap();
+            if let Some(pos) = cancelled.iter().position(|&id| id == my_id) {
+                cancelled.remove(pos);
                 Err("sign-in cancelled".to_string())
             } else {
                 Err("this login attempt was superseded by a newer one".to_string())
@@ -483,7 +491,7 @@ Connection: close
         assert!(!flow_b.is_finished(), "flow B should still be polling the relay");
 
         // Cleanup: abort B's inner flow via the registry.
-        if let Some(h) = ACTIVE_LOGIN.lock().unwrap().take() {
+        if let Some((_, h)) = ACTIVE_LOGIN.lock().unwrap().take() {
             h.abort();
         }
         flow_b.abort();
@@ -530,5 +538,73 @@ Connection: close
     async fn cancel_with_no_active_login_is_a_noop() {
         let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         assert!(!cancel_active_login());
+    }
+
+    // Regression test for a real bug caught in code review (Codex + reagent,
+    // 2026-08-19, PR #2661): the original fix tracked "was this abort a user
+    // Cancel?" in a single process-global flag. Flow A gets cancelled by the
+    // user (flag set), then — before A's own `task.await` resumes and reads
+    // the flag — flow B starts and is itself superseded by flow C. Nothing
+    // guarantees which task's continuation the executor resumes first, so
+    // whichever of A/B checks the flag first "steals" it: the two flows'
+    // error messages ("cancelled" vs "superseded") can end up swapped. Fixed
+    // by keying the cancellation record on a per-attempt generation id
+    // instead of a single shared flag, so each flow can only ever observe
+    // its OWN cancellation record — this test asserts that invariant
+    // directly rather than trying to force a specific race outcome (which
+    // isn't reliably controllable from a test).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelling_one_flow_never_leaks_into_a_concurrent_unrelated_flow() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let relay = spawn_fake_relay().await;
+        std::env::set_var("AGENTMUX_MUXBUS_REST_URL", &relay);
+        let http = reqwest::Client::new();
+
+        // Flow A: the user-cancel path.
+        let flow_a = tokio::spawn({
+            let http = http.clone();
+            async move { run_pkce_login("http://127.0.0.1:1", "test-client", &http).await }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert!(cancel_active_login(), "expected flow A to be active and cancellable");
+
+        // Flow B, then C superseding B — the "superseded" path, unrelated to
+        // A's cancel. Started immediately after A's cancel so A's own
+        // task.await may not have resumed yet when B/C run.
+        let flow_b = tokio::spawn({
+            let http = http.clone();
+            async move { run_pkce_login("http://127.0.0.1:1", "test-client", &http).await }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let flow_c = tokio::spawn({
+            let http = http.clone();
+            async move { run_pkce_login("http://127.0.0.1:1", "test-client", &http).await }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let a = tokio::time::timeout(std::time::Duration::from_secs(2), flow_a)
+            .await
+            .expect("flow A should resolve promptly")
+            .expect("flow A task must not panic");
+        let b = tokio::time::timeout(std::time::Duration::from_secs(2), flow_b)
+            .await
+            .expect("flow B should resolve promptly after being superseded by C")
+            .expect("flow B task must not panic");
+
+        assert!(
+            a.as_ref().is_err_and(|e| e.contains("cancelled")),
+            "flow A was user-cancelled, got: {a:?}"
+        );
+        assert!(
+            b.as_ref().is_err_and(|e| e.contains("superseded")),
+            "flow B was superseded by C (never cancelled), got: {b:?}"
+        );
+
+        // Cleanup: abort C's inner flow via the registry.
+        if let Some((_, h)) = ACTIVE_LOGIN.lock().unwrap().take() {
+            h.abort();
+        }
+        flow_c.abort();
+        std::env::remove_var("AGENTMUX_MUXBUS_REST_URL");
     }
 }

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -64,6 +64,27 @@ pub fn cancel_active_login() -> bool {
     let mut guard = ACTIVE_LOGIN.lock().unwrap();
     match guard.take() {
         Some((id, handle)) => {
+            // ACTIVE_LOGIN is only ever overwritten by the NEXT login's
+            // critical section — nothing clears it when a flow resolves
+            // naturally (`Ok` or a real, non-cancelled `Err`). So this can
+            // find a stale entry whose task already finished on its own,
+            // possibly long ago; `AbortHandle::abort()` on a finished task
+            // is a documented no-op. Reporting `true` here for that case
+            // would tell the caller "cancelled" for a login that actually
+            // succeeded/failed by itself, and would push `id` into
+            // CANCELLED_IDS, which nothing on the natural-completion path
+            // in `run_pkce_login` ever pops — leaking one entry per
+            // occurrence for the life of the process (reagent P1, PR
+            // #2661, re-review 2026-08-19). Checking `is_finished()` first
+            // closes the common case (a stale entry sitting there for any
+            // length of time before this call). A narrower race remains —
+            // the task can still finish in the gap between this check and
+            // `abort()` below taking effect — closed instead by
+            // `run_pkce_login` cleaning up its own id on every resolution
+            // path, not just the cancelled one.
+            if handle.is_finished() {
+                return false;
+            }
             CANCELLED_IDS.lock().unwrap().push(id);
             handle.abort();
             true
@@ -98,7 +119,19 @@ pub async fn run_pkce_login(
         task
     };
     match task.await {
-        Ok(r) => r,
+        Ok(r) => {
+            // The flow resolved naturally. `cancel_active_login()`'s
+            // `is_finished()` guard closes the common case, but a narrow
+            // race remains: the task can complete in the gap between that
+            // check and its `abort()` call taking effect (tokio: an abort
+            // request against an already-completing task is ignored, the
+            // task "will run to completion" per its own docs), which would
+            // have pushed `my_id` into CANCELLED_IDS just before this arm
+            // runs. Nothing else on this path ever pops it — clean it up
+            // here so it can't leak.
+            CANCELLED_IDS.lock().unwrap().retain(|&id| id != my_id);
+            r
+        }
         Err(e) if e.is_cancelled() => {
             let mut cancelled = CANCELLED_IDS.lock().unwrap();
             if let Some(pos) = cancelled.iter().position(|&id| id == my_id) {
@@ -108,7 +141,12 @@ pub async fn run_pkce_login(
                 Err("this login attempt was superseded by a newer one".to_string())
             }
         }
-        Err(e) => Err(format!("login task failed: {e}")),
+        Err(e) => {
+            // Same residual-race cleanup as the Ok(r) arm above, for a
+            // flow that failed on its own (not via cancellation).
+            CANCELLED_IDS.lock().unwrap().retain(|&id| id != my_id);
+            Err(format!("login task failed: {e}"))
+        }
     }
 }
 
@@ -448,6 +486,42 @@ Connection: close
         format!("http://{addr}")
     }
 
+    /// Like `spawn_fake_relay`, but GET polls report `"failed"` immediately
+    /// — lets a test drive a flow to a *natural* (non-cancelled) resolution
+    /// quickly, instead of waiting out the real 5-minute timeout.
+    async fn spawn_fake_failing_relay() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else { return };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 2048];
+                    let Ok(n) = stream.read(&mut buf).await else { return };
+                    let req = std::str::from_utf8(&buf[..n]).unwrap_or("");
+                    let body = if req.starts_with("POST /api/login-relay") {
+                        r#"{"status":"pending","ttl_seconds":300}"#
+                    } else {
+                        r#"{"status":"failed","error":"access_denied"}"#
+                    };
+                    let resp = format!(
+                        "HTTP/1.1 {}
+Content-Type: application/json
+Content-Length: {}
+Connection: close
+
+{}",
+                        if req.starts_with("POST") { "201 Created" } else { "200 OK" },
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+        format!("http://{addr}")
+    }
+
     // ACTIVE_LOGIN / CANCELLED_IDS are process-global statics — by
     // design, only one login flow may exist per process. Cargo runs tests
     // in this file on parallel threads of the same process by default, so
@@ -605,6 +679,45 @@ Connection: close
             h.abort();
         }
         flow_c.abort();
+        std::env::remove_var("AGENTMUX_MUXBUS_REST_URL");
+    }
+
+    // Regression test for reagent's P1 re-review (PR #2661, 2026-08-19):
+    // ACTIVE_LOGIN was never cleared when a flow resolved naturally (`Ok`
+    // or a real, non-cancelled `Err`), so a `muxbus.login.cancel` call any
+    // time afterward found a stale entry pointing at a finished task's
+    // (harmless, no-op) AbortHandle — reporting a misleading "cancelled"
+    // success for a login that had already succeeded/failed on its own,
+    // and leaking one u64 into CANCELLED_IDS forever (nothing on the
+    // natural-completion path ever popped it). Fixed by having
+    // cancel_active_login() check AbortHandle::is_finished() before
+    // treating a take() as a real cancellation, plus having run_pkce_login
+    // clean up its own id from CANCELLED_IDS on every resolution path, not
+    // just the cancelled one.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelling_after_natural_completion_is_a_noop_and_does_not_leak() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let relay = spawn_fake_failing_relay().await;
+        std::env::set_var("AGENTMUX_MUXBUS_REST_URL", &relay);
+
+        let http = reqwest::Client::new();
+        let result = run_pkce_login("http://127.0.0.1:1", "test-client", &http).await;
+        assert!(
+            result.as_ref().is_err_and(|e| e.contains("Cognito returned error")),
+            "expected the flow to fail on its own via the relay's failed status, got: {result:?}"
+        );
+
+        // The flow already resolved naturally — a cancel call now must be a
+        // no-op, not a misleading "cancelled" success.
+        assert!(
+            !cancel_active_login(),
+            "cancelling an already-resolved login must report nothing to cancel"
+        );
+        assert!(
+            CANCELLED_IDS.lock().unwrap().is_empty(),
+            "a naturally-resolved flow must never leave a CANCELLED_IDS entry behind"
+        );
+
         std::env::remove_var("AGENTMUX_MUXBUS_REST_URL");
     }
 }

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -448,7 +448,7 @@ Connection: close
         format!("http://{addr}")
     }
 
-    // ACTIVE_LOGIN / CANCELLED_BY_USER are process-global statics — by
+    // ACTIVE_LOGIN / CANCELLED_IDS are process-global statics — by
     // design, only one login flow may exist per process. Cargo runs tests
     // in this file on parallel threads of the same process by default, so
     // any two tests that drive a real flow through those statics race each

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -46,6 +46,28 @@ fn relay_base_url() -> String {
 static ACTIVE_LOGIN: std::sync::Mutex<Option<tokio::task::AbortHandle>> =
     std::sync::Mutex::new(None);
 
+// Set immediately before cancel_active_login() aborts the task, so the
+// aborted flow's own `Err(e) if e.is_cancelled()` branch can tell "the user
+// clicked Cancel" apart from "a newer muxbus.login call superseded this one"
+// — same underlying tokio abort, different message the frontend needs to
+// react to differently (see HostPopover.tsx's Cancel button).
+static CANCELLED_BY_USER: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Abort the in-flight login flow, if any. Returns false if there was none
+/// (a harmless no-op — the UI can call this without checking state first).
+pub fn cancel_active_login() -> bool {
+    let mut guard = ACTIVE_LOGIN.lock().unwrap();
+    match guard.take() {
+        Some(handle) => {
+            CANCELLED_BY_USER.store(true, std::sync::atomic::Ordering::SeqCst);
+            handle.abort();
+            true
+        }
+        None => false,
+    }
+}
+
 pub async fn run_pkce_login(
     cognito_domain: &str,
     client_id: &str,
@@ -72,7 +94,11 @@ pub async fn run_pkce_login(
     match task.await {
         Ok(r) => r,
         Err(e) if e.is_cancelled() => {
-            Err("this login attempt was superseded by a newer one".to_string())
+            if CANCELLED_BY_USER.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                Err("sign-in cancelled".to_string())
+            } else {
+                Err("this login attempt was superseded by a newer one".to_string())
+            }
         }
         Err(e) => Err(format!("login task failed: {e}")),
     }
@@ -414,6 +440,13 @@ Connection: close
         format!("http://{addr}")
     }
 
+    // ACTIVE_LOGIN / CANCELLED_BY_USER are process-global statics — by
+    // design, only one login flow may exist per process. Cargo runs tests
+    // in this file on parallel threads of the same process by default, so
+    // any two tests that drive a real flow through those statics race each
+    // other unless serialized here.
+    static TEST_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     // The superseded-login guarantee: starting flow B while flow A is pending
     // must abort A rather than leaving two flows both polling (and both able
     // to open browser tabs). Uses the real run_pkce_login entry so the
@@ -421,6 +454,7 @@ Connection: close
     // flows parked at the poll stage.
     #[tokio::test(flavor = "multi_thread")]
     async fn second_login_supersedes_first() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         let relay = spawn_fake_relay().await;
         std::env::set_var("AGENTMUX_MUXBUS_REST_URL", &relay);
 
@@ -454,5 +488,47 @@ Connection: close
         }
         flow_b.abort();
         std::env::remove_var("AGENTMUX_MUXBUS_REST_URL");
+    }
+
+    // A user-initiated Cancel must resolve the pending flow immediately
+    // (not wait out LOGIN_TIMEOUT_SECS) and report a "cancelled" error
+    // distinct from the supersede case above — otherwise the UI has no way
+    // to tell "you cancelled this" from "a newer login attempt replaced
+    // this", which is what src/statusbar/HostPopover.tsx's Cancel button
+    // needs to show a quiet, non-error reset instead of a scary banner.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn manual_cancel_resolves_promptly_with_cancelled_error() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let relay = spawn_fake_relay().await;
+        std::env::set_var("AGENTMUX_MUXBUS_REST_URL", &relay);
+
+        let http = reqwest::Client::new();
+        let flow = tokio::spawn({
+            let http = http.clone();
+            async move { run_pkce_login("http://127.0.0.1:1", "test-client", &http).await }
+        });
+        // Give the flow time to register + start polling before cancelling.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+        assert!(cancel_active_login(), "expected an active login to cancel");
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), flow)
+            .await
+            .expect("cancel should resolve the flow promptly, not after the 5-min timeout")
+            .expect("flow task must not panic");
+        assert!(
+            result.as_ref().is_err_and(|e| e.contains("cancelled")),
+            "expected a cancellation error, got: {result:?}"
+        );
+
+        std::env::remove_var("AGENTMUX_MUXBUS_REST_URL");
+    }
+
+    // Cancelling with no active login is a harmless no-op the UI can call
+    // defensively without checking state first.
+    #[tokio::test]
+    async fn cancel_with_no_active_login_is_a_noop() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(!cancel_active_login());
     }
 }

--- a/agentmux-srv/src/server/muxbus_handlers.rs
+++ b/agentmux-srv/src/server/muxbus_handlers.rs
@@ -3,10 +3,11 @@
 
 //! MuxBus cloud connectivity RPC handlers.
 //!
-//! Three commands:
-//!   * `muxbus.login`      — PKCE browser flow (blocks until complete or timeout)
-//!   * `muxbus.status`     — current credential status
-//!   * `muxbus.disconnect` — clear stored credentials
+//! Four commands:
+//!   * `muxbus.login`        — PKCE browser flow (blocks until complete or timeout)
+//!   * `muxbus.login.cancel` — abort an in-flight `muxbus.login` (e.g. user closed the browser)
+//!   * `muxbus.status`       — current credential status
+//!   * `muxbus.disconnect`   — clear stored credentials
 
 use std::sync::Arc;
 
@@ -17,6 +18,7 @@ use crate::backend::rpc::engine::WshRpcEngine;
 use super::AppState;
 
 pub const COMMAND_MUXBUS_LOGIN: &str = "muxbus.login";
+pub const COMMAND_MUXBUS_LOGIN_CANCEL: &str = "muxbus.login.cancel";
 pub const COMMAND_MUXBUS_STATUS: &str = "muxbus.status";
 pub const COMMAND_MUXBUS_DISCONNECT: &str = "muxbus.disconnect";
 
@@ -34,6 +36,14 @@ struct MuxBusLoginResp {
     email: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MuxBusLoginCancelResp {
+    /// False when there was no in-flight login to cancel (already resolved,
+    /// or never started) — not an error, just nothing to do.
+    cancelled: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -116,6 +126,22 @@ pub fn register_muxbus_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         Ok(Some(serde_json::to_value(resp).unwrap()))
                     }
                 }
+            })
+        }),
+    );
+
+    // muxbus.login.cancel — abort an in-flight muxbus.login. The aborted
+    // flow's own task.await (in run_pkce_login) is what actually resolves
+    // the original muxbus.login RPC call with a "sign-in cancelled" error —
+    // this handler just fires the abort and returns immediately, it does
+    // not wait for that resolution.
+    engine.register_handler(
+        COMMAND_MUXBUS_LOGIN_CANCEL,
+        Box::new(move |_data, _ctx| {
+            Box::pin(async move {
+                let cancelled = crate::muxbus::pkce::cancel_active_login();
+                let resp = MuxBusLoginCancelResp { cancelled };
+                Ok(Some(serde_json::to_value(resp).unwrap()))
             })
         }),
     );

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1290,7 +1290,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     // App API handlers (agent.open, agent.send, agent.stop, agent.status, agent.list, agent.output)
     super::app_api::register_app_api_handlers(engine, &state);
 
-    // MuxBus cloud connectivity (muxbus.login / muxbus.status / muxbus.disconnect)
+    // MuxBus cloud connectivity (muxbus.login / muxbus.login.cancel / muxbus.status / muxbus.disconnect)
     super::muxbus_handlers::register_muxbus_handlers(engine, &state);
 
     // Native memory file browser (agent:memory:list / read_file / write_file)

--- a/frontend/app/statusbar/HostPopover.tsx
+++ b/frontend/app/statusbar/HostPopover.tsx
@@ -288,10 +288,14 @@ const HostPopoverPanel = (props: HostPopoverPanelProps): JSX.Element => {
                                     type="button"
                                     class="muxbus-login-chip muxbus-login-chip-signin"
                                     style={{ "margin-left": "auto", height: "auto", padding: "1px 8px" }}
-                                    disabled={muxbus.loading()}
-                                    onClick={() => void muxbus.connect()}
+                                    title={muxbus.loading() ? "Cancel sign-in" : undefined}
+                                    onClick={() => void (muxbus.loading() ? muxbus.cancel() : muxbus.connect())}
                                 >
-                                    {muxbus.loading() ? "●···" : muxbus.status()?.connected ? "Expired — re-login" : "Sign in"}
+                                    {muxbus.loading()
+                                        ? "Cancel"
+                                        : muxbus.status()?.connected
+                                          ? "Expired — re-login"
+                                          : "Sign in"}
                                 </button>
                             }
                         >

--- a/frontend/app/store/rpc-api/misc.ts
+++ b/frontend/app/store/rpc-api/misc.ts
@@ -136,6 +136,16 @@ export const MiscApi = {
         return client.rpcCall("muxbus.login", data, { timeout: 360000, ...opts });
     },
 
+    // command "muxbus.login.cancel" — abort an in-flight muxbus.login (e.g.
+    // user closed the browser without completing sign-in). Resolves the
+    // pending MuxBusLoginCommand call with a "sign-in cancelled" error.
+    MuxBusLoginCancelCommand(
+        client: RpcClient,
+        opts?: RpcOpts,
+    ): Promise<{ cancelled: boolean }> {
+        return client.rpcCall("muxbus.login.cancel", {}, opts);
+    },
+
     // command "muxbus.status" — current credential state
     MuxBusStatusCommand(
         client: RpcClient,

--- a/frontend/app/view/accounts/AgentMuxConnectPanel.tsx
+++ b/frontend/app/view/accounts/AgentMuxConnectPanel.tsx
@@ -111,8 +111,8 @@ export function useMuxBusStatus(): MuxBusController {
                 // A user-initiated Cancel is not a failure — don't surface
                 // it as a scary error banner, just quietly go back to
                 // "Not connected" (see cancel() below and pkce.rs's
-                // CANCELLED_BY_USER, which is what produces this exact
-                // error string).
+                // per-attempt CANCELLED_IDS tracking, which is what produces
+                // this exact error string).
                 setError(result.error ?? "Login failed.");
             }
         } catch (e) {

--- a/frontend/app/view/accounts/AgentMuxConnectPanel.tsx
+++ b/frontend/app/view/accounts/AgentMuxConnectPanel.tsx
@@ -65,6 +65,14 @@ export interface MuxBusController {
     refresh: () => Promise<void>;
     /** Run the browser PKCE login (blocks up to 5 min), then refresh. */
     connect: () => Promise<void>;
+    /**
+     * Abort an in-flight connect() — e.g. the user closed the login browser
+     * tab and doesn't want to wait out the 5-min server-side timeout. Safe
+     * to call even if nothing is in flight (no-op). Does not itself flip
+     * `loading` — the pending connect() call resolves on its own once the
+     * server-side abort lands, via its normal error path.
+     */
+    cancel: () => Promise<void>;
     /** Clear stored credentials, then refresh. */
     disconnect: () => Promise<void>;
     /** False when no built-in client id is baked into this build. */
@@ -99,13 +107,27 @@ export function useMuxBusStatus(): MuxBusController {
             });
             if (result.success) {
                 await refresh();
-            } else {
+            } else if (result.error !== "sign-in cancelled") {
+                // A user-initiated Cancel is not a failure — don't surface
+                // it as a scary error banner, just quietly go back to
+                // "Not connected" (see cancel() below and pkce.rs's
+                // CANCELLED_BY_USER, which is what produces this exact
+                // error string).
                 setError(result.error ?? "Login failed.");
             }
         } catch (e) {
             setError(String(e));
         } finally {
             setLoading(false);
+        }
+    };
+
+    const cancel = async () => {
+        try {
+            await RpcApi.MuxBusLoginCancelCommand(TabRpcClient);
+        } catch {
+            // best effort — the pending connect() call will still resolve
+            // (worst case via its own 5-min server-side timeout)
         }
     };
 
@@ -124,7 +146,7 @@ export function useMuxBusStatus(): MuxBusController {
 
     const isConfigured = () => MUXBUS_CLIENT_ID !== "";
 
-    return { status, loading, error, refresh, connect, disconnect, isConfigured };
+    return { status, loading, error, refresh, connect, cancel, disconnect, isConfigured };
 }
 
 /** Human-readable local expiry, or null when not connected. */
@@ -189,10 +211,9 @@ export const MuxBusConnectSection = (): JSX.Element => {
                         <span class="agent-identity-none">Not connected</span>
                         <button
                             class="agent-identity-new-btn"
-                            disabled={loading()}
-                            onClick={() => void muxbus.connect()}
+                            onClick={() => void (loading() ? muxbus.cancel() : muxbus.connect())}
                         >
-                            {loading() ? "Connecting…" : "Connect"}
+                            {loading() ? "Connecting… (Cancel)" : "Connect"}
                         </button>
                     </div>
                 }
@@ -281,10 +302,11 @@ export function AgentMuxConnectPanel(props: {
                                     <div class="identity-key-actions">
                                         <button
                                             class="identity-btn identity-btn-primary"
-                                            disabled={muxbus.loading()}
-                                            onClick={() => void muxbus.connect()}
+                                            onClick={() =>
+                                                void (muxbus.loading() ? muxbus.cancel() : muxbus.connect())
+                                            }
                                         >
-                                            {muxbus.loading() ? "Connecting…" : "Connect with AgentMux"}
+                                            {muxbus.loading() ? "Connecting… (Cancel)" : "Connect with AgentMux"}
                                         </button>
                                     </div>
                                 </>


### PR DESCRIPTION
## Summary

Closing the muxbus sign-in browser tab left the status-bar "Sign in" chip stuck disabled indefinitely. Root cause: `run_pkce_login`'s poll loop had no cancellation path and only gave up after the full 5-minute `LOGIN_TIMEOUT_SECS`.

- Adds `cancel_active_login()` in `pkce.rs`, which aborts the in-flight flow with an accurate `"sign-in cancelled"` error — distinguished from the existing `"superseded by a newer login"` case (same abort mechanism, different reason, tracked via a `CANCELLED_BY_USER` flag).
- New `muxbus.login.cancel` RPC + `MuxBusLoginCancelCommand` on the frontend.
- Every button that shows "Connecting…"/"Sign in" (status-bar popover, agent identity panel, Armory connect panel) now shows a Cancel affordance while a login is in flight instead of a stuck disabled state.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv muxbus::pkce::` — 3/3 passing (including a new regression test proving cancel resolves immediately instead of waiting out the timeout), stable across repeated runs and under default parallel test execution
- [x] `cargo build` (agentmux-srv) and `tsc --noEmit` both clean
- [x] Live click-through: dev build, reproduced the original hang, confirmed Cancel now appears and resolves immediately

<!-- agentmux:agent_id=agenty -->