### PR TITLE
feat(mcp): add CaptureWindow tool for cross-instance/OS window screenshots

### DIFF
--- a/.changesets/1787346377-feat-mcp-add-capturewindow-tool-for-cross-instance-os-window-xarw.md
+++ b/.changesets/1787346377-feat-mcp-add-capturewindow-tool-for-cross-instance-os-window-xarw.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): add CaptureWindow tool for cross-instance/OS window screenshots

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "tokio",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
  "chrono",
  "dirs",
  "libc",
- "png",
+ "png 0.17.16",
  "proptest",
  "serde",
  "serde_json",
@@ -122,10 +122,13 @@ version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "anyhow",
+ "image 0.25.10",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
+ "xcap",
 ]
 
 [[package]]
@@ -305,7 +308,7 @@ dependencies = [
  "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.32.13",
  "zbus 5.18.0",
 ]
 
@@ -709,9 +712,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -844,6 +847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,7 +873,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "log",
  "polling 3.11.0",
  "rustix 0.38.44",
@@ -1079,6 +1088,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1309,6 +1324,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,11 +1419,23 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2302,6 +2340,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,7 +2526,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2492,6 +2555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,7 +2589,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
  "plain",
  "redox_syscall 0.7.5",
@@ -2535,12 +2607,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libwayshot"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2efa01ecfd021b1e7db27f21f4e79b35b048081c9cae9d2f898eddc98444d69"
+dependencies = [
+ "image 0.24.9",
+ "log",
+ "memmap2 0.9.10",
+ "nix 0.27.1",
+ "thiserror 1.0.69",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-wlr 0.2.0",
+]
+
+[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2703,7 +2791,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e16d10087ae9e375bad7a40e8ef5504bc08e808ccc6019067ff9de42a84570f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "debugid",
  "num-derive",
  "num-traits",
@@ -2718,7 +2806,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1fc14d6ded915b8e850801465e7096f77ed60bf87e4e85878d463720d9dc4d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "byteorder",
  "cfg-if",
  "crash-context",
@@ -2787,6 +2875,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,11 +2898,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2816,7 +2925,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -2838,7 +2947,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2983,8 +3092,93 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2 0.3.1",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2 0.3.1",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2995,9 +3189,80 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
- "dispatch2",
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2 0.3.1",
+ "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2 0.3.1",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2 0.3.1",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -3012,9 +3277,22 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -3025,6 +3303,51 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3137,7 +3460,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3149,6 +3472,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3286,7 +3622,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "hex",
  "serde",
 ]
@@ -3299,7 +3635,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -3309,6 +3645,12 @@ dependencies = [
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3321,6 +3663,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3517,7 +3868,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3526,7 +3877,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3638,7 +3989,7 @@ checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
 dependencies = [
  "ashpd",
  "block2",
- "dispatch2",
+ "dispatch2 0.3.1",
  "js-sys",
  "log",
  "objc2",
@@ -3674,7 +4025,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3717,7 +4068,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3730,7 +4081,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3887,7 +4238,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4134,7 +4485,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytemuck",
  "calloop",
  "calloop-wayland-source",
@@ -4149,8 +4500,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
+ "wayland-protocols 0.32.13",
+ "wayland-protocols-wlr 0.3.12",
  "wayland-scanner",
  "xkbcommon",
  "xkeysym",
@@ -4310,7 +4661,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4587,7 +4938,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5055,7 +5406,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5081,7 +5432,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -5093,7 +5444,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -5111,13 +5462,38 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
 version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
 ]
 
@@ -5127,10 +5503,10 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.32.13",
  "wayland-scanner",
 ]
 
@@ -5141,7 +5517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -5230,6 +5606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,15 +5644,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
+dependencies = [
+ "windows-collections 0.1.1",
+ "windows-core 0.60.1",
+ "windows-future 0.1.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.1.1",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
+dependencies = [
+ "windows-core 0.60.1",
 ]
 
 [[package]]
@@ -5284,11 +5688,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -5301,11 +5718,21 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
+dependencies = [
+ "windows-core 0.60.1",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5317,6 +5744,17 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5355,6 +5793,16 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
+dependencies = [
+ "windows-core 0.60.1",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
@@ -5379,6 +5827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5745,7 +6202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -5806,6 +6263,45 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "xcap"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd25cdb442bb7f63f13fdee2f59d991b04668d37c69aee00dc2a1cc9d0e9a1"
+dependencies = [
+ "dbus",
+ "dispatch2 0.2.0",
+ "image 0.25.10",
+ "lazy_static",
+ "libwayshot",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-media",
+ "objc2-core-video",
+ "objc2-foundation",
+ "percent-encoding",
+ "scopeguard",
+ "thiserror 2.0.18",
+ "widestring",
+ "windows 0.60.0",
+ "xcb",
+]
+
+[[package]]
+name = "xcb"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "quick-xml 0.41.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,10 +122,12 @@ version = "0.55.18"
 dependencies = [
  "agentmux-common",
  "anyhow",
+ "dirs",
  "image 0.25.10",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "uuid",
  "xcap",

--- a/agentmux-mcp/Cargo.toml
+++ b/agentmux-mcp/Cargo.toml
@@ -17,3 +17,9 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+# Cross-platform (Windows/macOS/Linux) window enumeration + capture for the
+# CaptureWindow tool — deliberately not hand-rolled per-platform GDI/
+# CoreGraphics/X11 FFI (see docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md §1.3).
+xcap = "0.4"
+image = { version = "0.25", default-features = false, features = ["png"] }
+uuid = { version = "1", features = ["v4"] }

--- a/agentmux-mcp/Cargo.toml
+++ b/agentmux-mcp/Cargo.toml
@@ -19,11 +19,16 @@ serde_json = "1"
 anyhow = "1"
 # Cross-platform (Windows/macOS/Linux) window enumeration + capture for the
 # CaptureWindow tool — deliberately not hand-rolled per-platform GDI/
-# CoreGraphics/X11 FFI (see docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md §1.3).
+# CoreGraphics/X11 FFI.
 xcap = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "5"
+# Process-tree walking so CaptureWindow can exclude the caller's own
+# AgentMux instance (see main.rs's own_instance_pids() doc comment).
+# Version matches agentmux-srv's own pin — 0.34.2 had a real Windows
+# handle leak (STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md), fixed in 0.35+.
+sysinfo = "0.35"
 
 [dev-dependencies]
 tempfile = "3"

--- a/agentmux-mcp/Cargo.toml
+++ b/agentmux-mcp/Cargo.toml
@@ -23,3 +23,7 @@ anyhow = "1"
 xcap = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }
 uuid = { version = "1", features = ["v4"] }
+dirs = "5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -778,6 +778,53 @@ fn require_agent_env(local_url: &str, auth_key: &str, block_id: &str) -> Result<
     Ok(())
 }
 
+/// Where `CaptureWindow` writes its PNGs. Mirrors `agentmux-srv`'s own
+/// `get_wave_data_dir()` (`AGENTMUX_DATA_HOME` env var, else `~/.agentmux`)
+/// rather than the shared OS temp dir — reagent P2 on this tool's own PR
+/// (#2709 round 1): `std::env::temp_dir()` is world-readable on a
+/// multi-user host, and CaptureWindow can capture arbitrary OS windows
+/// (not just AgentMux's own pane), so a captured image could leak to other
+/// local users. `agentmux-mcp` can't import `agentmux-srv`'s function
+/// directly (separate crate/process), so this replicates its exact logic
+/// instead of inventing a new convention.
+fn capture_window_dir() -> std::path::PathBuf {
+    let base = std::env::var("AGENTMUX_DATA_HOME")
+        .ok()
+        .filter(|d| !d.is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("/"))
+                .join(".agentmux")
+        });
+    base.join("tmp/capture-window")
+}
+
+const CAPTURE_RETENTION: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+/// Same bug class, same fix, as `agentmux-srv`'s `prune_old_screenshots`
+/// (`ui_handlers.rs`, reagent P2, PR #2662) — reapplied here per reagent's
+/// review of this tool's own PR (#2709 round 1), which found it wasn't
+/// reused. Best-effort, on the write path, PNG-only.
+fn prune_old_captures(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("png") {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else { continue };
+        let Ok(modified) = metadata.modified() else { continue };
+        let Ok(age) = now.duration_since(modified) else { continue };
+        if age > CAPTURE_RETENTION {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
 /// The calling agent's slug (its `AGENTMUX_AGENT_ID`), injected by AgentMux into
 /// this MCP server's trusted environment. The App API identity/preset/memory
 /// REST endpoints stamp their `agent_id` from this — the agent's own model
@@ -2025,13 +2072,19 @@ async fn call_tool(
                 .capture_image()
                 .map_err(|e| anyhow::anyhow!("capture failed: {e}"))?;
 
-            let dir = std::env::temp_dir().join("agentmux-capture-window");
+            let dir = capture_window_dir();
             std::fs::create_dir_all(&dir)
-                .map_err(|e| anyhow::anyhow!("failed to create temp dir {}: {e}", dir.display()))?;
+                .map_err(|e| anyhow::anyhow!("failed to create capture dir {}: {e}", dir.display()))?;
             let path = dir.join(format!("{}.png", uuid::Uuid::new_v4()));
             image
                 .save(&path)
                 .map_err(|e| anyhow::anyhow!("failed to save capture to {}: {e}", path.display()))?;
+            // Unbounded growth over repeated/looped calls otherwise — same bug
+            // class as UIScreenshot's own screenshot dir (reagent P2, PR #2662)
+            // and reagent's own review of this PR (round 1) pointing out that
+            // fix wasn't reused here. Same fix, same shape: best-effort, on the
+            // write path.
+            prune_old_captures(&dir);
 
             Ok(format!(
                 "Captured window {title:?} to {} — use Read on that path to view it yourself, or OpenMedia to show it to the user.",
@@ -2727,6 +2780,53 @@ fn format_duration(d: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mirrors `agentmux-srv`'s `prune_old_screenshots_deletes_only_stale_pngs`
+    /// (`ui_handlers.rs`) exactly — same bug class, same fix, same test shape
+    /// (reagent P1/P2 on this tool's own PR, #2709 round 1).
+    #[test]
+    fn prune_old_captures_deletes_only_stale_pngs() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let fresh = dir.path().join("fresh.png");
+        std::fs::write(&fresh, b"png").unwrap();
+
+        let stale = dir.path().join("stale.png");
+        std::fs::write(&stale, b"png").unwrap();
+        let old_time = std::time::SystemTime::now() - (CAPTURE_RETENTION * 2);
+        let file = std::fs::File::options().write(true).open(&stale).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        // Non-PNG files must never be touched, however old.
+        let other = dir.path().join("notes.txt");
+        std::fs::write(&other, b"keep me").unwrap();
+        let file = std::fs::File::options().write(true).open(&other).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        prune_old_captures(dir.path());
+
+        assert!(fresh.exists(), "fresh capture must survive pruning");
+        assert!(!stale.exists(), "stale capture must be pruned");
+        assert!(other.exists(), "non-png files must never be pruned");
+    }
+
+    /// `AGENTMUX_DATA_HOME`, when set, must win over the `~/.agentmux` default
+    /// — the same override `agentmux-srv`'s own `get_wave_data_dir()` honors,
+    /// which this function replicates rather than reinventing.
+    #[test]
+    fn capture_window_dir_honors_agentmux_data_home_override() {
+        // SAFETY: test-only, single-threaded within this process's env;
+        // no other test in this crate reads/writes AGENTMUX_DATA_HOME.
+        unsafe { std::env::set_var("AGENTMUX_DATA_HOME", "/tmp/custom-agentmux-home") };
+        let dir = capture_window_dir();
+        unsafe { std::env::remove_var("AGENTMUX_DATA_HOME") };
+        assert_eq!(
+            dir,
+            std::path::PathBuf::from("/tmp/custom-agentmux-home/tmp/capture-window")
+        );
+    }
 
     /// Every tool advertised by `tools/list` must be valid JSON with a `name`
     /// and `inputSchema` — the server `expect("static json")`s these at runtime,

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -222,6 +222,27 @@ const UI_QUERY_TOOL: &str = r#"{
   }
 }"#;
 
+// docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md
+// §1 — deliberately NOT part of the ui_handlers.rs signed-identity/pane-
+// ownership scheme UIScreenshot/UIClick/UIQuery use: this captures an
+// arbitrary OS window (a DIFFERENT AgentMux instance/process, or any other
+// application), which crosses no AgentMux agent-to-agent trust boundary —
+// there's no shared srv/auth-key domain to protect here, unlike reaching
+// into another agent's pane within this same instance (see that doc §2 for
+// why THAT capability is deliberately not offered by any tool today).
+const CAPTURE_WINDOW_TOOL: &str = r#"{
+  "name": "CaptureWindow",
+  "description": "Screenshot any top-level OS window by (partial, case-insensitive) title match — a DIFFERENT AgentMux instance/process, or any other application on the desktop. Not scoped to AgentMux's own pane/agent boundary (unlike UIScreenshot, which only sees your own pane). Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "title_contains": { "type": "string", "description": "Substring to match against window titles, case-insensitive" },
+      "index": { "type": "number", "description": "If multiple windows match, which one to capture (0-based, default 0). The error message lists all matches when this is ambiguous." }
+    },
+    "required": ["title_contains"]
+  }
+}"#;
+
 // Fleet control (SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md) — select,
 // broadcast, and bulk-act on many agents at once, from an agent's own
 // perspective. FleetList is a thin, fleet-framed alias of DiscoverAgents
@@ -677,6 +698,8 @@ async fn main() {
                     serde_json::from_str(UI_SCREENSHOT_TOOL).expect("static json");
                 let ui_click: Value = serde_json::from_str(UI_CLICK_TOOL).expect("static json");
                 let ui_query: Value = serde_json::from_str(UI_QUERY_TOOL).expect("static json");
+                let capture_window: Value =
+                    serde_json::from_str(CAPTURE_WINDOW_TOOL).expect("static json");
                 let fleet_list: Value = serde_json::from_str(FLEET_LIST_TOOL).expect("static json");
                 let fleet_broadcast: Value =
                     serde_json::from_str(FLEET_BROADCAST_TOOL).expect("static json");
@@ -705,7 +728,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -1957,6 +1980,64 @@ async fn call_tool(
                 result.path
             ))
         }
+        "CaptureWindow" => {
+            let title_contains = arguments
+                .get("title_contains")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: title_contains"))?;
+            let index = arguments
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize;
+
+            let windows =
+                xcap::Window::all().map_err(|e| anyhow::anyhow!("failed to enumerate windows: {e}"))?;
+            let needle = title_contains.to_lowercase();
+            let matches: Vec<&xcap::Window> = windows
+                .iter()
+                .filter(|w| {
+                    w.title()
+                        .map(|t| t.to_lowercase().contains(&needle))
+                        .unwrap_or(false)
+                })
+                .collect();
+
+            if matches.is_empty() {
+                let titles: Vec<String> = windows
+                    .iter()
+                    .filter_map(|w| w.title().ok())
+                    .filter(|t| !t.is_empty())
+                    .collect();
+                anyhow::bail!(
+                    "no window title contains {title_contains:?}. Visible window titles: {}",
+                    titles.join(", ")
+                );
+            }
+            let window = matches.get(index).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "index {index} out of range — only {} window(s) matched {title_contains:?}",
+                    matches.len()
+                )
+            })?;
+            let title = window.title().unwrap_or_default();
+
+            let image = window
+                .capture_image()
+                .map_err(|e| anyhow::anyhow!("capture failed: {e}"))?;
+
+            let dir = std::env::temp_dir().join("agentmux-capture-window");
+            std::fs::create_dir_all(&dir)
+                .map_err(|e| anyhow::anyhow!("failed to create temp dir {}: {e}", dir.display()))?;
+            let path = dir.join(format!("{}.png", uuid::Uuid::new_v4()));
+            image
+                .save(&path)
+                .map_err(|e| anyhow::anyhow!("failed to save capture to {}: {e}", path.display()))?;
+
+            Ok(format!(
+                "Captured window {title:?} to {} — use Read on that path to view it yourself, or OpenMedia to show it to the user.",
+                path.display()
+            ))
+        }
         "UIClick" => {
             require_agent_env(local_url, auth_key, block_id)?;
             let auth = sign_ui_automation_auth()?;
@@ -2688,6 +2769,7 @@ mod tests {
             FLEET_LIST_TOOL,
             FLEET_BROADCAST_TOOL,
             FLEET_BULK_STOP_TOOL,
+            CAPTURE_WINDOW_TOOL,
         ];
         // This array (and its count) has drifted from the real `tools/list`
         // response before this change too — SHELL_INPUT/STATUS, the three
@@ -2697,8 +2779,10 @@ mod tests {
         // (SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md) alongside the 3
         // memory-version-history tools merged in from a concurrent PR, on
         // top of whatever this test already covered, so at least those
-        // don't silently join the drift.
-        assert_eq!(defs.len(), 33, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools");
+        // don't silently join the drift. CAPTURE_WINDOW_TOOL added here too
+        // (ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md)
+        // — same reasoning, not fixing the pre-existing drift.
+        assert_eq!(defs.len(), 34, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -222,22 +222,31 @@ const UI_QUERY_TOOL: &str = r#"{
   }
 }"#;
 
-// docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md
-// §1 — deliberately NOT part of the ui_handlers.rs signed-identity/pane-
-// ownership scheme UIScreenshot/UIClick/UIQuery use: this captures an
-// arbitrary OS window (a DIFFERENT AgentMux instance/process, or any other
-// application), which crosses no AgentMux agent-to-agent trust boundary —
-// there's no shared srv/auth-key domain to protect here, unlike reaching
-// into another agent's pane within this same instance (see that doc §2 for
-// why THAT capability is deliberately not offered by any tool today).
+// Deliberately NOT part of the ui_handlers.rs signed-identity/pane-ownership
+// scheme UIScreenshot/UIClick/UIQuery use: this captures a DIFFERENT
+// AgentMux instance/process's top-level window (e.g. a separate `task dev`
+// build), which crosses no agent-to-agent trust boundary within one
+// instance — there's no shared srv/auth-key domain to protect there, unlike
+// reaching into another agent's pane within this same instance (that
+// capability is deliberately not offered by any tool today — see
+// docs/specs/SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md §6 and
+// PR #2662's history of real vulnerabilities found in that exact area).
+//
+// Scoped to AgentMux's own windows only (matched via app_name(), not an
+// unrestricted OS-wide target) — reagent P1 (PR #2709 round 2): an earlier
+// version of this tool could screenshot ANY top-level window, which is the
+// "arbitrary third-party app" capability docs/specs/computer-use-pane.md
+// (draft, unbuilt) already scopes out as needing its own per-app approval
+// gating, mutex, and app-tier warnings before ever being built — not
+// something to back into accidentally via a narrower tool's scope creep.
 const CAPTURE_WINDOW_TOOL: &str = r#"{
   "name": "CaptureWindow",
-  "description": "Screenshot any top-level OS window by (partial, case-insensitive) title match — a DIFFERENT AgentMux instance/process, or any other application on the desktop. Not scoped to AgentMux's own pane/agent boundary (unlike UIScreenshot, which only sees your own pane). Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user.",
+  "description": "Screenshot a DIFFERENT AgentMux window/instance by (partial, case-insensitive) title match — e.g. a separate task dev build running alongside this one. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool). Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user.",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "title_contains": { "type": "string", "description": "Substring to match against window titles, case-insensitive" },
-      "index": { "type": "number", "description": "If multiple windows match, which one to capture (0-based, default 0). The error message lists all matches when this is ambiguous." }
+      "title_contains": { "type": "string", "description": "Substring to match against other AgentMux windows' titles, case-insensitive" },
+      "index": { "type": "number", "description": "If multiple AgentMux windows match, which one to capture (0-based, default 0). The error message lists all matching AgentMux window titles when this is ambiguous." }
     },
     "required": ["title_contains"]
   }
@@ -2039,8 +2048,27 @@ async fn call_tool(
 
             let windows =
                 xcap::Window::all().map_err(|e| anyhow::anyhow!("failed to enumerate windows: {e}"))?;
+            // Scoped to AgentMux's own processes only — reagent P1 (PR #2709
+            // round 2): as originally written, this reached ANY top-level OS
+            // window (confirmed in testing: it could screenshot a KeePass
+            // password-manager window with zero gating), which is the
+            // "arbitrary third-party app" capability `docs/specs/computer-use-pane.md`
+            // already scoped out as needing its own per-app approval model —
+            // not this tool's actual motivating need, which was only ever
+            // "see a different AgentMux instance's window." `app_name()`
+            // matching (not `title()`) because AgentMux's own process names
+            // are version-stamped (`agentmux-0.55.18`, etc.), not a single
+            // fixed string, but they all share the `agentmux` prefix.
+            let agentmux_windows: Vec<&xcap::Window> = windows
+                .iter()
+                .filter(|w| {
+                    w.app_name()
+                        .map(|a| a.to_lowercase().starts_with("agentmux"))
+                        .unwrap_or(false)
+                })
+                .collect();
             let needle = title_contains.to_lowercase();
-            let matches: Vec<&xcap::Window> = windows
+            let matches: Vec<&&xcap::Window> = agentmux_windows
                 .iter()
                 .filter(|w| {
                     w.title()
@@ -2050,13 +2078,28 @@ async fn call_tool(
                 .collect();
 
             if matches.is_empty() {
-                let titles: Vec<String> = windows
+                // Only lists OTHER AgentMux windows' titles, not every
+                // window on the desktop — reagent P2 (PR #2709 round 2):
+                // the original version dumped every visible window's title
+                // on any miss, which let a caller enumerate arbitrary
+                // window titles (confirmed in testing: this leaked a
+                // password manager's document title) with no real match
+                // required at all. Still helpful for the actual in-scope
+                // case (multiple AgentMux instances open) without that leak.
+                let titles: Vec<String> = agentmux_windows
                     .iter()
                     .filter_map(|w| w.title().ok())
                     .filter(|t| !t.is_empty())
                     .collect();
+                if titles.is_empty() {
+                    anyhow::bail!(
+                        "no AgentMux window title contains {title_contains:?} — \
+                         no other AgentMux windows are currently open"
+                    );
+                }
                 anyhow::bail!(
-                    "no window title contains {title_contains:?}. Visible window titles: {}",
+                    "no AgentMux window title contains {title_contains:?}. \
+                     Open AgentMux window titles: {}",
                     titles.join(", ")
                 );
             }

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -246,7 +246,7 @@ const UI_QUERY_TOOL: &str = r#"{
 // something to back into accidentally via a narrower tool's scope creep.
 const CAPTURE_WINDOW_TOOL: &str = r#"{
   "name": "CaptureWindow",
-  "description": "Screenshot a DIFFERENT AgentMux window/instance by (partial, case-insensitive) title match — e.g. a separate task dev build running alongside this one. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool). Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user.",
+  "description": "Screenshot a DIFFERENT AgentMux window/instance by (partial, case-insensitive) title match — e.g. a separate task dev build running alongside this one. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool), and never your own instance's window. Every call is logged (who, what, outcome) to an audit trail in this instance's own data dir — a full approval/capability-flag gate is tracked separately, not yet built. Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -911,6 +911,159 @@ fn own_instance_pids() -> std::collections::HashSet<u32> {
         }
     }
     result
+}
+
+/// The actual `CaptureWindow` logic — window enumeration, own-instance and
+/// third-party-app exclusion, capture, and save. Extracted to its own
+/// function (rather than living inline in the `"CaptureWindow" =>` match
+/// arm) so its `Result` can be captured once and unconditionally audit-
+/// logged by the caller before propagating — see `audit_log_capture_window`.
+fn capture_window_impl(title_contains: &str, index: usize) -> Result<String> {
+    let windows =
+        xcap::Window::all().map_err(|e| anyhow::anyhow!("failed to enumerate windows: {e}"))?;
+    // Scoped to AgentMux's own processes only — reagent P1 (PR #2709
+    // round 2): as originally written, this reached ANY top-level OS
+    // window (confirmed in testing: it could screenshot a KeePass
+    // password-manager window with zero gating), which is the
+    // "arbitrary third-party app" capability `docs/specs/computer-use-pane.md`
+    // already scoped out as needing its own per-app approval model —
+    // not this tool's actual motivating need, which was only ever
+    // "see a different AgentMux instance's window." `app_name()`
+    // matching (not `title()`) because AgentMux's own process names
+    // are version-stamped (`agentmux-0.55.18`, etc.), not a single
+    // fixed string, but they all share the `agentmux` prefix.
+    // Excludes the CALLING agent's own instance — reagent P0 (PR
+    // #2709 round 3): the app_name()-only filter above matches every
+    // AgentMux instance's windows, including this one. One AgentMux
+    // instance's top-level window contains every agent's pane in it
+    // (pane-level isolation is enforced only inside that window, via
+    // the signed-identity scheme UIScreenshot/UIClick/UIQuery use —
+    // see the doc comment above CAPTURE_WINDOW_TOOL). Without this
+    // exclusion, any agent could pass a title_contains matching its
+    // OWN instance's window and capture every other agent's pane
+    // content in that same window — exactly the isolation boundary
+    // this tool claims not to cross. See own_instance_pids()'s own
+    // doc comment for how "same instance" is determined.
+    let own_pids = own_instance_pids();
+    let agentmux_windows: Vec<&xcap::Window> = windows
+        .iter()
+        .filter(|w| {
+            let is_agentmux = w
+                .app_name()
+                .map(|a| a.to_lowercase().starts_with("agentmux"))
+                .unwrap_or(false);
+            let is_own_instance = w.pid().map(|p| own_pids.contains(&p)).unwrap_or(true);
+            is_agentmux && !is_own_instance
+        })
+        .collect();
+    let needle = title_contains.to_lowercase();
+    let matches: Vec<&&xcap::Window> = agentmux_windows
+        .iter()
+        .filter(|w| {
+            w.title()
+                .map(|t| t.to_lowercase().contains(&needle))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if matches.is_empty() {
+        // Only lists OTHER AgentMux windows' titles, not every
+        // window on the desktop — reagent P2 (PR #2709 round 2):
+        // the original version dumped every visible window's title
+        // on any miss, which let a caller enumerate arbitrary
+        // window titles (confirmed in testing: this leaked a
+        // password manager's document title) with no real match
+        // required at all. Still helpful for the actual in-scope
+        // case (multiple AgentMux instances open) without that leak.
+        let titles: Vec<String> = agentmux_windows
+            .iter()
+            .filter_map(|w| w.title().ok())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if titles.is_empty() {
+            anyhow::bail!(
+                "no AgentMux window title contains {title_contains:?} — \
+                 no other AgentMux windows are currently open"
+            );
+        }
+        anyhow::bail!(
+            "no AgentMux window title contains {title_contains:?}. \
+             Open AgentMux window titles: {}",
+            titles.join(", ")
+        );
+    }
+    let window = matches.get(index).ok_or_else(|| {
+        anyhow::anyhow!(
+            "index {index} out of range — only {} window(s) matched {title_contains:?}",
+            matches.len()
+        )
+    })?;
+    let title = window.title().unwrap_or_default();
+
+    let image = window
+        .capture_image()
+        .map_err(|e| anyhow::anyhow!("capture failed: {e}"))?;
+
+    let dir = capture_window_dir();
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| anyhow::anyhow!("failed to create capture dir {}: {e}", dir.display()))?;
+    let path = dir.join(format!("{}.png", uuid::Uuid::new_v4()));
+    image
+        .save(&path)
+        .map_err(|e| anyhow::anyhow!("failed to save capture to {}: {e}", path.display()))?;
+    // Unbounded growth over repeated/looped calls otherwise — same bug
+    // class as UIScreenshot's own screenshot dir (reagent P2, PR #2662)
+    // and reagent's own review of this PR (round 1) pointing out that
+    // fix wasn't reused here. Same fix, same shape: best-effort, on the
+    // write path.
+    prune_old_captures(&dir);
+
+    Ok(format!(
+        "Captured window {title:?} to {} — use Read on that path to view it yourself, or OpenMedia to show it to the user.",
+        path.display()
+    ))
+}
+
+/// Audit trail for `CaptureWindow` — reagent P1 (PR #2709 round 4): the
+/// residual risk after rounds 2-3's scoping (a different AgentMux
+/// instance's window, which can belong to a different OS user on a shared
+/// machine) is a disclosure-across-a-human-boundary question, not a
+/// technical one a capability flag alone would fully answer — a real
+/// per-agent opt-in gate is tracked as a separate follow-up (no existing
+/// settings/enforcement mechanism to build it on today). Logging every
+/// call — who, what was requested, what happened — is the honest,
+/// shippable Phase-1 answer: best-effort (a logging failure must never
+/// break the tool itself), append-only NDJSON inside `capture_window_dir()`
+/// itself — `prune_old_captures`'s PNG-only extension filter already
+/// leaves a `.log` file in that same directory untouched, so this doesn't
+/// need (or want) its own separate directory alongside it.
+fn audit_log_capture_window(title_contains: &str, outcome: &Result<String>) {
+    let entry = serde_json::json!({
+        "timestamp": std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        "agent_id": agent_slug().unwrap_or_else(|_| "unknown".to_string()),
+        "tool": "CaptureWindow",
+        "title_contains": title_contains,
+        "outcome": match outcome {
+            Ok(msg) => serde_json::json!({"result": "success", "detail": msg}),
+            Err(e) => serde_json::json!({"result": "error", "detail": e.to_string()}),
+        },
+    });
+    let dir = capture_window_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let line = format!("{entry}\n");
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("capture-window-audit.log"))
+    {
+        use std::io::Write;
+        let _ = f.write_all(line.as_bytes());
+    }
 }
 
 /// The calling agent's slug (its `AGENTMUX_AGENT_ID`), injected by AgentMux into
@@ -2119,115 +2272,28 @@ async fn call_tool(
             let title_contains = arguments
                 .get("title_contains")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow::anyhow!("missing required parameter: title_contains"))?;
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: title_contains"))?
+                .to_string();
             let index = arguments
                 .get("index")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0) as usize;
 
-            let windows =
-                xcap::Window::all().map_err(|e| anyhow::anyhow!("failed to enumerate windows: {e}"))?;
-            // Scoped to AgentMux's own processes only — reagent P1 (PR #2709
-            // round 2): as originally written, this reached ANY top-level OS
-            // window (confirmed in testing: it could screenshot a KeePass
-            // password-manager window with zero gating), which is the
-            // "arbitrary third-party app" capability `docs/specs/computer-use-pane.md`
-            // already scoped out as needing its own per-app approval model —
-            // not this tool's actual motivating need, which was only ever
-            // "see a different AgentMux instance's window." `app_name()`
-            // matching (not `title()`) because AgentMux's own process names
-            // are version-stamped (`agentmux-0.55.18`, etc.), not a single
-            // fixed string, but they all share the `agentmux` prefix.
-            // Excludes the CALLING agent's own instance — reagent P0 (PR
-            // #2709 round 3): the app_name()-only filter above matches every
-            // AgentMux instance's windows, including this one. One AgentMux
-            // instance's top-level window contains every agent's pane in it
-            // (pane-level isolation is enforced only inside that window, via
-            // the signed-identity scheme UIScreenshot/UIClick/UIQuery use —
-            // see the doc comment above CAPTURE_WINDOW_TOOL). Without this
-            // exclusion, any agent could pass a title_contains matching its
-            // OWN instance's window and capture every other agent's pane
-            // content in that same window — exactly the isolation boundary
-            // this tool claims not to cross. See own_instance_pids()'s own
-            // doc comment for how "same instance" is determined.
-            let own_pids = own_instance_pids();
-            let agentmux_windows: Vec<&xcap::Window> = windows
-                .iter()
-                .filter(|w| {
-                    let is_agentmux = w
-                        .app_name()
-                        .map(|a| a.to_lowercase().starts_with("agentmux"))
-                        .unwrap_or(false);
-                    let is_own_instance = w.pid().map(|p| own_pids.contains(&p)).unwrap_or(true);
-                    is_agentmux && !is_own_instance
-                })
-                .collect();
-            let needle = title_contains.to_lowercase();
-            let matches: Vec<&&xcap::Window> = agentmux_windows
-                .iter()
-                .filter(|w| {
-                    w.title()
-                        .map(|t| t.to_lowercase().contains(&needle))
-                        .unwrap_or(false)
-                })
-                .collect();
-
-            if matches.is_empty() {
-                // Only lists OTHER AgentMux windows' titles, not every
-                // window on the desktop — reagent P2 (PR #2709 round 2):
-                // the original version dumped every visible window's title
-                // on any miss, which let a caller enumerate arbitrary
-                // window titles (confirmed in testing: this leaked a
-                // password manager's document title) with no real match
-                // required at all. Still helpful for the actual in-scope
-                // case (multiple AgentMux instances open) without that leak.
-                let titles: Vec<String> = agentmux_windows
-                    .iter()
-                    .filter_map(|w| w.title().ok())
-                    .filter(|t| !t.is_empty())
-                    .collect();
-                if titles.is_empty() {
-                    anyhow::bail!(
-                        "no AgentMux window title contains {title_contains:?} — \
-                         no other AgentMux windows are currently open"
-                    );
-                }
-                anyhow::bail!(
-                    "no AgentMux window title contains {title_contains:?}. \
-                     Open AgentMux window titles: {}",
-                    titles.join(", ")
-                );
-            }
-            let window = matches.get(index).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "index {index} out of range — only {} window(s) matched {title_contains:?}",
-                    matches.len()
-                )
-            })?;
-            let title = window.title().unwrap_or_default();
-
-            let image = window
-                .capture_image()
-                .map_err(|e| anyhow::anyhow!("capture failed: {e}"))?;
-
-            let dir = capture_window_dir();
-            std::fs::create_dir_all(&dir)
-                .map_err(|e| anyhow::anyhow!("failed to create capture dir {}: {e}", dir.display()))?;
-            let path = dir.join(format!("{}.png", uuid::Uuid::new_v4()));
-            image
-                .save(&path)
-                .map_err(|e| anyhow::anyhow!("failed to save capture to {}: {e}", path.display()))?;
-            // Unbounded growth over repeated/looped calls otherwise — same bug
-            // class as UIScreenshot's own screenshot dir (reagent P2, PR #2662)
-            // and reagent's own review of this PR (round 1) pointing out that
-            // fix wasn't reused here. Same fix, same shape: best-effort, on the
-            // write path.
-            prune_old_captures(&dir);
-
-            Ok(format!(
-                "Captured window {title:?} to {} — use Read on that path to view it yourself, or OpenMedia to show it to the user.",
-                path.display()
-            ))
+            // Audit trail, not a capability gate — reagent P1 (PR #2709
+            // round 4): a real per-agent opt-in gate is a bigger feature
+            // (settings storage + enforcement, no existing mechanism
+            // anywhere in the codebase to build on — confirmed by the
+            // spec this tool's own doc comment already cites) than fits
+            // reactively on this PR, and this tool's actual residual risk
+            // after rounds 2-3's scoping is disclosure across a human
+            // boundary (a different AgentMux instance's window can belong
+            // to a different OS user on a shared machine), not a technical
+            // one — logging every call (who, what was requested, what
+            // happened) is the honest, shippable Phase-1 answer while the
+            // real gate is tracked separately (operator-confirmed).
+            let outcome = capture_window_impl(&title_contains, index);
+            audit_log_capture_window(&title_contains, &outcome);
+            return outcome;
         }
         "UIClick" => {
             require_agent_env(local_url, auth_key, block_id)?;
@@ -2919,6 +2985,16 @@ fn format_duration(d: Duration) -> String {
 mod tests {
     use super::*;
 
+    /// Guards every test that mutates `AGENTMUX_DATA_HOME` (a process-global
+    /// env var) so they never run concurrently against each other — cargo
+    /// runs tests in parallel by default, and two tests independently
+    /// setting/clearing the same env var would otherwise be a genuine race,
+    /// not just a stale comment. Acquire this at the start of any such test,
+    /// before touching the env var, and hold it for the env var's entire
+    /// mutated lifetime (not just around `capture_window_dir()`/
+    /// `audit_log_capture_window()` themselves).
+    static DATA_HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Mirrors `agentmux-srv`'s `prune_old_screenshots_deletes_only_stale_pngs`
     /// (`ui_handlers.rs`) exactly — same bug class, same fix, same test shape
     /// (reagent P1/P2 on this tool's own PR, #2709 round 1).
@@ -2955,8 +3031,11 @@ mod tests {
     /// which this function replicates rather than reinventing.
     #[test]
     fn capture_window_dir_honors_agentmux_data_home_override() {
-        // SAFETY: test-only, single-threaded within this process's env;
-        // no other test in this crate reads/writes AGENTMUX_DATA_HOME.
+        // SAFETY: test-only; DATA_HOME_ENV_LOCK held for the env var's
+        // entire mutated lifetime serializes this against every other test
+        // that touches AGENTMUX_DATA_HOME (see that lock's own doc comment
+        // — cargo runs tests in parallel by default, so this isn't optional).
+        let _guard = DATA_HOME_ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("AGENTMUX_DATA_HOME", "/tmp/custom-agentmux-home") };
         let dir = capture_window_dir();
         unsafe { std::env::remove_var("AGENTMUX_DATA_HOME") };
@@ -2983,6 +3062,38 @@ mod tests {
             pids.contains(&std::process::id()),
             "own_instance_pids() must always include this process's own pid"
         );
+    }
+
+    /// `audit_log_capture_window` must append one valid NDJSON line per
+    /// call, for both success and failure outcomes, without ever panicking
+    /// or returning an error to its caller (it's a fire-and-forget
+    /// best-effort side effect — reagent P1, PR #2709 round 4).
+    #[test]
+    fn audit_log_capture_window_appends_ndjson_for_success_and_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: test-only; see DATA_HOME_ENV_LOCK's own doc comment for
+        // why this guard (not just the tempdir) is required.
+        let _guard = DATA_HOME_ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("AGENTMUX_DATA_HOME", dir.path()) };
+
+        audit_log_capture_window("first query", &Ok("captured ok".to_string()));
+        audit_log_capture_window("second query", &Err(anyhow::anyhow!("no match")));
+
+        unsafe { std::env::remove_var("AGENTMUX_DATA_HOME") };
+
+        let log_path = dir.path().join("tmp/capture-window/capture-window-audit.log");
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2, "one NDJSON line per call");
+
+        let first: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["tool"], "CaptureWindow");
+        assert_eq!(first["title_contains"], "first query");
+        assert_eq!(first["outcome"]["result"], "success");
+
+        let second: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["title_contains"], "second query");
+        assert_eq!(second["outcome"]["result"], "error");
     }
 
     /// Every tool advertised by `tools/list` must be valid JSON with a `name`

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -231,6 +231,11 @@ const UI_QUERY_TOOL: &str = r#"{
 // capability is deliberately not offered by any tool today — see
 // docs/specs/SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md §6 and
 // PR #2662's history of real vulnerabilities found in that exact area).
+// "Crosses no boundary within one instance" is an enforced invariant, not
+// just a design intent — see own_instance_pids()'s doc comment (reagent P0,
+// PR #2709 round 3): the caller's OWN instance is always excluded from the
+// candidate set, since one instance's top-level window contains every
+// agent's pane in it.
 //
 // Scoped to AgentMux's own windows only (matched via app_name(), not an
 // unrestricted OS-wide target) — reagent P1 (PR #2709 round 2): an earlier
@@ -832,6 +837,80 @@ fn prune_old_captures(dir: &std::path::Path) {
             let _ = std::fs::remove_file(&path);
         }
     }
+}
+
+/// Max ancestor hops to walk from this MCP process before giving up —
+/// bounds the fallback search (see `own_instance_pids`'s doc comment for why
+/// this is a fallback, not the primary signal), while never walking so far
+/// up the tree (e.g. to `explorer.exe`) that "same instance" degrades into
+/// "everything on the desktop."
+const OWN_INSTANCE_ANCESTOR_HOPS: usize = 8;
+
+/// PIDs `CaptureWindow` must treat as "this agent's own AgentMux instance"
+/// and always exclude — reagent P0 (PR #2709 round 3).
+///
+/// **Primary signal: `AGENTMUX_APP_PATH`.** Every process belonging to this
+/// exact running instance (portable build or install) is launched from
+/// under that one directory — confirmed directly (not assumed): this
+/// agent's own host process's `Process::exe()` path
+/// (`...\agentmux-0.55.18+....-x64-portable\runtime\agentmux-0.55.18.exe`)
+/// starts with `AGENTMUX_APP_PATH`
+/// (`...\agentmux-0.55.18+....-x64-portable`) exactly. This is more precise
+/// than matching on version number alone — it correctly tells apart two
+/// separate instances that happen to share a version (e.g. two portable
+/// builds of the same release), which a version-string match would
+/// conflate.
+///
+/// **Fallback signal: bounded process-ancestor walk.** Kept as a second,
+/// additive layer (union, not replacement) for the case `AGENTMUX_APP_PATH`
+/// isn't set (confirmed present for `AGENTMUX_RUNTIME_MODE=portable`; not
+/// separately confirmed for `task dev` instances). **This alone is not
+/// reliable** — verified directly by testing: Windows recycles PIDs and a
+/// process's recorded parent-PID can point at an already-exited process, so
+/// `sys.process(stale_ppid)` returns `None` and the walk silently stops
+/// short of the real ancestor chain. Confirmed this exact failure in
+/// testing (the walk never reached this instance's own host process). Kept
+/// only as defense-in-depth alongside the path-based signal, never alone.
+///
+/// Fails safe: an unresolvable `pid()` on a *candidate* window (checked by
+/// the caller, `CaptureWindow`'s handler) is treated as "assume it's mine,
+/// exclude it" — so a window this function's own signals can't positively
+/// place is still excluded, not silently let through.
+fn own_instance_pids() -> std::collections::HashSet<u32> {
+    let sys = sysinfo::System::new_all();
+    let mut result = std::collections::HashSet::new();
+
+    if let Ok(app_path) = std::env::var("AGENTMUX_APP_PATH") {
+        if !app_path.is_empty() {
+            let app_path = std::path::Path::new(&app_path);
+            for (pid, proc) in sys.processes() {
+                if proc.exe().map(|e| e.starts_with(app_path)).unwrap_or(false) {
+                    result.insert(pid.as_u32());
+                }
+            }
+        }
+    }
+
+    let my_pid = sysinfo::Pid::from(std::process::id() as usize);
+    let mut ancestors = vec![my_pid];
+    let mut current = my_pid;
+    for _ in 0..OWN_INSTANCE_ANCESTOR_HOPS {
+        let Some(proc) = sys.process(current) else { break };
+        let Some(parent) = proc.parent() else { break };
+        ancestors.push(parent);
+        current = parent;
+    }
+    result.extend(ancestors.iter().map(|p| p.as_u32()));
+    for (pid, proc) in sys.processes() {
+        let Some(ppid) = proc.parent() else { continue };
+        if !ancestors.contains(&ppid) {
+            continue;
+        }
+        if proc.name().to_string_lossy().to_lowercase().starts_with("agentmux") {
+            result.insert(pid.as_u32());
+        }
+    }
+    result
 }
 
 /// The calling agent's slug (its `AGENTMUX_AGENT_ID`), injected by AgentMux into
@@ -2059,12 +2138,28 @@ async fn call_tool(
             // matching (not `title()`) because AgentMux's own process names
             // are version-stamped (`agentmux-0.55.18`, etc.), not a single
             // fixed string, but they all share the `agentmux` prefix.
+            // Excludes the CALLING agent's own instance — reagent P0 (PR
+            // #2709 round 3): the app_name()-only filter above matches every
+            // AgentMux instance's windows, including this one. One AgentMux
+            // instance's top-level window contains every agent's pane in it
+            // (pane-level isolation is enforced only inside that window, via
+            // the signed-identity scheme UIScreenshot/UIClick/UIQuery use —
+            // see the doc comment above CAPTURE_WINDOW_TOOL). Without this
+            // exclusion, any agent could pass a title_contains matching its
+            // OWN instance's window and capture every other agent's pane
+            // content in that same window — exactly the isolation boundary
+            // this tool claims not to cross. See own_instance_pids()'s own
+            // doc comment for how "same instance" is determined.
+            let own_pids = own_instance_pids();
             let agentmux_windows: Vec<&xcap::Window> = windows
                 .iter()
                 .filter(|w| {
-                    w.app_name()
+                    let is_agentmux = w
+                        .app_name()
                         .map(|a| a.to_lowercase().starts_with("agentmux"))
-                        .unwrap_or(false)
+                        .unwrap_or(false);
+                    let is_own_instance = w.pid().map(|p| own_pids.contains(&p)).unwrap_or(true);
+                    is_agentmux && !is_own_instance
                 })
                 .collect();
             let needle = title_contains.to_lowercase();
@@ -2871,6 +2966,25 @@ mod tests {
         );
     }
 
+    /// `own_instance_pids()` must always include the calling process's own
+    /// pid at minimum (the first element of its ancestor-walk fallback,
+    /// independent of whether `AGENTMUX_APP_PATH` is set in this test's
+    /// environment). Not a full behavioral test of the exclusion logic
+    /// itself — mocking `sysinfo`'s real OS process table isn't practical —
+    /// but it does verify the function runs without panicking and its one
+    /// environment-independent guarantee holds. The actual exclusion
+    /// behavior (reagent P0, PR #2709 round 3) was verified manually against
+    /// this repo's own live process tree — see that commit's message for
+    /// the before/after evidence.
+    #[test]
+    fn own_instance_pids_always_includes_the_calling_process_itself() {
+        let pids = own_instance_pids();
+        assert!(
+            pids.contains(&std::process::id()),
+            "own_instance_pids() must always include this process's own pid"
+        );
+    }
+
     /// Every tool advertised by `tools/list` must be valid JSON with a `name`
     /// and `inputSchema` — the server `expect("static json")`s these at runtime,
     /// so a malformed const would panic on the first `tools/list`. Also pins the
@@ -2923,8 +3037,7 @@ mod tests {
         // memory-version-history tools merged in from a concurrent PR, on
         // top of whatever this test already covered, so at least those
         // don't silently join the drift. CAPTURE_WINDOW_TOOL added here too
-        // (ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md)
-        // — same reasoning, not fixing the pre-existing drift.
+        // (PR #2709) — same reasoning, not fixing the pre-existing drift.
         assert_eq!(defs.len(), 34, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");

--- a/docs/specs/SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md
+++ b/docs/specs/SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md
@@ -371,6 +371,59 @@ harden:
      boundary given AgentMux has zero OS-level capture/injection code to
      build on today.
 
+## 6.1 2026-08-21 addendum — narrow interim exception for `CaptureWindow` (repo-owner confirmed)
+
+**This is a real, narrow, repo-owner-confirmed exception, not a claim of a
+blanket policy change** — recorded here specifically so it's a citable spec
+diff, not just a commit-message assertion, matching this repo's own
+established standard for distinguishing a genuine decision from an
+unverified one (see `CLAUDE.md`'s jekt security section for the same
+pattern applied to a different subsystem: a real change ships with a spec
+diff and tests, not just prose).
+
+**What's confirmed, directly, by the repo owner, in this conversation, on
+this date:** PR #2709's `CaptureWindow` tool — OS-level window capture via
+`xcap`, which §5 places out of Phase-1 scope in its general form — ships
+with **audit logging only**, not the capability-flag gate §6
+recommendation 2 requires, as an accepted interim state. The full gate is
+tracked separately: issue #2714 (agentmuxai/agentmux).
+
+**Why this is narrower than "§5's out-of-scope boundary no longer applies":**
+
+1. §5's stated reason for excluding the `xcap`/`computer-use-pane.md`
+   approach was "arbitrary third-party apps, real OS input queue, no DOM
+   ground-truth" — `CaptureWindow` doesn't have that shape. It's
+   screenshot-only (no input injection at all — `enigo` is not a
+   dependency), and scoped to AgentMux's own windows specifically (matched
+   via `app_name()`, verified in testing to exclude non-AgentMux
+   applications — confirmed capturing a password-manager window was
+   possible before this scoping and is not possible after it). The
+   residual capability is closer to "see a different AgentMux instance,"
+   not "drive an arbitrary desktop app."
+2. It also excludes the caller's own instance (verified in live testing
+   against this repo's actual running process tree, not assumed — see PR
+   #2709's commit history for the before/after evidence), which closes the
+   worse of the two risks §6 already names for cross-window targeting
+   generally (reading/acting on a *different agent's* pane within the same
+   instance). What's left is narrower: a different AgentMux *instance's*
+   window, which can belong to a different OS *user* on a shared machine —
+   a real residual risk, not eliminated, which is exactly why the interim
+   answer is audit logging (detection) rather than a claim that the risk is
+   fully closed.
+3. §6 recommendation 4 (audit logging, "actor, target, timestamp") is
+   satisfied for this tool specifically — every call appends an NDJSON
+   entry to `capture-window-audit.log` in the instance's own private data
+   dir.
+
+**What's still genuinely open, not resolved by this addendum:** §6
+recommendation 2's capability-flag gate itself. This addendum does not
+claim that requirement is satisfied — it records a deliberate, scoped,
+time-bounded exception to shipping without it for this one tool, pending
+issue #2714. A future PR that wants to *widen* `CaptureWindow` (e.g. add
+input injection, or drop the AgentMux-only/own-instance-exclusion scoping)
+would need its own fresh justification — this addendum covers exactly what
+shipped in PR #2709, not a general loosening of §5/§6.
+
 ## 7. Relationship to today's fix
 
 The muxbus sign-in Cancel-button fix that prompted this spec


### PR DESCRIPTION
## Summary

- `UIScreenshot` is (deliberately) scoped to only the caller's own pane — a real credential/content-isolation boundary within one AgentMux instance (see `docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md` §2 for the full history, including a real P0 that boundary was closing).
- No agent-facing tool exists for screenshotting a genuinely *different* OS window — a separate AgentMux instance, or any other application. That crosses no agent-to-agent trust boundary at all (no shared srv/auth-key domain), so it's a much lower-risk, separately-scoped gap (see the same analysis doc, §1).
- New `CaptureWindow` MCP tool fills that gap: matches a top-level window by partial title, captures via `xcap` (cross-platform), independent of `ui_handlers.rs`'s signed-identity scheme entirely.

## Verification

Built + tested on Windows: `cargo build -p agentmux-mcp` / `cargo test -p agentmux-mcp` clean, 4/4 tests pass. Drove the compiled binary directly over JSON-RPC (no env vars set — confirms it needs none) and captured a real, separate AgentMux instance's window; verified the resulting PNG visually.

**macOS/Linux unverified from this machine** — tracked in #2708.

## Test plan
- [x] `cargo build -p agentmux-mcp`
- [x] `cargo test -p agentmux-mcp`
- [x] Manual JSON-RPC `tools/call` against the built binary, verified output PNG
- [ ] macOS build/run (tracked separately, #2708)
- [ ] Linux build/run (tracked separately, #2708)

<!-- agentmux:agent_id=agenty -->