### PR TITLE
fix(srv): bump sysinfo 0.34→0.35 to fix CreateToolhelp32Snapshot handle leak

### DIFF
--- a/.changesets/1787152102-fix-srv-bump-sysinfo-to-0-35-to-fix-createtoolhelp32snapshot-nbgb.md
+++ b/.changesets/1787152102-fix-srv-bump-sysinfo-to-0-35-to-fix-createtoolhelp32snapshot-nbgb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): bump sysinfo to 0.35 to fix CreateToolhelp32Snapshot handle leak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1871,7 +1871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2497,7 +2497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2507,7 +2507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3017,6 +3017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,7 +3080,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4290,14 +4300,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.34.2"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
+ "objc2-io-kit",
  "windows",
 ]
 
@@ -5250,24 +5261,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5276,22 +5300,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5299,17 +5323,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5329,17 +5342,33 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5348,7 +5377,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5357,7 +5395,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5402,7 +5440,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5442,7 +5480,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5451,6 +5489,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -32,7 +32,7 @@ libc = "0.2"
 whoami = "1"
 async-stream = "0.3"
 portable-pty = "0.9"
-sysinfo = "0.34"
+sysinfo = "0.35"
 parking_lot = "0.12"
 notify = "7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -590,6 +590,55 @@ mod handle_anomaly_tests {
         assert!(count.is_some_and(|c| c > 0), "got {count:?}");
     }
 
+    /// Regression test for the `sysinfo` v0.34.2 `CreateToolhelp32Snapshot`
+    /// handle leak (docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md,
+    /// docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md).
+    /// That version's Windows `refresh_processes_specifics` never closed the
+    /// handle it got from `CreateToolhelp32Snapshot`, leaking one `Section`
+    /// object (kernel-charged, pagefile-backed) per call — invisible to this
+    /// process's own working-set/private-bytes, only visible as a climbing
+    /// `GetProcessHandleCount`. Repeats the exact call pattern
+    /// `run_sysinfo_loop` makes per tick (`ProcessesToUpdate::All`, the light
+    /// refresh kind used for the parent-link pass) many times and asserts
+    /// this process's own handle count does NOT grow linearly with call
+    /// count — a fixed `sysinfo` leaks ~0 handles/call; the broken 0.34.2
+    /// leaked exactly 1/call, so 500 calls would have shown +500, not "a
+    /// small bounded amount from unrelated one-time OS/runtime activity."
+    #[test]
+    fn refresh_processes_specifics_does_not_leak_a_handle_per_call() {
+        let pid = std::process::id();
+        let mut sys = sysinfo::System::new();
+        // Warm up: first call(s) can allocate one-time bookkeeping (e.g. the
+        // process list's initial capacity) that isn't part of the per-call
+        // leak this test is checking for.
+        for _ in 0..5 {
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::All,
+                false,
+                ProcessRefreshKind::nothing(),
+            );
+        }
+        let before = process_handle_count(pid).expect("own handle count must be queryable");
+
+        const CALLS: u32 = 500;
+        for _ in 0..CALLS {
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::All,
+                false,
+                ProcessRefreshKind::nothing(),
+            );
+        }
+        let after = process_handle_count(pid).expect("own handle count must be queryable");
+
+        let grew_by = after.saturating_sub(before);
+        assert!(
+            grew_by < CALLS / 2,
+            "handle count grew by {grew_by} over {CALLS} refresh_processes_specifics calls \
+             (before={before}, after={after}) — consistent with a per-call handle leak \
+             (the fixed-in-0.35.0 CreateToolhelp32Snapshot bug leaked exactly 1/call)"
+        );
+    }
+
     fn anomaly(pid: u32) -> HandleAnomaly {
         HandleAnomaly { pid, name: format!("proc{pid}.exe"), handles: 99_999, is_agentmux: false }
     }

--- a/docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md
+++ b/docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md
@@ -1,0 +1,314 @@
+# Status: Live Recurrence of the `agentmux-srv` Section Handle Leak — Windows 11 (2026-08-19)
+
+**This is a follow-up to `docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md`
+(still open, unpatched).** Today's investigation started from a user report
+framed as "AgentMux causes growing Page File pressure on Windows 11; Windows
+10 doesn't have it" and a request to check repo history. This doc (a) answers
+the Win10-vs-Win11 framing directly, (b) reports a live, current-day
+reproduction of the exact 2026-08-08 fingerprint on this machine, and (c)
+consolidates the full history across all three related investigation threads
+so this doesn't need re-discovering again.
+
+> **Update, same day — ROOT CAUSE CONFIRMED, source-level.** §7 below pins
+> the exact bug: the vendored `sysinfo` crate v0.34.2 (agentmux-srv's pinned
+> version) never closes the Windows handle it obtains from
+> `CreateToolhelp32Snapshot` in its `refresh_processes_specifics` — on any
+> code path — and that handle is backed by a kernel `Section` object. Fixed
+> upstream between sysinfo v0.34.2 and v0.35.0 (confirmed by reading both
+> versions' source directly). **No code archaeology or live tracing was
+> needed to close this — it's a one-line-summary dependency bug: bump
+> `sysinfo` to ≥0.35.0 (latest stable: 0.39.6).** See §7 for full evidence
+> chain and §8 for the recommended fix.
+
+**Status: ROOT CAUSE CONFIRMED (§7) AND FIX APPLIED + VERIFIED (§8), same
+day — `sysinfo` bumped 0.34→0.35, build+tests pass, and a new regression
+test proved broken-vs-fixed on this exact code (fails against 0.34.2, passes
+against 0.35.2). PR pending. No restart of the live, already-leaking
+production instance investigated in §3 was performed or is needed — the fix
+lands in a new build; the existing leaked instance still needs a normal
+restart/update to pick it up, same as any other fix.**
+
+## 1. Does Windows 11 specifically leak, and Windows 10 doesn't?
+
+**No evidence of an OS-version-gated code path exists, in either direction.**
+`git grep` across `agentmux-srv` and `agentmux-cef` for `IsWindows11OrGreater`,
+`IsWindows10OrGreater`, `RtlGetVersion`, `dwBuildNumber`, or any OS-version
+branch returns **zero matches** — the app has no Windows-version-conditional
+logic at all. The one place in the repo that reasons explicitly about a
+Win10/Win11 split, `docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md`,
+found the **opposite** direction (a Windows 10 machine hit OOM-abort crashes
+from a *shrunk* pagefile ceiling) and its own conclusion (§4) was explicit:
+*"Not a kernel-version bug... the dominant lever is environmental (free disk
+→ pagefile growth)."*
+
+The most likely explanation for the user's own Win10-clean / Win11-affected
+observation: the leak mechanisms found below scale with **process uptime and
+usage pattern** (handle count climbs continuously the longer `agentmux-srv`
+runs), not OS version — two machines with different typical session lengths,
+pane counts, or background-service topology will show very different symptom
+severity by coincidence, independent of which Windows version they run. The
+one *confirmed, fixed* Windows-11-specific bug in the repo
+(`docs/retro/retro-windows-terminal-window-leak-2026-06-21.md` — missing
+`CREATE_NO_WINDOW` caused Win11's DefTerm to pop a visible Terminal window
+per CLI/LSP spawn) is real and Windows-11-specific, but it leaks **window
+handles/UX clutter**, not commit/page-file — a different mechanism, already
+fixed in commit `b76ecd1e4`.
+
+## 2. Full history (three independent threads, chronological)
+
+1. **2026-07-02 → 2026-07-16 — GPU/driver renderer-pool commit.** Every pane's
+   isolated Chromium `RequestContext` costs the GPU driver ~1 GB of invisible,
+   kernel-charged, pagefile-backed commit. Confirmed *not* a leak (07-16:
+   closing AgentMux instantly released 43.6 GB) — it's a live floor that
+   ratchets up because pooled renderers weren't torn down on pane close.
+   Tracked as issue **#2218**; fixed by PRs **#2220/#2221/#2222** (shipped
+   v0.54.4). `--disable-gpu` was explicitly rejected as a mitigation (owner
+   policy: GPU stays enabled). See `docs/retro/retro-commit-charge-pagefile-growth-2026-07-02.md`
+   and `docs/retro/retro-commit-restart-reclaim-2026-07-16.md`.
+2. **2026-07-24 → 2026-07-25 — Audiosrv (OS-level, unrelated to AgentMux).**
+   A ~55 KB, 16-section investigation (`docs/status/STATUS_PF_COMMIT_GROWTH_INVESTIGATION_2026_07_24.md`)
+   chased ~800 MB/hour of unattributed commit growth through several dead
+   ends (including reproducing an apparently-identical pattern in plain MS
+   Edge) before finding, via a handle-count sweep, that Windows' own
+   `Audiosrv` (Windows Audio service) was leaking ~1 pagefile-backed
+   `Section` handle/sec (~17 GB/day) — invisible to any per-process memory
+   view because Sections aren't charged to a process's private bytes.
+   `Restart-Service Audiosrv` reclaimed 16.4 GB in ~9 seconds. **AgentMux was
+   fully exonerated** in this thread. Likely trigger: an always-on audio
+   interface (unconfirmed, never conclusively pinned, judged out of
+   AgentMux's scope). This doc is also where the Windows-vs-macOS framing was
+   first raised (§4) as "highest-value open thread" — it was never actually
+   executed before the investigation resolved via the Audiosrv path instead.
+3. **2026-08-08 → 2026-08-09 — `agentmux-srv` itself leaking Section handles.
+   STILL OPEN.** This time the leak is inside AgentMux's own backend process,
+   not an OS service — same fingerprint as Audiosrv (near-100% anonymous
+   `Section` handles) but a different, unpinned cause. See §3 below: this is
+   what reproduced live today.
+
+## 3. Live reproduction, this machine, today (2026-08-19)
+
+- **System commit: 2149 MB free / 186,899 MB total — 98.9% used**, confirmed
+  two ways: raw `Win32_OperatingSystem`/`Win32_PageFileUsage` WMI counters,
+  and AgentMux's own `muxlog mem` doctor (agrees: "98.9% used → ok" — worth
+  noting the tool doesn't yet flag this level as a problem itself).
+- Two `agentmux-srv` instances were running side by side, different versions
+  and uptimes — a natural A/B pair:
+
+  | PID | Build | Started | Total handles | `Section` handles | Threads | Private MB |
+  |---|---|---|---|---|---|---|
+  | 30088 | 0.55.10 | Sun Aug 16 | **517,490** | **500,106 (96.6%)** | 70 | 267 |
+  | 74924 | 0.55.15 | Tue Aug 18 | 8,662 | 2,817 (32.5%) | 53 | 161 |
+
+  (Full `handle64 -s` breakdown for PID 30088: Section 500,106, File 8,281,
+  Semaphore 8,231, Process 355, Thread 160, Event 117, everything else
+  small. GDI/USER object counts for both `agentmux-srv` PIDs are ~0/1 —
+  this is **not** a GDI or window-handle leak, ruling out any connection to
+  the fixed Terminal-window bug from §1.)
+- **This is the identical fingerprint to the 2026-08-08 finding**
+  (`agentmux-srv-0.54.10`, PID 45728, 215,705 handles, 99.5% Section) —
+  same process, same handle type, same near-total-anonymous pattern — just a
+  newer version (0.55.10 vs 0.54.10) and a higher absolute count (11 days of
+  no fix + longer uptime on this instance).
+- **Live growth measured directly, this session:** two `HandleCount`
+  snapshots 30 seconds apart on PID 30088: 517,363 → 517,377 (**+14 in 31s,
+  ≈ 27/min, ≈ 39,000/day** at that instant). This is the same order of
+  magnitude as 08-08's lifetime-average rate (0.87/sec ≈ 75,000/day) and its
+  live-sampled rate (up to 2.4/sec) — consistent with the same ongoing bug,
+  not a new/different one.
+- Event-log check (`Get-WinEvent`, Application log) found only older,
+  unrelated crashes (`agentmux-cef.exe`/`libcef.dll` faults from July, an
+  `agentmux-0.46.6` hang from June) — no direct corroboration there, but
+  nothing contradicting this either; these predate the version in question.
+- `muxlog srv grep mem_attribution` — the telemetry the 07-24/08-08 docs
+  proposed building to make exactly this kind of gap self-diagnosing —
+  returned **no matching lines** on this machine/version. Worth checking
+  whether that instrumentation (referenced in `CLAUDE.md`'s muxlog table,
+  commit `4b809d477`/PR #2483 per the 08-08 doc's own notes) actually shipped
+  and is emitting, or whether it's present but silent under current
+  conditions, or whether it never fully landed. Not chased further this
+  session — flagged as the first thing to check before assuming new
+  telemetry needs to be built from scratch.
+
+## 4. Root cause: CONFIRMED — see §7
+
+(Superseded — this section originally said "not pinned." The investigation
+continued the same day; §7 has the full evidence chain. Left here only so
+the doc's own history is legible: the leading hypothesis below turned out to
+be correct, just needed one more step — reading `sysinfo`'s actual vendored
+source instead of stopping at "it keeps file descriptors open for
+performance.")
+
+Per the 08-08 doc, `memmap2` and `portable-pty` were ruled out by source
+inspection (neither calls `CreateFileMapping`/`Section` APIs on Windows).
+The leading hypothesis was the `sysinfo` crate (v0.34.2)'s whole-machine
+process-refresh calls in `agentmux-srv/src/backend/sysinfo.rs` — correct,
+confirmed below.
+
+## 5. Recommended next steps (superseded by §8 — kept for the record)
+
+~~1. Check whether `mem_attribution` telemetry is actually live~~ — still
+worth doing, unrelated to the fix.
+~~2. Pin the exact leaking call via controlled bisection~~ — **not needed in
+the end; reading the dependency's source directly was faster and more
+precise than a bisection experiment would have been.**
+3. A graceful srv-only restart path still does not exist — still relevant,
+see §8.
+4. Playbook note — still valid, kept for future recurrences of a *different*
+mechanism.
+
+## 6. Tools used (for reproducibility)
+
+- `Get-CimInstance Win32_OperatingSystem` / `Win32_PageFileUsage` — system
+  commit/page-file totals.
+- `Get-Process` + `GetGuiResources` (P/Invoke via `Add-Type`) — per-process
+  handle/GDI/USER counts across all `agentmux*` processes at once.
+- Sysinternals `handle64.exe -accepteula -s -p <pid>` — handle-type
+  breakdown by object type (already present at
+  `%LOCALAPPDATA%\Temp\handle64.exe` on this machine from a prior session;
+  not vendored in the repo).
+- `node ~/.agentmux/shell/muxlog.mjs mem` and `... srv cat --grep <re>` —
+  AgentMux's own built-in memory doctor and log search.
+
+## 7. Root cause — confirmed, source-level (same day, follow-up)
+
+**The bug: `sysinfo` v0.34.2's Windows backend leaks one kernel `Section`
+handle on every single call to `refresh_processes_specifics`.** No live
+tracing, bisection, or debugger attach was needed — reading the actual
+vendored dependency source directly gave a complete, unambiguous answer.
+
+**The exact code** (found locally at
+`~/.cargo/registry/src/index.crates.io-.../sysinfo-0.34.2/src/windows/system.rs`,
+lines 232–301 — this is the literal source Cargo compiles into
+`agentmux-srv` per the pinned `sysinfo = "0.34"` in `agentmux-srv/Cargo.toml`):
+
+```rust
+let snapshot = match unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) } {
+    Ok(handle) => handle,
+    Err(_err) => {
+        sysinfo_debug!(/* ... */);
+        return 0;                    // ← leaks: no cleanup on this path
+    }
+};
+// ... Process32FirstW/Process32NextW loop using `snapshot` ...
+num_procs                            // ← leaks: no cleanup on this path either
+```
+
+**`snapshot` is a plain `windows::Win32::Foundation::HANDLE`** (imported
+directly, confirmed via the file's `use` block) — a non-owning, `Copy`,
+`repr(transparent)` newtype with no `Drop` implementation. `CloseHandle` is
+never called on it anywhere in the file or the rest of the crate (confirmed
+by grepping every `CloseHandle` call site in the vendored source — the only
+two hits are for an unrelated `event` handle in `cpu.rs` and a `HandleWrapper`
+type in `utils.rs` that the crate authors clearly know to use elsewhere, just
+not here). Every single call — success or either error path — leaks the
+handle `CreateToolhelp32Snapshot` returned.
+
+**Why this produces exactly the observed symptom:**
+- `CreateToolhelp32Snapshot`'s returned handle is Microsoft-documented to
+  require `CloseHandle`
+  ("[Snapshots of the System](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/ToolHelp/snapshots-of-the-system.md)":
+  *"If you do not destroy a snapshot, the process will leak memory until it
+  exits."*) — the failure mode is a leak that only clears on process exit,
+  matching every restart-reclaims-it observation in both this doc and 08-08.
+- The handle type this API leaks is independently, publicly documented as
+  `Section`-backed — this is the exact same fingerprint (near-100% anonymous
+  `Section` handles) found on 2026-08-08 and reproduced live today (§3).
+- **An independent, previously-published confirmation of the identical bug
+  pattern exists**: [RUSTSEC-2025-0125](https://osv.dev/vulnerability/RUSTSEC-2025-0125),
+  filed against the unrelated `thread-amount` crate, describes the *exact*
+  same mistake — calling `CreateToolhelp32Snapshot` without a matching
+  `CloseHandle` — with the advisory's own words: *"Repeated calls to this
+  function will cause the handle count of the process to grow indefinitely,
+  eventually leading to system instability or process termination when the
+  handle limit is reached."* This is not a novel or exotic bug class; it's a
+  known Rust/Windows footgun that has bitten more than one crate.
+- **Call-frequency arithmetic matches the observed leak rate.** In
+  `agentmux-srv/src/backend/sysinfo.rs`'s `run_sysinfo_loop` (the loop that's
+  been running continuously since srv started), `sys.refresh_processes_specifics(...)`
+  is called via **two separate call sites every single main-loop tick**
+  (default 1s, configurable 0.2–2s via `telemetry:interval`): once for the
+  light `ProcessesToUpdate::All` pass (line ~984, populates parent links) and
+  once for the targeted `ProcessesToUpdate::Some(&all_pids)` pass (line
+  ~1014, per-pane CPU/mem). **Both funnel through the same buggy function** —
+  Windows' toolhelp API has no "snapshot just these PIDs" mode, so even the
+  "targeted" call still does a full `CreateToolhelp32Snapshot` internally and
+  filters client-side. A third call site fires every 30s in
+  `log_memory_attribution` (the attribution feature literally built to
+  diagnose this exact leak class — see the doc comment at
+  `sysinfo.rs:126-138`, itself now retroactively describing its own root
+  cause). A fourth, lower-frequency call site exists in
+  `backend/reactive/registry.rs`'s `pid_alive()` helper (on-demand, not a
+  fixed loop). At the default 1s interval: **~2 leaked handles/sec from the
+  main loop alone ≈ 172,800/day** — the right order of magnitude against
+  §3's live-measured ~27/min (≈39,000/day at that instant) and the 08-08
+  doc's lifetime-average 0.87/sec (≈75,000/day); exact rate varies with
+  configured interval, pane count (more panes → more PIDs in the targeted
+  pass, but the snapshot cost is dominated by the fixed per-call leak, not
+  pane count), and how long the urgent-attribution path (10s cooldown) fires
+  under pressure.
+
+**Confirmed fixed upstream, and the exact version range pinned:**
+- `sysinfo` v0.34.2 (our pinned version) — **broken**, confirmed by reading
+  the actual vendored source (above).
+- `sysinfo` v0.35.0 — **fixed**, confirmed by fetching that tag's
+  `src/windows/system.rs` directly: the handle is wrapped
+  (`let snapshot = unsafe { Owned::new(snapshot) };` with the comment *"This
+  owns the above handle and makes sure that close will be called when
+  dropped"*) — a `windows`-crate RAII wrapper that closes on every path,
+  including both early returns, automatically.
+- `sysinfo` v0.36.0 and current `main` (latest release 0.39.6 at time of
+  writing) — also fixed, same `Owned` wrapper pattern, confirmed by fetching
+  both directly.
+- The changelog's one Windows-leak entry ("Windows: Fix resource leak",
+  v0.27.7) is a different, much older fix — already included in our 0.34.2,
+  unrelated to this bug. No changelog entry explicitly documents *this* fix
+  by name; it was found by direct source diffing, not changelog reading.
+
+## 8. Fix applied — 2026-08-19, same day
+
+**Bumped `sysinfo` from `"0.34"` to `"0.35"`** in `agentmux-srv/Cargo.toml`
+(→ `0.35.2` in `Cargo.lock`) — deliberately the minimal fixed version, not
+current stable `0.39.6`: **`sysinfo` 0.39.x requires Rust 1.95**, ahead of
+this machine's toolchain (`rustc 1.93.0`); CI's `dtolnay/rust-toolchain@stable`
+would likely satisfy that, but `0.35.2` gets the exact fix with zero MSRV
+change and a far smaller `Cargo.lock` diff (avoids an unrelated `windows`
+crate 0.57→0.62 major-version churn that came bundled with jumping straight
+to 0.39.6). Revisit the `0.39` upgrade separately, unbundled from this fix,
+once the toolchain question is resolved.
+
+**Verification performed, all before opening the PR:**
+1. `cargo build -p agentmux-srv` (release profile) — clean build, only
+   pre-existing dead-code warnings unrelated to this change.
+2. `cargo test -p agentmux-srv --bin agentmux-srv backend::sysinfo::` — all
+   15 existing tests in the module pass unchanged, including
+   `log_memory_attribution_runs_against_the_real_process_table_without_panicking`
+   (exercises the exact fixed code path against the real Win32 process
+   table).
+3. **Added a new regression test**,
+   `refresh_processes_specifics_does_not_leak_a_handle_per_call` — calls
+   `sys.refresh_processes_specifics(ProcessesToUpdate::All, ...)` 500 times
+   (the same call `run_sysinfo_loop` makes every tick) and asserts this
+   process's own `GetProcessHandleCount` doesn't grow linearly with call
+   count.
+4. **Proved the test is a real discriminator, not just a green checkmark**:
+   temporarily re-pinned to the broken `sysinfo = "0.34.2"`, rebuilt, and
+   reran the new test — **it failed**, reporting *"handle count grew by 506
+   over 500 refresh_processes_specifics calls"* — essentially exactly 1
+   handle leaked per call, an exact match to the theorized mechanism in §7.
+   Restored the `0.35` pin and reran — passes clean. This is the closing
+   data point neither this doc's earlier draft nor the 08-08 doc were able
+   to collect (no restart/rebuild had been performed against the live
+   instance under investigation) — a controlled, repeatable, broken-vs-fixed
+   A/B on the exact same code, not just an upstream changelog claim.
+
+This also closes out `docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md`
+— same bug, same fix, now landing via PR (see that doc for the original
+live-incident details this fix resolves).
+
+**Not yet done** (out of scope for this fix, tracked as future work): a
+multi-hour live-production soak test confirming `handle64 -s -p <pid>` stays
+flat on a real running instance over the timescales the original incidents
+took to become severe (hours to days) — the 500-call synthetic test above is
+a fast, reliable proxy (proven to discriminate broken/fixed) but is not a
+substitute for confirming in the actual `run_sysinfo_loop` production
+context over real uptime.


### PR DESCRIPTION
## Summary

`sysinfo` v0.34.2's Windows `refresh_processes_specifics()` never closes the
handle it gets from `CreateToolhelp32Snapshot` — on any code path (success
or either early-return error branch). That handle is backed by a kernel
`Section` object, so every call leaks one — invisible to the process's own
working-set/private-bytes, only visible as a climbing
`GetProcessHandleCount`.

This is the confirmed root cause of
`docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md` (still open) and
today's live recurrence,
`docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md`
(§7 has the full evidence chain — direct read of the vendored dependency
source, cross-checked against Microsoft's own docs and an independent
RustSec advisory for the identical bug pattern in a different crate). Live
on this machine at time of writing: one `agentmux-srv` instance at 517K
total handles, 500K of them `Section` — a 3-day-old process, still growing
(~27 handles/min measured live).

`run_sysinfo_loop` calls `refresh_processes_specifics` ~2×/tick (default 1s
interval) plus once more every 30s in the commit-attribution pass — so this
leaks continuously for the lifetime of every `agentmux-srv` process,
eventually contributing to system-wide page-file/commit exhaustion.

## Fix

Bump `sysinfo` `"0.34"` → `"0.35"` in `agentmux-srv/Cargo.toml`. Confirmed
via direct source comparison that the handle-close fix (an `Owned` RAII
wrapper) landed between 0.34.2 and 0.35.0. Deliberately targeting the
minimum fixed version rather than current stable (0.39.6) — that version
requires Rust 1.95, ahead of this repo's toolchain, and pulls in an
unrelated `windows` crate 0.57→0.62 major bump. A follow-up 0.39 upgrade can
happen separately once the toolchain question is resolved.

## Verification

- `cargo build -p agentmux-srv` (release) — clean.
- `cargo test -p agentmux-srv --bin agentmux-srv backend::sysinfo::` — all
  15 existing tests pass unchanged.
- **New regression test**,
  `refresh_processes_specifics_does_not_leak_a_handle_per_call` — calls
  `refresh_processes_specifics` 500× (the same pattern `run_sysinfo_loop`
  uses) and asserts the process's own handle count doesn't grow linearly.
- **Proved the test is a real discriminator**: temporarily re-pinned to the
  broken `sysinfo = "0.34.2"` and reran — it fails, reporting *"handle count
  grew by 506 over 500 calls"* (≈ exactly 1/call, matching the theorized
  mechanism exactly). Restored `0.35` — passes clean.

Not done in this PR (tracked as follow-up in the status doc): a multi-hour
live-production soak test confirming `handle64 -s -p <pid>`'s `Section`
count stays flat on a real running instance over realistic uptime — the
500-call synthetic test is a fast, proven-accurate proxy but not a
substitute for confirming in the actual production loop over hours/days.

## Test plan

- [x] `cargo build -p agentmux-srv`
- [x] `cargo test -p agentmux-srv --bin agentmux-srv backend::sysinfo::`
- [x] New regression test passes against the fix, fails against the bug
- [ ] Live soak test on a real instance (follow-up, not blocking)

<!-- agentmux:agent_id=agentx -->