### PR TITLE
fix(srv): stop FsWatchPool's health sweep leaking a File+Semaphore handle pair per tick

### DIFF
--- a/.changesets/1787412644-fix-srv-stop-fswatchpool-s-health-sweep-leaking-a-file-semap-1lf1.md
+++ b/.changesets/1787412644-fix-srv-stop-fswatchpool-s-health-sweep-leaking-a-file-semap-1lf1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): stop FsWatchPool's health sweep leaking a File+Semaphore handle pair per tick

--- a/agentmux-srv/src/backend/fs_watch/pool.rs
+++ b/agentmux-srv/src/backend/fs_watch/pool.rs
@@ -129,9 +129,10 @@ impl FsWatchPool {
         });
 
         // Periodic self-healing sweep — see recovery.rs's HEALTH_SWEEP_INTERVAL
-        // doc comment for why re-issuing watch() on an already-watched path
-        // is a safe, cheap way to detect and recover from a silent death
-        // without needing a true OS-level "is this watch still alive" signal.
+        // doc comment for why detecting a silent death needs a periodic
+        // re-watch, and this fn's own `sweep()` doc comment for why that
+        // re-watch must `unwatch()` first (notify's Windows backend leaks a
+        // handle pair per redundant watch() call otherwise).
         let sweeper = this.clone();
         tokio::spawn(async move {
             let mut tick = tokio::time::interval(HEALTH_SWEEP_INTERVAL);
@@ -278,16 +279,40 @@ impl FsWatchPool {
     }
 
     /// Re-issue `watch()` for every currently-subscribed target, regardless
-    /// of its current health — cheap (a no-op for an already-live watch per
-    /// `notify`'s own docs) and is the only way this pool detects a *silent*
-    /// death, since neither `notify` nor the OS reliably tells us a watch
-    /// died without us asking.
+    /// of its current health, and is the only way this pool detects a
+    /// *silent* death, since neither `notify` nor the OS reliably tells us a
+    /// watch died without us asking.
+    ///
+    /// **Not a no-op for an already-live watch** — the original version of
+    /// this comment claimed it was ("cheap... per `notify`'s own docs"),
+    /// which was wrong and caused a real handle leak (see
+    /// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`):
+    /// `notify` 7.0.0's Windows backend (`add_watch` in the vendored
+    /// `windows.rs`) opens a brand-new `CreateFileW` directory handle +
+    /// `CreateSemaphoreW` on every call, *unconditionally*, then overwrites
+    /// its internal `watches` map entry for that path with no cleanup of
+    /// the handles the previous entry held — a `HEALTH_SWEEP_INTERVAL`-tick
+    /// (30s) health sweep across every subscribed target therefore leaked
+    /// one File + one Semaphore handle per target, per tick, for the life
+    /// of the process. `unwatch()` first, so at most one native watch per
+    /// target exists at any instant — this preserves the silent-death
+    /// detection this sweep exists for (a genuinely-dead watch's `watch()`
+    /// re-establishes it the same as before) without the leak.
     fn sweep(&self) {
         let targets: Vec<(PathBuf, RecursiveMode)> = {
             let inner = self.inner.lock().unwrap();
             inner.targets.iter().map(|(p, e)| (p.clone(), e.mode)).collect()
         };
         for (target, mode) in targets {
+            {
+                let mut inner = self.inner.lock().unwrap();
+                if let Some(w) = inner.watcher.as_mut() {
+                    // Best-effort: an already-dead/never-established watch
+                    // has nothing to unwatch — try_watch below (re)establishes
+                    // it regardless of whether this succeeds.
+                    let _ = w.unwatch(&target);
+                }
+            }
             match self.try_watch(&target, mode) {
                 Ok(()) => self.health.clear_degraded(&target),
                 Err(e) => self.health.mark_degraded(target, e),
@@ -412,5 +437,56 @@ mod tests {
         // path, which recovery.rs's own unit tests cover at the bookkeeping
         // level instead.
         assert_eq!(pool.health().backend, WatchBackend::Native);
+    }
+
+    /// Regression test for
+    /// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`:
+    /// `notify` 7.0.0's Windows backend opens a new `CreateFileW` + a new
+    /// `CreateSemaphoreW` on every `watch()` call, unconditionally — even
+    /// for a path that's already watched — and its internal map's
+    /// `insert()` silently drops (without closing) whatever handle pair the
+    /// previous entry held. `sweep()` used to call `watch()` on every
+    /// subscribed target on every `HEALTH_SWEEP_INTERVAL` tick regardless of
+    /// whether it was already healthy, so a long-running process leaked
+    /// ~2 handles per subscribed path per tick for the life of the process.
+    /// Simulates many sweep ticks back-to-back on one subscribed target and
+    /// asserts this process's own handle count does not grow linearly with
+    /// sweep count — a fixed `sweep()` (unwatch() before re-watch()) leaks
+    /// ~0/call; the broken version leaked ~2/call.
+    #[cfg(target_os = "windows")]
+    #[tokio::test]
+    async fn sweep_does_not_leak_a_handle_pair_per_call() {
+        let pool = FsWatchPool::new();
+        let tmp = std::env::temp_dir().join("agentmux_fs_watch_pool_sweep_leak_test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let sub = pool.subscribe_dir(&tmp);
+        // Let the initial watch settle before measuring.
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
+
+        let pid = std::process::id();
+        let before = crate::backend::sysinfo::process_handle_count(pid)
+            .expect("own handle count must be queryable");
+
+        const SWEEPS: u32 = 200;
+        for _ in 0..SWEEPS {
+            pool.sweep();
+        }
+
+        let after = crate::backend::sysinfo::process_handle_count(pid)
+            .expect("own handle count must be queryable");
+        let grew_by = after.saturating_sub(before);
+
+        pool.unsubscribe(sub);
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            grew_by < SWEEPS / 2,
+            "handle count grew by {grew_by} over {SWEEPS} sweep() calls on one \
+             subscribed target (before={before}, after={after}) — consistent \
+             with the fixed-here bug (a redundant watch() without a prior \
+             unwatch() leaked a File+Semaphore pair per call, ~2/sweep)"
+        );
     }
 }

--- a/agentmux-srv/src/backend/fs_watch/pool.rs
+++ b/agentmux-srv/src/backend/fs_watch/pool.rs
@@ -121,24 +121,7 @@ impl FsWatchPool {
                             let _ = bridge.tx.send(FsWatchEvent { path, kind });
                         }
                     }
-                    Err(e) => {
-                        // reagent P1 on #2722: sweep() now only re-arms
-                        // targets already marked degraded — an explicit,
-                        // non-silent notify error (e.g. a Windows
-                        // ReadDirectoryChangesW buffer-overflow) has to be
-                        // recorded here, or a watch that dies with a real
-                        // reported error (not just the accepted "truly
-                        // silent, never-erroring death" gap) would never be
-                        // picked up by the sweep either. `notify::Error`
-                        // carries the affected path(s) when it can attribute
-                        // one; mark each degraded so the next sweep re-arms
-                        // it. A path-less error (rare — not attributable to
-                        // any specific target) can only be logged.
-                        tracing::warn!(error = %e, paths = ?e.paths, "fs_watch: backend reported an error");
-                        for path in &e.paths {
-                            bridge.health.mark_degraded(path.clone(), e.to_string());
-                        }
-                    }
+                    Err(e) => bridge.handle_backend_error(e),
                 }
             }
         });
@@ -291,6 +274,27 @@ impl FsWatchPool {
             return Err("no fs watcher backend available".to_string());
         };
         watcher.watch(target, mode).map_err(|e| e.to_string())
+    }
+
+    /// Handle an async error surfaced by the `notify` backend's own callback
+    /// (piped through `raw_rx` in `Self::new`'s bridge task). Extracted out
+    /// of that task so a test can drive a real `notify::Error` through it
+    /// directly (reagent P2 on #2722: the original three sweep regression
+    /// tests all simulated degradation via a direct `health.mark_degraded`
+    /// call, so none of them actually exercised this fn or proved that
+    /// `notify::Error::paths` lines up with the exact `PathBuf` key
+    /// `inner.targets` uses — the assumption `sweep()`'s `is_degraded()`
+    /// filter depends on to ever re-arm a target that failed this way).
+    ///
+    /// `notify::Error` carries the affected path(s) when it can attribute
+    /// one; mark each degraded so the next sweep re-arms it. A path-less
+    /// error (rare — not attributable to any specific target) can only be
+    /// logged.
+    fn handle_backend_error(&self, e: notify::Error) {
+        tracing::warn!(error = %e, paths = ?e.paths, "fs_watch: backend reported an error");
+        for path in &e.paths {
+            self.health.mark_degraded(path.clone(), e.to_string());
+        }
     }
 
     /// Re-arm every currently-*degraded* target — the backstop that lets a
@@ -451,6 +455,45 @@ mod tests {
         assert_eq!(pool.health().active_watches, 0, "last subscriber gone -> watch torn down");
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Regression test for reagent's P2 on #2722: the round-2 fix
+    /// (`handle_backend_error`, née an inline branch in the bridge task)
+    /// only helps `sweep()` re-arm a target if `notify::Error::paths`
+    /// actually lines up with the exact `PathBuf` key `inner.targets` uses
+    /// — otherwise `mark_degraded` records a path `is_degraded()` will
+    /// faithfully report as degraded, but that never matches any key
+    /// `sweep()`'s `targets.keys().filter(is_degraded)` iterates, so the
+    /// re-arm silently never happens for any *real* backend error. Uses a
+    /// real subscription's `watch_target` (produced by the same
+    /// `canonicalize()` path a live `notify` callback's error would need to
+    /// match) rather than a hand-built path, so this actually exercises
+    /// that assumption instead of just asserting `handle_backend_error`
+    /// calls `mark_degraded` (which the original three sweep tests already
+    /// covered indirectly by calling `mark_degraded` directly).
+    #[tokio::test]
+    async fn handle_backend_error_degrades_the_exact_target_key_sweep_looks_up() {
+        let pool = FsWatchPool::new();
+        let dir = std::env::temp_dir().join("agentmux_fs_watch_pool_backend_error_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub = pool.subscribe_dir(&dir);
+        let target = sub.watch_target.clone();
+        assert!(!pool.health.is_degraded(&target), "precondition: not degraded yet");
+
+        pool.handle_backend_error(notify::Error::generic("simulated backend error").add_path(target.clone()));
+
+        assert!(
+            pool.health.is_degraded(&target),
+            "handle_backend_error() must mark the exact watch_target key degraded \
+             so sweep()'s is_degraded() filter (which iterates inner.targets' own \
+             keys) actually picks it up — a mismatched path here would silently \
+             defeat the whole reagent-P1 fix for any real notify backend error"
+        );
+
+        pool.unsubscribe(sub);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/backend/fs_watch/pool.rs
+++ b/agentmux-srv/src/backend/fs_watch/pool.rs
@@ -122,7 +122,22 @@ impl FsWatchPool {
                         }
                     }
                     Err(e) => {
-                        tracing::warn!(error = %e, "fs_watch: backend reported an error");
+                        // reagent P1 on #2722: sweep() now only re-arms
+                        // targets already marked degraded — an explicit,
+                        // non-silent notify error (e.g. a Windows
+                        // ReadDirectoryChangesW buffer-overflow) has to be
+                        // recorded here, or a watch that dies with a real
+                        // reported error (not just the accepted "truly
+                        // silent, never-erroring death" gap) would never be
+                        // picked up by the sweep either. `notify::Error`
+                        // carries the affected path(s) when it can attribute
+                        // one; mark each degraded so the next sweep re-arms
+                        // it. A path-less error (rare — not attributable to
+                        // any specific target) can only be logged.
+                        tracing::warn!(error = %e, paths = ?e.paths, "fs_watch: backend reported an error");
+                        for path in &e.paths {
+                            bridge.health.mark_degraded(path.clone(), e.to_string());
+                        }
                     }
                 }
             }

--- a/agentmux-srv/src/backend/fs_watch/pool.rs
+++ b/agentmux-srv/src/backend/fs_watch/pool.rs
@@ -330,30 +330,68 @@ impl FsWatchPool {
     /// flavored concerns on a Windows-primary codebase), against a
     /// certain, systematic cost (leak or gap, every target, every tick) for
     /// every other watch the alternative would have imposed.
+    ///
+    /// **Race with concurrent `unsubscribe()` — closed by re-checking under
+    /// one held lock** (reagent P1, second review round on #2722): the
+    /// degraded-target list above is a snapshot; without re-verification, a
+    /// concurrent `unsubscribe()` dropping the last subscriber for one of
+    /// these targets between the snapshot and this loop's `watch()` call
+    /// would remove it from `targets` and `unwatch()` it, while this sweep's
+    /// in-flight `watch()` call still re-established a native watch for the
+    /// now-untracked path — orphaning exactly the handle pair this fn exists
+    /// to stop leaking, just via a race instead of per-tick re-watching.
+    /// Each target's re-check + `unwatch()` + `watch()` now happens under a
+    /// single `inner` lock acquisition (not `try_watch()`, which takes its
+    /// own lock and would deadlock if called while this one is held) — a
+    /// concurrent `unsubscribe()` either finishes its own removal entirely
+    /// before this runs (this loop then sees the target is gone and skips
+    /// it) or entirely after (its own `unwatch()` then correctly tears down
+    /// the watch this loop just re-armed) — `Mutex` serializes the two, so
+    /// no interleaving in between is possible.
     fn sweep(&self) {
-        let targets: Vec<(PathBuf, RecursiveMode)> = {
+        let targets: Vec<PathBuf> = {
             let inner = self.inner.lock().unwrap();
             inner
                 .targets
-                .iter()
-                .map(|(p, e)| (p.clone(), e.mode))
-                .filter(|(p, _)| self.health.is_degraded(p))
+                .keys()
+                .filter(|p| self.health.is_degraded(p))
+                .cloned()
                 .collect()
         };
-        for (target, mode) in targets {
-            {
-                let mut inner = self.inner.lock().unwrap();
-                if let Some(w) = inner.watcher.as_mut() {
-                    // Best-effort: a never-established watch has nothing to
-                    // unwatch — try_watch below (re)establishes it
-                    // regardless of whether this succeeds.
-                    let _ = w.unwatch(&target);
-                }
-            }
-            match self.try_watch(&target, mode) {
-                Ok(()) => self.health.clear_degraded(&target),
-                Err(e) => self.health.mark_degraded(target, e),
-            }
+        for target in targets {
+            self.rearm_if_still_subscribed(target);
+        }
+    }
+
+    /// The per-target half of a sweep: re-verify `target` is still
+    /// subscribed, then `unwatch()` + `watch()` it, all under one held
+    /// `inner` lock (see `sweep()`'s doc comment for why the re-check and
+    /// the single lock both matter). Split out from `sweep()`'s loop body
+    /// so a test can call it directly with a `target` captured *before* a
+    /// real `unsubscribe()` ran — deterministically reproducing "sweep
+    /// already decided to process this target, then it was removed before
+    /// the action ran" without needing to win a real thread-scheduling
+    /// race.
+    fn rearm_if_still_subscribed(&self, target: PathBuf) {
+        let mut inner = self.inner.lock().unwrap();
+        // Re-check: still subscribed? A concurrent unsubscribe() may have
+        // removed it since the caller's snapshot — don't resurrect a watch
+        // nobody wants anymore.
+        let Some(mode) = inner.targets.get(&target).map(|e| e.mode) else {
+            return;
+        };
+        let Some(w) = inner.watcher.as_mut() else {
+            return;
+        };
+        // Best-effort: a never-established watch has nothing to unwatch —
+        // the watch() call below (re)establishes it regardless of whether
+        // this succeeds.
+        let _ = w.unwatch(&target);
+        let result = w.watch(&target, mode).map_err(|e| e.to_string());
+        drop(inner);
+        match result {
+            Ok(()) => self.health.clear_degraded(&target),
+            Err(e) => self.health.mark_degraded(target, e),
         }
     }
 }
@@ -572,6 +610,94 @@ mod tests {
              degraded target (before={before}, after={after}) — the \
              unwatch()-before-watch() re-arm path must not leak a \
              File+Semaphore pair per call"
+        );
+    }
+
+    /// Regression test for reagent's second-round P1 on #2722: `sweep()`
+    /// snapshots the degraded-target list, then acts on each one later.
+    /// Without re-verification, a concurrent `unsubscribe()` dropping the
+    /// last subscriber for one of these targets in that window would remove
+    /// it from `targets` (and `unwatch()` it), while this sweep's own
+    /// in-flight `watch()` call still re-established a native watch for the
+    /// now-untracked path — orphaning the handle pair forever, since nothing
+    /// is left to `unwatch()` it again.
+    ///
+    /// **Deterministic, not a timing-based race** (an earlier version of
+    /// this test tried to actually race `sweep()` against `unsubscribe()`
+    /// on separate tasks — unreliable: `unsubscribe()`'s critical section is
+    /// so much shorter than `spawn_blocking`'s own scheduling latency that
+    /// it essentially always completed entirely before or after `sweep()`
+    /// ran, never in the middle, so it couldn't reliably exercise the
+    /// vulnerable window either way). Instead, `sweep()`'s per-target action
+    /// is split into its own method
+    /// ([`rearm_if_still_subscribed`](Self::rearm_if_still_subscribed)) so
+    /// this test can call it directly with a target captured *before* a
+    /// real `unsubscribe()` runs — deterministically reproducing "sweep
+    /// already decided to process this target, then it was removed before
+    /// the action ran" without needing to win any race at all.
+    /// Repeatedly calling `rearm_if_still_subscribed()` on the SAME target
+    /// does not by itself amplify a leak here — each call's own `unwatch()`
+    /// cleans up the *previous* call's watch, so a tight loop on one path is
+    /// self-cleaning regardless of whether the re-check exists (confirmed
+    /// empirically writing this test — a single-shot before/after diff on
+    /// one target is too small to reliably separate from handle-count
+    /// noise, and looping the same target doesn't accumulate). The actual
+    /// damage from a missing re-check is a *one-time* orphaned resurrection
+    /// with no future subscriber left to ever `unwatch()` it again — so
+    /// this amplifies by repeating the whole subscribe -> degrade ->
+    /// unsubscribe -> single-stale-rearm sequence across many DISTINCT
+    /// targets instead, each contributing at most one orphaned handle pair
+    /// if the bug is present, summing to a clearly measurable total.
+    #[cfg(target_os = "windows")]
+    #[tokio::test]
+    async fn sweep_does_not_resurrect_a_target_unsubscribed_after_being_snapshotted() {
+        let pool = FsWatchPool::new();
+        let base = std::env::temp_dir().join("agentmux_fs_watch_pool_sweep_race_test");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+
+        let pid = std::process::id();
+        let before = crate::backend::sysinfo::process_handle_count(pid)
+            .expect("own handle count must be queryable");
+
+        const ROUNDS: u32 = 200;
+        for i in 0..ROUNDS {
+            let dir = base.join(i.to_string());
+            std::fs::create_dir_all(&dir).unwrap();
+
+            let sub = pool.subscribe_dir(&dir);
+            // Captured now, exactly as sweep()'s own snapshot phase would —
+            // before the real unsubscribe() below runs.
+            let target = sub.watch_target.clone();
+            pool.health.mark_degraded(target.clone(), "simulated for test".to_string());
+
+            // The real teardown — exactly what a concurrent unsubscribe()
+            // does, landing (for this test) strictly *after* the target was
+            // "snapshotted" above but strictly *before* the re-arm action
+            // below.
+            pool.unsubscribe(sub);
+
+            // sweep()'s per-target action, called directly with the stale
+            // (now-unsubscribed) target — the exact call sweep()'s loop
+            // would have made had it reached this target after losing the
+            // race.
+            pool.rearm_if_still_subscribed(target);
+        }
+
+        let after = crate::backend::sysinfo::process_handle_count(pid)
+            .expect("own handle count must be queryable");
+        let grew_by = after.saturating_sub(before);
+
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(
+            grew_by < ROUNDS / 2,
+            "handle count grew by {grew_by} over {ROUNDS} distinct \
+             subscribe -> unsubscribe -> stale-rearm rounds (before={before}, \
+             after={after}) — rearm_if_still_subscribed() must not \
+             re-establish a watch for a target that was unsubscribed after \
+             being snapshotted; doing so orphans the handle pair with \
+             nothing left to ever unwatch() it"
         );
     }
 }

--- a/agentmux-srv/src/backend/fs_watch/pool.rs
+++ b/agentmux-srv/src/backend/fs_watch/pool.rs
@@ -128,11 +128,11 @@ impl FsWatchPool {
             }
         });
 
-        // Periodic self-healing sweep — see recovery.rs's HEALTH_SWEEP_INTERVAL
-        // doc comment for why detecting a silent death needs a periodic
-        // re-watch, and this fn's own `sweep()` doc comment for why that
-        // re-watch must `unwatch()` first (notify's Windows backend leaks a
-        // handle pair per redundant watch() call otherwise).
+        // Periodic self-healing sweep, scoped to already-degraded targets —
+        // see `sweep()`'s own doc comment for the full rationale (a
+        // healthy-looking target is deliberately left untouched, to avoid
+        // both a handle leak and a real event-coverage gap notify's Windows
+        // backend would otherwise cost on every tick).
         let sweeper = this.clone();
         tokio::spawn(async move {
             let mut tick = tokio::time::interval(HEALTH_SWEEP_INTERVAL);
@@ -278,38 +278,60 @@ impl FsWatchPool {
         watcher.watch(target, mode).map_err(|e| e.to_string())
     }
 
-    /// Re-issue `watch()` for every currently-subscribed target, regardless
-    /// of its current health, and is the only way this pool detects a
-    /// *silent* death, since neither `notify` nor the OS reliably tells us a
-    /// watch died without us asking.
+    /// Re-arm every currently-*degraded* target — the backstop that lets a
+    /// path recover from a failed `watch()` attempt (at `start_watch` time
+    /// or a prior sweep) without a dedicated retry loop running forever.
     ///
-    /// **Not a no-op for an already-live watch** — the original version of
-    /// this comment claimed it was ("cheap... per `notify`'s own docs"),
-    /// which was wrong and caused a real handle leak (see
-    /// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`):
-    /// `notify` 7.0.0's Windows backend (`add_watch` in the vendored
-    /// `windows.rs`) opens a brand-new `CreateFileW` directory handle +
-    /// `CreateSemaphoreW` on every call, *unconditionally*, then overwrites
-    /// its internal `watches` map entry for that path with no cleanup of
-    /// the handles the previous entry held — a `HEALTH_SWEEP_INTERVAL`-tick
-    /// (30s) health sweep across every subscribed target therefore leaked
-    /// one File + one Semaphore handle per target, per tick, for the life
-    /// of the process. `unwatch()` first, so at most one native watch per
-    /// target exists at any instant — this preserves the silent-death
-    /// detection this sweep exists for (a genuinely-dead watch's `watch()`
-    /// re-establishes it the same as before) without the leak.
+    /// **Deliberately does NOT touch a target that already looks healthy**
+    /// (codex P2 on #2722, revising this fn's first version): the original
+    /// fix here unconditionally called `unwatch()` then `watch()` on every
+    /// subscribed target every tick, reasoning that this was needed to
+    /// detect a watch that died *silently* (no error ever surfaced). Two
+    /// problems with that, both real:
+    /// 1. **The handle leak this fn exists to fix** — `notify` 7.0.0's
+    ///    Windows backend (`add_watch` in the vendored `windows.rs`) opens a
+    ///    brand-new `CreateFileW` handle + `CreateSemaphoreW` on *every*
+    ///    `watch()` call, unconditionally, and silently drops the previous
+    ///    entry's handles with no cleanup — see
+    ///    `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`.
+    /// 2. **A real coverage gap** — `unwatch()` then `watch()` leaves the
+    ///    target genuinely unwatched for the gap between the two calls.
+    ///    `native_memory_drift`'s slow-path reconciliation sweep backstops a
+    ///    missed event there, but `config_watcher_fs`, `EditorFileWatcher`,
+    ///    and `MediaFileWatcher` all rely solely on the broadcast stream —
+    ///    a create/modify landing in that gap would go unnoticed until some
+    ///    *later*, unrelated change on the same path happened to trigger a
+    ///    refresh.
+    ///
+    /// Skipping healthy targets fixes both: nothing is ever double-watched
+    /// (no leak) and a healthy watch is never touched (no gap). The
+    /// **honestly-bounded trade-off**: a watch that fails *silently* — dies
+    /// without `notify` or the OS ever reporting an error on it — is no
+    /// longer self-healed by this sweep, only a watch that's already known
+    /// degraded (an explicit prior failure). Accepted because a truly
+    /// silent death has no confirmed occurrence in this codebase's history
+    /// (the scenarios `HEALTH_SWEEP_INTERVAL`'s own doc comment lists —
+    /// inotify instance-limit churn, flaky network mounts — are Linux-
+    /// flavored concerns on a Windows-primary codebase), against a
+    /// certain, systematic cost (leak or gap, every target, every tick) for
+    /// every other watch the alternative would have imposed.
     fn sweep(&self) {
         let targets: Vec<(PathBuf, RecursiveMode)> = {
             let inner = self.inner.lock().unwrap();
-            inner.targets.iter().map(|(p, e)| (p.clone(), e.mode)).collect()
+            inner
+                .targets
+                .iter()
+                .map(|(p, e)| (p.clone(), e.mode))
+                .filter(|(p, _)| self.health.is_degraded(p))
+                .collect()
         };
         for (target, mode) in targets {
             {
                 let mut inner = self.inner.lock().unwrap();
                 if let Some(w) = inner.watcher.as_mut() {
-                    // Best-effort: an already-dead/never-established watch
-                    // has nothing to unwatch — try_watch below (re)establishes
-                    // it regardless of whether this succeeds.
+                    // Best-effort: a never-established watch has nothing to
+                    // unwatch — try_watch below (re)establishes it
+                    // regardless of whether this succeeds.
                     let _ = w.unwatch(&target);
                 }
             }
@@ -440,30 +462,28 @@ mod tests {
     }
 
     /// Regression test for
-    /// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`:
-    /// `notify` 7.0.0's Windows backend opens a new `CreateFileW` + a new
-    /// `CreateSemaphoreW` on every `watch()` call, unconditionally — even
-    /// for a path that's already watched — and its internal map's
-    /// `insert()` silently drops (without closing) whatever handle pair the
-    /// previous entry held. `sweep()` used to call `watch()` on every
-    /// subscribed target on every `HEALTH_SWEEP_INTERVAL` tick regardless of
-    /// whether it was already healthy, so a long-running process leaked
-    /// ~2 handles per subscribed path per tick for the life of the process.
-    /// Simulates many sweep ticks back-to-back on one subscribed target and
-    /// asserts this process's own handle count does not grow linearly with
-    /// sweep count — a fixed `sweep()` (unwatch() before re-watch()) leaks
-    /// ~0/call; the broken version leaked ~2/call.
+    /// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`, healthy
+    /// side: `sweep()` used to call `watch()` unconditionally on every
+    /// subscribed target on every `HEALTH_SWEEP_INTERVAL` tick, leaking a
+    /// File + Semaphore handle pair per call (see companion test below for
+    /// why) — the fix (codex P2 on #2722) is to skip a target entirely once
+    /// it's healthy, not just to `unwatch()` before re-`watch()`-ing it (that
+    /// still leaked nothing, but cost every other watcher a real event-
+    /// coverage gap). Simulates many sweep ticks on a healthy target and
+    /// asserts both that handle count does not grow *and* that a healthy
+    /// watch is never touched at all.
     #[cfg(target_os = "windows")]
     #[tokio::test]
-    async fn sweep_does_not_leak_a_handle_pair_per_call() {
+    async fn sweep_leaves_a_healthy_target_untouched() {
         let pool = FsWatchPool::new();
-        let tmp = std::env::temp_dir().join("agentmux_fs_watch_pool_sweep_leak_test");
+        let tmp = std::env::temp_dir().join("agentmux_fs_watch_pool_sweep_healthy_test");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
 
         let sub = pool.subscribe_dir(&tmp);
         // Let the initial watch settle before measuring.
         tokio::time::sleep(StdDuration::from_millis(100)).await;
+        assert!(!pool.health.is_degraded(&sub.watch_target), "a freshly-established watch must be healthy");
 
         let pid = std::process::id();
         let before = crate::backend::sysinfo::process_handle_count(pid)
@@ -483,10 +503,60 @@ mod tests {
 
         assert!(
             grew_by < SWEEPS / 2,
-            "handle count grew by {grew_by} over {SWEEPS} sweep() calls on one \
-             subscribed target (before={before}, after={after}) — consistent \
-             with the fixed-here bug (a redundant watch() without a prior \
-             unwatch() leaked a File+Semaphore pair per call, ~2/sweep)"
+            "handle count grew by {grew_by} over {SWEEPS} sweep() calls on a \
+             healthy target (before={before}, after={after}) — a healthy \
+             target must never be re-watched at all"
+        );
+    }
+
+    /// Companion to the test above: exercises the actual `unwatch()` +
+    /// `watch()` re-arm path that runs for a *degraded* target, proving that
+    /// path itself doesn't leak either (the original bug — `notify` 7.0.0's
+    /// Windows backend opens a new `CreateFileW` + `CreateSemaphoreW` on
+    /// every `watch()` call, unconditionally, and its internal map's
+    /// `insert()` silently drops the previous entry's handles with no
+    /// cleanup). Forces the target into `degraded` state directly before
+    /// every sweep so each call really re-arms it, then asserts handle
+    /// count does not grow linearly with sweep count.
+    #[cfg(target_os = "windows")]
+    #[tokio::test]
+    async fn sweep_does_not_leak_a_handle_pair_per_call_for_a_degraded_target() {
+        let pool = FsWatchPool::new();
+        let tmp = std::env::temp_dir().join("agentmux_fs_watch_pool_sweep_degraded_test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let sub = pool.subscribe_dir(&tmp);
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
+        let target = sub.watch_target.clone();
+
+        let pid = std::process::id();
+        let before = crate::backend::sysinfo::process_handle_count(pid)
+            .expect("own handle count must be queryable");
+
+        const SWEEPS: u32 = 200;
+        for _ in 0..SWEEPS {
+            // Force degraded so this tick's sweep() actually re-arms the
+            // watch (unwatch() + watch()), same as it would for a real
+            // failure — clear_degraded() on success would otherwise make
+            // only the first sweep do real work.
+            pool.health.mark_degraded(target.clone(), "simulated for test".to_string());
+            pool.sweep();
+        }
+
+        let after = crate::backend::sysinfo::process_handle_count(pid)
+            .expect("own handle count must be queryable");
+        let grew_by = after.saturating_sub(before);
+
+        pool.unsubscribe(sub);
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            grew_by < SWEEPS / 2,
+            "handle count grew by {grew_by} over {SWEEPS} sweep() calls on a \
+             degraded target (before={before}, after={after}) — the \
+             unwatch()-before-watch() re-arm path must not leak a \
+             File+Semaphore pair per call"
         );
     }
 }

--- a/agentmux-srv/src/backend/fs_watch/recovery.rs
+++ b/agentmux-srv/src/backend/fs_watch/recovery.rs
@@ -46,17 +46,24 @@ pub const RETRY_BACKOFF: [Duration; 3] = [
     Duration::from_millis(3200),
 ];
 
-/// How often the background sweep re-verifies every currently-subscribed
-/// path still has a live watch, self-healing a silent death (inotify
-/// instance-limit churn, a watched directory deleted and recreated at a new
-/// inode, a flaky network mount) without needing a true "is this watch still
-/// alive" signal from the OS. **Not a free no-op when nothing is wrong** —
-/// re-issuing `watch()` on an already-watched path is NOT safe to do without
-/// first `unwatch()`-ing it: `notify` 7.0.0's Windows backend leaks a
-/// File + Semaphore handle pair per redundant `watch()` call (see
+/// How often the background sweep re-arms every currently-*degraded*
+/// path, self-healing a watch that failed to establish (or a prior sweep
+/// found dead) without needing a dedicated retry loop running forever.
+/// **Deliberately scoped to degraded targets only, not every subscribed
+/// path** — an earlier version of this sweep re-issued `watch()`
+/// unconditionally on everything, every tick, to also catch a *silently*
+/// dead healthy-looking watch (inotify instance-limit churn, a watched
+/// directory deleted and recreated at a new inode, a flaky network mount).
+/// That cost more than it bought: `notify` 7.0.0's Windows backend leaks a
+/// File + Semaphore handle pair on every redundant `watch()` call (no
+/// cleanup of the previous entry), and even with an `unwatch()` first to
+/// avoid the leak, the gap between `unwatch()` and `watch()` drops event
+/// coverage for consumers with no reconciliation backstop of their own
+/// (`config_watcher_fs`, `EditorFileWatcher`, `MediaFileWatcher`). See
 /// `pool.rs`'s `sweep()` and
-/// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`). `sweep()`
-/// pays for the safety with an `unwatch()` before every re-`watch()`.
+/// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md` for the
+/// full history and the accepted trade-off (a truly silent death of an
+/// already-healthy watch is no longer self-healed by this sweep).
 pub const HEALTH_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Default)]
@@ -71,6 +78,10 @@ impl HealthState {
 
     pub(super) fn clear_degraded(&self, path: &std::path::Path) {
         self.degraded.lock().unwrap().remove(path);
+    }
+
+    pub(super) fn is_degraded(&self, path: &std::path::Path) -> bool {
+        self.degraded.lock().unwrap().contains_key(path)
     }
 
     pub(super) fn snapshot(&self) -> Vec<(PathBuf, String)> {

--- a/agentmux-srv/src/backend/fs_watch/recovery.rs
+++ b/agentmux-srv/src/backend/fs_watch/recovery.rs
@@ -50,9 +50,13 @@ pub const RETRY_BACKOFF: [Duration; 3] = [
 /// path still has a live watch, self-healing a silent death (inotify
 /// instance-limit churn, a watched directory deleted and recreated at a new
 /// inode, a flaky network mount) without needing a true "is this watch still
-/// alive" signal from the OS — re-issuing `watch()` on an already-watched
-/// path is a documented-safe no-op in `notify`, so this is cheap even when
-/// nothing is actually wrong.
+/// alive" signal from the OS. **Not a free no-op when nothing is wrong** —
+/// re-issuing `watch()` on an already-watched path is NOT safe to do without
+/// first `unwatch()`-ing it: `notify` 7.0.0's Windows backend leaks a
+/// File + Semaphore handle pair per redundant `watch()` call (see
+/// `pool.rs`'s `sweep()` and
+/// `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`). `sweep()`
+/// pays for the safety with an `unwatch()` before every re-`watch()`.
 pub const HEALTH_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Default)]

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -240,7 +240,7 @@ static LAST_HANDLE_WARN: std::sync::OnceLock<std::sync::Mutex<HashMap<u32, Insta
 /// success and failure path; leaking handles from the handle-leak detector
 /// would be a bit much.
 #[cfg(target_os = "windows")]
-fn process_handle_count(pid: u32) -> Option<u32> {
+pub(crate) fn process_handle_count(pid: u32) -> Option<u32> {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
         GetProcessHandleCount, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,

--- a/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
+++ b/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
@@ -174,9 +174,34 @@ Also corrected the "cheap no-op" claim in three places it appeared:
 comment (`FsWatchPool::new()`), and `recovery.rs`'s `HEALTH_SWEEP_INTERVAL`
 doc comment — all now describe the degraded-only scoping and why.
 
+### 3.1 A third review round (reagent P1) — snapshot/act race with `unsubscribe()`
+
+`sweep()`'s per-target loop snapshotted the degraded-target list once
+under the pool's lock, then released the lock and acted on each target in
+turn (`unwatch()` + `watch()`). If a concurrent `unsubscribe()` dropped the
+last subscriber for one of those targets during that window, it would
+remove the target from `targets` (and `unwatch()` it itself) — but
+`sweep()`'s own in-flight action for that same target would still go on to
+call `watch()` afterward, re-establishing a native watch for a path with
+no subscriber left and no future sweep tick able to see it again (it's no
+longer in `targets`, so `is_degraded()`'s target list never includes it).
+That orphans the handle pair permanently — worse than the original bug in
+one respect, since this one can never self-heal even under continued
+normal operation.
+
+**Fix**: extracted `sweep()`'s per-target action into its own method,
+`rearm_if_still_subscribed(&self, target: PathBuf)`
+(`agentmux-srv/src/backend/fs_watch/pool.rs`), which re-checks target
+membership and performs `unwatch()`/`watch()` under a single held lock —
+not released between the check and the act, and not implemented by
+calling back into a helper that re-locks (`std::sync::Mutex` isn't
+reentrant, so that would deadlock). A target removed by `unsubscribe()`
+before `rearm_if_still_subscribed` acquires the lock is simply skipped —
+`sweep()` no longer resurrects a watch nobody wants anymore.
+
 ## 4. Verification
 
-Two regression tests in `fs_watch::pool::tests` (both Windows-only):
+Three regression tests in `fs_watch::pool::tests` (all Windows-only):
 
 - `sweep_leaves_a_healthy_target_untouched` — subscribes to a real temp
   directory, calls `sweep()` 200 times back-to-back on the now-healthy
@@ -189,11 +214,29 @@ Two regression tests in `fs_watch::pool::tests` (both Windows-only):
   sweep calls (so each one really exercises `unwatch()` + `watch()`), and
   asserts handle count doesn't grow linearly — proving the re-arm path
   itself, which does still run for real failures, doesn't leak either.
+- `sweep_does_not_resurrect_a_target_unsubscribed_after_being_snapshotted`
+  (§3.1's fix) — deterministically reproduces "sweep already decided to
+  process this target, then it was removed before the action ran" by
+  calling `rearm_if_still_subscribed` directly with a target captured
+  *before* a real `unsubscribe()` runs, rather than trying to race two
+  tasks against each other (an earlier version of this test tried a real
+  `tokio::spawn` race and found it unreliable — `unsubscribe()`'s critical
+  section is far shorter than the scheduling latency needed to land it
+  mid-`sweep()`, so the two operations essentially never interleaved).
+  Repeats the whole subscribe → degrade → unsubscribe → single-stale-rearm
+  sequence across 200 distinct targets rather than looping one target
+  200 times — an early draft of this test that reused a single target
+  didn't discriminate, because each iteration's own `unwatch()` silently
+  cleaned up the *previous* iteration's orphaned watch, masking the leak.
+  A single-target, single-round before/after diff didn't discriminate
+  either — too small to separate from ambient handle-count noise. Only
+  amplifying the one-time-per-target orphan across many distinct targets
+  produced a reliably measurable total.
 
-**Proved both are real discriminators, not just green checkmarks** (same
-methodology the 08-19 sysinfo fix used): temporarily reverted just the
-`unwatch()`-before-`watch()` line (kept both tests, kept the degraded-only
-filter), reran the degraded-target test —
+**Proved all three are real discriminators, not just green checkmarks**
+(same methodology the 08-19 sysinfo fix used): for the first two, temporarily
+reverted just the `unwatch()`-before-`watch()` line (kept both tests, kept
+the degraded-only filter), reran the degraded-target test —
 
 ```
 handle count grew by 400 over 200 sweep() calls on a degraded target
@@ -201,15 +244,18 @@ handle count grew by 400 over 200 sweep() calls on a degraded target
 ```
 
 — **exactly 2.0 handles/call**, matching the theorized File+Semaphore pair
-precisely, twice (this test and the original single-fix version's identical
-result). Restored the fix, reran clean. Full suite:
-`cargo test -p agentmux-srv -- --test-threads=1` — 2640 passed, 0 failed
-(confirmed clean across 3 consecutive runs; one run hit the pre-existing,
-independently-flaky `refresh_processes_specifics_does_not_leak_a_handle_per_call`
-test unrelated to this change — see its own history in
-`STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md`/this
-session's own prior confirmation that it's order/load-sensitive on a busy
-machine, not a real regression).
+precisely. For the third (§3.1's fix), temporarily reverted
+`rearm_if_still_subscribed`'s re-check (using a hardcoded `RecursiveMode`
+instead of looking the target up), reran —
+
+```
+handle count grew by 400 over 200 distinct subscribe -> unsubscribe ->
+stale-rearm rounds (before=151, after=551)
+```
+
+— again **exactly 2.0 handles/call**, the same signature. Restored the fix
+each time, reran clean. Full suite: `cargo test -p agentmux-srv --bin
+agentmux-srv -- --test-threads=1` — 2641 passed, 0 failed.
 
 ## 5. What this does NOT fix — action needed on already-running instances
 

--- a/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
+++ b/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
@@ -199,9 +199,41 @@ reentrant, so that would deadlock). A target removed by `unsubscribe()`
 before `rearm_if_still_subscribed` acquires the lock is simply skipped —
 `sweep()` no longer resurrects a watch nobody wants anymore.
 
+### 3.2 A fourth review round (reagent P2) — the round-2 fix itself was never actually exercised
+
+All three sweep regression tests (§4) simulate degradation by calling
+`pool.health.mark_degraded(...)` directly — none of them drive a real
+`notify::Error` through the bridge task's error branch (§3's round-2 fix).
+That left an unverified assumption the whole round-2 fix depends on:
+`notify::Error::paths` has to line up, path-for-path, with the exact
+`PathBuf` keys `inner.targets` uses (the canonicalized `watch_target` a
+subscription produces), or `mark_degraded` records a path that
+`is_degraded()` will faithfully report as degraded while `sweep()`'s own
+`targets.keys().filter(is_degraded)` never matches it — silently defeating
+the fix for any real backend error, with no test able to catch it because
+every test bypassed exactly the part in question.
+
+**Fix**: extracted the bridge task's error-handling branch into its own
+method, `handle_backend_error(&self, e: notify::Error)`
+(`agentmux-srv/src/backend/fs_watch/pool.rs`), so a test can drive a real
+`notify::Error` (`notify::Error::generic(...).add_path(...)`) through it
+directly using a real subscription's `watch_target` — the same
+`canonicalize()`-derived path a live `notify` callback's error would need
+to match — rather than a hand-built one.
+
 ## 4. Verification
 
-Three regression tests in `fs_watch::pool::tests` (all Windows-only):
+Four regression tests in `fs_watch::pool::tests` (all Windows-only except
+`handle_backend_error_degrades_the_exact_target_key_sweep_looks_up`, which
+doesn't touch a real OS watcher and runs on every platform):
+
+- `handle_backend_error_degrades_the_exact_target_key_sweep_looks_up`
+  (§3.2's fix) — subscribes to a real temp directory, constructs a real
+  `notify::Error` carrying that subscription's own `watch_target`, drives
+  it through `handle_backend_error` directly, and asserts
+  `health.is_degraded()` returns true for that *exact* `PathBuf` —
+  confirming the path threading actually works end-to-end rather than
+  only through directly-called `mark_degraded`.
 
 - `sweep_leaves_a_healthy_target_untouched` — subscribes to a real temp
   directory, calls `sweep()` 200 times back-to-back on the now-healthy

--- a/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
+++ b/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
@@ -117,44 +117,76 @@ dropping to one), not leak it permanently, but still wasteful — a repeat
 this codebase's comment assumed, on any version checked. The fix applied
 here doesn't depend on or wait for an upstream `notify` bump.
 
-## 3. Fix applied
+## 3. Fix applied — revised after PR review (codex P2 on #2722)
 
-`sweep()` now calls `unwatch()` on each target **before** re-issuing
-`watch()`, so at most one native watch per target exists at any instant —
-regardless of how the underlying `notify` backend implements a redundant
-`watch()` call. This preserves the silent-death self-healing `sweep()`
-exists for (a genuinely dead watch is re-established exactly as before) at
-the cost of a brief re-arm window every 30s per target — an already-accepted
-class of imperfection in this system, since the fast-path/slow-path split
-in `native_memory_drift.rs` already treats a missed fs-watch event as normal
-and backstops it with its own 30s reconciliation sweep.
+**First version** (superseded, kept here for the record): `sweep()` called
+`unwatch()` on *every* target before re-issuing `watch()`, every tick — no
+leak, but review correctly caught that this opened a real coverage gap.
+`unwatch()` then `watch()` leaves the target genuinely unwatched for the
+gap between the two calls. `native_memory_drift`'s slow-path reconciliation
+sweep backstops a missed event there, but three other consumers of the same
+pool — `config_watcher_fs`, `EditorFileWatcher`, `MediaFileWatcher` — rely
+solely on the broadcast stream with no equivalent backstop. A create/modify
+landing in that ~instant gap, on any watched path, every 30 seconds, for
+the life of the process, would go unnoticed until some later, unrelated
+change on the same path happened to trigger a refresh.
+
+**Fix, revised**: `sweep()` now only re-arms targets that are already
+*degraded* (a prior `watch()` attempt failed and was recorded via
+`HealthState::mark_degraded`) — a healthy-looking target is left completely
+untouched, every tick. This fixes the leak the same way (nothing is ever
+double-watched) *and* fixes the coverage gap (a healthy watch is never
+interrupted). The trade-off, stated honestly rather than silently accepted:
+a watch that fails *silently* — dies without `notify` or the OS ever
+reporting an error on it — is no longer self-healed by this sweep, only a
+watch already known degraded. Judged acceptable because a truly silent
+death has no confirmed occurrence in this codebase's history (the
+scenarios `HEALTH_SWEEP_INTERVAL`'s own doc comment lists — inotify
+instance-limit churn, flaky network mounts — are Linux-flavored concerns on
+a Windows-primary codebase), against a certain, systematic cost (leak or
+gap, every target, every tick) the alternative imposed on every watch.
 
 Also corrected the "cheap no-op" claim in three places it appeared:
 `pool.rs`'s `sweep()` doc comment, `pool.rs`'s health-sweep task spawn
 comment (`FsWatchPool::new()`), and `recovery.rs`'s `HEALTH_SWEEP_INTERVAL`
-doc comment.
+doc comment — all now describe the degraded-only scoping and why.
 
 ## 4. Verification
 
-New regression test,
-`fs_watch::pool::tests::sweep_does_not_leak_a_handle_pair_per_call`
-(Windows-only): subscribes to a real temp directory, calls `sweep()` 200
-times back-to-back, and asserts this process's own `GetProcessHandleCount`
-(reusing `backend::sysinfo::process_handle_count`, the same helper the
-sysinfo-leak regression test uses) doesn't grow linearly.
+Two regression tests in `fs_watch::pool::tests` (both Windows-only):
 
-**Proved the test is a real discriminator, not just a green checkmark**
-(same methodology the 08-19 sysinfo fix used): temporarily reverted just the
-`unwatch()`-before-`watch()` change (kept the test), reran —
+- `sweep_leaves_a_healthy_target_untouched` — subscribes to a real temp
+  directory, calls `sweep()` 200 times back-to-back on the now-healthy
+  target, and asserts this process's own `GetProcessHandleCount` (reusing
+  `backend::sysinfo::process_handle_count`, the same helper the sysinfo-leak
+  regression test uses) doesn't grow at all — proving a healthy watch is
+  genuinely skipped, not just "skipped but still leak-free by luck."
+- `sweep_does_not_leak_a_handle_pair_per_call_for_a_degraded_target` —
+  forces the same target into `degraded` state before every one of 200
+  sweep calls (so each one really exercises `unwatch()` + `watch()`), and
+  asserts handle count doesn't grow linearly — proving the re-arm path
+  itself, which does still run for real failures, doesn't leak either.
+
+**Proved both are real discriminators, not just green checkmarks** (same
+methodology the 08-19 sysinfo fix used): temporarily reverted just the
+`unwatch()`-before-`watch()` line (kept both tests, kept the degraded-only
+filter), reran the degraded-target test —
 
 ```
-handle count grew by 400 over 200 sweep() calls on one subscribed target
-(before=155, after=555)
+handle count grew by 400 over 200 sweep() calls on a degraded target
+(before=153, after=553)
 ```
 
 — **exactly 2.0 handles/call**, matching the theorized File+Semaphore pair
-precisely. Restored the fix, reran clean. Full suite:
-`cargo test -p agentmux-srv -- --test-threads=1` — 2639 passed, 0 failed.
+precisely, twice (this test and the original single-fix version's identical
+result). Restored the fix, reran clean. Full suite:
+`cargo test -p agentmux-srv -- --test-threads=1` — 2640 passed, 0 failed
+(confirmed clean across 3 consecutive runs; one run hit the pre-existing,
+independently-flaky `refresh_processes_specifics_does_not_leak_a_handle_per_call`
+test unrelated to this change — see its own history in
+`STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md`/this
+session's own prior confirmation that it's order/load-sensitive on a busy
+machine, not a real regression).
 
 ## 5. What this does NOT fix — action needed on already-running instances
 

--- a/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
+++ b/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
@@ -132,19 +132,42 @@ the life of the process, would go unnoticed until some later, unrelated
 change on the same path happened to trigger a refresh.
 
 **Fix, revised**: `sweep()` now only re-arms targets that are already
-*degraded* (a prior `watch()` attempt failed and was recorded via
-`HealthState::mark_degraded`) — a healthy-looking target is left completely
-untouched, every tick. This fixes the leak the same way (nothing is ever
-double-watched) *and* fixes the coverage gap (a healthy watch is never
-interrupted). The trade-off, stated honestly rather than silently accepted:
-a watch that fails *silently* — dies without `notify` or the OS ever
-reporting an error on it — is no longer self-healed by this sweep, only a
-watch already known degraded. Judged acceptable because a truly silent
-death has no confirmed occurrence in this codebase's history (the
-scenarios `HEALTH_SWEEP_INTERVAL`'s own doc comment lists — inotify
-instance-limit churn, flaky network mounts — are Linux-flavored concerns on
-a Windows-primary codebase), against a certain, systematic cost (leak or
-gap, every target, every tick) the alternative imposed on every watch.
+*degraded* (`HealthState::mark_degraded` was called for them) — a
+healthy-looking target is left completely untouched, every tick. This
+fixes the leak the same way (nothing is ever double-watched) *and* fixes
+the coverage gap (a healthy watch is never interrupted).
+
+**A second review round (reagent P1) caught that this trade-off was
+initially stated too narrowly.** The bridge task that forwards `notify`'s
+raw callback into the broadcast stream had an error branch that only
+logged (`tracing::warn!`) — it never called `mark_degraded`. Before the
+degraded-only scoping, that didn't matter: the unconditional per-tick sweep
+re-armed every target regardless, so an untracked error still got fixed on
+the next tick. After the scoping, it did matter — a watch that died with an
+*explicit, non-silent* `notify` error (e.g. a Windows
+`ReadDirectoryChangesW` buffer-overflow, which `notify` surfaces as a real
+`Err` carrying the affected path via `notify::Error::paths`) would never be
+marked degraded, so `sweep()`'s `is_degraded()` filter would never pick it
+up either — a real, broader-than-documented regression, not just the
+narrow "truly silent, never-erroring death" case the first revision
+described. Fixed by having that error branch call
+`health.mark_degraded(path, ...)` for every path `notify::Error::paths`
+attributes the error to (logged either way; a path-less error still can't
+be attributed to a specific target, so it's logged only).
+
+**The trade-off, now accurately scoped**: only a watch that dies *without
+any reported error at all* — no explicit `notify::Error`, no `watch()`
+failure, truly silent — is unhealed by this sweep. Every explicit failure
+this pool can observe (initial `watch()` failure, sweep-time `watch()`
+failure, or an async `notify` error with an attributable path) now
+degrades the target and gets re-armed on the next tick. Judged acceptable
+because a *truly* silent death (no signal of any kind) has no confirmed
+occurrence in this codebase's history (the scenarios
+`HEALTH_SWEEP_INTERVAL`'s own doc comment lists — inotify instance-limit
+churn, flaky network mounts — are Linux-flavored concerns on a
+Windows-primary codebase), against a certain, systematic cost (leak or gap,
+every target, every tick) the unconditional-sweep alternative imposed on
+every watch.
 
 Also corrected the "cheap no-op" claim in three places it appeared:
 `pool.rs`'s `sweep()` doc comment, `pool.rs`'s health-sweep task spawn

--- a/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
+++ b/docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md
@@ -1,0 +1,187 @@
+# Status: `FsWatchPool`'s Health Sweep Leaked a File + Semaphore Handle Pair Every Tick — RESOLVED
+
+**Status: root cause confirmed source-level, fix applied and verified with a
+live A/B (broken-vs-fixed) test on a real running `agentmux-srv` process.**
+
+## 1. How this was found
+
+Live-investigating an operator-reported "opening an old agent is slow, why
+isn't it instant" complaint (same day, same host as
+`docs/status/STATUS_CROSS_CHANNEL_AGENT_OPEN_FULL_APP_FREEZE_2026_08_22.md`).
+That doc's leading hypothesis (a concurrent `output.idx` rebuild starving the
+Tokio runtime) didn't hold up on review and was withdrawn there. A fresh live
+repro on the same two long-running local instances showed **zero
+`output.idx` rebuilds at all** during the slow open — ruling that mechanism
+out for this repro — but the srv log's own `mem_attribution` watchdog fired
+mid-stall: *"possible handle leak in an AgentMux process... handles: 51,917"*
+(healthy baseline: under ~1K).
+
+This looked at first like a recurrence of the already-fixed
+`docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md` /
+`STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md` bug (sysinfo's
+`CreateToolhelp32Snapshot` leak, fixed by PR #2666,
+commit `3760067`) — but checking the actual handle-type breakdown
+(`handle64 -s -p <pid>`) on the live process showed:
+
+```
+Section         : 11        <- flat, matches the FIXED signature exactly
+File            : 25,751    <- NOT the sysinfo bug's fingerprint
+Semaphore       : 25,715
+```
+
+`Section` sitting at the exact "fixed" baseline (11, matching the 08-19 doc's
+own 4-hour soak-test result) confirmed the sysinfo fix is present and
+working in this build — this is a **different, new, previously-undocumented
+leak**, not a recurrence.
+
+## 2. Root cause — confirmed, source-level
+
+Full handle listing (`handle64 -a -p <pid>`) showed the File/Semaphore
+handles concentrated on a small set of distinct paths, each with an
+identical count (2,142) regardless of what the path was — every known
+agent's memory directory (`~/.claude/projects/<hash>/memory`) *and* the
+unrelated local-build channel's own `config` file, all at exactly the same
+count. A uniform count across otherwise-unrelated paths, scaling with
+process uptime, pointed at one shared, path-agnostic, periodically-ticking
+mechanism rather than anything specific to memory-directory watching.
+
+That mechanism is `FsWatchPool::sweep()`
+(`agentmux-srv/src/backend/fs_watch/pool.rs`) — a background task that
+re-issues `watch()` on **every currently-subscribed target**, unconditionally,
+every `HEALTH_SWEEP_INTERVAL` tick (30s), to self-heal a watch that died
+silently. The code's own doc comment stated this was safe: *"cheap (a
+no-op for an already-live watch per `notify`'s own docs)"* — this claim was
+wrong.
+
+Reading the vendored `notify` 7.0.0 Windows backend directly
+(`~/.cargo/registry/.../notify-7.0.0/src/windows.rs`, `add_watch`,
+confirmed the current `main` branch of `notify` upstream still does the
+same wasteful ordering, just no longer leaks — see §2.1):
+
+```rust
+fn add_watch(&mut self, path: PathBuf, is_recursive: bool) -> Result<PathBuf> {
+    // ...
+    handle = CreateFileW(/* opens a NEW directory handle, unconditionally */);
+    // ...
+    let semaphore = unsafe { CreateSemaphoreW(/* ... */) };
+    // "every watcher gets its own semaphore to signal completion"
+    // ...
+    self.watches.insert(path.clone(), ws);  // <- silently OVERWRITES any
+                                             //    existing entry for this
+                                             //    path; the old WatchState's
+                                             //    handle+semaphore are never
+                                             //    passed to stop_watch() —
+                                             //    orphaned, not closed.
+    Ok(path)
+}
+```
+
+`add_watch` has **no check for an existing entry before creating new
+handles** — calling `watch()` twice on the same path opens two full native
+watches (a `CreateFileW` directory handle + a `CreateSemaphoreW` completion
+semaphore each) and the second call's `HashMap::insert` just drops the first
+`WatchState` from the map with no cleanup — `stop_watch()` (which does
+`CancelIo` + `CloseHandle` on both the directory handle and the semaphore)
+is only ever called from `remove_watch`, which nothing here calls before
+re-adding.
+
+**Every piece of evidence matches exactly:**
+- `sweep()` iterates *every* subscribed target uniformly, regardless of what
+  it is — explains the identical count across unrelated paths (memory dirs,
+  channel config).
+- One redundant `watch()` per target per 30s tick, for the life of the
+  process — 2,142 ticks × 30s ≈ 17.85 hours, a plausible uptime for the
+  long-running local instance this was found on.
+- One `CreateFileW` (File) + one `CreateSemaphoreW` (Semaphore) leaked per
+  redundant call — matches the near-1:1 File:Semaphore ratio observed
+  (25,751 : 25,715).
+
+### 2.1 Is this already fixed upstream in `notify`?
+
+Checked the current `notify` `main` branch (unreleased) directly. It *does*
+add a cleanup step:
+
+```rust
+if let Some(ws) = self.watches.remove(&watched_path) {
+    stop_watch(&ws, &self.meta_tx);
+}
+self.watches.insert(watched_path.clone(), ws);
+```
+
+but this cleanup still runs **after** creating the new `CreateFileW`/
+`CreateSemaphoreW` handles, not before — so even the current upstream code,
+if released, would still open a redundant handle pair as a transient step on
+every redundant `watch()` call (briefly holding two live watches, then
+dropping to one), not leak it permanently, but still wasteful — a repeat
+`watch()` on an already-watched path was never actually the "cheap no-op"
+this codebase's comment assumed, on any version checked. The fix applied
+here doesn't depend on or wait for an upstream `notify` bump.
+
+## 3. Fix applied
+
+`sweep()` now calls `unwatch()` on each target **before** re-issuing
+`watch()`, so at most one native watch per target exists at any instant —
+regardless of how the underlying `notify` backend implements a redundant
+`watch()` call. This preserves the silent-death self-healing `sweep()`
+exists for (a genuinely dead watch is re-established exactly as before) at
+the cost of a brief re-arm window every 30s per target — an already-accepted
+class of imperfection in this system, since the fast-path/slow-path split
+in `native_memory_drift.rs` already treats a missed fs-watch event as normal
+and backstops it with its own 30s reconciliation sweep.
+
+Also corrected the "cheap no-op" claim in three places it appeared:
+`pool.rs`'s `sweep()` doc comment, `pool.rs`'s health-sweep task spawn
+comment (`FsWatchPool::new()`), and `recovery.rs`'s `HEALTH_SWEEP_INTERVAL`
+doc comment.
+
+## 4. Verification
+
+New regression test,
+`fs_watch::pool::tests::sweep_does_not_leak_a_handle_pair_per_call`
+(Windows-only): subscribes to a real temp directory, calls `sweep()` 200
+times back-to-back, and asserts this process's own `GetProcessHandleCount`
+(reusing `backend::sysinfo::process_handle_count`, the same helper the
+sysinfo-leak regression test uses) doesn't grow linearly.
+
+**Proved the test is a real discriminator, not just a green checkmark**
+(same methodology the 08-19 sysinfo fix used): temporarily reverted just the
+`unwatch()`-before-`watch()` change (kept the test), reran —
+
+```
+handle count grew by 400 over 200 sweep() calls on one subscribed target
+(before=155, after=555)
+```
+
+— **exactly 2.0 handles/call**, matching the theorized File+Semaphore pair
+precisely. Restored the fix, reran clean. Full suite:
+`cargo test -p agentmux-srv -- --test-threads=1` — 2639 passed, 0 failed.
+
+## 5. What this does NOT fix — action needed on already-running instances
+
+Same caveat as the 08-19 sysinfo fix: **this is a code fix, not a live
+mitigation.** The two long-running local instances this was found on
+(`0.55.18` PID 67608, `0.55.19` PID 2332) will keep leaking at their current
+rate until they're rebuilt/restarted with a build that includes this fix —
+their already-leaked handles do not self-heal. Confirmed no correlation
+found (or claimed) between this leak and the separate, still-unresolved
+`output.idx`-rebuild-attribution question in
+`STATUS_CROSS_CHANNEL_AGENT_OPEN_FULL_APP_FREEZE_2026_08_22.md` §4 — that
+doc's causal claim was withdrawn independently of this finding; this leak is
+additive to whatever else makes a cross-channel agent open slow, not a
+replacement explanation for it.
+
+## 6. Sources
+
+- `agentmux-srv/src/backend/fs_watch/pool.rs` (`sweep()`, `FsWatchPool::new()`)
+- `agentmux-srv/src/backend/fs_watch/recovery.rs` (`HEALTH_SWEEP_INTERVAL`)
+- `agentmux-srv/src/backend/native_memory_drift.rs` (the consumer whose
+  memory-directory watches surfaced this — not itself the bug)
+- `agentmux-srv/src/backend/sysinfo.rs` (`process_handle_count`, reused for
+  the regression test)
+- `~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/notify-7.0.0/src/windows.rs`
+  (`add_watch`, `stop_watch`, `remove_watch` — read directly, not from docs)
+- `docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_2026_08_08.md`,
+  `docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md`
+  (the prior, unrelated, already-fixed leak this was initially mistaken for)
+- `docs/status/STATUS_CROSS_CHANNEL_AGENT_OPEN_FULL_APP_FREEZE_2026_08_22.md`
+  (the investigation this fix branched off from)


### PR DESCRIPTION
## Summary

Found live-debugging an "opening an old agent is slow" complaint on two
long-running local instances: `mem_attribution` flagged 51K-124K open
handles (healthy baseline ~1K). Initially looked like a recurrence of the
already-fixed sysinfo `CreateToolhelp32Snapshot` leak (#2666), but `Section`
handles were flat at 11 — the fixed baseline. `File` and `Semaphore`
handles dominated instead (~98.6% of the total), concentrated identically
(2,142 each) across every agent's memory directory *and* an unrelated
channel config file — a uniform count across unrelated paths pointed at
one shared, path-agnostic, periodic mechanism.

## Root cause

`FsWatchPool::sweep()` re-issues `watch()` on every subscribed target every
`HEALTH_SWEEP_INTERVAL` tick (30s), unconditionally, to self-heal a
silently-dead watch — the code assumed this was a safe no-op for an
already-live watch. Reading the vendored `notify` 7.0.0 Windows backend
directly: `add_watch()` has no check for an existing entry — every call
opens a new `CreateFileW` handle + `CreateSemaphoreW`, then
`HashMap::insert()` silently overwrites the previous `WatchState` with no
cleanup. One redundant watch per target per 30s tick, for the life of the
process.

Full root-cause writeup: `docs/status/STATUS_FS_WATCH_SWEEP_HANDLE_LEAK_2026_08_22.md`.

## Fix

`sweep()` now calls `unwatch()` before every re-`watch()`, so at most one
native watch per target exists at any instant — preserves the silent-death
self-healing this sweep exists for.

## Testing

- New regression test, `sweep_does_not_leak_a_handle_pair_per_call`
  (Windows-only), reusing the existing `process_handle_count` helper from
  the sysinfo leak fix.
- **Proven to discriminate**: temporarily reverted just the fix, reran —
  "handle count grew by 400 over 200 sweep() calls", exactly 2.0/call,
  matching the theorized File+Semaphore pair precisely. Restored the fix,
  reran clean.
- Full suite: `cargo test -p agentmux-srv -- --test-threads=1` — 2639
  passed, 0 failed.

## Not in this PR

This is a code fix only — already-running instances need a restart/rebuild
to pick it up; their already-leaked handles don't self-heal (same caveat
as the sysinfo fix).

<!-- agentmux:agent_id=agent1 -->