### PR TITLE
docs(specs): quick-fork, pane mirroring, and host/LAN/WAN naming specs

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -42,6 +42,8 @@ See also:
 | [SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17](SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md) | App-API `agent.*` surface (open/fork/define) |
 | [SPEC_APP_API_AGENT_DEFINE_2026_06_06](SPEC_APP_API_AGENT_DEFINE_2026_06_06.md) | `agent.define` RPC |
 | [SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06](SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md) | Agent fork / continuation across sessions |
+| [SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21](SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md) | Quick-fork an agent into a new tab (hot clone, full identity) |
+| [SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22](SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md) | Display naming/addressing scheme shared by the fork and pane-mirror specs |
 | [SPEC_AGENT_GLOBAL_PORTABILITY_2026-06-16](SPEC_AGENT_GLOBAL_PORTABILITY_2026-06-16.md) | Agent definitions shared across workspaces |
 | [SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13](SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md) | Cross-channel conversation continuity |
 | [SPEC_ASK_USER_QUESTION_2026_06_15](SPEC_ASK_USER_QUESTION_2026_06_15.md) | `ask_user_question` tool |
@@ -128,6 +130,7 @@ See also:
 | [SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16](SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.md) | Agent discovery + persistent delivery |
 | [SPEC_OBJ_UPDATE_BRIDGE_2026-05-14](SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md) | Obj-update bridge (sidecar↔renderer) |
 | [SPEC_CROSS_PROCESS_DISPATCH_2026-05-01](SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md) | Cross-process dispatch architecture |
+| [SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21](SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md) | Mirrored agent panes across channels/LAN/WAN — reuses the jekt trust model for input authorization |
 
 ## Packaging / Build
 

--- a/docs/specs/SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md
+++ b/docs/specs/SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md
@@ -1,0 +1,356 @@
+# SPEC: Agent display naming & addressing across host, LAN, and WAN
+
+**Date:** 2026-08-22
+**Status:** Draft — architecture proposal, no code landed. Shared substrate spec:
+consumed by, not superseding, its two sibling specs below.
+**Scope:** Agent **display naming** only (the human-facing label shown in tabs,
+pickers, presence indicators). Does **not** touch `AGENTMUX_AGENT_ID`, jekt
+signing identity, or any routing/security identity — those are already solved
+and orthogonal to this layer (see §7).
+**Related:** `SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md` (needs a naming
+pattern for forked agents), `SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md`
+(needs a shared "which peer owns this" concept for discovery/presence),
+`SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` (established the host-global
+agent registry this spec's host tier builds on), `SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md`
+(the existing but under-specified "#2" auto-naming rule), `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`
+(the LAN peer-identification this spec's LAN tier reuses). **Cross-repo (agentmuxai/agentmux-cloud,
+verified at commit `e0a756e`):** `muxbus/server/src/agent-ownership.ts` (the
+`(account_user_id, agent_id)` table this spec's WAN tier anchors to),
+`muxbus/server/src/agent-binding.ts` (a *different*, narrower existing use of
+"binding" — see §2.3, do not reuse that word for this spec's concepts),
+`muxbus/SPEC_AGENT_PUBLIC_ID_2026_06_21.md` (confirms `agent_id` is flat/global/
+unnamespaced in muxbus today — the real gap this spec's WAN qualifier
+compensates for), `muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`
+(the abandoned per-agent-credential design; its open-question #2 is directly
+relevant to §4.6's proposal)
+
+> **Naming.** "Qualified" vs. "unqualified" name, borrowed deliberately from git
+> (`main` vs. `origin/main`) and email (`user` vs. `user@host`) — both are
+> well-understood precedents for "a short name works until it might collide, at
+> which point prefix/suffix the origin, don't invent a new namespace." The
+> per-peer/per-host identifier used for qualification is a **`HostLabel`** (§4.2)
+> — deliberately not called a "channel" (already a different, data-isolation
+> concept in this codebase, see `SPEC_DATA_CHANNELS_2026_05_24.md`) or an
+> "identity" (already the credential/Armory concept).
+
+---
+
+## 1. Problem / TL;DR
+
+Two sibling specs each independently need a notion of "which machine/peer is
+this agent actually on": the fork spec, to decide whether a forked agent's
+"#N" counter can collide with a fork of the same lineage happening elsewhere;
+the mirror spec, to discover and label the peer a pane is being mirrored
+to/from. Solving this once, as a shared naming/addressing layer both specs
+consume, avoids two independently-invented, subtly-incompatible notions of
+"host" appearing in the codebase. This spec also directly answers a concrete
+question raised while drafting the fork spec: **if "AgentX #3" exists on one
+channel and "AgentX #4" gets minted on a different channel on the same host at
+roughly the same time, does the counter still work?** — and extends that
+answer outward to what happens once agents/panes are addressed across LAN and
+eventually WAN, which both sibling specs anticipate as a "fluid across all
+three tiers" end state.
+
+## 2. Current architecture (code-verified)
+
+**Host tier: the registry is already global per-host, not per-channel.**
+`SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` (implemented, load-bearing
+per this repo's `CLAUDE.md`) re-rooted agent definitions and instances to
+`~/.agentmux/shared/agents/{registry,definitions}/` — one shared store per
+**machine**, read/written by every channel and version running on it. So a
+fork minted on `stable` and a fork minted on a `local-<branch>-<hash>` dev
+channel, on the *same* host, already see and write the *same* underlying
+store — this part of "does the count still work" is already true by
+construction, not something this spec needs to build.
+
+**But the write primitive is overwrite-safe, not allocation-safe.**
+`agentmux-srv/src/registry/atomic.rs`'s `write_atomic` (temp file → `fsync` →
+rename-over-target) guarantees no reader ever observes a half-written file. It
+does **not** provide exclusive-create or compare-and-swap — nothing prevents
+two processes from independently computing "current max is 3" and both
+writing a *different* new record (different UUID, different file) both
+displaying "AgentX #4". This is a real, code-confirmed gap, not a hypothetical
+one: `SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE` §11.5 landmine #2 flags exactly
+this class of concern ("verify \[atomic rename\] holds under simultaneous
+startup migrations") without fully resolving it for the counter-allocation
+case specifically.
+
+**LAN tier already has an implicit host-identification concept, just not
+surfaced as a naming primitive.** `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`'s
+per-agent Ed25519 verification fetches "the claimed sender's own public key...
+from whichever LAN peer hosts that agent" — meaning the system already has to
+resolve, for every LAN-addressable agent, which physical peer hosts it. This
+resolution is currently internal to the signing/verification path; nothing
+today exposes it as a user-facing label.
+
+**WAN tier's identity anchor, verified against `agentmuxai/agentmux-cloud`
+at commit `e0a756e` — corrects and sharpens the original draft of this
+section.** `MUXBUS_AGENT_ID` mirrors `AGENTMUX_AGENT_ID` at spawn so muxbus
+can route to an agent by identity across the WAN (per this repo's `CLAUDE.md`)
+— but muxbus's own data model is more specific, and more useful, than a bare
+identity mirror:
+
+- **`agent_id` is a flat, global, self-declared string, with no per-account
+  namespace** (`muxbus/SPEC_AGENT_PUBLIC_ID_2026_06_21.md`; enforced via
+  `normalizeAgentId()`, `muxbus/server/src/index.ts`). **Two different
+  accounts' agents named `korp` collide on the exact same routing key today**
+  — explicitly flagged as unsolved, out-of-scope Phase-3 work in
+  `muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`. This spec's WAN
+  qualifier isn't cosmetic disambiguation on top of an already-unique id — it
+  is compensating for a **real, currently-open collision gap** in muxbus's
+  own storage.
+- **A real ownership pairing already exists and is queryable:**
+  `muxbus/server/src/agent-ownership.ts` — table `muxbus-agent-ownership-{env}`,
+  PK `account_user_id`, SK `agent_id`, checked via `isAgentOwnedByAccount()`.
+  **Decision: the WAN qualifier is `<account_user_id>/<host-label>`** (or a
+  resolved display form, e.g. the account's email), anchored to this
+  already-shipped table — not a vaguer "muxbus account" hand-wave.
+- **Do not call this a "binding"** — `agent-binding.ts`'s `checkAgentBinding()`
+  already uses that word for a narrower, different thing (does *this*
+  authenticated request's account match the ownership record for the
+  `agent_id` it's sending *as*). Reusing "binding" here would collide
+  semantically with already-shipped code.
+- **Critical constraint the original draft missed: muxbus cannot resolve
+  "host" server-side, at all, today.** WAN delivery is mailbox/poll-based —
+  every connected sidecar wakes on a broadcast ping and independently checks
+  `GET /reactive/pending/:agent_id` for whatever it locally hosts
+  (`muxbus/server/src/index.ts`, `broadcast.ts`). The WebSocket connections
+  table is deliberately zero-metadata (`ws-connect.ts`: "$connect only needs
+  to know a socket is open — no agent/account ownership is recorded here").
+  **There is no host concept in muxbus's data model at all.** Consequence:
+  the `host-label` half of a WAN-qualified name must be **asserted
+  client-side** (by the sidecar itself, which knows what machine/channel it's
+  running on) — muxbus can confirm *ownership* (`account_user_id` ↔
+  `agent_id`) but can never independently verify *which host*. This is
+  consistent with, not a workaround for, this spec's own G4 ("a qualifier is
+  a label, never a trust claim") — a self-asserted host-label was always
+  going to be exactly as trustworthy as `TRUST=network-claimed` already is
+  for WAN jekt, no more.
+
+**The existing fork auto-naming rule doesn't specify its own scope.**
+`SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md`'s "Senior Dev" → "Senior Dev #2"
+rule predates the host-global registry work and never states whether the
+counter is meant to be unique per-channel, per-host, or wider — this spec
+closes that gap explicitly (§4.3).
+
+## 3. Design goals
+
+| # | Goal |
+|---|---|
+| G1 | A short, unqualified name ("AgentX #4") is sufficient for the overwhelming common case — most agents never leave their host |
+| G2 | The short name never has to *change* when a boundary is later crossed — a qualifier is appended, non-destructively, never a rename |
+| G3 | The fork spec and the mirror spec share exactly **one** host/peer-identification primitive, not two independently-invented ones |
+| G4 | A naming qualifier is a **label**, never a trust claim — matches the jekt trust model's own posture that crossing a network boundary never proves identity by itself |
+| G5 | Mirroring a pane never mints a new name (§4.5) |
+
+## 4. Proposed design
+
+### 4.1 Three tiers, matching jekt's existing DELIVERY split
+
+Deliberately reuse the exact host/lan/wan three-way split jekt's `DELIVERY`
+field already establishes, rather than inventing a fourth taxonomy for naming:
+
+| Tier | Unqualified name valid when | Qualified form |
+|---|---|---|
+| **Host** | Always, within one host's global registry (§2) | `AgentX #4` (no qualifier shown) |
+| **LAN** | Never, once a name is visible to a second machine | `AgentX #4@<host-label>` |
+| **WAN** | Never | `AgentX #4@<account_user_id-display>/<host-label>` — account half server-verifiable against `muxbus-agent-ownership-{env}`, host-label half self-asserted (§2) |
+
+The qualifier is appended only once a name actually becomes visible outside
+its host of origin (a mirror connects, a fork lands on a remote peer) — a
+purely host-local agent never shows one (G2).
+
+### 4.2 `HostLabel` — one shared primitive for both sibling specs
+
+```
+HostLabel {
+  display: string,     // human-facing — default: OS hostname; user-overridable (§6, open Q1)
+  scope: "lan" | "wan", // host tier needs no HostLabel at all — see §4.1
+  stable_id: string,    // the actual anchor: LAN peer id (from the discovery already
+                         // backing SPEC_JEKT_LAN_TIER_SIGNING's pubkey fetch) for "lan";
+                         // self-asserted by the sidecar (muxbus has no host concept
+                         // to verify against, §2) for "wan" -- paired with, but
+                         // distinct from, the server-verifiable account_user_id half
+}
+```
+
+For WAN specifically, the full qualifier is **two independently-sourced
+halves**, not one opaque id: `account_user_id` (server-verifiable against
+`muxbus-agent-ownership-{env}`) and `host-label` (client-asserted,
+unverifiable by muxbus, §2). Never collapse these into a single "WAN
+HostLabel" value that looks server-verified end to end — it isn't, and
+presenting it as if it were would violate G4.
+
+Both sibling specs resolve to this one type instead of each defining their
+own notion of "which machine":
+- **Fork spec** (`SPEC_AGENT_QUICK_FORK_NEW_TAB`): if/when a fork lands on a
+  remote peer rather than the local host (explicitly a non-goal there today,
+  called out here as the reason this spec exists ahead of that capability),
+  the new instance's qualifier is that peer's `HostLabel`.
+- **Mirror spec** (`SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC`): its Phase
+  B/C discovery sections should resolve peers to `HostLabel` values directly,
+  replacing their current ad hoc "LAN peer"/"WAN peer" prose (see §4.5 and the
+  patch applied to that spec alongside this one).
+
+### 4.3 Counter allocation, tier by tier (resolves the race question)
+
+- **Host tier:** best-effort scan-and-increment (as `SPEC_MULTI_SESSION_AGENT_FORK`
+  already does), explicitly **not** treated as atomic/collision-proof, because
+  §2 confirms the underlying write primitive can't provide that. Mitigation:
+  pair the number with a short, inherently-collision-resistant suffix — reuse
+  the same disambiguator the workspace-folder naming convention already uses
+  (a short date+letter tag, or a few hex characters of the instance UUID) —
+  so a rare simultaneous double-fork produces `AgentX #4-0822k` vs.
+  `AgentX #4-0822p`: momentarily the same *number*, never actually ambiguous
+  as *strings*. No new atomic-sequencer infrastructure required.
+- **LAN/WAN tiers: do not attempt to synchronize the counter across hosts at
+  all.** This is the resolution to "does the count still work across
+  channels/hosts": **it doesn't need to** once a name is qualified. `AgentX #4@hostA`
+  and `AgentX #4@hostB` are simply different strings the moment they're
+  qualified — there is no ambiguity to resolve, so there is no need for, and
+  no cheap way to build, a cross-machine sequencer. Treat this as a
+  deliberate non-goal (§8), not a gap.
+
+### 4.4 Forking across tiers
+
+`SPEC_AGENT_QUICK_FORK_NEW_TAB`'s v1 only ever lands a fork on the same host
+(its own §8 non-goals). Under this scheme, that means v1 quick-forks **never
+need a qualifier** — only the host-tier counter+suffix from §4.3. The
+qualifier machinery in this spec exists specifically so that *when* (not if,
+per the "fluid across all three tiers" framing) a future capability forks
+directly onto a LAN/WAN peer, the new instance is unambiguous on arrival —
+qualified immediately by its landing peer's `HostLabel`, no retrofit needed.
+
+### 4.5 Mirroring never mints a name
+
+This is the key correction to the mirror spec: **a mirror connection is a new
+*viewer* of an existing name, never a new registry entry, never a name
+variant.** The mirrored pane's chrome renders the existing (possibly already
+host/LAN/WAN-qualified) name plus a **presence list** of active viewers, each
+one itself labeled with *its own* `HostLabel` — e.g. "AgentX #4 — also open
+from: korp-laptop (LAN)". This reuses `HostLabel` in the opposite direction
+from §4.4 (labeling a *viewer*, not an *owner*) but it's the same primitive,
+which is exactly the point of extracting it once.
+
+### 4.6 Synergy: this spec's WAN anchor and jekt's unbuilt WAN signing gap
+
+Raised directly by the human while this spec was being written, and worth
+making explicit rather than leaving as a coincidence: this spec's WAN
+qualifier work and jekt's own known gap — "general agent-to-agent WAN signing
+does not exist yet... an arbitrary WAN jekt's `source_agent` remains exactly
+as forgeable as before" (this repo's `CLAUDE.md`, `agentmux-cloud` issue
+#2586's unbuilt half) — **could plausibly be closed by the same piece of new
+infrastructure**, verified against `agentmux-cloud`'s actual code rather than
+assumed:
+
+- **The wire format and storage path for a real per-sender WAN signature
+  already exist, end to end, proven for exactly one identity.**
+  `muxbus/consumers/github/handler.ts` signs every reagent-originated jekt
+  with a pinned Ed25519 key and attaches `reagent_sig`/`reagent_key_id`/
+  `reagent_msg_id`/`reagent_ts_secs` to the `Injection` record
+  (`muxbus/server/src/store.ts`); the receiving agentmux-srv verifies it
+  client-side against a pinned public key (`agentmux_common::jekt_sign`).
+  Critically, **these fields are generic in the schema** — nothing about
+  `Injection`'s shape hardcodes "reagent"; only the one Lambda that currently
+  populates them does. The proven, shipped part of "general WAN signing" is
+  exactly this: the fields exist, the storage is opaque pass-through
+  (`store.ts`: "the server never verifies it"), and client-side verification
+  already works for one sender.
+- **What's missing is per-agent (or per-account) key issuance and pinning —
+  and this spec already needs an identity anchor to hang it on.** The
+  abandoned `PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md` design's own
+  open-question #2 floated, but never built, "a self-issued, KMS-signed
+  capability token" per agent. **If the already-shipped `agent-ownership.ts`
+  row (`account_user_id`, `agent_id`) grows a public-key field** (or a new
+  table keyed identically), the same record this spec's WAN qualifier already
+  needs to look up for the *account* half of a display name could *also*
+  serve as the trust anchor jekt's WAN signing gap needs — one new field,
+  reused for two purposes, instead of two independent designs each inventing
+  their own identity record.
+- **This does not close the gap by itself** — naming only needs to *display*
+  the account/agent pairing; it doesn't need the pairing to carry a
+  verifiable signature. Actually closing jekt's WAN gap requires someone to
+  build key issuance, rotation, and the `Injection`-population logic
+  analogous to `handler.ts`'s reagent path, generalized to any owned agent —
+  real work, not a byproduct of this spec. What this spec's research
+  establishes is narrower and still useful: **the two problems share a
+  natural home for their identity anchor**, so whoever eventually builds
+  general WAN signing should extend `agent-ownership.ts` rather than invent a
+  parallel identity table this spec would then have to reconcile with.
+
+This is explicitly a **note for whoever picks up jekt's WAN-signing gap
+later**, not a phase this spec commits to delivering — see §8 non-goals.
+
+## 5. Decision tables
+
+### 5.1 Why not one global (UUID-based) namespace for every agent, always?
+
+| | **Tiered qualification (this spec)** | Always-global unique names |
+|---|---|---|
+| Common case (host-only agent) | Clean, short, unqualified (G1/G2) | Every agent always shows a long/opaque qualifier, even when never leaving the host |
+| New infrastructure needed | None beyond `HostLabel` (already implicit in LAN signing) | A real global naming authority |
+| Matches existing codebase bias | Yes — mirrors the registry's own "cheap, eventually-consistent" design philosophy | No |
+
+**Decision: tiered qualification.** Only pay the naming-complexity cost once a
+name actually needs to travel.
+
+### 5.2 Why not build a cross-host atomic counter/sequencer?
+
+| | **No cross-host sequencer (this spec)** | Hosted/distributed sequencer |
+|---|---|---|
+| New dependency | None | A new always-on service (or LAN consensus protocol) — a new single point of failure for a purely cosmetic concern |
+| Solves the actual problem? | Yes — qualification already removes the ambiguity a sequencer would exist to prevent | Also yes, but at much higher cost for no additional benefit |
+
+**Decision: no sequencer, ever.** Qualification is strictly cheaper and
+already sufficient (§4.3).
+
+## 6. Phasing
+
+| Phase | Deliverable | Gated by |
+|---|---|---|
+| **1** | Host-tier fix: pair the existing "#N" auto-naming rule with a collision-safe suffix (§4.3) | Independent — can ship alongside `SPEC_AGENT_QUICK_FORK_NEW_TAB` Phase 1-2 |
+| **2** | Formalize `HostLabel` for LAN scope, surfaced from existing LAN peer discovery (no new discovery mechanism, just exposing what `SPEC_JEKT_LAN_TIER_SIGNING` already resolves internally) | Needed once either sibling spec's LAN phase ships |
+| **3** | `HostLabel` for WAN scope (`muxbus-account/host-id`) | Needed once the mirror spec's WAN phase (Phase C) ships |
+
+## 7. Relationship to routing/security identity (non-overlap, stated explicitly)
+
+This spec is strictly the **display** layer. It changes nothing about:
+- `AGENTMUX_AGENT_ID` (routing identity, tied to the `AgentDefinition` slug).
+- Jekt's HMAC (host)/Ed25519 (LAN)/reagent-pinned-key (WAN) signing — a
+  `HostLabel` is never presented as, or treated as, proof of anything; it is a
+  label a human reads, not a credential a system trusts (G4). A LAN mirror's
+  `HostLabel` says "this claims to be korp-laptop" with exactly the same
+  epistemic weight `TRUST=network-claimed` already carries for jekt — labeling
+  and trust are deliberately kept separate.
+
+## 8. Non-goals
+
+- A global (cross-host) uniqueness *guarantee* for unqualified short names —
+  never the goal; qualification is the tool, not elimination of the
+  possibility that two hosts both have an "AgentX."
+- Any cross-host atomic counter/sequencer (§5.2, explicitly rejected).
+- Changing how `AGENTMUX_AGENT_ID` or any jekt signing key is minted or
+  scoped — orthogonal (§7).
+- User-facing UI for renaming/customizing a `HostLabel` beyond the basic
+  override noted in §9 Q1 — a full "manage my host labels" surface is a later
+  polish pass, not required for either sibling spec's v1.
+- **Building general agent-to-agent WAN jekt signing.** §4.6 identifies a
+  shared identity anchor a future signing scheme *could* reuse; this spec
+  does not design or deliver that scheme itself — that's issue #2586's own
+  scope, not this one's.
+- **Turning on `ENFORCE_AGENT_BINDING=true`** (`agentmux-cloud`,
+  currently log-only in every environment per
+  `PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`) — this spec's WAN
+  qualifier reads the same ownership table that check already guards, but
+  flipping enforcement on is an independent, `agentmux-cloud`-side decision
+  with its own blast radius, out of scope here.
+
+## 9. Open questions
+
+| # | Question | Default/Recommendation |
+|---|---|---|
+| 1 | Can a user customize their own host's label (vanity name), or is it always the OS hostname? | Default to OS hostname; allow an override in Settings (this is a **Preference**-tier value per `SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE`'s own three-tier data model — channel-scoped, not identity-scoped) |
+| 2 | Should the qualified form ever be shown by default, even at host tier, for consistency? | No — only show a qualifier once a name is actually visible beyond its host of origin; an always-qualified UI would violate G1/G2 for the common case |
+| 3 | Where does `HostLabel` get persisted/surfaced in the API surface? | Not fully specified here — likely piggybacks on whatever peer-list structure LAN discovery already maintains for `SPEC_JEKT_LAN_TIER_SIGNING`'s pubkey lookups, plus a small new muxbus-account lookup for WAN. Flagged as an implementation detail for whichever sibling spec's LAN/WAN phase ships first. |
+| 4 | How is the WAN qualifier's account half actually *displayed* (raw `account_user_id`/Cognito `sub`, or a resolved email/display name)? | Resolve to a display name (email is the obvious candidate, muxbus already has it via Cognito) — a raw `sub` is meaningless to a human reading a presence indicator |
+| 5 | Does resolving the WAN account display name require a new muxbus endpoint, or does the dashboard's existing account-lookup path (`SPEC_CLOUD_SERVICES_DASHBOARD_2026_08_18.md`) already expose it? | Check the dashboard spec's account API before building a new one — likely already covered since "my agents" there is already keyed on `account_user_id` |

--- a/docs/specs/SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md
+++ b/docs/specs/SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md
@@ -95,10 +95,22 @@ identity mirror:
   `normalizeAgentId()`, `muxbus/server/src/index.ts`). **Two different
   accounts' agents named `korp` collide on the exact same routing key today**
   — explicitly flagged as unsolved, out-of-scope Phase-3 work in
-  `muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`. This spec's WAN
-  qualifier isn't cosmetic disambiguation on top of an already-unique id — it
-  is compensating for a **real, currently-open collision gap** in muxbus's
-  own storage.
+  `muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`.
+  **Correction (Codex's review of PR #2721 caught this precisely): this
+  spec's WAN qualifier does NOT fix that collision — it only fixes the
+  *display* of it.** `GET /reactive/pending/:agent_id` and every other
+  muxbus routing/polling path still key on the unchanged, unnamespaced
+  `agent_id` string. Two accounts' same-named agents can still have messages
+  routed to, or read from, the wrong mailbox — actual traffic
+  misdelivery/exposure, not just a confusing UI label — regardless of what
+  qualifier this spec's display layer renders. **This spec explicitly does
+  not resolve that routing-level collision** (§8 non-goals) — it only
+  ensures a human *looking at two same-named agents* can tell them apart.
+  Fixing the underlying routing key is real, separate, unscoped work
+  (muxbus-side namespacing, likely `<account_user_id>:<agent_id>` as the
+  actual storage/routing key, not just the display qualifier) that this
+  spec deliberately leaves as an **open, unresolved blocker** rather than
+  implying is already handled.
 - **A real ownership pairing already exists and is queryable:**
   `muxbus/server/src/agent-ownership.ts` — table `muxbus-agent-ownership-{env}`,
   PK `account_user_id`, SK `agent_id`, checked via `isAgentOwnedByAccount()`.
@@ -338,6 +350,14 @@ This spec is strictly the **display** layer. It changes nothing about:
   shared identity anchor a future signing scheme *could* reuse; this spec
   does not design or deliver that scheme itself — that's issue #2586's own
   scope, not this one's.
+- **Fixing muxbus's underlying WAN routing-key collision** (flagged by
+  Codex's review of PR #2721, addressed in §2). Two accounts' same-named
+  agents genuinely collide at the routing level in muxbus today
+  (`agent_id` is flat and unnamespaced in every polling/routing path); this
+  spec's `HostLabel` qualifier fixes how that collision is *displayed*, not
+  the collision itself. Left as an explicit, open, unresolved blocker —
+  namespacing the actual muxbus storage/routing key is separate,
+  `agentmux-cloud`-side work this spec does not scope or deliver.
 - **Turning on `ENFORCE_AGENT_BINDING=true`** (`agentmux-cloud`,
   currently log-only in every environment per
   `PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`) — this spec's WAN

--- a/docs/specs/SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md
@@ -1,0 +1,352 @@
+# SPEC: Cross-channel / LAN / WAN agent pane sync (mirrored panes)
+
+**Date:** 2026-08-21
+**Status:** Draft — architecture proposal + research, no code landed, opinion piece
+on feasibility and sequencing as requested
+**Scope:** WebSocket pub/sub (`agentmux-srv/src/server/websocket.rs`), cross-channel
+discovery/forwarding (`backend/reactive/registry.rs`), jekt trust model
+(`backend/reactive/{handler.rs,sanitize.rs}`, `agentmux_common::jekt_sign`)
+**Related:** `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`,
+`SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`,
+`SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`, `SPEC_JEKT_SENSITIVE_TIER_NARROWING_2026_08_15.md`,
+`SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md`, `SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`
+(the single-owner-block invariant this spec must not silently break),
+`SPEC_DATA_CHANNELS_2026_05_24.md` (defines "channel" — see naming note below),
+`SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` (the `HostLabel`
+primitive this spec's discovery/presence UI should resolve peers to, §4.3/§5
+below — written after this spec, to be consumed by it rather than duplicated)
+
+> **Naming collision to resolve up front.** This codebase already uses "channel"
+> for a **data-isolation bucket** (`stable`, `beta`, `local-<branch>-<hash>` — each
+> its own srv process, own port, own data dir on the *same* machine —
+> `SPEC_DATA_CHANNELS_2026_05_24.md`) — completely unrelated to the Slack/Discord
+> sense used by the messaging-bridge specs. **This spec's "cross-channel" means the
+> data-isolation sense**: syncing a pane between, e.g., a `stable` install and a
+> `local-<branch>-<hash>` dev build running side by side on one host. It has
+> nothing to do with the chat-platform bridges. I'll use **"mirror"** (not "sync")
+> for the pane-replication feature itself, reserving "sync" for the general
+> concept, because "sync" already means something narrower and different in
+> collaborative-editing literature (conflict resolution between diverging copies)
+> than what's needed here (one live source, N read replicas + floor-controlled
+> write access — see §6).
+
+---
+
+## 1. Problem / TL;DR
+
+Today, an agent pane has **exactly one owner** — one window/tab/block, full stop.
+Moving it between windows *reparents* it (`MoveTab`, `SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`
+§2.2); it never has two live viewers. The ask: open the same agent ("AgentX") from
+a second AgentMux **channel** instance on the same host and have it **mirror
+live** — type in one, see it in both, and vice versa — then extend that to LAN and
+eventually WAN peers. This is a genuinely new capability, not a variant of
+anything that exists. This spec is (a) an inventory of what's actually reusable,
+(b) a recommended architecture phased by network scope (same-host → LAN → WAN),
+and (c) an explicit accounting of why the security bar rises sharply at each
+phase, grounded in this repo's own jekt trust model rather than inventing a
+parallel one.
+
+**My opinion, stated up front:** build it in the phased order below, and treat
+Phase C (WAN) as a materially different, much higher-risk feature from Phases A/B
+— not a scope extension of the same thing. The same-host and LAN cases reuse
+infrastructure this repo already trusts (localhost-only forwarding, per-agent Ed25519
+LAN signing); WAN mirroring is the first feature in this codebase that would let a
+**remote, network-only-proven identity inject keystrokes into a running agent**,
+which is precisely the class of action the entire jekt trust layer was built to
+require the highest bar for. That doesn't mean don't build it — it means WAN
+mirroring needs its own explicit pairing ceremony and default-deny posture, not
+"the same feature, just also over the internet."
+
+## 2. Current architecture (code-verified)
+
+**Within one srv instance: real-time pub/sub exists, but it's local and
+single-owner.** One `/ws` route per srv instance (`server/mod.rs:391`,
+`server/websocket.rs`) is the transport every window/tab of *that instance* uses.
+Block/pane content is already published on a per-block scope string
+(`"blockstats:block:<id>"`, `websocket.rs:303`) — this is the primitive that lets
+a torn-off tab in its own OS window render the same live block: it's really just
+another subscriber to one instance's own event bus. **What doesn't exist:** any
+second srv instance subscribing to another instance's `block:<id>` stream, or a
+block having more than one owning window/tab at a time. `SPEC_CROSS_WINDOW_TAB_REMOUNT`
+confirms this is architecturally load-bearing, not incidental: blocks/layout are
+children of the Tab object and *travel with it* on move — there's no "keep both
+ends live" concept anywhere in that model.
+
+**`FleetBroadcast` is not a stream — don't build on the name.**
+(`agentmux-mcp/src/main.rs:225-257`, handler `main.rs:1373`, `backend/app_api/fleet.rs`)
+Per its own doc comment: it loops the *same signed single-target `SendMessage`
+delivery path*, once per target, client-side. It's "send the same discrete
+message N times," not "replicate live state to N viewers." A real terminology
+trap — this spec's mirror feature needs new plumbing, not a rename of this tool.
+
+**Cross-channel discrete messaging already exists and is the closest analog.**
+`backend/reactive/registry.rs:487-506` (`list_all_shared`) backs `host.cross_channel[]`
+in the `/agentmux/discovery` endpoint — a host-global filesystem registry letting
+agents in *different* channels on the *same machine* find and jekt each other over
+127.0.0.1-only forwarding. Exercised for real on 2026-08-21
+(`docs/retro/RETRO_JEKT_CROSS_CHANNEL_TRUST_SELF_DECLARED_2026_08_21.md` — two
+agents in different channels messaged each other and it correctly surfaced under
+`host.cross_channel` vs. same-channel `host.addressable`). This registry/forwarding
+mechanism (`registry/paths.rs`, `resolve_shared_reactive_dir`) is the right
+foundation to **discover** a mirror target across channels — it is not itself a
+streaming transport, but it's how a mirror request would find the other instance
+in the first place.
+
+**UI-capture tools are self-pane-only automation primitives, not mirroring
+building blocks.** `UIScreenshot`/`UIQuery`/`UIClick` are explicitly scoped to
+"your own pane and shared app chrome... cannot reach a different pane or agent's
+UI" (`main.rs:194-223`). `GetAgentTranscript` (`main.rs:133-144`) IS cross-agent
+but is a pull-based, best-effort, read-only tail read for Warden/Supervisor
+polling — "does not deliver anything to the target." None of these imply or
+enable multi-viewer mirroring; `GetAgentTranscript`'s poll-the-transcript-file
+pattern is a reasonable *fallback* sync mechanism (§5.4) but is explicitly the
+weaker alternative to a live socket, not evidence one exists.
+
+**The jekt trust model — this is the part any mirror-input path must sit inside,
+verbatim, not a simplified version of it.** Summarized from this repo's own
+`CLAUDE.md` (authoritative, code-anchored):
+
+| `DELIVERY` | Proof mechanism | Outcomes |
+|---|---|---|
+| `host` | Per-agent HMAC-SHA256 (`AGENTMUX_JEKT_KEY`, injected at spawn, never shared) | `host-verified` (proven), `unverified` (active forgery — always `sensitive`), `self-declared` (no key exists — not "trusted," just unauthenticated-by-construction) |
+| `lan` | Per-agent Ed25519 keypair, pubkey fetched from the LAN peer hosting that agent (`SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`) | `lan-verified` (proven, own distinct label), a *found-but-failed* signature is always forced `sensitive` (forged-identity case), unsigned/key-not-found defaults to `network-claimed` (no longer auto-sensitive as of 2026-08-15) |
+| `wan` | Only reagent's own service has a pinned key today; general agent-to-agent WAN signing **does not exist yet** (issue #2586's unbuilt half) | reagent `SIG=verified` ≈ `host-verified`; `SIG=invalid` always forced `sensitive`; any other WAN sender is `network-claimed`, exactly as forgeable as before |
+
+**The load-bearing default:** crossing a network boundary **never proves identity
+by itself** — `TRUST=network-claimed` is the default for LAN/WAN absent one of the
+two narrow cryptographic exceptions above, and clean-content traffic at that trust
+level now settles at the *declared* tier (default `coord`) rather than being
+auto-escalated — but `sensitive`-forcing red flags (an active signature failure,
+a declared-sensitive tier, credential keywords) still apply on top regardless of
+trust level, and `ESCALATE=required` on those cases explicitly **cannot be
+satisfied by another agent's confirmation over the same network** — only a human,
+in-pane. This last rule exists because of a real incident pattern (a spoofed
+request followed by a spoofed "confirmation" over the same channel) that maps
+directly onto the risk a naive pane-mirror-input feature would recreate if it let
+remote keystrokes act with implicit trust.
+
+## 3. Design goals / non-goals
+
+| # | Goal |
+|---|---|
+| G1 | Output (the agent's own conversation stream) mirrors to every connected viewer in real time, same-host case first |
+| G2 | Input (what a human types) from any connected viewer reaches the one underlying agent process |
+| G3 | Never weaken the jekt trust model to make this easier — extend it, don't bypass it |
+| G4 | Never break the single-owner-block invariant that crash recovery and transcript persistence depend on (`SPEC_CROSS_WINDOW_TAB_REMOUNT`) |
+| G5 | LAN and WAN are explicit, later, opt-in phases — never silently enabled by turning on same-host mirroring |
+| NG1 | (non-goal, v1) True concurrent multi-cursor editing of the same in-flight composer text — see §6.2 |
+| NG2 | (non-goal) Any of this replacing jekt for actual agent-to-agent coordination — mirroring is human-viewer-facing, not agent-to-agent |
+
+## 4. What a mirror actually needs — splitting read from write
+
+The two directions of "mirror" have very different difficulty, and conflating
+them is the most common mistake in this space (confirmed by the collaborative-
+editing research below): **output is trivial fan-out; input is the hard part.**
+
+### 4.1 Output (read) — append-only stream, already the easy case
+
+The agent's own transcript is append-only from one source (the agent process).
+Mirroring it to N viewers is exactly a pub/sub fan-out problem, not a merge
+problem — no CRDT/OT needed. This is close to what `block:<id>`'s existing
+WebSocket scope already does *within* one instance; extending it *across*
+instances is a transport problem (§5), not a data-structure problem.
+
+### 4.2 Input (write) — this is where real design judgment is needed
+
+If two humans can type into the same composer from two mirrored viewers, what
+happens on genuine concurrent edits? Research on this exact tradeoff (collaborative
+text editors) is directly applicable and gives a clear steer:
+
+- **CRDTs (Yjs, Automerge) over a WebSocket relay is the modern default** for
+  structured collaborative state, and is easier to get right than OT for new
+  systems, particularly for offline-tolerant/peer-adjacent scenarios.
+- **But CRDTs have real, documented sharp edges for anything beyond plain text**
+  — Figma moved *to* CRDTs, but rich-text specifically is flagged industry-wide as
+  the case where CRDTs "lose sight of user intent" (e.g. applying formatting near
+  a collaborator's cursor can misbehave); Notion's answer was a **hybrid** — CRDT
+  for structure, OT for the text *inside* one block, specifically to keep
+  fine-grained control where it matters.
+- An agent pane's composer is a **single plain-text input**, not a rich document —
+  the good news is this sidesteps the hard CRDT cases entirely. But it's also a
+  case where **true concurrent typing by two humans is rarely what anyone actually
+  wants** (garbled interleaved text, unclear whose "send" wins) — unlike a shared
+  document, a chat-style composer's realistic use case is "hand off who's driving,"
+  not "two people typing the same sentence."
+
+**Decision for v1: floor control, not CRDT merge.** Exactly one viewer is the
+active "driver" at a time (indicated with presence — "Bob is typing" style, easily
+derived from the same primitive the research calls "awareness"); switching driver
+is an explicit, visible action, not implicit. A CRDT-backed shared composer is
+listed as a possible v2 if genuine simultaneous co-typing turns out to be wanted —
+but it should not gate v1, and the plain-text nature of this specific composer
+means the risk CRDTs are usually chosen to solve (rich-text merge conflicts)
+doesn't actually apply here. **"Send"** (submitting a full message to the agent
+process) is always a single atomic event regardless of driver model — this is
+the one place a simple last-writer-wins-on-submit is sufficient, since only one
+submitted message reaches the agent at a time by construction (it's a turn-based
+conversation, not simultaneous free-text authorship of one shared document).
+
+### 4.3 Naming — a mirror never mints a new name
+
+Per `SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` §4.5: a mirror
+connection is a new **viewer** of an existing agent's name, never a new
+registry entry and never a name variant. The mirrored pane's chrome renders
+the existing (possibly already-qualified) name plus a **presence list** of
+active viewers, each labeled with its own `HostLabel` — "AgentX #4 — also open
+from: korp-laptop (LAN)." This matters for this spec specifically because it
+means the discovery mechanism in each phase below (§5) has exactly one job:
+resolve a peer to a `HostLabel`, not mint or reconcile any name.
+
+## 5. Proposed architecture — phased strictly by network scope
+
+### Phase A — same host, cross-channel (lowest risk)
+
+- **Discovery:** reuse the existing cross-channel registry (`registry/paths.rs`,
+  `list_all_shared`) unchanged — a mirror target is just another entry alongside
+  `host.cross_channel`'s existing agent-discovery use.
+  Transport is still 127.0.0.1-only, the same trust boundary this registry already
+  operates inside. No `HostLabel` needed at this tier (per the naming spec's
+  §4.1, host-tier names are never qualified) — presence indicators, if shown at
+  all for same-host viewers, can just say "also open on: \<channel name\>."
+- **Transport:** extend the existing per-block WebSocket scope
+  (`"blockstats:block:<id>"`) with a new **stream** delivery type that a *different
+  srv instance* can subscribe to over localhost, rather than only same-instance
+  browser clients. This is new plumbing (no srv-to-srv subscription exists today)
+  but stays inside a trust boundary (same machine, same user) this codebase
+  already relies on elsewhere (the cross-channel jekt registry makes the identical
+  assumption).
+- **Authorization:** since this never leaves the machine, treat it like
+  `DELIVERY=host` — the mirroring instance and the source instance can mutually
+  authenticate the same way an agent's own HMAC key proves host-tier identity
+  (§2), just applied to the *srv processes* rather than individual agents.
+- **Floor control (§4.2):** whichever viewer's keystroke reaches the srv first
+  becomes the driver until idle timeout or explicit hand-off.
+
+### Phase B — LAN
+
+- **Discovery:** reuse whatever LAN peer discovery already backs
+  `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md` (peers already need to find each
+  other to fetch pubkeys for LAN jekt verification — the same discovery answers
+  "which LAN peer is running the pane I want to mirror"). Surface that
+  resolution as a `HostLabel` (`SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md`
+  §4.2) rather than inventing a second, parallel "which peer" concept just for
+  mirroring — the presence indicator (§4.3 above) and the pairing UX below both
+  key off the same value.
+- **Authorization — this is the part that must not be shortcut:** treat a
+  mirror-viewer connection exactly like a `DELIVERY=lan` jekt sender. Extend the
+  existing **per-agent Ed25519 LAN signing scheme** to **per-viewer pairing keys**:
+  opening a mirror from a LAN peer requires an explicit pairing step (analogous to
+  how `tmate`/`upterm` hand out a one-time session address, or how `sshx` issues a
+  join link) that mints a keypair the *source* pane's owner explicitly approved —
+  not silent, not automatic discovery-based connection. A LAN mirror-input event
+  with a signature that fails verification against a known pairing key is a
+  forged-identity case and must be treated with the same unconditional-`sensitive`
+  severity as a failed LAN jekt signature (§2's table) — worse than unpaired, never
+  a lesser version of it.
+- **Unpaired/unsigned LAN mirror requests:** default-deny for *write* access
+  (input) always; *read-only* mirroring (view but don't type) for an unpaired
+  viewer is a reasonable lower-risk option to consider, but even that should
+  require the source pane owner's one-time approval, not silent LAN auto-discovery
+  — LAN mirroring is meaningfully more sensitive than LAN jekt (a message vs.
+  live control of a running agent).
+
+### Phase C — WAN (materially higher risk — treat as a separate feature)
+
+- **Transport: relay server, not P2P WebRTC mesh, for v1.** The collaborative-
+  editing research is consistent on this: WebSocket-relay architectures are
+  simpler to secure, authenticate, and scale (auth at the relay, filter every
+  broadcast by current permission, horizontal scaling via a broker) than raw P2P;
+  WebRTC's main advantage (no server in the data path) matters most for
+  bandwidth/latency-sensitive peer-to-peer media, not for a text/event stream
+  where centralized auth is exactly what you want. Precedent: `upterm` supports
+  SSH *and* a WebSocket fallback through a relay (`uptermd`) specifically because
+  raw P2P isn't always reachable through NAT/firewalls anyway; `sshx` (the current
+  best-of-breed in this space) is fully relay-based and adds real-time
+  cursors/chat/presence on top — i.e. the ergonomics users actually want here
+  (see reference list) are relay-native, not P2P-native.
+- **No general WAN agent-to-agent signing scheme exists yet in this codebase**
+  (§2 — issue #2586's unbuilt half). Phase C should **not** invent one just for
+  mirroring; it should either wait on that general scheme landing, or (if it ships
+  first) use a **narrower, mirror-specific pairing token** modeled on `tmate`/
+  `upterm`'s ephemeral session tokens: short-lived, single-use, generated by an
+  explicit "share this pane" action on the source side, never a persistent
+  standing credential.
+- **Mandatory end-to-end encryption of relayed content.** A hosted relay
+  otherwise sees every mirrored keystroke and the full transcript stream — which
+  may contain exactly the kind of secrets/credentials this repo's jekt keyword-
+  scanning already treats as sensitive. The research explicitly flags this as a
+  standard pattern (client-side encrypt before the relay, decrypt on arrival) —
+  adopt it as a hard requirement for Phase C, not an optional hardening pass.
+- **Authorization posture:** WAN mirror-input is `DELIVERY=wan`/`TRUST=network-claimed`
+  by default, same as any other WAN traffic in this codebase, **unless** signed
+  with a paired token per above. The first connection of a new WAN viewer to a
+  pane should carry the **same human-in-the-loop friction as `ESCALATE=required`**
+  — explicit confirmation from the pane owner, visible in-pane, not satisfiable by
+  any remote party's own claim — precisely because the failure mode being guarded
+  against (a spoofed remote actor typing into a running agent) is a strict escalation
+  of the exact spoofed-jekt-plus-spoofed-confirmation attack pattern this repo's
+  trust layer was hardened against once already (the PR #2536 incident referenced
+  in `CLAUDE.md`).
+
+## 6. Decision tables
+
+### 6.1 Transport per phase
+
+| Phase | Transport | Reuses | New work |
+|---|---|---|---|
+| A (same host) | Extended WebSocket scope, srv-to-srv, localhost | Cross-channel registry, `block:<id>` pubsub shape | srv-to-srv subscription (doesn't exist today) |
+| B (LAN) | Same extended scope, over the LAN discovery path | LAN peer discovery, Ed25519 per-agent signing scheme | Per-viewer pairing keys; explicit pairing UX |
+| C (WAN) | Hosted relay (WebSocket), E2E-encrypted payloads | Relay-architecture best practice (industry-standard, not this repo's own code) | Relay service itself; pairing-token issuance; E2E encryption layer |
+
+**Decision:** no phase uses raw P2P WebRTC. Even LAN, where P2P is most feasible,
+gains nothing over extending the existing WebSocket infra, and WAN specifically
+benefits from centralized auth/filtering a relay provides.
+
+### 6.2 Input concurrency model
+
+| | **Floor control (v1, recommended)** | CRDT-merged composer (possible v2) |
+|---|---|---|
+| Complexity | Low — one boolean (who's driving) + presence indicator | Meaningfully higher — a CRDT library, awareness protocol, merge semantics even for "just text" |
+| Matches the actual use case | Yes — "hand off," not "co-author a sentence" | Arguably over-built for a single-line/multi-line plain-text composer |
+| Precedent | Standard pairing-tool UX (tmate/upterm/sshx all effectively single-active-typer for meaningful input, even though raw PTY byte-interleaving technically allows simultaneous keystrokes) | Google Docs/Figma/Notion-class rich documents, a different problem shape |
+
+**Decision:** floor control for v1 (§4.2); revisit only if user feedback
+specifically asks for true simultaneous co-typing.
+
+## 7. Open questions
+
+| # | Question | Default/Recommendation |
+|---|---|---|
+| 1 | Does a mirrored viewer need its own full pane chrome, or a lighter "observer" rendering? | Full chrome for the active driver; a visually distinct "observing" state for non-driving viewers, reusing existing presence-indicator patterns rather than inventing new UI |
+| 2 | What happens to a mirror connection when the source pane closes/the agent process exits? | Mirror connections should degrade to a clear "session ended" state, not hang or silently reconnect to a new, different agent under the same name |
+| 3 | Should Phase A (same-host) require any pairing step at all, given it's already inside a trust boundary this codebase relies on elsewhere (cross-channel jekt)? | Lean toward "no explicit pairing needed for same-host, read-only; still require one confirmation click before granting write/input access" — matches G5's "opt-in, not silent" bar even at the lowest-risk phase |
+| 4 | Does Phase C's relay service run as AgentMux-hosted infrastructure, or can users self-host it (mirroring `upterm`'s self-hostable `uptermd` model)? | Recommend self-hostable-by-default, consistent with this project's general preference for not introducing mandatory hosted dependencies — needs a real infra decision, flagged here rather than assumed |
+| 5 | How does floor control interact with an agent mid-tool-call or awaiting `AskUserQuestion`? | The driver who receives/answers a validation gate should be unambiguous — likely: whichever viewer is current driver at the moment the gate appears is the only one who can answer it, to avoid two viewers racing to answer the same gate differently |
+
+## 8. Non-goals (v1, all phases)
+
+- True concurrent multi-cursor text editing in one composer (§6.2, NG1).
+- Agent-to-agent coordination via this mechanism — mirroring is strictly
+  human-viewer-facing; agents still coordinate via jekt, unchanged.
+- Mirroring across more than 2 network hops of trust (e.g. WAN peer mirroring a
+  LAN peer mirroring a host peer) — v1 is source-instance-to-N-viewers, not
+  transitive/relayed mirror chains.
+- Recording/replay of a mirrored session as a distinct artifact — out of scope,
+  though the existing transcript persistence means a mirrored session is no less
+  recoverable than any other.
+
+## 9. References
+
+Internal (this repo, cited above): `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`,
+`SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`, `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`,
+`SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`, `SPEC_DATA_CHANNELS_2026_05_24.md`,
+`docs/retro/RETRO_JEKT_CROSS_CHANNEL_TRUST_SELF_DECLARED_2026_08_21.md`.
+
+External (research for this spec, 2026-08-21):
+- Terminal-sharing architecture survey (tmate/upterm/ttyd/sshx) —
+  [saashub.com ttyd vs upterm comparison](https://www.saashub.com/compare-ttyd-vs-upterm-secure-terminal-sharing),
+  [Upterm project site](https://upterm.dev/)
+- CRDT vs. OT and WebSocket-relay-vs-WebRTC best practices for collaborative
+  state — [HackerNoon: CRDTs vs Operational Transformation](https://hackernoon.com/crdts-vs-operational-transformation-a-practical-guide-to-real-time-collaboration),
+  [Tiny.cloud: OT vs CRDT](https://www.tiny.cloud/blog/real-time-collaboration-ot-vs-crdt/),
+  [Fordel Studios: Real-Time Data Sync patterns](https://fordelstudios.com/research/real-time-data-sync-patterns)

--- a/docs/specs/SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md
@@ -9,8 +9,14 @@ discovery/forwarding (`backend/reactive/registry.rs`), jekt trust model
 **Related:** `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`,
 `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`,
 `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`, `SPEC_JEKT_SENSITIVE_TIER_NARROWING_2026_08_15.md`,
-`SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md`, `SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`
-(the single-owner-block invariant this spec must not silently break),
+`SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md`, `SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`
+(§ the `workspace.*` command set — `MoveTabToWorkspace`, `TearOffBlock`,
+`PromoteBlockToTab`, `MoveBlockToTab`, `RestoreTornOffTab` — the single-owner-block
+invariant below is inferred from this being an exhaustive move/promote/restore
+vocabulary with no duplicate/mirror command among it, not from a dedicated
+architecture doc — **correction below, see §2**: an earlier draft of this spec
+cited a `SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` that does not exist
+anywhere in this repo; flagged by reagent's review of PR #2721, fixed here),
 `SPEC_DATA_CHANNELS_2026_05_24.md` (defines "channel" — see naming note below),
 `SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` (the `HostLabel`
 primitive this spec's discovery/presence UI should resolve peers to, §4.3/§5
@@ -35,8 +41,12 @@ below — written after this spec, to be consumed by it rather than duplicated)
 ## 1. Problem / TL;DR
 
 Today, an agent pane has **exactly one owner** — one window/tab/block, full stop.
-Moving it between windows *reparents* it (`MoveTab`, `SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`
-§2.2); it never has two live viewers. The ask: open the same agent ("AgentX") from
+Moving it between windows *reparents* it (`MoveTabToWorkspace`/`PromoteBlockToTab`/
+`MoveBlockToTab`, per the `workspace.*` command set in
+`SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md` §"App-API surface" — every
+cross-window/cross-tab operation in that vocabulary is move, promote, or
+restore, never duplicate); it never has two live viewers. The ask: open the
+same agent ("AgentX") from
 a second AgentMux **channel** instance on the same host and have it **mirror
 live** — type in one, see it in both, and vice versa — then extend that to LAN and
 eventually WAN peers. This is a genuinely new capability, not a variant of
@@ -67,13 +77,24 @@ Block/pane content is already published on a per-block scope string
 a torn-off tab in its own OS window render the same live block: it's really just
 another subscriber to one instance's own event bus. **What doesn't exist:** any
 second srv instance subscribing to another instance's `block:<id>` stream, or a
-block having more than one owning window/tab at a time. `SPEC_CROSS_WINDOW_TAB_REMOUNT`
-confirms this is architecturally load-bearing, not incidental: blocks/layout are
-children of the Tab object and *travel with it* on move — there's no "keep both
-ends live" concept anywhere in that model.
+block having more than one owning window/tab at a time. **Correction (flagged by
+reagent's review of PR #2721): an earlier draft cited a
+`SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` as confirming this — that file
+does not exist anywhere in this repo.** The inference stands on weaker but real
+grounds instead: `SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`'s `workspace.*`
+surface (`MoveTabToWorkspace`, `TearOffBlock`, `PromoteBlockToTab`,
+`MoveBlockToTab`, `RestoreTornOffTab`) is move/promote/restore vocabulary
+throughout, with no duplicate-or-mirror command anywhere in it — consistent
+with, but not verified proof of, a single-owner invariant. Treat "no mirror
+concept exists today" as well-supported and "this is architecturally
+load-bearing for crash recovery specifically" as this spec's own reasonable
+inference, not a cited fact, until someone confirms it against the actual
+crash-recovery code.
 
 **`FleetBroadcast` is not a stream — don't build on the name.**
-(`agentmux-mcp/src/main.rs:225-257`, handler `main.rs:1373`, `backend/app_api/fleet.rs`)
+(`agentmux-mcp/src/main.rs:225-257`, handler `main.rs:1373`,
+`agentmux-srv/src/server/app_api/fleet.rs` — corrected path, flagged by
+reagent's review; the file is not at `backend/app_api/fleet.rs`)
 Per its own doc comment: it loops the *same signed single-target `SendMessage`
 delivery path*, once per target, client-side. It's "send the same discrete
 message N times," not "replicate live state to N viewers." A real terminology
@@ -132,7 +153,7 @@ remote keystrokes act with implicit trust.
 | G1 | Output (the agent's own conversation stream) mirrors to every connected viewer in real time, same-host case first |
 | G2 | Input (what a human types) from any connected viewer reaches the one underlying agent process |
 | G3 | Never weaken the jekt trust model to make this easier — extend it, don't bypass it |
-| G4 | Never break the single-owner-block invariant that crash recovery and transcript persistence depend on (`SPEC_CROSS_WINDOW_TAB_REMOUNT`) |
+| G4 | Never break the single-owner-block invariant that crash recovery and transcript persistence depend on (see §2's correction — inferred from `SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`'s move/promote/restore-only `workspace.*` vocabulary, not a dedicated architecture doc) |
 | G5 | LAN and WAN are explicit, later, opt-in phases — never silently enabled by turning on same-host mirroring |
 | NG1 | (non-goal, v1) True concurrent multi-cursor editing of the same in-flight composer text — see §6.2 |
 | NG2 | (non-goal) Any of this replacing jekt for actual agent-to-agent coordination — mirroring is human-viewer-facing, not agent-to-agent |
@@ -339,7 +360,7 @@ specifically asks for true simultaneous co-typing.
 
 Internal (this repo, cited above): `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`,
 `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`, `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`,
-`SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`, `SPEC_DATA_CHANNELS_2026_05_24.md`,
+`SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`, `SPEC_DATA_CHANNELS_2026_05_24.md`,
 `docs/retro/RETRO_JEKT_CROSS_CHANNEL_TRUST_SELF_DECLARED_2026_08_21.md`.
 
 External (research for this spec, 2026-08-21):

--- a/docs/specs/SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md
@@ -9,14 +9,17 @@ discovery/forwarding (`backend/reactive/registry.rs`), jekt trust model
 **Related:** `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`,
 `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`,
 `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`, `SPEC_JEKT_SENSITIVE_TIER_NARROWING_2026_08_15.md`,
-`SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md`, `SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`
-(§ the `workspace.*` command set — `MoveTabToWorkspace`, `TearOffBlock`,
-`PromoteBlockToTab`, `MoveBlockToTab`, `RestoreTornOffTab` — the single-owner-block
-invariant below is inferred from this being an exhaustive move/promote/restore
-vocabulary with no duplicate/mirror command among it, not from a dedicated
-architecture doc — **correction below, see §2**: an earlier draft of this spec
-cited a `SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` that does not exist
-anywhere in this repo; flagged by reagent's review of PR #2721, fixed here),
+`SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md`, `specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`
+(**note the path** — this repo has two spec trees, `docs/specs/` and a
+top-level `specs/`; this doc lives in the latter. §2.2 there: `Command::MoveTab`
+reducer — "blocks and layout state are children of the Tab object — they
+travel automatically" — is the real, verified basis for this spec's
+single-owner-block invariant. **Correction history, for the record:** reagent's
+first review of PR #2721 claimed this file didn't exist; I re-checked with a
+`head`-truncated `find` and wrongly agreed, replacing a valid citation with a
+false "does not exist" claim in the previous commit; reagent's *second*
+review caught that error and pointed at the real path — restored here,
+correctly cited this time),
 `SPEC_DATA_CHANNELS_2026_05_24.md` (defines "channel" — see naming note below),
 `SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` (the `HostLabel`
 primitive this spec's discovery/presence UI should resolve peers to, §4.3/§5
@@ -41,12 +44,10 @@ below — written after this spec, to be consumed by it rather than duplicated)
 ## 1. Problem / TL;DR
 
 Today, an agent pane has **exactly one owner** — one window/tab/block, full stop.
-Moving it between windows *reparents* it (`MoveTabToWorkspace`/`PromoteBlockToTab`/
-`MoveBlockToTab`, per the `workspace.*` command set in
-`SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md` §"App-API surface" — every
-cross-window/cross-tab operation in that vocabulary is move, promote, or
-restore, never duplicate); it never has two live viewers. The ask: open the
-same agent ("AgentX") from
+Moving it between windows *reparents* it (`Command::MoveTab`,
+`specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` §2.2 — "blocks and layout
+state are children of the Tab object — they travel automatically"); it never
+has two live viewers. The ask: open the same agent ("AgentX") from
 a second AgentMux **channel** instance on the same host and have it **mirror
 live** — type in one, see it in both, and vice versa — then extend that to LAN and
 eventually WAN peers. This is a genuinely new capability, not a variant of
@@ -77,19 +78,24 @@ Block/pane content is already published on a per-block scope string
 a torn-off tab in its own OS window render the same live block: it's really just
 another subscriber to one instance's own event bus. **What doesn't exist:** any
 second srv instance subscribing to another instance's `block:<id>` stream, or a
-block having more than one owning window/tab at a time. **Correction (flagged by
-reagent's review of PR #2721): an earlier draft cited a
-`SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` as confirming this — that file
-does not exist anywhere in this repo.** The inference stands on weaker but real
-grounds instead: `SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`'s `workspace.*`
-surface (`MoveTabToWorkspace`, `TearOffBlock`, `PromoteBlockToTab`,
-`MoveBlockToTab`, `RestoreTornOffTab`) is move/promote/restore vocabulary
-throughout, with no duplicate-or-mirror command anywhere in it — consistent
-with, but not verified proof of, a single-owner invariant. Treat "no mirror
-concept exists today" as well-supported and "this is architecturally
-load-bearing for crash recovery specifically" as this spec's own reasonable
-inference, not a cited fact, until someone confirms it against the actual
-crash-recovery code.
+block having more than one owning window/tab at a time.
+`specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` §2.2 confirms this is
+architecturally load-bearing, not incidental: `Command::MoveTab`
+(`agentmux-srv/src/reducer/tab.rs:341-449`) reparents `tab.workspace_id` and
+"nothing about a tab move touches `blockids` or `layoutstate`" — blocks and
+layout are children of the Tab object and travel with it whole, never split
+or duplicated across two tabs.
+
+**Correction history, for the record (this went through two rounds of
+reviewer back-and-forth and is worth being honest about):** an earlier draft
+of this spec cited this exact file and section correctly. reagent's first
+review of PR #2721 claimed the file didn't exist. I re-checked with a
+`find` command whose output I truncated with `head -20` — the file was
+genuinely present, just past the truncation point in a 29-result list — and
+wrongly concluded reagent was right, replacing a valid citation with a false
+"does not exist" claim. reagent's second review caught that error and
+supplied the real path (`specs/`, not `docs/specs/` — this repo has two
+spec trees). Restored correctly here.
 
 **`FleetBroadcast` is not a stream — don't build on the name.**
 (`agentmux-mcp/src/main.rs:225-257`, handler `main.rs:1373`,
@@ -153,7 +159,7 @@ remote keystrokes act with implicit trust.
 | G1 | Output (the agent's own conversation stream) mirrors to every connected viewer in real time, same-host case first |
 | G2 | Input (what a human types) from any connected viewer reaches the one underlying agent process |
 | G3 | Never weaken the jekt trust model to make this easier — extend it, don't bypass it |
-| G4 | Never break the single-owner-block invariant that crash recovery and transcript persistence depend on (see §2's correction — inferred from `SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`'s move/promote/restore-only `workspace.*` vocabulary, not a dedicated architecture doc) |
+| G4 | Never break the single-owner-block invariant that crash recovery and transcript persistence depend on (`specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` §2.2) |
 | G5 | LAN and WAN are explicit, later, opt-in phases — never silently enabled by turning on same-host mirroring |
 | NG1 | (non-goal, v1) True concurrent multi-cursor editing of the same in-flight composer text — see §6.2 |
 | NG2 | (non-goal) Any of this replacing jekt for actual agent-to-agent coordination — mirroring is human-viewer-facing, not agent-to-agent |
@@ -360,7 +366,7 @@ specifically asks for true simultaneous co-typing.
 
 Internal (this repo, cited above): `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md`,
 `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`, `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`,
-`SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`, `SPEC_DATA_CHANNELS_2026_05_24.md`,
+`specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`, `SPEC_DATA_CHANNELS_2026_05_24.md`,
 `docs/retro/RETRO_JEKT_CROSS_CHANNEL_TRUST_SELF_DECLARED_2026_08_21.md`.
 
 External (research for this spec, 2026-08-21):

--- a/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
@@ -1,0 +1,274 @@
+# SPEC: Quick-fork an agent into a new tab (hot clone, full identity)
+
+**Date:** 2026-08-21
+**Status:** Draft — architecture proposal, no code landed
+**Scope:** `agent.open` (`agentmux-srv/src/server/app_api/agent_open.rs`), `NewTab`/`SetActiveTab`
+MCP tools, `AgentDefinition`/`AgentInstance` model, Armory identity binding
+**Related:** `SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md` (designs
+`ForkAgentDefinitionCommand`, not yet built), `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md`
+(in-pane fork bar — the closest existing sibling feature, `--fork-session` validation
+gate already passed there), `SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md`
+(App-API `agent.*` surface incl. `agent.open`/`agent.fork`/`agent.define`),
+`SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` (the naming
+scheme this spec's forked agents follow, §4.5)
+
+> **Naming.** This is a **quick-fork**, not a duplicate of the in-pane **fork bar**
+> from `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS`. Both features share one backend
+> mechanism (fork the `AgentDefinition`, spawn with `--resume <sid> --fork-session`)
+> and differ only in *where the result lands*: the fork bar pushes the new block onto
+> the **same pane's** `blockStack`; a quick-fork opens it as a **new tab**, fully
+> independent, immediately visible, no bottom-bar row to notice or switch to. "Hot
+> clone" describes the user-facing effect (identical context, up and running
+> instantly); "quick-fork" is the mechanism name, kept consistent with the
+> codebase's existing fork vocabulary rather than inventing a new one.
+
+---
+
+## 1. Problem / TL;DR
+
+A user mid-conversation hits a fork in the road — two directions worth pursuing, or
+a tangent worth exploring without losing the current thread — and wants a **second,
+fully independent agent** that starts from the exact same context and can be handed
+off to (or run in parallel) immediately, in its own tab. Today:
+
+- `NewTab` (MCP tool) opens an **empty** tab — no agent, no context (`agentmux-mcp/src/main.rs:172-181`
+  → `agentmux-srv/src/server/service/tab_lifecycle.rs:20-140`, generic `Command::CreateTab`,
+  no agent semantics at all).
+- The only existing "fork" UX (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS`) lands the fork **in the
+  same pane**, behind a bottom fork-bar row the user has to notice and switch to. It
+  is not yet built (Phase 2–3 of that spec).
+- `ForkAgentDefinitionCommand`, the RPC that would mint a forked `AgentDefinition`
+  (`SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md` §5.1), is **designed but not implemented**.
+
+This spec proposes reusing both of those designs, unchanged, and pointing the
+result at a **new tab** instead of an in-pane block-stack — plus resolving one
+thing neither prior spec settled: what "full identity" means for the clone, and
+whether it inherits the parent's bound credentials (Armory/GitHub) or starts clean.
+
+## 2. Current architecture (code-verified)
+
+**Tab creation is generic and agent-blind.** `NewTab` → `POST /api/v1/tab/new` →
+`handle_tab_new` (`agentmux-srv/src/server/mod.rs:1492-1515`) → dispatches
+`workspace.CreateTab` → reducer applies events, auto-activates. Produces an empty
+tab with no panes. `SetActiveTab`/`FocusWindow`/`Layout` are the read/navigate
+verbs around it — none spawn an agent.
+
+**Spawning an agent into a pane is a separate, heavier path.** `agent.open`
+(`agentmux-srv/src/server/app_api/agent_open.rs`, ~1113 lines) does the real work:
+resolves the `AgentDefinition`, computes `routing_id` (the definition's `slug`) and
+sets `AGENTMUX_AGENT_ID` to it (lines ~340-351), serializes cwd/CLI-path/args into
+`meta["cmd:env"]`, seeds `agent:sessionid` from the shared registry for resume,
+guards concurrent opens of the same definition via `AGENT_OPEN_LOCKS` (lines 22-32),
+and dispatches `Command::CreateBlock` through the reducer (required for later
+tear-off — comment at lines 503-509). **This is the file a quick-fork action needs
+to call into, not `NewTab` alone.**
+
+**Identity is a property of the `AgentDefinition`, not the instance.**
+`AGENTMUX_AGENT_ID` = the definition's `slug`. Forking the definition (see below)
+already mints a new `id` and, per the auto-naming rule in
+`SPEC_MULTI_SESSION_AGENT_FORK`, a new `slug`/label ("Senior Dev" → "Senior Dev #2")
+— so **a genuinely new routing identity falls out of forking the definition for
+free**; no separate identity-minting step is needed for that layer. Jekt's own
+per-agent HMAC signing key (`AGENTMUX_JEKT_KEY`, injected at spawn per this repo's
+`CLAUDE.md`) is likewise minted at spawn time, not copied from the parent's stored
+`cmd:env` — a forked instance gets its own key by construction, not by inheritance.
+
+**Armory/credential identity is a second, separate layer that is NOT resolved by
+forking the definition.** `IdentityAccounts`/`IdentityValidate` read from
+`db_agent_identity_links` (per-agent binding rows, `storage/agents.rs:79, 286-289`),
+resolved at spawn via `Store::resolve_effective_provider_id`
+(`agent_open.rs:57-66`). **Neither `SPEC_MULTI_SESSION_AGENT_FORK` nor
+`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS` says whether a forked definition copies these
+rows, leaves them unbound, or requires explicit re-binding.** This is the open
+question this spec resolves (§5).
+
+**Conversation context is file-based and already provably cheap to clone.**
+Provider transcripts are JSONL files keyed by session id
+(`SPEC_UNIFIED_AGENT_HISTORY_STORE_2026-06-10.md`); AgentMux's own UI-snapshot zone
+is `agent:<definition_id>:current` (`agent_session.rs`), **one zone per definition**
+— which is exactly why forking the *definition* (not reusing it) is required: two
+live conversations under the same `definition_id` would collide on that zone.
+`--resume <parentSid> --fork-session` was **empirically validated** against the
+bundled Claude CLI on 2026-06-15 (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS` §6.4): the
+fork inherits full history to the fork point, mints its own session id, the parent
+is untouched, and two forks of the same parent get independent ids. Non-Claude
+providers without an equivalent flag fall back to "fork = new definition, fresh
+start" — the same honest fallback this spec inherits.
+
+**`AgentInstance` already models lineage.** `{ id, definition_id,
+parent_instance_id, block_id, session_id, status, identity_id, memory_id,
+instance_name, working_directory }` (`storage/agents.rs`) — `parent_instance_id` is
+already the fork-tracking field; nothing new needed here.
+
+## 3. Design goals
+
+| # | Goal |
+|---|---|
+| G1 | One action, one keystroke/click, from any active agent pane — no modal flow for the common case |
+| G2 | Result is a **new tab**, visible and focused immediately (not a bottom-bar row requiring a second action to see) |
+| G3 | Clone carries full conversation context up to the fork point (Claude: exact; other providers: honest fallback, no silent context loss) |
+| G4 | Clone gets a genuinely distinct identity (`AGENTMUX_AGENT_ID`, jekt signing key) — never shares routing or signing identity with the parent |
+| G5 | Credential/Armory identity inheritance is an explicit, informed choice, not a silent default either way |
+| G6 | Zero change to the existing runtime invariants (one block = one conversation = one transcript zone) — reuse, don't reinvent |
+
+## 4. Proposed design
+
+### 4.1 Mechanism — reuse verbatim, retarget the landing spot
+
+1. **Fork the definition:** `ForkAgentDefinitionCommand(source=activeDefinitionId)`
+   (build per `SPEC_MULTI_SESSION_AGENT_FORK` §5.1's already-designed struct) → new
+   `AgentDefinition` with `parent_id`, auto `branch_label`, fresh `working_directory`
+   (or explicitly inherit the parent's cwd — see open questions), `is_seeded=0`.
+2. **Create the `AgentInstance`:** `parent_instance_id = activeInstanceId`,
+   `continueSessionId = activeSessionId`.
+3. **Open a new tab:** `NewTab` (existing, unchanged) to get an empty tab, or a
+   combined call if the App-API is extended to accept a target definition directly
+   (see §4.3).
+4. **Spawn into it:** `agent.open` with the forked definition, `--resume
+   <parentSid> --fork-session` in `cli_args` (already-supported per §6.3 of the
+   forks spec — `subprocess.rs`/`persistent.rs` accept these via `cli_args` today).
+5. Tab activates on the new block; parent pane/tab is completely untouched.
+
+This is identical machinery to the in-pane fork bar's §6.3 — the only difference
+is step 3 targets a new tab via `NewTab`+`agent.open` instead of pushing a blockId
+onto the current pane's `blockStack`.
+
+### 4.2 Decision: new tab vs. in-pane fork bar vs. new window
+
+| | **New tab (this spec)** | In-pane fork bar (existing spec) | New OS window |
+|---|---|---|---|
+| Visibility | Immediate, full tab, no extra click | Requires noticing/switching the bottom bar | Immediate, but heavier (new window chrome, tear-off machinery) |
+| Use case fit | "Hand this off, work it in parallel, side by side" | "Explore a tangent, come back to the main thread" | Rare — multi-monitor workflows |
+| Backend reuse | 100% — same fork+spawn mechanism | 100% (source of the mechanism) | 100% + tear-off saga |
+| New structural concept | None (tabs already exist) | `blockStack` at the layout node (that spec's one new concept) | None (tear-off already exists) |
+
+**Decision: new tab.** It matches the stated use case (a peer to hand off to, not a
+background tangent) with zero new structural concepts — tabs, `NewTab`, and
+`agent.open` all exist today. A "quick-fork to new window" variant is a trivial
+follow-on (swap the target of step 3 for the existing tear-off saga) but is not
+needed for v1.
+
+### 4.3 Trigger / UX
+
+- **Primary affordance: right-click the tab → "Quick-fork to new tab."** Mirrors
+  a pattern every user already has from browsers ("Duplicate Tab") — discoverable
+  without adding persistent chrome, and it puts the action where the object it
+  operates on lives (the tab), matching where the result lands (a new tab).
+  Deliberately **not** a new icon in the pane itself: `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS`
+  already documents ~16 hand-stacked pane surfaces as a problem to fix, not add
+  to, and a pane-level fork icon would risk visual confusion with that spec's
+  own in-pane fork bar (two different-looking "fork" affordances in one pane,
+  landing in two different places).
+- **Secondary: a keybinding** for the no-mouse path (G1) — tab-scoped, in the
+  same family as other tab-level shortcuts (new tab, close tab), not a
+  pane-level binding, for the same reason as above.
+- No modal by default (G1) — one click/keystroke does steps 1-5 above with sane
+  defaults (§4.4). An optional long-press/right-click-submenu variant opens a
+  small confirmation surfacing the identity choice (§5) for users who want to
+  decide per-fork rather than rely on the default.
+- Auto-generated tab title = the forked definition's auto-generated name (§4.5),
+  consistent with existing fork auto-naming.
+- Deferred: should the tab strip's own "+ New Tab" button grow a split/dropdown
+  (plain new tab vs. fork current) for users who never discover right-click?
+  Ship right-click-only for v1; add the split-button only if discoverability
+  turns out to be a real problem in practice.
+
+### 4.4 Non-Claude provider fallback
+
+Identical honesty requirement to `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS` §6.4: for a
+provider without an equivalent to `--fork-session`, the new tab still opens
+immediately (G1/G2 hold) but starts a **fresh conversation** on the forked
+definition, with a visible, non-dismissable-by-accident note in the new tab's
+first turn ("this provider doesn't support forking mid-conversation — starting
+fresh") rather than silently pretending context carried over.
+
+### 4.5 Naming the fork
+
+Per `SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` (written
+alongside this spec once the naming question came up): the forked definition
+keeps the parent's base name and gets a **flat, lineage-wide counter**
+("AgentX" → "AgentX #2"), not a nested/dotted scheme reflecting fork depth
+("AgentX #2.1") — the tree structure is already tracked structurally via
+`parent_instance_id`, so the display name doesn't need to re-encode it.
+
+The counter is **best-effort, not atomic** — the registry's write primitive
+(`registry/atomic.rs`) guarantees no corrupted file, not exclusive allocation
+of a number, so two forks of the same lineage minted at nearly the same
+moment (even across two different channels on the same host — the registry
+is host-global per `SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE`) could both compute
+the same next number. Mitigation, per the naming spec: pair the number with
+a short collision-resistant suffix (reusing the existing workspace-folder
+date+letter tag or a few hex characters of the instance UUID), so a rare
+collision is cosmetic (`AgentX #4-0822k` vs. `AgentX #4-0822p`) rather than
+truly ambiguous. **v1 of quick-fork only ever lands on the local host** (§8),
+so no LAN/WAN qualifier is ever shown — that only becomes relevant if a
+future capability forks directly onto a remote peer, at which point the
+naming spec's tiering (§4.1 there) already covers it without change here.
+
+## 5. Identity: resolving the open question prior specs left unsettled
+
+**Routing/signing identity (`AGENTMUX_AGENT_ID`, jekt key) is never shared** — this
+falls out of forking the definition regardless of any choice made here (§2). The
+only real decision is **credential identity** (Armory account bindings /
+`db_agent_identity_links`):
+
+| Option | Behavior | Risk |
+|---|---|---|
+| **Inherit (copy rows)** | Forked agent launches with the same bound GitHub PAT/provider account as the parent | Silent credential fan-out — a "quick" action ends up minting a second agent that can act under the same PAT without the user noticing; harder to audit which agent did what against a shared account |
+| **Unbound (default, recommended)** | Forked agent starts with no Armory bindings, same as any newly-created definition; falls back to the global, non-identity-bound `provider_auth_dir()` path (`agent_open.rs`), matching what a plain agent spawn already does today | Fork may not be able to push/PR under the same identity as the parent without a manual re-bind step |
+| **Explicit choice at fork time** | The long-press/confirmation variant (§4.3) lets the user pick "same identity" or "unbound" per-fork | Adds one decision to the non-default path only — doesn't slow down the common case |
+
+**Decision: unbound by default, explicit opt-in to inherit.** Matches this
+codebase's existing default-secure posture elsewhere (e.g. Armory account
+isolation defaulting to isolated-by-channel per `SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`)
+and avoids a "quick" action having a non-obvious credential-sharing side effect.
+A user who explicitly wants the clone to act as the same GitHub identity opts in
+via the confirmation variant, not the default one-click path.
+
+## 6. Phasing
+
+| Phase | Deliverable | Depends on |
+|---|---|---|
+| **1** | Implement `ForkAgentDefinitionCommand` (currently just designed, per `SPEC_MULTI_SESSION_AGENT_FORK` §5.1) | — |
+| **2** | Wire quick-fork action: `NewTab` + forked-definition `agent.open` with `--resume --fork-session`, unbound-identity default | Phase 1 |
+| **3** | UX polish: keybinding, `+` affordance, auto tab title, non-Claude fallback messaging | Phase 2 |
+| **4** | Long-press/confirmation variant exposing the identity choice (§5) | Phase 2 |
+
+Phases 1-2 alone deliver the full G1-G4 use case; Phases 3-4 are polish and the
+opt-in identity path.
+
+## 7. Open questions
+
+| # | Question | Default/Recommendation |
+|---|---|---|
+| 1 | Does the forked definition inherit the parent's `working_directory`, or start at a repo-root default? | Inherit — the use case is "pick up immediately," a different cwd would break that |
+| 2 | Should quick-fork be blocked/warned when the parent has an in-flight tool call or pending `AskUserQuestion`? | Warn, don't block — forking mid-tool-call is legal (the fork session captures history up to the fork point regardless) but the user should know the fork won't see the in-flight call's *result* |
+| 3 | Dormant-fork lifecycle for the new tab (keep-alive vs. suspend) | Same as `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS` §6.6 — no reason to diverge; new tabs are "active" by definition on open, this only matters once the user switches away |
+| 4 | Should the fork-bar feature (in-pane) and quick-fork (new tab) share one underlying `useForkAgent()` hook/command, or duplicate? | Share — both call the same `ForkAgentDefinitionCommand` + spawn sequence, differing only in the landing-tab step |
+
+## 8. Non-goals (v1)
+
+- Merging two forks back together, or diffing their transcripts — out of scope,
+  same as the in-pane fork spec.
+- Cross-machine "hot clone" (spawning the fork on a different host) — that's
+  `SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md`'s territory, a
+  different feature (mirroring a *running* pane, not forking a *new* one).
+- A picker/modal for choosing which prior message to fork from (mid-scrollback
+  fork points) — v1 forks from "now," matching the validated `--fork-session`
+  behavior.
+
+## 9. Files this would touch (orientation)
+
+- **New:** `ForkAgentDefinitionCommand` implementation (backend, per
+  `SPEC_MULTI_SESSION_AGENT_FORK` §5.1's struct) if not already landed by the time
+  this ships.
+- **New:** quick-fork action/command (frontend), likely alongside
+  `commands/global/btw.ts` if that has landed, or as its own
+  `commands/global/quick-fork.ts`.
+- **Reuse, no change:** `agent_open.rs` (spawn path), `NewTab`/`SetActiveTab`
+  (`agentmux-mcp/src/main.rs`, `agentmux-srv/src/server/mod.rs`), `AgentInstance`
+  storage (`storage/agents.rs`), `--resume`/`--fork-session` `cli_args` plumbing
+  (`subprocess.rs`/`persistent.rs`).
+- **Touch:** identity-binding resolution at spawn (`agent_open.rs:57-66`) to
+  respect the unbound-by-default decision (§5) for forked definitions
+  specifically, if it doesn't already default that way.

--- a/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
@@ -4,8 +4,9 @@
 **Status:** Draft — architecture proposal, no code landed
 **Scope:** `agent.open` (`agentmux-srv/src/server/app_api/agent_open.rs`), `NewTab`/`SetActiveTab`
 MCP tools, `AgentDefinition`/`AgentInstance` model, Armory identity binding
-**Related:** `SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md` (designs
-`ForkAgentDefinitionCommand`, not yet built), `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md`
+**Related:** `SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md` (designed
+`ForkAgentDefinitionCommand` — **now implemented**, see §2's correction),
+`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md`
 (in-pane fork bar — the closest existing sibling feature, `--fork-session` validation
 gate already passed there), `SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md`
 (App-API `agent.*` surface incl. `agent.open`/`agent.fork`/`agent.define`),
@@ -34,16 +35,25 @@ off to (or run in parallel) immediately, in its own tab. Today:
 - `NewTab` (MCP tool) opens an **empty** tab — no agent, no context (`agentmux-mcp/src/main.rs:172-181`
   → `agentmux-srv/src/server/service/tab_lifecycle.rs:20-140`, generic `Command::CreateTab`,
   no agent semantics at all).
-- The only existing "fork" UX (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS`) lands the fork **in the
-  same pane**, behind a bottom fork-bar row the user has to notice and switch to. It
-  is not yet built (Phase 2–3 of that spec).
-- `ForkAgentDefinitionCommand`, the RPC that would mint a forked `AgentDefinition`
-  (`SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md` §5.1), is **designed but not implemented**.
+- **Corrected below (reagent + Codex review of PR #2721 caught this — an
+  earlier draft of this spec had the current state wrong in two ways):**
+  `ForkAgentDefinitionCommand` **is already implemented** (`frontend/app/store/rpc-api/agent.ts:331`,
+  backend handler in `agentmux-srv/src/server/agent_handlers/template.rs`),
+  not "designed but not built" — the codebase has moved on since
+  `SPEC_MULTI_SESSION_AGENT_FORK_2026_06_06.md` was written. It's invoked
+  from `AgentPicker.tsx`'s fork prompt today, landing as a separate block/pane
+  per that flow. **But the real, shipped fork action does not actually carry
+  conversation history** — see §2's `handleFork` finding — despite
+  `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS`'s `--resume --fork-session` mechanism
+  being empirically validated as *possible*. The validated spike was never
+  wired into the real UI action. This spec's G3 (full context carryover) is
+  therefore **new work**, not a "just reuse it" claim.
 
-This spec proposes reusing both of those designs, unchanged, and pointing the
-result at a **new tab** instead of an in-pane block-stack — plus resolving one
-thing neither prior spec settled: what "full identity" means for the clone, and
-whether it inherits the parent's bound credentials (Armory/GitHub) or starts clean.
+This spec proposes reusing the definition-forking half that already works,
+fixing the history-carryover half that was validated but never wired up, and
+pointing the result at a **new tab** — plus resolving what "full identity"
+means for the clone, and whether it inherits the parent's bound credentials
+(Armory/GitHub) or starts clean.
 
 ## 2. Current architecture (code-verified)
 
@@ -53,15 +63,50 @@ whether it inherits the parent's bound credentials (Armory/GitHub) or starts cle
 tab with no panes. `SetActiveTab`/`FocusWindow`/`Layout` are the read/navigate
 verbs around it — none spawn an agent.
 
-**Spawning an agent into a pane is a separate, heavier path.** `agent.open`
-(`agentmux-srv/src/server/app_api/agent_open.rs`, ~1113 lines) does the real work:
-resolves the `AgentDefinition`, computes `routing_id` (the definition's `slug`) and
-sets `AGENTMUX_AGENT_ID` to it (lines ~340-351), serializes cwd/CLI-path/args into
-`meta["cmd:env"]`, seeds `agent:sessionid` from the shared registry for resume,
-guards concurrent opens of the same definition via `AGENT_OPEN_LOCKS` (lines 22-32),
-and dispatches `Command::CreateBlock` through the reducer (required for later
-tear-off — comment at lines 503-509). **This is the file a quick-fork action needs
-to call into, not `NewTab` alone.**
+**Spawning an agent into a pane is a separate, heavier path — and the public
+`agent.open` App-API surface is NOT the mechanism that actually supports
+forking, contrary to an earlier draft of this spec.** `CommandAgentOpenData`
+(`agentmux-srv/src/backend/rpc_types/agent.rs:13-19`) — the request shape for
+`agent.open` — has exactly five fields: `agent_id`, `tab_id`,
+`split_direction`, `split_reference_block_id`, `focus`. **No resume/continuation
+field, no fork flag, nowhere to put `--fork-session`.** Codex's review of PR
+#2721 caught this directly: "the proposed spawn call cannot carry the
+arguments shown here."
+
+**The real spawn mechanism with fork/resume support is frontend-internal:
+`launchAgentDefinition`** (`frontend/app/view/agent/agent-model.ts:320`),
+called as `launchAgentDefinition(agent, overrides?, targetBlockId?)`. Its
+`overrides` (`LaunchOverrides`) carries `continueSessionId` (resume target)
+and a separate `forkSession: boolean` flag; `agent-model.ts:426-428` only
+pushes `--fork-session` onto `cliArgs` when **both** `overrides.forkSession`
+is true **and** `provider.id === "claude"` — every other provider silently
+falls back to a fresh conversation (the honest fallback §4.4 already
+describes, now grounded in the actual gating condition rather than assumed).
+**This is the function a quick-fork action must call — not `agent.open`.**
+The public `agent.open` RPC stays exactly as it is; extending it is not
+required, since a quick-fork action lives in the frontend and can call
+`launchAgentDefinition` directly, the same way the existing fork-prompt flow
+already does (see next finding).
+
+**The existing fork-prompt flow (`AgentPicker.tsx`) proves the definition-fork
+half works, and proves the history-carryover half is not actually wired up
+today.** `handleFork` (`frontend/app/view/agent/components/AgentPicker.tsx:386-413`):
+calls `RpcApi.ForkAgentDefinitionCommand({source_id, branch_label})` (real,
+implemented — see above), then `launchAgentDefinition(forkedDef, {
+instanceName, agentType, environment, accountId, memoryId })`. **Notice what's
+missing from that overrides object: no `continueSessionId`, no
+`forkSession`.** Compare `handleReattach` a few lines above it in the same
+file, which explicitly sets `continueSessionId: row.session_id ?? ""` for a
+plain resume. **The shipped "fork" action mints a new definition (config/
+instructions/skills clone) and launches it as a completely fresh
+conversation — it does not carry conversation history**, despite
+`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS` §6.4 having empirically validated that
+`--resume <parentSid> --fork-session` works. The validated mechanism exists;
+it was never plumbed into the actual UI action. **Fixing this — adding
+`continueSessionId: <parent's session id>, forkSession: true` to the
+`launchAgentDefinition` call in the fork flow — is real, scoped, still-needed
+work this spec depends on, not something to take for granted as "already
+built."**
 
 **Identity is a property of the `AgentDefinition`, not the instance.**
 `AGENTMUX_AGENT_ID` = the definition's `slug`. Forking the definition (see below)
@@ -100,6 +145,18 @@ parent_instance_id, block_id, session_id, status, identity_id, memory_id,
 instance_name, working_directory }` (`storage/agents.rs`) — `parent_instance_id` is
 already the fork-tracking field; nothing new needed here.
 
+**The existing auto-naming counter is scoped to the immediate parent, not
+the lineage — confirmed bug, flagged by Codex's review of PR #2721.**
+`template.rs`'s fork-name logic (both the actual fork path, ~line 347, and
+`ForkAgentDefinitionSuggestCommand`'s preview, ~line 475) filters
+`a.parent_id == cmd.source_id` — counting only definitions forked directly
+from *this* source, not the whole tree. Forking "AgentX #2" therefore
+produces "AgentX #2 #2," not the flat lineage-wide "AgentX #3" this spec's
+naming section (§4.5) and `SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md`
+both require. **This needs a real code change** (walk to the lineage root,
+count all descendants, not just `template.rs`'s current immediate-parent
+filter) — not just a naming convention this spec can assume already holds.
+
 ## 3. Design goals
 
 | # | Goal |
@@ -113,25 +170,37 @@ already the fork-tracking field; nothing new needed here.
 
 ## 4. Proposed design
 
-### 4.1 Mechanism — reuse verbatim, retarget the landing spot
+### 4.1 Mechanism — corrected against real code (PR #2721 review round)
 
-1. **Fork the definition:** `ForkAgentDefinitionCommand(source=activeDefinitionId)`
-   (build per `SPEC_MULTI_SESSION_AGENT_FORK` §5.1's already-designed struct) → new
-   `AgentDefinition` with `parent_id`, auto `branch_label`, fresh `working_directory`
-   (or explicitly inherit the parent's cwd — see open questions), `is_seeded=0`.
-2. **Create the `AgentInstance`:** `parent_instance_id = activeInstanceId`,
-   `continueSessionId = activeSessionId`.
-3. **Open a new tab:** `NewTab` (existing, unchanged) to get an empty tab, or a
-   combined call if the App-API is extended to accept a target definition directly
-   (see §4.3).
-4. **Spawn into it:** `agent.open` with the forked definition, `--resume
-   <parentSid> --fork-session` in `cli_args` (already-supported per §6.3 of the
-   forks spec — `subprocess.rs`/`persistent.rs` accept these via `cli_args` today).
-5. Tab activates on the new block; parent pane/tab is completely untouched.
+An earlier draft of this section assumed `agent.open` could carry
+resume/fork-session arguments and that the fork mechanism was fully wired
+end to end. Neither is true (§2). The real sequence, using the actual
+frontend spawn path:
 
-This is identical machinery to the in-pane fork bar's §6.3 — the only difference
-is step 3 targets a new tab via `NewTab`+`agent.open` instead of pushing a blockId
-onto the current pane's `blockStack`.
+1. **Fork the definition:** `RpcApi.ForkAgentDefinitionCommand({source_id:
+   activeDefinitionId, branch_label})` — already implemented and already
+   invoked elsewhere (`AgentPicker.tsx`). Requires the lineage-wide counter
+   fix (§2) for `branch_label`'s auto-suggestion to match §4.5's naming
+   rule.
+2. **Open a new tab:** `NewTab` → capture the returned tab id explicitly.
+   **Do not omit it** — Codex's review flagged that `agent.open`/
+   `launchAgentDefinition` resolving "whichever tab is active at execution
+   time" when no target is passed is a real race if the user switches tabs
+   between the two awaited calls, leaving the fork spawned in the wrong
+   place and the newly created tab empty.
+3. **Spawn into that specific tab:** `launchAgentDefinition(forkedDef, {
+   continueSessionId: activeSessionId, forkSession: true, ...identity
+   overrides per §5 }, newTabId)` — passing the new tab id as the explicit
+   third argument, not relying on ambient active-tab state. **This requires
+   fixing the fork-flow's `launchAgentDefinition` call to actually set
+   `continueSessionId`/`forkSession`** (§2) — today's `handleFork` doesn't,
+   so this is new work, not a "just call the existing thing" step.
+4. Tab activates on the new block; parent pane/tab is completely untouched.
+
+Non-Claude providers: `forkSession: true` is silently ignored unless
+`provider.id === "claude"` (`agent-model.ts`'s own gating condition) — this is
+exactly the honest fallback §4.4 describes, now tied to the real code path
+rather than assumed.
 
 ### 4.2 Decision: new tab vs. in-pane fork bar vs. new window
 
@@ -139,14 +208,16 @@ onto the current pane's `blockStack`.
 |---|---|---|---|
 | Visibility | Immediate, full tab, no extra click | Requires noticing/switching the bottom bar | Immediate, but heavier (new window chrome, tear-off machinery) |
 | Use case fit | "Hand this off, work it in parallel, side by side" | "Explore a tangent, come back to the main thread" | Rare — multi-monitor workflows |
-| Backend reuse | 100% — same fork+spawn mechanism | 100% (source of the mechanism) | 100% + tear-off saga |
+| Backend reuse | Definition-forking: 100%. History carryover: **0% wired today** (§2) — same fix needed regardless of landing spot | Same gap — the in-pane fork bar's own `/btw` action (§6.3 there) isn't built yet either | Same gap + tear-off saga |
 | New structural concept | None (tabs already exist) | `blockStack` at the layout node (that spec's one new concept) | None (tear-off already exists) |
 
 **Decision: new tab.** It matches the stated use case (a peer to hand off to, not a
-background tangent) with zero new structural concepts — tabs, `NewTab`, and
-`agent.open` all exist today. A "quick-fork to new window" variant is a trivial
-follow-on (swap the target of step 3 for the existing tear-off saga) but is not
-needed for v1.
+background tangent) with zero new *structural* concepts — tabs and `NewTab`
+exist today. The history-carryover fix (§2) is required work regardless of
+which landing spot is chosen, so it isn't a point in favor of either option;
+it's simply a shared prerequisite. A "quick-fork to new window" variant is a
+trivial follow-on (swap the target of step 3 for the existing tear-off saga)
+but is not needed for v1.
 
 ### 4.3 Trigger / UX
 
@@ -200,7 +271,17 @@ the same next number. Mitigation, per the naming spec: pair the number with
 a short collision-resistant suffix (reusing the existing workspace-folder
 date+letter tag or a few hex characters of the instance UUID), so a rare
 collision is cosmetic (`AgentX #4-0822k` vs. `AgentX #4-0822p`) rather than
-truly ambiguous. **v1 of quick-fork only ever lands on the local host** (§8),
+truly ambiguous.
+
+**This is not purely a future-proofing concern — it's a live bug today.**
+§2 confirms `template.rs`'s existing fork-count logic filters
+`parent_id == source_id` (immediate parent only), so forking an *already-forked*
+definition currently produces "AgentX #2 #2," not "AgentX #3." Fixing this —
+walking to the lineage root and counting all descendants before formatting
+the suggested label — is required before this spec's naming requirement
+holds even for the plain in-pane fork flow, not just quick-fork.
+
+**v1 of quick-fork only ever lands on the local host** (§8),
 so no LAN/WAN qualifier is ever shown — that only becomes relevant if a
 future capability forks directly onto a remote peer, at which point the
 naming spec's tiering (§4.1 there) already covers it without change here.
@@ -227,15 +308,22 @@ via the confirmation variant, not the default one-click path.
 
 ## 6. Phasing
 
+Revised against the real state confirmed during PR #2721's review (reagent +
+Codex) — `ForkAgentDefinitionCommand` already ships; what's actually missing
+is narrower and different from the original draft's Phase 1:
+
 | Phase | Deliverable | Depends on |
 |---|---|---|
-| **1** | Implement `ForkAgentDefinitionCommand` (currently just designed, per `SPEC_MULTI_SESSION_AGENT_FORK` §5.1) | — |
-| **2** | Wire quick-fork action: `NewTab` + forked-definition `agent.open` with `--resume --fork-session`, unbound-identity default | Phase 1 |
-| **3** | UX polish: keybinding, `+` affordance, auto tab title, non-Claude fallback messaging | Phase 2 |
+| **1** | Fix the two confirmed bugs blocking correctness even for the *existing* fork flow: (a) wire `continueSessionId`/`forkSession: true` into the fork path's `launchAgentDefinition` call (§2 — currently missing entirely), (b) fix `template.rs`'s fork-count filter to walk the lineage root instead of the immediate parent (§4.5) | — |
+| **2** | Wire the quick-fork action itself: `NewTab` (capture the returned tab id) → `launchAgentDefinition(forkedDef, {continueSessionId, forkSession: true, ...}, newTabId)` — explicit tab id, not ambient active-tab state (§4.1) | Phase 1 |
+| **3** | UX polish: right-click affordance, keybinding, auto tab title, non-Claude fallback messaging | Phase 2 |
 | **4** | Long-press/confirmation variant exposing the identity choice (§5) | Phase 2 |
 
-Phases 1-2 alone deliver the full G1-G4 use case; Phases 3-4 are polish and the
-opt-in identity path.
+Phase 1 is **not optional polish** — without it, quick-fork (and the existing
+in-pane fork prompt) both silently produce fresh-start clones with no
+conversation history, contradicting this spec's core promise (G3). Phases
+1-2 together deliver the full G1-G4 use case; Phases 3-4 are UX polish and
+the opt-in identity path.
 
 ## 7. Open questions
 
@@ -257,18 +345,29 @@ opt-in identity path.
   fork points) — v1 forks from "now," matching the validated `--fork-session`
   behavior.
 
-## 9. Files this would touch (orientation)
+## 9. Files this would touch (orientation, corrected against real code)
 
-- **New:** `ForkAgentDefinitionCommand` implementation (backend, per
-  `SPEC_MULTI_SESSION_AGENT_FORK` §5.1's struct) if not already landed by the time
-  this ships.
-- **New:** quick-fork action/command (frontend), likely alongside
-  `commands/global/btw.ts` if that has landed, or as its own
+- **Fix (Phase 1a):** `frontend/app/view/agent/components/AgentPicker.tsx`'s
+  `handleFork` — add `continueSessionId`/`forkSession: true` to its
+  `launchAgentDefinition` call. This fixes the *existing* fork-prompt flow's
+  missing history carryover, not just quick-fork's.
+- **Fix (Phase 1b):** `agentmux-srv/src/server/agent_handlers/template.rs`'s
+  fork-count filter (~lines 347, 475) — walk to the lineage root instead of
+  filtering on the immediate `source_id`.
+- **New (Phase 2):** quick-fork action/command (frontend) calling
+  `launchAgentDefinition` directly with an explicit new-tab id, likely
+  alongside `commands/global/btw.ts` if that's landed, or its own
   `commands/global/quick-fork.ts`.
-- **Reuse, no change:** `agent_open.rs` (spawn path), `NewTab`/`SetActiveTab`
-  (`agentmux-mcp/src/main.rs`, `agentmux-srv/src/server/mod.rs`), `AgentInstance`
-  storage (`storage/agents.rs`), `--resume`/`--fork-session` `cli_args` plumbing
-  (`subprocess.rs`/`persistent.rs`).
+- **Reuse, no change:** `ForkAgentDefinitionCommand` (already implemented,
+  `template.rs`), `launchAgentDefinition`'s `LaunchOverrides` shape
+  (`agent-model.ts` — `continueSessionId`/`forkSession` already exist as
+  fields, just unused by the fork flow today), `NewTab`/`SetActiveTab`
+  (`agentmux-mcp/src/main.rs`, `agentmux-srv/src/server/mod.rs`),
+  `AgentInstance` storage (`storage/agents.rs`).
+- **Not touched, contrary to an earlier draft:** `agent.open`
+  (`agentmux-srv/src/server/app_api/agent_open.rs`) and its
+  `CommandAgentOpenData` request shape — the real fix lives entirely in the
+  frontend `launchAgentDefinition` call, not the App-API surface.
 - **Touch:** identity-binding resolution at spawn (`agent_open.rs:57-66`) to
   respect the unbound-by-default decision (§5) for forked definitions
   specifically, if it doesn't already default that way.


### PR DESCRIPTION
## Summary

Three linked, no-code design specs, written together because they share one underlying naming/addressing substrate:

- **`SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md`** — quick-fork the active agent into a new tab: full independent identity (routing ID + jekt signing key never shared; Armory/credential identity unbound by default, opt-in to inherit), reusing the already-designed `ForkAgentDefinitionCommand` and the already-validated `--resume --fork-session` mechanism from the in-pane fork-bar spec, just targeting a new tab instead of a block-stack row. Trigger is right-click-the-tab ("Duplicate Tab"-style), not a new pane icon, to avoid adding to the pane's already-documented accessory sprawl.

- **`SPEC_AGENT_PANE_CROSS_CHANNEL_LAN_WAN_SYNC_2026_08_21.md`** — mirror a running agent's pane across channels/LAN/WAN. Phased strictly by network scope (same-host → LAN → WAN); floor-control rather than CRDT-merge for the shared composer (backed by research — this is a plain-text field, not a rich document); relay architecture (not P2P WebRTC) for the eventual WAN phase; every phase's input-authorization sits inside the *existing* jekt trust model (DELIVERY/TRUST/ESCALATE) rather than a parallel one.

- **`SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md`** — the shared naming layer both specs above consume: names are unqualified within a host ("AgentX #4"), qualified with a `HostLabel` only once they cross a boundary (git `origin/branch` style). Verified directly against `agentmuxai/agentmux-cloud` (commit `e0a756e`): the WAN qualifier anchors to the already-shipped `agent-ownership.ts` table rather than a hand-wavy "muxbus account," and the spec explicitly flags that muxbus has **no server-side host-resolution at all** today (WAN delivery is mailbox/poll-based) — the host half of a WAN name must be self-asserted, same trust weight as `TRUST=network-claimed`. Also documents a real synergy for whoever eventually builds jekt's still-missing general WAN signing (issue #2586): the `reagent_sig`/`reagent_key_id` wire format already exists end-to-end for one hardcoded sender; a public key on the existing ownership row could serve as the trust anchor both problems need, instead of two independent identity tables.

## Test plan

- [ ] Docs-only PR — no code, no build/test impact.
- [ ] Cross-links between the three specs (and to prior art: `SPEC_MULTI_SESSION_AGENT_FORK`, `SPEC_AGENT_PANE_FORKS_AND_AUX_PINS`, the jekt trust-layer specs) resolve correctly.
- [ ] `docs/specs/INDEX.md` entries added under the right sections.

<!-- agentmux:agent_id=agentx -->