### PR TITLE
chore: release v0.55.19

### DIFF
--- a/.changesets/1787195739-feat-agent-pane-live-dispatch-cards-for-agent-task-workflow--cabe.md
+++ b/.changesets/1787195739-feat-agent-pane-live-dispatch-cards-for-agent-task-workflow--cabe.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): live dispatch cards for Agent/Task/Workflow tool calls in the transcript

--- a/.changesets/1787282050-fix-sound-ui-tool-call-tone-default-to-0-25-widget-bar-hover-arha.md
+++ b/.changesets/1787282050-fix-sound-ui-tool-call-tone-default-to-0-25-widget-bar-hover-arha.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sound,ui): tool-call tone default to 0.25; widget-bar hover-then-click no longer closes menu

--- a/.changesets/1787295688-fix-agent-recover-the-largest-on-disk-session-before-falling-q26s.md
+++ b/.changesets/1787295688-fix-agent-recover-the-largest-on-disk-session-before-falling-q26s.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): recover the largest on-disk session before falling back to a blank conversation on a stale --resume

--- a/.changesets/1787297005-fix-jekt-remove-unsafe-global-settings-agent-id-fallback-aud-aogv.md
+++ b/.changesets/1787297005-fix-jekt-remove-unsafe-global-settings-agent-id-fallback-aud-aogv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(jekt): remove unsafe global-settings agent-id fallback, audit registration events

--- a/.changesets/1787299190-feat-jekt-verify-recipient-identity-before-delivery-rcwt.md
+++ b/.changesets/1787299190-feat-jekt-verify-recipient-identity-before-delivery-rcwt.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): verify recipient identity before delivery

--- a/.changesets/1787299971-feat-jekt-stash-registration-tab-showing-live-jekt-delivery--f02x.md
+++ b/.changesets/1787299971-feat-jekt-stash-registration-tab-showing-live-jekt-delivery--f02x.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): Stash Registration tab showing live jekt delivery status

--- a/.changesets/1787323193-fix-agent-expand-in-working-dir-too-when-recovering-a-stale--e7bz.md
+++ b/.changesets/1787323193-fix-agent-expand-in-working-dir-too-when-recovering-a-stale--e7bz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): expand ~ in working_dir too when recovering a stale-resume session

--- a/.changesets/1787323870-fix-build-raise-node-heap-limit-for-frontend-production-buil-uc7n.md
+++ b/.changesets/1787323870-fix-build-raise-node-heap-limit-for-frontend-production-buil-uc7n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(build): raise Node heap limit for frontend production build

--- a/.changesets/1787324251-fix-agent-pane-reuse-fresh-output-idx-cache-instead-of-resca-65hl.md
+++ b/.changesets/1787324251-fix-agent-pane-reuse-fresh-output-idx-cache-instead-of-resca-65hl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): reuse fresh output.idx cache instead of rescanning full history on every pane open

--- a/.changesets/1787328437-feat-muxspect-verify-sender-8f3q.md
+++ b/.changesets/1787328437-feat-muxspect-verify-sender-8f3q.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxspect): add `verify-sender` — registry-liveness lookup for a JEKT's claimed FROM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.18"
+version = "0.55.19"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.18"
+version = "0.55.19"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.18"
+version = "0.55.19"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.18"
+version = "0.55.19"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.18"
+version = "0.55.19"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.18"
+version = "0.55.19"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.18"
+version = "0.55.19"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,19 @@
 # AgentMux Version History
 
+## 0.55.19 — 2026-08-21
+
+- feat(agent-pane): live dispatch cards for Agent/Task/Workflow tool calls in the transcript
+- fix(sound,ui): tool-call tone default to 0.25; widget-bar hover-then-click no longer closes menu
+- fix(agent): recover the largest on-disk session before falling back to a blank conversation on a stale --resume
+- fix(jekt): remove unsafe global-settings agent-id fallback, audit registration events
+- feat(jekt): verify recipient identity before delivery
+- feat(jekt): Stash Registration tab showing live jekt delivery status
+- fix(agent): expand ~ in working_dir too when recovering a stale-resume session
+- fix(build): raise Node heap limit for frontend production build
+- fix(agent-pane): reuse fresh output.idx cache instead of rescanning full history on every pane open
+- feat(muxspect): add `verify-sender` — registry-liveness lookup for a JEKT's claimed FROM
+
+
 ## 0.55.18 — 2026-08-20
 
 - feat(dashboard): make db_background_tasks a real read source for the agent-pane and muxspect dock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.18",
+  "version": "0.55.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.18",
+      "version": "0.55.19",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.18",
+  "version": "0.55.19",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 10 pending changesets, **forced to a patch
bump** (`--as patch`) despite 4 of them being `minor`-level — a
deliberate override per instruction, not a computed result.

`0.55.18 -> 0.55.19`. All five version-consistency-invariant locations
verified in agreement: `VERSION_HISTORY.md`, `package.json`,
`Cargo.toml`, `Cargo.lock` (workspace members), `package-lock.json`.

## Changes shipping under this patch

- feat(agent-pane): live dispatch cards for Agent/Task/Workflow tool calls in the transcript
- fix(sound,ui): tool-call tone default to 0.25; widget-bar hover-then-click no longer closes menu
- fix(agent): recover the largest on-disk session before falling back to a blank conversation on a stale --resume
- fix(jekt): remove unsafe global-settings agent-id fallback, audit registration events
- feat(jekt): verify recipient identity before delivery
- feat(jekt): Stash Registration tab showing live jekt delivery status
- fix(agent): expand ~ in working_dir too when recovering a stale-resume session
- fix(build): raise Node heap limit for frontend production build
- fix(agent-pane): reuse fresh output.idx cache instead of rescanning full history on every pane open
- feat(muxspect): add `verify-sender` — registry-liveness lookup for a JEKT's claimed FROM

<!-- agentmux:agent_id=agent1 -->