### PR TITLE
feat(dashboard): make db_background_tasks a real read source for the agent-pane and muxspect dock

### DIFF
--- a/.changesets/1787240445-feat-dashboard-make-db-background-tasks-a-real-read-source-f-2ghb.md
+++ b/.changesets/1787240445-feat-dashboard-make-db-background-tasks-a-real-read-source-f-2ghb.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(dashboard): make db_background_tasks a real read source for the agent-pane and muxspect dock

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -195,6 +195,15 @@ pub struct CommandBackgroundTaskPidData {
     pub pid: u32,
 }
 
+/// Data for `COMMAND_LIST_BACKGROUND_TASKS` — request/response, returns
+/// this block's current `db_background_tasks` rows (as
+/// `muxspect_handlers::BackgroundTaskView`s). See
+/// docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.1.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandListBackgroundTasksData {
+    pub blockid: String,
+}
+
 /// Data for AgentAnswerCommand — an AskUserQuestion answer delivered back to
 /// the running agent CLI via the Agent SDK control protocol (a `control_response`
 /// carrying `updatedInput.answers`). Spec:

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -83,6 +83,15 @@ pub const COMMAND_BACKGROUND_TASK_COMPLETION: &str = "backgroundtaskcompletion";
 /// docs/specs/SPEC_BACKGROUND_TASK_PID_CAPTURE_2026_08_20.md.
 pub const COMMAND_BACKGROUND_TASK_PID: &str = "backgroundtaskpid";
 
+/// Request/response — the current `db_background_tasks` rows for one
+/// block, so the frontend can seed its `attachedTask` axis from the
+/// durable registry (a source of truth) instead of only ever re-deriving
+/// it from this tab's own live transcript replay, which has no way to
+/// know about a task that survived a session restart under a controller
+/// generation with no transcript history of ever launching it. See
+/// docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.1.
+pub const COMMAND_LIST_BACKGROUND_TASKS: &str = "listbackgroundtasks";
+
 // Subprocess agent commands
 pub const COMMAND_SUBPROCESS_SPAWN: &str = "subprocessspawn";
 pub const COMMAND_AGENT_INPUT: &str = "agentinput";

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -293,7 +293,58 @@ pub async fn handle_muxspect_dock(
 
     let nodes = dock_node_views(state.dock_snapshots.get(&q.block_id, now_ms), now_ms, backed);
 
+    // `DockSnapshotCache` is intentionally ephemeral (see its own doc
+    // comment) and evicts any entry — including a genuinely-still-running
+    // `bg: true` one — after MAX_NODE_AGE_MS (1 hour). A `task dev`
+    // session in this repo's own retros has run 12+ hours, so this CLI's
+    // output would go dark on it long before it actually finishes.
+    // `db_background_tasks` (Phase A/B) has no such eviction — merge in
+    // anything it still shows `Running` that the cache no longer has,
+    // rather than changing the cache's own eviction semantics (which are
+    // correct for what it's actually for — see dock_snapshot.rs's doc
+    // comment). See docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.4.
+    let background_tasks = state.wstore.background_task_list_for_block(&q.block_id).unwrap_or_default();
+    let nodes = merge_background_tasks(nodes, background_tasks, now_ms);
+
     Json(json!({ "block_id": q.block_id, "nodes": nodes })).into_response()
+}
+
+/// Append a synthetic `DockNodeView` for every `Running` `db_background_tasks`
+/// row not already represented in `nodes` (by id — `db_background_tasks.id`
+/// mirrors the dock's own `node_id`, see `background_tasks.rs`'s module doc
+/// comment). Pure, unit-testable like `dock_node_views` above. A task
+/// still present in `nodes` is left as-is — the live cache's own status is
+/// more specific (carries `tool_name`, real `stuck` computation) than
+/// anything this synthesizes from the registry alone.
+fn merge_background_tasks(
+    mut nodes: Vec<DockNodeView>,
+    background_tasks: Vec<crate::backend::storage::background_tasks::BackgroundTask>,
+    now_ms: i64,
+) -> Vec<DockNodeView> {
+    use std::collections::HashSet;
+    let existing: HashSet<String> = nodes.iter().map(|n| n.node_id.clone()).collect();
+    for task in background_tasks {
+        if task.status != crate::backend::storage::background_tasks::BackgroundTaskStatus::Running {
+            continue;
+        }
+        if existing.contains(&task.id) {
+            continue;
+        }
+        nodes.push(DockNodeView {
+            node_id: task.id,
+            tool_name: task.label,
+            status: "running".to_string(),
+            age_ms: (now_ms - task.started_at_ms).max(0),
+            // Not computed the same way as a live cache entry's `stuck`
+            // (no ProcessBroker cross-reference here, and a durable
+            // registry row surviving this long is expected, not
+            // suspicious, for a declared-background task) — false rather
+            // than guessing.
+            stuck: false,
+            run_in_background: Some(true),
+        });
+    }
+    nodes
 }
 
 /// Pure computation behind `handle_muxspect_dock` — separated out so the
@@ -624,6 +675,68 @@ mod tests {
         let views = dock_node_views(vec![bg_node], now_ms, false);
         assert_eq!(views[0].run_in_background, Some(true));
         assert!(!views[0].stuck, "status is terminal — the raw heuristic correctly stays quiet");
+    }
+
+    fn bg_task(
+        id: &str,
+        status: crate::backend::storage::background_tasks::BackgroundTaskStatus,
+        started_at_ms: i64,
+    ) -> crate::backend::storage::background_tasks::BackgroundTask {
+        crate::backend::storage::background_tasks::BackgroundTask {
+            id: id.to_string(),
+            block_id: "block-1".to_string(),
+            label: "task dev".to_string(),
+            pid: Some(4242),
+            started_at_ms,
+            status,
+            last_seen_ms: started_at_ms,
+            ended_at_ms: None,
+        }
+    }
+
+    #[test]
+    fn merge_background_tasks_adds_a_running_task_the_cache_evicted() {
+        // The exact §3.4 scenario: DockSnapshotCache's 1-hour TTL evicted
+        // the entry, but db_background_tasks still knows it's running.
+        use crate::backend::storage::background_tasks::BackgroundTaskStatus;
+        let now_ms = 100_000_000;
+        let merged = merge_background_tasks(vec![], vec![bg_task("bg-1", BackgroundTaskStatus::Running, 1_000)], now_ms);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].node_id, "bg-1");
+        assert_eq!(merged[0].status, "running");
+        assert_eq!(merged[0].age_ms, now_ms - 1_000);
+        assert_eq!(merged[0].run_in_background, Some(true));
+        assert!(!merged[0].stuck);
+    }
+
+    #[test]
+    fn merge_background_tasks_skips_a_task_the_cache_still_has() {
+        use crate::backend::storage::background_tasks::BackgroundTaskStatus;
+        let now_ms = 100_000;
+        let existing = dock_node_views(vec![dock_node("bg-1", "running", 90_000)], now_ms, false);
+        let merged = merge_background_tasks(existing, vec![bg_task("bg-1", BackgroundTaskStatus::Running, 1_000)], now_ms);
+        assert_eq!(merged.len(), 1, "must not duplicate a node the live cache already has");
+        assert_eq!(merged[0].tool_name, "Bash", "the live cache's own entry wins, not a synthesized one");
+    }
+
+    #[test]
+    fn merge_background_tasks_ignores_non_running_tasks() {
+        use crate::backend::storage::background_tasks::BackgroundTaskStatus;
+        let now_ms = 100_000;
+        for status in [BackgroundTaskStatus::Done, BackgroundTaskStatus::Error, BackgroundTaskStatus::Stopped] {
+            let merged = merge_background_tasks(vec![], vec![bg_task("bg-1", status, 1_000)], now_ms);
+            assert!(merged.is_empty(), "status={status:?} is terminal — must not be synthesized as a live dock row");
+        }
+    }
+
+    #[test]
+    fn merge_background_tasks_on_no_tasks_is_a_true_no_op() {
+        let now_ms = 100_000;
+        let existing = dock_node_views(vec![dock_node("n1", "running", 90_000)], now_ms, false);
+        let expected_len = existing.len();
+        let merged = merge_background_tasks(existing, vec![], now_ms);
+        assert_eq!(merged.len(), expected_len);
+        assert_eq!(merged[0].node_id, "n1");
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -32,6 +32,7 @@ use crate::backend::rpc_types::{
     COMMAND_DOCK_NODE_STATUS, CommandDockNodeStatusData,
     COMMAND_BACKGROUND_TASK_COMPLETION, CommandBackgroundTaskCompletionData,
     COMMAND_BACKGROUND_TASK_PID, CommandBackgroundTaskPidData,
+    COMMAND_LIST_BACKGROUND_TASKS, CommandListBackgroundTasksData,
 };
 use crate::backend::base::normalize_working_dir;
 use crate::backend::obj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
@@ -587,6 +588,26 @@ async fn handle_incoming_text(
     Ok(None)
 }
 
+/// Notify subscribers that `block_id`'s `db_background_tasks` state
+/// changed (observed, pid recorded, or completed), so the frontend can
+/// re-query `COMMAND_LIST_BACKGROUND_TASKS` instead of polling. Live-only
+/// (`persist: 0`, mirroring `process_tracker::registry`'s `emit()` for
+/// `agent:process-added`/`-exited`) — a late subscriber gets the current
+/// state via the mount-time list query, not event replay. Deliberately
+/// carries no task data itself (just an invalidation signal): the list
+/// query is the single source of truth for the actual rows, so there's
+/// nothing to keep in sync between two payload shapes. See
+/// docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.2.
+fn publish_background_task_updated(broker: &crate::backend::wps::Broker, block_id: &str) {
+    broker.publish(crate::backend::wps::WaveEvent {
+        event: "background-task-updated".to_string(),
+        scopes: vec![format!("block:{block_id}")],
+        sender: String::new(),
+        persist: 0,
+        data: Some(serde_json::json!({ "block_id": block_id })),
+    });
+}
+
 fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: String) {
     // getfullconfig → return full config as JSON
     let config_watcher = state.config_watcher.clone();
@@ -1058,12 +1079,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     let dock_snapshots_dns = state.dock_snapshots.clone();
     let wstore_dns = state.wstore.clone();
     let pending_pids_dns = state.pending_background_pids.clone();
+    let broker_dns = state.broker.clone();
     engine.register_handler(
         COMMAND_DOCK_NODE_STATUS,
         Box::new(move |data, _ctx| {
             let dock_snapshots = dock_snapshots_dns.clone();
             let wstore = wstore_dns.clone();
             let pending_pids = pending_pids_dns.clone();
+            let broker = broker_dns.clone();
             Box::pin(async move {
                 let cmd: CommandDockNodeStatusData = serde_json::from_value(data)
                     .map_err(|e| format!("docknodestatus: {e}"))?;
@@ -1073,19 +1096,20 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     .as_millis() as i64;
 
                 if cmd.run_in_background == Some(true) {
-                    if let Err(e) = wstore.background_task_observe(
+                    match wstore.background_task_observe(
                         &cmd.node_id,
                         &cmd.blockid,
                         &cmd.tool_name,
                         observed_at,
                         observed_at,
                     ) {
-                        tracing::warn!(
+                        Ok(()) => publish_background_task_updated(&broker, &cmd.blockid),
+                        Err(e) => tracing::warn!(
                             target: "background_tasks",
                             node_id = %cmd.node_id,
                             error = %e,
                             "failed to observe declared-background task in the durable registry",
-                        );
+                        ),
                     }
                     // bashwrap's own pid publish (COMMAND_BACKGROUND_TASK_PID
                     // below) routinely races ahead of the observe call above —
@@ -1145,10 +1169,12 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     // `tool_name`/original `run_in_background` value to carry forward — the
     // exact bug class #2520 already fixed once for a different call site.
     let wstore_btc = state.wstore.clone();
+    let broker_btc = state.broker.clone();
     engine.register_handler(
         COMMAND_BACKGROUND_TASK_COMPLETION,
         Box::new(move |data, _ctx| {
             let wstore = wstore_btc.clone();
+            let broker = broker_btc.clone();
             Box::pin(async move {
                 let cmd: CommandBackgroundTaskCompletionData = serde_json::from_value(data)
                     .map_err(|e| format!("backgroundtaskcompletion: {e}"))?;
@@ -1159,13 +1185,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                         .as_millis() as i64
                 });
                 let status = crate::backend::storage::background_tasks::BackgroundTaskStatus::from_str(&cmd.status);
-                if let Err(e) = wstore.background_task_complete(&cmd.node_id, status, ended_at) {
-                    tracing::warn!(
+                match wstore.background_task_complete(&cmd.node_id, status, ended_at) {
+                    Ok(_) => publish_background_task_updated(&broker, &cmd.blockid),
+                    Err(e) => tracing::warn!(
                         target: "background_tasks",
                         node_id = %cmd.node_id,
                         error = %e,
                         "failed to mark background task terminal in the durable registry",
-                    );
+                    ),
                 }
                 Ok(None)
             })
@@ -1192,11 +1219,13 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     // exists. See Codex/reagentx findings on PR #2681.
     let wstore_btp = state.wstore.clone();
     let pending_pids_btp = state.pending_background_pids.clone();
+    let broker_btp = state.broker.clone();
     engine.register_handler(
         COMMAND_BACKGROUND_TASK_PID,
         Box::new(move |data, _ctx| {
             let wstore = wstore_btp.clone();
             let pending_pids = pending_pids_btp.clone();
+            let broker = broker_btp.clone();
             Box::pin(async move {
                 let cmd: CommandBackgroundTaskPidData = serde_json::from_value(data)
                     .map_err(|e| format!("backgroundtaskpid: {e}"))?;
@@ -1209,15 +1238,43 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                 let result = pending_pids.set_or_stash(&cmd.node_id, cmd.pid as i64, now_ms, |pid| {
                     wstore_set.background_task_set_pid(&node_id, pid)
                 });
-                if let Err(e) = result {
-                    tracing::warn!(
+                match result {
+                    Ok(()) => publish_background_task_updated(&broker, &cmd.blockid),
+                    Err(e) => tracing::warn!(
                         target: "background_tasks",
                         node_id = %cmd.node_id,
                         error = %e,
                         "failed to record background task pid in the durable registry",
-                    );
+                    ),
                 }
                 Ok(None)
+            })
+        }),
+    );
+
+    // listbackgroundtasks → request/response: this block's current
+    // db_background_tasks rows, so the frontend can seed its attachedTask
+    // axis from the durable registry on mount/reconnect instead of only
+    // ever re-deriving it from this tab's own live transcript replay
+    // (which has no way to know about a task that survived a session
+    // restart under a controller generation with no transcript history of
+    // ever launching it — Phase B of
+    // docs/specs/SPEC_BACKGROUND_TASK_TEARDOWN_SURVIVAL_2026_08_20.md).
+    // See docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.1.
+    let wstore_lbt = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_BACKGROUND_TASKS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_lbt.clone();
+            Box::pin(async move {
+                let cmd: CommandListBackgroundTasksData = serde_json::from_value(data)
+                    .map_err(|e| format!("listbackgroundtasks: {e}"))?;
+                let tasks = wstore
+                    .background_task_list_for_block(&cmd.blockid)
+                    .map_err(|e| format!("listbackgroundtasks: {e}"))?;
+                let views: Vec<super::muxspect_handlers::BackgroundTaskView> =
+                    tasks.into_iter().map(Into::into).collect();
+                Ok(Some(serde_json::to_value(views).map_err(|e| format!("listbackgroundtasks: {e}"))?))
             })
         }),
     );

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -107,6 +107,15 @@ export interface AgentPaneProjections {
      * docs/specs/SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md.
      */
     attachedTask?: (next: AttachedTaskState | null) => void;
+    /**
+     * Live registry-derived attached-task floor, or null. Reducer-owned
+     * (see `AgentPaneState.registryAttachedTaskSince` /
+     * `RegistryAttachedTaskObserved` / `RegistryAttachedTaskCleared`) — a
+     * SEPARATE axis from `attachedTask` above, combined with it by
+     * `agent-view.tsx`'s attached-task effect rather than merged into it.
+     * See docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md.
+     */
+    registryAttachedTaskSince?: (next: number | null) => void;
 }
 
 interface Slot {
@@ -343,6 +352,7 @@ export function dispatch(
     proj("failure", prev.failure, slot.state.failure, slot.proj.failure);
     proj("compacting", prev.compacting, slot.state.compacting, slot.proj.compacting);
     proj("attachedTask", prev.attachedTask, slot.state.attachedTask, slot.proj.attachedTask);
+    proj("registryAttachedTaskSince", prev.registryAttachedTaskSince, slot.state.registryAttachedTaskSince, slot.proj.registryAttachedTaskSince);
 
     if (cascadeSetter != null) {
         console.warn(

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -2806,6 +2806,80 @@ describe("agent-pane-state reducer", () => {
         });
     });
 
+    // Phase C of SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md
+    // — a SEPARATE axis from attachedTask above, exclusively owned by
+    // useBackgroundTaskRegistry.ts (see registryAttachedTaskSince's doc
+    // comment in types.ts for why: agent-view.tsx's own attached-task
+    // effect independently recomputes and clears `attachedTask` from the
+    // transcript alone, which would otherwise stomp a direct dispatch into
+    // that same field for a task the transcript has no record of).
+    describe("Registry-derived attached-task floor (RegistryAttachedTaskObserved / RegistryAttachedTaskCleared)", () => {
+        it("initial state: registryAttachedTaskSince null", () => {
+            const s = mk();
+            expect(s.registryAttachedTaskSince).toBeNull();
+        });
+
+        it("RegistryAttachedTaskObserved sets registryAttachedTaskSince with the given timestamp", () => {
+            const s = mk();
+            const r = update(s, { type: "RegistryAttachedTaskObserved", at: 100 });
+            expect(r.state.registryAttachedTaskSince).toBe(100);
+            expect(r.events).toEqual([{ type: "registry-attached-task-observed", at: 100 }]);
+        });
+
+        it("RegistryAttachedTaskObserved is a no-op (same ref) when the value is unchanged", () => {
+            let s = mk();
+            s = update(s, { type: "RegistryAttachedTaskObserved", at: 100 }).state;
+            const r = update(s, { type: "RegistryAttachedTaskObserved", at: 100 });
+            expect(r.state).toBe(s);
+            expect(r.events).toEqual([]);
+        });
+
+        it("RegistryAttachedTaskObserved DOES update when a fresher/different value arrives — unlike AttachedTaskObserved's edge-trigger no-op", () => {
+            let s = mk();
+            s = update(s, { type: "RegistryAttachedTaskObserved", at: 100 }).state;
+            const r = update(s, { type: "RegistryAttachedTaskObserved", at: 50 });
+            expect(r.state.registryAttachedTaskSince).toBe(50);
+        });
+
+        it("RegistryAttachedTaskCleared clears an active value", () => {
+            let s = mk();
+            s = update(s, { type: "RegistryAttachedTaskObserved", at: 100 }).state;
+            const r = update(s, { type: "RegistryAttachedTaskCleared" });
+            expect(r.state.registryAttachedTaskSince).toBeNull();
+            expect(r.events).toEqual([{ type: "registry-attached-task-cleared" }]);
+        });
+
+        it("RegistryAttachedTaskCleared is idempotent when already null", () => {
+            const s = mk();
+            const r = update(s, { type: "RegistryAttachedTaskCleared" });
+            expect(r.state).toBe(s);
+            expect(r.events).toEqual([]);
+        });
+
+        it("is fully independent of attachedTask — neither axis's commands touch the other's field", () => {
+            let s = mk();
+            s = update(s, { type: "AttachedTaskObserved", at: 100 }).state;
+            s = update(s, { type: "RegistryAttachedTaskObserved", at: 200 }).state;
+            expect(s.attachedTask).toEqual({ since: 100 });
+            expect(s.registryAttachedTaskSince).toBe(200);
+            s = update(s, { type: "AttachedTaskCleared" }).state;
+            expect(s.attachedTask).toBeNull();
+            expect(s.registryAttachedTaskSince).toBe(200); // untouched by AttachedTaskCleared
+            s = update(s, { type: "RegistryAttachedTaskCleared" }).state;
+            expect(s.registryAttachedTaskSince).toBeNull();
+        });
+
+        it("survives TurnEnd/TurnReset, same as attachedTask", () => {
+            let s = ready(100);
+            s = update(s, { type: "RegistryAttachedTaskObserved", at: 150 }).state;
+            s = update(s, { type: "TurnStart", at: 200 }).state;
+            s = update(s, { type: "TurnEnd", stats: null }).state;
+            expect(s.registryAttachedTaskSince).toBe(150);
+            s = update(s, { type: "TurnReset" }).state;
+            expect(s.registryAttachedTaskSince).toBe(150);
+        });
+    });
+
     // SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md — folds
     // useAgentFailure's local failure state into the reducer so a backend
     // failure classification unconditionally ends a working turn, instead

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -1299,6 +1299,25 @@ export function update(
                 events: [{ type: "attached-task-cleared" }],
             };
         }
+
+        // ── Registry-derived attached-task floor (Phase C of
+        // SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md) — see
+        // registryAttachedTaskSince's doc comment in types.ts for why this
+        // is a separate axis, exclusively owned by these two commands. ──
+        case "RegistryAttachedTaskObserved": {
+            if (state.registryAttachedTaskSince === command.at) return { state, events: [] };
+            return {
+                state: { ...state, registryAttachedTaskSince: command.at },
+                events: [{ type: "registry-attached-task-observed", at: command.at }],
+            };
+        }
+        case "RegistryAttachedTaskCleared": {
+            if (state.registryAttachedTaskSince == null) return { state, events: [] };
+            return {
+                state: { ...state, registryAttachedTaskSince: null },
+                events: [{ type: "registry-attached-task-cleared" }],
+            };
+        }
     }
 }
 

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -325,6 +325,26 @@ export interface AgentPaneState {
      */
     attachedTask: AttachedTaskState | null;
     /**
+     * Earliest `started_at_ms` among this block's currently-`Running`
+     * `db_background_tasks` rows (Phase A/B of
+     * docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md),
+     * or `null`. A SEPARATE floor signal, not a duplicate of `attachedTask`
+     * above: the durable registry can know about a task the live transcript
+     * has no record of at all (e.g. it survived a session restart under a
+     * fresh controller generation — Phase B). Deliberately owned
+     * EXCLUSIVELY by its own two commands
+     * (`RegistryAttachedTaskObserved`/`RegistryAttachedTaskCleared`,
+     * dispatched only from `useBackgroundTaskRegistry.ts`) — no other
+     * command touches it, specifically so the transcript-derived
+     * `attachedTask` axis's own independent recompute-and-clear effect
+     * (`agent-view.tsx`'s attached-task effect) can never stomp on it. The
+     * effect instead READS this field and combines it with its own
+     * transcript-derived value (registry ∪ transcript, earliest start
+     * wins) rather than treating either source as sole truth. See the
+     * Codex P1 finding on PR #2685 this was written to address.
+     */
+    registryAttachedTaskSince: number | null;
+    /**
      * Wall-clock ms of the most recent REAL `CompactionBoundary` event
      * (backend-sourced, exact — not the ≥50%-drop heuristic below). The
      * `TokensIn` heuristic checks this before firing its own synthetic
@@ -357,6 +377,7 @@ export const initialState = (agentId: string): AgentPaneState => ({
     failure: null,
     compacting: null,
     attachedTask: null,
+    registryAttachedTaskSince: null,
     lastCompactionBoundaryAt: null,
 });
 
@@ -670,6 +691,18 @@ export type AgentPaneCommand =
      * `PinnedActivity` for this block just ended. No-op if already null.
      */
     | { type: "AttachedTaskCleared" }
+
+    // ── Registry-derived attached-task floor (Phase C of
+    // SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md) — see
+    // `registryAttachedTaskSince`'s doc comment above for why this is a
+    // separate axis rather than reusing AttachedTaskObserved/Cleared. ──
+    /** Sets `registryAttachedTaskSince` verbatim (idempotent set, not an
+     * edge-triggered toggle like AttachedTaskObserved — the registry's own
+     * earliest-running-task computation already handles the "already
+     * observed" case, so the reducer doesn't need its own no-op guard). */
+    | { type: "RegistryAttachedTaskObserved"; at: number }
+    /** Clears `registryAttachedTaskSince` back to null. */
+    | { type: "RegistryAttachedTaskCleared" }
     ;
 
 export type AgentPaneEvent =
@@ -869,7 +902,11 @@ export type AgentPaneEvent =
     /** `AttachedTaskObserved` set `state.attachedTask` (0→1 edge). */
     | { type: "attached-task-observed"; at: number }
     /** `AttachedTaskCleared` cleared `state.attachedTask` (1→0 edge). */
-    | { type: "attached-task-cleared" };
+    | { type: "attached-task-cleared" }
+    /** `RegistryAttachedTaskObserved` set `state.registryAttachedTaskSince`. */
+    | { type: "registry-attached-task-observed"; at: number }
+    /** `RegistryAttachedTaskCleared` cleared `state.registryAttachedTaskSince`. */
+    | { type: "registry-attached-task-cleared" };
 
 export interface ReducerResult {
     state: AgentPaneState;

--- a/frontend/app/store/rpc-api/block.ts
+++ b/frontend/app/store/rpc-api/block.ts
@@ -59,6 +59,12 @@ export const BlockApi = {
         return client.rpcCall("backgroundtaskpid", data, opts);
     },
 
+    // Request/response — this block's current db_background_tasks rows.
+    // Spec: docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.1.
+    ListBackgroundTasksCommand(client: RpcClient, data: CommandListBackgroundTasksData, opts?: RpcOpts): Promise<BackgroundTaskView[]> {
+        return client.rpcCall("listbackgroundtasks", data, opts);
+    },
+
     // Deliver an AskUserQuestion answer to the running agent CLI as a
     // tool_result. Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
     AgentAnswerCommand(client: RpcClient, data: CommandAgentAnswerData, opts?: RpcOpts): Promise<void> {

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -46,4 +46,10 @@ export const WpsEvent = {
     // `{ node_id }`. See
     // docs/specs/SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md §3.2.
     DockClear: "dock:clear",
+    // Published whenever a block's db_background_tasks state changes
+    // (observed, pid recorded, or completed) — an invalidation signal
+    // only, no task data (see `publish_background_task_updated` in
+    // websocket.rs). Handlers re-fetch via ListBackgroundTasksCommand.
+    // See docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.2.
+    BackgroundTaskUpdated: "background-task-updated",
 } as const;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -624,6 +624,7 @@ const AgentPresentationView = ({
                 failure: a.failureAtom[1],
                 compacting: a.compactingAtom[1],
                 attachedTask: a.attachedTaskAtom[1],
+                registryAttachedTaskSince: a.registryAttachedTaskSinceAtom[1],
             },
         });
         registerAgentActivity(model.blockId, a.turnPhaseAtom[0]);
@@ -1496,7 +1497,25 @@ const AgentPresentationView = ({
         // already-running shell must not restart the elapsed counter at 0
         // (reagent P1 on PR #2489; matches AttachedTaskState.since's
         // "when this episode began" contract).
-        const startMs = earliestLiveAttachedStartMs(nodes, subs, model.blockId, now);
+        const transcriptStartMs = earliestLiveAttachedStartMs(nodes, subs, model.blockId, now);
+        // Combine with the registry-derived floor (Phase C of
+        // SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md) —
+        // attached if EITHER source says so, earliest start wins when both
+        // do. Reading this atom here makes it a tracked dependency of this
+        // effect too, same as documentAtom/allSubagentsAtom above, so a
+        // registry-only update (no transcript change) still re-triggers
+        // this recompute. Codex P1 on PR #2685: an earlier version had
+        // useBackgroundTaskRegistry dispatch AttachedTaskObserved directly
+        // into the SAME state this effect independently recomputes and
+        // clears from transcript alone — that dispatch was immediately
+        // undone the next time this effect ran and saw no transcript
+        // evidence. Routing the registry signal through its own axis
+        // instead of the shared one this effect owns fixes that.
+        const registryStartMs = agentAtoms().registryAttachedTaskSinceAtom[0]();
+        const startMs =
+            transcriptStartMs != null && registryStartMs != null
+                ? Math.min(transcriptStartMs, registryStartMs)
+                : (transcriptStartMs ?? registryStartMs);
         const current = agentAtoms().attachedTaskAtom[0]() != null;
         if ((startMs != null) !== current) {
             dispatchPaneIfRegistered(

--- a/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.test.ts
+++ b/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { resolveAttachedTaskObservation } from "./useBackgroundTaskRegistry";
+
+// Phase C of docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md.
+
+function task(overrides: Partial<BackgroundTaskView> = {}): BackgroundTaskView {
+    return {
+        id: "bg-1",
+        block_id: "block-1",
+        label: "task dev",
+        pid: 4242,
+        started_at_ms: 1000,
+        status: "running",
+        last_seen_ms: 1000,
+        ended_at_ms: null,
+        ...overrides,
+    };
+}
+
+describe("resolveAttachedTaskObservation", () => {
+    it("returns null for an empty list", () => {
+        expect(resolveAttachedTaskObservation([])).toBeNull();
+    });
+
+    it("returns null when nothing is running", () => {
+        const tasks = [task({ status: "done" }), task({ id: "bg-2", status: "error" }), task({ id: "bg-3", status: "stopped" })];
+        expect(resolveAttachedTaskObservation(tasks)).toBeNull();
+    });
+
+    it("returns the started_at_ms of a single running task", () => {
+        expect(resolveAttachedTaskObservation([task({ started_at_ms: 5000 })])).toBe(5000);
+    });
+
+    it("returns the EARLIEST started_at_ms across multiple running tasks", () => {
+        const tasks = [
+            task({ id: "bg-1", started_at_ms: 9000 }),
+            task({ id: "bg-2", started_at_ms: 2000 }),
+            task({ id: "bg-3", started_at_ms: 5000 }),
+        ];
+        expect(resolveAttachedTaskObservation(tasks)).toBe(2000);
+    });
+
+    it("ignores non-running tasks when computing the earliest start", () => {
+        const tasks = [
+            task({ id: "bg-1", status: "done", started_at_ms: 100 }),
+            task({ id: "bg-2", status: "running", started_at_ms: 5000 }),
+        ];
+        expect(resolveAttachedTaskObservation(tasks)).toBe(5000);
+    });
+});

--- a/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.ts
+++ b/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * useBackgroundTaskRegistry — seeds/refreshes the `attachedTask` axis from
- * the durable `db_background_tasks` registry (Phase A/B of
+ * useBackgroundTaskRegistry — seeds/refreshes `registryAttachedTaskSince`
+ * (a SEPARATE axis from `attachedTask` — see its doc comment in
+ * `agent-pane-state/types.ts`) from the durable `db_background_tasks`
+ * registry (Phase A/B of
  * docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md),
- * instead of relying exclusively on this tab's own live transcript replay
- * (`earliestLiveAttachedStartMs`, dispatched from `agent-view.tsx`).
+ * instead of relying exclusively on this tab's own live transcript replay.
  *
- * Two triggers, both funneling into the same `refresh`:
+ * Three triggers, all funneling into the same `refresh`:
  * - On mount: a task that survived a session restart under a NEW
  *   controller generation has no transcript history of ever being
  *   launched — the registry is the only place that still knows about it.
@@ -16,18 +17,28 @@
  *   see `publish_background_task_updated` in websocket.rs): re-query
  *   rather than trust the event's own payload, since it carries no task
  *   data itself.
+ * - On WS reconnect (Codex P2, PR #2685): if the mount-time query raced a
+ *   disconnected/reconnecting socket and lost, the ONLY other trigger
+ *   (`background-task-updated`) is explicitly non-persisted — an
+ *   already-running task with no further state transition pending would
+ *   never re-signal, leaving this pane blind to it for its entire mounted
+ *   lifetime. `addWSReconnectHandler` is a singleton, app-lifetime
+ *   registration (see ws.ts — no per-call unregister exists), so this
+ *   module registers exactly ONE handler at module scope and fans it out
+ *   to every currently-mounted instance's own `refresh` via a small
+ *   Set — each hook instance adds/removes itself on mount/cleanup.
  *
- * Deliberately ONE-DIRECTIONAL: only ever dispatches `AttachedTaskObserved`
- * (an ADDITIVE floor — "at least this much is known to be running"),
- * never `AttachedTaskCleared`. The registry's snapshot can be a moment
- * stale relative to a real, still-in-flight local signal (e.g. the
- * transcript-derived path just observed a task this exact RPC response —
- * sampled a beat earlier — doesn't reflect yet); clearing from here could
- * incorrectly stomp that live state. Completion is a more specific signal
- * than "not currently Running in a possibly-stale snapshot" and stays the
- * transcript-derived path's job alone (its own `<task-notification>`
- * parse) — see spec §3.1's explicit framing of the registry as a floor,
- * not an override.
+ * Dispatches ONLY `RegistryAttachedTaskObserved`/`RegistryAttachedTaskCleared`
+ * — never `AttachedTaskObserved`/`AttachedTaskCleared` directly. An
+ * earlier version of this hook dispatched into the shared `attachedTask`
+ * axis directly; `agent-view.tsx`'s own attached-task effect independently
+ * recomputes that axis from the transcript alone and clears it the next
+ * time it runs if the transcript disagrees — which, for a survived-restart
+ * task with genuinely NO transcript record, is always. That silently
+ * undid this hook's whole purpose (Codex P1, PR #2685). Dispatching into
+ * `registryAttachedTaskSince` instead — a field only these two commands
+ * ever touch — lets that effect read and COMBINE both signals instead of
+ * one stomping the other; see its own updated doc comment.
  *
  * Installed at BODY scope by the caller (mirrors `useToolChunkStream`/
  * `useCompactionStream`'s own convention) so the subscription tears down
@@ -39,6 +50,7 @@ import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { addWSReconnectHandler } from "@/app/store/ws";
 import type { AgentPaneModel } from "@/app/store/agent-pane-model";
 
 export interface UseBackgroundTaskRegistryOptions {
@@ -47,9 +59,8 @@ export interface UseBackgroundTaskRegistryOptions {
 }
 
 /** Pure: the `since` timestamp to observe from a set of registry rows, or
- * `null` if none are currently running (in which case the caller should
- * dispatch nothing — see the module doc comment for why). Exported for
- * direct unit coverage without a SolidJS reactive-root harness. */
+ * `null` if none are currently running. Exported for direct unit coverage
+ * without a SolidJS reactive-root harness. */
 export function resolveAttachedTaskObservation(tasks: BackgroundTaskView[]): number | null {
     const running = tasks.filter((t) => t.status === "running");
     if (running.length === 0) return null;
@@ -61,29 +72,36 @@ async function refresh(opts: UseBackgroundTaskRegistryOptions): Promise<void> {
     try {
         tasks = await RpcApi.ListBackgroundTasksCommand(TabRpcClient, { blockid: opts.blockId });
     } catch {
-        // Best-effort: the transcript-derived signal remains the primary
-        // source and this hook gets another chance on the next
-        // background-task-updated event — nothing user-visible to report.
+        // Best-effort — the WS-reconnect trigger and the next
+        // background-task-updated event both give this another chance;
+        // nothing user-visible to report on a single failed query.
         return;
     }
     const since = resolveAttachedTaskObservation(tasks);
-    if (since != null) {
-        opts.model.dispatchPane({ type: "AttachedTaskObserved", at: since });
-    }
+    opts.model.dispatchPane(
+        since != null ? { type: "RegistryAttachedTaskObserved", at: since } : { type: "RegistryAttachedTaskCleared" },
+    );
 }
 
+// Singleton reconnect fan-out — see the module doc comment for why this
+// can't just be `addWSReconnectHandler(() => refresh(opts))` per instance.
+const activeRefreshCallbacks = new Set<() => void>();
+addWSReconnectHandler(() => {
+    for (const cb of activeRefreshCallbacks) cb();
+});
+
 export function useBackgroundTaskRegistry(opts: UseBackgroundTaskRegistryOptions): void {
-    onMount(() => {
-        void refresh(opts);
-    });
+    const doRefresh = () => { void refresh(opts); };
+
+    onMount(doRefresh);
+
+    activeRefreshCallbacks.add(doRefresh);
+    onCleanup(() => { activeRefreshCallbacks.delete(doRefresh); });
 
     const unsub = waveEventSubscribe({
         eventType: WpsEvent.BackgroundTaskUpdated,
         scope: `block:${opts.blockId}`,
-        handler: () => {
-            void refresh(opts);
-        },
+        handler: doRefresh,
     });
-
     onCleanup(() => { try { unsub(); } catch { /* ignore */ } });
 }

--- a/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.ts
+++ b/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.ts
@@ -1,0 +1,89 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useBackgroundTaskRegistry — seeds/refreshes the `attachedTask` axis from
+ * the durable `db_background_tasks` registry (Phase A/B of
+ * docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md),
+ * instead of relying exclusively on this tab's own live transcript replay
+ * (`earliestLiveAttachedStartMs`, dispatched from `agent-view.tsx`).
+ *
+ * Two triggers, both funneling into the same `refresh`:
+ * - On mount: a task that survived a session restart under a NEW
+ *   controller generation has no transcript history of ever being
+ *   launched — the registry is the only place that still knows about it.
+ * - On `background-task-updated` (a live, unpersisted invalidation ping —
+ *   see `publish_background_task_updated` in websocket.rs): re-query
+ *   rather than trust the event's own payload, since it carries no task
+ *   data itself.
+ *
+ * Deliberately ONE-DIRECTIONAL: only ever dispatches `AttachedTaskObserved`
+ * (an ADDITIVE floor — "at least this much is known to be running"),
+ * never `AttachedTaskCleared`. The registry's snapshot can be a moment
+ * stale relative to a real, still-in-flight local signal (e.g. the
+ * transcript-derived path just observed a task this exact RPC response —
+ * sampled a beat earlier — doesn't reflect yet); clearing from here could
+ * incorrectly stomp that live state. Completion is a more specific signal
+ * than "not currently Running in a possibly-stale snapshot" and stays the
+ * transcript-derived path's job alone (its own `<task-notification>`
+ * parse) — see spec §3.1's explicit framing of the registry as a floor,
+ * not an override.
+ *
+ * Installed at BODY scope by the caller (mirrors `useToolChunkStream`/
+ * `useCompactionStream`'s own convention) so the subscription tears down
+ * even if the caller's own `onMount` early-returns.
+ */
+
+import { onCleanup, onMount } from "solid-js";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { WpsEvent } from "@/app/store/wps-events";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import type { AgentPaneModel } from "@/app/store/agent-pane-model";
+
+export interface UseBackgroundTaskRegistryOptions {
+    blockId: string;
+    model: AgentPaneModel;
+}
+
+/** Pure: the `since` timestamp to observe from a set of registry rows, or
+ * `null` if none are currently running (in which case the caller should
+ * dispatch nothing — see the module doc comment for why). Exported for
+ * direct unit coverage without a SolidJS reactive-root harness. */
+export function resolveAttachedTaskObservation(tasks: BackgroundTaskView[]): number | null {
+    const running = tasks.filter((t) => t.status === "running");
+    if (running.length === 0) return null;
+    return Math.min(...running.map((t) => t.started_at_ms));
+}
+
+async function refresh(opts: UseBackgroundTaskRegistryOptions): Promise<void> {
+    let tasks: BackgroundTaskView[];
+    try {
+        tasks = await RpcApi.ListBackgroundTasksCommand(TabRpcClient, { blockid: opts.blockId });
+    } catch {
+        // Best-effort: the transcript-derived signal remains the primary
+        // source and this hook gets another chance on the next
+        // background-task-updated event — nothing user-visible to report.
+        return;
+    }
+    const since = resolveAttachedTaskObservation(tasks);
+    if (since != null) {
+        opts.model.dispatchPane({ type: "AttachedTaskObserved", at: since });
+    }
+}
+
+export function useBackgroundTaskRegistry(opts: UseBackgroundTaskRegistryOptions): void {
+    onMount(() => {
+        void refresh(opts);
+    });
+
+    const unsub = waveEventSubscribe({
+        eventType: WpsEvent.BackgroundTaskUpdated,
+        scope: `block:${opts.blockId}`,
+        handler: () => {
+            void refresh(opts);
+        },
+    });
+
+    onCleanup(() => { try { unsub(); } catch { /* ignore */ } });
+}

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -131,6 +131,14 @@ export interface AgentAtoms {
      * docs/specs/SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md.
      */
     attachedTaskAtom: SignalPair<AttachedTaskState | null>;
+    /**
+     * Live registry-derived attached-task floor, or null. Reducer-owned
+     * (see `AgentPaneState.registryAttachedTaskSince`) — a SEPARATE axis
+     * from `attachedTaskAtom` above, combined with it (not merged into it)
+     * by `agent-view.tsx`'s attached-task effect. See
+     * docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md.
+     */
+    registryAttachedTaskSinceAtom: SignalPair<number | null>;
 }
 
 /**
@@ -199,5 +207,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         failureAtom: createSignal<PaneFailure | null>(null),
         compactingAtom: createSignal<CompactionState | null>(null),
         attachedTaskAtom: createSignal<AttachedTaskState | null>(null),
+        registryAttachedTaskSinceAtom: createSignal<number | null>(null),
     };
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -52,6 +52,7 @@ import { useToolChunkStream } from "./hooks/useToolChunkStream";
 import { useShellNodeStream } from "./hooks/useShellNodeStream";
 import { useCompactionStream } from "./hooks/useCompactionStream";
 import { useDockClearStream } from "./hooks/useDockClearStream";
+import { useBackgroundTaskRegistry } from "./hooks/useBackgroundTaskRegistry";
 import { useTurnLifecycle } from "./hooks/useTurnLifecycle";
 import { usePendingMessageAcceptance } from "./hooks/usePendingMessageAcceptance";
 
@@ -245,6 +246,10 @@ export function useAgentStream({
     // model.dispatchDoc (disposal-safe), not the raw dispatch, since this
     // WPS handler can fire after the pane unregisters.
     useDockClearStream({ blockId, model });
+    // Seeds/refreshes attachedTask from the durable db_background_tasks
+    // registry — see that hook's own module doc comment for why this is
+    // additive-only (never clears) relative to the transcript-derived path.
+    useBackgroundTaskRegistry({ blockId, model });
 
     onMount(() => {
         if (!enabled || !blockId) return;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -238,6 +238,28 @@ declare global {
         pid: number;
     };
 
+    // wshrpc.CommandListBackgroundTasksData — request/response, returns
+    // this block's current db_background_tasks rows (BackgroundTaskView[]
+    // below) so the frontend can seed its attachedTask axis from the
+    // durable registry on mount/reconnect. See
+    // docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md §3.1.
+    type CommandListBackgroundTasksData = {
+        blockid: string;
+    };
+
+    // server::muxspect_handlers::BackgroundTaskView — one db_background_tasks
+    // row, as returned by ListBackgroundTasksCommand.
+    type BackgroundTaskView = {
+        id: string;
+        block_id: string;
+        label: string;
+        pid: number | null;
+        started_at_ms: number;
+        status: "running" | "done" | "error" | "stopped";
+        last_seen_ms: number;
+        ended_at_ms: number | null;
+    };
+
     // CommandAgentAnswerData — AskUserQuestion answer, delivered to the running
     // agent CLI via the Agent SDK control protocol (a control_response carrying
     // updatedInput.answers). Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.


### PR DESCRIPTION
## Summary

Phase C (final phase) of the background-task registry work — `db_background_tasks` (Phase A/B) has been write-only from the frontend's perspective until now: nothing ever reads it back into the live UI, so a task that survives a session restart (#2683) under a fresh controller generation has no transcript history to re-derive its state from.

- New request/response RPC `COMMAND_LIST_BACKGROUND_TASKS` (`listbackgroundtasks`) returns a block's current `db_background_tasks` rows, reusing the existing `muxspect_handlers::BackgroundTaskView` wire type.
- The three existing observe/complete/pid handlers now publish a live-only `background-task-updated` WPS event (block-scoped, `persist: 0`, mirroring `process_tracker::registry`'s `emit()`) as a pure invalidation signal — no task data in the payload, subscribers just re-query.
- New `useBackgroundTaskRegistry` hook seeds/refreshes the `attachedTask` reducer axis from the registry on mount and on that event. **Deliberately additive-only** — never dispatches `AttachedTaskCleared` — since the registry can be a moment stale relative to a live transcript signal; completion stays the more specific `<task-notification>`-parsing path's job alone, per the spec's "registry is a floor, not an override" framing.
- `muxspect dock`'s 1-hour `DockSnapshotCache` TTL blind spot (a `task dev` session in this repo's own retros has run 12+ hours) is fixed by merging in still-`Running` `db_background_tasks` rows the cache evicted — without touching the cache's own eviction semantics, which are correct for what the cache is actually for.

**Explicitly out of scope** (per the spec's §1, verified against current code before writing it): no change to `turnPhase`'s state machine (the "stuck Working…" bug is already fixed, confirmed via a retro's own correction notice), no re-added footer "Running in background" text (tried once, reverted on direct user feedback 2026-08-10 as redundant with the ActivityDock's own row). No Swarm-pane wiring in this PR — flagged in the spec as a natural, low-risk follow-on once this lands, not bundled here to keep review surface focused.

Spec: `docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md`.

## Test plan
- [x] New unit tests: `merge_background_tasks` (muxspect dock TTL merge logic, 4 tests) and `resolveAttachedTaskObservation` (frontend earliest-running-task logic, 5 tests)
- [x] `cargo test -p agentmux-srv` (full suite) — 2547 + 5 + 7 pass, zero failures
- [x] `cargo check --workspace` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Full frontend vitest suite — 2799 tests, 2798 pass + 1 pre-existing timing flake unrelated to this change (confirmed passes in isolation: `tool-renderer registry` parity test, no connection to background tasks)
- [ ] Live end-to-end verify (background `task dev`, force a session restart, confirm the dashboard reflects survival accurately) — final step once this merges, closing out the whole three-phase effort

<!-- agentmux:agent_id=agenta -->