### PR TITLE
feat(memory): version history UI in Stash and a new Armory Native Memory tab

### DIFF
--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -74,7 +74,12 @@ export const MemoryApi = {
 
     NativeMemoryDiffCommand(
         client: RpcClient,
-        data: { from_version_id: string; to_version_id: string },
+        // agent_id required (reagent P1 on agent1/memory-version-core):
+        // the backend verifies BOTH versions belong to this agent before
+        // returning their content — every caller shares one instance-wide
+        // X-AuthKey, so without it any caller could read any other
+        // agent's memory content by version id.
+        data: { agent_id: string; from_version_id: string; to_version_id: string },
         opts?: RpcOpts,
     ): Promise<NativeMemoryDiffResult> {
         return client.rpcCall("agent:memory:diff", data, opts);

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -56,7 +56,35 @@ export const MemoryApi = {
         return client.rpcCall("agent:memory:read_file", data, opts);
     },
 
-    NativeMemoryWriteFileCommand(client: RpcClient, data: { agent_id: string; filename: string; content: string }, opts?: RpcOpts): Promise<void> {
+    NativeMemoryWriteFileCommand(
+        client: RpcClient,
+        data: { agent_id: string; filename: string; content: string; provenance?: NativeMemoryWriteProvenance },
+        opts?: RpcOpts,
+    ): Promise<void> {
         return client.rpcCall("agent:memory:write_file", data, opts);
+    },
+
+    NativeMemoryHistoryCommand(
+        client: RpcClient,
+        data: { agent_id: string; filename: string },
+        opts?: RpcOpts,
+    ): Promise<NativeMemoryHistoryResult> {
+        return client.rpcCall("agent:memory:history", data, opts);
+    },
+
+    NativeMemoryDiffCommand(
+        client: RpcClient,
+        data: { from_version_id: string; to_version_id: string },
+        opts?: RpcOpts,
+    ): Promise<NativeMemoryDiffResult> {
+        return client.rpcCall("agent:memory:diff", data, opts);
+    },
+
+    NativeMemoryRevertCommand(
+        client: RpcClient,
+        data: { agent_id: string; filename: string; target_version_id: string },
+        opts?: RpcOpts,
+    ): Promise<NativeMemoryRevertResult> {
+        return client.rpcCall("agent:memory:revert", data, opts);
     },
 };

--- a/frontend/app/view/agent/agent-native-memory-model.ts
+++ b/frontend/app/view/agent/agent-native-memory-model.ts
@@ -201,6 +201,10 @@ export class AgentNativeMemoryModel {
                 agent_id: this.agentId,
                 filename,
                 content,
+                // reagent P1 on PR #2678: without this, the backend
+                // defaults to "agent_inferred", permanently mislabeling a
+                // human-authored Stash edit as "Agent" in the history UI.
+                provenance: { source: "human" },
             });
             this.setContent(content);
             this.setEditing(false);
@@ -233,6 +237,7 @@ export class AgentNativeMemoryModel {
                 agent_id: this.agentId,
                 filename,
                 content,
+                provenance: { source: "human" },
             });
             await this.loadFiles();
             await this.selectFile(filename);

--- a/frontend/app/view/agent/agent-native-memory-model.ts
+++ b/frontend/app/view/agent/agent-native-memory-model.ts
@@ -73,7 +73,11 @@ export class AgentNativeMemoryModel {
 
     private _content = createSignal<string | null>(null);
     contentAtom: Accessor<string | null> = this._content[0];
-    private setContent = this._content[1];
+    // Not private: NativeMemoryHistoryPanel's revert flow (mounted as a
+    // sibling view inside the same detail pane, see AgentNativeMemoryModal)
+    // pushes the newly-restored content here directly rather than doing a
+    // second read_file round trip of its own.
+    setContent = this._content[1];
 
     private _editing = createSignal<boolean>(false);
     editingAtom: Accessor<boolean> = this._editing[0];

--- a/frontend/app/view/agent/components/AgentNativeMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNativeMemoryModal.tsx
@@ -16,9 +16,10 @@
  * Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md §5.
  */
 
-import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { AgentNativeMemoryModel, normalizeMemoryFilename, validateMemoryFilename } from "../agent-native-memory-model";
+import { NativeMemoryHistoryPanel } from "./NativeMemoryHistoryPanel";
 import "./AgentNativeMemoryModal.scss";
 
 interface AgentNativeMemoryModalProps {
@@ -90,6 +91,17 @@ export const AgentNativeMemoryModal = (props: AgentNativeMemoryModalProps): JSX.
     // adopted here per SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.2.
     const inDetail = () => model.selectedFilenameAtom() !== null;
     const [creatingIndex, setCreatingIndex] = createSignal(false);
+
+    // Version history toggle (SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md
+    // §4.3) — a third view alongside "read" and "edit" within the same
+    // detail pane, not a separate modal/route. Reset whenever the selected
+    // file changes so switching files doesn't leave a stale file's history
+    // showing under a new filename.
+    const [showHistory, setShowHistory] = createSignal(false);
+    createEffect(() => {
+        model.selectedFilenameAtom();
+        setShowHistory(false);
+    });
 
     const listView = (
         <div class="agent-memory-modal-list">
@@ -191,45 +203,77 @@ export const AgentNativeMemoryModal = (props: AgentNativeMemoryModalProps): JSX.
     const detailView = (
         <div class="agent-memory-modal-detail">
             <Show
-                when={model.editingAtom()}
+                when={showHistory()}
                 fallback={
-                    <div class="agent-memory-modal-view">
-                        <pre class="agent-memory-modal-content">
-                            {model.contentAtom() ?? "Loading…"}
-                        </pre>
-                        <div class="agent-memory-modal-detail-actions">
-                            <button
-                                class="agent-memory-modal-btn"
-                                disabled={model.contentAtom() === null}
-                                onClick={() => model.startEdit()}
-                            >
-                                Edit
-                            </button>
+                    <Show
+                        when={model.editingAtom()}
+                        fallback={
+                            <div class="agent-memory-modal-view">
+                                <pre class="agent-memory-modal-content">
+                                    {model.contentAtom() ?? "Loading…"}
+                                </pre>
+                                <div class="agent-memory-modal-detail-actions">
+                                    <button
+                                        class="agent-memory-modal-btn"
+                                        disabled={model.contentAtom() === null}
+                                        onClick={() => setShowHistory(true)}
+                                    >
+                                        History
+                                    </button>
+                                    <button
+                                        class="agent-memory-modal-btn"
+                                        disabled={model.contentAtom() === null}
+                                        onClick={() => model.startEdit()}
+                                    >
+                                        Edit
+                                    </button>
+                                </div>
+                            </div>
+                        }
+                    >
+                        <div class="agent-memory-modal-edit">
+                            <textarea
+                                class="agent-memory-modal-textarea"
+                                value={model.draftContentAtom()}
+                                onInput={(e) => model.setDraftContent(e.currentTarget.value)}
+                                spellcheck={false}
+                            />
+                            <div class="agent-memory-modal-detail-actions">
+                                <button
+                                    class="agent-memory-modal-btn"
+                                    disabled={model.savingAtom()}
+                                    onClick={() => model.cancelEdit()}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    class="agent-memory-modal-btn agent-memory-modal-btn-primary"
+                                    disabled={model.savingAtom()}
+                                    onClick={() => void model.saveEdit()}
+                                >
+                                    {model.savingAtom() ? "Saving…" : "Save"}
+                                </button>
+                            </div>
                         </div>
-                    </div>
+                    </Show>
                 }
             >
-                <div class="agent-memory-modal-edit">
-                    <textarea
-                        class="agent-memory-modal-textarea"
-                        value={model.draftContentAtom()}
-                        onInput={(e) => model.setDraftContent(e.currentTarget.value)}
-                        spellcheck={false}
-                    />
+                <div class="agent-memory-modal-view">
+                    <Show when={model.selectedFilenameAtom()} keyed>
+                        {(filename) => (
+                            <NativeMemoryHistoryPanel
+                                agentId={props.agentId}
+                                filename={filename}
+                                onContentReverted={(content) => {
+                                    model.setContent(content);
+                                    void model.loadFiles();
+                                }}
+                            />
+                        )}
+                    </Show>
                     <div class="agent-memory-modal-detail-actions">
-                        <button
-                            class="agent-memory-modal-btn"
-                            disabled={model.savingAtom()}
-                            onClick={() => model.cancelEdit()}
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            class="agent-memory-modal-btn agent-memory-modal-btn-primary"
-                            disabled={model.savingAtom()}
-                            onClick={() => void model.saveEdit()}
-                        >
-                            {model.savingAtom() ? "Saving…" : "Save"}
+                        <button class="agent-memory-modal-btn" onClick={() => setShowHistory(false)}>
+                            Back to content
                         </button>
                     </div>
                 </div>

--- a/frontend/app/view/agent/components/NativeMemoryHistoryPanel.scss
+++ b/frontend/app/view/agent/components/NativeMemoryHistoryPanel.scss
@@ -1,0 +1,208 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Styles for NativeMemoryHistoryPanel — shared version history/diff/revert
+// view, mounted from both AgentNativeMemoryModal (Stash) and Armory's
+// Native Memory tab. Follows the same variable/spacing conventions as
+// AgentNativeMemoryModal.scss (its usual host).
+
+.native-memory-history {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    min-height: 0;
+    overflow-y: auto;
+    padding: var(--space-2);
+}
+
+.native-memory-history-error {
+    padding: var(--space-1-5) var(--space-2);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 30%, transparent);
+    color: var(--error-color);
+    font-size: var(--text-sm);
+}
+
+.native-memory-history-loading,
+.native-memory-history-empty {
+    padding: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    font-style: italic;
+}
+
+.native-memory-history-hint {
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+}
+
+.native-memory-history-list {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border: 1px solid var(--border-color);
+}
+
+.native-memory-history-item {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-1-5);
+    padding: var(--space-1-5) var(--space-2);
+    border-bottom: 1px solid var(--border-color);
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    &.is-selected {
+        background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+    }
+}
+
+.native-memory-history-item-select {
+    flex-shrink: 0;
+    padding-top: 2px;
+}
+
+.native-memory-history-item-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.native-memory-history-item-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    font-size: var(--text-sm);
+}
+
+.native-memory-history-item-source {
+    font-weight: 600;
+    color: var(--main-text-color);
+
+    &.is-warning {
+        color: var(--warning-color);
+    }
+}
+
+.native-memory-history-item-time {
+    color: var(--secondary-text-color);
+    font-size: var(--text-xs);
+}
+
+.native-memory-history-item-badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 1px 5px;
+    color: var(--accent-color);
+    background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+}
+
+.native-memory-history-item-warning {
+    font-size: var(--text-xs);
+    color: var(--warning-color);
+}
+
+.native-memory-history-revert-btn {
+    flex-shrink: 0;
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    font-size: var(--text-xs);
+    cursor: default;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+    }
+}
+
+.native-memory-history-revert-confirm {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+}
+
+.native-memory-history-btn {
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-xs);
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+    }
+
+    &.native-memory-history-btn-primary {
+        background: var(--accent-color);
+        color: var(--button-text-color);
+        border-color: var(--accent-color);
+
+        &:hover:not(:disabled) {
+            opacity: 0.85;
+        }
+    }
+}
+
+.native-memory-history-diff {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-color);
+}
+
+.native-memory-history-diff-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-1-5) var(--space-2);
+    border-bottom: 1px solid var(--border-color);
+    background: var(--panel-bg-color);
+    font-size: var(--text-sm);
+    font-weight: 600;
+}
+
+.native-memory-history-diff-body {
+    margin: 0;
+    padding: var(--space-1-5) var(--space-2);
+    max-height: 320px;
+    overflow: auto;
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-xs);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+.native-memory-diff-line {
+    color: var(--main-text-color);
+
+    &.is-added {
+        color: var(--success-color);
+        background: color-mix(in srgb, var(--success-color) 8%, transparent);
+    }
+
+    &.is-removed {
+        color: var(--error-color);
+        background: color-mix(in srgb, var(--error-color) 8%, transparent);
+    }
+}

--- a/frontend/app/view/agent/components/NativeMemoryHistoryPanel.tsx
+++ b/frontend/app/view/agent/components/NativeMemoryHistoryPanel.tsx
@@ -1,0 +1,182 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NativeMemoryHistoryPanel — version history / diff / revert for one memory
+ * file. Shared component, mounted from two places (props are the only
+ * difference between them, never the underlying data):
+ *   - AgentNativeMemoryModal (Stash "Memory" tab) — agentId fixed to the
+ *     pane's own agent.
+ *   - NativeMemoryManager (Armory "Native Memory" tab) — agentId comes from
+ *     an agent picker.
+ * Both read the identical agent:memory:history/diff/revert RPCs — one
+ * source of truth, two entry points. See
+ * docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3.
+ *
+ * Remounts per (agentId, filename) — this component does not itself react
+ * to those props changing after mount; callers that let the user switch
+ * agent/file (e.g. Armory's picker) must force a remount (e.g. a keyed
+ * <Show>) rather than relying on this component to re-fetch internally.
+ */
+
+import { For, Show, createSignal, onCleanup, type JSX } from "solid-js";
+import { NativeMemoryHistoryModel, sourceLabel, sourceWarning } from "../native-memory-history-model";
+import "./NativeMemoryHistoryPanel.scss";
+
+interface NativeMemoryHistoryPanelProps {
+    agentId: string;
+    filename: string;
+    /** Called with the restored content immediately after a successful
+     *  revert, so a caller showing "current content" elsewhere (e.g.
+     *  AgentNativeMemoryModal's own view pane) can refresh without a
+     *  separate read_file round trip of its own. */
+    onContentReverted?: (content: string) => void;
+}
+
+function formatTimestamp(ms: number): string {
+    if (!ms) return "unknown time";
+    return new Date(ms).toLocaleString(undefined, {
+        year: "numeric", month: "short", day: "numeric",
+        hour: "2-digit", minute: "2-digit",
+    });
+}
+
+/** One line of `NativeMemoryDiffResult.diff`, tagged for styling. */
+function diffLineClass(line: string): string {
+    if (line.startsWith("+ ")) return "native-memory-diff-line is-added";
+    if (line.startsWith("- ")) return "native-memory-diff-line is-removed";
+    return "native-memory-diff-line";
+}
+
+export const NativeMemoryHistoryPanel = (props: NativeMemoryHistoryPanelProps): JSX.Element => {
+    const model = new NativeMemoryHistoryModel(props.agentId, props.filename);
+    onCleanup(() => model.dispose());
+    if (props.onContentReverted) {
+        model.onReverted = props.onContentReverted;
+    }
+
+    const [confirmingRevert, setConfirmingRevert] = createSignal<string | null>(null);
+
+    return (
+        <div class="native-memory-history">
+            <Show when={model.errorAtom()}>
+                <div class="native-memory-history-error">{model.errorAtom()}</div>
+            </Show>
+
+            <Show
+                when={!model.loadingAtom()}
+                fallback={<div class="native-memory-history-loading">Loading history…</div>}
+            >
+                <Show
+                    when={model.versionsAtom().length > 0}
+                    fallback={<div class="native-memory-history-empty">No recorded versions yet.</div>}
+                >
+                    <div class="native-memory-history-hint">
+                        Select two versions to compare, or revert directly to one.
+                    </div>
+                    <ul class="native-memory-history-list">
+                        <For each={model.versionsAtom()}>
+                            {(v, i) => {
+                                const warning = sourceWarning(v);
+                                const selected = () => model.diffSelectionAtom().includes(v.id);
+                                return (
+                                    <li
+                                        class="native-memory-history-item"
+                                        classList={{ "is-selected": selected(), "is-latest": i() === 0 }}
+                                    >
+                                        <label class="native-memory-history-item-select">
+                                            <input
+                                                type="checkbox"
+                                                checked={selected()}
+                                                onChange={() => model.toggleDiffSelection(v.id)}
+                                            />
+                                        </label>
+                                        <div class="native-memory-history-item-body">
+                                            <div class="native-memory-history-item-meta">
+                                                <span
+                                                    class="native-memory-history-item-source"
+                                                    classList={{ "is-warning": warning !== null }}
+                                                >
+                                                    {sourceLabel(v.source)}
+                                                </span>
+                                                <span class="native-memory-history-item-time">
+                                                    {formatTimestamp(v.created_at)}
+                                                </span>
+                                                <Show when={i() === 0}>
+                                                    <span class="native-memory-history-item-badge">current</span>
+                                                </Show>
+                                            </div>
+                                            <Show when={warning}>
+                                                <div class="native-memory-history-item-warning" title={warning ?? undefined}>
+                                                    ⚠ {warning}
+                                                </div>
+                                            </Show>
+                                        </div>
+                                        <Show when={i() !== 0}>
+                                            <Show
+                                                when={confirmingRevert() === v.id}
+                                                fallback={
+                                                    <button
+                                                        class="native-memory-history-revert-btn"
+                                                        disabled={model.revertingAtom()}
+                                                        onClick={() => setConfirmingRevert(v.id)}
+                                                    >
+                                                        Revert to this
+                                                    </button>
+                                                }
+                                            >
+                                                <div class="native-memory-history-revert-confirm">
+                                                    <span>Restore this content as a new version?</span>
+                                                    <button
+                                                        class="native-memory-history-btn"
+                                                        disabled={model.revertingAtom()}
+                                                        onClick={() => setConfirmingRevert(null)}
+                                                    >
+                                                        Cancel
+                                                    </button>
+                                                    <button
+                                                        class="native-memory-history-btn native-memory-history-btn-primary"
+                                                        disabled={model.revertingAtom()}
+                                                        onClick={() => {
+                                                            setConfirmingRevert(null);
+                                                            void model.revertTo(v.id);
+                                                        }}
+                                                    >
+                                                        {model.revertingAtom() ? "Reverting…" : "Confirm revert"}
+                                                    </button>
+                                                </div>
+                                            </Show>
+                                        </Show>
+                                    </li>
+                                );
+                            }}
+                        </For>
+                    </ul>
+                </Show>
+            </Show>
+
+            <Show when={model.diffSelectionAtom().length === 2}>
+                <div class="native-memory-history-diff">
+                    <div class="native-memory-history-diff-header">
+                        <span>Diff</span>
+                        <button class="native-memory-history-btn" onClick={() => model.clearDiffSelection()}>
+                            Clear selection
+                        </button>
+                    </div>
+                    <Show
+                        when={!model.diffLoadingAtom()}
+                        fallback={<div class="native-memory-history-loading">Loading diff…</div>}
+                    >
+                        <pre class="native-memory-history-diff-body">
+                            <For each={(model.diffTextAtom() ?? "").split("\n").filter((_, idx, arr) => idx < arr.length - 1 || arr[idx] !== "")}>
+                                {(line) => <div class={diffLineClass(line)}>{line || " "}</div>}
+                            </For>
+                        </pre>
+                    </Show>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+NativeMemoryHistoryPanel.displayName = "NativeMemoryHistoryPanel";

--- a/frontend/app/view/agent/native-memory-history-model.test.ts
+++ b/frontend/app/view/agent/native-memory-history-model.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { orderVersionsOldestFirst } from "./native-memory-history-model";
+
+function meta(id: string): NativeMemoryVersionMeta {
+    return {
+        id,
+        content_hash: "",
+        parent_version_id: null,
+        source: "human",
+        source_detail: "{}",
+        session_id: "",
+        created_at: 0,
+    };
+}
+
+describe("orderVersionsOldestFirst", () => {
+    // versionsAtom() is newest-first: index 0 = newest, higher index = older.
+    const versions = [meta("v3-newest"), meta("v2"), meta("v1-oldest")];
+
+    it("returns [oldest, newest] regardless of click order — first click newer", () => {
+        const [from, to] = orderVersionsOldestFirst("v3-newest", "v1-oldest", versions);
+        expect(from).toBe("v1-oldest");
+        expect(to).toBe("v3-newest");
+    });
+
+    it("returns [oldest, newest] regardless of click order — first click older", () => {
+        // Regression for reagent P1: an earlier revision had this branch's
+        // output backwards, putting the newer id in `from`.
+        const [from, to] = orderVersionsOldestFirst("v1-oldest", "v3-newest", versions);
+        expect(from).toBe("v1-oldest");
+        expect(to).toBe("v3-newest");
+    });
+
+    it("handles two adjacent versions in either click order — v2 is older than v3-newest", () => {
+        expect(orderVersionsOldestFirst("v2", "v3-newest", versions)).toEqual(["v2", "v3-newest"]);
+        expect(orderVersionsOldestFirst("v3-newest", "v2", versions)).toEqual(["v2", "v3-newest"]);
+    });
+
+    it("falls back to input order when an id is not found", () => {
+        expect(orderVersionsOldestFirst("unknown-a", "unknown-b", versions)).toEqual(["unknown-a", "unknown-b"]);
+    });
+});

--- a/frontend/app/view/agent/native-memory-history-model.test.ts
+++ b/frontend/app/view/agent/native-memory-history-model.test.ts
@@ -1,8 +1,21 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
-import { orderVersionsOldestFirst } from "./native-memory-history-model";
+import { createRoot } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        NativeMemoryHistoryCommand: vi.fn(),
+        NativeMemoryDiffCommand: vi.fn(),
+        NativeMemoryRevertCommand: vi.fn(),
+        NativeMemoryReadFileCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { NativeMemoryHistoryModel, orderVersionsOldestFirst } from "./native-memory-history-model";
 
 function meta(id: string): NativeMemoryVersionMeta {
     return {
@@ -41,5 +54,89 @@ describe("orderVersionsOldestFirst", () => {
 
     it("falls back to input order when an id is not found", () => {
         expect(orderVersionsOldestFirst("unknown-a", "unknown-b", versions)).toEqual(["unknown-a", "unknown-b"]);
+    });
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+// Regression for reagent P2 on PR #2678: computeDiff() had no request-id
+// guard — selecting one version pair, then a different pair before the
+// first NativeMemoryDiffCommand resolved, could let the stale response
+// land after the newer one and overwrite diffTextAtom.
+describe("NativeMemoryHistoryModel diff request staleness", () => {
+    const versions = [meta("v3-newest"), meta("v2"), meta("v1-oldest")];
+    let dispose: (() => void) | undefined;
+
+    afterEach(() => {
+        dispose?.();
+        dispose = undefined;
+        vi.clearAllMocks();
+    });
+
+    async function makeModel(): Promise<NativeMemoryHistoryModel> {
+        vi.mocked(RpcApi.NativeMemoryHistoryCommand).mockResolvedValue({ versions });
+        let model!: NativeMemoryHistoryModel;
+        createRoot((d) => {
+            dispose = d;
+            model = new NativeMemoryHistoryModel("agent-1", "MEMORY.md");
+        });
+        // Let the constructor's fire-and-forget loadHistory() settle.
+        await Promise.resolve();
+        await Promise.resolve();
+        return model;
+    }
+
+    it("discards a stale diff response that resolves after a newer selection's diff", async () => {
+        const model = await makeModel();
+
+        const first = deferred<NativeMemoryDiffResult>();
+        const second = deferred<NativeMemoryDiffResult>();
+        vi.mocked(RpcApi.NativeMemoryDiffCommand)
+            .mockReturnValueOnce(first.promise)
+            .mockReturnValueOnce(second.promise);
+
+        // First pair selected — fires the first (slow) diff request.
+        model.toggleDiffSelection("v1-oldest");
+        model.toggleDiffSelection("v2");
+
+        // Deselect one and pick a different pair before the first request
+        // resolves — fires the second (fast) diff request.
+        model.toggleDiffSelection("v2");
+        model.toggleDiffSelection("v3-newest");
+
+        // The second, newer request resolves first.
+        second.resolve({ diff: "second diff" });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(model.diffTextAtom()).toBe("second diff");
+
+        // The first, now-stale request resolves after — must be discarded,
+        // not overwrite the newer diff already shown.
+        first.resolve({ diff: "first diff (stale)" });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(model.diffTextAtom()).toBe("second diff");
+    });
+
+    it("discards a stale diff response after the selection is cleared entirely", async () => {
+        const model = await makeModel();
+
+        const pending = deferred<NativeMemoryDiffResult>();
+        vi.mocked(RpcApi.NativeMemoryDiffCommand).mockReturnValueOnce(pending.promise);
+
+        model.toggleDiffSelection("v1-oldest");
+        model.toggleDiffSelection("v2");
+        model.clearDiffSelection();
+
+        pending.resolve({ diff: "stale diff" });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(model.diffTextAtom()).toBeNull();
     });
 });

--- a/frontend/app/view/agent/native-memory-history-model.ts
+++ b/frontend/app/view/agent/native-memory-history-model.ts
@@ -1,0 +1,202 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NativeMemoryHistoryModel — view model for one memory file's version
+ * history: list, diff any two versions, revert to a prior version. Backs
+ * `NativeMemoryHistoryPanel`, which is mounted from two places — the
+ * agent's own Stash "Memory" tab (`AgentNativeMemoryModal`) and Armory's
+ * "Native Memory" tab (agent-picker + this same panel) — both reading the
+ * identical `agent:memory:history/diff/revert` RPCs, so there is one
+ * source of truth and two entry points, per
+ * docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3.
+ */
+
+import { createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+/** Human label for a version's `source` field. */
+export function sourceLabel(source: string): string {
+    switch (source) {
+        case "human": return "Human";
+        case "agent_inferred": return "Agent";
+        case "jekt": return "Jekt";
+        case "external_fs_write": return "Detected outside AgentMux";
+        case "revert": return "Revert";
+        default: return source;
+    }
+}
+
+/** Whether a version's source warrants a visible warning tag — a claim
+ *  about *why* the write happened that the operator should specifically
+ *  notice, per the spec's §4.4 (distinguishing "unverified sender" from
+ *  "untracked write path" — two materially different weaker claims). */
+export function sourceWarning(v: NativeMemoryVersionMeta): string | null {
+    if (v.source === "jekt") {
+        let tier = "";
+        let trust = "";
+        try {
+            const detail = JSON.parse(v.source_detail || "{}") as Record<string, unknown>;
+            tier = typeof detail.TIER === "string" ? detail.TIER : "";
+            trust = typeof detail.TRUST === "string" ? detail.TRUST : "";
+        } catch {
+            // source_detail wasn't valid JSON — fall through with an empty tier/trust.
+        }
+        const parts = [tier && `TIER=${tier}`, trust && `TRUST=${trust}`].filter(Boolean);
+        return `written in response to a jekt${parts.length ? ` — ${parts.join(", ")}` : ""}`;
+    }
+    if (v.source === "external_fs_write") {
+        let detectedVia = "";
+        try {
+            const detail = JSON.parse(v.source_detail || "{}") as Record<string, unknown>;
+            detectedVia = typeof detail.detected_via === "string" ? detail.detected_via : "";
+        } catch {
+            // ignore
+        }
+        return `detected outside AgentMux's write path — provenance unknown${detectedVia ? ` (${detectedVia})` : ""}`;
+    }
+    return null;
+}
+
+export class NativeMemoryHistoryModel {
+    readonly agentId: string;
+    readonly filename: string;
+
+    private _versions = createSignal<NativeMemoryVersionMeta[]>([]);
+    versionsAtom: Accessor<NativeMemoryVersionMeta[]> = this._versions[0];
+    private setVersions = this._versions[1];
+
+    private _loading = createSignal<boolean>(false);
+    loadingAtom: Accessor<boolean> = this._loading[0];
+    private setLoading = this._loading[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    private setError = this._error[1];
+
+    /** Up to two version ids selected for comparison, oldest-first once both are set. */
+    private _diffSelection = createSignal<string[]>([]);
+    diffSelectionAtom: Accessor<string[]> = this._diffSelection[0];
+    private setDiffSelection = this._diffSelection[1];
+
+    private _diffText = createSignal<string | null>(null);
+    diffTextAtom: Accessor<string | null> = this._diffText[0];
+    private setDiffText = this._diffText[1];
+
+    private _diffLoading = createSignal<boolean>(false);
+    diffLoadingAtom: Accessor<boolean> = this._diffLoading[0];
+    private setDiffLoading = this._diffLoading[1];
+
+    private _reverting = createSignal<boolean>(false);
+    revertingAtom: Accessor<boolean> = this._reverting[0];
+    private setReverting = this._reverting[1];
+
+    /** Called after a successful revert so the caller (e.g.
+     *  AgentNativeMemoryModel) can refresh the live file content it shows
+     *  elsewhere — this model only owns history/diff/revert state, not the
+     *  "current content" view that already exists on the sibling model. */
+    onReverted?: (newContent: string) => void;
+
+    constructor(agentId: string, filename: string) {
+        this.agentId = agentId;
+        this.filename = filename;
+        void this.loadHistory();
+    }
+
+    async loadHistory(): Promise<void> {
+        this.setLoading(true);
+        this.setError(null);
+        try {
+            const res = await RpcApi.NativeMemoryHistoryCommand(TabRpcClient, {
+                agent_id: this.agentId,
+                filename: this.filename,
+            });
+            this.setVersions(res.versions);
+        } catch (e) {
+            this.setError(`Failed to load history: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setLoading(false);
+        }
+    }
+
+    /** Toggle a version in/out of the (at most 2) diff selection. Selecting
+     *  a third clears down to just the newly-clicked one — simpler than a
+     *  queue, and matches "pick two things to compare" as the only real
+     *  use case. */
+    toggleDiffSelection(versionId: string): void {
+        const current = this.diffSelectionAtom();
+        if (current.includes(versionId)) {
+            this.setDiffSelection(current.filter((id) => id !== versionId));
+            this.setDiffText(null);
+            return;
+        }
+        const next = current.length >= 2 ? [versionId] : [...current, versionId];
+        this.setDiffSelection(next);
+        this.setDiffText(null);
+        if (next.length === 2) void this.computeDiff(next[0], next[1]);
+    }
+
+    private async computeDiff(idA: string, idB: string): Promise<void> {
+        // Order oldest -> newest so the diff reads as "what changed since
+        // the earlier version", regardless of click order.
+        const versions = this.versionsAtom();
+        const indexOf = (id: string) => versions.findIndex((v) => v.id === id);
+        const [from, to] = indexOf(idA) > indexOf(idB) ? [idB, idA] : [idA, idB];
+
+        this.setDiffLoading(true);
+        this.setError(null);
+        try {
+            const res = await RpcApi.NativeMemoryDiffCommand(TabRpcClient, {
+                from_version_id: from,
+                to_version_id: to,
+            });
+            this.setDiffText(res.diff);
+        } catch (e) {
+            this.setError(`Failed to load diff: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setDiffLoading(false);
+        }
+    }
+
+    clearDiffSelection(): void {
+        this.setDiffSelection([]);
+        this.setDiffText(null);
+    }
+
+    /** Revert to `versionId` — recorded as a NEW version (source "revert"),
+     *  never a rewrite of history. Reloads history afterward so the new
+     *  version shows up immediately. */
+    async revertTo(versionId: string): Promise<void> {
+        this.setReverting(true);
+        this.setError(null);
+        try {
+            await RpcApi.NativeMemoryRevertCommand(TabRpcClient, {
+                agent_id: this.agentId,
+                filename: this.filename,
+                target_version_id: versionId,
+            });
+            this.clearDiffSelection();
+            await this.loadHistory();
+            const reverted = this.versionsAtom().find((v) => v.id === versionId);
+            if (reverted && this.onReverted) {
+                // Fetch the reverted content directly rather than trusting
+                // any cached copy — read_file is cheap and this only fires
+                // on an explicit user action, not a hot path.
+                const read = await RpcApi.NativeMemoryReadFileCommand(TabRpcClient, {
+                    agent_id: this.agentId,
+                    filename: this.filename,
+                });
+                this.onReverted(read.content);
+            }
+        } catch (e) {
+            this.setError(`Revert failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setReverting(false);
+        }
+    }
+
+    dispose(): void {
+        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+}

--- a/frontend/app/view/agent/native-memory-history-model.ts
+++ b/frontend/app/view/agent/native-memory-history-model.ts
@@ -113,6 +113,13 @@ export class NativeMemoryHistoryModel {
     revertingAtom: Accessor<boolean> = this._reverting[0];
     private setReverting = this._reverting[1];
 
+    /** reagent P2 on PR #2678: guards computeDiff against a stale response —
+     *  selecting one version pair, then a different pair before the first
+     *  NativeMemoryDiffCommand resolves, could otherwise let the stale
+     *  response overwrite diffTextAtom after the newer selection's request
+     *  already completed. */
+    private latestDiffRequestId = 0;
+
     /** Called after a successful revert so the caller (e.g.
      *  AgentNativeMemoryModel) can refresh the live file content it shows
      *  elsewhere — this model only owns history/diff/revert state, not the
@@ -146,6 +153,12 @@ export class NativeMemoryHistoryModel {
      *  queue, and matches "pick two things to compare" as the only real
      *  use case. */
     toggleDiffSelection(versionId: string): void {
+        // Any change to the selection invalidates whatever diff request (if
+        // any) was previously in flight — otherwise a stale response could
+        // still land afterward and repopulate diffTextAtom for a selection
+        // the user has since abandoned, even on a path (like selecting a
+        // third id, below) that doesn't itself start a new diff request.
+        this.latestDiffRequestId++;
         const current = this.diffSelectionAtom();
         if (current.includes(versionId)) {
             this.setDiffSelection(current.filter((id) => id !== versionId));
@@ -163,6 +176,9 @@ export class NativeMemoryHistoryModel {
         // the earlier version", regardless of click order.
         const [from, to] = orderVersionsOldestFirst(idA, idB, this.versionsAtom());
 
+        // toggleDiffSelection already bumped latestDiffRequestId for this
+        // call — capture it as-is rather than bumping again here.
+        const requestId = this.latestDiffRequestId;
         this.setDiffLoading(true);
         this.setError(null);
         try {
@@ -171,15 +187,18 @@ export class NativeMemoryHistoryModel {
                 from_version_id: from,
                 to_version_id: to,
             });
+            if (requestId !== this.latestDiffRequestId) return;
             this.setDiffText(res.diff);
         } catch (e) {
+            if (requestId !== this.latestDiffRequestId) return;
             this.setError(`Failed to load diff: ${(e as Error).message ?? e}`);
         } finally {
-            this.setDiffLoading(false);
+            if (requestId === this.latestDiffRequestId) this.setDiffLoading(false);
         }
     }
 
     clearDiffSelection(): void {
+        this.latestDiffRequestId++;
         this.setDiffSelection([]);
         this.setDiffText(null);
     }

--- a/frontend/app/view/agent/native-memory-history-model.ts
+++ b/frontend/app/view/agent/native-memory-history-model.ts
@@ -148,6 +148,7 @@ export class NativeMemoryHistoryModel {
         this.setError(null);
         try {
             const res = await RpcApi.NativeMemoryDiffCommand(TabRpcClient, {
+                agent_id: this.agentId,
                 from_version_id: from,
                 to_version_id: to,
             });

--- a/frontend/app/view/agent/native-memory-history-model.ts
+++ b/frontend/app/view/agent/native-memory-history-model.ts
@@ -16,6 +16,27 @@ import { createSignal, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 
+/** Order two version ids oldest-first, given `versions` in the model's own
+ *  newest-first order (matches `agent:memory:history`'s response order —
+ *  see `agent_native_memory_version_list`'s `ORDER BY created_at DESC` on
+ *  the backend). Extracted as a standalone, unit-testable function after
+ *  reagent P1 caught this exact ordering inverted in an earlier revision —
+ *  a larger index in a newest-first list means an OLDER version, easy to
+ *  get backwards inline. Returns `[idA, idB]` unchanged if either id isn't
+ *  found in `versions` (defensive default; callers only invoke this with
+ *  ids known to be present). */
+export function orderVersionsOldestFirst(
+    idA: string,
+    idB: string,
+    versions: NativeMemoryVersionMeta[],
+): [string, string] {
+    const indexOf = (id: string) => versions.findIndex((v) => v.id === id);
+    const idxA = indexOf(idA);
+    const idxB = indexOf(idB);
+    if (idxA < 0 || idxB < 0) return [idA, idB];
+    return idxA > idxB ? [idA, idB] : [idB, idA];
+}
+
 /** Human label for a version's `source` field. */
 export function sourceLabel(source: string): string {
     switch (source) {
@@ -140,9 +161,7 @@ export class NativeMemoryHistoryModel {
     private async computeDiff(idA: string, idB: string): Promise<void> {
         // Order oldest -> newest so the diff reads as "what changed since
         // the earlier version", regardless of click order.
-        const versions = this.versionsAtom();
-        const indexOf = (id: string) => versions.findIndex((v) => v.id === id);
-        const [from, to] = indexOf(idA) > indexOf(idB) ? [idB, idA] : [idA, idB];
+        const [from, to] = orderVersionsOldestFirst(idA, idB, this.versionsAtom());
 
         this.setDiffLoading(true);
         this.setError(null);

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -6,7 +6,12 @@ import { useBlockAtom } from "@/app/store/global";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, type Accessor } from "solid-js";
 
-export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles";
+// "native_memory" deliberately does NOT reuse the word "memory" — that's
+// already the (confusingly-named, legacy) section id for the global-brain
+// tab below, distinct from a bundle's own "bundles" section (whose backing
+// component, MemoryManager, is itself a naming leftover — see
+// docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3).
+export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles" | "native_memory";
 
 // Label text only (not icon/tooltip, which stay armory-view.tsx's own
 // presentation detail) — hoisted here so viewName can read it without
@@ -19,6 +24,7 @@ export const ARMORY_SECTION_LABELS: Record<ArmorySection, string> = {
     skills: "Skills",
     mcp: "MCP Servers",
     bundles: "ABF",
+    native_memory: "Native Memory",
 };
 
 function isArmorySection(v: unknown): v is ArmorySection {

--- a/frontend/app/view/armory/armory-view.test.tsx
+++ b/frontend/app/view/armory/armory-view.test.tsx
@@ -107,11 +107,11 @@ describe("ArmoryView rail", () => {
         expect(screen.queryByText("Memory")).not.toBeInTheDocument();
     });
 
-    it("orders the rail as Accounts, Memories, Skills, MCP Servers, ABF", () => {
+    it("orders the rail as Accounts, Memories, Skills, MCP Servers, ABF, Native Memory", () => {
         renderArmory();
         const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
         const labels = Array.from(rail.querySelectorAll("button span")).map((el) => el.textContent);
-        expect(labels).toEqual(["Accounts", "Memories", "Skills", "MCP Servers", "ABF"]);
+        expect(labels).toEqual(["Accounts", "Memories", "Skills", "MCP Servers", "ABF", "Native Memory"]);
     });
 });
 

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -11,6 +11,7 @@ import { AccountsManager } from "@/app/view/accounts/accounts-manager";
 import { GlobalBrainManager } from "@/app/view/brain/global-brain-manager";
 import { McpManager } from "@/app/view/mcp/mcp-manager";
 import { SkillManager } from "@/app/view/skill/skill-manager";
+import { NativeMemoryManager } from "@/app/view/native-memory/native-memory-manager";
 import { ARMORY_SECTION_LABELS, type ArmorySection, type ArmoryViewModel } from "./armory-model";
 import "./armory-view.scss";
 
@@ -20,6 +21,7 @@ const RAIL: { id: ArmorySection; label: string; tooltip?: string; icon: string }
     { id: "skills",   label: ARMORY_SECTION_LABELS.skills,   icon: "wand-magic-sparkles" },
     { id: "mcp",      label: ARMORY_SECTION_LABELS.mcp,      icon: "plug" },
     { id: "bundles",  label: ARMORY_SECTION_LABELS.bundles,  tooltip: "Armory Bundle Format (ABF)", icon: "layer-group" },
+    { id: "native_memory", label: ARMORY_SECTION_LABELS.native_memory, tooltip: "Per-agent memory version history — diff and revert", icon: "clock-rotate-left" },
 ];
 
 export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Element {
@@ -86,7 +88,7 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                 </nav>
                 <div class="bundle-manager-section">
                     {/*
-                     * All five managers stay mounted — toggling is instant and
+                     * All six managers stay mounted — toggling is instant and
                      * never re-fetches. All stay consistent via WPS *:changed events.
                      */}
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "accounts" }}>
@@ -103,6 +105,9 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                     </div>
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "bundles" }}>
                         <MemoryManager />
+                    </div>
+                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "native_memory" }}>
+                        <NativeMemoryManager />
                     </div>
                 </div>
                 <nav class="bundle-manager-tab-bar" aria-label="Armory section">

--- a/frontend/app/view/native-memory/native-memory-manager.scss
+++ b/frontend/app/view/native-memory/native-memory-manager.scss
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Styles for NativeMemoryManager — Armory's "Native Memory" tab
+// (agent picker + file picker + NativeMemoryHistoryPanel).
+
+.native-memory-manager {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.native-memory-manager-header {
+    flex-shrink: 0;
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-2);
+    border-bottom: 1px solid var(--border-color);
+    background: var(--panel-bg-color);
+}
+
+.native-memory-manager-field {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+    max-width: 320px;
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+
+    select {
+        padding: var(--space-1) var(--space-1-5);
+        border: 1px solid var(--border-color);
+        border-radius: 0;
+        background: var(--main-bg-color);
+        color: var(--main-text-color);
+        font-size: var(--text-sm);
+
+        &:disabled {
+            opacity: 0.6;
+        }
+    }
+}
+
+.native-memory-manager-error {
+    flex-shrink: 0;
+    margin: var(--space-2);
+    padding: var(--space-1-5) var(--space-2);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 30%, transparent);
+    color: var(--error-color);
+    font-size: var(--text-sm);
+}
+
+.native-memory-manager-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.native-memory-manager-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: var(--space-4);
+    text-align: center;
+    color: var(--secondary-text-color);
+    font-size: var(--text-sm);
+    font-style: italic;
+}

--- a/frontend/app/view/native-memory/native-memory-manager.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.tsx
@@ -1,0 +1,117 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NativeMemoryManager — Armory's "Native Memory" rail tab: an agent picker
+ * in front of the same NativeMemoryHistoryPanel a Stash pane's own Memory
+ * tab uses. Both read the identical agent:memory:{list,history,diff,revert}
+ * RPCs — one source of truth, two entry points (per-agent Stash, cross-
+ * agent Armory) — no copy or migration step between them. See
+ * docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3.
+ *
+ * Deliberately named/placed away from `frontend/app/view/memory/` (Armory's
+ * *Bundles* tab — `MemoryManager`, a legacy name predating the
+ * Preset→Bundle rename — see that spec's §4.3 "naming collision to avoid").
+ * This directory and component are about native memory only.
+ */
+
+import { createEffect, createSignal, For, Show, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { useAgentDefinitions } from "@/app/view/agent/components/AgentPicker";
+import { NativeMemoryHistoryPanel } from "@/app/view/agent/components/NativeMemoryHistoryPanel";
+import "./native-memory-manager.scss";
+
+export function NativeMemoryManager(): JSX.Element {
+    const [agents] = useAgentDefinitions();
+    const [selectedAgentId, setSelectedAgentId] = createSignal<string>("");
+    const [files, setFiles] = createSignal<NativeMemoryFileMeta[]>([]);
+    const [selectedFilename, setSelectedFilename] = createSignal<string>("");
+    const [filesLoading, setFilesLoading] = createSignal(false);
+    const [filesError, setFilesError] = createSignal<string | null>(null);
+
+    // Re-fetch the file list whenever the selected agent changes; clear the
+    // file selection so a stale filename from a different agent can't leak
+    // into NativeMemoryHistoryPanel's props.
+    createEffect(() => {
+        const agentId = selectedAgentId();
+        setSelectedFilename("");
+        setFiles([]);
+        if (!agentId) return;
+        setFilesLoading(true);
+        setFilesError(null);
+        RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agentId })
+            .then((res) => setFiles(res.files))
+            .catch((e: Error) => setFilesError(`Failed to list memory files: ${e.message ?? e}`))
+            .finally(() => setFilesLoading(false));
+    });
+
+    return (
+        <div class="native-memory-manager">
+            <div class="native-memory-manager-header">
+                <label class="native-memory-manager-field">
+                    <span>Agent</span>
+                    <select
+                        value={selectedAgentId()}
+                        onChange={(e) => setSelectedAgentId(e.currentTarget.value)}
+                    >
+                        <option value="">Select an agent…</option>
+                        <For each={agents()}>
+                            {(agent) => <option value={agent.id}>{agent.name || agent.slug || agent.id}</option>}
+                        </For>
+                    </select>
+                </label>
+
+                <Show when={selectedAgentId()}>
+                    <label class="native-memory-manager-field">
+                        <span>File</span>
+                        <select
+                            value={selectedFilename()}
+                            disabled={filesLoading() || files().length === 0}
+                            onChange={(e) => setSelectedFilename(e.currentTarget.value)}
+                        >
+                            <option value="">
+                                {filesLoading() ? "Loading…" : files().length === 0 ? "No memory files" : "Select a file…"}
+                            </option>
+                            <For each={files()}>
+                                {(file) => <option value={file.filename}>{file.filename}</option>}
+                            </For>
+                        </select>
+                    </label>
+                </Show>
+            </div>
+
+            <Show when={filesError()}>
+                <div class="native-memory-manager-error">{filesError()}</div>
+            </Show>
+
+            <div class="native-memory-manager-body">
+                <Show
+                    when={selectedAgentId() && selectedFilename()}
+                    fallback={
+                        <div class="native-memory-manager-empty">
+                            {selectedAgentId()
+                                ? "Pick a memory file to see its version history."
+                                : "Pick an agent to browse its native memory version history."}
+                        </div>
+                    }
+                >
+                    {/* Keyed on agentId:filename so switching either forces a
+                        clean remount — NativeMemoryHistoryPanel's own doc
+                        comment: it does not react to prop changes after
+                        mount by design. */}
+                    <Show when={`${selectedAgentId()}:${selectedFilename()}`} keyed>
+                        {(_key) => (
+                            <NativeMemoryHistoryPanel
+                                agentId={selectedAgentId()}
+                                filename={selectedFilename()}
+                            />
+                        )}
+                    </Show>
+                </Show>
+            </div>
+        </div>
+    );
+}
+
+NativeMemoryManager.displayName = "NativeMemoryManager";

--- a/frontend/app/view/native-memory/native-memory-manager.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.tsx
@@ -29,21 +29,40 @@ export function NativeMemoryManager(): JSX.Element {
     const [selectedFilename, setSelectedFilename] = createSignal<string>("");
     const [filesLoading, setFilesLoading] = createSignal(false);
     const [filesError, setFilesError] = createSignal<string | null>(null);
+    let latestRequestId = 0;
 
     // Re-fetch the file list whenever the selected agent changes; clear the
     // file selection so a stale filename from a different agent can't leak
     // into NativeMemoryHistoryPanel's props.
+    //
+    // `requestId` guards against a stale response: switching agents twice in
+    // quick succession fires two overlapping fetches, and network ordering
+    // doesn't guarantee the later request's response arrives last. Only the
+    // effect run whose id still matches the latest one is allowed to apply
+    // its result — an in-flight response from an abandoned agent selection
+    // is silently dropped instead of overwriting the current selection's
+    // file list (reagent P2 on PR #2678).
     createEffect(() => {
         const agentId = selectedAgentId();
+        const requestId = ++latestRequestId;
         setSelectedFilename("");
         setFiles([]);
         if (!agentId) return;
         setFilesLoading(true);
         setFilesError(null);
         RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agentId })
-            .then((res) => setFiles(res.files))
-            .catch((e: Error) => setFilesError(`Failed to list memory files: ${e.message ?? e}`))
-            .finally(() => setFilesLoading(false));
+            .then((res) => {
+                if (requestId !== latestRequestId) return;
+                setFiles(res.files);
+            })
+            .catch((e: Error) => {
+                if (requestId !== latestRequestId) return;
+                setFilesError(`Failed to list memory files: ${e.message ?? e}`);
+            })
+            .finally(() => {
+                if (requestId !== latestRequestId) return;
+                setFilesLoading(false);
+            });
     });
 
     return (

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1523,7 +1523,7 @@ declare global {
         "subagent:session"?: string;
         // Selected rail section, meta-backed so it survives a block remount
         // and the view model can react to it (armory-model.ts/warden-model.ts).
-        "armory:section"?: "accounts" | "memory" | "skills" | "mcp" | "bundles";
+        "armory:section"?: "accounts" | "memory" | "skills" | "mcp" | "bundles" | "native_memory";
         "warden:section"?: "host" | "lan" | "internet" | "audit" | "supervisor";
     };
 
@@ -2517,6 +2517,41 @@ declare global {
     // wshrpc.NativeMemoryReadFileResult
     type NativeMemoryReadFileResult = {
         content: string;
+    };
+
+    // wshrpc.NativeMemoryWriteProvenance — optional caller-supplied context
+    // for a memory write, see SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.1.
+    type NativeMemoryWriteProvenance = {
+        source: string; // "human" | "agent_inferred" | "jekt" | ...
+        detail?: unknown;
+    };
+
+    // wshrpc.NativeMemoryVersionMeta — one recorded version's metadata,
+    // without its full content (list-view shape).
+    type NativeMemoryVersionMeta = {
+        id: string;
+        content_hash: string;
+        parent_version_id: string | null;
+        source: string; // "human" | "agent_inferred" | "jekt" | "external_fs_write" | "revert"
+        source_detail: string; // JSON string
+        session_id: string;
+        created_at: number; // unix ms
+    };
+
+    // wshrpc.NativeMemoryHistoryResult — newest first.
+    type NativeMemoryHistoryResult = {
+        versions: NativeMemoryVersionMeta[];
+    };
+
+    // wshrpc.NativeMemoryDiffResult — a minimal line-based diff: each line
+    // prefixed "  " (context), "- " (removed), or "+ " (added).
+    type NativeMemoryDiffResult = {
+        diff: string;
+    };
+
+    // wshrpc.NativeMemoryRevertResult
+    type NativeMemoryRevertResult = {
+        version: NativeMemoryVersionMeta;
     };
 
     // wshrpc.CommandActivitySummaryData

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -292,12 +292,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "agent.send",
     "agent.status",
     "agent.stop",
-    // Registered in agent1/memory-version-core; the frontend bindings land
-    // in the stacked agent1/memory-version-frontend PR, which removes
-    // these three entries once rpc-api.ts declares them.
-    "agent:memory:diff",
-    "agent:memory:history",
-    "agent:memory:revert",
     "bundle.delete",
     "bundle.export",
     "bundle.export_for_agent",


### PR DESCRIPTION
## Summary

Stacked on #2674 (base branch: `agent1/memory-version-core`) — this PR (3 of 3) is the UI for the version history/diff/revert RPCs that PR adds.

- Shared `NativeMemoryHistoryPanel` component (`agentId`+`filename` props) — version list with source tags (human/agent_inferred/jekt-with-trust-marker/external_fs_write/revert), diff between any two versions, revert with confirmation.
- Mounted from two places, reading the identical backend RPCs — one source of truth, no copy/migration step between them:
  - Stash's own **Memory** tab (`AgentNativeMemoryModal`) — a "History" toggle next to the existing content view.
  - A new Armory **Native Memory** rail tab (`NativeMemoryManager`) — an agent picker in front of the same panel, for browsing any agent's memory history without opening that agent's own pane.
- Deliberately named/placed away from `frontend/app/view/memory/` (Armory's *Bundles* tab — `MemoryManager`, a legacy name predating the Preset→Bundle rename) to avoid deepening an existing naming collision — see `docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md` §4.3.
- Includes a follow-up fix: threads `agent_id` through the `agent:memory:diff` call to match #2674's ownership-check fix (the Rust/TS wire shapes aren't type-linked, so `tsc` alone didn't catch the mismatch after that PR's fix landed).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 1236 passed across the touched areas (agent/armory views), 0 failed
- [x] Manually traced the "one source, two views" property: both mount points call the identical `agent:memory:history/diff/revert` RPCs with no intermediate cache/copy

<!-- agentmux:agent_id=agent1 -->