### PR TITLE
chore: release v0.55.16

### DIFF
--- a/.changesets/1787098345-fix-ci-nightly-artifacts-build-delegates-to-reusable-build-y-wno9.md
+++ b/.changesets/1787098345-fix-ci-nightly-artifacts-build-delegates-to-reusable-build-y-wno9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): nightly artifacts build delegates to reusable build-*.yml workflows

--- a/.changesets/1787102240-fix-agent-pane-preserve-cache-read-cache-creation-token-brea-xzy9.md
+++ b/.changesets/1787102240-fix-agent-pane-preserve-cache-read-cache-creation-token-brea-xzy9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): preserve cache-read/cache-creation token breakdown instead of collapsing it into input_tokens

--- a/.changesets/1787104458-feat-agent-pane-add-manual-compact-now-trigger-for-claude-se-eudr.md
+++ b/.changesets/1787104458-feat-agent-pane-add-manual-compact-now-trigger-for-claude-se-eudr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): add manual 'Compact now' trigger for Claude sessions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.15"
+version = "0.55.16"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.15"
+version = "0.55.16"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.15"
+version = "0.55.16"
 dependencies = [
  "base64",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.15"
+version = "0.55.16"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.15"
+version = "0.55.16"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.15"
+version = "0.55.16"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.15"
+version = "0.55.16"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,12 @@
 # AgentMux Version History
 
+## 0.55.16 — 2026-08-19
+
+- fix(ci): nightly artifacts build delegates to reusable build-*.yml workflows
+- fix(agent-pane): preserve cache-read/cache-creation token breakdown instead of collapsing it into input_tokens
+- feat(agent-pane): add manual 'Compact now' trigger for Claude sessions
+
+
 ## 0.55.15 — 2026-08-18
 
 - fix(agent-pane): stop the CLI's own tool_result echo from clobbering an answered AskUserQuestion's answerText

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.15",
+  "version": "0.55.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.15",
+      "version": "0.55.16",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.15",
+  "version": "0.55.16",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming the 3 pending changesets, forced to a **patch** bump (`--as patch`) per explicit request even though the compact-trigger changeset was `minor` — that feature ships under this patch version.

- fix(ci): nightly artifacts build delegates to reusable build-*.yml workflows
- fix(agent-pane): preserve cache-read/cache-creation token breakdown instead of collapsing it into input_tokens (#2658)
- feat(agent-pane): add manual 'Compact now' trigger for Claude sessions (#2659)

`0.55.15` → `0.55.16`. All 5 version-consistency locations agree (`package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`, `VERSION_HISTORY.md`).

## Test plan

- [x] `scripts/release.sh --as patch` — clean, all 5 version locations verified in sync by the script itself
- [x] No source changes in this PR (version bump + changeset consumption only)

<!-- agentmux:agent_id=agenta -->