### PR TITLE
docs: session-continuity investigation — retro, status, and two follow-up specs

### DIFF
--- a/docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md
+++ b/docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md
@@ -1,0 +1,232 @@
+# Analysis + Plan: Widening `UIScreenshot`/`UIClick`/`UIQuery` beyond "your own pane"
+
+**Status:** analysis, not implemented. One half has a clear, low-risk path; the
+other half is a genuine security-design task, not a quick widening.
+**Author:** AgentY
+**Date:** 2026-08-21
+**Related:** `docs/specs/SPEC_AGENT_GENERIC_PANE_OPEN_TOOL_2026_08_21.md` (the
+sibling "make agent-facing pane control general-purpose" effort this
+continues), `docs/specs/SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md`
+(the existing design — already anticipates and explicitly defers exactly this
+ask), `agentmux-srv/src/server/ui_handlers.rs`, `agentmux-mcp/src/main.rs`
+(`UIScreenshot`/`UIClick`/`UIQuery`/`FocusWindow` handlers),
+`agentmux-cef/src/browser_api/{routes.rs,resolver.rs,scripts/query.js}`.
+
+---
+
+## 0. Motivation and a scope correction made during this analysis
+
+The concrete trigger: while testing ABF, I couldn't screenshot a *separate
+`task dev` instance's window* (a different OS process, different `srv`,
+different agent registry entirely) — my `UIScreenshot` tool only sees my own
+pane. The operator's response, generalizing the ask: *"UIScreenshot needs to
+be a general purpose tool. you should have access to everywhere."*
+
+**Investigating the actual mechanism surfaced that "everywhere" bundles two
+genuinely different capabilities with very different risk profiles, and the
+motivating case (a separate instance's window) is the lower-risk one:**
+
+1. **Cross-instance / cross-window** — screenshotting or clicking into a
+   *different AgentMux window entirely* (a separate `task dev` process, a
+   separate portable build, another window on the desktop generally). This
+   is architecturally closer to general OS window automation than to
+   anything AgentMux's own agent-to-agent trust model governs — there is no
+   shared `srv`, no shared auth key, no "another agent's pane" involved at
+   all in the motivating case (an empty/idle dev window).
+2. **Cross-pane, same instance** — one agent's `UIScreenshot`/`UIClick`
+   reaching into a *different agent's pane within the same running
+   instance*. This is the one that's actually security-sensitive, and —
+   important finding below — it's not a gap nobody thought about. It's a
+   **deliberately deferred, already-designed-for, previously-exploited**
+   piece of this exact feature.
+
+This doc treats them separately because the right next step for each is
+different: (1) is close to shippable; (2) needs a real decision, not just an
+implementation.
+
+---
+
+## 1. Cross-instance / cross-window targeting
+
+### 1.1 What exists today
+
+Nothing in AgentMux's own tool surface reaches a different instance/window —
+confirmed directly: I could not drive the `task dev` window's UI from
+production earlier this session (`mcp__agentmux__UI*` tools are scoped to
+"your own pane and shared app chrome," full stop, and there's no
+cross-instance variant).
+
+### 1.2 Why this is the lower-risk half
+
+- No shared authentication domain to worry about leaking across — a
+  different instance is a different `srv` process with its own `X-AuthKey`,
+  its own agent registry. Nothing in *this* instance's trust model is
+  implicated.
+- The underlying OS already exposes what's needed: any window on the desktop
+  can be captured/interacted with via standard Win32 APIs
+  (`PrintWindow`/`BitBlt` for screenshots, `SendMessage`/`PostMessage` or
+  UI Automation for clicks), independent of AgentMux entirely. This isn't a
+  gap in AgentMux's architecture so much as a missing convenience tool
+  wrapping a capability that's already available to anything running on the
+  machine (I already have `Bash`, and could drive this via a PowerShell
+  script today, ad hoc — the gap is a *supported, repeatable tool*, not raw
+  capability).
+- Risk is closer to "can an agent see/interact with the desktop generally"
+  (a machine-level capability question, same category as `Bash` already
+  granted) than "can Agent A read Agent B's private conversation" (the
+  cross-pane question below).
+
+### 1.3 Recommended plan
+
+Build a new tool — e.g. `CaptureWindow` — that:
+- Takes a window title/handle (or a partial-title match) as its target,
+  independent of any AgentMux-specific block/tab/window id.
+- Implemented via the same OS-level mechanism I already improvised ad hoc
+  this session (PowerShell + `user32.dll`), formalized into a real,
+  repeatable tool rather than a one-off script each time.
+- Does **not** need to touch `ui_handlers.rs`'s signed-identity scheme at
+  all — it's a different code path entirely (no `srv` proxy, no CEF-host
+  `TargetCache` resolution), which is exactly why it's lower-risk: it
+  doesn't need to reason about AgentMux's own agent-to-agent trust boundary
+  because it isn't crossing one.
+- Scope question worth a deliberate answer before building, not left
+  implicit: should this be screenshot-only (matching the motivating need),
+  or also support clicking into an arbitrary window? Clicking into an
+  arbitrary *other application's* window is a materially bigger capability
+  grant than reading pixels from one — recommend screenshot-only for v1,
+  revisit click separately if a real need for it shows up.
+
+This can proceed without further security review beyond the above scope
+question — it doesn't touch the mechanism §2 is about.
+
+---
+
+## 2. Cross-pane, same-instance targeting
+
+### 2.1 The actual current mechanism (verified against live code)
+
+`UIScreenshot`/`UIClick`/`UIQuery` do **not** derive "your own pane" from a
+client-supplied block id at all (unlike `OpenEditor`/`FocusWindow`, which do
+send `AGENTMUX_BLOCKID` verbatim). Instead:
+
+1. The MCP tool (`agentmux-mcp/src/main.rs`) HMAC-signs a fixed identity
+   tuple using `AGENTMUX_JEKT_KEY` (the same per-agent signing key jekt
+   sender-verification uses) — `sign_ui_automation_auth()`, producing
+   `UiAutomationAuth { agent_id, ts_secs, sig }`. This is the *only* payload
+   sent; no block/pane id is transmitted by the client at all.
+2. The server (`ui_handlers.rs`'s `verified_block_id`) verifies that
+   signature against the claimed agent's own key on file, rejects anything
+   stale (>300s) or forged, and **only then** looks up that agent's *actual
+   current* block_id from a live, server-owned registry
+   (`reactive::handler::get_global_handler()`) — never trusting anything the
+   client claims about which pane it is.
+3. That server-derived block_id (never client-supplied) is what actually
+   gets proxied to the CEF host for the screenshot/click/query.
+
+**The underlying CEF/CDP layer has no such restriction** — its
+`TargetCache::resolve` already works against an arbitrary `block_id`, any
+pane in the system. The "own pane only" boundary is entirely an
+`agentmux-srv` *policy* decision layered on top of a capability that's
+already technically unrestricted underneath.
+
+### 2.2 This is not an oversight — it's deliberate, documented, and was
+### already exploited once
+
+`docs/specs/SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md` §6
+("Security model — the actual hard part") **already considered and rejected**
+exactly the ask being made now. Quoting its own reasoning: a Click/Screenshot
+tool that could target another pane "can read another pane's on-screen
+content (credentials in a form, private conversation text) and act on
+another agent's UI (e.g. clicking 'Confirm' on someone else's destructive
+dialog) — not just steal focus." It explicitly defers cross-agent targeting
+as "a distinct, explicitly higher-sensitivity capability" pending a
+capability-flag gate that **does not exist in code today** (confirmed: zero
+hits for any capability-flag mechanism anywhere in the repo).
+
+This isn't theoretical caution — the same spec's own "Review findings
+(2026-08-19, PR #2662)" section documents **two real P0 vulnerabilities**
+found and fixed after initial implementation:
+- `block_id` was originally accepted as a plain client-supplied field —
+  meaning any agent could already read the shared instance-wide `X-AuthKey`
+  from its own environment and simply claim a different pane's block_id.
+  Fixed by replacing it with the signed-identity scheme in §2.1.
+- The DOM-ownership check for the "shared chrome" exception (`query.js`)
+  originally checked whether a matched element was *inside* a foreign pane
+  but not whether it *contained* one — meaning `body`/`#root` was waved
+  through as chrome and could see/click into every pane on screen. Fixed by
+  checking descendants too.
+
+There's a real regression test locking the fix in:
+`ui_click_rejects_a_forged_agent_identity` (`agentmux-srv/src/server/tests.rs:715-749`)
+— an agent signs correctly as itself but claims to *be* a different agent;
+rejected.
+
+### 2.3 The precedent to explicitly avoid
+
+`FocusWindow` already supports targeting an arbitrary `window_id` — but by
+sending the raw client-supplied id straight through with **zero ownership
+verification**, unlike the signed-identity scheme above. The UI-automation
+spec's own authors already named this as the anti-pattern *not* to repeat
+for Click/Screenshot, verbatim: *"any agent can already focus … a different
+agent's window … A Click/Screenshot tool inheriting this exact pattern would
+be strictly worse."* **Do not model a widened design on `FocusWindow`'s
+mechanism** — it's the one the original design explicitly rejected for this
+exact capability, for documented reasons, not an oversight to copy.
+
+### 2.4 What a real widening would actually require
+
+Not a parameter addition. At minimum:
+1. **A real authorization policy**, decided deliberately (a product/security
+   call, not an implementation detail) — options include: always-allow
+   within the same instance (closest to "everywhere," but reopens exactly
+   the risk §2.2 already found and fixed once); an explicit per-agent
+   opt-in/capability flag (the original spec's own deferred proposal);
+   scoping to "panes in the same workspace as the caller" as a middle
+   ground; or per-request human/target-agent confirmation for anything
+   crossing the boundary (matching this repo's own jekt `ESCALATE=required`
+   pattern for a comparable trust decision).
+2. **Extending the signed-identity scheme, not bypassing it** — e.g. signing
+   over a claimed *target* block_id too, so a forged-target attempt is
+   cryptographically rejected the same way a forged-identity attempt already
+   is, rather than reverting to `FocusWindow`'s trust-the-client shape.
+3. **Screenshot needs separate treatment from Click/Query.** Even within the
+   *already-shipped* "shared chrome" exception, Screenshot was deliberately
+   left stricter than Click/Query (no chrome exception at all) because a
+   screenshot's single rectangular clip can't exclude another pane sitting
+   between the caller and a chrome element the way a DOM-ownership check
+   can. Any widening proposal needs to solve this per-tool, not assume one
+   mechanism covers all three.
+4. **New tests in the existing idiom**, not invented from scratch — this
+   area already has a real regression-test pattern to extend
+   (`signed_ui_auth()` test helper, `agentmux-srv/src/server/tests.rs:646-845`),
+   including a forged-identity attack test to mirror for whatever new
+   forged-target attack a widened design introduces.
+
+### 2.5 Recommendation
+
+**Do not implement this as a quick widening.** Treat it as what the original
+spec already correctly scoped it as: a distinct, higher-sensitivity
+capability requiring its own explicit design pass and a real answer to
+"what's the authorization policy" (§2.4.1) before any code changes — not
+because it's impossible, but because this exact shortcut (skip the policy
+question, ship the parameter) produced two real P0s the first time this
+feature was built. The honest plan is: pick an authorization model
+deliberately, write it up as its own spec (extending
+`SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md` rather than
+starting over), and implement against the existing signed-identity
+foundation rather than around it.
+
+---
+
+## 3. Summary / next steps
+
+| Capability | Risk | Status | Next step |
+|---|---|---|---|
+| Cross-instance/window capture (§1) | Low — no shared trust domain, OS-level capability already available via `Bash` | Ready to build | Implement `CaptureWindow` (screenshot-only for v1) as a new MCP tool, independent of `ui_handlers.rs` |
+| Cross-pane, same-instance targeting (§2) | High — real, previously-exploited (PR #2662) agent-to-agent trust boundary | Needs a deliberate authorization-policy decision first | Write a follow-up spec extending `SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md` §6 once that policy question has an actual answer; do not implement ahead of it |
+
+Immediate recommendation: proceed with §1 (`CaptureWindow`) now — it directly
+serves the motivating need (the `task dev` window) with no open design
+questions blocking it. Treat §2 as a separate, longer-lead item requiring
+the operator's own product/security call on the authorization model before
+any implementation starts.

--- a/docs/retro/retro-agenty-global-claude-home-leak-2026-08-20.md
+++ b/docs/retro/retro-agenty-global-claude-home-leak-2026-08-20.md
@@ -1,0 +1,220 @@
+# Retro — AgentY's sessions have been leaking into the operator's global `~/.claude` home since ~2026-08-05, breaking cross-restart continuity
+
+**Date:** 2026-08-20
+**Trigger:** Operator closed this agent's pane on AgentMux v0.55.15 and reopened it on
+v0.55.18, expecting a carry-over summary. None appeared — the pane started with zero
+memory of prior work, no "New session started" divider, no visible warning of any kind.
+**Author:** AgentY (agent, `~/.agentmux/agents/agenty-0629j`), at operator request,
+live-investigating its own pane.
+**Status:** Symptom (§1) fully confirmed with direct forensic evidence and still stands.
+**The root-cause hypothesis chain in §3/§4/§5 below turned out to be a wrong turn** —
+see `docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md` §8 for the
+actual resolution: the credential-isolation gate is not broken; §4's "0 identity
+links" finding queried the wrong (per-channel) database, and the account
+actually bound to AgentY (`"Claude (personal)"`) genuinely points at the
+operator's own global `~/.claude` by its own configuration, not a gate
+bypass. Kept as-written below (not rewritten) as the real record of how this
+investigation actually unfolded, including the wrong turn — see the status
+doc for the corrected conclusion before acting on anything in §3-§5.
+
+---
+
+## 1. What actually happened (confirmed)
+
+This pane's block (`block_id=0a8d11f8-6962-486a-987e-2d4d366804da`, agent `AgentY`,
+`definition_id=dedc33bf-b69c-4236-9b34-20bda3ef2738`) was restarted at
+**2026-08-20T20:17:27Z**, attempting `--resume 705f6a8a-3ad0-4a7d-99f2-42097a1bcf1f`
+(the session_id persisted in `agent:sessionid` block meta). Claude CLI's own stderr said:
+
+```
+No conversation found with session ID: 705f6a8a-3ad0-4a7d-99f2-42097a1bcf1f
+```
+
+AgentMux detected this (`persistent.rs`'s "stale --resume session id unreachable"
+handling), cleared the id, and retried fresh with no `--resume` flag at all — silently,
+from the operator's perspective. That fresh spawn (pid 50148) is the process this very
+conversation has been running in ever since (confirmed via `session:active_pid` in the
+block's own meta, matching the log).
+
+**The stale session file is not missing.** It exists, is valid JSON, and sits at exactly
+the path `--resume` should search:
+
+```
+C:\Users\asafe\.agentmux\shared\providers\claude\projects\C--Users-asafe--agentmux-agents-agenty-0629j\705f6a8a-3ad0-4a7d-99f2-42097a1bcf1f.jsonl
+```
+
+47.6MB, created 2026-07-10, **last written 2026-07-29**. Content confirms it's genuinely
+this agent's own prior work (a MuxBus PR #1916 conversation).
+
+**Every session since has been landing in the wrong place.** Listing
+`C:\Users\asafe\.claude\projects\C--Users-asafe--agentmux-agents-agenty-0629j\` — the
+operator's own **global**, non-isolated Claude Code home — shows an unbroken chain of this
+agent's own session files:
+
+| Session id | Size | Last written |
+|---|---|---|
+| `584c96f9-...` | 7.9MB | 2026-08-05 |
+| `3e1d85a5-...` | 37.8MB | 2026-08-09 |
+| `48759f2a-...` | 88.9MB | 2026-08-11 |
+| `894b0648-...` | 12.7MB | 2026-08-18 |
+| `8462c17f-...` (this conversation) | growing | now |
+
+None of these exist under the isolated `CLAUDE_CONFIG_DIR`
+(`~/.agentmux/shared/providers/claude/`) that this pane's own block meta (`cmd:env`)
+says it's launched with. **The last session correctly isolated is the July 29 one; every
+session since has silently run against the operator's personal, shared, un-isolated
+`~/.claude` home instead.**
+
+This means every `--resume` attempt since 2026-08-05 has been guaranteed to fail (the CLI
+is searching the isolated dir for a session that was actually written to the global dir),
+and — more seriously than the continuity nuisance — this agent's traffic has been
+commingling with the operator's own personal Claude Code account/config for over two
+weeks, which is exactly the isolation boundary
+`docs/specs/SPEC_PROVIDER_ISOLATION_2026_06_20.md`'s **INV-A** ("never the user's global
+`~/.<P>` dir") exists to prevent.
+
+## 2. What this is *not*
+
+Not the gap `docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md` Part B
+(rehydrate-before-resume) targets — that's about a session file existing somewhere but not
+in the *current instance's* isolated home (a cross-version/cross-machine problem). Here the
+file is in the *correct* isolated home; the live process just isn't looking there anymore.
+
+## 3. Three known, previously-documented issues in the same subsystem
+
+All three were found already written up in this repo, independently, by different
+investigations at different times — none of them, as far as I can tell, has been
+conclusively tied to *this* specific symptom before:
+
+1. **`docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`** — a
+   five-commit arc (2026-05-22 → 2026-07-14) accidentally orphaned the "auto-isolate an
+   unbound agent" behavior that used to satisfy INV-A implicitly. Today's gate
+   (`inject_identity_env_with_broker` / `gate_oauth_failure`, `inject.rs:265+`) has only two
+   outcomes for an oauth-class provider with no binding: **block**, or (if
+   `use_ambient_login=true`) **true ambient — zero isolation, no `CLAUDE_CONFIG_DIR` set at
+   all**. A migration grandfathered pre-existing linkless agents onto
+   `use_ambient_login=true`, believing it preserved their old (actually isolated) behavior.
+
+2. **`docs/specs/REPORT_HISTORY_CONTINUITY_ACROSS_VERSION_UPGRADE_2026_08_17.md`** — written
+   by a prior instance of this same agent, at the operator's own request, after a near-
+   identical complaint. Root cause there: `db_agent_identity_links`/`db_accounts` (the
+   "agent X uses account Y" binding row) is looked up via `id_store`, which resolves to a
+   **per-channel-isolated database by default on every non-`stable` channel**
+   (`resolve_shared_store_path()`, `agentmux-srv/src/registry/paths.rs:63-72`). A
+   version/channel switch means a fresh, empty store — the binding row doesn't survive.
+   Verdict at the time: **"Not solved."**
+
+3. **Live evidence gathered just now**: this pane's `identity_id` is confirmed **empty**
+   (`db_agent_instances.identity_id = ''`), `db_agent_identity_links` is confirmed
+   **completely empty** (0 rows) in the live channel's own store, and the WARN this pane logs
+   on every single spawn —
+   `"instance ... has empty/blank identity_id — falling through to the layer-3 gate instead
+   of ambient creds. Legacy row or UI regression?"` (`inject.rs:305-312`) — fires every time.
+
+## 4. The synthesis (high confidence, not yet fully proven)
+
+Most likely sequence: this agent had a genuine, working isolated session through
+2026-07-29. Sometime between then and 2026-08-05 — plausibly a version/channel switch,
+matching finding #2's mechanism exactly — this agent's identity binding row stopped being
+found (finding #2's per-channel `id_store` reset), leaving `identity_id` empty on the
+instance row (finding #3). With no binding to resolve, the gate described in finding #1
+took over — and since some code path evidently does **not** block this specific agent
+(see §5), the practical effect since 2026-08-05 has been equivalent to "true ambient":
+no `CLAUDE_CONFIG_DIR` isolation, silently falling back to Claude CLI's own default
+(`~/.claude`).
+
+## 5. What's NOT yet confirmed — read before implementing anything
+
+**Contradiction found while verifying:** this agent definition's `use_ambient_login` flag
+is `0` (false) — confirmed by direct DB query. Per the gate logic in `inject.rs` (and its
+own test `spawn_blocked_when_oauth_def_provider_has_no_binding_and_flag_false`, which
+covers exactly this shape: provider=claude, no binding, flag=false), the expected outcome
+is **`SpawnGateError::MissingCredentials` — the spawn should be blocked outright**. It
+isn't; this agent spawns and runs successfully every time. So either:
+
+- `inject_identity_env_with_broker` isn't actually being called on this pane's respawn
+  path at all (plausible: the research done earlier this session found that
+  `agent_io.rs`/`input.rs` re-read `cmd:env` **verbatim from persisted block meta** on every
+  respawn, rather than recomputing it — which would mean the gate only ever runs once, at
+  original launch time, not on every `--resume` retry); or
+- there's a separate, unexamined code path for "default" (never-Armory-bound) agents —
+  `agent_open.rs`'s `provider_auth_dir()`, per this repo's own `CLAUDE.md` ("a plain agent
+  keeps launching off the same credentials it always did... stays global/channel-
+  independent regardless of isolation") — that's actually authoritative here, and the
+  isolated-vs-global divergence has a different explanation than findings #1/#2 entirely.
+
+I was not able to resolve this from static code reading alone within this session — the
+two candidate explanations make different, testable predictions (does the gate run on
+every respawn, or only at first launch?) but confirming needs either runtime tracing
+(a log line at the actual `CreateProcess`/spawn call showing the real env block used) or
+reading `persistent.rs`'s full respawn path end-to-end against `agent_open.rs`, which
+wasn't completed here.
+
+## 6. §5 resolved further — the gate is real, current, and provably never fires
+
+Traced the full call chain end to end against live `origin/main` (confirmed included in
+the actual `v0.55.18` build — the gate-hardening commit `860fb0b6a`, 2026-07-23, is an
+ancestor of the `v0.55.18` release commit `b9dd447a6`, 2026-08-20):
+
+- `agent_io.rs:179-211` (`AgentSendCommand` handler) calls
+  `inject_identity_env_async(...).await` **on every message send**, before ever touching
+  the persistent controller. `input.rs` does the same for `AgentInputCommand`.
+- `provider_class("claude")` is confirmed, by a pinned unit test, to be
+  `Some(ProviderClass::OAuth { config_dir_env_var: "CLAUDE_CONFIG_DIR" })`.
+- With `identity_id=""`, zero rows in `db_agent_identity_links`, and `def_provider =
+  Some("claude")` (oauth-class), the function's own Step 5 (`inject.rs:654-674`) has all
+  three guard conditions satisfied and **must** call `gate_oauth_failure("claude", "no
+  account bound for the agent's provider")`.
+- That closure (`inject.rs:401-416`) is unconditional as of the `860fb0b6a` refactor — its
+  own comment states `use_ambient_login` "no longer has any effect on the outcome
+  (single-point enforcement)". It always returns
+  `Err(SpawnGateError::MissingCredentials)`.
+- The caller (`agent_io.rs:189-211`) treats that `Err` as fatal: it appends a persisted
+  `error_during_execution` frame to the pane and returns before the CLI is ever spawned.
+
+**Per this trace, my own pane should never have been able to spawn even once.** It has
+spawned dozens of times today alone.
+
+**Direct log check (decisive): the WARN this closure always logs on the way to returning
+`Err` — `"identity.spawn.blocked: no credentials for provider ..."` — appears **zero
+times** in a full day of `v0.55.18` server logs (2026-08-20 and 2026-08-21), for *any*
+agent, not just this one.** The gate is real code, compiled into the running binary,
+covered by its own passing unit tests in isolation — and, per the server's own logs, it
+has not executed even once in production today.
+
+This means one of:
+
+1. The `agent_io.rs`/`input.rs` code path I traced is not actually the one exercised for
+   an already-running persistent controller's message delivery — there may be a separate,
+   more direct route for a live process that never re-enters this handler after the
+   controller's first spawn (would explain "gate runs once, structurally can't run
+   again" — but doesn't explain why it never even blocks the *first* spawn, since this
+   agent's identity_id/bindings have been in this same broken state since ~2026-08-05).
+2. `inject_identity_env_async`'s `Err` path is somehow not reaching the `agent_io.rs`
+   handling I read — e.g., a `tokio::task::spawn_blocking` interaction, an `await` that
+   isn't actually on the hot path for this RPC, or a stale/dead-code function that looks
+   wired in but isn't actually called from the compiled binary's real dispatch table.
+3. Something about this agent's specific shape (a very old, "legacy row" per the code's
+   own comment, predating the whole identity/Armory system) takes a code path I haven't
+   found yet that never reaches `inject_identity_env_async` at all.
+
+## 7. Recommended next step
+
+This needs live runtime instrumentation, not more static reading — I've traced the code
+as far as reading can go and it flatly contradicts observed behavior. Add a temporary
+`tracing::info!` at the very top of `inject_identity_env_with_broker` (or confirm via a
+debugger/breakpoint) logging `block_id` on every invocation, restart this pane once, and
+check whether it appears in the log at all. If it doesn't appear, the RPC handler I read
+isn't the one actually driving this pane's spawn and the real dispatch path needs to be
+found from scratch. If it does appear but returns `Ok`, the bug is inside the function
+(bindings/def_provider resolution reading different data than my direct DB query saw). If
+it appears and correctly computes `Err`, the bug is in how `agent_io.rs` handles that
+`Err` (swallowed somewhere before it reaches the pane/blocks the spawn).
+
+**This is a more consequential finding than the original continuity complaint**: a
+security-relevant credential-isolation gate, deliberately hardened in `860fb0b6a` to close
+a known "silent fallback to the user's global login" hole (exactly
+`retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`'s own subject), appears
+to not be enforcing at all in production, for any agent. Recommend treating this as
+higher priority than implementing any fix from findings #1/#2/#3 in isolation — those
+fixes would be built on top of a gate that, per §6, isn't actually running.

--- a/docs/specs/SPEC_AGENT_GENERIC_PANE_OPEN_TOOL_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_GENERIC_PANE_OPEN_TOOL_2026_08_21.md
@@ -1,0 +1,350 @@
+# Spec: `OpenPane` — a general-purpose, agent-facing "open any pane" MCP tool
+
+**Status:** design, not implemented.
+**Author:** AgentY
+**Date:** 2026-08-21
+**Related:** `agentmux-mcp/src/main.rs` (`OpenEditor`, `OpenMedia` — the direct
+precedent this spec generalizes), `docs/specs/SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03.md`
+(the last time this exact pattern — whitelist a view in `build_pane_meta` +
+add an MCP tool — was done, for `media`), `docs/specs/SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md`,
+`agentmux-srv/src/server/app_api/pane.rs` (`build_pane_meta`, the whitelist
+this spec widens), `agentmux-srv/src/server/app_api/mod.rs` (`open_pane`,
+the shared reducer-backed core both the WS RPC and HTTP route call),
+`frontend/app/block/block-registry.ts` (`blockViewRegistry` — the
+authoritative list of view types that actually render), `CLAUDE.md`'s
+"Widgets" / "Not widgets" tables (the human-facing surface this tool mirrors
+for agents).
+
+---
+
+## 0. Motivation
+
+Live gap hit today: verifying ABF (Armory Bundle Format) features required
+opening the Armory pane from an agent's own conversation. No agent-facing way
+to do this exists — `OpenEditor` and `OpenMedia` are the only two "open a
+pane" MCP tools, and both are hardcoded to one view each (`editor`, `media`).
+Every other pane a human can open by clicking the hamburger menu or a widget
+— Armory, Settings, Toolchain, Swarm, Warden, Drone, Sysinfo, Help, Browser,
+Terminal — has no agent-facing equivalent at all.
+
+This is bigger than "add one more `OpenArmory` tool." The operator's framing
+during investigation: *"being able to open panes and control agentmux is a
+first-class feature of agentmux"* — the ask is a general capability, not a
+one-off. Backed up by what the research below confirms: the **backend is
+already generic** (one RPC, one function deciding what a `view` string means)
+— it's only the agent-facing MCP layer that's been built one hardcoded tool
+at a time. Continuing that pattern for every future view (Armory alone has
+6 internal sections) doesn't scale and actively works against the "first
+class" framing.
+
+## 1. Research — the actual current mechanism (verified against live code, not assumed)
+
+### 1.1 Correction to an earlier premise
+
+Investigating this, it was initially assumed the hamburger menu (where
+"Armory" lives for humans) is a native OS/Electron menu unreachable by
+`UIClick`/`UIQuery` (which only see the web DOM). **That's wrong, checked
+directly:** `frontend/app/window/hamburger-menu.tsx:117-121` is a plain
+SolidJS-rendered flyout — `onClick: () => fireAndForget(() =>
+openOrFocusPaneByView("armory"))`. It's reachable by web-DOM automation tools
+after all. This doesn't change the motivation (an agent still has no
+first-class *tool* to call), but the real gap is "no agent-facing verb for
+this," not "the menu is unreachable."
+
+### 1.2 There are two pane-creation paths today, not one
+
+**(a) Low-level, unvalidated — `object.CreateBlock`** (WebSocket RPC only,
+no HTTP route, not usable by an MCP tool without adding one):
+- Used by the hamburger menu (`openOrFocusPaneByView`,
+  `frontend/app/store/block-component-registry.ts:71-89`) and the widget bar
+  (`frontend/app/window/action-widgets-config.ts:220-222`, blockdefs sourced
+  from `agentmux-srv/src/config/widgets.json`).
+- Backend: `agentmux-srv/src/server/service/object.rs:44-148`, the
+  `"CreateBlock"` case of the `"object"` WSH service. Takes an arbitrary
+  `BlockDef` — **no view-string whitelist, no per-view field validation** —
+  and dispatches straight through the reducer.
+
+**(b) High-level, validated — `pane.open`** (WS RPC *and* HTTP route; this is
+the one `OpenEditor`/`OpenMedia` already use and the one this spec builds
+on):
+- Command constant: `agentmux-srv/src/backend/rpc_types/commands.rs:337`
+  (`COMMAND_PANE_OPEN = "pane.open"`).
+- Request shape: `CommandPaneOpenData` (`agentmux-srv/src/backend/rpc_types/block.rs:404-468`)
+  — `view, file, url, cwd, title, tab_id, split_direction,
+  split_reference_block_id, focus, tree_expanded, floating, meta,
+  skip_placement, reuse_editor_pane`.
+- HTTP route: `POST /api/v1/pane/open` (`agentmux-srv/src/server/mod.rs:425`,
+  handler `handle_pane_open` at `mod.rs:928-950`) — a thin wrapper over the
+  shared core.
+- Shared core: `open_pane(state, cmd)` (`agentmux-srv/src/server/app_api/mod.rs:67`),
+  whose own doc comment already says it's "shared by the WebSocket RPC
+  handler … and the HTTP route … (`agentmux-mcp`'s `OpenEditor` tool)" — i.e.
+  this spec's new tool is exactly the kind of caller this function already
+  anticipates.
+- **The gap**: `build_pane_meta` (`pane.rs:208-265`) — the function that
+  turns a bare `view` string into real block meta — only has arms for
+  `editor`, `term`, `browser`, `sysinfo`, `help`, `media`. Every other real,
+  rendering view (`armory`, `settings`, `toolchain`, `memory`, `warden`,
+  `drone`, `swarm`, `agent`, `identity`, `cpuplot`, `launcher`) hits the
+  `other =>` arm and 400s with `INVALID_VIEW` — **unless** the caller
+  supplies `cmd.meta` directly, which `open_pane` uses as-is
+  (`mod.rs:75-78`), bypassing `build_pane_meta` entirely. This is exactly how
+  the widget bar's unvalidated path (§1.2a) effectively works today for
+  those views, just through a different RPC.
+
+This is the concrete inconsistency behind the "architecture rethink"
+question: two different pane-creation paths, one validated (narrow
+whitelist), one not (whatever the frontend hands it), doing the same job.
+
+### 1.3 Authoritative view-type list
+
+`frontend/app/block/block-registry.ts:25-47` (`blockViewRegistry`), the
+ground truth for what actually renders:
+
+```
+term, cpuplot, sysinfo, help, launcher, agent, swarm, editor, browser,
+memory, media, identity, drone, warden, toolchain, armory, settings
+```
+
+Plus a legacy alias (`block.tsx:53`): `view: "forge"` renders as `agent`.
+
+Per-view required extra meta, confirmed against `agentmux-srv/src/config/widgets.json`
+and each view's own model:
+- `editor` — none required (optional `editor:tree_expanded`).
+- `media` — `media:path` (a file).
+- `browser` — `url`.
+- `term` — none required (widget sets `controller: "shell"`, not user-supplied).
+- `armory`, `settings`, `toolchain`, `sysinfo`, `help`, `swarm`, `drone`,
+  `warden`, `memory` — **none required**, `view` alone is sufficient.
+- `agent` — has its own much richer, already-agent-facing flow
+  (`agent_open.rs`) with its own dedicated `agent.open` command; out of scope
+  here (see Non-goals).
+
+**Armory's internal sections are not separate `view` strings.** They're a
+second block-meta key, `armory:section`, patched *after* the Armory pane
+already exists (`frontend/app/view/armory/armory-view.tsx:33-37`, a
+`SetMetaCommand` RPC). Valid values —
+`ArmorySection` (`frontend/app/view/armory/armory-model.ts:14`):
+`"accounts" | "memory" | "skills" | "mcp" | "bundles" | "native_memory"`.
+(Note: `"skills"` plural — matches the earlier finding that ABF's
+programmatic-access view registers under `memory`, distinct from Armory's
+`"memory"` *section* label, which is Armory Native Memory, not ABF. See §4
+open question — this naming collision needs to be resolved carefully in the
+tool's own argument description so a caller doesn't confuse "ABF" with
+"Armory's memory section.")
+
+### 1.4 The `OpenEditor`/`OpenMedia` template
+
+Both live in `agentmux-mcp/src/main.rs`: schema consts (`OPEN_EDITOR_TOOL`
+at `main.rs:323-337`, `OPEN_MEDIA_TOOL` at `main.rs:339-352`) plus handler
+arms (`main.rs:1091-1170` and `main.rs:1172-1241`). Each: reads args, checks
+`AGENTMUX_LOCAL_URL`/`AGENTMUX_AUTH_KEY`/`AGENTMUX_BLOCKID` env, builds a
+`PaneOpenRequest`, POSTs to `{local_url}/api/v1/pane/open` with an
+`X-AuthKey` header, parses `{block_id}` back, returns a one-line confirmation
+string. This is the exact shape `OpenPane`'s handler copies.
+
+Two independent places a tool must be registered, confirmed by
+`SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03.md`'s own post-review
+correction (do not repeat that near-miss):
+1. The production `"tools/list"` response array, `main.rs:513`.
+2. The test-only `defs` validity/count array, `main.rs:1719-1747` (bump
+   `assert_eq!(defs.len(), N, ...)`).
+
+### 1.5 Tests
+
+No MCP-tool-layer tests exist for `NewTab`/`OpenEditor`/`OpenMedia` (thin
+HTTP wrappers, nothing to unit test). Real coverage is server-side:
+`agentmux-srv/src/server/app_api/mod.rs`'s `pane_open_reducer_tests` module
+(`docked_pane_open_block_is_in_reducer_and_tears_off`,
+`skip_placement_creates_block_without_touching_the_layout_tree`) —
+`#[tokio::test]`, `test_state()` in-memory `AppState`, hand-built
+`CommandPaneOpenData { .. }`, `open_pane(&state, cmd).await`, assert against
+`state.srv_state.blocks`. **No test today exercises `build_pane_meta`'s
+`INVALID_VIEW` rejection or a not-yet-whitelisted view** — this spec's
+backend change adds the first such coverage, in the same module/idiom.
+
+---
+
+## 2. Design decision — one generic tool, not one tool per view
+
+Explicitly settling the "separate commands per pane vs. one command with a
+pane argument" question raised during design:
+
+**One generic `OpenPane` tool**, taking `view` as its primary argument. Not
+a new hardcoded tool per view.
+
+Reasoning:
+1. The backend already treats this uniformly in intent (one `pane.open`
+   command, one `build_pane_meta` dispatch) — building N MCP tools on top of
+   one generic mechanism is an asymmetry that gets worse as the view list
+   grows (already 17 entries, and Armory alone fans out into 6 sections).
+2. Every future view becomes agent-usable the moment it's added to
+   `build_pane_meta`'s whitelist, with no follow-up MCP-tool PR — this is
+   what makes it a "first-class, general" capability rather than a series of
+   one-offs.
+3. It closes the §1.2 inconsistency as a side effect: widening
+   `build_pane_meta` to cover the full `blockViewRegistry` set means the
+   *validated* path (`pane.open`) becomes capable of everything the
+   *unvalidated* path (`object.CreateBlock`) already does today, rather than
+   adding a third, MCP-tool-specific bypass (raw `meta` passthrough) that
+   would just paper over the gap instead of closing it.
+
+**`OpenEditor`/`OpenMedia` are kept as-is** — not retired, not required to
+change. They're established, presumably-in-use tools with genuinely distinct
+ergonomics (`collapse_tree` for Editor; file-type handling for Media)
+that read better as dedicated, self-documenting tools than as
+`OpenPane(view: "editor", file: ...)`. `OpenPane` is additive: the general
+entry point for everything else, and a template any future dedicated tool
+can still choose to peel off from if a view earns bespoke ergonomics later
+(non-goal to unify them into shared Rust code right now — see §5).
+
+---
+
+## 3. Design
+
+### 3.1 Backend: widen `build_pane_meta`'s whitelist
+
+`agentmux-srv/src/server/app_api/pane.rs:211-258`. Add arms for every
+no-extra-arg view confirmed in §1.3:
+
+```rust
+"armory" | "settings" | "toolchain" | "memory" | "warden" | "drone"
+    | "swarm" | "identity" | "cpuplot" | "launcher" => {
+    meta.insert("view".to_string(), json!(cmd.view.as_str()));
+}
+```
+
+(`agent` deliberately excluded — it has its own dedicated, much richer
+`agent.open` flow; routing it through this generic arm would bypass that
+flow's real setup logic. See Non-goals §5.)
+
+For `armory` specifically, accept an optional `section` field on
+`CommandPaneOpenData` (new field, or reuse the existing generic `meta`
+passthrough for it) and, when present, additionally insert
+`"armory:section": json!(section)` into the built meta — validated against
+the real `ArmorySection` enum (`"accounts" | "memory" | "skills" | "mcp" |
+"bundles" | "native_memory"`) server-side, erroring the same way an
+unrecognized `view` does now, rather than trusting the caller's string
+blindly.
+
+Update the `INVALID_VIEW` error message (`pane.rs:255`) to list the full
+expanded set so a typo'd view string still gets an accurate hint.
+
+**Open question (not resolved by research, needs a real check before/during
+implementation):** does the Armory pane's frontend read `armory:section`
+from a block's *initial* meta (set at creation) the same way it reads a
+later `SetMeta` patch? `armory-view.tsx:33-37`'s existing usage is
+patch-after-create, not create-with-section already set. If the Armory
+`ViewModel`'s section signal only initializes from a live subscription and
+not from initial mount meta, this needs a small frontend read-path fix
+alongside the backend change, or the tool needs to issue a follow-up
+`SetMeta` call itself after `pane.open` returns (matching the two-step
+dance a human's UI already does) rather than assuming a one-shot create
+works. Verify empirically (open an Armory pane via a hand-crafted
+`pane.open` call with `meta: {"view":"armory","armory:section":"bundles"}`
+and observe) before committing to the one-call design.
+
+### 3.2 New MCP tool: `OpenPane`
+
+`agentmux-mcp/src/main.rs`, mirroring `OPEN_EDITOR_TOOL`/`OPEN_MEDIA_TOOL`:
+
+```rust
+const OPEN_PANE_TOOL: &str = r#"{
+  "name": "OpenPane",
+  "description": "Open any AgentMux pane by view type next to this conversation — Armory (Bundles/MCP Servers/Skills/Accounts/Native Memory), Settings, Toolchain, Swarm, Warden, Drone, Sysinfo, Help, Browser, Terminal. For editor/media files specifically, prefer OpenEditor/OpenMedia instead. Fire-and-forget: returns once the pane is opened.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "view":     { "type": "string", "enum": ["armory","settings","toolchain","memory","warden","drone","swarm","identity","cpuplot","launcher","sysinfo","help","browser","term"], "description": "Which pane to open. 'memory' is ABF (Armory Bundle Format), distinct from Armory's own 'native_memory' section — see 'section'." },
+      "section":  { "type": "string", "enum": ["accounts","memory","skills","mcp","bundles","native_memory"], "description": "Only valid when view='armory' — jump straight to this Armory sub-tab (e.g. 'bundles' for ABF, 'mcp' for MCP Servers)." },
+      "url":      { "type": "string", "description": "Required when view='browser' — the URL to load." },
+      "title":    { "type": "string", "description": "Optional tab/pane title." },
+      "split":    { "type": "string", "enum": ["right", "left", "down", "up"], "description": "Where to place the new pane relative to this agent pane (default: right). Ignored when floating is true." },
+      "floating": { "type": "boolean", "description": "Open in a floating window instead of a docked split. Default: false." }
+    },
+    "required": ["view"]
+  }
+}"#;
+```
+
+Handler (`"OpenPane" => { ... }`): same shape as `OpenEditor`'s — env
+checks, build a `PaneOpenRequest { view, url: (browser only), title, focus:
+Some(true), split_direction, split_reference_block_id, floating, meta: (if
+section present, Some({"armory:section": section})), file: None,
+tree_expanded: None, reuse_editor_pane: None }`, POST to
+`{local_url}/api/v1/pane/open`, return `"Opened {view} pane (block
+{block_id})"` (or `"... section {section}"` when set).
+
+Register in both places per §1.4 — production `tools/list` array
+(`main.rs:513`) and the test `defs` array + bumped count
+(`main.rs:1719-1747`).
+
+### 3.3 Tests
+
+Backend: extend `pane_open_reducer_tests`
+(`agentmux-srv/src/server/app_api/mod.rs`) with:
+- One test per newly-whitelisted no-arg view (or table-driven over the list)
+  confirming `open_pane` now succeeds instead of `INVALID_VIEW`.
+- A `view: "armory", meta: Some({"armory:section": "bundles"})` test,
+  resolving §3.1's open question — assert the created block's meta actually
+  carries `armory:section` (whether that's sufficient for the frontend to
+  render the right tab is a separate, UI-level check, but this pins the
+  backend contract).
+- A still-rejected case (an unknown view string) to lock in the widened-but-
+  still-finite whitelist and the updated error message.
+
+MCP layer: no existing precedent for tool-handler unit tests (§1.5) — follow
+that precedent (none) unless this changes for `OpenEditor`/`OpenMedia` too.
+
+---
+
+## 4. Open questions
+
+1. **§3.1's `armory:section` initial-meta question** — needs a real check,
+   not an assumption, before implementation is considered done.
+2. **Should `browser`'s `url` requirement be enforced in the new whitelist
+   arm** (mirroring `media`'s `MISSING_ARG` pattern in the `OpenMedia` spec)
+   **or left to the frontend to show its own empty-state?** Leans toward
+   requiring it server-side, matching `media`'s existing precedent exactly
+   rather than introducing a new laxer convention.
+3. **Naming clash**: `memory` (top-level ABF view) vs. Armory's own
+   `"memory"` *section* value (Armory Native Memory, a different feature).
+   The tool schema's description above calls this out explicitly, but is
+   that enough, or does this warrant renaming one of the two identifiers at
+   the source (a much larger, separate change, and explicitly out of scope
+   here — flagged only so it isn't lost)?
+4. **Should `agent` ever be included?** Deliberately excluded in §3.1 because
+   `agent.open` already exists as its own rich, dedicated flow — but if a
+   future need arises for "open a *view* of an already-running agent's pane
+   without going through the launch flow," that might belong here instead.
+   Not needed for this spec's motivating case (Armory/ABF).
+
+## 5. Non-goals
+
+- Refactoring `OpenEditor`/`OpenMedia` to share Rust implementation code
+  with `OpenPane` internally. Worth doing eventually (all three ultimately
+  build a `PaneOpenRequest` and POST it) but not required to ship this, and
+  risks destabilizing two already-working tools for a pure DRY win.
+- Routing `view: "agent"` through this tool (see Open question 4).
+- Closing the §1.2 inconsistency at the `object.CreateBlock` layer itself
+  (the widget bar / hamburger menu's own unvalidated path). This spec only
+  widens the *validated* path to match it in capability; it doesn't touch
+  or restrict the existing unvalidated one.
+- A generic "close pane" / "list open panes" / "focus pane" agent-facing
+  tool set. `OpenPane` is scoped to opening; a fuller pane-lifecycle control
+  surface (matching the "control agentmux" framing more completely) is a
+  natural follow-up but a separately-scoped one.
+
+## 6. Files (anticipated — this spec does not implement)
+
+| File | Relevance |
+|------|-----------|
+| `agentmux-srv/src/server/app_api/pane.rs:211-258` | `build_pane_meta` — widen the whitelist (§3.1), the real gap |
+| `agentmux-srv/src/server/app_api/mod.rs` (`pane_open_reducer_tests`) | New tests per §3.3 |
+| `agentmux-mcp/src/main.rs:323-352` | `OPEN_EDITOR_TOOL`/`OPEN_MEDIA_TOOL` — pattern `OPEN_PANE_TOOL` copies |
+| `agentmux-mcp/src/main.rs:1091-1241` | `"OpenEditor"`/`"OpenMedia"` handler arms — pattern the new `"OpenPane"` arm copies |
+| `agentmux-mcp/src/main.rs:513` | Production `tools/list` registration — add `open_pane` |
+| `agentmux-mcp/src/main.rs:1719-1747` | Test `defs` array + count assertion — add `OPEN_PANE_TOOL`, bump count |
+| `frontend/app/view/armory/armory-model.ts:14` | `ArmorySection` — the enum `section` validates against |
+| `frontend/app/view/armory/armory-view.tsx:33-37` | Existing `SetMeta` pattern for `armory:section` — reference for §3.1's open question |
+| `frontend/app/block/block-registry.ts:25-47` | `blockViewRegistry` — authoritative view-type list this spec's whitelist widening targets |

--- a/docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md
+++ b/docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md
@@ -1,0 +1,213 @@
+# Status: The OAuth-class Credential-Isolation Spawn Gate Appears to Never Fire in Production (2026-08-20)
+
+**Status: RESOLVED — the headline claim in this doc's own title was wrong. See §8
+(2026-08-21 update).** The gate does fire and does work correctly; the "empty
+identity_id" WARN that started this investigation is a red herring (binding
+resolution keys off `definition_id`, not `identity_id` — see §8). The real,
+still-open question this investigation surfaces is narrower and different in
+kind: whether the specific account AgentY (and Lark) are bound to —
+**"Claude (personal)," whose `secret_ref` points at the operator's own real,
+global `~/.claude`** — was bound to these agents intentionally. Tracked
+separately, see §8.
+
+**Trigger:** Operator closed this agent's (`AgentY`) pane on AgentMux v0.55.15 and reopened
+it on v0.55.18, expecting conversation continuity. None occurred — investigating why led
+to a much larger finding than the original complaint. Full forensic trail:
+`docs/retro/retro-agenty-global-claude-home-leak-2026-08-20.md`. This doc is the
+action-oriented summary for anyone picking this up next.
+
+Sections 1-7 below are kept as-written (the investigation as it actually happened,
+including the wrong turn) rather than silently rewritten — §8 is the correction.
+
+---
+
+## 1. The headline finding
+
+`agentmux-srv/src/identity/resolver/inject.rs`'s spawn-time credential gate
+(`inject_identity_env_with_broker` → `gate_oauth_failure`) is supposed to unconditionally
+block any spawn of an oauth-class-provider agent (claude/codex/gemini/copilot/openclaw)
+that has no bound account — a deliberate hardening (commit `860fb0b6a`, 2026-07-23, "single-
+point enforcement... `use_ambient_login` no longer has any effect") of the exact hole
+`docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md` documented:
+silent fallback to the user's personal, global `~/.claude` login.
+
+**By every static read of the code, this agent's own pane (`identity_id=""`, zero rows in
+`db_agent_identity_links`, provider `claude`) should be blocked on every single spawn.** It
+is not — it has spawned and run successfully dozens of times today, with the gate's own
+`"identity.spawn.blocked"` warning appearing **zero times** in a full day of `v0.55.18`
+server logs, for any agent, not just this one.
+
+**Confirmed, separately, on-disk consequence:** this agent's sessions have been writing to
+the operator's global `~/.claude/projects/` home instead of the isolated per-agent
+`CLAUDE_CONFIG_DIR` since ~2026-08-05 — exactly the outcome the gate exists to prevent.
+
+## 2. Why this is higher priority than the original continuity complaint
+
+If the gate genuinely isn't enforcing, credential isolation between agents — and between
+an agent and the operator's own personal account — may not be reliably enforced right now
+for any agent whose identity binding is empty/missing, not just this one. That's a
+security/isolation property, not a UX nuisance. It also means any fix built directly on
+top of findings from the two related docs below would be built on a foundation
+(the gate) that isn't actually running — worth confirming that first.
+
+## 3. Three related, previously-documented issues feeding into this
+
+1. `docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md` — the
+   original "auto-isolate" behavior for unbound agents was orphaned across five commits
+   (2026-05-22 → 2026-07-14); today's gate is the eventual hardening response to it.
+2. `docs/specs/REPORT_HISTORY_CONTINUITY_ACROSS_VERSION_UPGRADE_2026_08_17.md` — a prior
+   instance of this same agent found that `db_agent_identity_links`/`db_accounts` resolve
+   through a **per-channel-isolated** store by default on any non-`stable` channel, so a
+   version/channel switch can silently empty an agent's binding row. Verdict at the time:
+   "Not solved." Plausible explanation for why this agent's `identity_id` went blank
+   sometime around 2026-08-05.
+3. This investigation — traced the gate all the way through and found it structurally
+   should fire but empirically never does, per live server logs.
+
+## 4. Confirmed facts (DB state, queried directly against the live channel store)
+
+```
+db_agent_instances.identity_id = ''   (for this agent's running instance)
+db_agent_identity_links: 0 rows total (in the live channel's own store)
+db_agent_definitions.use_ambient_login = 0  (false — should make no difference; see §1)
+```
+
+## 5. What's needed to close this out (not done in this investigation — see retro §7)
+
+Add a temporary `tracing::info!` at the top of `inject_identity_env_with_broker` logging
+`block_id`, trigger one real spawn/respawn of an affected agent, and check whether it
+appears in the log at all:
+
+- **Doesn't appear at all** → the `agent_io.rs`/`input.rs` RPC handlers traced in this
+  investigation are not the code path actually driving a live persistent controller's
+  message delivery; the real dispatch path needs to be found from scratch.
+- **Appears, returns `Ok`** → the bug is inside the function — it's reading different
+  binding/provider data at runtime than the direct DB query in §4 saw.
+- **Appears, correctly computes `Err`** → the bug is in how the caller handles that `Err`
+  (swallowed somewhere before it blocks the spawn / surfaces in the pane).
+
+This was deliberately not attempted in this investigation to avoid restarting a live,
+in-use pane mid-conversation. Do this on a disposable/throwaway test agent first if
+possible, to avoid disrupting a real agent's session.
+
+## 6. Update — the gate function itself is proven correct; the bug is structural
+
+Ran this module's own test suite (`cargo test -p agentmux-srv identity::resolver::inject`)
+against the diagnostic build: **all 7 tests pass**, including
+`inject_empty_identity_is_gated_same_as_blank` — a test that covers this agent's exact
+production shape (`identity_id=""`, oauth-class provider, no binding, `use_ambient_login
+=false`) and asserts the gate correctly returns `Err(SpawnGateError::MissingCredentials)`.
+
+**This rules out a logic bug inside `inject_identity_env_with_broker`/`gate_oauth_failure`.**
+Given this exact state, the function is proven — by its own test suite, run fresh against
+the current code — to compute the correct "block" outcome. The discrepancy is therefore
+structural: something prevents this correctly-computed `Err` from ever being reached or
+ever taking effect on this agent's actual live respawn path in production, where the
+identical state (confirmed via direct DB query, §4) does not block the spawn.
+
+Also ruled out: a stale/duplicate DB copy from an older version. The channel this agent
+actually runs under (`local-main-b28b7a-697d25a4`) only has a `versions/0.55.18/` folder —
+no older `0.55.15`/`0.55.16` sibling for this specific channel to be silently reading from
+instead (those version folders exist only under a *different* channel hash,
+`local-main-b28b7a-01f827a1`, used by other agents — not this one).
+
+**A cross-instance runtime test (spin up a fresh `task dev` instance, create a disposable
+never-bound test agent, and drive it via the UI to check whether the diagnostic log lines
+fire) was attempted and abandoned**: this agent's own `mcp__agentmux__UI*` tools are
+confirmed scoped to "your own pane, cannot reach a different pane or agent's UI" — no
+tool available in this session can drive a separate AgentMux window's UI. The dev instance
+was built successfully (confirms the diagnostic-instrumented code compiles and the
+`860fb0b6a` gate-hardening logic is present in a real `v0.55.18`-equivalent build) but was
+torn down without a UI-driven test, to avoid burning further time on tooling that
+structurally can't reach it from here.
+
+Temporary diagnostic `tracing::info!` lines remain in
+`agentmux-srv/src/identity/resolver/inject.rs` (marked `TEMP DIAGNOSTIC`, referencing this
+doc) at: function entry, the no-instance-row early return, immediately before
+`gate_oauth_failure` returns `Err`, and the final `Ok(())` return. These are cheap,
+`info`-level, and safe to ship as-is if a restart happens before someone gets to remove
+them — but should be removed once this is closed out.
+
+**Remaining concrete next step, unchanged in substance from §5 but now more targeted:**
+one real restart of an affected agent's pane (this one, or the disposable dev-instance
+route if UI automation becomes available) with these diagnostic lines live, checking which
+of the four DIAG lines actually appears in the log. Given the function is now proven
+correct in isolation, the two live outcomes to distinguish are just:
+- **No DIAG line at all appears** → `agent_io.rs`/`input.rs`'s `AgentSendCommand`/
+  `AgentInputCommand` handlers are not the code path actually driving this agent's
+  respawn (e.g., an internal `persistent.rs` retry — `retry_after_resume_failure` — may
+  reuse a previously-resolved `env_vars`/config without re-invoking the gate at all,
+  rather than re-entering the RPC handler). This would mean the gate only ever runs once,
+  at a spawn's *original* triggering message — and if identity was still valid at that
+  original moment (before whatever broke it later), every subsequent respawn of the
+  *same* long-lived controller would keep reusing that stale-but-still-approved config
+  forever, never re-checking.
+- **The `Err`-about-to-return DIAG line appears, but the spawn proceeds anyway** → the
+  `Err` is being swallowed or ignored somewhere between `inject_identity_env_async`'s
+  return and `agent_io.rs`'s handling of it.
+
+## 7. Non-goals / what this doc is not about
+
+Not about Part B/C of `docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md`
+(cross-instance session rehydration) — that gap is real but unrelated; this agent's
+session file is in the *correct* isolated location and simply isn't being looked at
+because the live process isn't using that `CLAUDE_CONFIG_DIR` at all.
+
+## 8. Resolution (2026-08-21) — §5's recommended test was run; the gate works
+
+§5/§6 asked for exactly one thing: a real restart with the `DIAG` lines live,
+to see which branch actually executes. That test happened — not on this pane
+(deliberately avoided disrupting a live conversation, as noted at the time),
+but on a disposable `task dev` instance, opening an **existing** agent
+("Lark") that was never touched by this investigation before.
+
+**Result: the `DIAG` lines fired, and the gate returned `Ok` — correctly.**
+Full log sequence:
+
+```
+DIAG: inject_identity_env_with_broker called for block 1f833386-...
+WARN: instance 1f833386-... has empty/blank identity_id — falling through to
+      the layer-3 gate instead of ambient creds. Legacy row or UI regression?
+INFO: injected CLAUDE_CONFIG_DIR for oauth provider claude
+      (identity=, account=a1990489-6de6-484a-9e20-83688c641524)
+DIAG: inject_identity_env_with_broker returning Ok for block 1f833386-...
+```
+
+This is §5's second predicted outcome ("Appears, returns `Ok` → something
+upstream is feeding it different (working) data than what I saw in the DB")
+— confirmed, and the reason was found immediately: **`resolve_bindings_for_instance`
+keys off `instance.definition_id`, not `instance.identity_id`** (this is
+explicitly documented in that function's own doc comment, which this
+investigation read earlier but didn't fully connect at the time). The "empty
+identity_id" WARN is cosmetic — it does NOT mean "no binding." A direct query
+of the correct store (`~/.agentmux/shared/identity-store.db` — **global**,
+not the per-channel `objects.db` this investigation's §4 mistakenly queried)
+confirms AgentY has a real, valid, `status: "valid"` binding:
+
+```
+db_agent_identity_links: (AgentY's definition_id, account a1990489-..., 'claude')
+db_accounts: account a1990489-..., name "Claude (personal)", kind "oauth",
+             secret_ref: {"backend":"oauth_config_dir","dir":"C:\Users\asafe\.claude"}
+```
+
+**So: the gate is not broken. §4's "0 rows" finding was a real fact about the
+wrong database** (the per-channel `id_store`, which — per
+`REPORT_HISTORY_CONTINUITY_ACROSS_VERSION_UPGRADE_2026_08_17.md`'s own
+finding — legitimately does reset per channel) — **but the actual binding
+lookup this gate performs reads the always-global `identity_store` instead**
+(the PR #2632 fix), where the real binding has been sitting correctly the
+whole time. Two different, both-real facts about two different databases got
+conflated into one wrong headline conclusion. Worth remembering for next
+time: confirm which store a piece of code *actually* reads before treating a
+query against "a" store as decisive.
+
+**What's actually still open, now correctly scoped:** the account itself —
+"Claude (personal)" — has a `secret_ref` pointing at the operator's own real,
+global `~/.claude`, not an isolated per-agent directory. That's real, and
+it's why AgentY's (and Lark's) sessions land in the operator's personal
+Claude Code history instead of an isolated one. Whether that's intentional
+(the operator deliberately wanting these two agents to run on their own
+personal login) or an unintentional/legacy binding is a product question,
+not a bug — the credential-isolation gate enforced exactly what's configured.
+Tracked as a follow-up issue rather than resolved here, since only the
+operator can answer that.


### PR DESCRIPTION
## Summary

Docs only, no code changes. Four documents from one investigation thread:

- `docs/retro/retro-agenty-global-claude-home-leak-2026-08-20.md` — full investigation trail, starting from "AgentY's pane carried no summary across a v0.55.15 → v0.55.18 reopen."
- `docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md` — **corrected conclusion**: the credential-isolation spawn gate is NOT broken (§8). A live-instrumented test (opening a different agent, "Lark," in a disposable dev instance) confirmed the gate fires and correctly returns `Ok` — the earlier "0 identity links" finding queried the wrong (per-channel) database. The actually-still-open question: AgentY/Lark's real, valid account binding ("Claude (personal)") points at the operator's own global `~/.claude` — intentional, or not? Product question, not a bug.
- `docs/specs/SPEC_AGENT_GENERIC_PANE_OPEN_TOOL_2026_08_21.md` — design for a general `OpenPane` MCP tool (not yet implemented).
- `docs/analysis/ANALYSIS_AGENT_UI_AUTOMATION_CROSS_PANE_AND_CROSS_INSTANCE_TARGETING_2026_08_21.md` — §1 (cross-instance capture) shipped separately as `CaptureWindow` (#2709); §2 (cross-pane targeting within one instance) deliberately NOT implemented — real security precedent (PR #2662, two prior P0s in this exact area) means it needs a real authorization-policy decision first, not a quick widening.

Follow-up tracking issues for the not-yet-implemented pieces to follow this PR.

<!-- agentmux:agent_id=agenty -->