### PR TITLE
[Manoz@Area54] feat(jekt): verify recipient identity before delivery

### DIFF
--- a/.changesets/1787299190-feat-jekt-verify-recipient-identity-before-delivery-rcwt.md
+++ b/.changesets/1787299190-feat-jekt-verify-recipient-identity-before-delivery-rcwt.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(jekt): verify recipient identity before delivery

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -235,6 +235,20 @@ pub trait Controller: Send + Sync {
         None
     }
 
+    /// Refresh this block's own captured jekt/muxbus identity (see
+    /// [`agent_id`](Controller::agent_id)'s doc comment). Called whenever
+    /// `ReactiveHandler::register_agent`/`register_agent_with_nonce`
+    /// (re-)registers THIS block's block_id under a (possibly different)
+    /// agent_id, so the two independently-written copies never drift apart
+    /// (reagentx P1 on #2697: `agent_id()` was captured once at spawn and
+    /// never refreshed, while `agent_to_block` gets re-keyed on every
+    /// `register_agent` call — e.g. `handle_reactive_register`'s
+    /// frontend-initiated HTTP path — causing a legitimately renamed or
+    /// reconfigured agent's own messages to be falsely rejected as an
+    /// identity mismatch). Default no-op for controller types that don't
+    /// override [`agent_id`](Controller::agent_id) either.
+    fn set_agent_id(&self, _id: Option<String>) {}
+
     /// Downcast support for concrete controller types.
     fn as_any(&self) -> &dyn Any;
 }

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -221,6 +221,20 @@ pub trait Controller: Send + Sync {
     #[allow(dead_code)]
     fn block_id(&self) -> &str;
 
+    /// This block's own live, spawn-time-captured jekt/muxbus identity, if
+    /// it has one — an independent source of truth for the recipient-
+    /// identity check in `ReactiveHandler::inject_message_inner`, deliberately
+    /// NOT derived from `ReactiveHandler`'s own `agent_to_block`/`agent_info`
+    /// maps (checking a registry against itself would be a tautology and
+    /// catch nothing). Default `None` for controller types that aren't
+    /// jekt-addressable at all (e.g. plain terminals) — only `ShellController`
+    /// and `PersistentSubprocessController` currently override this, mirroring
+    /// the two paths that already resolve a jekt-registration identity at
+    /// spawn time (`resolve_agent_id_for_jekt`, `muxbus_agent_id_from_env`).
+    fn agent_id(&self) -> Option<String> {
+        None
+    }
+
     /// Downcast support for concrete controller types.
     fn as_any(&self) -> &dyn Any;
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -587,6 +587,16 @@ pub struct PersistentSubprocessController {
     /// actually exits; a `Weak` avoids a reference cycle (this same
     /// struct's `spawn_process` is what schedules that task).
     self_ref: Mutex<Option<std::sync::Weak<Self>>>,
+    /// This controller's own muxbus/jekt identity, captured once at spawn
+    /// time from `muxbus_agent_id_from_env` — the independent source of
+    /// truth `Controller::agent_id()` exposes for `inject_message_inner`'s
+    /// recipient-identity check. Deliberately its own field, not part of
+    /// `PersistentInner` — `config` (and its `env_vars`, where the identity
+    /// is read from) isn't available until `spawn_process`, well after
+    /// `new()`, and this value doesn't participate in any of `PersistentInner`'s
+    /// carefully-ordered spawn/resume/queue state transitions. `None` for a
+    /// persistent block with no muxbus identity set (a non-agent process).
+    agent_id: Mutex<Option<String>>,
 }
 
 /// How long to wait after delivering an AskUserQuestion answer before assuming
@@ -668,6 +678,7 @@ impl PersistentSubprocessController {
             health_monitor,
             stdout_seq: Arc::new(AtomicU64::new(0)),
             self_ref: Mutex::new(None),
+            agent_id: Mutex::new(None),
         }
     }
 
@@ -2411,6 +2422,7 @@ impl PersistentSubprocessController {
         // aware MessageSender (→ send_user_message), not PTY keystrokes.
         // See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
         let agent_id_for_muxbus = muxbus_agent_id_from_env(&config.env_vars);
+        *self.agent_id.lock().unwrap() = agent_id_for_muxbus.clone();
         if let Some(ref agent_id) = agent_id_for_muxbus {
             // `_with_nonce` variants record this spawn's process-wide
             // registration nonce so this exact spawn's exit-handler can
@@ -3689,6 +3701,10 @@ impl Controller for PersistentSubprocessController {
 
     fn block_id(&self) -> &str {
         &self.block_id
+    }
+
+    fn agent_id(&self) -> Option<String> {
+        self.agent_id.lock().unwrap().clone()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -3707,6 +3707,10 @@ impl Controller for PersistentSubprocessController {
         self.agent_id.lock().unwrap().clone()
     }
 
+    fn set_agent_id(&self, id: Option<String>) {
+        *self.agent_id.lock().unwrap() = id;
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -6089,5 +6093,43 @@ mod resume_poison_tests {
             effects.is_empty(),
             "tracking is still live, so the line must be held back, not persisted immediately"
         );
+    }
+}
+
+#[cfg(test)]
+mod agent_id_tests {
+    use super::*;
+
+    fn controller() -> PersistentSubprocessController {
+        PersistentSubprocessController::new(
+            "tab".to_string(),
+            "block".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    /// reagentx P1 on #2697: `agent_id()` was captured once at spawn and
+    /// never refreshed on re-registration, so a legitimately renamed or
+    /// reconfigured agent's own messages could be falsely rejected as an
+    /// identity mismatch by `inject_message_inner`'s recipient-identity
+    /// check (#2695). `set_agent_id` (called from `handle_reactive_register`
+    /// on every re-registration) must actually overwrite the captured value,
+    /// not just the initial spawn-time one.
+    #[test]
+    fn set_agent_id_overwrites_a_stale_captured_value() {
+        let ctrl = controller();
+        assert_eq!(ctrl.agent_id(), None);
+
+        ctrl.set_agent_id(Some("agentx".to_string()));
+        assert_eq!(ctrl.agent_id(), Some("agentx".to_string()));
+
+        ctrl.set_agent_id(Some("agenty".to_string()));
+        assert_eq!(ctrl.agent_id(), Some("agenty".to_string()));
+
+        ctrl.set_agent_id(None);
+        assert_eq!(ctrl.agent_id(), None);
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/shell/controller.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/controller.rs
@@ -66,6 +66,12 @@ pub(super) struct ShellControllerInner {
     pub(super) last_pty_output: Option<Instant>,
     /// True if this pane is running an agent CLI (e.g. claude).
     pub(super) is_agent_pane: bool,
+    /// This pane's own jekt/muxbus identity, captured once at spawn time
+    /// from `resolve_agent_id_for_jekt` (see that fn's doc comment) — the
+    /// independent source of truth `Controller::agent_id()` exposes for
+    /// `inject_message_inner`'s recipient-identity check. `None` for a
+    /// plain (non-agent) terminal pane.
+    pub(super) agent_id: Option<String>,
     /// Next expected input seq number (per-TermViewModel monotonic counter).
     pub(super) input_seq_next: u64,
     /// Out-of-order input packets waiting for their seq slot (capped at SHELL_INPUT_CH_SIZE).
@@ -131,6 +137,7 @@ impl ShellController {
                 spawn_ts_ms: None,
                 last_pty_output: None,
                 is_agent_pane: false,
+                agent_id: None,
                 input_seq_next: 0,
                 input_seq_buf: std::collections::BTreeMap::new(),
             })),

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -512,6 +512,7 @@ impl Controller for ShellController {
             }
             inner.spawn_ts_ms = Some(spawn_ts_ms);
             inner.is_agent_pane = is_agent;
+            inner.agent_id = agent_id_for_jekt.clone();
         }
 
         // Auto-register with jekt if AGENTMUX_AGENT_ID was set in the block env.
@@ -1129,6 +1130,10 @@ impl Controller for ShellController {
 
     fn block_id(&self) -> &str {
         &self.block_id
+    }
+
+    fn agent_id(&self) -> Option<String> {
+        self.inner.lock().unwrap().agent_id.clone()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -1136,6 +1136,10 @@ impl Controller for ShellController {
         self.inner.lock().unwrap().agent_id.clone()
     }
 
+    fn set_agent_id(&self, id: Option<String>) {
+        self.inner.lock().unwrap().agent_id = id;
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -1231,5 +1235,47 @@ mod agent_id_for_jekt_tests {
         let this_blocks_meta = MetaMapType::new();
         assert_eq!(resolve_agent_id_for_jekt(&other_blocks_meta), Some("agenty".to_string()));
         assert_eq!(resolve_agent_id_for_jekt(&this_blocks_meta), None);
+    }
+}
+
+#[cfg(test)]
+mod controller_agent_id_tests {
+    use super::super::controller::ShellController;
+    use super::super::super::Controller;
+
+    fn controller() -> ShellController {
+        ShellController::new(
+            "shell".to_string(),
+            "tab1".to_string(),
+            "block1".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    /// reagentx P1 on #2697: `agent_id()` was captured once at spawn and
+    /// never refreshed on re-registration, so a legitimately renamed or
+    /// reconfigured agent's own messages could be falsely rejected as an
+    /// identity mismatch by `inject_message_inner`'s recipient-identity
+    /// check (#2695). `set_agent_id` (called from `handle_reactive_register`
+    /// on every re-registration) must actually overwrite the captured value,
+    /// not just the initial spawn-time one.
+    #[test]
+    fn set_agent_id_overwrites_a_stale_captured_value() {
+        let ctrl = controller();
+        assert_eq!(ctrl.agent_id(), None);
+
+        ctrl.set_agent_id(Some("agentx".to_string()));
+        assert_eq!(ctrl.agent_id(), Some("agentx".to_string()));
+
+        // A later re-registration under a different name (rename,
+        // reconfigured cmd:env) must be reflected, not stuck at "agentx".
+        ctrl.set_agent_id(Some("agenty".to_string()));
+        assert_eq!(ctrl.agent_id(), Some("agenty".to_string()));
+
+        ctrl.set_agent_id(None);
+        assert_eq!(ctrl.agent_id(), None);
     }
 }

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -103,6 +103,11 @@ pub struct Handler {
     /// When set, it is tried before the PTY keystroke path so messages reach (and
     /// steer) agents that have no terminal. See `set_message_sender`.
     message_sender: Option<MessageSender>,
+    /// Queries a resolved delivery target's own live identity before
+    /// delivering, as a check independent of this handler's own
+    /// `agent_to_block` map. See `AgentIdentityConfirmer`'s doc comment and
+    /// `set_agent_identity_confirmer`.
+    agent_identity_confirmer: Option<AgentIdentityConfirmer>,
     audit_log: Vec<AuditLogEntry>,
     rate_limiter: RateLimiter,
     include_source_in_message: bool,
@@ -122,6 +127,7 @@ impl Handler {
             agent_info: HashMap::new(),
             input_sender: None,
             message_sender: None,
+            agent_identity_confirmer: None,
             audit_log: Vec::with_capacity(AUDIT_LOG_MAX),
             rate_limiter: RateLimiter::new(RATE_LIMIT_MAX),
             include_source_in_message: false,
@@ -140,6 +146,14 @@ impl Handler {
     /// back so injection falls through to the keystroke path.
     pub fn set_message_sender(&mut self, sender: MessageSender) {
         self.message_sender = Some(sender);
+    }
+
+    /// Set the agent-identity confirmer used by `inject_message_inner` to
+    /// double-check a resolved delivery target against its own live,
+    /// spawn-time-captured identity before delivering. Optional — if never
+    /// set, delivery proceeds exactly as before this check existed (fail-open).
+    pub fn set_agent_identity_confirmer(&mut self, confirmer: AgentIdentityConfirmer) {
+        self.agent_identity_confirmer = Some(confirmer);
     }
 
     /// Set whether to include source agent prefix in injected messages.
@@ -391,6 +405,60 @@ impl Handler {
                 };
             }
         };
+
+        // Recipient-identity check (issue #2695): before delivering, compare
+        // the resolved block's own live, spawn-time-captured identity
+        // (queried via `agent_identity_confirmer`, which goes straight to
+        // the controller — independent of this handler's own agent_to_block
+        // map) against who this jekt is addressed to. Checking agent_to_block
+        // against itself would be a tautology and catch nothing; this is a
+        // genuine second, independently-written source of truth that can
+        // drift from the registry (e.g. a stale registry entry survived a
+        // respawn, or a resync overwrote registration without updating the
+        // block's own field).
+        //
+        // `None` (no confirmer configured, or this controller type doesn't
+        // implement `agent_id()`) is "unverifiable," not "confirmed absent" —
+        // delivery proceeds exactly as before this check existed. Matches
+        // this codebase's existing jekt trust philosophy elsewhere (see the
+        // TRUST=/ESCALATE= rules): only an ACTIVE mismatch is a red flag,
+        // mere absence of proof is not.
+        if let Some(confirmer) = &self.agent_identity_confirmer {
+            if let Some(actual_agent_id) = confirmer(&block_id) {
+                if actual_agent_id.to_lowercase() != req.target_agent.to_lowercase() {
+                    let err = format!(
+                        "identity mismatch: block {} resolved for target '{}' but its own live identity is '{}'",
+                        block_id, req.target_agent, actual_agent_id
+                    );
+                    tracing::error!(
+                        target = %req.target_agent,
+                        block_id = %block_id,
+                        actual_agent_id = %actual_agent_id,
+                        "reactive inject: recipient identity mismatch — rejecting delivery"
+                    );
+                    self.log_audit(
+                        req.source_agent.as_deref(),
+                        &req.target_agent,
+                        &block_id,
+                        &sanitized,
+                        false,
+                        Some(&err),
+                        &request_id,
+                        Some("identity-mismatch"),
+                        reason,
+                    );
+                    return InjectionResponse {
+                        success: false,
+                        request_id,
+                        block_id: Some(block_id),
+                        error: Some(err),
+                        timestamp: now,
+                        effective_tier: None,
+                        requires_stop: None,
+                    };
+                }
+            }
+        }
 
         // Determine effective jekt tier.
         // Escalation rules (spec §5.2, extended by
@@ -995,6 +1063,13 @@ impl ReactiveHandler {
 
     pub fn set_message_sender(&self, sender: MessageSender) {
         self.inner.lock().unwrap().set_message_sender(sender);
+    }
+
+    pub fn set_agent_identity_confirmer(&self, confirmer: AgentIdentityConfirmer) {
+        self.inner
+            .lock()
+            .unwrap()
+            .set_agent_identity_confirmer(confirmer);
     }
 
     #[allow(dead_code)]

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -453,6 +453,144 @@ async fn test_handler_inject_success() {
     assert!(payload.ends_with('\r'), "trailing CR submits the message");
 }
 
+/// issue #2695 (Phase 2): the resolved block's own live identity, queried
+/// via `agent_identity_confirmer`, must be checked against the jekt's
+/// `target_agent` — an ACTIVE mismatch rejects delivery and never reaches
+/// the input sender, distinct from "agent not found".
+#[tokio::test]
+async fn test_handler_inject_rejects_on_identity_mismatch() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone
+            .lock()
+            .unwrap()
+            .push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler
+        .register_agent("agent1", "block1", None)
+        .unwrap();
+    // Simulates a registry/controller drift: agent_to_block says "block1"
+    // belongs to "agent1", but the block's own live identity (as the real
+    // controller would report it) is actually "agent2" — the exact same-
+    // host misdelivery shape reported live.
+    handler.set_agent_identity_confirmer(Arc::new(|_block_id: &str| {
+        Some("agent2".to_string())
+    }));
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: "hello".to_string(),
+        source_agent: Some("src".to_string()),
+        request_id: Some("req-mismatch".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert!(!resp.success);
+    assert_eq!(resp.block_id.as_deref(), Some("block1"));
+    assert!(resp.error.as_deref().unwrap().contains("identity mismatch"));
+    assert!(
+        sent.lock().unwrap().is_empty(),
+        "a mismatch must never reach the input sender"
+    );
+
+    let log = handler.get_audit_log(10);
+    let mismatch_entry = log
+        .iter()
+        .find(|e| e.outcome.as_deref() == Some("identity-mismatch"))
+        .expect("identity-mismatch outcome should be audited");
+    assert_eq!(mismatch_entry.target_agent, "agent1");
+    assert_eq!(mismatch_entry.block_id, "block1");
+    assert!(!mismatch_entry.success);
+}
+
+/// The confirmer returning `None` (unverifiable — e.g. a controller type
+/// that doesn't implement `agent_id()`) must NOT block delivery — "no
+/// proof available" is not the same as "proof of mismatch." Guards against
+/// this check regressing into a fail-closed one.
+#[tokio::test]
+async fn test_handler_inject_proceeds_when_confirmer_returns_none() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone
+            .lock()
+            .unwrap()
+            .push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler
+        .register_agent("agent1", "block1", None)
+        .unwrap();
+    handler.set_agent_identity_confirmer(Arc::new(|_block_id: &str| None));
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-unverifiable".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert!(!sent.lock().unwrap().is_empty(), "delivery must still happen");
+}
+
+/// A confirmer whose returned identity matches (case-insensitively) must
+/// also proceed — the check is on mismatch, not on the mere presence of a
+/// confirmer.
+#[tokio::test]
+async fn test_handler_inject_proceeds_when_confirmer_matches_case_insensitively() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone
+            .lock()
+            .unwrap()
+            .push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler
+        .register_agent("Agent1", "block1", None)
+        .unwrap();
+    handler.set_agent_identity_confirmer(Arc::new(|_block_id: &str| {
+        Some("agent1".to_string())
+    }));
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "AGENT1".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-case".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert!(!sent.lock().unwrap().is_empty());
+}
+
 // SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md §1 — a WAN jekt verified
 // against reagent's pinned Ed25519 key is no longer forced to SENSITIVE by
 // delivery tier alone (superseding the original SPEC_JEKT_LAN_WAN_TRUST_

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -435,3 +435,15 @@ pub type InputSender = Arc<dyn Fn(&str, &[u8]) -> Result<(), String> + Send + Sy
 ///   persistent process is not running); the caller must NOT fall back to PTY,
 ///   since such controllers reject raw keystrokes.
 pub type MessageSender = Arc<dyn Fn(&str, &str) -> Result<bool, String> + Send + Sync>;
+
+/// Function type for querying a block's own live, spawn-time-captured jekt
+/// identity — an independent source of truth for `inject_message_inner`'s
+/// recipient-identity check, deliberately NOT derived from `Handler`'s own
+/// `agent_to_block`/`agent_info` maps (see `Controller::agent_id`'s doc
+/// comment for why checking a registry against itself would be a
+/// tautology). Given `block_id`, returns `Some(agent_id)` if that block's
+/// controller has a captured identity, `None` if it doesn't (a non-agent
+/// controller, or a controller type that doesn't implement `agent_id()`) —
+/// `None` is treated as "unverifiable," not "confirmed absent," so delivery
+/// proceeds unaffected when no positive check is possible.
+pub type AgentIdentityConfirmer = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -982,6 +982,15 @@ pub fn spawn_background_subsystems(
             Err(e) => Err(e),
         }
     }));
+    // Recipient-identity check (issue #2695): before delivering, compare the
+    // resolved target's own live, spawn-time-captured identity (queried from
+    // the actual controller, independent of reactive_handler's own
+    // agent_to_block map) against who the jekt was addressed to. See
+    // Controller::agent_id's doc comment for why this can't be derived from
+    // reactive_handler's own state.
+    reactive_handler.set_agent_identity_confirmer(Arc::new(|block_id: &str| {
+        backend::blockcontroller::get_controller(block_id).and_then(|c| c.agent_id())
+    }));
     let poller = Arc::new(Poller::new(
         PollerConfig {
             muxbus_url: None,

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -503,6 +503,23 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                     let registered = crate::backend::reactive::handler::get_global_handler()
                         .register_agent(&agent_name, &cmd.blockid, None);
                     if registered.is_ok() {
+                        // Refresh the block's OWN captured identity too
+                        // (reagentx P1, round 2 on #2697): this call runs on
+                        // EVERY turn, using block.meta["agentName"] as the
+                        // source of truth — which can diverge from whatever
+                        // a PersistentSubprocessController captured at its
+                        // original spawn_process call (rename, reconfigured
+                        // cmd:env) without the block ever respawning. Without
+                        // this, inject_message_inner's recipient-identity
+                        // check (#2695) would compare the current (correct)
+                        // target_agent against that stale spawn-time value
+                        // and falsely reject the agent's own, correctly-
+                        // addressed jekts as an identity mismatch. A no-op
+                        // for controller types that don't override
+                        // set_agent_id (e.g. SubprocessController).
+                        if let Some(ctrl) = crate::backend::blockcontroller::get_controller(&cmd.blockid) {
+                            ctrl.set_agent_id(Some(agent_name.clone()));
+                        }
                         if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
                             sub.add_agent(&agent_name);
                         }

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 use serde_json::json;
 
+use crate::backend::blockcontroller;
 use crate::backend::reactive::{InjectionRequest, SupervisorAction};
 use crate::backend::reactive::registry as agent_registry;
 use crate::backend::subagent_watcher;
@@ -847,6 +848,20 @@ pub(super) async fn handle_reactive_register(
         .register_agent(&req.agent_id, &req.block_id, req.tab_id.as_deref())
     {
         Ok(()) => {
+            // Refresh the block's OWN captured identity too (reagentx P1 on
+            // #2697): this HTTP path can (re-)register an existing block_id
+            // under a different agent_id (a rename, or a reconfigured
+            // cmd:env) — without this, the controller's `agent_id()` stays
+            // stale at whatever it was captured as at spawn time, and
+            // `inject_message_inner`'s recipient-identity check (#2695)
+            // would then falsely reject the agent's own, correctly-addressed
+            // messages as a mismatch. `get_controller` returning `None`
+            // (block not tracked, or a controller type that doesn't
+            // implement `agent_id()`/`set_agent_id()`) is a harmless no-op.
+            if let Some(ctrl) = blockcontroller::get_controller(&req.block_id) {
+                ctrl.set_agent_id(Some(req.agent_id.clone()));
+            }
+
             // Also write to cross-instance file registry so other AgentMux
             // instances can forward inject requests to this one.
             let data_dir = base::get_wave_data_dir();


### PR DESCRIPTION
## Summary

Phase 2 of the jekt misdelivery hardening (#2695), stacked on #2694 (Phase 1 — merge that first).

Phase 1 closed the specific collision that caused a live-reported misdelivery incident (jekts addressed to one agent landing on a different agent, same host, separate instances), but the underlying architectural gap remained: `inject_message_inner` resolved a delivery target purely from `Handler`'s own `agent_to_block` map and trusted it blindly. There was no point where the receiving block confirmed its own identity before a message was delivered to it — so a stale or drifted registry entry (e.g. surviving a respawn, or a resync overwriting registration without updating what the block itself believes it is) could still silently misdeliver, with nothing to catch it.

This adds a genuine second, independent source of truth:

- Each block controller now captures its own jekt/muxbus identity once at spawn time — `ShellController` via `resolve_agent_id_for_jekt` (added in #2694), `PersistentSubprocessController` via `muxbus_agent_id_from_env` (pre-existing) — and retains it on the controller struct itself, not just in `Handler`'s maps.
- New `Controller::agent_id() -> Option<String>` trait method (default `None`) exposes it.
- New `Handler::agent_identity_confirmer` hook, mirroring the existing `input_sender`/`message_sender` pattern, wired in `bootstrap.rs` to query the real controller via `blockcontroller::get_controller(block_id)`.
- `inject_message_inner` now calls the confirmer right after resolving `block_id`: an **active mismatch** (confirmer returns `Some(actual)` that differs from `target_agent`) rejects delivery with a distinct error and audits an `"identity-mismatch"` outcome. A confirmer that's unset, or returns `None` (unverifiable — e.g. a controller type that doesn't implement `agent_id()`), leaves delivery unaffected — matching this codebase's existing jekt trust philosophy elsewhere (`TRUST=`/`ESCALATE=`): only an active red flag is acted on, mere absence of proof is not.

Checking `agent_to_block` against itself would have been a tautology and caught nothing — the whole point is that the controller's own captured value is written independently, at a different time, by different code, from the registry's own bookkeeping.

## Test plan

- [x] New test: an active mismatch (confirmer returns a different agent_id) rejects delivery, never reaches the input sender, and is audited with `outcome: "identity-mismatch"`
- [x] New test: confirmer returning `None` does not block delivery (fail-open, no regression)
- [x] New test: confirmer match is case-insensitive (consistent with `agent_to_block`'s own lowercased-key lookup)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv reactive::` — 130 passed, 0 failed
- [x] `cargo build -p agentmux-srv --bin agentmux-srv` — full workspace build clean (pre-existing warnings only)

Follow-up: #2696 (Phase 3 — Stash UI indicator, including a badge for `identity-mismatch` audit entries this PR now produces).

<!-- agentmux:agent_id=manoz -->