### PR TITLE
chore: release v0.55.17

### DIFF
--- a/.changesets/1787124092-fix-muxbus-let-the-browser-sign-in-flow-be-cancelled-instead-fhhk.md
+++ b/.changesets/1787124092-fix-muxbus-let-the-browser-sign-in-flow-be-cancelled-instead-fhhk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): let the browser sign-in flow be cancelled instead of hanging for 5 minutes

--- a/.changesets/1787124588-feat-agent-api-add-uiscreenshot-uiclick-uiquery-agent-facing-2u0s.md
+++ b/.changesets/1787124588-feat-agent-api-add-uiscreenshot-uiclick-uiquery-agent-facing-2u0s.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-api): add UIScreenshot/UIClick/UIQuery — agent-facing UI automation

--- a/.changesets/1787128834-fix-security-close-host-ipc-register-identity-spoofing-race--g988.md
+++ b/.changesets/1787128834-fix-security-close-host-ipc-register-identity-spoofing-race--g988.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(security): close host_ipc.Register identity-spoofing race with a host-only shared secret

--- a/.changesets/1787145741-feat-config-non-stable-channels-default-to-isolated-per-chan-fs20.md
+++ b/.changesets/1787145741-feat-config-non-stable-channels-default-to-isolated-per-chan-fs20.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(config): non-stable channels default to isolated per-channel settings.json

--- a/.changesets/1787149266-fix-muxbus-collapse-macos-linux-keychain-token-storage-from--h4mq.md
+++ b/.changesets/1787149266-fix-muxbus-collapse-macos-linux-keychain-token-storage-from--h4mq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): collapse macOS/Linux keychain token storage from 12 entries to 1, stopping the multi-prompt Keychain access storm

--- a/.changesets/1787152102-fix-srv-bump-sysinfo-to-0-35-to-fix-createtoolhelp32snapshot-nbgb.md
+++ b/.changesets/1787152102-fix-srv-bump-sysinfo-to-0-35-to-fix-createtoolhelp32snapshot-nbgb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): bump sysinfo to 0.35 to fix CreateToolhelp32Snapshot handle leak

--- a/.changesets/1787170221-fix-sound-tool-call-tones-default-to-max-volume-centralize-s-xyum.md
+++ b/.changesets/1787170221-fix-sound-tool-call-tones-default-to-max-volume-centralize-s-xyum.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sound): tool-call tones default to max volume; centralize scattered gain-default literals

--- a/.changesets/1787170368-feat-settings-add-missing-waiting-for-input-tone-enable-togg-cfyo.md
+++ b/.changesets/1787170368-feat-settings-add-missing-waiting-for-input-tone-enable-togg-cfyo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(settings): add missing waiting-for-input tone enable toggle + volume slider

--- a/.changesets/1787170999-feat-settings-make-the-askuserquestion-auto-answer-timeout-u-14b4.md
+++ b/.changesets/1787170999-feat-settings-make-the-askuserquestion-auto-answer-timeout-u-14b4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(settings): make the AskUserQuestion auto-answer timeout user-configurable

--- a/.changesets/1787196138-feat-memory-version-controlled-native-memory-history-with-fs-xkn4.md
+++ b/.changesets/1787196138-feat-memory-version-controlled-native-memory-history-with-fs-xkn4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(memory): version-controlled native memory history with fs-watch drift detection and Armory/Stash UI

--- a/.changesets/1787196269-fix-swarm-robust-dispatch-attribution-and-formalized-session-n5fp.md
+++ b/.changesets/1787196269-fix-swarm-robust-dispatch-attribution-and-formalized-session-n5fp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): robust dispatch attribution and formalized session lifecycle

--- a/.changesets/1787210241-fix-identity-bound-keychain-reads-writes-with-a-15s-timeout--kwu8.md
+++ b/.changesets/1787210241-fix-identity-bound-keychain-reads-writes-with-a-15s-timeout--kwu8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): bound keychain reads/writes with a 15s timeout so an unanswered OS consent prompt fails fast instead of hanging indefinitely

--- a/.changesets/1787214347-feat-background-tasks-wire-db-background-tasks-pid-into-a-re-gim9.md
+++ b/.changesets/1787214347-feat-background-tasks-wire-db-background-tasks-pid-into-a-re-gim9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(background-tasks): wire db_background_tasks.pid into a real production path

--- a/.changesets/1787236397-docs-retro-synthesizing-the-macos-keychain-prompt-saga-and-t-hfz6.md
+++ b/.changesets/1787236397-docs-retro-synthesizing-the-macos-keychain-prompt-saga-and-t-hfz6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: retro synthesizing the macOS Keychain prompt saga and the self-heal chicken-and-egg gap it surfaced

--- a/.changesets/1787236804-fix-agent-declared-background-tasks-survive-a-session-restar-gqze.md
+++ b/.changesets/1787236804-fix-agent-declared-background-tasks-survive-a-session-restar-gqze.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): declared-background tasks survive a session restart, not just idle-timeout

--- a/.changesets/1787237984-fix-armory-use-block-tile-app-icon-for-agentmux-tile-shorten-flbz.md
+++ b/.changesets/1787237984-fix-armory-use-block-tile-app-icon-for-agentmux-tile-shorten-flbz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): use block-tile app icon for AgentMux tile, shorten Cloud subtitle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.16"
+version = "0.55.17"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.16"
+version = "0.55.17"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.16"
+version = "0.55.17"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.16"
+version = "0.55.17"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.16"
+version = "0.55.17"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.16"
+version = "0.55.17"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.16"
+version = "0.55.17"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,25 @@
 # AgentMux Version History
 
+## 0.55.17 — 2026-08-20
+
+- fix(muxbus): let the browser sign-in flow be cancelled instead of hanging for 5 minutes
+- feat(agent-api): add UIScreenshot/UIClick/UIQuery — agent-facing UI automation
+- fix(security): close host_ipc.Register identity-spoofing race with a host-only shared secret
+- feat(config): non-stable channels default to isolated per-channel settings.json
+- fix(muxbus): collapse macOS/Linux keychain token storage from 12 entries to 1, stopping the multi-prompt Keychain access storm
+- fix(srv): bump sysinfo to 0.35 to fix CreateToolhelp32Snapshot handle leak
+- fix(sound): tool-call tones default to max volume; centralize scattered gain-default literals
+- feat(settings): add missing waiting-for-input tone enable toggle + volume slider
+- feat(settings): make the AskUserQuestion auto-answer timeout user-configurable
+- feat(memory): version-controlled native memory history with fs-watch drift detection and Armory/Stash UI
+- fix(swarm): robust dispatch attribution and formalized session lifecycle
+- fix(identity): bound keychain reads/writes with a 15s timeout so an unanswered OS consent prompt fails fast instead of hanging indefinitely
+- feat(background-tasks): wire db_background_tasks.pid into a real production path
+- docs: retro synthesizing the macOS Keychain prompt saga and the self-heal chicken-and-egg gap it surfaced
+- fix(agent): declared-background tasks survive a session restart, not just idle-timeout
+- fix(armory): use block-tile app icon for AgentMux tile, shorten Cloud subtitle
+
+
 ## 0.55.16 — 2026-08-19
 
 - fix(ci): nightly artifacts build delegates to reusable build-*.yml workflows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.16",
+  "version": "0.55.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.16",
+      "version": "0.55.17",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.16",
+  "version": "0.55.17",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Consumes 16 pending changesets. `task release -- --as patch` forced a patch bump — the computed bump from the queued changesets was `minor` (several `feat:` entries are included), so those minor-level changes ship under this patch version per the explicit override.

## Version consistency
All 5 required locations agree at `0.55.17`:
- `VERSION_HISTORY.md` top section
- `package.json`
- `Cargo.toml` `[workspace.package].version`
- `Cargo.lock` workspace-member versions
- `package-lock.json` root version

## Test plan
- [x] `git diff --staged` reviewed before commit — only version files + changeset deletions + `VERSION_HISTORY.md` entry
- [x] No source code changes in this PR (release-only)

<!-- agentmux:agent_id=agent1 -->