### PR TITLE
[Manoz@Area54] fix(jekt): remove unsafe global-settings agent-id fallback, audit registration events

### DIFF
--- a/.changesets/1787297005-fix-jekt-remove-unsafe-global-settings-agent-id-fallback-aud-aogv.md
+++ b/.changesets/1787297005-fix-jekt-remove-unsafe-global-settings-agent-id-fallback-aud-aogv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(jekt): remove unsafe global-settings agent-id fallback, audit registration events

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -32,25 +32,58 @@ use crate::backend::shellexec::ShellProc;
 use crate::backend::wps;
 
 /// Resolve the effective AGENTMUX_AGENT_ID for jekt auto-registration from a
-/// block's own spawn metadata (or the legacy WAVEMUX_AGENT_ID env var).
-/// Priority: block metadata > WAVEMUX_AGENT_ID env compat. Deliberately does
-/// NOT fall back to the global settings' cmd_env.AGENTMUX_AGENT_ID: that
-/// value is shared across every pane in the instance/channel, so a pane
-/// spawned without its own explicit per-block ID would silently inherit
-/// whatever another pane happened to configure there — and
-/// register_agent_with_nonce unconditionally evicts whoever previously held
-/// that agent_key, so the second such pane to register silently steals the
-/// first's jekt identity (same-host cross-instance jekt misdelivery). A pane
-/// with no block-scoped identity is simply not jekt-registered, matching
-/// persistent.rs's muxbus_agent_id_from_env, which never had this fallback.
+/// block's own spawn metadata — both the canonical key and the legacy
+/// WAVEMUX_AGENT_ID alias, checked in the SAME block-scoped `cmd:env` map.
+/// Deliberately does NOT fall back to `std::env::var` for either key: that
+/// reads THIS SRV PROCESS's own environment, shared by every block/pane
+/// this instance spawns — reintroducing exactly the same collision as the
+/// global-settings fallback below (reagentx P1, round 2: an earlier version
+/// of this fn read `std::env::var("WAVEMUX_AGENT_ID")` here, which is process-
+/// global env, not per-pane, despite this file's own line ~404 comment
+/// already correctly describing WAVEMUX_AGENT_ID as "process-global env
+/// state" in a different context — the two were inconsistent). Nor does it
+/// fall back to the global settings' cmd_env.AGENTMUX_AGENT_ID: that value
+/// is shared across every pane in the instance/channel, so a pane spawned
+/// without its own explicit per-block ID would silently inherit whatever
+/// another pane happened to configure there — and register_agent_with_nonce
+/// unconditionally evicts whoever previously held that agent_key, so the
+/// second such pane to register silently steals the first's jekt identity
+/// (same-host cross-instance jekt misdelivery). See the child-env injection
+/// loop below (`settings.cmd_env` iteration) for the matching fix that keeps
+/// this global value out of the pane's OWN environment too — otherwise a
+/// pane could still pick it up via OSC 16162 and re-register through the
+/// frontend's `/agentmux/reactive/register` path instead (reagentx P1,
+/// round 2), even with THIS function never reading it directly. A pane with
+/// no block-scoped identity is simply not jekt-registered, matching
+/// persistent.rs's muxbus_agent_id_from_env, which never had either fallback.
 fn resolve_agent_id_for_jekt(block_meta: &MetaMapType) -> Option<String> {
-    block_meta
-        .get(META_KEY_CMD_ENV)
-        .and_then(|m| m.as_object())
-        .and_then(|obj| obj.get("AGENTMUX_AGENT_ID"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .or_else(|| std::env::var("WAVEMUX_AGENT_ID").ok())
+    let cmd_env = block_meta.get(META_KEY_CMD_ENV).and_then(|m| m.as_object());
+    for key in ["AGENTMUX_AGENT_ID", "WAVEMUX_AGENT_ID"] {
+        if let Some(v) = cmd_env.and_then(|obj| obj.get(key)).and_then(|v| v.as_str()) {
+            let trimmed = v.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Whether `key` may be injected into a pane's actual OS environment from
+/// the global settings' `cmd_env` defaults (`start()`'s child-env-injection
+/// loop, lowest priority — the block's own `cmd:env` override, highest
+/// priority, is never filtered by this and can always set either key
+/// explicitly). Identity keys are excluded (reagentx P1, round 2 on #2694):
+/// without this, a global cmd_env.AGENTMUX_AGENT_ID setting would still land
+/// in every pane's real environment even though `resolve_agent_id_for_jekt`
+/// never reads it for registration — shell integration echoes an injected
+/// AGENTMUX_AGENT_ID back via OSC 16162, and the frontend's own
+/// `POST /agentmux/reactive/register` path (triggered by that OSC) would
+/// pick it up and register the pane under the shared value anyway, silently
+/// reopening the same-host identity collision this PR removes from the
+/// backend auto-register path specifically.
+fn is_global_cmd_env_injectable(key: &str) -> bool {
+    !matches!(key, "AGENTMUX_AGENT_ID" | "WAVEMUX_AGENT_ID")
 }
 
 impl Controller for ShellController {
@@ -410,8 +443,8 @@ impl Controller for ShellController {
             );
             let settings = config.get_settings();
             for (k, v) in &settings.cmd_env {
-                if k == "AGENTMUX_AGENT_ID" {
-                    has_agent_id = true;
+                if !is_global_cmd_env_injectable(k) {
+                    continue;
                 }
                 let expanded = crate::backend::base::expand_home_dir_safe(v);
                 c.env(k, expanded.to_string_lossy().as_ref());
@@ -1105,53 +1138,93 @@ impl Controller for ShellController {
 
 #[cfg(test)]
 mod agent_id_for_jekt_tests {
-    use super::resolve_agent_id_for_jekt;
+    use super::{is_global_cmd_env_injectable, resolve_agent_id_for_jekt};
     use crate::backend::blockcontroller::META_KEY_CMD_ENV;
     use crate::backend::obj::MetaMapType;
 
-    // WAVEMUX_AGENT_ID is process-global env state and these tests mutate
-    // it directly (no HashMap indirection like persistent.rs's
-    // muxbus_agent_id_from_env), so everything that touches it lives in one
-    // #[test] fn — Rust's test harness runs tests in the same binary
-    // concurrently, and separate fns each doing remove/set/assert/remove on
-    // the same env var would race.
     #[test]
-    fn resolves_block_scoped_and_legacy_env_but_never_global_settings() {
-        // No block-scoped AGENTMUX_AGENT_ID and no WAVEMUX_AGENT_ID set:
-        // this is the collision-fix regression case. Before the fix, this
-        // path fell back to `ConfigWatcher`'s global cmd_env.AGENTMUX_AGENT_ID
-        // setting; resolve_agent_id_for_jekt's signature no longer even
-        // accepts a way to reach global settings, so a pane with neither
-        // source set is simply not jekt-registered.
-        std::env::remove_var("WAVEMUX_AGENT_ID");
+    fn identity_keys_are_never_globally_injectable() {
+        // reagentx P1, round 2 on #2694: these must never come from global
+        // settings.cmd_env — only from a block's own explicit override.
+        assert!(!is_global_cmd_env_injectable("AGENTMUX_AGENT_ID"));
+        assert!(!is_global_cmd_env_injectable("WAVEMUX_AGENT_ID"));
+    }
+
+    #[test]
+    fn other_global_cmd_env_keys_remain_injectable() {
+        // Cosmetic/unrelated global defaults (colors, arbitrary user
+        // cmd_env entries) are unaffected — only the two identity keys are
+        // excluded.
+        assert!(is_global_cmd_env_injectable("AGENTMUX_AGENT_COLOR"));
+        assert!(is_global_cmd_env_injectable("SOME_OTHER_VAR"));
+    }
+
+    fn meta_with_env(pairs: &[(&str, &str)]) -> MetaMapType {
+        let mut obj = serde_json::Map::new();
+        for (k, v) in pairs {
+            obj.insert(k.to_string(), serde_json::json!(v));
+        }
+        let mut meta = MetaMapType::new();
+        meta.insert(META_KEY_CMD_ENV.to_string(), serde_json::Value::Object(obj));
+        meta
+    }
+
+    #[test]
+    fn no_block_scoped_identity_resolves_to_none() {
+        // This is the collision-fix regression case: a pane with neither
+        // AGENTMUX_AGENT_ID nor WAVEMUX_AGENT_ID set in its OWN cmd:env is
+        // simply not jekt-registered — no fallback to global settings, and
+        // (reagentx P1, round 2) no fallback to this srv PROCESS's own
+        // std::env::var either, since that's process-global, not per-pane.
         let empty_meta = MetaMapType::new();
         assert_eq!(resolve_agent_id_for_jekt(&empty_meta), None);
+    }
 
-        // Block metadata's own cmd:env.AGENTMUX_AGENT_ID takes priority.
-        let mut meta_with_id = MetaMapType::new();
-        meta_with_id.insert(
-            META_KEY_CMD_ENV.to_string(),
-            serde_json::json!({ "AGENTMUX_AGENT_ID": "agentx" }),
-        );
-        assert_eq!(
-            resolve_agent_id_for_jekt(&meta_with_id),
-            Some("agentx".to_string())
-        );
+    #[test]
+    fn resolves_block_scoped_agentmux_agent_id() {
+        let meta = meta_with_env(&[("AGENTMUX_AGENT_ID", "agentx")]);
+        assert_eq!(resolve_agent_id_for_jekt(&meta), Some("agentx".to_string()));
+    }
 
-        // Legacy WAVEMUX_AGENT_ID env var still works as a fallback when no
-        // block-scoped ID is set (this one is genuinely block-scoped — it's
-        // read from the spawned child's own env, not a shared global
-        // setting, so it doesn't reintroduce the collision).
-        std::env::set_var("WAVEMUX_AGENT_ID", "legacy-agent");
+    #[test]
+    fn resolves_block_scoped_legacy_wavemux_agent_id() {
+        // The legacy alias is read from the SAME block-scoped cmd:env map,
+        // not process env (reagentx P1, round 2) — genuinely per-pane, so
+        // it can't reintroduce the same-host collision.
+        let meta = meta_with_env(&[("WAVEMUX_AGENT_ID", "legacy-agent")]);
         assert_eq!(
-            resolve_agent_id_for_jekt(&empty_meta),
+            resolve_agent_id_for_jekt(&meta),
             Some("legacy-agent".to_string())
         );
-        // Block metadata still wins over the legacy env var when both are set.
-        assert_eq!(
-            resolve_agent_id_for_jekt(&meta_with_id),
-            Some("agentx".to_string())
-        );
-        std::env::remove_var("WAVEMUX_AGENT_ID");
+    }
+
+    #[test]
+    fn agentmux_agent_id_wins_over_legacy_wavemux_when_both_set_on_the_same_block() {
+        let meta = meta_with_env(&[
+            ("AGENTMUX_AGENT_ID", "agentx"),
+            ("WAVEMUX_AGENT_ID", "legacy-agent"),
+        ]);
+        assert_eq!(resolve_agent_id_for_jekt(&meta), Some("agentx".to_string()));
+    }
+
+    #[test]
+    fn blank_value_is_treated_as_absent() {
+        // Matches persistent.rs's muxbus_agent_id_from_env: a present-but-
+        // whitespace-only value doesn't count as a real identity.
+        let meta = meta_with_env(&[("AGENTMUX_AGENT_ID", "   ")]);
+        assert_eq!(resolve_agent_id_for_jekt(&meta), None);
+    }
+
+    #[test]
+    fn a_different_blocks_env_never_leaks_in() {
+        // resolve_agent_id_for_jekt takes ONE block's own metadata — there
+        // is no code path here that could read another block's or the
+        // process's own env, unlike the bug this fn was rewritten to fix.
+        // This test exists to make that structurally obvious: the fn's
+        // only input is the map passed in.
+        let other_blocks_meta = meta_with_env(&[("AGENTMUX_AGENT_ID", "agenty")]);
+        let this_blocks_meta = MetaMapType::new();
+        assert_eq!(resolve_agent_id_for_jekt(&other_blocks_meta), Some("agenty".to_string()));
+        assert_eq!(resolve_agent_id_for_jekt(&this_blocks_meta), None);
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -31,6 +31,28 @@ use crate::backend::obj::{self, MetaMapType};
 use crate::backend::shellexec::ShellProc;
 use crate::backend::wps;
 
+/// Resolve the effective AGENTMUX_AGENT_ID for jekt auto-registration from a
+/// block's own spawn metadata (or the legacy WAVEMUX_AGENT_ID env var).
+/// Priority: block metadata > WAVEMUX_AGENT_ID env compat. Deliberately does
+/// NOT fall back to the global settings' cmd_env.AGENTMUX_AGENT_ID: that
+/// value is shared across every pane in the instance/channel, so a pane
+/// spawned without its own explicit per-block ID would silently inherit
+/// whatever another pane happened to configure there — and
+/// register_agent_with_nonce unconditionally evicts whoever previously held
+/// that agent_key, so the second such pane to register silently steals the
+/// first's jekt identity (same-host cross-instance jekt misdelivery). A pane
+/// with no block-scoped identity is simply not jekt-registered, matching
+/// persistent.rs's muxbus_agent_id_from_env, which never had this fallback.
+fn resolve_agent_id_for_jekt(block_meta: &MetaMapType) -> Option<String> {
+    block_meta
+        .get(META_KEY_CMD_ENV)
+        .and_then(|m| m.as_object())
+        .and_then(|obj| obj.get("AGENTMUX_AGENT_ID"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("WAVEMUX_AGENT_ID").ok())
+}
+
 impl Controller for ShellController {
     fn start(
         &self,
@@ -166,20 +188,9 @@ impl Controller for ShellController {
         let interactive = Self::is_interactive(&block_meta);
 
         // Resolve effective AGENTMUX_AGENT_ID for jekt auto-registration.
-        // Priority: block metadata > global settings > WAVEMUX_AGENT_ID env compat.
-        let agent_id_for_jekt: Option<String> = block_meta
-            .get(META_KEY_CMD_ENV)
-            .and_then(|m| m.as_object())
-            .and_then(|obj| obj.get("AGENTMUX_AGENT_ID"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| {
-                let cfg = crate::backend::wconfig::ConfigWatcher::with_config(
-                    crate::backend::wconfig::build_default_config(),
-                );
-                cfg.get_settings().cmd_env.get("AGENTMUX_AGENT_ID").cloned()
-            })
-            .or_else(|| std::env::var("WAVEMUX_AGENT_ID").ok());
+        // See resolve_agent_id_for_jekt's doc comment for why this
+        // deliberately does not fall back to global settings.
+        let agent_id_for_jekt: Option<String> = resolve_agent_id_for_jekt(&block_meta);
 
         // Detect agent pane: cmd contains a known agent CLI or has AGENTMUX_AGENT_ID set.
         // Computed here (before spawn) rather than after so the commit-aware admission
@@ -1089,5 +1100,58 @@ impl Controller for ShellController {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod agent_id_for_jekt_tests {
+    use super::resolve_agent_id_for_jekt;
+    use crate::backend::blockcontroller::META_KEY_CMD_ENV;
+    use crate::backend::obj::MetaMapType;
+
+    // WAVEMUX_AGENT_ID is process-global env state and these tests mutate
+    // it directly (no HashMap indirection like persistent.rs's
+    // muxbus_agent_id_from_env), so everything that touches it lives in one
+    // #[test] fn — Rust's test harness runs tests in the same binary
+    // concurrently, and separate fns each doing remove/set/assert/remove on
+    // the same env var would race.
+    #[test]
+    fn resolves_block_scoped_and_legacy_env_but_never_global_settings() {
+        // No block-scoped AGENTMUX_AGENT_ID and no WAVEMUX_AGENT_ID set:
+        // this is the collision-fix regression case. Before the fix, this
+        // path fell back to `ConfigWatcher`'s global cmd_env.AGENTMUX_AGENT_ID
+        // setting; resolve_agent_id_for_jekt's signature no longer even
+        // accepts a way to reach global settings, so a pane with neither
+        // source set is simply not jekt-registered.
+        std::env::remove_var("WAVEMUX_AGENT_ID");
+        let empty_meta = MetaMapType::new();
+        assert_eq!(resolve_agent_id_for_jekt(&empty_meta), None);
+
+        // Block metadata's own cmd:env.AGENTMUX_AGENT_ID takes priority.
+        let mut meta_with_id = MetaMapType::new();
+        meta_with_id.insert(
+            META_KEY_CMD_ENV.to_string(),
+            serde_json::json!({ "AGENTMUX_AGENT_ID": "agentx" }),
+        );
+        assert_eq!(
+            resolve_agent_id_for_jekt(&meta_with_id),
+            Some("agentx".to_string())
+        );
+
+        // Legacy WAVEMUX_AGENT_ID env var still works as a fallback when no
+        // block-scoped ID is set (this one is genuinely block-scoped — it's
+        // read from the spawned child's own env, not a shared global
+        // setting, so it doesn't reintroduce the collision).
+        std::env::set_var("WAVEMUX_AGENT_ID", "legacy-agent");
+        assert_eq!(
+            resolve_agent_id_for_jekt(&empty_meta),
+            Some("legacy-agent".to_string())
+        );
+        // Block metadata still wins over the legacy env var when both are set.
+        assert_eq!(
+            resolve_agent_id_for_jekt(&meta_with_id),
+            Some("agentx".to_string())
+        );
+        std::env::remove_var("WAVEMUX_AGENT_ID");
     }
 }

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -178,14 +178,16 @@ impl Handler {
         let agent_key = agent_id.to_lowercase();
 
         // Remove existing registration for this agent
-        if let Some(old_block) = self.agent_to_block.remove(&agent_key) {
-            self.block_to_agent.remove(&old_block);
+        let evicted_block = self.agent_to_block.remove(&agent_key);
+        if let Some(ref old_block) = evicted_block {
+            self.block_to_agent.remove(old_block);
         }
 
         // Remove existing registration for this block
-        if let Some(old_agent) = self.block_to_agent.remove(block_id) {
-            self.agent_to_block.remove(&old_agent);
-            self.agent_info.remove(&old_agent);
+        let evicted_agent = self.block_to_agent.remove(block_id);
+        if let Some(ref old_agent) = evicted_agent {
+            self.agent_to_block.remove(old_agent);
+            self.agent_info.remove(old_agent);
         }
 
         let now = now_unix_millis();
@@ -205,6 +207,14 @@ impl Handler {
             },
         );
 
+        self.log_audit_registration(
+            "register",
+            agent_id,
+            block_id,
+            evicted_block.as_deref(),
+            evicted_agent.as_deref(),
+        );
+
         Ok(())
     }
 
@@ -213,6 +223,7 @@ impl Handler {
         let agent_key = agent_id.to_lowercase();
         if let Some(block_id) = self.agent_to_block.remove(&agent_key) {
             self.block_to_agent.remove(&block_id);
+            self.log_audit_registration("unregister", agent_id, &block_id, None, None);
         }
         self.agent_info.remove(&agent_key);
     }
@@ -222,6 +233,7 @@ impl Handler {
         if let Some(agent_id) = self.block_to_agent.remove(block_id) {
             self.agent_to_block.remove(&agent_id);
             self.agent_info.remove(&agent_id);
+            self.log_audit_registration("unregister", &agent_id, block_id, None, None);
         }
     }
 
@@ -908,6 +920,46 @@ impl Handler {
             request_id: request_id.to_string(),
             outcome: outcome.map(|s| s.to_string()),
             reason: reason.map(|s| s.to_string()),
+            event_kind: "delivery".to_string(),
+            evicted_block: None,
+            evicted_agent: None,
+        };
+
+        if self.audit_log.len() >= AUDIT_LOG_MAX {
+            self.audit_log.remove(0);
+        }
+        self.audit_log.push(entry);
+    }
+
+    /// Record a registration/eviction event in the audit log — the
+    /// counterpart to [`log_audit`] (which only ever recorded delivery
+    /// attempts). `evicted_block`/`evicted_agent` capture whichever prior
+    /// mapping a "register" call displaced, so a same-host identity
+    /// collision (two panes racing to register the same agent_id) is
+    /// reconstructable after the fact instead of leaving no trace.
+    pub(super) fn log_audit_registration(
+        &mut self,
+        event_kind: &str,
+        agent_id: &str,
+        block_id: &str,
+        evicted_block: Option<&str>,
+        evicted_agent: Option<&str>,
+    ) {
+        let entry = AuditLogEntry {
+            timestamp: now_unix_millis(),
+            source_agent: None,
+            target_agent: agent_id.to_string(),
+            block_id: block_id.to_string(),
+            message_hash: String::new(),
+            message_length: 0,
+            success: true,
+            error_message: None,
+            request_id: String::new(),
+            outcome: None,
+            reason: None,
+            event_kind: event_kind.to_string(),
+            evicted_block: evicted_block.map(|s| s.to_string()),
+            evicted_agent: evicted_agent.map(|s| s.to_string()),
         };
 
         if self.audit_log.len() >= AUDIT_LOG_MAX {

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -222,6 +222,75 @@ fn test_handler_unregister_block() {
     assert!(handler.get_agent("agent1").is_none());
 }
 
+#[test]
+fn test_handler_register_audits_registration_event() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent("agent1", "block1", None)
+        .unwrap();
+
+    let entries = handler.get_audit_log(10);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].event_kind, "register");
+    assert_eq!(entries[0].target_agent, "agent1");
+    assert_eq!(entries[0].block_id, "block1");
+    assert!(entries[0].evicted_block.is_none());
+    assert!(entries[0].evicted_agent.is_none());
+}
+
+#[test]
+fn test_handler_register_replaces_existing_audits_eviction() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent("agent1", "block1", None)
+        .unwrap();
+    handler
+        .register_agent("agent1", "block2", None)
+        .unwrap();
+
+    let entries = handler.get_audit_log(10);
+    assert_eq!(entries.len(), 2);
+    // get_audit_log returns newest-first (see log_audit_registration).
+    let second_register = &entries[0];
+    assert_eq!(second_register.event_kind, "register");
+    assert_eq!(second_register.block_id, "block2");
+    assert_eq!(second_register.evicted_block.as_deref(), Some("block1"));
+}
+
+#[test]
+fn test_handler_unregister_agent_audits_unregistration() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent("agent1", "block1", None)
+        .unwrap();
+    handler.unregister_agent("agent1");
+
+    let entries = handler.get_audit_log(10);
+    let unregister_entry = entries
+        .iter()
+        .find(|e| e.event_kind == "unregister")
+        .expect("unregister event should be audited");
+    assert_eq!(unregister_entry.target_agent, "agent1");
+    assert_eq!(unregister_entry.block_id, "block1");
+}
+
+#[test]
+fn test_handler_unregister_block_audits_unregistration() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent("agent1", "block1", None)
+        .unwrap();
+    handler.unregister_block("block1");
+
+    let entries = handler.get_audit_log(10);
+    let unregister_entry = entries
+        .iter()
+        .find(|e| e.event_kind == "unregister")
+        .expect("unregister event should be audited");
+    assert_eq!(unregister_entry.target_agent, "agent1");
+    assert_eq!(unregister_entry.block_id, "block1");
+}
+
 /// Issue #2363 / codex P1 on PR #2500: the guarded unregister removes
 /// only its own spawn's registration — a newer spawn's (or replacement
 /// controller's) re-registration under a different nonce must survive a
@@ -1150,7 +1219,14 @@ fn test_handler_audit_log() {
         ..Default::default()
     });
 
-    let log = handler.get_audit_log(10);
+    // register_agent's own setup call above now also audits a "register"
+    // event (event_kind), so filter to the delivery entry this test is
+    // actually about.
+    let log: Vec<_> = handler
+        .get_audit_log(10)
+        .into_iter()
+        .filter(|e| e.event_kind == "delivery")
+        .collect();
     assert_eq!(log.len(), 1);
     assert_eq!(log[0].target_agent, "agent1");
     assert_eq!(log[0].request_id, "req-1");
@@ -1177,7 +1253,14 @@ fn test_handler_audit_log_ordinary_jekt_has_no_outcome() {
         ..Default::default()
     });
 
-    let log = handler.get_audit_log(10);
+    // register_agent's own setup call above now also audits a "register"
+    // event (event_kind), so filter to the delivery entry this test is
+    // actually about.
+    let log: Vec<_> = handler
+        .get_audit_log(10)
+        .into_iter()
+        .filter(|e| e.event_kind == "delivery")
+        .collect();
     assert_eq!(log.len(), 1);
     assert!(log[0].outcome.is_none());
     assert!(log[0].reason.is_none());
@@ -1228,6 +1311,9 @@ fn test_audit_log_entry_outcome_field_serde_roundtrip() {
         request_id: "req-1".to_string(),
         outcome: Some("nudge_declined".to_string()),
         reason: Some("consecutive-nudge ceiling reached".to_string()),
+        event_kind: "delivery".to_string(),
+        evicted_block: None,
+        evicted_agent: None,
     };
     let json = serde_json::to_value(&with_outcome).unwrap();
     assert_eq!(json["outcome"], "nudge_declined");
@@ -1292,7 +1378,13 @@ fn test_record_supervisor_decision_decline_logs_one_entry_no_delivery() {
     assert!(resp.success);
     assert_eq!(resp.block_id.as_deref(), Some("block1"));
 
-    let log = handler.get_audit_log(10);
+    // register_agent's own setup call above now also audits a "register"
+    // event (event_kind), so filter to the decision's own delivery entry.
+    let log: Vec<_> = handler
+        .get_audit_log(10)
+        .into_iter()
+        .filter(|e| e.event_kind == "delivery")
+        .collect();
     assert_eq!(log.len(), 1);
     assert_eq!(log[0].outcome.as_deref(), Some("nudge_declined"));
     assert_eq!(
@@ -1323,7 +1415,13 @@ async fn test_record_supervisor_decision_nudge_failure_is_audited_and_not_counte
         .expect("a failed delivery is still Ok — it's not a ceiling refusal");
     assert!(!resp.success);
 
-    let log = handler.get_audit_log(10);
+    // register_agent's own setup call above now also audits a "register"
+    // event (event_kind), so filter to the decision's own delivery entry.
+    let log: Vec<_> = handler
+        .get_audit_log(10)
+        .into_iter()
+        .filter(|e| e.event_kind == "delivery")
+        .collect();
     assert_eq!(log.len(), 1);
     assert_eq!(log[0].outcome.as_deref(), Some("nudge_failed"));
     assert!(!log[0].success);

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -309,6 +309,29 @@ pub struct AuditLogEntry {
     /// Not used by ordinary (non-Supervisor) jekt entries.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// "delivery" (default — an inject_message attempt, the only kind this
+    /// log ever recorded before this field existed) | "register" |
+    /// "unregister". Lets `GET /agentmux/reactive/audit` reconstruct
+    /// registration/eviction history, not just delivery attempts — prior to
+    /// this, register_agent_with_nonce/unregister_agent* wrote nothing here
+    /// at all, so a same-host cross-instance identity collision left no
+    /// trace of who registered as an agent_id or who it evicted.
+    #[serde(default = "default_event_kind")]
+    pub event_kind: String,
+    /// For a "register" event: the block_id this agent_key was previously
+    /// mapped to, if registering evicted an existing mapping. `None` if this
+    /// was a fresh registration (no prior holder).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evicted_block: Option<String>,
+    /// For a "register" event: the agent_id this block_id was previously
+    /// registered to, if registering evicted an existing mapping. `None` if
+    /// this block had no prior tenant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evicted_agent: Option<String>,
+}
+
+fn default_event_kind() -> String {
+    "delivery".to_string()
 }
 
 /// A Warden Supervisor watcher agent's decision about a target agent that

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -2661,7 +2661,12 @@ mod fleet_tests {
             .reactive_handler
             .get_audit_log(10_000)
             .into_iter()
-            .filter(|e| e.block_id == block_id)
+            // register_agent's own setup call above now also audits a
+            // "register" event (event_kind, #2694) alongside the stop's
+            // own delivery-attempt entry — both share this test's unique
+            // block_id, so filter to the delivery entry this test is
+            // actually about.
+            .filter(|e| e.block_id == block_id && e.event_kind == "delivery")
             .collect();
 
         assert_eq!(matching.len(), 1, "exactly one audit entry for this test's own block_id");

--- a/frontend/app/view/warden-audit/warden-audit-shared.ts
+++ b/frontend/app/view/warden-audit/warden-audit-shared.ts
@@ -30,6 +30,22 @@ export interface AuditEntry {
     outcome?: string;
     /** Supervisor's stated reasoning, populated alongside `outcome`. */
     reason?: string;
+    /** "delivery" (default, the only kind this feed shows) | "register" |
+     *  "unregister" — the latter two are agent registration/eviction
+     *  bookkeeping (issue #2694), not a jekt delivery or Supervisor
+     *  decision, and are filtered out of this feed by `fetchWardenAudit`
+     *  below rather than rendered as misleading blank "ok" rows. Surfaced
+     *  in the Stash "Registration" tab instead (issue #2696), the
+     *  purpose-built surface for registration/eviction history. */
+    event_kind?: string;
+    /** For a "register" event: the block_id this agent_key was previously
+     *  mapped to, if registering evicted an existing mapping. Not rendered
+     *  in this feed — see `event_kind`'s doc comment. */
+    evicted_block?: string;
+    /** For a "register" event: the agent_id this block_id was previously
+     *  registered to, if registering evicted an existing mapping. Not
+     *  rendered in this feed — see `event_kind`'s doc comment. */
+    evicted_agent?: string;
 }
 
 export async function fetchWardenAudit(): Promise<AuditEntry[]> {
@@ -41,5 +57,13 @@ export async function fetchWardenAudit(): Promise<AuditEntry[]> {
         throw new Error(`warden: GET /agentmux/reactive/audit → ${resp.status}`);
     }
     const data = await resp.json();
-    return Array.isArray(data) ? (data as AuditEntry[]) : [];
+    const entries = Array.isArray(data) ? (data as AuditEntry[]) : [];
+    // register/unregister entries (issue #2694) are registration
+    // bookkeeping, not a jekt delivery or Supervisor decision — this feed's
+    // rows assume an outcome-less entry is an ordinary delivery (message
+    // bytes, success/fail), so an unfiltered register/unregister row would
+    // render as a misleading blank "ok, 0b" line. `undefined` passes
+    // through too: back-compat with any entry predating this field, which
+    // is always a delivery.
+    return entries.filter((e) => e.event_kind === undefined || e.event_kind === "delivery");
 }


### PR DESCRIPTION
## Summary

A PTY-shell pane spawned without its own block-scoped `AGENTMUX_AGENT_ID` fell back to a **global settings value** (`cmd_env.AGENTMUX_AGENT_ID`), shared by every pane in the instance/channel, for jekt auto-registration. `register_agent_with_nonce` unconditionally evicts whoever previously held an `agent_key`, so two panes across instances/channels sharing a `settings.json` would collide — the second to register silently steals the first's jekt identity, and future messages addressed to that agent go to whichever pane registered last. This matches a live reported symptom: jekts addressed to one agent being delivered to a different agent, both running in separate instances on the same host.

The parallel `persistent.rs` path (used for Claude-based agents, `muxbus_agent_id_from_env`) never had this fallback — it already reads identity strictly from the block's own spawn env. This PR brings the PTY-shell path in line with that already-safe pattern.

- Removed the global-settings fallback from `agent_id_for_jekt` resolution in `shell/lifecycle.rs`, extracted into a testable `resolve_agent_id_for_jekt` free function. A pane with no block-scoped identity is now simply not jekt-registered (matches `persistent.rs`).
- Extended `AuditLogEntry` with `event_kind` ("delivery" | "register" | "unregister") and `evicted_block`/`evicted_agent`, and added `Handler::log_audit_registration`, called from `register_agent_with_nonce`/`unregister_agent`/`unregister_block`. Previously registration/eviction events left zero audit trail — only delivery attempts were logged — so an incident like this couldn't be reconstructed after the fact. `GET /agentmux/reactive/audit` now surfaces this with no other changes needed.
- Added regression tests locking in both behaviors (see Test plan).

This is Phase 1 of a 3-phase plan; Phase 2 (recipient-side identity verification at delivery time) and Phase 3 (Stash UI registration indicator) are filed as follow-up issues referencing this PR.

## Test plan

- [x] New test: `resolve_agent_id_for_jekt` never falls back to global settings, block metadata takes priority over legacy `WAVEMUX_AGENT_ID`, legacy env still works when no block-scoped ID is set (`shell/lifecycle.rs`'s `agent_id_for_jekt_tests`)
- [x] New tests: `register_agent`/`unregister_agent`/`unregister_block` now audit `register`/`unregister` events with correct `evicted_block`/`evicted_agent` (`backend/reactive/tests.rs`)
- [x] Fixed 4 pre-existing tests whose exact audit-log-length assertions broke now that `register_agent`'s setup call also audits an event — filtered to `event_kind == "delivery"`, matching each test's actual intent
- [x] `cargo test -p agentmux-srv --bin agentmux-srv reactive::` — 127 passed, 0 failed
- [x] `cargo test -p agentmux-srv --bin agentmux-srv agent_id_for_jekt` — 1 passed, 0 failed

<!-- agentmux:agent_id=manoz -->