### PR TITLE
fix(build): raise Node heap limit for frontend production build

### DIFF
--- a/.changesets/1787323870-fix-build-raise-node-heap-limit-for-frontend-production-buil-uc7n.md
+++ b/.changesets/1787323870-fix-build-raise-node-heap-limit-for-frontend-production-buil-uc7n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): raise Node heap limit for frontend production build

--- a/scripts/vite-build.sh
+++ b/scripts/vite-build.sh
@@ -17,6 +17,12 @@ cd "$REAL_ROOT"
 # heap out of memory" (exit 134) on the macOS CI runner, reproducing on both
 # ci-nightly-artifacts.yml and release.yml. CI runners across all three
 # platforms have well over 4GB free, Node just wasn't told it could use it.
-export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=4096"
+# Only apply the default if the caller hasn't already sized the heap
+# themselves — Node keeps the LAST --max-old-space-size when duplicated, so
+# unconditionally appending ours would silently shrink an explicit larger
+# value instead of just providing a floor.
+if [[ "${NODE_OPTIONS:-}" != *"max-old-space-size"* && "${NODE_OPTIONS:-}" != *"max-heap-size"* ]]; then
+    export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=4096"
+fi
 
 exec npx vite build "$@"

--- a/scripts/vite-build.sh
+++ b/scripts/vite-build.sh
@@ -12,4 +12,11 @@ REAL_ROOT=$(node -e "console.log(require('fs').realpathSync.native(process.cwd()
 # cd to the native-cased path so process.cwd() matches filesystem casing
 cd "$REAL_ROOT"
 
+# Node's default V8 old-space limit (~2GB) is no longer enough headroom for
+# this frontend's production build — it started crashing with "JavaScript
+# heap out of memory" (exit 134) on the macOS CI runner, reproducing on both
+# ci-nightly-artifacts.yml and release.yml. CI runners across all three
+# platforms have well over 4GB free, Node just wasn't told it could use it.
+export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=4096"
+
 exec npx vite build "$@"


### PR DESCRIPTION
## Summary
- `vite build` (via `scripts/vite-build.sh`) was crashing with `FATAL ERROR: JavaScript heap out of memory` (exit 134) against Node's default ~2GB V8 old-space limit.
- Reproduced 3x in a row: `ci-nightly-artifacts.yml` macOS job (last night), and `release.yml` macOS job on two separate attempts while cutting v0.55.18.
- Windows/Linux builds are unaffected (more available headroom on those runners apparently), but nothing in the repo ever set `NODE_OPTIONS`/`--max-old-space-size` anywhere, so all three platforms were one bundle-size-bump away from the same crash.
- Fix: bump the heap limit to 4096MB in `scripts/vite-build.sh`, which both `build:frontend` and `build:frontend:dev` Taskfile tasks go through on every platform.

## Test plan
- [x] Confirmed the crash reproduces identically in `ci-nightly-artifacts.yml` run 32456518687 and `release.yml` run 32440595121 (both `task: Failed to run task "build:frontend": exit status 134`, same heap-limit stack trace).
- [ ] CI on this PR (build-windows/build-linux/build-macos via ci-pr.yml or equivalent) builds clean.
- [ ] After merge, re-cut the v0.55.18 release tag against a commit including this fix and confirm the macOS build succeeds end-to-end (publish + landing deploy).

<!-- agentmux:agent_id=camper -->