### PR TITLE
fix(agent): recover the largest on-disk session before falling back to a blank conversation on a stale --resume

### DIFF
--- a/.changesets/1787295688-fix-agent-recover-the-largest-on-disk-session-before-falling-q26s.md
+++ b/.changesets/1787295688-fix-agent-recover-the-largest-on-disk-session-before-falling-q26s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): recover the largest on-disk session before falling back to a blank conversation on a stale --resume

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -1527,6 +1527,33 @@ impl PersistentSubprocessController {
         }
     }
 
+    /// Publish a session-outcome line immediately, via the same append
+    /// path `session_outcome_line`'s other call sites use
+    /// (`persistent_resume::ResumeEffect::EmitSessionOutcome`'s normal
+    /// handling). Used by `retry_after_resume_failure` for the ONE case
+    /// it can decide unambiguously and immediately: no recovery candidate
+    /// exists, so this is genuinely, unconditionally a fresh conversation
+    /// — see that function's own doc comment for why the Resumed case is
+    /// deliberately NOT emitted here.
+    fn emit_session_outcome_now(
+        &self,
+        outcome: persistent_resume::SessionOutcome,
+        attempted_sid: String,
+        actual_sid: Option<String>,
+    ) {
+        let Some(ref broker) = self.broker else { return };
+        let line = session_outcome_line(outcome, attempted_sid, actual_sid);
+        let global_output_zone = super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
+        super::shell::handle_append_block_file(
+            broker,
+            &self.block_id,
+            PERSISTENT_OUTPUT_SUBJECT,
+            line.as_bytes(),
+            self.filestore.as_ref(),
+            global_output_zone.as_deref(),
+        );
+    }
+
     /// After a confirmed-stale `--resume` failure, try to recover a REAL
     /// session instead of giving up and starting blank
     /// (`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`).
@@ -1559,15 +1586,49 @@ impl PersistentSubprocessController {
     /// fired this retry (the process-waiter's own `my_generation_wait`) —
     /// `decide_retry_batch_action` needs it to tell a live NEWER spawn
     /// apart from the impossible "our own process is somehow still
-    /// running" case (issue #2367).
+    /// running" case (issue #2367). `attempted_sid` is the id that was
+    /// just confirmed unreachable — threaded through from
+    /// `persistent_resume::ResumeEffect::FireRetry` so this function can
+    /// emit the eventual `EmitSessionOutcome` itself once recovery is
+    /// known (reagentx + Codex on PR #2693 — `persistent_resume.rs` can
+    /// no longer decide Fresh-vs-Resumed at the point it fires this
+    /// retry, since recovery might succeed).
     fn retry_after_resume_failure(
         &self,
         retry_generation: u64,
         mut config: PersistentSpawnConfig,
         mut entries: Vec<persistent_resume::QueuedRetryEntry>,
         held_error_line: Option<String>,
+        attempted_sid: String,
     ) {
-        config.session_id = self.find_recovery_session_id(&config).unwrap_or_default();
+        let recovered = self.find_recovery_session_id(&config);
+        config.session_id = recovered.clone().unwrap_or_default();
+        match &recovered {
+            // A real on-disk session was found — don't claim "Resumed"
+            // yet (codex P1 on PR #2693: the CLI can still reject this
+            // recovered id too, e.g. a corrupt file or a non-top-level
+            // session). Left unemitted here on purpose: the spawn below
+            // now threads this attempt through the SAME resume-tracking
+            // machinery a genuine first-time `--resume` uses (`Some(first
+            // .clone())`, not `None`), so `persistent_resume.rs`'s
+            // already-correct, already-tested `SessionCaptured` handling
+            // emits `Resumed` once the CLI actually confirms it — or, if
+            // this recovered id is ALSO stale, cascades into another
+            // `ConfirmedRetry` → this same function again, where
+            // `find_recovery_session_id`'s poison guard refuses to
+            // re-recover the identical dead id and this arm's `None`
+            // branch below correctly emits `Fresh` instead.
+            Some(_) => {}
+            // No recovery candidate — this IS genuinely, unambiguously a
+            // fresh conversation, decided right now. Safe to emit
+            // immediately: nothing downstream can turn this back into a
+            // resume.
+            None => self.emit_session_outcome_now(
+                persistent_resume::SessionOutcome::Fresh,
+                attempted_sid,
+                None,
+            ),
+        }
         let Some(first) = (!entries.is_empty()).then(|| entries.remove(0)) else {
             // Nothing to retry at all (shouldn't happen in practice —
             // the batch always has at least the triggering message) —
@@ -1661,7 +1722,23 @@ impl PersistentSubprocessController {
                 // see `clear_session_id_for_fresh_spawn`).
                 self.clear_session_id_for_fresh_spawn();
                 let retry_config = config.clone();
-                let spawn_result = self.spawn_process(config, None);
+                // `Some(first.clone())`, not `None` (codex P1 on PR
+                // #2693): when `config.session_id` holds a recovered
+                // on-disk session (not empty), this MUST thread through
+                // as a real resume-tracking seed — same as any first-time
+                // `--resume` attempt (mirrors `SendAction::BecomeSpawner`'s
+                // own `spawn_process` call above) — or a recovered id
+                // that turns out to be ALSO stale/rejected has no
+                // detection/retry-cascade at all, stranding the batch on
+                // that attempt's raw error instead of eventually falling
+                // through to the promised blank-conversation fallback.
+                // Harmless when there's nothing to resume: `spawn_process`
+                // only constructs `SpawnedWithResume` tracking when
+                // `inner.session_id` actually ends up populated, which it
+                // won't if `config.session_id` is empty — this always
+                // correctly falls back to `SpawnedFresh` in that case,
+                // same as passing `None` used to.
+                let spawn_result = self.spawn_process(config, Some(first.clone()));
                 match &spawn_result {
                     Ok(_) => self.mark_turn_active_and_publish(),
                     Err(e) => tracing::error!(
@@ -3187,7 +3264,7 @@ impl PersistentSubprocessController {
                                     }
                                 }
                             }
-                            persistent_resume::ResumeEffect::FireRetry { retry, held_error_line } => {
+                            persistent_resume::ResumeEffect::FireRetry { retry, held_error_line, attempted_sid } => {
                                 // Issue #2368: the retry is firing and will
                                 // very likely succeed within milliseconds —
                                 // the doomed attempt's own terminal error
@@ -3211,6 +3288,7 @@ impl PersistentSubprocessController {
                                         retry.config,
                                         retry.messages,
                                         held_error_line,
+                                        attempted_sid,
                                     );
                                 } else if let Some(line) = held_error_line {
                                     // The controller itself is already gone
@@ -4018,7 +4096,7 @@ mod send_input_tests {
             session_id: "dead-sid".to_string(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None);
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "dead-sid".to_string());
 
         assert_eq!(
             c.inner.lock().unwrap().session_id,
@@ -4148,7 +4226,7 @@ mod send_input_tests {
             message_id: None,
         };
 
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None);
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "dead-sid".to_string());
 
         assert_eq!(
             c.inner.lock().unwrap().session_id,
@@ -4908,7 +4986,7 @@ mod send_input_tests {
             session_id: "dead-sid".to_string(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None);
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "dead-sid".to_string());
 
         assert_eq!(
             c.inner.lock().unwrap().session_id.as_deref(),
@@ -4945,6 +5023,7 @@ mod send_input_tests {
             config,
             vec![qentry(1, "msg-1"), qentry(2, "msg-2"), qentry(3, "msg-3")],
             None,
+            "dead-sid".to_string(),
         );
 
         assert_eq!(rx.recv().await.unwrap(), "msg-1");
@@ -4975,7 +5054,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "stuck")], None);
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "stuck")], None, "dead-sid".to_string());
 
         let inner = c.inner.lock().unwrap();
         assert_eq!(
@@ -5018,6 +5097,7 @@ mod send_input_tests {
             config,
             vec![qentry(1, "msg-1"), qentry(2, "msg-2"), qentry(3, "msg-3")],
             None,
+            "dead-sid".to_string(),
         );
 
         let inner = c.inner.lock().unwrap();
@@ -5057,7 +5137,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "stuck")], None);
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "stuck")], None, "dead-sid".to_string());
 
         {
             let inner = c.inner.lock().unwrap();
@@ -5107,6 +5187,7 @@ mod send_input_tests {
             config,
             vec![qentry(1, "batch-1"), qentry(2, "batch-2")],
             None,
+            "dead-sid".to_string(),
         );
 
         // Races in while the flush task holds the drain claim: must be
@@ -5162,7 +5243,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], Some("boom\n".to_string()));
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], Some("boom\n".to_string()), "dead-sid".to_string());
 
         let flushed = filestore
             .read_file(&block_id, PERSISTENT_OUTPUT_SUBJECT)
@@ -5173,6 +5254,101 @@ mod send_input_tests {
             flushed,
             "a held error line must be flushed to the blockfile when the retry's own respawn fails, \
              not silently dropped"
+        );
+    }
+
+    /// Regression test for reagentx + Codex (PR #2693 review): when no
+    /// recovery candidate exists, this IS unambiguously known right now
+    /// — the outcome must be emitted immediately, not silently dropped
+    /// just because the premature emission at the `persistent_resume.rs`
+    /// state-machine layer was removed.
+    #[test]
+    fn retry_after_resume_failure_emits_fresh_outcome_immediately_when_no_recovery_found() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "block-emits-fresh-no-recovery".to_string();
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            block_id.clone(),
+            Some(broker),
+            None,
+            None,
+            Some(filestore.clone()),
+        );
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(), // no CLAUDE_CONFIG_DIR — nothing to recover
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "dead-sid".to_string());
+
+        let content = filestore
+            .read_file(&block_id, PERSISTENT_OUTPUT_SUBJECT)
+            .unwrap()
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .unwrap_or_default();
+        assert!(
+            content.contains("agentmux_session_outcome") && content.contains("\"fresh\""),
+            "a genuinely blank fallback (no recovery candidate) must emit the Fresh outcome \
+             immediately — got: {content:?}"
+        );
+    }
+
+    /// Regression test for reagentx + Codex (PR #2693 review), the other
+    /// half: when a recovery candidate IS found, this function must NOT
+    /// emit ANY outcome yet — the CLI hasn't confirmed it (Codex P1: it
+    /// could still reject the recovered id too). The eventual outcome is
+    /// left to `persistent_resume.rs`'s already-tested `SessionCaptured`
+    /// handling, once the (now resume-tracked) recovery attempt actually
+    /// resolves.
+    #[test]
+    fn retry_after_resume_failure_does_not_emit_an_outcome_yet_when_recovery_is_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().to_string_lossy().to_string();
+        let working_dir = r"C:\Users\asafe\.agentmux\agents\agentx-0623n".to_string();
+        let slug = crate::backend::session_backfill::encode_project_slug(&working_dir);
+        let dir = tmp.path().join("projects").join(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("972a6a4f-live.jsonl"), vec![b'x'; 2_800_000]).unwrap();
+
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "block-defers-outcome-on-recovery".to_string();
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            block_id.clone(),
+            Some(broker),
+            None,
+            None,
+            Some(filestore.clone()),
+        );
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), config_dir);
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir,
+            env_vars,
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "d019e2e4-stale".to_string(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "d019e2e4-stale".to_string());
+
+        let content = filestore
+            .read_file(&block_id, PERSISTENT_OUTPUT_SUBJECT)
+            .unwrap()
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .unwrap_or_default();
+        assert!(
+            !content.contains("agentmux_session_outcome"),
+            "must not claim any outcome until the CLI actually confirms the recovered id — got: {content:?}"
         );
     }
 
@@ -5217,7 +5393,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "stuck")], Some("boom\n".to_string()));
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "stuck")], Some("boom\n".to_string()), "dead-sid".to_string());
         tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
 
         let flushed = filestore
@@ -5277,7 +5453,7 @@ mod send_input_tests {
             session_id: String::new(),
             message_id: None,
         };
-        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], Some("boom\n".to_string()));
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], Some("boom\n".to_string()), "dead-sid".to_string());
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         let flushed = filestore

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -1527,6 +1527,34 @@ impl PersistentSubprocessController {
         }
     }
 
+    /// After a confirmed-stale `--resume` failure, try to recover a REAL
+    /// session instead of giving up and starting blank
+    /// (`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`).
+    /// Looks for the largest on-disk session under this spawn's own
+    /// `CLAUDE_CONFIG_DIR`/working dir — the same "largest session wins"
+    /// recovery `session_backfill::backfill_session_ids` already trusts
+    /// for the analogous cross-channel-open case.
+    ///
+    /// Returns `None` (caller falls back to starting blank, same as
+    /// before this existed) when: `CLAUDE_CONFIG_DIR` isn't set on this
+    /// config, no session exists there, or the only candidate found is
+    /// the SAME id already confirmed poisoned — guards against looping
+    /// forever "recovering" an id that is itself dead (nothing on disk
+    /// changes between attempts, so an unguarded retry would rediscover
+    /// the identical bad id every time).
+    fn find_recovery_session_id(&self, config: &PersistentSpawnConfig) -> Option<String> {
+        let config_dir = config.env_vars.get("CLAUDE_CONFIG_DIR")?;
+        let candidate = crate::backend::session_backfill::find_largest_session_for_working_dir(
+            config_dir,
+            &config.working_dir,
+        )?;
+        let already_poisoned = self.inner.lock().unwrap().resume_poisoned.as_deref() == Some(candidate.as_str());
+        if already_poisoned {
+            return None;
+        }
+        Some(candidate)
+    }
+
     /// `retry_generation` is the spawn generation whose `ProcessExited`
     /// fired this retry (the process-waiter's own `my_generation_wait`) —
     /// `decide_retry_batch_action` needs it to tell a live NEWER spawn
@@ -1539,7 +1567,7 @@ impl PersistentSubprocessController {
         mut entries: Vec<persistent_resume::QueuedRetryEntry>,
         held_error_line: Option<String>,
     ) {
-        config.session_id = String::new();
+        config.session_id = self.find_recovery_session_id(&config).unwrap_or_default();
         let Some(first) = (!entries.is_empty()).then(|| entries.remove(0)) else {
             // Nothing to retry at all (shouldn't happen in practice —
             // the batch always has at least the triggering message) —
@@ -3996,6 +4024,136 @@ mod send_input_tests {
             c.inner.lock().unwrap().session_id,
             None,
             "must clear inner.session_id directly, not rely on poison_resume having already done so"
+        );
+    }
+
+    /// Regression test for
+    /// `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`:
+    /// a confirmed-stale `--resume` must try to recover the largest REAL
+    /// session on disk before giving up and starting blank.
+    #[test]
+    fn find_recovery_session_id_recovers_the_largest_on_disk_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().to_string_lossy().to_string();
+        let working_dir = r"C:\Users\asafe\.agentmux\agents\agentx-0623n".to_string();
+        let slug = crate::backend::session_backfill::encode_project_slug(&working_dir);
+        let dir = tmp.path().join("projects").join(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("972a6a4f-live.jsonl"), vec![b'x'; 2_800_000]).unwrap();
+
+        let c = controller();
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), config_dir);
+        let config = PersistentSpawnConfig {
+            cli_command: "claude".to_string(),
+            cli_args: vec![],
+            working_dir,
+            env_vars,
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "d019e2e4-stale".to_string(),
+            message_id: None,
+        };
+
+        assert_eq!(
+            c.find_recovery_session_id(&config).as_deref(),
+            Some("972a6a4f-live"),
+            "must recover the largest real on-disk session, not give up"
+        );
+    }
+
+    #[test]
+    fn find_recovery_session_id_is_none_without_a_config_dir() {
+        let c = controller();
+        let config = PersistentSpawnConfig {
+            cli_command: "claude".to_string(),
+            cli_args: vec![],
+            working_dir: "/wherever".to_string(),
+            env_vars: HashMap::new(), // no CLAUDE_CONFIG_DIR — same as the pre-fix world
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        assert_eq!(c.find_recovery_session_id(&config), None);
+    }
+
+    /// Guards against an infinite retry loop: if the ONLY candidate
+    /// recovery finds is the exact id already confirmed poisoned this
+    /// attempt, don't recover it again — nothing on disk changes between
+    /// attempts, so an unguarded recovery would rediscover the identical
+    /// dead id forever.
+    #[test]
+    fn find_recovery_session_id_refuses_an_already_poisoned_candidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().to_string_lossy().to_string();
+        let working_dir = "/agents/agentx".to_string();
+        let slug = crate::backend::session_backfill::encode_project_slug(&working_dir);
+        let dir = tmp.path().join("projects").join(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("dead-sid.jsonl"), vec![b'x'; 1_000]).unwrap();
+
+        let c = controller();
+        c.inner.lock().unwrap().resume_poisoned = Some("dead-sid".to_string());
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), config_dir);
+        let config = PersistentSpawnConfig {
+            cli_command: "claude".to_string(),
+            cli_args: vec![],
+            working_dir,
+            env_vars,
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+
+        assert_eq!(
+            c.find_recovery_session_id(&config),
+            None,
+            "must not re-recover the same id already confirmed dead this attempt"
+        );
+    }
+
+    /// End-to-end through `retry_after_resume_failure`: when a real,
+    /// larger session exists on disk under this spawn's own
+    /// `CLAUDE_CONFIG_DIR`, the respawn must hydrate `inner.session_id` to
+    /// THAT recovered id — not fall back to a blank conversation — even
+    /// though the actual process spawn itself fails fast here (nonexistent
+    /// binary), mirroring
+    /// `retry_after_resume_failure_clears_inner_session_id_even_when_poison_resume_has_not_run_yet`
+    /// above but for the recovery path instead of the give-up path.
+    #[test]
+    fn retry_after_resume_failure_hydrates_inner_session_id_from_the_recovered_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().to_string_lossy().to_string();
+        let working_dir = r"C:\Users\asafe\.agentmux\agents\agentx-0623n".to_string();
+        let slug = crate::backend::session_backfill::encode_project_slug(&working_dir);
+        let dir = tmp.path().join("projects").join(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("972a6a4f-live.jsonl"), vec![b'x'; 2_800_000]).unwrap();
+
+        let c = controller();
+        c.inner.lock().unwrap().session_id = Some("d019e2e4-stale".to_string());
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), config_dir);
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir,
+            env_vars,
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "d019e2e4-stale".to_string(),
+            message_id: None,
+        };
+
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None);
+
+        assert_eq!(
+            c.inner.lock().unwrap().session_id,
+            Some("972a6a4f-live".to_string()),
+            "must resume the recovered real session, not silently start blank"
         );
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent_resume.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent_resume.rs
@@ -228,7 +228,11 @@ pub(super) enum ResumeEffect {
     /// the caller's own spawn attempt). The caller drops it on success
     /// and flushes it on failure — see
     /// `persistent::PersistentSubprocessController::retry_after_resume_failure`.
-    FireRetry { retry: RetryPayload, held_error_line: Option<String> },
+    /// `attempted_sid` is the id that was just confirmed unreachable —
+    /// carried through so the caller can emit the eventual
+    /// `EmitSessionOutcome` itself once it knows whether recovery
+    /// succeeded (PR #2693 — this module can no longer decide that here).
+    FireRetry { retry: RetryPayload, held_error_line: Option<String>, attempted_sid: String },
     /// Genuinely done, not retrying — publish the terminal status.
     PublishDone,
     /// A `--resume <attempted_sid>` attempt's outcome just became
@@ -538,21 +542,28 @@ pub(super) fn update(state: ResumeState, event: ResumeEvent) -> (ResumeState, Ve
                 // caller's own spawn attempt), so it's bundled into the
                 // effect rather than pre-decided here.
                 //
-                // The resume was CONFIRMED unreachable (`ResumeUnreachable`
-                // already fired to reach `ConfirmedRetry`) — the retry
-                // about to fire clears `session_id` before respawning
-                // (`retry_after_resume_failure`), so this is unambiguously
-                // a Fresh outcome, known now even though the retry itself
-                // hasn't launched yet. See
-                // SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1.
-                vec![
-                    ResumeEffect::EmitSessionOutcome {
-                        outcome: SessionOutcome::Fresh,
-                        attempted_sid,
-                        actual_sid: None,
-                    },
-                    ResumeEffect::FireRetry { retry, held_error_line },
-                ]
+                // reagentx + Codex (PR #2693 review): the outcome is NO
+                // LONGER decidable here. This module used to assume the
+                // retry unconditionally clears `session_id` and starts
+                // blank — true before #2693, which added a recovery
+                // lookup (`retry_after_resume_failure` now tries to find
+                // a real on-disk session before giving up). Pre-emitting
+                // `Fresh` here was provably wrong whenever recovery
+                // succeeds: the frontend treats a `Fresh` node as a
+                // permanent scroll-anchor that a later `Resumed` outcome
+                // can never clear (`session-outcome.ts`), so the pane
+                // would show a truncated scrollback even when the model
+                // genuinely has full prior context. The caller now
+                // decides and emits the outcome itself, once recovery is
+                // actually known — immediately if it falls back to blank
+                // (see `PersistentSubprocessController::retry_after_resume_failure`),
+                // or via this same module's existing, already-correct
+                // `SessionCaptured` handling above once the recovery
+                // attempt (now itself resume-tracked, not fire-and-forget)
+                // resolves. `attempted_sid` is threaded through
+                // `FireRetry` so the caller has it either way. See
+                // `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`.
+                vec![ResumeEffect::FireRetry { retry, held_error_line, attempted_sid }]
             };
             (ResumeState::NotTracking { current_generation: generation }, effects)
         }
@@ -718,14 +729,11 @@ mod tests {
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
         assert_eq!(
             effects,
-            vec![
-                ResumeEffect::EmitSessionOutcome {
-                    outcome: SessionOutcome::Fresh,
-                    attempted_sid: "dead-sid".to_string(),
-                    actual_sid: None,
-                },
-                ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: Some("boom".to_string()) },
-            ]
+            vec![ResumeEffect::FireRetry {
+                retry: dummy_retry(),
+                held_error_line: Some("boom".to_string()),
+                attempted_sid: "dead-sid".to_string(),
+            }]
         );
     }
 
@@ -780,14 +788,11 @@ mod tests {
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
         assert_eq!(
             effects,
-            vec![
-                ResumeEffect::EmitSessionOutcome {
-                    outcome: SessionOutcome::Fresh,
-                    attempted_sid: "dead-sid".to_string(),
-                    actual_sid: None,
-                },
-                ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: Some("boom".to_string()) },
-            ]
+            vec![ResumeEffect::FireRetry {
+                retry: dummy_retry(),
+                held_error_line: Some("boom".to_string()),
+                attempted_sid: "dead-sid".to_string(),
+            }]
         );
     }
 
@@ -1030,14 +1035,11 @@ mod tests {
         assert_eq!(state, ResumeState::NotTracking { current_generation: 1 });
         assert_eq!(
             effects,
-            vec![
-                ResumeEffect::EmitSessionOutcome {
-                    outcome: SessionOutcome::Fresh,
-                    attempted_sid: "dead-sid".to_string(),
-                    actual_sid: None,
-                },
-                ResumeEffect::FireRetry { retry: dummy_retry(), held_error_line: None },
-            ]
+            vec![ResumeEffect::FireRetry {
+                retry: dummy_retry(),
+                held_error_line: None,
+                attempted_sid: "dead-sid".to_string(),
+            }]
         );
     }
 

--- a/agentmux-srv/src/backend/session_backfill.rs
+++ b/agentmux-srv/src/backend/session_backfill.rs
@@ -65,6 +65,24 @@ pub fn largest_session_id(projects_dirs: &[PathBuf], slug: &str) -> Option<Strin
     best.map(|(_, stem)| stem)
 }
 
+/// Recovery lookup for a confirmed-stale `--resume` failure
+/// (`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`):
+/// rather than giving up and starting a blank conversation the moment a
+/// registry/inherited `session_id` turns out to be unreachable, look for
+/// the largest session actually on disk under this exact `config_dir` (the
+/// `CLAUDE_CONFIG_DIR` the CLI process is about to run with) for
+/// `working_dir`. `None` when `config_dir` is empty/unset (nothing to
+/// search) or no session exists — callers fall back to starting blank in
+/// either case, same as before this existed.
+pub fn find_largest_session_for_working_dir(config_dir: &str, working_dir: &str) -> Option<String> {
+    if config_dir.is_empty() {
+        return None;
+    }
+    let projects_dir = Path::new(config_dir).join("projects");
+    let slug = encode_project_slug(working_dir);
+    largest_session_id(&[projects_dir], &slug)
+}
+
 /// Populate `session_id` for registry records that lack one, from the agent's
 /// largest provider session. Idempotent (skips records that already carry a
 /// non-empty id). Returns the number populated. Best-effort per record — a
@@ -159,6 +177,44 @@ mod tests {
         );
         // Missing project dir is graceful.
         assert_eq!(largest_session_id(&[projects], "nope"), None);
+    }
+
+    #[test]
+    fn find_largest_session_for_working_dir_locates_the_real_transcript() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path();
+        let working_dir = r"C:\Users\asafe\.agentmux\agents\agentx-0623n";
+        let slug = encode_project_slug(working_dir);
+        let dir = config_dir.join("projects").join(&slug);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("972a6a4f-live.jsonl"), vec![b'x'; 2_800_000]).unwrap();
+
+        assert_eq!(
+            find_largest_session_for_working_dir(&config_dir.to_string_lossy(), working_dir).as_deref(),
+            Some("972a6a4f-live")
+        );
+    }
+
+    #[test]
+    fn find_largest_session_for_working_dir_is_none_for_an_empty_config_dir() {
+        // An unset CLAUDE_CONFIG_DIR (empty string) must not be treated as
+        // "search the current directory" — nothing to recover from.
+        assert_eq!(
+            find_largest_session_for_working_dir("", r"C:\Users\asafe\.agentmux\agents\agentx-0623n"),
+            None
+        );
+    }
+
+    #[test]
+    fn find_largest_session_for_working_dir_is_none_when_nothing_exists_there() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            find_largest_session_for_working_dir(
+                &tmp.path().to_string_lossy(),
+                r"C:\Users\asafe\.agentmux\agents\nobody-here",
+            ),
+            None
+        );
     }
 
     fn rec(id: &str, base: Option<&str>, wd: &str, sid: Option<&str>) -> NamedAgentRecord {

--- a/agentmux-srv/src/backend/session_backfill.rs
+++ b/agentmux-srv/src/backend/session_backfill.rs
@@ -74,11 +74,20 @@ pub fn largest_session_id(projects_dirs: &[PathBuf], slug: &str) -> Option<Strin
 /// `working_dir`. `None` when `config_dir` is empty/unset (nothing to
 /// search) or no session exists — callers fall back to starting blank in
 /// either case, same as before this existed.
+///
+/// `config_dir` is expanded the same way the actual spawn path expands
+/// every env var (`core::apply_working_dir` -> `expand_home_dir_safe`)
+/// before applying it to the child process — a `CLAUDE_CONFIG_DIR` of
+/// `~/.claude` must resolve to the real home directory here too, or this
+/// searches a literal, nonexistent `~/.claude/projects` while the CLI
+/// itself reads the real expanded path, silently defeating recovery for
+/// every `~`-shorthand config dir (Codex P2 on PR #2693).
 pub fn find_largest_session_for_working_dir(config_dir: &str, working_dir: &str) -> Option<String> {
     if config_dir.is_empty() {
         return None;
     }
-    let projects_dir = Path::new(config_dir).join("projects");
+    let expanded = crate::backend::base::expand_home_dir_safe(config_dir);
+    let projects_dir = expanded.join("projects");
     let slug = encode_project_slug(working_dir);
     largest_session_id(&[projects_dir], &slug)
 }
@@ -214,6 +223,35 @@ mod tests {
                 r"C:\Users\asafe\.agentmux\agents\nobody-here",
             ),
             None
+        );
+    }
+
+    /// Codex P2 on PR #2693: `config_dir` must be expanded the same way the
+    /// actual spawn path expands every env var (`core::apply_working_dir`'s
+    /// `expand_home_dir_safe`) — a literal, un-expanded `~/...` must not be
+    /// searched as-is, or recovery silently fails for every config dir that
+    /// uses `~`-shorthand. Writes into a uniquely-named folder under the
+    /// REAL home directory (there's no way to test `~` resolution without
+    /// one) and removes it afterward regardless of outcome.
+    #[test]
+    fn find_largest_session_for_working_dir_expands_a_tilde_config_dir() {
+        let home = dirs::home_dir().expect("test requires a resolvable home dir");
+        let rel = format!(".agentmux-test-tilde-expansion-{}", std::process::id());
+        let config_dir_abs = home.join(&rel);
+        let working_dir = r"C:\Users\test\.agentmux\agents\tilde-test";
+        let slug = encode_project_slug(working_dir);
+        let dir = config_dir_abs.join("projects").join(&slug);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("abc123-session.jsonl"), b"{}").unwrap();
+
+        let result = find_largest_session_for_working_dir(&format!("~/{rel}"), working_dir);
+
+        fs::remove_dir_all(&config_dir_abs).ok();
+
+        assert_eq!(
+            result.as_deref(),
+            Some("abc123-session"),
+            "a ~-prefixed config_dir must resolve to the real home directory, not be searched literally"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2691.

When a `--resume <sid>` attempt is confirmed unreachable, the retry
unconditionally cleared `session_id` and started completely blank — even
when the agent's actual, much larger conversation was sitting right there
on disk the whole time. Reproduced case (see
`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`):
a stale shared-registry `session_id` pointed at a long-dead subagent
session from 6 days earlier, while the real 2.8MB conversation went
unconsulted, and the pane silently started a brand-new empty session with
no error surfaced to the user.

## Fix

- `session_backfill::find_largest_session_for_working_dir` — reuses the
  same "largest session wins" recovery logic `backfill_session_ids`
  already trusts for the analogous cross-channel-open case, scoped to a
  single `CLAUDE_CONFIG_DIR`/`working_dir` pair.
- Wired into `retry_after_resume_failure` via a new
  `find_recovery_session_id` helper: instead of unconditionally clearing
  `session_id` to empty, it now looks for a real recoverable session first.
- Guards against an infinite retry loop: refuses to re-recover a candidate
  that's already the confirmed-`resume_poisoned` id for this attempt — disk
  state can't change between attempts, so an unguarded retry would
  rediscover the identical dead id forever and loop.
- **Additive only**: falls back to the exact pre-fix behavior (blank
  conversation) when `CLAUDE_CONFIG_DIR` isn't set on the spawn config or
  no session exists on disk — no behavior change for the no-signal case.

## Testing

- 7 new tests: 3 for `find_largest_session_for_working_dir`, 3 for
  `find_recovery_session_id` (recovers correctly / no config dir / refuses
  an already-poisoned candidate), 1 end-to-end through
  `retry_after_resume_failure` confirming `inner.session_id` hydrates to
  the recovered session rather than staying blank.
- All 10 pre-existing `retry_after_resume_failure_*` tests pass unchanged
  (confirms no regression to the existing stale-resume state machine).
- Full suite: `cargo test -p agentmux-srv` — 2577 passed, 0 failed.

## Not in scope for this PR

- Making the shared registry `session_id` a live pointer instead of
  write-once (the other fix direction from the status doc) — this PR is
  the safety-net recovery path; the write-once staleness itself is a
  separate, larger change.
- Surfacing the recovery/failure to the user in the UI.
- How a subagent's session id ended up written into the registry as the
  parent's own in the first place (noted as a separate follow-up in the
  status doc).

<!-- agentmux:agent_id=agentx -->