### PR TITLE
fix(swarm): robust dispatch attribution and formalized session lifecycle

### DIFF
--- a/.changesets/1787196269-fix-swarm-robust-dispatch-attribution-and-formalized-session-n5fp.md
+++ b/.changesets/1787196269-fix-swarm-robust-dispatch-attribution-and-formalized-session-n5fp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): robust dispatch attribution and formalized session lifecycle

--- a/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
@@ -627,26 +627,24 @@ impl SubagentWatcher {
         state.info.member_count = state.journal_started.max(state.member_files);
         state.info.members_done = state.journal_results.max(state.members_completed);
         state.info.last_event_at = now_millis();
-        Self::refresh_dispatch_status(state);
+        // Called only in response to genuinely NEW member evidence (a spawn
+        // or a completion just landed) — always allowed to recompute, even
+        // overriding a prior Abandoned, mirroring the existing SubAgent-level
+        // precedent that a late-arriving Result always wins
+        // (`reconcile_stale_subagents_then_late_result_line_ends_completed_
+        // not_stuck_abandoned`). Codex P2 on PR #2677: an earlier version of
+        // this guard was unconditional (also applied here), permanently
+        // stranding a dispatch at Abandoned even once every member had
+        // actually finished. See `refresh_dispatch_status`'s own doc comment
+        // for why the READ-ONLY path (list_dispatches) still needs the guard.
+        Self::recompute_dispatch_status(state);
     }
 
     /// Counts-complete + 60s quiet ⇒ Completed. There is no timer: the flip
     /// happens lazily at the next event or ListDispatches read. `started ==
     /// results` alone is not terminal — it also holds between phases of a
     /// still-running workflow, hence the quiet window.
-    ///
-    /// `Abandoned` is terminal and never recomputed here — early return.
-    /// `reconcile_stale_subagents` is the ONLY writer of `Abandoned`
-    /// (SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2),
-    /// and `list_dispatches()` calls this function on every single read
-    /// (not just on new events) — without this guard, the very next
-    /// `ListDispatches` RPC after a reconciliation pass would silently
-    /// overwrite Abandoned back to Running/Completed based on counts alone,
-    /// discarding the reconciliation before any client ever observed it.
-    pub(super) fn refresh_dispatch_status(state: &mut DispatchState) {
-        if state.info.status == DispatchStatus::Abandoned {
-            return;
-        }
+    pub(super) fn recompute_dispatch_status(state: &mut DispatchState) {
         let counts_complete = state.info.member_count > 0
             && state.info.members_done >= state.info.member_count;
         let quiet = now_millis().saturating_sub(state.info.last_event_at) > 60_000;
@@ -655,6 +653,24 @@ impl SubagentWatcher {
         } else {
             DispatchStatus::Running
         };
+    }
+
+    /// Read-only variant for `list_dispatches()` — `Abandoned` is terminal
+    /// and never recomputed here, since this call has no new evidence
+    /// (unlike `refresh_dispatch_info`'s call to `recompute_dispatch_status`
+    /// above, triggered by a genuinely new member event). `reconcile_stale_
+    /// subagents` is the ONLY writer of `Abandoned`
+    /// (SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2),
+    /// and `list_dispatches()` calls this on every single read (not just on
+    /// new events) — without this guard, the very next `ListDispatches` RPC
+    /// after a reconciliation pass would silently overwrite Abandoned back
+    /// to Running/Completed based on counts alone, discarding the
+    /// reconciliation before any client ever observed it.
+    pub(super) fn refresh_dispatch_status(state: &mut DispatchState) {
+        if state.info.status == DispatchStatus::Abandoned {
+            return;
+        }
+        Self::recompute_dispatch_status(state);
     }
 
     pub(super) fn broadcast_dispatch_updated(&self, info: &AgentDispatch) {

--- a/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
@@ -634,7 +634,19 @@ impl SubagentWatcher {
     /// happens lazily at the next event or ListDispatches read. `started ==
     /// results` alone is not terminal — it also holds between phases of a
     /// still-running workflow, hence the quiet window.
+    ///
+    /// `Abandoned` is terminal and never recomputed here — early return.
+    /// `reconcile_stale_subagents` is the ONLY writer of `Abandoned`
+    /// (SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2),
+    /// and `list_dispatches()` calls this function on every single read
+    /// (not just on new events) — without this guard, the very next
+    /// `ListDispatches` RPC after a reconciliation pass would silently
+    /// overwrite Abandoned back to Running/Completed based on counts alone,
+    /// discarding the reconciliation before any client ever observed it.
     pub(super) fn refresh_dispatch_status(state: &mut DispatchState) {
+        if state.info.status == DispatchStatus::Abandoned {
+            return;
+        }
         let counts_complete = state.info.member_count > 0
             && state.info.members_done >= state.info.member_count;
         let quiet = now_millis().saturating_sub(state.info.last_event_at) > 60_000;

--- a/agentmux-srv/src/backend/subagent_watcher/query.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/query.rs
@@ -62,7 +62,17 @@ impl SubagentWatcher {
         if !sub.dispatch_id.starts_with("solo:") {
             return None;
         }
-        let done = matches!(sub.status, SubAgentStatus::Completed | SubAgentStatus::Abandoned);
+        // A solo dispatch's status mirrors its one member's directly — the
+        // member IS the dispatch, no separate aggregation to compute. Kept
+        // as three distinct arms (not `done as usize` collapsing Completed/
+        // Abandoned together) so a dead dispatch reads as Abandoned, not
+        // ambiguously "Completed," in the UI. See
+        // docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2.
+        let (status, done) = match sub.status {
+            SubAgentStatus::Completed => (DispatchStatus::Completed, true),
+            SubAgentStatus::Abandoned => (DispatchStatus::Abandoned, true),
+            SubAgentStatus::Active => (DispatchStatus::Running, false),
+        };
         Some(AgentDispatch {
             dispatch_id: sub.dispatch_id.clone(),
             kind: DispatchKind::Solo,
@@ -71,7 +81,7 @@ impl SubagentWatcher {
             session_id: sub.session_id.clone(),
             member_count: 1,
             members_done: done as usize,
-            status: if done { DispatchStatus::Completed } else { DispatchStatus::Running },
+            status,
             last_event_at: sub.last_event_at,
             // A solo dispatch's name IS its one member's display_name — no
             // separate dispatch_name storage needed for the Solo kind (only

--- a/agentmux-srv/src/backend/subagent_watcher/scan.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/scan.rs
@@ -237,6 +237,25 @@ impl SubagentWatcher {
                 if dispatch_id.starts_with("solo:") {
                     continue;
                 }
+                let Some(state) = dispatches.get_mut(dispatch_id) else { continue };
+                // reagent P2 on PR #2677: `statuses` only reflects members
+                // currently visible in `session.subagents` — a member whose
+                // JSONL file the filesystem watcher hasn't picked up yet
+                // (an async notify/debounce lag racing this exact
+                // reconciliation pass) is invisible here, so `all_done`
+                // could be true against an INCOMPLETE member set. Cross-
+                // check against the dispatch's own authoritative
+                // `member_count` (tracked separately via journal_started/
+                // member_files) — only trust `all_done` when we've actually
+                // seen status for every member the dispatch itself believes
+                // exist. Under-counting here is safe (skip this round, the
+                // next new-evidence event or reconciliation pass reruns
+                // this check with a fuller picture) — over-counting would
+                // risk abandoning a dispatch with a member reconciliation
+                // hasn't even observed yet.
+                if statuses.len() < state.info.member_count {
+                    continue;
+                }
                 let all_done = statuses
                     .iter()
                     .all(|s| matches!(s, SubAgentStatus::Completed | SubAgentStatus::Abandoned));
@@ -244,18 +263,16 @@ impl SubagentWatcher {
                 if !(all_done && any_abandoned) {
                     continue;
                 }
-                if let Some(state) = dispatches.get_mut(dispatch_id) {
-                    if state.info.status != DispatchStatus::Abandoned {
-                        state.info.status = DispatchStatus::Abandoned;
-                        tracing::info!(
-                            dispatch_id = %dispatch_id,
-                            parent_block_id = %parent_block_id,
-                            session_id = %session_id,
-                            member_count = statuses.len(),
-                            "dispatch reconciled: -> abandoned (all members done, at least one abandoned)"
-                        );
-                        updated.push(state.info.clone());
-                    }
+                if state.info.status != DispatchStatus::Abandoned {
+                    state.info.status = DispatchStatus::Abandoned;
+                    tracing::info!(
+                        dispatch_id = %dispatch_id,
+                        parent_block_id = %parent_block_id,
+                        session_id = %session_id,
+                        member_count = statuses.len(),
+                        "dispatch reconciled: -> abandoned (all members done, at least one abandoned)"
+                    );
+                    updated.push(state.info.clone());
                 }
             }
             updated

--- a/agentmux-srv/src/backend/subagent_watcher/scan.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/scan.rs
@@ -7,6 +7,7 @@
 //! parent's turn is confirmed idle), `broadcast_subagents_abandoned`, and
 //! `scan_subagents_dir` (the capped cold-backfill file walk).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
@@ -86,41 +87,89 @@ impl SubagentWatcher {
     /// started yet, so every subagent found on disk predates this process
     /// and is unambiguously history, not in-flight.
     ///
-    /// Only reconciles on a *confirmed-idle* read (`Some(false)`) —
-    /// `unwrap_or(true)` treats "no controller registered yet" or any
-    /// other uncertainty as "assume active, don't touch it," matching the
-    /// same conservative bias `ReconcileTurnActive` uses on the frontend
-    /// (only ever promote/correct on positive evidence, never guess).
+    /// Only reconciles on a *confirmed-idle* read (`Some(false)`).
+    /// `Some(true)` (confirmed active) skips with no follow-up — correct,
+    /// nothing to reconcile. `None` ("no controller registered yet") used
+    /// to be folded into the same "assume active, don't touch it" bucket as
+    /// confirmed-active, permanently — a previously-flagged, unconfirmed
+    /// race (`SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md`
+    /// §5 Open Question 2) where this call site, reached from
+    /// `scan_session_subagents` at pane-reopen backfill time, can run
+    /// before the freshly-spawned controller has registered in
+    /// `CONTROLLER_REGISTRY`. Left unresolved, an entry hitting that race
+    /// stayed `Active`-looking forever, since nothing else ever revisits it
+    /// (see `SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md`
+    /// §2, mechanism 4). Fixed by treating `None` as "retry once, don't
+    /// give up silently" (`retry_reconcile_once`) instead of a terminal
+    /// no-op — still conservative (a genuine `Some(true)` never retries;
+    /// only the single ambiguous case does, and only once).
     /// Called from two places as of SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_
     /// RETIRE_2026_07_20 Phase A: `scan_session_subagents` (reopen/backfill,
     /// unchanged) and `blockcontroller::persistent`'s turn-end hook (live —
     /// closes docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md
     /// Open Question 1, which deliberately deferred real-time wiring).
     /// `pub(crate)` so the live call site (a different module) can reach it.
+    /// Thin entry point — always allows the one `None`-case retry described
+    /// above. The retry itself calls `reconcile_stale_subagents_impl`
+    /// directly with `allow_retry: false`, so a still-`None` second attempt
+    /// gives up rather than chaining into an unbounded retry loop.
     pub(crate) fn reconcile_stale_subagents(&self, parent_block_id: &str, session_id: &str) {
-        let parent_turn_active =
-            crate::backend::blockcontroller::get_block_controller_status(parent_block_id)
-                .map(|s| s.turn_active)
-                .unwrap_or(true);
-        if parent_turn_active {
-            // reagent (PR #2143 round 1): info!, not debug! — see the note on
-            // the backfill log above; the default production filter drops
-            // debug-level lines, which would make this and the pass-summary
-            // log below invisible in a normally-running srv.
-            tracing::info!(
-                parent_block_id = %parent_block_id,
-                session_id = %session_id,
-                "reconcile_stale_subagents: parent turn active (or unknown) — nothing to reconcile"
-            );
-            return;
+        self.reconcile_stale_subagents_impl(parent_block_id, session_id, true);
+    }
+
+    // pub(super), not private — `tests.rs` (a sibling module, not a
+    // descendant of `scan`) needs to call this directly with
+    // `allow_retry: false` to test the exhausted-retry path without
+    // depending on a real spawned watcher's tokio::spawn actually firing.
+    pub(super) fn reconcile_stale_subagents_impl(&self, parent_block_id: &str, session_id: &str, allow_retry: bool) {
+        let turn_active = crate::backend::blockcontroller::get_block_controller_status(parent_block_id)
+            .map(|s| s.turn_active);
+        match turn_active {
+            Some(true) => {
+                tracing::info!(
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    "reconcile_stale_subagents: parent turn active — nothing to reconcile"
+                );
+                return;
+            }
+            None if allow_retry => {
+                tracing::info!(
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    "reconcile_stale_subagents: controller not yet registered — retrying once, not skipping silently"
+                );
+                self.retry_reconcile_once(parent_block_id, session_id);
+                return;
+            }
+            None => {
+                tracing::info!(
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    "reconcile_stale_subagents: controller still not registered after retry — giving up (bounded to one retry)"
+                );
+                return;
+            }
+            Some(false) => {} // confirmed idle — proceed below
         }
 
-        // Scoped so the `sessions` lock is released before broadcasting
-        // below — `broadcast_subagents_abandoned` doesn't need it, and this
-        // call site can now run live (Phase A), not just at reopen, so
-        // holding the lock any longer than the mutation itself is
-        // unnecessary contention against the live filesystem watcher.
-        let reconciled_agent_ids: Vec<String> = {
+        // Scoped so the `sessions` lock is released before broadcasting (or
+        // touching `self.dispatches`, a separate mutex — never held at the
+        // same time as `sessions` anywhere in this function, to avoid any
+        // lock-ordering deadlock risk against other call sites) below —
+        // `broadcast_subagents_abandoned` doesn't need it, and this call
+        // site can now run live (Phase A), not just at reopen, so holding
+        // the lock any longer than the mutation itself is unnecessary
+        // contention against the live filesystem watcher.
+        //
+        // Alongside `reconciled_agent_ids`, also snapshot every member's
+        // (dispatch_id, status) for this block — not just the ones just
+        // reconciled — so the Workflow-dispatch aggregation pass below has
+        // the full picture per dispatch_id, not just this pass's deltas.
+        let (reconciled_agent_ids, member_statuses_by_dispatch): (
+            Vec<String>,
+            HashMap<String, Vec<SubAgentStatus>>,
+        ) = {
             let mut sessions = self.sessions.lock().unwrap();
             let Some(session) = sessions.get_mut(session_id) else { return };
             // A session's subagent map can hold entries from a DIFFERENT block —
@@ -134,6 +183,8 @@ impl SubagentWatcher {
             // owns (mirrors unwatch_agent's own parent-scoped filter). Reagent
             // P1 on PR #2131.
             let mut reconciled_agent_ids = Vec::new();
+            let mut member_statuses_by_dispatch: HashMap<String, Vec<SubAgentStatus>> =
+                std::collections::HashMap::new();
             for state in session.subagents.values_mut() {
                 if state.info.parent_block_id != parent_block_id {
                     continue;
@@ -155,8 +206,12 @@ impl SubagentWatcher {
                         "subagent reconciled: active -> abandoned (parent turn ended)"
                     );
                 }
+                member_statuses_by_dispatch
+                    .entry(state.info.dispatch_id.clone())
+                    .or_default()
+                    .push(state.info.status.clone());
             }
-            reconciled_agent_ids
+            (reconciled_agent_ids, member_statuses_by_dispatch)
         };
         if !reconciled_agent_ids.is_empty() {
             tracing::info!(
@@ -167,6 +222,75 @@ impl SubagentWatcher {
             );
             self.broadcast_subagents_abandoned(parent_block_id, &reconciled_agent_ids);
         }
+
+        // Propagate to the owning Workflow-kind `AgentDispatch` aggregate —
+        // a Solo dispatch needs no separate step (its status is synthesized
+        // directly from its one member's status, see `solo_dispatch`).
+        // SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2:
+        // Abandoned iff every member is Completed|Abandoned and at least one
+        // is Abandoned — otherwise leave the existing counts-based Running/
+        // Completed status (set by `refresh_dispatch_status`) alone.
+        let abandoned_dispatch_infos: Vec<AgentDispatch> = {
+            let mut dispatches = self.dispatches.lock().unwrap();
+            let mut updated = Vec::new();
+            for (dispatch_id, statuses) in &member_statuses_by_dispatch {
+                if dispatch_id.starts_with("solo:") {
+                    continue;
+                }
+                let all_done = statuses
+                    .iter()
+                    .all(|s| matches!(s, SubAgentStatus::Completed | SubAgentStatus::Abandoned));
+                let any_abandoned = statuses.iter().any(|s| *s == SubAgentStatus::Abandoned);
+                if !(all_done && any_abandoned) {
+                    continue;
+                }
+                if let Some(state) = dispatches.get_mut(dispatch_id) {
+                    if state.info.status != DispatchStatus::Abandoned {
+                        state.info.status = DispatchStatus::Abandoned;
+                        tracing::info!(
+                            dispatch_id = %dispatch_id,
+                            parent_block_id = %parent_block_id,
+                            session_id = %session_id,
+                            member_count = statuses.len(),
+                            "dispatch reconciled: -> abandoned (all members done, at least one abandoned)"
+                        );
+                        updated.push(state.info.clone());
+                    }
+                }
+            }
+            updated
+        };
+        for info in &abandoned_dispatch_infos {
+            self.broadcast_dispatch_updated(info);
+        }
+    }
+
+    /// Bounded one-shot retry for `reconcile_stale_subagents`'s `None`
+    /// (controller-not-yet-registered) case — see that function's doc
+    /// comment. Exactly one retry, not a loop: if the controller genuinely
+    /// never registers (e.g. the block was deleted in the meantime), a
+    /// single delayed re-check is enough to stop treating "unknown" as a
+    /// permanent no-op without risking an unbounded retry chain chasing a
+    /// block that's never coming back. 2s is long enough to clear the
+    /// observed registration race without meaningfully delaying the
+    /// correction a user would notice.
+    ///
+    /// Mirrors `trigger_eager_naming`'s `self_ref` upgrade-to-`Arc` pattern
+    /// for spawning a task that outlives this sync call; silently no-ops
+    /// for a bare `new()` watcher (most unit tests), same "untracked ->
+    /// safe no-op" convention as that method.
+    fn retry_reconcile_once(&self, parent_block_id: &str, session_id: &str) {
+        let Some(watcher) = self.self_ref.lock().unwrap().as_ref().and_then(|w| w.upgrade()) else {
+            return;
+        };
+        let parent_block_id = parent_block_id.to_string();
+        let session_id = session_id.to_string();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            // allow_retry: false — this IS the one retry; a second `None`
+            // here gives up rather than spawning another.
+            watcher.reconcile_stale_subagents_impl(&parent_block_id, &session_id, false);
+        });
     }
 
     /// One batched broadcast per reconciliation pass (not one per

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -1322,9 +1322,17 @@ fn reconcile_stale_subagents_leaves_active_alone_when_parent_turn_is_active() {
 #[test]
 fn reconcile_stale_subagents_leaves_active_alone_when_no_controller_is_registered() {
     // No register_stub_controller call — block id is guaranteed unique
-    // (per-test suffix) so get_block_controller_status returns None.
-    // unwrap_or(true) means "uncertain" defaults to "assume active,
-    // don't touch it" — the same conservative bias as ReconcileTurnActive.
+    // (per-test suffix) so get_block_controller_status returns None. The
+    // public entry point's synchronous behavior is unchanged by the
+    // None-retry fix: it queues a bounded one-shot retry
+    // (`retry_reconcile_once`) rather than leaving the entry untouched
+    // forever, but that retry itself silently no-ops here because
+    // `fixture_watcher()` is built via bare `new()` (no `self_ref` to
+    // upgrade to a real `Arc` — see `retry_reconcile_once`'s doc comment,
+    // same "untracked -> safe no-op" convention `trigger_eager_naming`
+    // uses). So immediately after this call, nothing has changed yet —
+    // covered directly (not via a real spawned retry) by the
+    // `_impl(..., allow_retry: false)` tests below.
     let block_id = format!("recon-unregistered-{}", now_millis());
 
     let watcher = fixture_watcher();
@@ -1341,6 +1349,55 @@ fn reconcile_stale_subagents_leaves_active_alone_when_no_controller_is_registere
 
     let info = watcher.get_info("sub-a").expect("sub-a should still exist");
     assert_eq!(info.status, SubAgentStatus::Active);
+}
+
+#[test]
+fn reconcile_stale_subagents_impl_with_retry_exhausted_leaves_active_alone_when_no_controller_is_registered() {
+    // The bounded-retry fix's terminal case: a second attempt (allow_retry:
+    // false, as the real tokio::spawn'd retry calls it) with the controller
+    // STILL unregistered must give up, not chain into another retry or
+    // panic. See SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2.
+    let block_id = format!("recon-unregistered-exhausted-{}", now_millis());
+
+    let watcher = fixture_watcher();
+    {
+        let mut sessions = watcher.sessions.lock().unwrap();
+        let mut s1 = SessionWatch { subagents: HashMap::new() };
+        let mut state = fixture_state("parent-1", "sub-a", "s1");
+        state.info.parent_block_id = block_id.clone();
+        s1.subagents.insert("sub-a".to_string(), state);
+        sessions.insert("s1".to_string(), s1);
+    }
+
+    watcher.reconcile_stale_subagents_impl(&block_id, "s1", false);
+
+    let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+    assert_eq!(info.status, SubAgentStatus::Active, "unregistered + retry exhausted must still not guess");
+}
+
+#[test]
+fn reconcile_stale_subagents_impl_reconciles_normally_once_the_controller_registers_before_the_retry() {
+    // The success path the retry exists for: controller was unregistered
+    // on the first attempt, but has since registered (confirmed idle) by
+    // the time the retry runs — reconciliation should proceed exactly as
+    // if it had been confirmed idle from the start.
+    let block_id = format!("recon-registers-before-retry-{}", now_millis());
+    register_stub_controller(&block_id, false);
+
+    let watcher = fixture_watcher();
+    {
+        let mut sessions = watcher.sessions.lock().unwrap();
+        let mut s1 = SessionWatch { subagents: HashMap::new() };
+        let mut state = fixture_state("parent-1", "sub-a", "s1");
+        state.info.parent_block_id = block_id.clone();
+        s1.subagents.insert("sub-a".to_string(), state);
+        sessions.insert("s1".to_string(), s1);
+    }
+
+    watcher.reconcile_stale_subagents_impl(&block_id, "s1", false);
+
+    let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+    assert_eq!(info.status, SubAgentStatus::Abandoned);
 }
 
 #[test]
@@ -1397,6 +1454,72 @@ fn reconcile_stale_subagents_never_touches_a_sibling_blocks_subagent_in_the_same
     assert_eq!(owned_info.status, SubAgentStatus::Abandoned, "this block's own subagent should still be reconciled");
     let sibling_info = watcher.get_info("sub-sibling").expect("sub-sibling should still exist");
     assert_eq!(sibling_info.status, SubAgentStatus::Active, "a sibling block's subagent must never be reconciled by an unrelated block's idle read");
+}
+
+#[test]
+fn reconcile_stale_subagents_marks_workflow_dispatch_abandoned_when_all_members_done_and_one_abandoned() {
+    // SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2's
+    // aggregation rule: a Workflow-kind AgentDispatch's own status must
+    // become Abandoned (not stay ambiguously Running/Completed) once every
+    // member is Completed|Abandoned and at least one is genuinely Abandoned.
+    let block_id = format!("recon-wf-abandon-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dispatch_id = "wf-recon-1";
+
+    let watcher = fixture_watcher();
+    {
+        let mut dispatches = watcher.dispatches.lock().unwrap();
+        dispatches.insert(dispatch_id.to_string(), fixture_dispatch_state(dispatch_id, &block_id));
+    }
+    {
+        let mut sessions = watcher.sessions.lock().unwrap();
+        let mut s1 = SessionWatch { subagents: HashMap::new() };
+        let mut done_member = fixture_state_for_block(&block_id, "sub-done", "s1");
+        done_member.info.dispatch_id = dispatch_id.to_string();
+        done_member.info.status = SubAgentStatus::Completed;
+        let mut still_active_member = fixture_state_for_block(&block_id, "sub-active", "s1");
+        still_active_member.info.dispatch_id = dispatch_id.to_string();
+        // Left Active — reconcile_stale_subagents will flip this one to
+        // Abandoned, which is what should trigger the dispatch-level
+        // aggregation (one member done+one already-completed = "all done,
+        // at least one abandoned").
+        s1.subagents.insert("sub-done".to_string(), done_member);
+        s1.subagents.insert("sub-active".to_string(), still_active_member);
+        sessions.insert("s1".to_string(), s1);
+    }
+
+    watcher.reconcile_stale_subagents(&block_id, "s1");
+
+    let dispatches = watcher.list_dispatches();
+    let d = dispatches.iter().find(|d| d.dispatch_id == dispatch_id).expect("dispatch should still exist");
+    assert_eq!(d.status, DispatchStatus::Abandoned);
+}
+
+#[test]
+fn reconcile_stale_subagents_does_not_touch_workflow_dispatch_status_when_parent_turn_is_active() {
+    let block_id = format!("recon-wf-active-{}", now_millis());
+    register_stub_controller(&block_id, true);
+    let dispatch_id = "wf-recon-2";
+
+    let watcher = fixture_watcher();
+    {
+        let mut dispatches = watcher.dispatches.lock().unwrap();
+        dispatches.insert(dispatch_id.to_string(), fixture_dispatch_state(dispatch_id, &block_id));
+    }
+    {
+        let mut sessions = watcher.sessions.lock().unwrap();
+        let mut s1 = SessionWatch { subagents: HashMap::new() };
+        let mut member = fixture_state_for_block(&block_id, "sub-a", "s1");
+        member.info.dispatch_id = dispatch_id.to_string();
+        s1.subagents.insert("sub-a".to_string(), member);
+        sessions.insert("s1".to_string(), s1);
+    }
+
+    watcher.reconcile_stale_subagents(&block_id, "s1");
+
+    let dispatches = watcher.list_dispatches();
+    let d = dispatches.iter().find(|d| d.dispatch_id == dispatch_id).expect("dispatch should still exist");
+    assert_eq!(d.status, DispatchStatus::Running, "a genuinely active parent turn must never abandon the dispatch");
 }
 
 /// SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §7 Open

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -1495,6 +1495,50 @@ fn reconcile_stale_subagents_marks_workflow_dispatch_abandoned_when_all_members_
     assert_eq!(d.status, DispatchStatus::Abandoned);
 }
 
+/// reagent P2 on PR #2677: a member whose JSONL file hasn't been picked up
+/// by the filesystem watcher yet (async notify/debounce lag) is invisible
+/// to `member_statuses_by_dispatch`, so the abandonment aggregation must
+/// not trust `all_done` when it has fewer statuses than the dispatch's own
+/// authoritative `member_count` — otherwise a dispatch could be marked
+/// Abandoned based on an incomplete member set.
+#[test]
+fn reconcile_stale_subagents_does_not_abandon_a_workflow_dispatch_when_a_member_is_not_yet_visible() {
+    let block_id = format!("recon-wf-missing-member-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dispatch_id = "wf-recon-missing";
+
+    let watcher = fixture_watcher();
+    {
+        let mut dispatches = watcher.dispatches.lock().unwrap();
+        let mut state = fixture_dispatch_state(dispatch_id, &block_id);
+        // The dispatch itself believes it has 2 members (e.g. from journal
+        // `started` records already read) — only 1 is visible below.
+        state.info.member_count = 2;
+        dispatches.insert(dispatch_id.to_string(), state);
+    }
+    {
+        let mut sessions = watcher.sessions.lock().unwrap();
+        let mut s1 = SessionWatch { subagents: HashMap::new() };
+        let mut only_visible_member = fixture_state_for_block(&block_id, "sub-a", "s1");
+        only_visible_member.info.dispatch_id = dispatch_id.to_string();
+        // Left Active — reconcile flips it to Abandoned, which alone would
+        // satisfy "all done, at least one abandoned" if the second,
+        // not-yet-visible member weren't cross-checked against member_count.
+        s1.subagents.insert("sub-a".to_string(), only_visible_member);
+        sessions.insert("s1".to_string(), s1);
+    }
+
+    watcher.reconcile_stale_subagents(&block_id, "s1");
+
+    let dispatches = watcher.list_dispatches();
+    let d = dispatches.iter().find(|d| d.dispatch_id == dispatch_id).expect("dispatch should still exist");
+    assert_eq!(
+        d.status,
+        DispatchStatus::Running,
+        "must not abandon a dispatch whose member set is incomplete relative to its own member_count"
+    );
+}
+
 #[test]
 fn reconcile_stale_subagents_does_not_touch_workflow_dispatch_status_when_parent_turn_is_active() {
     let block_id = format!("recon-wf-active-{}", now_millis());

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -1572,6 +1572,55 @@ fn reconcile_stale_subagents_then_late_result_line_ends_completed_not_stuck_aban
     std::fs::remove_dir_all(&dir).ok();
 }
 
+/// Dispatch-level counterpart (codex P2 on PR #2677): a Workflow dispatch
+/// manually forced into `Abandoned` must NOT be stuck there once new member
+/// evidence (a completing member) genuinely lands — `refresh_dispatch_info`
+/// (triggered by that new evidence, via `update_dispatch_membership`) must
+/// recompute, unlike the read-only `list_dispatches()` path which must NOT.
+/// Recomputing immediately after fresh evidence yields `Running`, not
+/// `Completed` (the 60s quiet window hasn't elapsed) — same lazy-completion
+/// behavior a normal, never-abandoned dispatch already has; the point of
+/// this test is only that it's no longer PERMANENTLY stuck at `Abandoned`.
+#[test]
+fn dispatch_marked_abandoned_is_not_stuck_once_new_member_evidence_lands() {
+    let dir = std::env::temp_dir().join(format!("amx-dispatch-late-evidence-{}", now_millis()));
+    let run_dir = dir.join("subagents").join("workflows").join("wf_late1");
+    std::fs::create_dir_all(&run_dir).unwrap();
+    let jsonl_path = run_dir.join("agent-member-a.jsonl");
+    std::fs::write(
+        &jsonl_path,
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"working\"}]}}\n",
+    )
+    .unwrap();
+
+    let watcher = fixture_watcher();
+    watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
+
+    // Force the dispatch into Abandoned, simulating a completed reconcile pass.
+    {
+        let mut dispatches = watcher.dispatches.lock().unwrap();
+        let state = dispatches.get_mut("wf_late1").expect("dispatch should be tracked");
+        state.info.status = DispatchStatus::Abandoned;
+    }
+    let abandoned = watcher.list_dispatches();
+    let d = abandoned.iter().find(|d| d.dispatch_id == "wf_late1").unwrap();
+    assert_eq!(d.status, DispatchStatus::Abandoned, "read-only list_dispatches() must never clobber Abandoned");
+
+    // New member evidence lands: the member's own Result line.
+    {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new().append(true).open(&jsonl_path).unwrap();
+        f.write_all(b"{\"type\":\"result\",\"result\":\"done\"}\n").unwrap();
+    }
+    watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
+
+    let dispatches = watcher.list_dispatches();
+    let d = dispatches.iter().find(|d| d.dispatch_id == "wf_late1").unwrap();
+    assert_ne!(d.status, DispatchStatus::Abandoned, "new member evidence must be allowed to move the dispatch off Abandoned, not leave it permanently stuck");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 /// End-to-end: a subagent JSONL with no terminal `result` line, backfilled
 /// via a real `scan_session_subagents` call while the parent's turn is
 /// confirmed idle, comes out `Abandoned` — not `Active` forever. This is

--- a/agentmux-srv/src/backend/subagent_watcher/types.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/types.rs
@@ -135,16 +135,19 @@ pub enum DispatchKind {
     Workflow,
 }
 
-// SPEC §9.3 (open): an Abandoned aggregation rule for DispatchStatus,
-// mirroring SubAgentStatus::Abandoned one level up, is proposed but not yet
-// implemented — this enum matches today's WorkflowStatus behavior (no
-// abandoned tracking at the dispatch level) rather than half-implementing
-// an undecided rule.
+// SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2: the
+// Abandoned aggregation rule flagged as open in an earlier spec is now
+// implemented. Solo kind: mirrors its one member's SubAgentStatus directly
+// (`solo_dispatch`). Workflow kind: `reconcile_stale_subagents` sets this
+// directly (not derived from the counts-based `refresh_dispatch_status`,
+// which only ever produces Running/Completed) whenever every member is
+// Completed|Abandoned and at least one is Abandoned.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum DispatchStatus {
     Running,
     Completed,
+    Abandoned,
 }
 
 /// Solo dispatch identity — a solo Task-tool call has no run-id from Claude

--- a/docs/reports/REPORT_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md
+++ b/docs/reports/REPORT_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md
@@ -1,0 +1,57 @@
+# Report: Robust dispatch attribution + swarm session lifecycle
+
+**Date:** 2026-08-19
+**Spec:** `docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md`
+**Status:** Implemented, tested. No interactive/visual verification (see Verification below — same constraint as the prior report today).
+
+## Context
+
+Follow-up to the transcript dispatch-card work. The user reported a real symptom: a session with only "a couple" of real `Agent`-tool calls showed **48 entries** in the Swarm panel, including rows that visually read as duplicates of the same name (e.g. many rows sharing a slug like "flittering-booping-duckling"). The user also asked for the underlying restart/session lifecycle to be formalized — when an AgentMux instance closes and reopens, its subagents are dead and present only for historical record, and there was no way for a human to manage that.
+
+Root-caused via two parallel research passes, then corrected mid-investigation: the exact-duplicate-name bug (task #44, 17 rows sharing one slug) turned out to already be fixed (`subagentDisplayLabel`'s short-id suffix) — the spec was updated to reflect this rather than re-fixing something already solved. The real causes were accumulation (unbounded historical retention, non-persisted dismissal) and a workflow-member spillage bug, plus a deeper gap: dispatches had no "dead" status of their own, and the reconciliation pass that should set one could silently no-op.
+
+## What changed
+
+**Phase A — attribution:**
+- `buildDispatchBuckets` (`swarm-model.ts`) no longer spills a Workflow dispatch's members individually into the flat Agent-Tool bucket when `ListDispatches` is stale — they're grouped into one synthesized placeholder `WorkflowDispatch` row per `dispatch_id`, preserving the one-row-per-Workflow-call invariant even during a lag.
+- Confirmed (not re-implemented) the naming-collision fix already in place; added no new code there, just corrected the spec's diagnosis.
+
+**Phase B — dispatch-level lifecycle (Rust backend):**
+- Added `DispatchStatus::Abandoned`. A Solo dispatch's status now mirrors its one member's `SubAgentStatus` directly (was previously collapsing `Completed`/`Abandoned` into one `Completed` bucket). A Workflow dispatch's status is set to `Abandoned` by `reconcile_stale_subagents` when every member is `Completed|Abandoned` and at least one is `Abandoned`.
+- Found and fixed a real bug while wiring this up: `refresh_dispatch_status` (called by `list_dispatches()` on *every* read) recomputed status purely from member counts, silently overwriting a freshly-set `Abandoned` back to `Running`/`Completed` on the very next RPC call. Fixed with an early-return guard treating `Abandoned` as terminal.
+- Fixed the flagged-but-never-confirmed race where `reconcile_stale_subagents` could run before a block's controller registers in `CONTROLLER_REGISTRY`, silently treating "unknown" the same as "confirmed active" forever. Now retries exactly once (2s delay) before giving up — bounded, not a loop, verified by a dedicated test for the exhausted-retry path.
+- 6 new Rust unit tests covering the aggregation rule, the retry's success/exhaustion paths, and the terminal-status guard.
+
+**Phase C — human-facing management:**
+- `_retiredRowKeys` (the existing per-row dismiss mechanism) now persists to `localStorage` (local-machine scope, per the user's decision) instead of resetting on every reload — mirrors the existing `toolchain-view.tsx` localStorage pattern.
+- New bulk "Clear completed (N)" button in the Swarm toolbar — retires every currently-visible terminal-status row in one click, only rendered when there's something to clear. Backed by a pure, directly-tested `collectClearableRows()` function.
+- Descoped: a full Live/Historical collapsed-section UI split. This is real information-architecture work deserving its own design pass; the persisted bulk-clear already lets a human resolve a 48-row backlog in one click and have it stay resolved, which directly answers the reported complaint without rushing a larger UI change.
+
+## Verification
+
+- `cargo check`/`cargo test -p agentmux-srv`: full suite passes, 2472 tests (0 failed, 6 pre-existing ignores).
+- `npx tsc --noEmit`: clean.
+- `npx vitest run`: full frontend suite passes, 2801 tests across 190 files (2 pre-existing skips).
+- New test coverage added this pass: 2 frontend tests (orphaned-member grouping), 4 frontend tests (retire persistence round-trip/corruption/overwrite), 6 frontend tests (bulk-clear eligibility), 6 Rust tests (dispatch abandonment aggregation, reconcile retry paths) — 18 new tests total, all passing alongside the pre-existing suite.
+
+**Not done:** interactive verification (triggering a real restart, watching 48 rows collapse to a manageable state, clicking "Clear completed," confirming persistence survives an actual app reload). Same constraint as before — this machine runs shared, live AgentMux instances I shouldn't disrupt, and this is a native desktop app rather than something screenshot-able via browser tooling.
+
+## Files touched
+
+```
+Backend (Rust):
+  agentmux-srv/src/backend/subagent_watcher/types.rs
+  agentmux-srv/src/backend/subagent_watcher/query.rs
+  agentmux-srv/src/backend/subagent_watcher/scan.rs
+  agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+  agentmux-srv/src/backend/subagent_watcher/tests.rs
+
+Frontend:
+  frontend/app/view/swarm/swarm-model.ts
+  frontend/app/view/swarm/swarm-model.test.ts
+  frontend/app/view/swarm/swarm-view.tsx
+  frontend/app/view/swarm/swarm-view.scss
+
+Spec (corrected in place during investigation, not just written once):
+  docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md
+```

--- a/docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md
+++ b/docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md
@@ -1,0 +1,265 @@
+# SPEC: Robust dispatch attribution + formalized session lifecycle for Swarm
+
+**Status:** Implemented (Phases A, B, C — C's Live/Historical section split descoped as a follow-up, see §3.3).
+**Date:** 2026-08-19
+
+## 1. Problem statement
+
+Reported live: a session with only "a couple" of real `Agent`-tool calls
+showed **48 entries** in the Swarm panel's Agent Tool bucket, including
+multiple rows sharing the exact same generated name (e.g. several rows all
+titled the same kebab-case slug). The expectation — and this spec's goal —
+is that **one real Agent/Workflow-tool call is always exactly one row,
+which expands to one continuous stream of everything that call produced**,
+with no duplicates and no unexplained accumulation.
+
+A second, related problem: when an AgentMux instance closes and reopens (or
+an agent respawns), its subagents are dead — no longer running, present
+only for historical record. There is currently no formalized way to tell
+"this dispatch is from a session that's still alive" apart from "this
+dispatch's owning app instance no longer exists," and no way for a human to
+manage (see, hide, or clear) that historical backlog.
+
+## 2. Root cause (evidenced, not fully live-confirmed — see §2.5)
+
+Two prior retros already fixed adjacent issues and are confirmed still
+fixed in current code, so they're ruled out as the cause here:
+- `retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md`'s
+  cross-pane misattribution bug — fixed (`session_belongs_to_block()` gate,
+  `agentmux-srv/src/backend/subagent_watcher/mod.rs:399,447,644`), and
+  wouldn't explain this symptom anyway since the frontend already filters
+  by `parent_block_id` (`swarm-model.ts:1441`) — all 48 rows share one real
+  block.
+- `RETRO_SWARM_PHANTOM_ROWS_AND_STALE_TRACKING_2026_08_06.md`'s phantom-row
+  hypothesis — the proposed fix (`hasRenderableBlock`) is present
+  (`swarm-model.ts:304`). Establishes the general failure class (stale
+  state outliving its real registration) but isn't the row-count cause.
+
+True duplication of one real subagent process into multiple
+`SubAgent`/`dispatch_id` entries is structurally hard to produce:
+`agent_id` is deterministic from the JSONL filename, the in-memory dedup
+key is `session.subagents` keyed by that same `agent_id`
+(`jsonl.rs:87,114`), and `dispatch_id` is a deterministic function of it.
+Re-scans of an already-known `agent_id` correctly see `is_new == false`.
+
+The evidence instead points to **accumulation + non-unique naming**,
+compounding into something that looks like duplication:
+
+1. **Unbounded backend retention, no persisted dismissal.** The backend's
+   `sessions`/`dispatches` maps hold every subagent/dispatch a block has
+   *ever* produced (`query.rs:17,35`, `list_active`/`list_dispatches` fully
+   unfiltered — filtering to one block happens client-side only). On pane
+   reopen or after an `srv` restart (state is not persisted to disk —
+   `SubagentWatcher::new` starts with empty maps, `mod.rs:147-158`;
+   `bootstrap.rs:1164` spawns a fresh watcher every launch), the backfill
+   scan replays up to `BACKFILL_MAX_FILES = 200`
+   (`types.rs:177`) historical `agent-*.jsonl` files as `is_new` spawns —
+   because from this fresh watcher's perspective, they genuinely are new.
+   Meanwhile the only "dismiss" mechanism (`retireRow`, see §2 of
+   `SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md`) is a client-local
+   `Set`, never persisted — confirmed at that spec's §7.3 non-goal. So a
+   long-lived pane's entire historical Agent-tool activity can resurface at
+   once on reload, dwarfing what actually happened in the visible current
+   turn.
+
+2. **CORRECTED (previously misdiagnosed here) — exact-duplicate-name rows
+   are already fixed, not an open bug.** Backfilled rows do skip eager
+   naming and fall back to Claude Code's own raw `slug` field, and that
+   slug genuinely is a **per-batch shared codename, not per-subagent-unique**
+   (`swarm-model.ts:316-336` cites a prior live incident, task #44 — 17
+   distinct agents sharing one visible slug, rendered as 17 apparently-
+   duplicate rows). But that incident's fix already shipped:
+   `subagentDisplayLabel()` (`swarm-model.ts:343-349`) appends a short,
+   always-unique `agent_id` suffix (`${slug} · ${shortId}`) whenever
+   `display_name` is absent, and `SubagentRow` (`swarm-view.tsx:757`) calls
+   it for every row in `agentToolRows` uniformly — confirmed by reading
+   both sites directly. So two genuinely-different backfilled subagents
+   sharing a slug do **not** render as identical text today.
+   What actually produces the *perception* of duplicates: many rows
+   sharing the same slug's memorable portion (mechanism 1's accumulation
+   makes this a large N), with only a small, easy-to-miss 7-char suffix
+   distinguishing them — visually reads as "48 duplicate rows" even though
+   each is technically unique. The real bug is accumulation (mechanism 1),
+   not naming — no naming fix is needed here beyond what already shipped.
+
+3. **Workflow-member spillage under stale dispatch data.** If
+   `ListDispatches` is lagging/stale when the tree builds,
+   `buildDispatchBuckets`'s `orphanedWorkflowMembers` fallback
+   (`swarm-model.ts:224-239`) spills a Workflow's members **individually**
+   into the flat Agent-Tool bucket instead of one grouped row — turning
+   "1-2 Workflow-tool calls" into dozens of same-slug Agent-Tool rows.
+
+4. **Reconciliation can silently no-op, so dead entries never even get
+   marked stale.** `reconcile_stale_subagents` only acts when the parent
+   block's turn is confirmed idle (`turn_active == Some(false)`) — unknown
+   (`None`) defaults to "assume active, don't touch"
+   (`scan.rs:104`, `unwrap_or(true)`). `SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md`
+   §5 Open Question 2 (flagged, never confirmed) notes reconcile can fire
+   before the block's controller registers in `CONTROLLER_REGISTRY`, in
+   which case `get_block_controller_status` returns `None` and the whole
+   pass no-ops. This compounds mechanism 1: even the cleanup path meant to
+   catch this can silently fail to run at exactly the moment (startup)
+   it's needed most.
+
+5. **Even when a member IS correctly marked `Abandoned`, the dispatch
+   itself is not.** `DispatchStatus` only has `Running`/`Completed` —
+   `Abandoned` was "proposed but not yet implemented"
+   (`types.rs:138-148`). `SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md`
+   §5.3 confirms reconciling a member never updates the dispatch's own
+   aggregate status. A dead dispatch can still read as ambiguous/running.
+
+6. **Abandoned rows never auto-clear.** The 60s auto-linger countdown
+   (`SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md`) only arms for a
+   clean terminal `"idle"` completion, explicitly not for
+   `"interrupted"`/`Abandoned` rows. Combined with #1's non-persisted
+   dismissal, a dead-session row has literally no path to ever leaving the
+   list on its own.
+
+### 2.5 What's confirmed vs. inferred
+
+Mechanisms 1, 3, 4, 5, 6 are confirmed directly from code (file:line cited
+above, independently re-verified for the most load-bearing claims:
+`types.rs`'s `DispatchStatus` enum, `scan.rs`'s `unwrap_or(true)` gate,
+`swarm-model.ts`/`swarm-view.tsx`'s naming-suffix fix). Mechanism 2 was
+investigated and found to be **already fixed**, not a live bug — corrected
+above rather than left as an open item. **No one has reproduced the exact
+48-row incident against srv logs** — proceeding on the strength of this
+code-level evidence rather than blocking on a live repro (decided together
+with the user); if the fixes below don't fully resolve a future recurrence,
+capture `muxlog srv grep "backfilling session subagents"` /
+`"capping cold-backfill replay"` around a fresh repro next.
+
+## 3. Design
+
+### 3.1 Robust one-call-one-stream attribution
+
+- **Naming-collision fix already shipped** (`subagentDisplayLabel`'s short-id
+  suffix, task #44) — no further work needed here; kept as a regression
+  guard (a unit test asserting the suffix, see §5 verification) rather than
+  re-implemented.
+- **`orphanedWorkflowMembers` must not spill members into the flat
+  Agent-Tool bucket.** When dispatch data is stale, either hold rendering
+  in a loading state until `ListDispatches` catches up, or group orphaned
+  members under a single synthesized placeholder row keyed by their shared
+  `dispatch_id`/workflow id — never as N independent flat rows.
+- **Reaffirm `dispatch_id` as the sole grouping/dedup key**, everywhere a
+  row is built or a component decides "is this the same call." No code
+  path should key off `slug`/`display_name` for identity, only for label
+  text — the two are already conflated in mechanism 2 above and that's
+  exactly the bug class to close off structurally, not just patch once.
+
+### 3.2 Formalized session lifecycle
+
+- **Add `DispatchStatus::Abandoned`** and propagate it: when
+  `reconcile_stale_subagents` marks a dispatch's last/all live members
+  abandoned, update the owning `AgentDispatch.status` too (aggregate rule:
+  `Abandoned` iff all members are `Completed | Abandoned` and at least one
+  is `Abandoned`; otherwise keep existing `Completed`-iff-all-members-done
+  behavior). This closes the gap where a dead dispatch reads as ambiguous.
+- **Make reconciliation's "unknown controller status" branch not a silent
+  no-op.** Today `None` (controller not yet registered) is treated
+  identically to "confirmed active." Distinguish them: `None` should either
+  retry once the controller registers (if that's recoverable within the
+  same process lifetime) or, at minimum, not be indistinguishable from
+  "genuinely still running" — the current behavior is the single most
+  likely reason dead entries survive a restart looking alive.
+- **No separate "boot id" concept needed** (simplified from an earlier draft
+  of this section) — once `DispatchStatus::Abandoned` exists (previous
+  bullet) and reconciliation reliably runs (this bullet), "is this dead"
+  is just `status ∈ {Completed, Abandoned}`. Nothing in this app persists
+  `SubagentWatcher` state across a restart (§2, mechanism 1), so an entry
+  surviving into a fresh process is either live (still being actively
+  written to, will resolve to `Completed` on its own) or genuinely dead
+  (will resolve to `Abandoned` once reconciliation runs) — no third state
+  to track separately.
+
+### 3.3 Human-facing management — implemented, scope note
+
+- **Persist dismissal/retire state past reload — shipped.**
+  `_retiredRowKeys` now round-trips through `localStorage`
+  (`loadRetiredRowKeysFromStorage`/`saveRetiredRowKeysToStorage`,
+  `swarm-model.ts`), local-machine scope per §6's decision. Every write
+  path (`retireRow`, the retired-entry pruning pass) goes through one
+  wrapped setter so persistence can't be bypassed by a future call site.
+- **Bulk clear action — shipped**, not a "Historical" collapsed section.
+  `collectClearableRows()` + `SwarmViewModel.retireAllCompleted()` +
+  a "Clear completed (N)" button in the Swarm toolbar (only rendered when
+  N > 0) retires every currently-visible terminal-status row in one click —
+  directly answers "we need a way for humans to manage that" without a
+  larger UI restructuring.
+- **Visual distinction for Abandoned — already closer to done than this
+  spec's draft assumed.** Re-checked `swarm-view.scss` directly: the status
+  *dot* already differs by color (`--interrupted`: warning-orange,
+  `--idle`: gray) — only the row/group-level dimming wrapper is identical
+  (0.55/0.85 opacity for both). Left as-is; the dot is the primary status
+  signal and a shared dimming level for "any terminal row" is reasonable,
+  not obviously broken. No change made here.
+- **NOT shipped: a full Live/Historical collapsed-section UI split.**
+  Descoped deliberately — a real information-architecture change (default-
+  collapsed section, its own retention bound, restructuring how
+  `AgentTreeNode`'s buckets render) that deserves its own design pass and
+  test coverage rather than being rushed alongside the backend lifecycle
+  work in this same pass. The persisted bulk-clear above already directly
+  addresses the reported symptom (a human can now clear a 48-row backlog in
+  one click, and it stays cleared across reload); the section split is a
+  further UX polish on top, tracked as a follow-up, not required to close
+  the original complaint.
+
+## 4. Non-goals
+
+- Not attempting to fix the recursive/nested-subagent attribution gap
+  discussed separately (`parentUuid`/`spawned_from_agent_id` not yet
+  consumed) — out of scope here, tracked separately.
+- Not persisting full historical dispatch data server-side across restarts
+  beyond what already exists (JSONL files on disk remain the source of
+  truth for backfill) — this spec formalizes *classification* (live vs.
+  historical) and *display*, not a new persistence layer for raw activity.
+
+## 5. Phasing
+
+- **Phase A — stop the bleeding (attribution):** §3.1's orphaned-member-
+  spillage fix (the naming fallback item is already fixed, kept only as a
+  regression-test target).
+- **Phase B — dispatch-level lifecycle:** §3.2's `DispatchStatus::Abandoned`
+  + reconcile-ordering fix. Makes "is this dead" answerable as a direct
+  `status` read instead of a timing-dependent heuristic.
+- **Phase C — human management surface:** §3.3's persisted retire +
+  Live/Historical split (driven by Phase B's `status`) + bulk clear +
+  visual distinction.
+
+B before C (C's Live/Historical split needs B's `DispatchStatus::Abandoned`
+to be meaningful). A is independent and lands first.
+
+## 6. Decisions (user delegated — "your choice, proceed", 2026-08-19)
+
+1. **Proceeding directly to fixes**, no live repro captured first — the
+   code-level evidence is strong enough per §2.5, and this environment
+   runs shared production instances that shouldn't be used for a
+   deliberate repro.
+2. **Retired/dismissed state persists to local settings** (per-machine,
+   not synced/cross-device) — lowest-risk option, consistent with how
+   other per-machine UI state already persists in this app.
+3. **Historical retention bound: cap at `BACKFILL_MAX_FILES` (200)
+   equivalent for display** — reuse the existing constant's value rather
+   than invent a new number; a bulk "Clear historical" action covers the
+   rest.
+
+## Critical files
+
+- `agentmux-srv/src/backend/subagent_watcher/types.rs` — `DispatchStatus`,
+  `SubAgentStatus`, `AgentDispatch`/`SubAgent` structs.
+- `agentmux-srv/src/backend/subagent_watcher/jsonl.rs` — eager-naming gate
+  (`live` param), `process_jsonl_change`.
+- `agentmux-srv/src/backend/subagent_watcher/scan.rs` — `reconcile_stale_subagents`,
+  `scan_subagents_dir`/backfill, the `unwrap_or(true)` gate.
+- `agentmux-srv/src/backend/subagent_watcher/query.rs` — `list_active`/`list_dispatches`
+  (unbounded, unfiltered).
+- `frontend/app/view/swarm/swarm-model.ts` — `buildDispatchBuckets`,
+  `orphanedWorkflowMembers`, `subagentDisplayLabel`, `_retiredRowKeys`.
+- `frontend/app/view/swarm/swarm-view.tsx` / `swarm-view.scss` — status
+  label mapping, `Abandoned`/`Completed` visual parity.
+- Prior specs this builds on: `SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md`,
+  `SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md`,
+  `SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06.md`,
+  `RETRO_SWARM_PHANTOM_ROWS_AND_STALE_TRACKING_2026_08_06.md`,
+  `retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md`.

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -19,6 +19,7 @@ import {
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     subagentRowKey,
+    workflowRetireSignal,
     type ActiveCron,
     type ActiveShell,
     type ActiveSubagent,
@@ -463,13 +464,13 @@ describe("collectClearableRows", () => {
         expect(collectClearableRows([node])).toEqual([]);
     });
 
-    it("includes a terminal ('retired', i.e. all-members-done) WorkflowDispatch row", () => {
+    it("includes a terminal ('retired', i.e. all-members-done) WorkflowDispatch row, keyed by workflowRetireSignal not lastEventAt", () => {
         const [wf] = buildDispatchBuckets(
-            [mkDispatch({ dispatch_id: "wf_1", status: "completed", last_event_at: 700 })],
+            [mkDispatch({ dispatch_id: "wf_1", status: "completed", last_event_at: 700, member_count: 2, members_done: 2 })],
             [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
         ).workflowRows;
         const rows = collectClearableRows([mkNode([], [wf])]);
-        expect(rows).toEqual([{ rowKey: "wf_1", lastEventAt: 700 }]);
+        expect(rows).toEqual([{ rowKey: "wf_1", lastEventAt: workflowRetireSignal(wf) }]);
     });
 
     it("excludes a still-running WorkflowDispatch row", () => {
@@ -519,6 +520,32 @@ describe("filterRetired", () => {
     it("is a no-op (identity semantics aside) when nothing is retired", () => {
         const rows = filterRetired([1, 2, 3], new Map(), keyFn, () => 0);
         expect(rows).toEqual([1, 2, 3]);
+    });
+});
+
+describe("workflowRetireSignal", () => {
+    it("encodes membersDone and memberCount into one comparable number", () => {
+        expect(workflowRetireSignal({ memberCount: 3, membersDone: 2 })).toBe(2_000_003);
+    });
+
+    it("produces the SAME signal for a placeholder and the eventual real dispatch representing identical, unchanged member progress", () => {
+        // Reagent P1 on PR #2677 — the actual regression this guards
+        // against: a placeholder WorkflowDispatch (buildDispatchBuckets's
+        // orphanedWorkflowMembers fallback) and the real AgentDispatch that
+        // eventually replaces it derive lastEventAt from two different
+        // clocks and essentially never match numerically, even with zero
+        // real activity in between — but they DO derive the same member
+        // counts from the same underlying member set, so the retire
+        // signal correctly stays stable across that transition.
+        const placeholder = { memberCount: 2, membersDone: 1 };
+        const real = { memberCount: 2, membersDone: 1 }; // same known members, nothing new happened
+        expect(workflowRetireSignal(placeholder)).toBe(workflowRetireSignal(real));
+    });
+
+    it("changes once a member's progress genuinely advances — the un-retire-on-new-activity case still works", () => {
+        const before = { memberCount: 2, membersDone: 1 };
+        const afterAnotherCompletes = { memberCount: 2, membersDone: 2 };
+        expect(workflowRetireSignal(before)).not.toBe(workflowRetireSignal(afterAnotherCompletes));
     });
 });
 

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -1,18 +1,21 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
     buildCronRows,
     buildDispatchBuckets,
     buildShellRows,
+    collectClearableRows,
     filterRetired,
     groupCacheKey,
     hasRenderableBlock,
+    loadRetiredRowKeysFromStorage,
     mergeDispatchActivityEntries,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     pruneRetiredEntries,
+    saveRetiredRowKeysToStorage,
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     subagentRowKey,
@@ -20,6 +23,7 @@ import {
     type ActiveShell,
     type ActiveSubagent,
     type AgentDispatch,
+    type AgentTreeNode,
     type DispatchActivityEntry,
     type WorkflowDispatch,
 } from "./swarm-model";
@@ -151,20 +155,41 @@ describe("buildDispatchBuckets", () => {
         expect(agentToolRows).toHaveLength(2);
     });
 
-    it("falls back to agentToolRows for a workflow-kind subagent whose dispatch is missing from `dispatches` (stale/failed ListDispatches)", () => {
+    it("synthesizes a placeholder workflowRows entry for a workflow-kind subagent whose dispatch is missing from `dispatches` (stale/failed ListDispatches) — never spilled into agentToolRows", () => {
         // `loadDispatches()` silently swallows RPC errors, so `dispatches`
         // can lag or miss entries that `subagents` (a separate fetch)
         // already has. A workflow member with no matching AgentDispatch row
-        // must degrade to an Agent Tool row, not vanish from the tree.
+        // must degrade to its OWN synthesized workflowRows row (grouped by
+        // dispatch_id), not vanish from the tree — and never spill into
+        // agentToolRows, which would break the one-row-per-Workflow-call
+        // invariant. See SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.1.
         const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 1 })];
         const subagents = [
             mk({ agent_id: "a1", dispatch_id: "wf_1" }),
             mk({ agent_id: "a2", dispatch_id: "wf_missing" }),
         ];
         const { agentToolRows, workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect(agentToolRows).toHaveLength(0);
+        expect(workflowRows).toHaveLength(2);
+        const placeholder = workflowRows.find((w) => w.dispatchId === "wf_missing");
+        expect(placeholder).toBeDefined();
+        expect(placeholder?.memberCount).toBe(1);
+    });
+
+    it("groups multiple orphaned members of the SAME missing dispatch into one placeholder row, not one per member", () => {
+        const subagents = [
+            mk({ agent_id: "a1", dispatch_id: "wf_missing", last_event_at: 100, status: "active" }),
+            mk({ agent_id: "a2", dispatch_id: "wf_missing", last_event_at: 200, status: "active" }),
+            mk({ agent_id: "a3", dispatch_id: "wf_missing", last_event_at: 150, status: "completed" }),
+        ];
+        const { agentToolRows, workflowRows } = buildDispatchBuckets([], subagents);
+        expect(agentToolRows).toHaveLength(0);
         expect(workflowRows).toHaveLength(1);
-        expect(agentToolRows).toHaveLength(1);
-        expect(agentToolRows[0].agent_id).toBe("a2");
+        expect(workflowRows[0].dispatchId).toBe("wf_missing");
+        expect(workflowRows[0].memberCount).toBe(3);
+        expect(workflowRows[0].membersDone).toBe(1);
+        expect(workflowRows[0].status).toBe("active");
+        expect(workflowRows[0].lastEventAt).toBe(200);
     });
 
     it("passes AgentDispatch.status through directly — running → active, completed → retired", () => {
@@ -179,6 +204,19 @@ describe("buildDispatchBuckets", () => {
         const completed = workflowRows.find((w) => w.dispatchId === "wf_2");
         expect(running?.status).toBe("active");
         expect(completed?.status).toBe("retired");
+    });
+
+    it("maps an abandoned AgentDispatch.status to 'retired', not 'active' — regression guard for the gap this exact bug would reopen", () => {
+        // DispatchStatus::Abandoned (SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md
+        // §3.2) is terminal, same as "completed" — a naive `status ===
+        // "completed" ? "retired" : "active"` mapping (the pre-fix version
+        // of this code) would silently read an abandoned dispatch as still
+        // "active", breaking collectClearableRows and the resultPill.
+        const { workflowRows } = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_1", status: "abandoned" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        );
+        expect(workflowRows[0].status).toBe("retired");
     });
 
     it("prefers the backend's eager dispatch_name over a member's slug", () => {
@@ -393,6 +431,66 @@ describe("subagentRowKey", () => {
     });
 });
 
+function mkNode(agentToolRows: ActiveSubagent[], workflowRows: WorkflowDispatch[]): AgentTreeNode {
+    return {
+        blockId: "block-1",
+        agentName: "Agent",
+        agentProvider: null,
+        activitySummary: null,
+        contextTokens: null,
+        agentStatus: "idle",
+        agentToolRows,
+        workflowRows,
+        shellRows: [],
+        cronRows: [],
+    };
+}
+
+describe("collectClearableRows", () => {
+    it("includes a terminal-status (completed) Agent Tool row", () => {
+        const node = mkNode([mk({ agent_id: "a1", status: "completed", last_event_at: 500 })], []);
+        const rows = collectClearableRows([node]);
+        expect(rows).toEqual([{ rowKey: "agent:a1", lastEventAt: 500 }]);
+    });
+
+    it("includes an abandoned Agent Tool row", () => {
+        const node = mkNode([mk({ agent_id: "a1", status: "abandoned", last_event_at: 300 })], []);
+        expect(collectClearableRows([node])).toEqual([{ rowKey: "agent:a1", lastEventAt: 300 }]);
+    });
+
+    it("excludes a still-active Agent Tool row", () => {
+        const node = mkNode([mk({ agent_id: "a1", status: "active", last_event_at: 500 })], []);
+        expect(collectClearableRows([node])).toEqual([]);
+    });
+
+    it("includes a terminal ('retired', i.e. all-members-done) WorkflowDispatch row", () => {
+        const [wf] = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_1", status: "completed", last_event_at: 700 })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        ).workflowRows;
+        const rows = collectClearableRows([mkNode([], [wf])]);
+        expect(rows).toEqual([{ rowKey: "wf_1", lastEventAt: 700 }]);
+    });
+
+    it("excludes a still-running WorkflowDispatch row", () => {
+        const [wf] = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_1", status: "running" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        ).workflowRows;
+        expect(collectClearableRows([mkNode([], [wf])])).toEqual([]);
+    });
+
+    it("collects across multiple blocks/nodes", () => {
+        const nodeA = mkNode([mk({ agent_id: "a1", status: "completed", last_event_at: 1 })], []);
+        const nodeB = mkNode([mk({ agent_id: "b1", status: "abandoned", last_event_at: 2 })], []);
+        expect(collectClearableRows([nodeA, nodeB])).toHaveLength(2);
+    });
+
+    it("returns an empty array when nothing is clearable", () => {
+        expect(collectClearableRows([mkNode([], [])])).toEqual([]);
+    });
+});
+
 describe("filterRetired", () => {
     const keyFn = (n: number) => `row-${n}`;
 
@@ -455,6 +553,39 @@ describe("pruneRetiredEntries", () => {
         const pruned = pruneRetiredEntries(retired, new Set());
         expect(pruned).not.toBe(retired);
         expect(pruned.size).toBe(0);
+    });
+});
+
+describe("loadRetiredRowKeysFromStorage / saveRetiredRowKeysToStorage", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("round-trips a map through localStorage", () => {
+        const retired = new Map<string, number>([
+            ["agent:a1", 100],
+            ["wf_1", 200],
+        ]);
+        saveRetiredRowKeysToStorage(retired);
+        const loaded = loadRetiredRowKeysFromStorage();
+        expect(loaded).toEqual(retired);
+    });
+
+    it("returns an empty map when nothing has been saved yet", () => {
+        expect(loadRetiredRowKeysFromStorage()).toEqual(new Map());
+    });
+
+    it("returns an empty map (not a throw) when the stored value is corrupt JSON", () => {
+        localStorage.setItem("agentmux:swarm-retired-rows", "{not valid json");
+        expect(loadRetiredRowKeysFromStorage()).toEqual(new Map());
+    });
+
+    it("overwrites the previously-saved value on a second save", () => {
+        saveRetiredRowKeysToStorage(new Map([["agent:a1", 100]]));
+        saveRetiredRowKeysToStorage(new Map([["agent:a2", 200]]));
+        const loaded = loadRetiredRowKeysFromStorage();
+        expect(loaded.has("agent:a1")).toBe(false);
+        expect(loaded.get("agent:a2")).toBe(200);
     });
 });
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -166,9 +166,10 @@ export interface WorkflowDispatch {
     memberCount: number;
     membersDone: number;
     /** "active" if any member is still active; "retired" once every member
-     *  has completed. Derived from AgentDispatch.status ("running" |
-     *  "completed") — different vocabulary, same meaning as the rest of
-     *  this file's group rows. */
+     *  has completed OR been abandoned. Derived from AgentDispatch.status
+     *  ("running" | "completed" | "abandoned") — both non-"running" values
+     *  fold into "retired" here, different vocabulary but same meaning as
+     *  the rest of this file's group rows. */
     status: "active" | "retired";
     lastEventAt: number;
 }
@@ -376,7 +377,9 @@ export function collectClearableRows(nodes: AgentTreeNode[]): { rowKey: string; 
             // this exact feature, not a bug — see that field's own doc
             // comment on the WorkflowDispatch interface above.
             if (w.status !== "active") {
-                result.push({ rowKey: w.dispatchId, lastEventAt: w.lastEventAt });
+                // workflowRetireSignal, NOT w.lastEventAt — see that
+                // function's doc comment (reagent P1 on PR #2677).
+                result.push({ rowKey: w.dispatchId, lastEventAt: workflowRetireSignal(w) });
             }
         }
     }
@@ -495,6 +498,33 @@ export function groupCacheKey(child: WorkflowDispatch): string {
  *  string templates drifting apart. */
 export function subagentRowKey(agentId: string): string {
     return `agent:${agentId}`;
+}
+
+/**
+ * The "has anything genuinely new happened" signal `filterRetired` compares
+ * for a `WorkflowDispatch` row — `memberCount`/`membersDone`, NOT
+ * `lastEventAt`. Reagent P1 on PR #2677: `lastEventAt` is sourced from two
+ * structurally different clocks depending on whether the row is currently a
+ * synthesized placeholder (`buildDispatchBuckets`'s `orphanedWorkflowMembers`
+ * fallback — `Math.max` of each member's OWN event timestamp, i.e. when
+ * Claude Code wrote that JSONL line) or the real `AgentDispatch`
+ * (`agentmux-srv`'s `refresh_dispatch_info` sets it to `now_millis()`, i.e.
+ * when the BACKEND processed that event — always later, by an unpredictable
+ * amount, than the event's own timestamp). Those two values essentially
+ * never numerically match for the same underlying activity, so retiring a
+ * placeholder row under `lastEventAt` and later comparing against the real
+ * row's `lastEventAt` looked like "new activity happened" the moment
+ * `ListDispatches` caught up — even with zero real change — silently
+ * un-retiring the exact row the placeholder fallback and the persisted-
+ * retire feature both exist to keep dismissed. `memberCount`/`membersDone`
+ * are counts, not timestamps — both the placeholder and the real dispatch
+ * derive them from "how many members are known, how many are done," which
+ * converges to the same numbers for the same underlying member set
+ * regardless of which representation (placeholder or real) is currently
+ * rendering it.
+ */
+export function workflowRetireSignal(w: Pick<WorkflowDispatch, "memberCount" | "membersDone">): number {
+    return w.membersDone * 1_000_000 + w.memberCount;
 }
 
 /**
@@ -1639,7 +1669,9 @@ export class SwarmViewModel implements ViewModel {
             // filterRetired's doc comment for the un-retire-on-new-activity
             // mechanism (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6).
             const agentToolRows = filterRetired(rawAgentToolRows, retired, (s) => subagentRowKey(s.agent_id), (s) => s.last_event_at);
-            const visibleWorkflowRows = filterRetired(workflowRows, retired, (w) => w.dispatchId, (w) => w.lastEventAt);
+            // workflowRetireSignal, NOT w.lastEventAt — see that function's
+            // doc comment (reagent P1 on PR #2677).
+            const visibleWorkflowRows = filterRetired(workflowRows, retired, (w) => w.dispatchId, (w) => workflowRetireSignal(w));
             const shellRows = buildShellRows(shells, blockId);
             const cronRows = buildCronRows(crons, blockId);
             return {

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -1329,11 +1329,21 @@ export class SwarmViewModel implements ViewModel {
      *  backlog. The persisted-retire fix (`_retiredRowKeys` now surviving
      *  reload) makes this genuinely useful — a bulk clear that reset itself
      *  every reload wouldn't have been worth adding.
+     *
+     *  One batched `setRetiredRowKeys` write (and one countdown-clear pass)
+     *  for the whole set, not N calls into `retireRow` — reagent P2 on
+     *  PR #2677: N sequential calls meant N full JSON.stringify +
+     *  localStorage.setItem round-trips for what's conceptually one action.
      *  See SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.3. */
     retireAllCompleted(): void {
-        for (const { rowKey, lastEventAt } of collectClearableRows(this.buildTree())) {
-            this.retireRow(rowKey, lastEventAt);
-        }
+        const rows = collectClearableRows(this.buildTree());
+        if (rows.length === 0) return;
+        this.setRetiredRowKeys((prev) => {
+            const next = new Map(prev);
+            for (const { rowKey, lastEventAt } of rows) next.set(rowKey, lastEventAt);
+            return next;
+        });
+        for (const { rowKey } of rows) this.clearCountdown(rowKey);
     }
 
     // ── Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06) ──

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -106,7 +106,14 @@ export interface AgentDispatch {
     session_id: string;
     member_count: number;
     members_done: number;
-    status: "running" | "completed";
+    /** `"abandoned"` (DispatchStatus::Abandoned, Rust) added
+     *  SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2 —
+     *  every member is Completed|Abandoned and at least one is Abandoned
+     *  (the parent block's turn ended before this dispatch finished). Both
+     *  `"completed"` and `"abandoned"` are terminal for UI purposes — see
+     *  `WorkflowDispatch.status`'s derivation below, which folds both into
+     *  `"retired"`. */
+    status: "running" | "completed" | "abandoned";
     last_event_at: number;
     /** For a Workflow-kind dispatch: a concise Haiku-generated name, resolved
      *  EAGERLY (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A)
@@ -215,7 +222,10 @@ export function buildDispatchBuckets(
                 name: d.dispatch_name || namedMember?.slug || d.dispatch_id,
                 memberCount: d.member_count,
                 membersDone: d.members_done,
-                status: d.status === "completed" ? ("retired" as const) : ("active" as const),
+                // Both "completed" and "abandoned" are terminal — an
+                // abandoned dispatch (dead parent, never finished) must not
+                // read as "active" just because it isn't "completed".
+                status: d.status === "running" ? ("active" as const) : ("retired" as const),
                 lastEventAt: d.last_event_at,
             };
         })
@@ -228,17 +238,51 @@ export function buildDispatchBuckets(
     // site), so `dispatches` here can lag or miss entries `subagents` (a
     // separate fetch) already has. Without this, any workflow-kind subagent
     // whose dispatch has no matching row in `workflowRows` would vanish from
-    // the tree entirely instead of degrading to an Agent Tool row.
+    // the tree entirely.
+    //
+    // Grouped into ONE synthesized placeholder `WorkflowDispatch` row per
+    // orphaned `dispatch_id`, appended to `workflowRows` — never spread
+    // individually into `agentToolRows`. Spreading them flat previously
+    // turned a lagging Workflow dispatch's member files into N separate
+    // Agent-Tool rows (up to member_count of them), breaking the "one row
+    // per Workflow-tool call" invariant `WorkflowDispatch`'s own doc comment
+    // establishes, and inflating the visible row count independent of the
+    // naming-collision issue (already fixed, see `subagentDisplayLabel`).
+    // See docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.1.
     const workflowDispatchIds = new Set(workflowRows.map((w) => w.dispatchId));
     const orphanedWorkflowMembers = subagents.filter(
         (s) => !s.dispatch_id.startsWith("solo:") && !workflowDispatchIds.has(s.dispatch_id)
     );
+    const orphanedByDispatchId = new Map<string, ActiveSubagent[]>();
+    for (const member of orphanedWorkflowMembers) {
+        const group = orphanedByDispatchId.get(member.dispatch_id);
+        if (group) group.push(member);
+        else orphanedByDispatchId.set(member.dispatch_id, [member]);
+    }
+    const placeholderWorkflowRows: WorkflowDispatch[] = Array.from(
+        orphanedByDispatchId.entries()
+    ).map(([dispatchId, members]) => {
+        const named = members.find((m) => m.display_name) ?? members.find((m) => m.slug);
+        return {
+            kind: "workflowDispatch" as const,
+            dispatchId,
+            name: named?.display_name || named?.slug || dispatchId,
+            // Best-effort lower bound — the real member_count isn't known
+            // until ListDispatches catches up; this only reflects the
+            // members ListActive has surfaced so far for this dispatch.
+            memberCount: members.length,
+            membersDone: members.filter((m) => m.status !== "active").length,
+            status: members.some((m) => m.status === "active") ? ("active" as const) : ("retired" as const),
+            lastEventAt: Math.max(...members.map((m) => m.last_event_at)),
+        };
+    });
 
-    const agentToolRows = [...solo, ...orphanedWorkflowMembers].sort(
-        (a, b) => b.last_event_at - a.last_event_at
+    const agentToolRows = solo.sort((a, b) => b.last_event_at - a.last_event_at);
+    const allWorkflowRows = [...workflowRows, ...placeholderWorkflowRows].sort(
+        (a, b) => b.lastEventAt - a.lastEventAt
     );
 
-    return { agentToolRows, workflowRows };
+    return { agentToolRows, workflowRows: allWorkflowRows };
 }
 
 /**
@@ -304,6 +348,39 @@ export function buildCronRows(crons: ActiveCron[], blockId: string | null): Acti
 export function hasRenderableBlock<T>(block: T | null | undefined, isLoading: boolean): boolean {
     if (isLoading) return true;
     return block != null;
+}
+
+/**
+ * Rows eligible for the bulk "Clear completed" action — every terminal-
+ * status (not currently `"active"`) row across every `AgentTreeNode`, as a
+ * flat list of `(rowKey, lastEventAt)` pairs ready to hand to `retireRow`.
+ * Extracted as a pure function for direct unit-testability, mirroring
+ * `buildShellRows`/`buildCronRows` above. A row already retired doesn't
+ * need separate exclusion here — `buildTree()` already filters retired
+ * rows out of the `AgentTreeNode`s this is called with (`filterRetired`),
+ * so nothing eligible for a fresh retire is ever double-counted.
+ * See SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.3.
+ */
+export function collectClearableRows(nodes: AgentTreeNode[]): { rowKey: string; lastEventAt: number }[] {
+    const result: { rowKey: string; lastEventAt: number }[] = [];
+    for (const node of nodes) {
+        for (const s of node.agentToolRows) {
+            if (s.status !== "active") {
+                result.push({ rowKey: subagentRowKey(s.agent_id), lastEventAt: s.last_event_at });
+            }
+        }
+        for (const w of node.workflowRows) {
+            // WorkflowDispatch.status is "active" | "retired" — "retired"
+            // here means "every member completed" (backend-derived), NOT
+            // "the user manually retired this row." Naming collision with
+            // this exact feature, not a bug — see that field's own doc
+            // comment on the WorkflowDispatch interface above.
+            if (w.status !== "active") {
+                result.push({ rowKey: w.dispatchId, lastEventAt: w.lastEventAt });
+            }
+        }
+    }
+    return result;
 }
 
 /**
@@ -460,6 +537,41 @@ export function pruneRetiredEntries(retired: Map<string, number>, liveKeys: Set<
         }
     }
     return changed ? next : retired;
+}
+
+// ── Retired-row persistence (SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.3) ──
+//
+// `_retiredRowKeys` used to be purely in-memory/ephemeral (reset on every
+// reload/restart) — the only "dismiss" mechanism for a dead-session row,
+// forgotten the moment the pane remounted, which is a direct contributor to
+// the "48 rows for a couple of real calls" symptom that spec root-causes.
+// Persisted to localStorage, local-machine scope (not synced/cross-device —
+// a deliberate choice, see that spec's §6 decisions), mirroring the
+// existing `toolchain-view.tsx` `loadWidgetPorts`/`saveWidgetPort` pattern
+// (namespaced key, JSON, defensive try/catch — localStorage access can
+// throw in some embedding contexts).
+
+const RETIRED_ROW_KEYS_STORAGE_KEY = "agentmux:swarm-retired-rows";
+
+export function loadRetiredRowKeysFromStorage(): Map<string, number> {
+    try {
+        const raw = localStorage.getItem(RETIRED_ROW_KEYS_STORAGE_KEY);
+        if (!raw) return new Map();
+        const entries = JSON.parse(raw) as [string, number][];
+        return new Map(entries);
+    } catch {
+        return new Map();
+    }
+}
+
+export function saveRetiredRowKeysToStorage(retired: Map<string, number>): void {
+    try {
+        localStorage.setItem(RETIRED_ROW_KEYS_STORAGE_KEY, JSON.stringify(Array.from(retired.entries())));
+    } catch {
+        // best-effort — a full localStorage or a context where it throws
+        // just means this session's retires don't survive reload, same as
+        // the old always-ephemeral behavior.
+    }
 }
 
 /**
@@ -760,18 +872,32 @@ export class SwarmViewModel implements ViewModel {
     expandedAgentIdsAtom: Accessor<Set<string>> = this._expandedAgentIds[0];
     private setExpandedAgentIds: Setter<Set<string>> = this._expandedAgentIds[1];
 
-    // Rows the user has retired (dismissed) — client-local, ephemeral (no
-    // backend write, resets on reload/restart, same as memory-pressure-
-    // banner.tsx's dismissedAt). Maps rowKey -> the row's own lastEventAt
-    // AT THE MOMENT it was retired, not just a bare membership set: this is
-    // what lets a row un-retire itself automatically the moment genuinely
-    // new activity arrives for that same key (buildTree()'s filter only
-    // suppresses a row whose CURRENT lastEventAt still matches the
-    // snapshot) instead of requiring an explicit un-retire action — see
-    // SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6.
-    private _retiredRowKeys = createSignal<Map<string, number>>(new Map());
+    // Rows the user has retired (dismissed) — client-local (no backend
+    // write), but persisted to localStorage as of
+    // SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.3, so a
+    // dismissal survives reload/restart instead of resurfacing every time
+    // (previously ephemeral, same as memory-pressure-banner.tsx's
+    // dismissedAt — that comparison no longer applies). Maps rowKey -> the
+    // row's own lastEventAt AT THE MOMENT it was retired, not just a bare
+    // membership set: this is what lets a row un-retire itself automatically
+    // the moment genuinely new activity arrives for that same key
+    // (buildTree()'s filter only suppresses a row whose CURRENT lastEventAt
+    // still matches the snapshot) instead of requiring an explicit
+    // un-retire action — see SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6.
+    private _retiredRowKeys = createSignal<Map<string, number>>(loadRetiredRowKeysFromStorage());
     retiredRowKeysAtom: Accessor<Map<string, number>> = this._retiredRowKeys[0];
-    private setRetiredRowKeys: Setter<Map<string, number>> = this._retiredRowKeys[1];
+    private rawSetRetiredRowKeys: Setter<Map<string, number>> = this._retiredRowKeys[1];
+    /** Every write to `_retiredRowKeys` must go through this — persists to
+     *  localStorage alongside the in-memory update, so a raw
+     *  `this.rawSetRetiredRowKeys` call is a bug (nothing enforces this at
+     *  the type level, but every call site in this file goes through here). */
+    private setRetiredRowKeys(updater: (prev: Map<string, number>) => Map<string, number>): void {
+        this.rawSetRetiredRowKeys((prev) => {
+            const next = updater(prev);
+            saveRetiredRowKeysToStorage(next);
+            return next;
+        });
+    }
 
     // Auto-linger countdown on a row's first clean-terminal appearance
     // (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06) — same rowKey space
@@ -1152,6 +1278,19 @@ export class SwarmViewModel implements ViewModel {
             return next;
         });
         this.clearCountdown(rowKey);
+    }
+
+    /** Bulk "Clear completed" — retires every currently-visible terminal-
+     *  status row across every block in one action, instead of requiring a
+     *  human to click Retire one row at a time on a large historical
+     *  backlog. The persisted-retire fix (`_retiredRowKeys` now surviving
+     *  reload) makes this genuinely useful — a bulk clear that reset itself
+     *  every reload wouldn't have been worth adding.
+     *  See SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.3. */
+    retireAllCompleted(): void {
+        for (const { rowKey, lastEventAt } of collectClearableRows(this.buildTree())) {
+            this.retireRow(rowKey, lastEventAt);
+        }
     }
 
     // ── Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06) ──

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -1107,14 +1107,23 @@ export class SwarmViewModel implements ViewModel {
     loadAll = async (): Promise<void> => {
         this.setLoading(true);
         try {
-            await Promise.all([
+            const [, subagentsOk, dispatchesOk] = await Promise.all([
                 this.loadTrackedBlocks(),
                 this.loadSubagents(),
                 this.loadDispatches(),
                 this.loadShells(),
                 this.loadCrons(),
             ]);
-            this.pruneRetiredRowKeys();
+            // codex P2 on PR #2677: a transient ListActive/ListDispatches
+            // failure is swallowed by its own loader (silent catch below),
+            // leaving the corresponding atom stale/empty — pruning against
+            // that would treat "not loaded yet" as "genuinely gone,"
+            // permanently deleting persisted retire entries for rows that
+            // are actually just not loaded yet. Only prune once BOTH
+            // sources this pass actually reflect real backend state.
+            if (subagentsOk && dispatchesOk) {
+                this.pruneRetiredRowKeys();
+            }
             this.reconcileCountdowns();
         } finally {
             this.setLoading(false);
@@ -1132,22 +1141,32 @@ export class SwarmViewModel implements ViewModel {
         }
     };
 
-    loadSubagents = async (): Promise<void> => {
+    /** @returns whether the RPC actually succeeded — callers use this to
+     *  decide whether it's safe to prune retired-row keys against the
+     *  resulting atom (codex P2 on PR #2677 — see `loadAll`/
+     *  `scheduleLoadSubagents`). */
+    loadSubagents = async (): Promise<boolean> => {
         try {
             const result = await callBackendService("subagent", "ListActive", []);
             const list = (result as ActiveSubagent[]) ?? [];
             this.setSubagents((prev) => mergeSubagentsPreservingIdentity(prev, list));
+            return true;
         } catch {
             // silently ignore
+            return false;
         }
     };
 
-    loadDispatches = async (): Promise<void> => {
+    /** @returns whether the RPC actually succeeded — see `loadSubagents`'s
+     *  doc comment. */
+    loadDispatches = async (): Promise<boolean> => {
         try {
             const result = await callBackendService("subagent", "ListDispatches", []);
             this.setDispatches((result as AgentDispatch[]) ?? []);
+            return true;
         } catch {
             // silently ignore
+            return false;
         }
     };
 
@@ -1180,8 +1199,12 @@ export class SwarmViewModel implements ViewModel {
         }
         this.loadSubagentsDebounceTimer = setTimeout(() => {
             this.loadSubagentsDebounceTimer = undefined;
-            void Promise.all([this.loadSubagents(), this.loadDispatches()]).then(() => {
-                this.pruneRetiredRowKeys();
+            void Promise.all([this.loadSubagents(), this.loadDispatches()]).then(([subagentsOk, dispatchesOk]) => {
+                // See loadAll's identical guard — don't prune against a
+                // transiently-failed fetch.
+                if (subagentsOk && dispatchesOk) {
+                    this.pruneRetiredRowKeys();
+                }
                 this.reconcileCountdowns();
             });
         }, SwarmViewModel.LOAD_SUBAGENTS_DEBOUNCE_MS);
@@ -1220,9 +1243,29 @@ export class SwarmViewModel implements ViewModel {
      *  `retiredRowKeysAtom`, which would be a reactive write-during-read). */
     private pruneRetiredRowKeys(): void {
         const liveKeys = new Set<string>();
-        for (const s of this.subagentsAtom()) liveKeys.add(subagentRowKey(s.agent_id));
-        for (const d of this.dispatchesAtom()) {
-            if (d.kind === "workflow") liveKeys.add(d.dispatch_id);
+        const subagents = this.subagentsAtom();
+        const dispatches = this.dispatchesAtom();
+        for (const s of subagents) liveKeys.add(subagentRowKey(s.agent_id));
+        const knownWorkflowDispatchIds = new Set<string>();
+        for (const d of dispatches) {
+            if (d.kind === "workflow") {
+                liveKeys.add(d.dispatch_id);
+                knownWorkflowDispatchIds.add(d.dispatch_id);
+            }
+        }
+        // codex P2 on PR #2677: a placeholder WorkflowDispatch row
+        // (`buildDispatchBuckets`'s `orphanedWorkflowMembers` fallback,
+        // rendered exactly when `dispatchesAtom` is lagging/missing this
+        // dispatch_id) is retired under its own `dispatch_id`, same as a
+        // real one. Without also treating an orphaned member's dispatch_id
+        // as live here, that key was never in `liveKeys` — the pruning pass
+        // judged it dead on the very next refresh and deleted the
+        // dismissal, resurrecting the row this same lag was already
+        // showing. Mirrors buildDispatchBuckets's own orphan detection.
+        for (const s of subagents) {
+            if (!s.dispatch_id.startsWith("solo:") && !knownWorkflowDispatchIds.has(s.dispatch_id)) {
+                liveKeys.add(s.dispatch_id);
+            }
         }
         this.setRetiredRowKeys((prev) => pruneRetiredEntries(prev, liveKeys));
     }

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -60,6 +60,31 @@
     padding: 6px 0 12px;
 }
 
+// Bulk "Clear completed" action (SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.3)
+// — only rendered at all when there's at least one clearable row.
+.swarm-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 4px 8px 0;
+}
+
+.swarm-clear-completed-btn {
+    appearance: none;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+    background: transparent;
+    color: var(--secondary-text-color);
+    border-radius: 4px;
+    font-size: 11px;
+    padding: 3px 8px;
+    cursor: default;
+
+    &:hover {
+        color: var(--main-text-color);
+        border-color: var(--secondary-text-color);
+        background: var(--highlight-bg);
+    }
+}
+
 // ── Agent group (root + its children) ───────────────────────────────────
 
 .swarm-agent-group {

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -3,7 +3,7 @@
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type Accessor, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
-import { collectClearableRows, subagentDisplayLabel, subagentRowKey, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
+import { collectClearableRows, subagentDisplayLabel, subagentRowKey, workflowRetireSignal, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import AnsiLine from "@/element/ansiline";
 import { callBackendService } from "@/store/wos";
@@ -546,7 +546,12 @@ function WorkflowDispatchRow({
     // ALREADY (label-)retired — nothing to dismiss on one still running.
     const handleRetire = (e: MouseEvent) => {
         e.stopPropagation();
-        model.retireRow(group.dispatchId, group.lastEventAt);
+        // workflowRetireSignal, NOT group.lastEventAt — see that function's
+        // doc comment (reagent P1 on PR #2677): lastEventAt is sourced from
+        // two different clocks depending on whether this row is currently
+        // a placeholder or the real dispatch, so it can't be trusted as a
+        // "did anything really change" snapshot across that transition.
+        model.retireRow(group.dispatchId, workflowRetireSignal(group));
     };
 
     // Auto-linger countdown (SPEC_SWARM_ROW_AUTO_LINGER_COUNTDOWN_2026_08_06)

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -3,7 +3,7 @@
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type Accessor, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
-import { subagentDisplayLabel, subagentRowKey, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
+import { collectClearableRows, subagentDisplayLabel, subagentRowKey, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import AnsiLine from "@/element/ansiline";
 import { callBackendService } from "@/store/wos";
@@ -123,6 +123,7 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
     });
 
     const tree = createMemo(() => model.buildTree());
+    const clearableCount = createMemo(() => collectClearableRows(tree()).length);
 
     // Derive the currently-focused block ID from the active tab's layout model.
     // focusedNode is already a reactive memo on LayoutModel, so this updates
@@ -153,6 +154,18 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
                         </div>
                     }
                 >
+                    <Show when={clearableCount() > 0}>
+                        <div class="swarm-toolbar">
+                            <button
+                                type="button"
+                                class="swarm-clear-completed-btn"
+                                title="Dismiss every completed/interrupted row currently shown"
+                                onClick={() => model.retireAllCompleted()}
+                            >
+                                Clear completed ({clearableCount()})
+                            </button>
+                        </div>
+                    </Show>
                     <div class="swarm-tree">
                         <For each={tree()}>
                             {(node) => <AgentRow node={node} focusedBlockId={focusedBlockId} model={model} />}


### PR DESCRIPTION
## Summary

Root-causes a real reported symptom: a session with only "a couple" of real `Agent`-tool calls showed **48 entries** in the Swarm panel, including rows that visually read as duplicates. Not one bug — accumulation (the backend never prunes historical subagents, and the only dismiss mechanism was ephemeral in-memory state) plus a workflow-member spillage bug, compounded by dispatches having no "dead" status of their own and a reconciliation pass that could silently no-op.

- `buildDispatchBuckets` no longer spills a lagging Workflow dispatch's members individually into the flat Agent-Tool bucket — grouped into one synthesized placeholder row.
- Added `DispatchStatus::Abandoned` (Rust) with proper aggregation from member reconciliation. Caught and fixed a real bug along the way: `refresh_dispatch_status` (called on *every* `ListDispatches` read) was silently clobbering a freshly-set `Abandoned` back to `Running`/`Completed`.
- Fixed a flagged-but-never-confirmed race where `reconcile_stale_subagents` could run before a block's controller registers, permanently treating "unknown" the same as "confirmed active" — now retries once (bounded, not a loop) before giving up.
- Retired/dismissed rows now persist to `localStorage` (local-machine scope) instead of resetting on every reload/restart, plus a new bulk **"Clear completed (N)"** action so a human can resolve a large historical backlog in one click.
- Also fixed a follow-on gap caught while wiring this up: the frontend `AgentDispatch.status` TS type and the `WorkflowDispatch.status` active/retired mapping didn't account for the new `"abandoned"` value at all — an abandoned Workflow dispatch would have silently read as still "active".

Deliberately descoped: a full Live/Historical collapsed-section UI split — real information-architecture work that deserves its own design pass, tracked as a follow-up in the spec rather than rushed in here.

See `docs/specs/SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md` and `docs/reports/REPORT_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md` for the full investigation and design rationale.

## Test plan

- [x] `cargo test -p agentmux-srv` — full suite passes (2472 tests, 0 failed)
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full frontend suite passes (2801+ tests)
- [x] New tests: 6 Rust (dispatch abandonment aggregation, reconcile retry paths), 13 frontend (orphaned-member grouping, retire persistence, bulk-clear eligibility, abandoned-status mapping regression)
- [ ] Interactive/visual verification not done — see report for why

<!-- agentmux:agent_id=naki -->