### PR TITLE
fix(agent-pane): reuse fresh output.idx cache instead of full-history rescan on every pane open

### DIFF
--- a/.changesets/1787324251-fix-agent-pane-reuse-fresh-output-idx-cache-instead-of-resca-65hl.md
+++ b/.changesets/1787324251-fix-agent-pane-reuse-fresh-output-idx-cache-instead-of-resca-65hl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): reuse fresh output.idx cache instead of rescanning full history on every pane open

--- a/agentmux-srv/src/backend/agent_session/archive.rs
+++ b/agentmux-srv/src/backend/agent_session/archive.rs
@@ -245,6 +245,13 @@ pub fn clear_local_current_zone(filestore: &FileStore, zone: &str) {
 /// a missing file is the expected "agent never mirrored" case (silent), other
 /// errors are logged but never propagated. Keeps the global zone in lockstep
 /// with the per-channel `:current` clear in [`archive_session`].
+///
+/// Also clears `output.idx` (codex P2 on #2701): its freshness check is a
+/// `covered_size` byte comparison against the current `output`, so a stale
+/// index left behind after `output` is deleted and rewritten from scratch
+/// could be spuriously accepted as fresh the moment the new output happens
+/// to reach the same byte size, silently reporting the old session's line
+/// count. Deleting it here forces a rebuild against the new content instead.
 pub fn clear_global_current_zone(definition_id: &str) {
     let Some(gfs) = global_transcript_store() else {
         return;
@@ -252,7 +259,7 @@ pub fn clear_global_current_zone(definition_id: &str) {
     let Ok(zone) = validate_and_current(definition_id) else {
         return;
     };
-    for name in [SNAPSHOT_FILE, OUTPUT_FILE, TSIDX_FILE] {
+    for name in [SNAPSHOT_FILE, OUTPUT_FILE, TSIDX_FILE, "output.idx"] {
         // Only delete what's present, so an absent file isn't logged as an error.
         match gfs.stat(&zone, name) {
             Ok(Some(_)) => {

--- a/agentmux-srv/src/backend/agent_session/archive.rs
+++ b/agentmux-srv/src/backend/agent_session/archive.rs
@@ -130,6 +130,18 @@ pub fn archive_session(
             );
         }
     }
+    // Clear the output.idx sidecar too (reagent P1 on #2701): same
+    // stale-cache-by-coincidence risk as the tsidx case above, but for
+    // blockfile:read_range's covered_size freshness check.
+    if let Ok(Some(_)) = filestore.stat(&current_zone, "output.idx") {
+        if let Err(e) = filestore.delete_file(&current_zone, "output.idx") {
+            tracing::warn!(
+                definition_id = %definition_id,
+                error = %e,
+                "agent_session: failed to clear current output.idx after archive"
+            );
+        }
+    }
 
     // Clear the GLOBAL current zone in the same lifecycle. Without this, the
     // cross-channel read fallback (`read_session_state` / `blockfile:read_range`
@@ -226,8 +238,16 @@ fn copy_tsidx_best_effort(src_store: &FileStore, src_zone: &str, dst_store: &Fil
 /// only for files that are present (so absence isn't logged as an error).
 /// Best-effort — used after the global-preferred archive has persisted the
 /// content, to retire this channel's (subset) copy.
+///
+/// Also clears `output.idx` (reagent P1 on #2701, mirroring codex's P2 on the
+/// global-zone twin of this function): `blockfile:read_range`'s freshness
+/// check is a `covered_size` byte comparison against the current `output`, so
+/// a stale index left behind after `output` is deleted and rewritten from
+/// scratch could be spuriously accepted the moment the new output happens to
+/// reach the same byte size, silently serving the old session's cached line
+/// count/offsets.
 pub fn clear_local_current_zone(filestore: &FileStore, zone: &str) {
-    for name in [SNAPSHOT_FILE, OUTPUT_FILE, TSIDX_FILE] {
+    for name in [SNAPSHOT_FILE, OUTPUT_FILE, TSIDX_FILE, "output.idx"] {
         match filestore.stat(zone, name) {
             Ok(Some(_)) => {
                 if let Err(e) = filestore.delete_file(zone, name) {

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -107,11 +107,16 @@ fn global_store_read_fallback_and_archive_clear() {
     // (codex's original P1 path.) Both must end cleared.
     seed_global(snap);
     write_zone_file(&per_channel, &zone, SNAPSHOT_FILE, b"{\"local\":true}").unwrap();
+    // A local output.idx sidecar too (reagent P1 on #2701): clear_local_current_zone
+    // must clear it, same as the global twin, or a same-size-by-coincidence next
+    // session could get its line count spuriously served from this stale index.
+    write_zone_file(&per_channel, &zone, "output.idx", b"stale-local-idx-bytes").unwrap();
     let archived_b = archive_session(&per_channel, def_id).unwrap();
     assert!(archived_b.is_some(), "should have archived the local current");
     assert!(global.stat(&zone, SNAPSHOT_FILE).unwrap().is_none(), "global snapshot not cleared (local-present path)");
     assert!(global.stat(&zone, OUTPUT_FILE).unwrap().is_none(), "global output not cleared (local-present path)");
     assert!(global.stat(&zone, "output.idx").unwrap().is_none(), "global output.idx not cleared (local-present path)");
+    assert!(per_channel.stat(&zone, "output.idx").unwrap().is_none(), "local output.idx not cleared (local-present path)");
     let (after_b, _) = read_session_state(&per_channel, def_id).unwrap();
     assert_eq!(after_b, None, "no resurrection after local archive");
 }
@@ -257,6 +262,28 @@ fn archive_carries_and_clears_tsidx_sidecar() {
     assert!(
         fs.stat(&current_zone, TSIDX_FILE).unwrap().is_none(),
         ":current tsidx must be cleared with output"
+    );
+}
+
+#[test]
+fn archive_clears_output_idx_sidecar() {
+    // reagent P1 on #2701: a stale output.idx left in :current after archive
+    // could be spuriously accepted as fresh by blockfile:read_range's
+    // covered_size check the moment a later session's output happens to
+    // reach the same byte size, silently serving the old cached line
+    // count/offsets. Must be cleared alongside output, same as tsidx above.
+    let fs = fresh_filestore();
+    let payload = br#"{"nodes":[]}"#;
+    write_session_state(&fs, "def-idx", payload).unwrap();
+    append_session_output(&fs, "def-idx", "raw1").unwrap();
+    let current_zone = agent_current_zone("def-idx");
+    write_zone_file(&fs, &current_zone, "output.idx", b"stale-idx-bytes").unwrap();
+
+    archive_session(&fs, "def-idx").unwrap().expect("archived");
+
+    assert!(
+        fs.stat(&current_zone, "output.idx").unwrap().is_none(),
+        ":current output.idx must be cleared with output"
     );
 }
 

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -70,6 +70,13 @@ fn global_store_read_fallback_and_archive_clear() {
             .make_file(&zone, OUTPUT_FILE, FileMeta::default(), FileOpts::default())
             .unwrap();
         global.append_data(&zone, OUTPUT_FILE, b"{\"type\":\"user\"}\n").unwrap();
+        // A cached output.idx sidecar (codex P2 on #2701): must be cleared
+        // alongside `output`, or a same-size-by-coincidence next session
+        // could get its line count spuriously served from this stale index.
+        global
+            .make_file(&zone, "output.idx", FileMeta::default(), FileOpts::default())
+            .unwrap();
+        global.write_file(&zone, "output.idx", b"stale-idx-bytes").unwrap();
     };
 
     // ---- Case A: cross-channel viewer (empty local, content only in global) ----
@@ -89,6 +96,7 @@ fn global_store_read_fallback_and_archive_clear() {
     assert!(archived.is_some(), "empty-local archive must preserve the global conversation");
     assert!(global.stat(&zone, SNAPSHOT_FILE).unwrap().is_none(), "global snapshot not cleared (empty-local path)");
     assert!(global.stat(&zone, OUTPUT_FILE).unwrap().is_none(), "global output not cleared (empty-local path)");
+    assert!(global.stat(&zone, "output.idx").unwrap().is_none(), "global output.idx not cleared (empty-local path)");
     // Preserved as a local archive (browsable here), not silently discarded.
     assert!(!list_archives(&per_channel, def_id, 0).unwrap().is_empty(), "global content must be archived locally");
     // No resurrection on the next open.
@@ -103,6 +111,7 @@ fn global_store_read_fallback_and_archive_clear() {
     assert!(archived_b.is_some(), "should have archived the local current");
     assert!(global.stat(&zone, SNAPSHOT_FILE).unwrap().is_none(), "global snapshot not cleared (local-present path)");
     assert!(global.stat(&zone, OUTPUT_FILE).unwrap().is_none(), "global output not cleared (local-present path)");
+    assert!(global.stat(&zone, "output.idx").unwrap().is_none(), "global output.idx not cleared (local-present path)");
     let (after_b, _) = read_session_state(&per_channel, def_id).unwrap();
     assert_eq!(after_b, None, "no resurrection after local archive");
 }

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -1493,17 +1493,41 @@ pub(super) fn global_output_source(
 /// Exact non-blank line count of the `output` file in `zone`, computed via the
 /// same streaming index builder `read_range` uses (so the two endpoints always
 /// agree). Returns `Some(0)` for an empty file, `None` on read failure.
+///
+/// Reuses `output.idx` when its `covered_size` header already matches the
+/// current `output` size — same freshness check
+/// `register_blockfile_read_range` (`blockfile.rs`) already does — instead of
+/// unconditionally rescanning the entire history on every call. Without this,
+/// every pane open for an agent with any global-zone history pays a full
+/// O(history size) rescan even when nothing has changed since the index was
+/// last built.
 pub(super) fn global_zone_line_count(
     gfs: &Arc<crate::backend::storage::filestore::FileStore>,
     zone: &str,
 ) -> Option<u64> {
+    use crate::backend::blockcontroller::shell::OUTPUT_IDX_HEADER_LEN;
+
     let stat = gfs
         .stat(zone, crate::backend::agent_session::OUTPUT_FILE)
         .ok()??;
     if stat.size == 0 {
         return Some(0);
     }
-    crate::backend::blockcontroller::shell::rebuild_output_idx(gfs, zone, stat.size as u64)
+    let output_size = stat.size as u64;
+
+    if let Ok(Some(idx_stat)) = gfs.stat(zone, "output.idx") {
+        if idx_stat.size >= OUTPUT_IDX_HEADER_LEN {
+            if let Ok((_, header)) = gfs.read_at(zone, "output.idx", 0, OUTPUT_IDX_HEADER_LEN) {
+                if let Ok(bytes) = <[u8; 8]>::try_from(header.as_slice()) {
+                    if u64::from_le_bytes(bytes) == output_size {
+                        return Some(((idx_stat.size - OUTPUT_IDX_HEADER_LEN) / 8) as u64);
+                    }
+                }
+            }
+        }
+    }
+
+    crate::backend::blockcontroller::shell::rebuild_output_idx(gfs, zone, output_size)
 }
 
 /// Resolve a tab ID: use the provided one, or fall back to the first workspace's active tab.
@@ -1807,6 +1831,36 @@ mod cross_channel_tests {
         // Empty / absent zone → Some(0) / None respectively.
         let empty_zone = "agent:def-empty:current";
         assert_eq!(global_zone_line_count(&global, empty_zone), None);
+    }
+
+    #[test]
+    fn global_zone_line_count_reuses_fresh_index_instead_of_rescanning() {
+        // Same fresh-index reuse the read_range path already does
+        // (blockfile.rs) — a header whose covered_size matches the current
+        // `output` size must be trusted as-is, not rebuilt from a full scan.
+        // Proven here by seeding a deliberately-wrong-but-size-matching index
+        // (2 entries) alongside real `output` content that would scan to 3
+        // non-blank lines: a fix that trusts the fresh header returns the
+        // cached 2; the old always-rebuild code returns the rescanned 3.
+        let global = mem_store();
+        let zone = "agent:def-cc-5:current";
+        let body: &[u8] = b"{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n";
+        seed_output(&global, zone, body);
+
+        let mut idx = Vec::new();
+        idx.extend_from_slice(&(body.len() as u64).to_le_bytes()); // covered_size == output size
+        idx.extend_from_slice(&0u64.to_le_bytes()); // fabricated entry 0
+        idx.extend_from_slice(&9u64.to_le_bytes()); // fabricated entry 1 (only 2, not 3)
+        global
+            .make_file(zone, "output.idx", FileMeta::default(), FileOpts::default())
+            .unwrap();
+        global.write_file(zone, "output.idx", &idx).unwrap();
+
+        assert_eq!(
+            global_zone_line_count(&global, zone),
+            Some(2),
+            "must trust the fresh cached index rather than rescanning `output`",
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Opening a pane for an agent with a lot of accumulated history was slow
on every single reopen — traced to `global_zone_line_count`
(`agentmux-srv/src/server/app_api/mod.rs`), which is hit first on
mount (`useHistoryPagination.ts`'s `needsHwmWidening` check, true on
almost every reopen since #2323 made pane reopen always spawn a new
block).

That function unconditionally called `rebuild_output_idx` — a full
streaming byte-scan of the agent's *entire* transcript — instead of
first checking whether the `output.idx` cache already sitting on disk
is fresh for the current `output` size. Its sibling handler,
`register_blockfile_read_range` (`blockfile.rs`), already does this
freshness check (`covered_size` header comparison) before rebuilding;
`global_zone_line_count` was added later by #1399 (globalize agent
transcript for cross-channel history) and simply never reused it.

Net effect: every pane open for an agent with any global-zone history
paid an O(total transcript size) rescan, even when nothing had
changed since the index was last built.

## Fix

Port the same freshness check `read_range` already uses into
`global_zone_line_count`: if `output.idx`'s 8-byte `covered_size`
header matches the current `output` file size, trust the cached line
count directly instead of calling `rebuild_output_idx`.

## Testing

- New test `global_zone_line_count_reuses_fresh_index_instead_of_rescanning`:
  seeds a deliberately-wrong-but-size-matching index (2 fabricated
  entries) alongside real `output` content that would scan to 3
  non-blank lines — proves the fix trusts the cached 2 rather than
  rescanning to 3.
- Existing `global_zone_line_count_counts_non_blank_lines` still passes
  unchanged (no-cache / empty / absent-zone cases).
- Full suite: `cargo test -p agentmux-srv -- --test-threads=1` — 2581
  passed, 0 failed. (Default parallel run shows one pre-existing flaky
  failure, `sysinfo::handle_anomaly_tests::refresh_processes_specifics_does_not_leak_a_handle_per_call`
  — confirmed unrelated: it also fails under parallel scheduling on a
  clean `main` checkout with no changes, and passes in isolation and
  single-threaded regardless of this diff.)

<!-- agentmux:agent_id=agent1 -->