### PR TITLE
[Manoz@Area54] feat(jekt): Stash Registration tab showing live jekt delivery status

### DIFF
--- a/.changesets/1787299971-feat-jekt-stash-registration-tab-showing-live-jekt-delivery--f02x.md
+++ b/.changesets/1787299971-feat-jekt-stash-registration-tab-showing-live-jekt-delivery--f02x.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(jekt): Stash Registration tab showing live jekt delivery status

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -288,7 +288,7 @@ fn shared_channel_path(shared_dir: &Path, agent_id: &str, channel: &str) -> Path
 /// same-host by construction (a local file only readable by local
 /// processes) — unlike a LAN/cloud registry, PID-liveness is an
 /// authoritative staleness signal, not just a heuristic.
-fn pid_alive(pid: u32) -> bool {
+pub(crate) fn pid_alive(pid: u32) -> bool {
     let target = sysinfo::Pid::from(pid as usize);
     let mut sys = sysinfo::System::new();
     // Targeted refresh, no CPU/memory/exe/cmdline needed — existence alone

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -1269,6 +1269,16 @@ pub(super) async fn handle_reactive_supervisor_decision(
 
 // ---- WS RPC: reactive.registrations (issue #2696, Stash UI indicator) ----
 
+/// Whether a host-global shared-registry entry is THIS instance's own
+/// registration (as opposed to a genuinely different instance/channel on
+/// the same host) — every agent unconditionally writes itself into that
+/// same registry, so a "remote"/"elsewhere" listing must exclude its own
+/// entry or it fires on every healthy agent (reagentx P1 on #2698). Same
+/// comparison this file already uses for Tier 2a/2b forwarding.
+pub(super) fn is_self_registration(entry_local_url: &str, this_instances_local_url: &str) -> bool {
+    entry_local_url == this_instances_local_url
+}
+
 /// One cross-instance/channel entry from the host-global shared registry
 /// (`backend::reactive::registry::AgentEntry`), narrowed to what the
 /// frontend actually needs to render a "registered elsewhere too" badge —
@@ -1329,10 +1339,21 @@ pub fn register_reactive_ws_handlers(engine: &std::sync::Arc<crate::backend::rpc
 
                 let local = state.reactive_handler.get_agent(&params.agent_id);
 
+                // Every agent (including this instance's own) unconditionally
+                // writes itself into the same host-global shared registry
+                // (write_shared_from_env, called from both the PTY-shell and
+                // persistent auto-register paths and from handle_reactive_
+                // register above) — so without filtering, `remote` always
+                // includes THIS instance's own entry alongside any genuinely
+                // other instance, and the "registered elsewhere too" badge
+                // would fire on every healthy agent (reagentx P1). Same
+                // self-filter this file already uses for Tier 2a/2b forwarding
+                // (`entry.local_url == state.local_web_url`, ~line 454/580).
                 let remote = crate::registry::resolve_shared_reactive_dir()
                     .map(|shared_dir| {
                         agent_registry::lookup_all_shared(&shared_dir, &params.agent_id)
                             .into_iter()
+                            .filter(|e| !is_self_registration(&e.local_url, &state.local_web_url))
                             .map(|e| RemoteRegistrationEntry {
                                 channel: e.channel,
                                 pid: e.pid,
@@ -1794,5 +1815,31 @@ mod resolve_delivery_tier_tests {
     #[test]
     fn full_auth_key_defaults_to_host_when_body_omits_the_field() {
         assert_eq!(resolve_delivery_tier(super::super::ReactiveAuthVia::FullAuthKey, None), "host");
+    }
+}
+
+#[cfg(test)]
+mod is_self_registration_tests {
+    use super::is_self_registration;
+
+    /// reagentx P1 on #2698: without this check, `reactive.registrations`'s
+    /// `remote` list always included this instance's own shared-registry
+    /// entry (every agent unconditionally writes itself into that same
+    /// registry), so the "registered elsewhere too" badge fired on every
+    /// healthy agent — defeating the whole point of the feature.
+    #[test]
+    fn same_local_url_is_self() {
+        assert!(is_self_registration(
+            "http://127.0.0.1:12345",
+            "http://127.0.0.1:12345"
+        ));
+    }
+
+    #[test]
+    fn different_local_url_is_not_self() {
+        assert!(!is_self_registration(
+            "http://127.0.0.1:12345",
+            "http://127.0.0.1:54321"
+        ));
     }
 }

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -1354,6 +1354,16 @@ pub fn register_reactive_ws_handlers(engine: &std::sync::Arc<crate::backend::rpc
                         agent_registry::lookup_all_shared(&shared_dir, &params.agent_id)
                             .into_iter()
                             .filter(|e| !is_self_registration(&e.local_url, &state.local_web_url))
+                            // A crashed sibling instance's entry otherwise
+                            // lingers until the next startup-only
+                            // cleanup_stale_shared sweep (bootstrap.rs) —
+                            // up to hours later — showing a false "Also
+                            // registered elsewhere" badge in the meantime
+                            // (reagentx P2). PID-liveness is authoritative
+                            // here (same-host by construction, per
+                            // pid_alive's own doc comment), so check it live
+                            // instead of waiting for that sweep.
+                            .filter(|e| agent_registry::pid_alive(e.pid))
                             .map(|e| RemoteRegistrationEntry {
                                 channel: e.channel,
                                 pid: e.pid,

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -9,7 +9,7 @@ use axum::{
 use serde_json::json;
 
 use crate::backend::blockcontroller;
-use crate::backend::reactive::{InjectionRequest, SupervisorAction};
+use crate::backend::reactive::{AgentRegistration, InjectionRequest, SupervisorAction};
 use crate::backend::reactive::registry as agent_registry;
 use crate::backend::subagent_watcher;
 use crate::backend::base;
@@ -1265,6 +1265,107 @@ pub(super) async fn handle_reactive_supervisor_decision(
         )
             .into_response(),
     }
+}
+
+// ---- WS RPC: reactive.registrations (issue #2696, Stash UI indicator) ----
+
+/// One cross-instance/channel entry from the host-global shared registry
+/// (`backend::reactive::registry::AgentEntry`), narrowed to what the
+/// frontend actually needs to render a "registered elsewhere too" badge —
+/// deliberately excludes `local_url`/`auth_key`, which are internal
+/// forwarding plumbing, not UI-relevant.
+#[derive(serde::Serialize)]
+pub(super) struct RemoteRegistrationEntry {
+    channel: String,
+    pid: u32,
+    updated_at: u64,
+}
+
+/// Summary of the most recent `identity-mismatch` audit entry for this
+/// agent_id, if any (see #2695's `Handler::inject_message_inner` check) —
+/// narrowed from `AuditLogEntry` to what the Stash badge needs.
+#[derive(serde::Serialize)]
+pub(super) struct MismatchAuditSummary {
+    timestamp: u64,
+    block_id: String,
+    error_message: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub(super) struct ReactiveRegistrationsResult {
+    /// This instance's own registration for the agent, if any — same data
+    /// `GET /agentmux/reactive/agent` exposes, reused here so the frontend
+    /// makes one call instead of two.
+    local: Option<AgentRegistration>,
+    /// Every OTHER instance/channel on this host currently claiming this
+    /// same agent_id, freshest first — a non-empty list here is the actual
+    /// risk signal the Stash badge exists to surface (issue #2694's root
+    /// cause was exactly two panes racing to hold the same agent_id).
+    remote: Vec<RemoteRegistrationEntry>,
+    recent_mismatch: Option<MismatchAuditSummary>,
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct ReactiveRegistrationsParams {
+    agent_id: String,
+}
+
+/// Registers `reactive.registrations`, called by the Stash "Registration"
+/// tab (`AgentIdentityLinksPanel`'s sibling — see `frontend/app/store/
+/// rpc-api/reactive.ts`) to answer "is this agent's jekt identity healthy
+/// right now": where it's registered locally, whether any OTHER
+/// instance/channel on this host also claims the same agent_id (the
+/// collision shape #2694 fixed one specific cause of), and whether a
+/// recent delivery hit the #2695 identity-mismatch guard.
+pub fn register_reactive_ws_handlers(engine: &std::sync::Arc<crate::backend::rpc::engine::WshRpcEngine>, state: &AppState) {
+    let state = state.clone();
+    engine.register_handler(
+        "reactive.registrations",
+        Box::new(move |data, _ctx| {
+            let state = state.clone();
+            Box::pin(async move {
+                let params: ReactiveRegistrationsParams = serde_json::from_value(data)
+                    .map_err(|e| format!("reactive.registrations: {e}"))?;
+
+                let local = state.reactive_handler.get_agent(&params.agent_id);
+
+                let remote = crate::registry::resolve_shared_reactive_dir()
+                    .map(|shared_dir| {
+                        agent_registry::lookup_all_shared(&shared_dir, &params.agent_id)
+                            .into_iter()
+                            .map(|e| RemoteRegistrationEntry {
+                                channel: e.channel,
+                                pid: e.pid,
+                                updated_at: e.updated_at,
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+
+                let target_lower = params.agent_id.to_lowercase();
+                let recent_mismatch = state
+                    .reactive_handler
+                    .get_audit_log(100)
+                    .into_iter()
+                    .find(|e| {
+                        e.outcome.as_deref() == Some("identity-mismatch")
+                            && e.target_agent.to_lowercase() == target_lower
+                    })
+                    .map(|e| MismatchAuditSummary {
+                        timestamp: e.timestamp,
+                        block_id: e.block_id,
+                        error_message: e.error_message,
+                    });
+
+                let result = ReactiveRegistrationsResult {
+                    local,
+                    remote,
+                    recent_mismatch,
+                };
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
+            })
+        }),
+    );
 }
 
 /// `verify_jekt_signature` unit tests (SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1339,6 +1339,9 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     // Provider model catalog (providers.models → authoritative /v1/models list)
     super::providers_handlers::register_providers_handlers(engine, &state);
 
+    // reactive.registrations → Stash "Registration" tab live status (#2696)
+    super::reactive::register_reactive_ws_handlers(engine, &state);
+
     // eventreadhistory → read persisted event history from the WPS broker
     let broker_history = state.broker.clone();
     engine.register_handler(

--- a/frontend/app/store/rpc-api/index.ts
+++ b/frontend/app/store/rpc-api/index.ts
@@ -20,12 +20,19 @@ import { IdentityApi } from "./identity";
 import { McpApi } from "./mcp";
 import { MemoryApi } from "./memory";
 import { MiscApi } from "./misc";
+import { ReactiveApi } from "./reactive";
 import { SessionApi } from "./session";
 import { SkillApi } from "./skill";
 import { WorkspaceApi } from "./workspace";
 
 export type { OAuthFlowStatus } from "./types";
 export type { FleetActionFailure, FleetActionResult, FleetGroup, FleetStagePlan } from "./fleet";
+export type {
+    ReactiveAgentRegistration,
+    ReactiveMismatchSummary,
+    ReactiveRegistrationsResult,
+    ReactiveRemoteRegistration,
+} from "./reactive";
 
 // WshServerCommandToDeclMap
 export const RpcApi = {
@@ -41,4 +48,5 @@ export const RpcApi = {
     ...SkillApi,
     ...BundleImportApi,
     ...FleetApi,
+    ...ReactiveApi,
 };

--- a/frontend/app/store/rpc-api/reactive.ts
+++ b/frontend/app/store/rpc-api/reactive.ts
@@ -1,0 +1,53 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Jekt/muxbus registration status for one agent — powers the Stash
+// "Registration" tab (issue #2696). Backed by the `reactive.registrations`
+// WS RPC command (agentmux-srv/src/server/reactive.rs's
+// register_reactive_ws_handlers), not the pre-existing `/agentmux/reactive/*`
+// HTTP routes (those exist for cross-instance/LAN server-to-server
+// forwarding, not frontend consumption — this file is the first frontend
+// caller of anything in that domain).
+
+import { RpcClient } from "../rpc-client";
+
+/** Mirrors agentmux-srv's `AgentRegistration` (backend/reactive/types.rs). */
+export interface ReactiveAgentRegistration {
+    agent_id: string;
+    block_id: string;
+    tab_id?: string;
+    registered_at: number;
+    last_seen: number;
+    registration_nonce: number;
+}
+
+/** One OTHER instance/channel on this host also claiming this agent_id —
+ *  the actual risk signal the "registered elsewhere too" badge surfaces. */
+export interface ReactiveRemoteRegistration {
+    channel: string;
+    pid: number;
+    updated_at: number;
+}
+
+/** Most recent #2695 identity-mismatch audit entry for this agent, if any. */
+export interface ReactiveMismatchSummary {
+    timestamp: number;
+    block_id: string;
+    error_message?: string;
+}
+
+export interface ReactiveRegistrationsResult {
+    local: ReactiveAgentRegistration | null;
+    remote: ReactiveRemoteRegistration[];
+    recent_mismatch: ReactiveMismatchSummary | null;
+}
+
+export const ReactiveApi = {
+    GetReactiveRegistrationsCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<ReactiveRegistrationsResult> {
+        return client.rpcCall("reactive.registrations", data, opts);
+    },
+};

--- a/frontend/app/view/agent/components/AgentRegistrationPanel.scss
+++ b/frontend/app/view/agent/components/AgentRegistrationPanel.scss
@@ -1,0 +1,125 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.agent-registration-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
+    overflow-y: auto;
+
+    &-error {
+        color: var(--error-text-color);
+        font-size: 12px;
+    }
+
+    &-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    &-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        color: var(--main-text-color);
+    }
+
+    &-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--tertiary-text-color, rgba(255, 255, 255, 0.4));
+        flex: 0 0 auto;
+
+        &.is-valid {
+            background: var(--success-text-color);
+        }
+        &.is-expired {
+            background: var(--error-text-color);
+        }
+        &.is-needs_reauth {
+            background: var(--warning-text-color);
+        }
+        &.is-unknown {
+            background: var(--tertiary-text-color, rgba(255, 255, 255, 0.4));
+        }
+    }
+
+    &-refresh {
+        padding: 4px 10px;
+        font-size: 12px;
+        background: transparent;
+        color: var(--accent-color);
+        border: 1px solid var(--accent-color);
+        border-radius: 0;
+        cursor: default;
+
+        &:hover {
+            background: var(--accent-color);
+            color: var(--main-bg-color);
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+    }
+
+    &-section {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 10px 12px;
+        border: 1px solid var(--border-color);
+
+        h3 {
+            margin: 0;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+            color: var(--secondary-text-color);
+        }
+
+        dl {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 2px 10px;
+            margin: 0;
+            font-size: 12px;
+        }
+
+        dt {
+            color: var(--secondary-text-color);
+        }
+
+        dd {
+            margin: 0;
+            word-break: break-all;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+            font-size: 12px;
+        }
+
+        &.is-warning {
+            border-color: var(--warning-text-color);
+        }
+
+        &.is-error {
+            border-color: var(--error-text-color);
+        }
+    }
+
+    &-hint {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        margin: 0;
+    }
+}

--- a/frontend/app/view/agent/components/AgentRegistrationPanel.tsx
+++ b/frontend/app/view/agent/components/AgentRegistrationPanel.tsx
@@ -1,0 +1,168 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentRegistrationPanel — the "Registration" tab body inside
+ * AgentStashModal. Read-only view of this agent's live jekt/muxbus
+ * delivery status: which block/instance owns it locally, whether any
+ * OTHER instance/channel on this host also currently claims the same
+ * agent_id (the actual risk signal — issue #2694's root cause was exactly
+ * two panes racing to hold the same agent_id), and whether a recent
+ * delivery hit the #2695 identity-mismatch guard. See issue #2696.
+ *
+ * No live-update event exists for registration changes (unlike
+ * AgentIdentityLinksPanel's `agentidentities:changed:<id>` WPS event) —
+ * this is a manual-refresh snapshot, matching the "check occasionally,
+ * not a persistent dashboard" way this panel is actually used.
+ */
+
+import { createEffect, createSignal, Show, type JSX } from "solid-js";
+import { RpcApi, type ReactiveRegistrationsResult } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import "./AgentRegistrationPanel.scss";
+
+interface AgentRegistrationPanelProps {
+    agentId: string;
+}
+
+type BadgeState = "registered-here" | "registered-elsewhere-too" | "recent-mismatch" | "not-registered";
+
+function badgeFor(result: ReactiveRegistrationsResult | null): {
+    state: BadgeState;
+    dot: "valid" | "expired" | "needs_reauth" | "unknown";
+    label: string;
+} {
+    if (!result) {
+        return { state: "not-registered", dot: "unknown", label: "Unknown" };
+    }
+    if (result.recent_mismatch) {
+        return { state: "recent-mismatch", dot: "expired", label: "Recent mismatch detected" };
+    }
+    if (result.remote.length > 0) {
+        return { state: "registered-elsewhere-too", dot: "needs_reauth", label: "Also registered elsewhere" };
+    }
+    if (result.local) {
+        return { state: "registered-here", dot: "valid", label: "Registered here" };
+    }
+    return { state: "not-registered", dot: "unknown", label: "Not registered" };
+}
+
+function formatTimestamp(ms: number): string {
+    return new Date(ms).toLocaleString();
+}
+
+export const AgentRegistrationPanel = (props: AgentRegistrationPanelProps): JSX.Element => {
+    const [result, setResult] = createSignal<ReactiveRegistrationsResult | null>(null);
+    const [error, setError] = createSignal<string | null>(null);
+    const [loading, setLoading] = createSignal(false);
+
+    const refresh = async (): Promise<void> => {
+        setLoading(true);
+        try {
+            const r = await RpcApi.GetReactiveRegistrationsCommand(TabRpcClient, { agent_id: props.agentId });
+            setResult(r);
+            setError(null);
+        } catch (e: any) {
+            setError(e?.message ?? "Failed to load registration status");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // Re-fetch whenever the agentId prop changes (mirrors
+    // AgentIdentityLinksPanel's re-subscribe-on-agentId-change effect).
+    createEffect(() => {
+        if (!props.agentId) return;
+        void refresh();
+    });
+
+    const badge = () => badgeFor(result());
+
+    return (
+        <div class="agent-registration-panel">
+            <Show when={error()}>
+                <div class="agent-registration-panel-error">{error()}</div>
+            </Show>
+
+            <div class="agent-registration-panel-header">
+                <span class="agent-registration-panel-status">
+                    <span class={`agent-registration-panel-dot is-${badge().dot}`} aria-hidden="true" />
+                    <span class="agent-registration-panel-status-label">{badge().label}</span>
+                </span>
+                <button
+                    type="button"
+                    class="agent-registration-panel-refresh"
+                    disabled={loading()}
+                    onClick={() => void refresh()}
+                >
+                    {loading() ? "Refreshing…" : "Refresh"}
+                </button>
+            </div>
+
+            <Show when={result()?.local}>
+                {(local) => (
+                    <div class="agent-registration-panel-section">
+                        <h3>This instance</h3>
+                        <dl>
+                            <dt>Block</dt>
+                            <dd>{local().block_id}</dd>
+                            <dt>Registered</dt>
+                            <dd>{formatTimestamp(local().registered_at)}</dd>
+                        </dl>
+                    </div>
+                )}
+            </Show>
+
+            <Show when={(result()?.remote.length ?? 0) > 0}>
+                <div class="agent-registration-panel-section is-warning">
+                    <h3>Also registered on this host</h3>
+                    <p class="agent-registration-panel-hint">
+                        Another AgentMux instance on this machine currently claims this same agent
+                        identity. Messages addressed to this agent may be delivered to whichever
+                        instance registered most recently instead of this one.
+                    </p>
+                    <ul>
+                        {result()!.remote.map((entry) => (
+                            <li>
+                                channel <strong>{entry.channel}</strong> (pid {entry.pid}), updated{" "}
+                                {formatTimestamp(entry.updated_at)}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </Show>
+
+            <Show when={result()?.recent_mismatch}>
+                {(mismatch) => (
+                    <div class="agent-registration-panel-section is-error">
+                        <h3>Recent identity mismatch</h3>
+                        <p class="agent-registration-panel-hint">
+                            A message addressed to this agent was rejected because the block it
+                            resolved to reported a different live identity — delivery was refused
+                            rather than sent to the wrong recipient.
+                        </p>
+                        <dl>
+                            <dt>When</dt>
+                            <dd>{formatTimestamp(mismatch().timestamp)}</dd>
+                            <dt>Block</dt>
+                            <dd>{mismatch().block_id}</dd>
+                            <Show when={mismatch().error_message}>
+                                <dt>Detail</dt>
+                                <dd>{mismatch().error_message}</dd>
+                            </Show>
+                        </dl>
+                    </div>
+                )}
+            </Show>
+
+            <Show when={!result()?.local && !loading() && !error()}>
+                <div class="agent-registration-panel-hint">
+                    This agent has no live jekt registration on this instance. It may not be
+                    running, or it may not be an agent-addressable pane.
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+AgentRegistrationPanel.displayName = "AgentRegistrationPanel";

--- a/frontend/app/view/agent/components/AgentStashModal.tsx
+++ b/frontend/app/view/agent/components/AgentStashModal.tsx
@@ -18,6 +18,11 @@
  *   - Skills      — the standalone Skill primitive (AgentSkillsModal).
  *   - Startup     — select an existing Bundle as Session Context's
  *                   "Startup Instructions" (AgentStartupModal).
+ *   - Registration — this agent's live jekt/muxbus delivery status:
+ *                   local registration, any OTHER instance/channel on this
+ *                   host also claiming the same identity, and any recent
+ *                   delivery rejected by the identity-mismatch guard
+ *                   (AgentRegistrationPanel — issues #2694/#2695/#2696).
  *
  * The tab list is a data array so future primitives slot in trivially.
  * Briefs is not wired here — it has no backend primitive at all yet
@@ -31,11 +36,12 @@ import { createSignal, For, Show, type JSX } from "solid-js";
 import { AgentIdentityLinksPanel } from "@/app/view/identity/agent-identity-links-panel";
 import { AgentMcpModal } from "./AgentMcpModal";
 import { AgentNativeMemoryModal } from "./AgentNativeMemoryModal";
+import { AgentRegistrationPanel } from "./AgentRegistrationPanel";
 import { AgentSkillsModal } from "./AgentSkillsModal";
 import { AgentStartupModal } from "./AgentStartupModal";
 import "./AgentStashModal.scss";
 
-type StashTabId = "accounts" | "memory" | "mcp" | "skills" | "startup";
+type StashTabId = "accounts" | "memory" | "mcp" | "skills" | "startup" | "registration";
 
 interface AgentStashModalProps {
     agentId: string;
@@ -66,6 +72,10 @@ export const AgentStashModal = (props: AgentStashModalProps): JSX.Element => {
         // this tab picks a bundle as startup instructions, so it's the same
         // concept scoped to one agent.
         { id: "startup", label: "Startup", icon: "layer-group" },
+        // tower-broadcast: distinct from "key" (Accounts, auth identity) —
+        // this tab is about jekt/muxbus delivery identity, a different
+        // concept (issue #2696).
+        { id: "registration", label: "Registration", icon: "tower-broadcast" },
     ];
 
     const [activeTab, setActiveTab] = createSignal<StashTabId>(props.initialTab ?? "accounts");
@@ -117,6 +127,10 @@ export const AgentStashModal = (props: AgentStashModalProps): JSX.Element => {
 
                 <Show when={activeTab() === "startup"}>
                     <AgentStartupModal agentId={props.agentId} />
+                </Show>
+
+                <Show when={activeTab() === "registration"}>
+                    <AgentRegistrationPanel agentId={props.agentId} />
                 </Show>
 
                 {/* Future primitives: Briefs */}


### PR DESCRIPTION
## Summary

Phase 3 of the jekt misdelivery hardening (#2696), stacked on #2697 (Phase 2) → #2694 (Phase 1) — merge those first, in order.

Phase 1 (#2694) and Phase 2 (#2697) fixed the underlying misdelivery risk and rejection-on-mismatch, but there was still no way to *see* an agent's live jekt registration state from the UI at all — no indication of which block currently owns an agent's identity, whether it's also (unexpectedly) registered on another instance/channel on this host, or whether a recent delivery hit the identity-mismatch guard.

- New `reactive.registrations` WS RPC command (`agentmux-srv/src/server/reactive.rs`, registered from `websocket.rs` alongside `providers.models`) merging:
  - this instance's local `AgentRegistration`
  - every OTHER instance/channel on this host claiming the same `agent_id`, via the existing host-global shared registry (`registry::lookup_all_shared`) — previously not exposed to the frontend at all
  - the most recent `identity-mismatch` audit entry for this agent, if any (from #2697)
- New `frontend/app/store/rpc-api/reactive.ts` wrapper — the first frontend caller of anything in the `/agentmux/reactive/*` domain.
- New "Registration" tab in `AgentStashModal`, following `AgentIdentityLinksPanel`'s fetch + status-badge pattern. Badge states: **registered-here** (green) / **registered-elsewhere-too** (amber — the actual risk signal for this bug class) / **recent-mismatch-detected** (red) / **not-registered** (gray). Manual-refresh, not live-subscribed — there's no registration-change event to subscribe to yet, and this is a "check occasionally" panel, not a persistent dashboard.

**Design deviation from the original issue:** #2696 sketched a new HTTP GET endpoint mirroring the pre-existing `/agentmux/reactive/*` HTTP routes. Those routes exist for cross-instance/LAN server-to-server forwarding; I verified every other frontend data-fetch in this codebase goes through the WS RPC command layer (`client.rpcCall`) instead, so this implements the same capability as a WS command for consistency with how the rest of the app talks to `agentmux-srv`, rather than introducing a second, inconsistent transport just for this one feature.

## Test plan

- [x] `cargo build -p agentmux-srv --bin agentmux-srv` — clean build, no new warnings
- [x] `npx tsc --noEmit -p tsconfig.json` — clean, whole-frontend typecheck
- [x] `npx stylelint frontend/app/view/agent/components/AgentRegistrationPanel.scss` — clean (uses `--success-text-color`/`--warning-text-color`/`--error-text-color` design tokens, no raw hex)
- [ ] Manual: open an agent pane's Stash → Registration tab and confirm the badge/sections render against a live instance (not yet run interactively — flagging for reviewer/follow-up manual check per this repo's UI verification norm)

<!-- agentmux:agent_id=manoz -->