### PR TITLE
feat(settings): make the AskUserQuestion auto-answer timeout user-configurable

### DIFF
--- a/.changesets/1787170999-feat-settings-make-the-askuserquestion-auto-answer-timeout-u-14b4.md
+++ b/.changesets/1787170999-feat-settings-make-the-askuserquestion-auto-answer-timeout-u-14b4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(settings): make the AskUserQuestion auto-answer timeout user-configurable

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -8,14 +8,15 @@
  * single- or multi-select options plus a free-text "Other", and submits the
  * answer so the caller can deliver it back to the agent as a tool_result.
  *
- * Also runs a 30s auto-timeout so an unanswered question can never block the
- * agent's turn forever: any question the user hasn't touched by zero is
+ * Also runs an auto-timeout (default 30s, user-configurable via
+ * `agent:askquestiontimeoutms`) so an unanswered question can never block
+ * the agent's turn forever: any question the user hasn't touched by zero is
  * filled in with its recommended option and the (possibly-merged) answer is
  * submitted automatically. See §2.3 for why this merges rather than
  * disarming on first interaction. Hovering the panel hides the countdown and
  * pauses the underlying deadline for a flat 15s from that hover, then
- * unconditionally resumes at a fresh 30s regardless of whether the mouse is
- * still there — a bounded, self-resuming pause, not the permanent disarm
+ * unconditionally resumes at a fresh timeout regardless of whether the mouse
+ * is still there — a bounded, self-resuming pause, not the permanent disarm
  * §2.3/§5.1 rejected. See the hover-pause spec above.
  *
  * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md,
@@ -26,17 +27,19 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
+import { getSettingsKeyAtom } from "@/app/store/global";
 import type { AskUserQuestionAnswer, AskUserQuestionOption, AskUserQuestionRequest, ToolNode } from "../types";
 import "./AgentQuestionPanel.scss";
 
-/** How long an AskUserQuestion panel waits for a human before auto-selecting
- *  the recommended option(s) and submitting. Hardcoded per
- *  SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §5.2 — not user-
- *  configurable in v1. */
-const AUTO_TIMEOUT_MS = 30_000;
+/** Fallback when `agent:askquestiontimeoutms` is unset — see
+ *  `autoTimeoutMs()` inside the component. Was a hardcoded constant per
+ *  SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §5.2 ("not user-
+ *  configurable in v1... a reasonable follow-up if requested later"); now
+ *  user-configurable, this is only the default. */
+const DEFAULT_AUTO_TIMEOUT_MS = 30_000;
 
 /** How long the countdown stays hidden after a hover into the panel, before
- *  an unanswered question-set's timer resumes (fresh AUTO_TIMEOUT_MS, not
+ *  an unanswered question-set's timer resumes (fresh autoTimeoutMs(), not
  *  resumed from wherever it was paused) — a flat window timed from the
  *  triggering `mouseenter`, unconditional regardless of whether the mouse is
  *  still over the panel when it elapses. See
@@ -112,11 +115,20 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     const queueDepth = () => props.pending().length;
     const request = (): AskUserQuestionRequest | null => head()?.question ?? null;
 
+    /** `agent:askquestiontimeoutms` if set to a positive number, else
+     *  `DEFAULT_AUTO_TIMEOUT_MS`. Read fresh at every re-arm point below
+     *  (not cached) so a mid-session settings change takes effect on the
+     *  next question rather than requiring a reload. */
+    const autoTimeoutMs = (): number => {
+        const v = getSettingsKeyAtom("agent:askquestiontimeoutms")();
+        return typeof v === "number" && v > 0 ? v : DEFAULT_AUTO_TIMEOUT_MS;
+    };
+
     const [minimized, setMinimized] = createSignal(false);
     const [state, setState] = createSignal<QState[]>([]);
     /** Milliseconds left before the auto-timeout fires. See the timer effect
      *  below (defined after `submit`, once all its dependencies exist). */
-    const [remainingMs, setRemainingMs] = createSignal(AUTO_TIMEOUT_MS);
+    const [remainingMs, setRemainingMs] = createSignal(autoTimeoutMs());
     /** True while the countdown is suppressed by a recent hover. Drives both
      *  the UI (rendered nothing while true, §3.4 of the hover-pause spec)
      *  and whether the timer effect below is armed. Bounded, NOT tied to
@@ -147,7 +159,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         void r?.tool_use_id; // touch so the effect re-runs on change
         setMinimized(false);
         setState((r?.questions ?? []).map(() => ({ selected: [], other: "" })));
-        setRemainingMs(AUTO_TIMEOUT_MS);
+        setRemainingMs(autoTimeoutMs());
         clearHideTimer();
         setHidden(false);
     });
@@ -181,7 +193,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         setHidden(true);
         hideTimeoutId = setTimeout(() => {
             hideTimeoutId = undefined;
-            setHidden(false); // timer effect below re-arms at a fresh AUTO_TIMEOUT_MS
+            setHidden(false); // timer effect below re-arms at a fresh autoTimeoutMs()
         }, HOVER_HIDE_GRACE_MS);
     };
 
@@ -309,7 +321,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     // Gated on `hidden()` (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md
     // §3.3): this is a *live, strictly bounded* pause, not a permanent
     // disarm — a hover starts a flat HOVER_HIDE_GRACE_MS window, and once it
-    // elapses this effect re-runs and re-arms at a fresh AUTO_TIMEOUT_MS
+    // elapses this effect re-runs and re-arms at a fresh autoTimeoutMs()
     // UNCONDITIONALLY, regardless of whether the mouse is still over the
     // panel (see onPanelPointerEnter's doc comment and spec §9 for why —
     // an earlier, rejected version of this stayed hidden for as long as the
@@ -327,7 +339,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         void r?.tool_use_id; // touch so the effect re-runs on change, same as the reset effect
         if (!r || hidden()) return; // paused while hidden; re-arms when hidden() flips false
 
-        setRemainingMs(AUTO_TIMEOUT_MS); // fresh retrigger, not resumed from wherever it was paused
+        setRemainingMs(autoTimeoutMs()); // fresh retrigger, not resumed from wherever it was paused
         const intervalId = setInterval(() => {
             setRemainingMs((prev) => {
                 if (prev <= 1000) {

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -24,7 +24,7 @@
  * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md.
  */
 
-import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, untrack, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { getSettingsKeyAtom } from "@/app/store/global";
@@ -118,9 +118,22 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     /** `agent:askquestiontimeoutms` if set to a positive number, else
      *  `DEFAULT_AUTO_TIMEOUT_MS`. Read fresh at every re-arm point below
      *  (not cached) so a mid-session settings change takes effect on the
-     *  next question rather than requiring a reload. */
+     *  next question rather than requiring a reload.
+     *
+     *  `untrack`ed deliberately: every call site below lives inside a
+     *  `createEffect` keyed on `tool_use_id`/`hidden()`, not on this
+     *  setting. Without `untrack`, Solid registers the settings read as a
+     *  dependency of whichever enclosing effect calls this — so the
+     *  question-reset effect (which unconditionally wipes `state`/
+     *  `minimized`/`hidden` — "keyed on tool_use_id so we never inherit a
+     *  prior question's selections") would ALSO re-run and discard an
+     *  in-progress answer whenever the user merely adjusted this setting
+     *  in Settings -> Advanced, unrelated to any new question arriving.
+     *  Confirmed independently by reagent (P1) and Codex (P2) on PR #2670.
+     *  `untrack` here still reads the CURRENT value at each call — it only
+     *  stops that read from being treated as a reactive trigger. */
     const autoTimeoutMs = (): number => {
-        const v = getSettingsKeyAtom("agent:askquestiontimeoutms")();
+        const v = untrack(() => getSettingsKeyAtom("agent:askquestiontimeoutms")());
         return typeof v === "number" && v > 0 ? v : DEFAULT_AUTO_TIMEOUT_MS;
     };
 

--- a/frontend/app/view/settings/sections/advanced-section.tsx
+++ b/frontend/app/view/settings/sections/advanced-section.tsx
@@ -24,6 +24,22 @@ export function AdvancedSection(): JSX.Element {
                     />
                 }
             />
+            <SectionHeader label="Agent panes" />
+            <SettingRow
+                label="Auto-answer timeout"
+                description="Seconds an AskUserQuestion panel waits for you before auto-selecting the recommended option(s)"
+                control={
+                    <input
+                        class="setting-number setting-number--wide"
+                        type="number" min={1}
+                        value={((s()["agent:askquestiontimeoutms"] as number) ?? 30000) / 1000}
+                        onBlur={(e) => {
+                            const v = parseFloat(e.currentTarget.value);
+                            if (!isNaN(v) && v >= 1) set("agent:askquestiontimeoutms", Math.round(v * 1000));
+                        }}
+                    />
+                }
+            />
             <SectionHeader label="Widgets" />
             <SettingRow
                 label="Icon-only widget labels"

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1698,6 +1698,7 @@ declare global {
         "dnd:enabled"?: boolean;
         "dnd:concurrency"?: number;
         "dnd:agentinserttoken"?: boolean;
+        "agent:askquestiontimeoutms"?: number;
     };
 
     // waveobj.StickerClickOptsType

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -292,6 +292,12 @@
           "type": "boolean",
           "default": true,
           "description": "Insert a file-reference token into the composer on drop (in addition to attaching the file). Default true."
+        },
+        "agent:askquestiontimeoutms": {
+          "type": "integer",
+          "minimum": 1000,
+          "default": 30000,
+          "description": "How long an AskUserQuestion panel waits for a human before auto-selecting the recommended option(s) and submitting, in milliseconds. Default 30000 (30s). See docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md §5.2."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
Was a hardcoded 30s constant, explicitly flagged as a spec-anticipated follow-up per `SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md` §5.2: *"a per-user or per-agent override is a reasonable follow-up if requested later... nothing here blocks adding one afterward."*

- New setting `agent:askquestiontimeoutms` (integer ms, default 30000, minimum 1000).
- Frontend-only — no Rust struct field, following the same precedent as the existing `dnd:*` settings (schema + `gotypes.d.ts` only, no `types.rs` change needed since nothing server-side reads it).
- Exposed in Settings → Advanced as a seconds-based numeric input, matching the existing `telemetry:interval`/`telemetry:numpoints` pattern in that section.
- The hover-pause grace window (`HOVER_HIDE_GRACE_MS`, 15s) stays hardcoded — only the auto-timeout itself was named as the anticipated injection point in the original spec.

Settings audit candidate #5 — `docs/specs/SPEC_SETTINGS_AUDIT_GOOD_PICKINGS_2026_08_19.md`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/view/agent/components/AgentQuestionPanel.test.tsx` — 21/21 passing (unchanged timing behavior, confirms the default-fallback path is exercised correctly by all existing 30s-timing tests)
- [x] `npx vitest run frontend/app/view/settings` — 6/6 passing
- [x] `schema/settings.json` validated as parseable JSON after the edit

<!-- agentmux:agent_id=agent2 -->