### PR TITLE
docs(spec,retro): tool-call bursts restart the Working row's type-out reveal

### DIFF
--- a/docs/retro/retro-agent-working-row-reveal-interrupted-by-tool-burst-2026-08-21.md
+++ b/docs/retro/retro-agent-working-row-reveal-interrupted-by-tool-burst-2026-08-21.md
@@ -1,0 +1,161 @@
+# Retro: Tool-call bursts interrupt the agent-pane "thinking" shimmer/type-out
+
+**Date:** 2026-08-21
+**Status:** Root cause confirmed via direct code reading, not yet fixed.
+**Trigger:** operator report — "sometimes (not often) tool calls will
+interrupt agent thinking dialog... I believe its on a state reducer" —
+reproduced live in AgentY's pane.
+
+## 1. Summary
+
+The agent pane's footer "Working…" row (`AgentWorkingRow`,
+`frontend/app/view/agent/components/AgentFooter.tsx`) type-out-reveals its
+text character by character, then shimmers once fully revealed
+(`docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md`).
+When several tool-related events land in quick succession — parallel tool
+calls in one assistant turn, or fast back-to-back tools — the row's text
+resets to character 0 and restarts its reveal on **every** intermediate
+transition instead of settling once, which reads visually as "the tool call
+interrupted the thinking dialog." This matches the "sometimes, not often"
+framing precisely: it only shows up during bursts, not on an ordinary
+single-tool turn.
+
+This was **not** found in the document/transcript content itself — the
+actual thinking-block markdown is written and preserved correctly (see §3).
+It is specifically a **presentation-layer race** in the footer's reveal
+effect, one layer above where the operator's "state reducer" hunch pointed:
+not `agent-document/reducer.ts` (which handles document nodes and is
+already hardened against this class of bug, see §3), but
+`agent-pane-state-store.ts`'s `dispatch()` — the pane-state store the
+footer's props are read from.
+
+## 2. Root cause — confirmed via direct code reading
+
+1. **The event loop that fires tool transitions synchronously, unbatched:**
+   `frontend/app/view/agent/useAgentStream.ts:540` — `for (const event of
+   streamEvents) { ... }` iterates every `StreamEvent` translated from a
+   single incoming backend chunk. Each `tool_call`/`tool_result` event in
+   that loop independently calls `model.dispatchPane(...)` synchronously
+   (lines 583–589 for `ToolStart`, line 592 for `ToolEnd`). A chunk carrying
+   several tool transitions (parallel tool_use blocks, or several small
+   tool calls arriving together) fires several `dispatchPane` calls in the
+   same synchronous pass, back to back.
+
+2. **No batching in the pane-state store's dispatch path:**
+   `frontend/app/store/agent-pane-state-store.ts` — confirmed by direct
+   grep: the file has **no `batch(` import or call anywhere**. Inside
+   `dispatch()` (starting line 222), each changed field is applied via its
+   own `proj(...)` call (e.g. `proj("currentTool", ...)` at line 337,
+   `proj("currentToolArg", ...)` at line 351) — a raw SolidJS signal setter
+   invoked directly, once per `dispatchPane` call. Every call in the
+   unbatched loop from §2.1 lands here independently and fires its own
+   reactive update immediately.
+
+   For contrast: `useAgentStream.ts`'s own top doc comment (lines 17–35)
+   documents that **document-node writes** (`ToolChunkAppend`,
+   `StreamFlush`) were deliberately funneled through a shared
+   `StreamFlushQueue` + RAF + `batch()` after a prior crash from unbatched
+   writes. That discipline was never extended to `dispatchPane`'s
+   `ToolStart`/`ToolEnd`/promotion path — this is the gap.
+
+3. **The effect that pays for it, restarting on every flip:**
+   `AgentFooter.tsx`:
+   - `loadingLeftText()` (lines 113–128) returns the live tool name (e.g.
+     `Bash · npm test`) instead of the rotating "Working…" phrase whenever
+     `props.currentTool` is set and not yet `props.toolPromoted` (line 122).
+   - `leftText` is a `createMemo` over that function (line 155) — it
+     recomputes on every `currentTool`/`currentToolArg`/`toolPromoted`
+     change.
+   - The reveal effect (lines 181–202) reruns on **every** change to
+     `leftText()`: unless `revealInstantly` is set, it calls
+     `setRevealed(0)` and starts a fresh `setInterval` typing the string out
+     at `REVEAL_CHAR_MS = 28`ms/char (lines 189–200).
+   - `toolPromoted` flipping true a few seconds after a tool starts (the
+     ActivityDock promotion) causes the **same** reset in reverse —
+     `loadingLeftText` falls back from the tool name to the "Working…"
+     phrase, again resetting `revealed` to 0.
+
+**The race, concretely:** any burst of `ToolStart`/`ToolEnd` dispatches
+processed in the same synchronous pass (§2.1) each independently flip
+`currentTool`/`currentToolArg` (§2.2) with no batching, and each flip
+independently re-triggers the reveal effect (§2.3) — restarting the
+type-out from character 0 before the previous one finishes. Visually this
+reads as the tool call interrupting the thinking-row text mid-reveal.
+
+## 3. What this is NOT — ruled out
+
+- **Not document/transcript corruption.** `frontend/app/view/agent/stream-parser.ts`
+  accumulates thinking deltas into `currentThinkingNode` (`thinkingToNode`,
+  lines 411–438), and each delta is flushed as its own document-node write
+  via `queue.pushNewNode`/`pushUpdatedNode` before a following `tool_call`
+  event resets the accumulator pointer (`eventToNode`, lines 340–343). No
+  thinking content is lost or truncated in the actual transcript — this was
+  confirmed by reading both `stream-parser.ts` and the reducer's own
+  ordering guarantees (`agent-document/reducer.ts:507–524`, hardened
+  against exactly this class of bug per
+  `REPORT_AGENT_PANE_TEXT_TRUNCATION_2026-05-28.md`).
+- **Not backend/wire-level reordering.** Anthropic's API delivers content
+  blocks strictly sequentially (a thinking block's `content_block_stop`
+  always precedes a following `tool_use` block's `content_block_start`).
+  `agentmux-srv` passes these through without reordering
+  (`agents/translator/claude.rs`). Confirmed directly against a live
+  transcript pulled from AgentY's session (`GetAgentTranscript`,
+  block_id `0a8d11f8-6962-486a-987e-2d4d366804da`) — the visible tail showed
+  a single large sequential tool call (one `Write`, streamed as one
+  `input_json_delta` block at a fixed content index) followed by a plain
+  text reply, consistent with normal sequential turn structure.
+
+## 4. Reproduction data
+
+- Reported live in AgentY's pane (far-left pane, this host/channel).
+- **Visual confirmation was not directly possible from this session**:
+  `UIScreenshot`/`UIQuery` are scoped to "your own pane and shared app
+  chrome" only (confirmed via tool description) — there is no cross-pane
+  capture capability today (see `docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md`,
+  written the same day, for exactly why that boundary exists and isn't a
+  quick widening).
+  `GetAgentTranscript` only returns text, and only the tail (server-capped
+  at 500 lines) — the specific burst moment that triggered the operator's
+  observation was not in the retrievable window, so this retro's root
+  cause rests on direct code reading (§2), not a captured live burst.
+- The mechanism reproduces deterministically from the code alone: any
+  input that causes `useAgentStream.ts`'s per-chunk `streamEvents` loop
+  (line 540) to contain more than one `tool_call`/`tool_result` transition
+  — parallel tool use in one message being the clearest case — will fire
+  more than one unbatched `dispatchPane` call in the same synchronous pass.
+
+## 5. Recommended fix directions (not implemented here)
+
+1. **Wrap the tool-transition dispatches in `batch()`** — either around the
+   `for` loop in `useAgentStream.ts:540` (batch all `dispatchPane` calls
+   produced from one incoming chunk), or inside `agent-pane-state-store.ts`'s
+   `dispatch()` itself if it can detect/coalesce a rapid sequence of calls.
+   The former is more surgical and matches the existing precedent
+   (`StreamFlushQueue`'s RAF/batch discipline for document nodes) without
+   touching the store's general dispatch path.
+2. **Debounce/coalesce the reveal effect itself** — e.g. only restart the
+   type-out if `leftText()` has been stable for some short window (a few
+   ms), rather than reacting to every intermediate value in a burst. More
+   defensive (guards against future unbatched writers too) but changes the
+   footer's own timing model, not just the write side.
+3. Either direction should add a regression test/story exercising a burst
+   of 2+ `ToolStart`/`ToolEnd` dispatches in the same tick and asserting
+   the reveal effect only restarts once (or not at all, if the net
+   `currentTool` value is unchanged after the burst settles).
+
+## 6. Sources
+
+- `frontend/app/view/agent/useAgentStream.ts:540` (unbatched per-chunk
+  event loop), `:581–592` (`ToolStart`/`ToolEnd` dispatch sites), `:17–35`
+  (existing `StreamFlushQueue`/`batch()` precedent for document nodes)
+- `frontend/app/store/agent-pane-state-store.ts:222` (`dispatch()`),
+  `:337`, `:351` (`proj("currentTool"/"currentToolArg", ...)`) — no
+  `batch(` anywhere in the file
+- `frontend/app/view/agent/components/AgentFooter.tsx:113–128`
+  (`loadingLeftText`), `:155` (`leftText` memo), `:181–202` (reveal effect)
+- `frontend/app/view/agent/stream-parser.ts:340–343`, `:411–438`
+  (thinking-node accumulation, ruled out as the cause)
+- `docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md`
+  (existing shimmer/type-out design)
+- `docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md`
+  (why cross-pane visual capture isn't available to confirm this live)

--- a/docs/retro/retro-agent-working-row-reveal-interrupted-by-tool-burst-2026-08-21.md
+++ b/docs/retro/retro-agent-working-row-reveal-interrupted-by-tool-burst-2026-08-21.md
@@ -32,14 +32,18 @@ footer's props are read from.
 ## 2. Root cause — confirmed via direct code reading
 
 1. **The event loop that fires tool transitions synchronously, unbatched:**
-   `frontend/app/view/agent/useAgentStream.ts:540` — `for (const event of
-   streamEvents) { ... }` iterates every `StreamEvent` translated from a
-   single incoming backend chunk. Each `tool_call`/`tool_result` event in
-   that loop independently calls `model.dispatchPane(...)` synchronously
-   (lines 583–589 for `ToolStart`, line 592 for `ToolEnd`). A chunk carrying
-   several tool transitions (parallel tool_use blocks, or several small
-   tool calls arriving together) fires several `dispatchPane` calls in the
-   same synchronous pass, back to back.
+   `frontend/app/view/agent/useAgentStream.ts:352-628` — the
+   `fileSubject.subscribe(...)` callback. One "append" notification can
+   carry several newline-delimited raw lines; `for (const line of lines)`
+   (line 371) processes all of them in one synchronous pass, and for each
+   the inner `for (const event of streamEvents) { ... }` (line 540)
+   independently calls `model.dispatchPane(...)` for each
+   `tool_call`/`tool_result` event (lines 583–589 for `ToolStart`, line
+   592 for `ToolEnd`). **The outer, per-line loop is the actual
+   burst boundary** — see §5's correction note: `streamEvents` (the inner
+   loop) is only ever the translation of one raw line, and for Claude a
+   tool's `ToolStart` and its later argument update arrive as separate
+   raw lines, not together in one `streamEvents` array.
 
 2. **No batching in the pane-state store's dispatch path:**
    `frontend/app/store/agent-pane-state-store.ts` — confirmed by direct
@@ -126,13 +130,29 @@ reads as the tool call interrupting the thinking-row text mid-reveal.
 
 ## 5. Recommended fix directions (not implemented here)
 
-1. **Wrap the tool-transition dispatches in `batch()`** — either around the
-   `for` loop in `useAgentStream.ts:540` (batch all `dispatchPane` calls
-   produced from one incoming chunk), or inside `agent-pane-state-store.ts`'s
-   `dispatch()` itself if it can detect/coalesce a rapid sequence of calls.
-   The former is more surgical and matches the existing precedent
-   (`StreamFlushQueue`'s RAF/batch discipline for document nodes) without
-   touching the store's general dispatch path.
+**Correction (2026-08-21, post-review on the follow-up spec PR #2706):**
+point 1 below originally named `useAgentStream.ts:540` — the *inner*
+`for (const event of streamEvents)` loop — as the batch boundary. Codex
+correctly flagged that this doesn't fix the reported Claude-path symptom:
+`streamEvents` is the translation of a single raw line, and a tool call's
+`ToolStart` and its later argument update arrive as **separate raw
+lines** for Claude, not together in one `streamEvents` array. The real
+"arrived together" boundary is the *outer* `for (const line of lines)`
+loop at `useAgentStream.ts:371` (inside the `fileSubject.subscribe`
+callback, `:352-628`), which can process several raw lines from one
+append notification in a single synchronous pass. See
+`docs/specs/SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md`
+§2.1 for the corrected design — updated below to match.
+
+1. **Wrap the tool-transition dispatches in `batch()`** — around the outer
+   `for (const line of lines)` loop in `useAgentStream.ts:371` (batch all
+   `dispatchPane` calls produced from one incoming append notification,
+   which may span several raw lines), or inside
+   `agent-pane-state-store.ts`'s `dispatch()` itself if it can
+   detect/coalesce a rapid sequence of calls. The former is more surgical
+   and matches the existing precedent (`StreamFlushQueue`'s RAF/batch
+   discipline for document nodes) without touching the store's general
+   dispatch path.
 2. **Debounce/coalesce the reveal effect itself** — e.g. only restart the
    type-out if `leftText()` has been stable for some short window (a few
    ms), rather than reacting to every intermediate value in a burst. More
@@ -145,9 +165,12 @@ reads as the tool call interrupting the thinking-row text mid-reveal.
 
 ## 6. Sources
 
-- `frontend/app/view/agent/useAgentStream.ts:540` (unbatched per-chunk
-  event loop), `:581–592` (`ToolStart`/`ToolEnd` dispatch sites), `:17–35`
-  (existing `StreamFlushQueue`/`batch()` precedent for document nodes)
+- `frontend/app/view/agent/useAgentStream.ts:352-628` (the
+  `fileSubject.subscribe` callback), `:371` (outer per-line loop — the
+  actual burst boundary), `:540` (inner per-event loop — insufficient in
+  isolation, see §5 correction note), `:581–592` (`ToolStart`/`ToolEnd`
+  dispatch sites), `:17–35` (existing `StreamFlushQueue`/`batch()`
+  precedent for document nodes)
 - `frontend/app/store/agent-pane-state-store.ts:222` (`dispatch()`),
   `:337`, `:351` (`proj("currentTool"/"currentToolArg", ...)`) — no
   `batch(` anywhere in the file

--- a/docs/specs/SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md
@@ -40,12 +40,17 @@ the row's final settled text — not one restart per intermediate value.
 
 Three pieces compose the bug, none of which is itself wrong in isolation:
 
-1. **`frontend/app/view/agent/useAgentStream.ts:540`** — `for (const event
-   of streamEvents) { ... }` processes every translated event from one
-   incoming backend chunk synchronously. Each `tool_call`/`tool_result`
-   fires its own `model.dispatchPane({ type: "ToolStart" | "ToolEnd", ... })`
-   call immediately (lines 583–592) — a chunk carrying several tool
-   transitions dispatches several times in the same synchronous pass.
+1. **`frontend/app/view/agent/useAgentStream.ts:352-628`** — the
+   `fileSubject.subscribe(...)` callback body. One "append" notification
+   can carry several newline-delimited raw lines (`lineBuffer.split("\n")`,
+   line 360); `for (const line of lines)` (line 371) processes all of them
+   synchronously in one callback invocation, and the inner `for (const
+   event of streamEvents)` loop (line 540) dispatches each translated
+   event's `tool_call`/`tool_result` via its own
+   `model.dispatchPane({ type: "ToolStart" | "ToolEnd", ... })` call
+   immediately (lines 583–592). **The burst-inducing multiplicity is at the
+   outer, per-line level, not the inner per-event level** — see the §2.1
+   revision note for why this distinction matters for the fix.
 
 2. **`frontend/app/store/agent-pane-state-store.ts`** — `dispatch()`
    (from line 222) applies each dispatched change via its own signal
@@ -76,44 +81,77 @@ settled value.
 
 ## 2. Proposed design
 
-### 2.1 Chosen approach: batch the per-chunk dispatch loop
+**Revision note (2026-08-21, post-review):** the original version of this
+section proposed batching `useAgentStream.ts`'s *inner* `for (const event
+of streamEvents)` loop (then cited as line 540). Codex correctly flagged
+that this doesn't fix the reported Claude-path symptom (PR #2706 review
+comment): `streamEvents` is the translation of a **single** raw NDJSON
+line, and for Claude, a tool call's initial dispatch (`content_block_start`
+→ `ToolStart`) and its later argument-bearing update
+(`content_block_stop`) arrive as **separate raw lines**, not together in
+one `streamEvents` array — so batching only the inner loop leaves each of
+those dispatches in its own, still-unbatched reactive commit. Parallel
+tool blocks likewise arrive as separate frames. §2.1 below replaces the
+original proposal with the correct boundary.
 
-Wrap the tool-transition dispatches inside `useAgentStream.ts`'s
-`streamEvents` loop (line 540) in SolidJS's `batch()`, so every
-`dispatchPane` call produced from one incoming chunk (a translated
-`translator.translate(rawEvent)` result) commits as a single reactive
-update instead of one-per-event.
+### 2.1 Chosen approach: batch the per-message line loop, not the per-line event loop
+
+The actual "things that arrived together" unit is **one `fileSubject`
+"append" notification** — `useAgentStream.ts:352-628`, the body of the
+`fileSubject.subscribe(...)` callback. A single append can carry multiple
+newline-delimited raw lines (`msg.data64` decoded, then `lineBuffer.split("\n")`
+at line 360); `for (const line of lines)` (line 371) processes all of them
+synchronously in one callback invocation, each producing its own
+`translator.translate(rawEvent)` → `streamEvents` → `dispatchPane` calls.
+**This outer loop, not the inner one, is where a burst of tool
+transitions actually lands together** — e.g. several small tool
+calls/results whose backend writes got coalesced into one append batch,
+or (per Codex's example) a tool's `ToolStart` and its later argument
+update arriving as two lines within the same append.
+
+Wrap the outer loop (lines 371–621, i.e. everything from the first
+`for (const line of lines)` line through its closing brace) in SolidJS's
+`batch()`, so every `dispatchPane` call produced while processing one
+append notification commits as a single reactive update:
 
 ```ts
 import { batch } from "solid-js";
 
 // ...
 batch(() => {
-    for (const event of streamEvents) {
-        // existing body — dispatchPane calls for tool_call/tool_result/
-        // provider_waiting, plus the parser.parseLine → pushNewNode/
-        // pushUpdatedNode path — unchanged internally.
+    for (const line of lines) {
+        // existing body, unchanged — trimmed-line parsing, the
+        // stderr/compact_boundary/session_outcome/token-extraction
+        // special cases, translator.translate(rawEvent), and the inner
+        // `for (const event of streamEvents)` loop's dispatchPane /
+        // parser.parseLine → pushNewNode/pushUpdatedNode calls.
     }
 });
 ```
 
-**Why this scope, not a wider one:** `streamEvents` is already the natural
-unit of "things that arrived together" — it's the translated output of one
-raw backend chunk. Batching at this boundary directly addresses the
-observed trigger (multiple tool transitions translated from one chunk,
-e.g. parallel tool_use blocks) without changing `dispatch()`'s general
-contract or touching call sites elsewhere in the codebase that call
-`dispatchPane` once per genuinely-independent event (a normal, non-bursty
-turn dispatches once per chunk here too, so `batch()` around a single call
-is a no-op cost-wise).
+**Why this scope, not the inner loop:** the inner `streamEvents` loop only
+sees what one raw line translates to (usually exactly one event for
+Claude); it has no visibility into sibling lines that arrived in the same
+append. The outer loop is the layer that actually observes "these N lines
+arrived together," which is the real definition of a burst here.
+
+**Interaction with the document-node queue:** the same outer-loop body
+already calls `queue.pushNewNode`/`pushUpdatedNode`/`scheduleFlush` for
+non-tool events (text/thinking/etc.), which route through the existing
+`StreamFlushQueue`/RAF mechanism (§ useAgentStream.ts:17–35), not through
+SolidJS signals directly. Wrapping the whole loop in `batch()` is additive
+to that — `batch()` only affects how/when SolidJS signal writes (the
+`dispatchPane`-driven pane-state fields) flush their reactive updates; it
+has no effect on the RAF-scheduled queue's own timing. No conflict
+expected, but call out explicitly for the implementer to verify (§3).
 
 **Why not batch inside `agent-pane-state-store.ts`'s `dispatch()` itself:**
 that function is called once per `dispatchPane` invocation, so wrapping
 its own body in `batch()` would only batch the handful of `proj(...)`
 calls *within a single dispatch* (already effectively atomic from the
 caller's perspective) — it would not coalesce *across* the multiple
-separate `dispatchPane` calls the burst produces. The loop-level fix in
-§2.1 is the layer that actually has visibility into "these N calls arrived
+separate `dispatchPane` calls a burst produces. The loop-level fix above
+is the layer that actually has visibility into "these calls arrived
 together."
 
 ### 2.2 Defense in depth (follow-up, not blocking): debounce the reveal effect
@@ -167,8 +205,11 @@ fix, to keep the initial change small and easy to verify in isolation.
 
 ## 5. Sources
 
-- `frontend/app/view/agent/useAgentStream.ts:540` (unbatched per-chunk
-  loop), `:581–592` (`ToolStart`/`ToolEnd` dispatch sites), `:17–35`
+- `frontend/app/view/agent/useAgentStream.ts:352-628` (the
+  `fileSubject.subscribe` callback), `:371` (outer per-line loop — the
+  correct batch boundary), `:540` (inner per-event loop — insufficient
+  boundary, see §2.1 revision note), `:581–592`
+  (`ToolStart`/`ToolEnd` dispatch sites), `:17–35`
   (existing `StreamFlushQueue`/`batch()` precedent for document nodes)
 - `frontend/app/store/agent-pane-state-store.ts:222` (`dispatch()`),
   `:337`, `:351` (unbatched `proj(...)` signal writes)

--- a/docs/specs/SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md
@@ -1,0 +1,180 @@
+# SPEC: Tool-call bursts restart the agent-pane "Working…" row's type-out reveal
+
+**Date:** 2026-08-21
+**Status:** proposed
+**Related:** `docs/retro/retro-agent-working-row-reveal-interrupted-by-tool-burst-2026-08-21.md`
+(root-cause investigation this spec formalizes into a fix design),
+`docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md`
+(the shimmer/type-out design this bug lives in)
+
+---
+
+## 0. Ask
+
+Reported symptom (operator, reproduced live in an agent pane): "sometimes
+(not often) tool calls will interrupt agent thinking dialog." Confirmed via
+code reading (retro above) to be the footer's `AgentWorkingRow`
+("Working…" / current-tool-name row below the transcript,
+`frontend/app/view/agent/components/AgentFooter.tsx`): during a burst of
+tool-related transitions — parallel tool calls in one assistant turn, or
+several tool calls arriving close together — the row's type-out reveal
+restarts from the first character multiple times in quick succession
+instead of settling once. Visually this reads as the tool call
+"interrupting" the row's text mid-reveal.
+
+**Note on scope:** a separate question — whether the actual *streamed
+thinking-text content* (the `metadata.thinking` markdown block in the
+transcript, not this footer row) can itself be visually cut off by a tool
+call — was also investigated (same retro) and no root cause was found
+there; the document/render path was verified not to drop or truncate
+content on a `tool_call` event. That question is **out of scope for this
+spec** and remains open pending a clearer reproduction.
+
+Desired behavior: a burst of tool-related state changes that settles
+within a short window should result in **at most one** reveal restart for
+the row's final settled text — not one restart per intermediate value.
+
+---
+
+## 1. Root cause (see retro for full detail)
+
+Three pieces compose the bug, none of which is itself wrong in isolation:
+
+1. **`frontend/app/view/agent/useAgentStream.ts:540`** — `for (const event
+   of streamEvents) { ... }` processes every translated event from one
+   incoming backend chunk synchronously. Each `tool_call`/`tool_result`
+   fires its own `model.dispatchPane({ type: "ToolStart" | "ToolEnd", ... })`
+   call immediately (lines 583–592) — a chunk carrying several tool
+   transitions dispatches several times in the same synchronous pass.
+
+2. **`frontend/app/store/agent-pane-state-store.ts`** — `dispatch()`
+   (from line 222) applies each dispatched change via its own signal
+   setter (`proj("currentTool", ...)` at line 337,
+   `proj("currentToolArg", ...)` at line 351) with **no `batch()`
+   anywhere in the file**. Every call from the loop above lands here
+   independently and fires a reactive update immediately — contrast with
+   `useAgentStream.ts`'s own document-node writes, which already go
+   through a shared `StreamFlushQueue` + RAF + `batch()` (its top doc
+   comment, lines 17–35) specifically to avoid this class of bug for
+   document nodes; that discipline was never extended to `dispatchPane`.
+
+3. **`frontend/app/view/agent/components/AgentFooter.tsx`** —
+   `loadingLeftText()` (lines 113–128) returns the current tool
+   name/arg whenever `currentTool` is set and not yet `toolPromoted`; the
+   `leftText` memo (line 155) recomputes on every change to those fields;
+   the reveal effect (lines 181–202) reruns on every `leftText()` change
+   and, unless `revealInstantly` is set, calls `setRevealed(0)` and
+   restarts a fresh `setInterval` type-out. `toolPromoted` flipping (the
+   few-seconds-later ActivityDock promotion) causes the same reset in
+   reverse.
+
+Net effect: N unbatched signal writes from one burst → up to N separate
+`leftText()` recomputations → up to N reveal restarts, instead of one
+settled value.
+
+---
+
+## 2. Proposed design
+
+### 2.1 Chosen approach: batch the per-chunk dispatch loop
+
+Wrap the tool-transition dispatches inside `useAgentStream.ts`'s
+`streamEvents` loop (line 540) in SolidJS's `batch()`, so every
+`dispatchPane` call produced from one incoming chunk (a translated
+`translator.translate(rawEvent)` result) commits as a single reactive
+update instead of one-per-event.
+
+```ts
+import { batch } from "solid-js";
+
+// ...
+batch(() => {
+    for (const event of streamEvents) {
+        // existing body — dispatchPane calls for tool_call/tool_result/
+        // provider_waiting, plus the parser.parseLine → pushNewNode/
+        // pushUpdatedNode path — unchanged internally.
+    }
+});
+```
+
+**Why this scope, not a wider one:** `streamEvents` is already the natural
+unit of "things that arrived together" — it's the translated output of one
+raw backend chunk. Batching at this boundary directly addresses the
+observed trigger (multiple tool transitions translated from one chunk,
+e.g. parallel tool_use blocks) without changing `dispatch()`'s general
+contract or touching call sites elsewhere in the codebase that call
+`dispatchPane` once per genuinely-independent event (a normal, non-bursty
+turn dispatches once per chunk here too, so `batch()` around a single call
+is a no-op cost-wise).
+
+**Why not batch inside `agent-pane-state-store.ts`'s `dispatch()` itself:**
+that function is called once per `dispatchPane` invocation, so wrapping
+its own body in `batch()` would only batch the handful of `proj(...)`
+calls *within a single dispatch* (already effectively atomic from the
+caller's perspective) — it would not coalesce *across* the multiple
+separate `dispatchPane` calls the burst produces. The loop-level fix in
+§2.1 is the layer that actually has visibility into "these N calls arrived
+together."
+
+### 2.2 Defense in depth (follow-up, not blocking): debounce the reveal effect
+
+Even with §2.1, a burst that spans two separate incoming chunks (e.g. two
+WPS payloads arriving within a few ms of each other, each individually
+batched but not batched *together*) could still cause two restarts.
+`AgentFooter.tsx`'s reveal effect (lines 181–202) could additionally only
+commit a restart after `leftText()` has been stable for a short window
+(e.g. one animation frame, or a small fixed delay well under human
+perception — on the order of 16–30ms) rather than reacting to every
+intermediate value synchronously. This is a strictly independent
+improvement — it guards against *any* future unbatched writer, not just
+this one — and is recommended as a follow-up rather than folded into this
+fix, to keep the initial change small and easy to verify in isolation.
+
+---
+
+## 3. Testing plan
+
+1. **Regression test at the dispatch layer**: simulate two or more
+   `ToolStart`/`ToolEnd`-equivalent `streamEvents` translated from one
+   chunk; assert the pane-state store's `currentTool`/`currentToolArg`
+   signals fire a single reactive update (batch boundary), not one per
+   event. (Exact test harness TBD at implementation time — depends on
+   what's practical to observe from outside a `batch()` call in the
+   existing SolidJS test setup for this store.)
+2. **Component-level test for `AgentWorkingRow`**: mount with a burst of
+   rapid `currentTool` prop changes (simulating what §2.1 will now
+   coalesce into fewer, settled values) and assert `revealed()` only
+   resets/restarts once per settled value, not once per intermediate one.
+3. Manual verification: reproduce the original burst condition (parallel
+   tool calls in one turn) against a build with the fix and confirm the
+   row's text no longer visibly restarts mid-reveal.
+
+---
+
+## 4. Out of scope
+
+- The separate, unconfirmed question of whether streamed thinking-text
+  *content* itself can be interrupted by a tool call (§0 note above) —
+  investigated, no root cause found, needs a clearer reproduction before
+  its own spec.
+- Any change to `dispatch()`'s general contract in
+  `agent-pane-state-store.ts`, or to how other (non-tool-transition)
+  dispatch call sites behave.
+- The optional debounce follow-up in §2.2 — tracked here as a known next
+  step, not implemented as part of this spec's fix.
+
+---
+
+## 5. Sources
+
+- `frontend/app/view/agent/useAgentStream.ts:540` (unbatched per-chunk
+  loop), `:581–592` (`ToolStart`/`ToolEnd` dispatch sites), `:17–35`
+  (existing `StreamFlushQueue`/`batch()` precedent for document nodes)
+- `frontend/app/store/agent-pane-state-store.ts:222` (`dispatch()`),
+  `:337`, `:351` (unbatched `proj(...)` signal writes)
+- `frontend/app/view/agent/components/AgentFooter.tsx:113–128`
+  (`loadingLeftText`), `:155` (`leftText` memo), `:181–202` (reveal effect)
+- `docs/retro/retro-agent-working-row-reveal-interrupted-by-tool-burst-2026-08-21.md`
+  (full investigation, including what was ruled out)
+- `docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md`
+  (existing shimmer/type-out design this bug lives in)


### PR DESCRIPTION
## Summary

Formalizes an operator-reported UI bug into a retro + fix spec, no code
changes in this PR.

- **Retro**: root-cause investigation for "tool calls interrupt agent
  thinking dialog" (reproduced live in an agent pane). Traced to
  `AgentWorkingRow`'s type-out reveal effect restarting on every
  intermediate `currentTool`/`toolPromoted` flip during a tool-call
  burst, not to any loss/truncation of the actual thinking-text
  content (that path was checked and ruled out — documented explicitly
  so it isn't re-litigated later).
- **Spec**: proposes batching the per-chunk dispatch loop in
  `useAgentStream.ts` (the layer that actually sees "these N tool
  transitions arrived together") as the fix, with a debounce-the-reveal-effect
  follow-up noted as defense in depth, not required for the initial fix.

## Not in this PR

Implementation of the fix itself — tracked as a follow-up issue.

<!-- agentmux:agent_id=agent1 -->