### PR TITLE
feat(settings): add missing waiting-for-input tone enable toggle + volume slider

### DIFF
--- a/.changesets/1787170368-feat-settings-add-missing-waiting-for-input-tone-enable-togg-cfyo.md
+++ b/.changesets/1787170368-feat-settings-add-missing-waiting-for-input-tone-enable-togg-cfyo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(settings): add missing waiting-for-input tone enable toggle + volume slider

--- a/frontend/app/view/settings/sections/sounds-section.tsx
+++ b/frontend/app/view/settings/sections/sounds-section.tsx
@@ -12,6 +12,7 @@ export function SoundsSection(): JSX.Element {
     const s = () => settingsAtom() ?? ({} as any);
     const soundsEnabled = () => s()["notify:sounds:enabled"] !== false;
     const toolTonesEnabled = () => s()["notify:tooltones:enabled"] !== false;
+    const waitingToneEnabled = () => s()["notify:sound:agent.waiting.for.input"] !== false;
 
     return (
         <div class="settings-section-body">
@@ -130,6 +131,25 @@ export function SoundsSection(): JSX.Element {
                             <option value="all">All panes</option>
                             <option value="focused">Focused pane only</option>
                         </select>
+                    }
+                />
+            </Show>
+            <SectionHeader label="Waiting for input" />
+            <SettingRow
+                label="Enable"
+                description="Play a looping ambient tone while an agent pane is blocked waiting for your input"
+                control={<ToggleControl checked={waitingToneEnabled()} onChange={(v) => set("notify:sound:agent.waiting.for.input", v)} />}
+            />
+            <Show when={waitingToneEnabled()}>
+                <SettingRow
+                    indent
+                    label="Volume"
+                    control={
+                        <SliderControl
+                            min={0} max={1} step={0.05}
+                            value={(s()["notify:sounds:waiting:volume"] as number) ?? 0.25}
+                            onChange={(v) => set("notify:sounds:waiting:volume", v)}
+                        />
                     }
                 />
             </Show>


### PR DESCRIPTION
## Summary
`notify:sound:agent.waiting.for.input` (per-event enable) and `notify:sounds:waiting:volume` were both fully wired end-to-end already (`sound-service.ts` gates/reads them) but had zero Settings UI — only the master notification-sounds and tool-tones categories got rows. Adds a "Waiting for input" subsection to the Sounds section, matching the existing "Tool-call tones" structure (SectionHeader, Enable toggle, nested Volume slider).

Settings audit candidate #6 — `docs/specs/SPEC_SETTINGS_AUDIT_GOOD_PICKINGS_2026_08_19.md`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/view/settings` — 6/6 passing

<!-- agentmux:agent_id=agent2 -->