### PR TITLE
chore: release v0.55.18

### DIFF
--- a/.changesets/1787240445-feat-dashboard-make-db-background-tasks-a-real-read-source-f-2ghb.md
+++ b/.changesets/1787240445-feat-dashboard-make-db-background-tasks-a-real-read-source-f-2ghb.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(dashboard): make db_background_tasks a real read source for the agent-pane and muxspect dock

--- a/.changesets/1787243687-feat-fleet-multi-agent-fleet-control-select-broadcast-and-bu-5c6u.md
+++ b/.changesets/1787243687-feat-fleet-multi-agent-fleet-control-select-broadcast-and-bu-5c6u.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(fleet): multi-agent fleet control — select, broadcast, and bulk-act on many agents at once

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.17"
+version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.17"
+version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.17"
+version = "0.55.18"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.17"
+version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.17"
+version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.17"
+version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.17"
+version = "0.55.18"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,11 @@
 # AgentMux Version History
 
+## 0.55.18 — 2026-08-20
+
+- feat(dashboard): make db_background_tasks a real read source for the agent-pane and muxspect dock
+- feat(fleet): multi-agent fleet control — select, broadcast, and bulk-act on many agents at once
+
+
 ## 0.55.17 — 2026-08-20
 
 - fix(muxbus): let the browser sign-in flow be cancelled instead of hanging for 5 minutes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.17",
+  "version": "0.55.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.17",
+      "version": "0.55.18",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.17",
+  "version": "0.55.18",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming the 2 pending changesets. Forced to a **patch** bump (both changesets requested `minor`) per explicit instruction.

- feat(dashboard): make db_background_tasks a real read source for the agent-pane and muxspect dock
- feat(fleet): multi-agent fleet control — select, broadcast, and bulk-act on many agents at once

## Test plan

- [x] `scripts/release.sh --as patch` confirms all 5 version locations agree at 0.55.18 (VERSION_HISTORY.md, package.json, Cargo.toml, Cargo.lock, package-lock.json)
- [x] No code changes beyond version bump + changelog — the underlying feature PRs (#2687 and the dashboard one) were already reviewed, tested, and merged separately

<!-- agentmux:agent_id=agenty -->