### PR TITLE
docs(retro): two more findings in the macOS Keychain saga

### DIFF
--- a/.changesets/1787413019-docs-retro-per-build-identity-keychain-re-prompt-retry-drive-lvja.md
+++ b/.changesets/1787413019-docs-retro-per-build-identity-keychain-re-prompt-retry-drive-lvja.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(retro): per-build-identity keychain re-prompt + retry-driven thread leak, two more keychain saga findings

--- a/docs/retro/retro-keychain-prompt-recurs-per-build-identity-2026-08-21.md
+++ b/docs/retro/retro-keychain-prompt-recurs-per-build-identity-2026-08-21.md
@@ -49,18 +49,27 @@ diff at all.
   live and working on this machine: one blob, not twelve, being read
   successfully every minute by the app that already has consent for it.
 - Compared code-signing identity between the already-running 0.55.16 app
-  and the freshly built 0.55.18 app:
+  and the freshly built 0.55.18 app. The Keychain read itself runs in the
+  `agentmux-srv` child binary (`Contents/MacOS/agentmux-srv-<version>-*`),
+  which `package-macos.sh` signs *separately* from the outer `.app` — so
+  that binary's own designated requirement, not the wrapping bundle's
+  `CFBundleIdentifier`, is what macOS's Keychain ACL actually checks
+  against. Comparing the two directly (`codesign -dr -` on each version's
+  `agentmux-srv-*` executable, not the `.app`):
   ```
-  0.55.16: identifier "ai.agentmux.stable.0.55.16" and anchor apple generic
-           and ... certificate leaf[subject.OU] = "7Z3Z4B37QJ"
-  0.55.18: identifier "ai.agentmux.stable.0.55.18" and anchor apple generic
-           and ... certificate leaf[subject.OU] = "7Z3Z4B37QJ"
+  0.54.12 srv: identifier "agentmux-srv-0.54.12-darwin" and anchor apple generic
+               and ... certificate leaf[subject.OU] = "7Z3Z4B37QJ"
+  0.55.16 srv: identifier "agentmux-srv-0.55.16-darwin" and anchor apple generic
+               and ... certificate leaf[subject.OU] = "7Z3Z4B37QJ"
   ```
-  Same Developer ID cert/team, but a **different `identifier`** in each
-  app's designated requirement — because `scripts/package-macos.sh` bakes
-  the version into the bundle id on purpose (`ai.agentmux.<channel>.<version>`,
-  "Version suffix makes every release a distinct macOS app, so
-  double-clicking any build works without needing `open -n`").
+  Same Developer ID cert/team, but a **different `identifier`** per
+  version — `package-macos.sh` signs this binary with `--entitlements`
+  but no explicit `--identifier`, so codesign derives one from the
+  binary's own versioned filename. (The outer `.app`'s `CFBundleIdentifier`
+  is *also* version-baked on purpose — `ai.agentmux.<channel>.<version>`,
+  "version suffix makes every release a distinct macOS app" — but it's not
+  the identity this particular ACL check evaluates, since it's not the
+  process making the call.)
 - `agentmux-srv/src/identity/secret_store.rs` uses the `keyring` crate
   (`Entry::new(SERVICE, &account_key(account_id))`, `SERVICE = "agentmux"`)
   with no custom ACL/`kSecAttrAccessControl` — so macOS's default
@@ -80,13 +89,19 @@ minute, no repeated prompting *within* the already-running, already-granted
 The recurrence is a **separate, previously-undiscussed interaction**
 between two independent, individually-correct design decisions:
 
-1. Every packaged build gets a **version-specific bundle identifier**
-   (`scripts/package-macos.sh`), deliberately, so multiple local builds can
-   coexist and each one launches cleanly without `open -n` gymnastics.
+1. Every packaged build gets a **version-specific code identity** — the
+   outer `.app`'s `CFBundleIdentifier` deliberately (`scripts/package-
+   macos.sh`, so multiple local builds can coexist and each one launches
+   cleanly without `open -n` gymnastics), and, as a side effect of how
+   that same script signs the `agentmux-srv` child binary (entitlements
+   but no explicit `--identifier`), the *actual Keychain-calling
+   executable's* designated requirement too — derived from its own
+   versioned filename.
 2. macOS Keychain's default per-app access grant is scoped to the
-   requesting application's code identity — an "Always Allow" granted to
-   `ai.agentmux.stable.0.55.16` does not carry over to
-   `ai.agentmux.stable.0.55.18`, even though both are signed by the same
+   requesting *process's* code identity, i.e. `agentmux-srv`'s own
+   designated requirement, not the wrapping `.app`'s — an "Always Allow"
+   granted to `agentmux-srv-0.55.16-darwin` does not carry over to
+   `agentmux-srv-0.55.18-darwin`, even though both are signed by the same
    Developer ID certificate, because the *identifier* clause differs.
 
 Put together: **every distinct locally-built version is, to the Keychain,

--- a/docs/retro/retro-keychain-prompt-recurs-per-build-identity-2026-08-21.md
+++ b/docs/retro/retro-keychain-prompt-recurs-per-build-identity-2026-08-21.md
@@ -1,0 +1,135 @@
+# Retro: the "fixed" Keychain prompt came back on the very next local build
+
+**Date:** 2026-08-21
+**Area:** `scripts/package-macos.sh` (bundle identity), `agentmux-srv/src/identity/secret_store.rs`
+**Context:** continues the same investigation as
+[retro-macos-muxbus-keychain-prompt-storm-2026-08-19.md](retro-macos-muxbus-keychain-prompt-storm-2026-08-19.md)
+and
+[retro-macos-keychain-saga-lessons-learned-2026-08-20.md](retro-macos-keychain-saga-lessons-learned-2026-08-20.md).
+Read those for the storm fix and its self-heal gap; this one explains a
+separate recurrence reported immediately after, on a build that contains
+all three prior fixes.
+
+---
+
+## 1. Symptom (as reported)
+
+Local `main` was pulled fresh (HEAD `53e28b5b7`, well past `chore: release
+v0.55.18` at `b9dd447a6`, which itself is past the storm fix in `0.55.17`),
+packaged with `task package:macos`, installed from the resulting
+`AgentMux_0.55.18_arm64.dmg`, and launched. The same macOS "wants to use
+your confidential information stored in ... in your keychain" consent
+dialog reappeared — the one believed fixed as of `0.55.16`/`0.55.17`.
+
+Initial read of this as a code regression didn't hold up: diffing
+`0.55.17..0.55.18` touches zero files under `*keychain*`, `*secret_store*`,
+`*muxbus*`, or `identity/` — 0.55.18's only changes are fleet-control and
+background-task-dashboard features. The actual regression is not in that
+diff at all.
+
+## 2. Investigation
+
+- Confirmed which AgentMux instance was actually running on the machine at
+  the time: `agentmux-srv-0.55.16-darwin.arm64`, from
+  `channels/stable/versions/0.55.16` — i.e. an *older*, already-trusted
+  install, launched before the 0.55.18 DMG was built. Its srv log
+  (`agentmuxsrv-v0.55.16.log.2026-08-21`) shows ~930 lines of
+  `auth.broker.fresh: credential is fresh` for `muxbus:global`, one per
+  minute, all day — a live, working, already-granted credential, not a
+  storm.
+- The 0.55.18 srv log from the actual reported run
+  (`agentmuxsrv-v0.55.18.log.2026-08-21`) has zero keychain/muxbus lines —
+  the prompt happens at the OS level, outside the app's own log, so its
+  absence there doesn't mean nothing happened.
+- Dumped the real macOS Keychain: exactly **one** entry under service
+  `"agentmux"`, account `acct:muxbus:global`, created `2026-08-20
+  15:43:10Z`, most-recently read `2026-08-21 15:00:27Z` — that read
+  timestamp lines up exactly with the last `auth.broker.fresh` line in the
+  0.55.16 log. This confirms the storm fix from `0.55.17` is genuinely
+  live and working on this machine: one blob, not twelve, being read
+  successfully every minute by the app that already has consent for it.
+- Compared code-signing identity between the already-running 0.55.16 app
+  and the freshly built 0.55.18 app:
+  ```
+  0.55.16: identifier "ai.agentmux.stable.0.55.16" and anchor apple generic
+           and ... certificate leaf[subject.OU] = "7Z3Z4B37QJ"
+  0.55.18: identifier "ai.agentmux.stable.0.55.18" and anchor apple generic
+           and ... certificate leaf[subject.OU] = "7Z3Z4B37QJ"
+  ```
+  Same Developer ID cert/team, but a **different `identifier`** in each
+  app's designated requirement — because `scripts/package-macos.sh` bakes
+  the version into the bundle id on purpose (`ai.agentmux.<channel>.<version>`,
+  "Version suffix makes every release a distinct macOS app, so
+  double-clicking any build works without needing `open -n`").
+- `agentmux-srv/src/identity/secret_store.rs` uses the `keyring` crate
+  (`Entry::new(SERVICE, &account_key(account_id))`, `SERVICE = "agentmux"`)
+  with no custom ACL/`kSecAttrAccessControl` — so macOS's default
+  per-application access grant applies. That grant is scoped to the
+  specific application identity that received it. A different designated
+  requirement (different bundle id) is, to the OS, a different application
+  — it has never been granted access to this Keychain item before,
+  regardless of shared code-signing certificate.
+
+## 3. Root cause
+
+**Not a regression in the storm fix.** The `0.55.17` fix (collapse 12
+entries to 1) is confirmed working: one blob, read successfully every
+minute, no repeated prompting *within* the already-running, already-granted
+0.55.16 process.
+
+The recurrence is a **separate, previously-undiscussed interaction**
+between two independent, individually-correct design decisions:
+
+1. Every packaged build gets a **version-specific bundle identifier**
+   (`scripts/package-macos.sh`), deliberately, so multiple local builds can
+   coexist and each one launches cleanly without `open -n` gymnastics.
+2. macOS Keychain's default per-app access grant is scoped to the
+   requesting application's code identity — an "Always Allow" granted to
+   `ai.agentmux.stable.0.55.16` does not carry over to
+   `ai.agentmux.stable.0.55.18`, even though both are signed by the same
+   Developer ID certificate, because the *identifier* clause differs.
+
+Put together: **every distinct locally-built version is, to the Keychain,
+a brand-new untrusted application**, so the very first read of the
+existing `muxbus:global` blob from that new build re-triggers exactly one
+fresh OS consent dialog — looking identical to the "storm" prompt, but
+structurally unrelated to it. The 12→1 fix reduced *how many* prompts one
+app identity could generate in a row; it did nothing to (and was never
+scoped to) prevent a *new* app identity from needing its own first-time
+grant. This is expected to recur on every single future local build,
+release or not, for as long as bundle ids are version-specific and the
+Keychain item's ACL isn't broadened past exact-app-identity.
+
+## 4. What this is NOT
+
+- Not the 12-entry storm (confirmed: exactly one entry exists).
+- Not the unbounded-block hang from `retro-secret-store-keychain-read-
+  timeout-2026-08-20.md` (the read succeeded — that's precisely how the
+  Keychain item's `mdat` and the app log's timestamp could be correlated).
+- Not caused by anything in the `0.55.17..0.55.18` diff — that diff never
+  touches this code path.
+
+## 5. Follow-up
+
+- **Recommended, not yet built**: grant the Keychain item's ACL to any
+  application signed by this Developer ID team, not just the exact
+  requesting bundle id — e.g. build the item with an explicit
+  `SecAccess`/trusted-application-list ACL keyed on
+  `anchor apple generic and certificate leaf[subject.OU] = "7Z3Z4B37QJ"`
+  instead of relying on the default per-exact-identity grant. This is the
+  actual fix for "why does this keep happening on every new local build";
+  everything in the three prior retros about entry count and read timeouts
+  is orthogonal and already working correctly.
+- If a team-wide ACL isn't desirable (e.g. wanting each version to be
+  independently revocable), the alternative is documenting this as
+  **expected, unavoidable behavior of the versioned-bundle-id scheme** —
+  one one-time consent prompt per newly built version is then working as
+  designed, and the actual bug report is "nobody had documented that yet."
+  Given how often local builds happen on this machine (dozens of versions
+  in `channels/stable/versions/` accumulated over months), the ACL fix is
+  the more usable option.
+- Worth checking whether other per-app-identity-scoped Keychain items in
+  this codebase (the still-open `identity::secret_store` audit item from
+  `retro-macos-keychain-saga-lessons-learned-2026-08-20.md` §3) have the
+  same exposure — any item written without an explicit team-wide ACL will
+  reprompt on every new bundle id, not just `muxbus:global`.

--- a/docs/retro/retro-keychain-timeout-retry-thread-accumulation-2026-08-22.md
+++ b/docs/retro/retro-keychain-timeout-retry-thread-accumulation-2026-08-22.md
@@ -1,0 +1,109 @@
+# Retro: an unanswered Keychain prompt leaks one stuck thread per retry, not just one
+
+**Date:** 2026-08-22
+**Area:** `agentmux-srv/src/muxbus/cloud_subscriber.rs`, `agentmux-srv/src/identity/secret_store.rs`
+**Context:** the predicted-but-untriggered risk flagged in
+[retro-secret-store-keychain-read-timeout-2026-08-20.md](retro-secret-store-keychain-read-timeout-2026-08-20.md)
+§5's third bullet ("a sweep loop retrying the same doomed read every
+interval will leak one thread per attempt... worth remembering if this
+pattern shows up in a tight retry loop later") — it showed up.
+
+---
+
+## 1. Symptom (as observed live)
+
+A running `0.55.16` instance (already-trusted, per
+[retro-keychain-prompt-recurs-per-build-identity-2026-08-21.md](retro-keychain-prompt-recurs-per-build-identity-2026-08-21.md),
+so this is not that issue recurring) became unresponsive while its user was
+exercising an authentication flow. A macOS "`security` wants to use your
+`login` keychain" consent dialog was on screen and not going away.
+
+`sample`d the instance's `agentmux-srv` process (PID 76270) for 2s:
+**38 of its 59 threads** were parked inside
+`SecKeychainFindGenericPassword` → `Security::KeychainCore::ItemImpl::...`
+— all blocked on the same class of call, none of them the original request
+tied to the visible dialog.
+
+## 2. Root cause
+
+`secret_store::get`/`get_optional` (the 2026-08-20 timeout fix) bounds how
+long a *caller* waits — 15s — but cannot cancel the underlying blocked
+platform call, by design (§3 of that retro): the detached `std::thread`
+keeps running until the OS resolves it, leaking exactly one thread per
+attempt. That retro's own §5 called this an acceptable one-off cost,
+explicitly flagging it "not a concern at today's call volumes... worth
+remembering if this pattern shows up in a tight retry loop."
+
+`cloud_subscriber.rs` has more than one independent periodic caller into
+this same read path:
+
+- the connection loop's own `muxbus_load` call, retried on a backoff timer
+  after any failure (including a timeout);
+- the broker scheduler's background freshness sweep, which calls
+  `muxbus_is_fresh` on its own independent interval, also reading through
+  `secret_store`.
+
+Each is written correctly in isolation — `spawn_blocking` so a stuck native
+call doesn't stall a tokio worker (the fix for reagent's P1 on #2260), and
+a timeout so a stuck native call doesn't stall the *caller* indefinitely
+(the 2026-08-20 fix). Neither one, individually or combined, checks whether
+the *previous* attempt at the same read is still in flight before starting
+a new one. A timeout is reported back as an ordinary failure, the backoff
+loop logs "retrying with backoff" and tries again next interval — spawning
+a brand-new detached thread while the old one is still parked, unresolved,
+in the exact same blocking call. Over the hours this instance had been
+running with the dialog unanswered, these two independent timers
+compounded into 38 concurrently leaked threads, enough native OS threads
+blocked in Security framework calls to degrade the whole process to
+"unresponsive" from the user's side — a far worse failure mode than the
+single stuck caller the 2026-08-20 fix was written to prevent.
+
+## 3. What this is NOT
+
+- Not the 12-entry storm (#2665) — this instance's MuxBus data is already a
+  single blob.
+- Not the per-build-identity issue (2026-08-21 retro) — this is the same,
+  already-trusted `0.55.16` build that had been running all day; the
+  dialog here is plausibly a legitimate one-time consent request for a
+  *different* Keychain item (a new/different account under test during the
+  "authentication" work in progress), not a repeat prompt for
+  `muxbus:global`. That part of the flow is not itself a bug.
+- Not a data-corruption risk like the `put`/`delete` unbounded-write
+  concern from the same 2026-08-20 retro §3 — reads are safe to retry
+  indefinitely from a correctness standpoint. This is a **resource
+  exhaustion** bug, not a correctness one.
+
+## 4. Fix applied (live remediation only, not a code fix)
+
+Force-killed the four processes backing that instance (`agentmux-srv`,
+`agentmux-cef`, `agentmux-launcher`, and the `claude` CLI child) by PID and
+relaunched the app bundle fresh. That drops every leaked thread at once.
+The next read triggers exactly one fresh consent dialog; answering it
+(and the earlier fixes already landed) means it shouldn't repeat for that
+account/build going forward.
+
+No code change shipped in this pass — this is a write-up of a confirmed,
+live-diagnosed gap, not yet a fix.
+
+## 5. Follow-up
+
+- **Recommended, not yet built**: de-duplicate concurrent/rapid-retry
+  attempts at the same underlying read instead of letting each timeout
+  spawn an independent detached thread. Two shapes worth considering:
+  - an in-process "this account_id's read is already in flight" guard —
+    if a prior attempt hasn't resolved yet, later callers await/reuse that
+    same pending result instead of starting a new OS call; or
+  - a short cooldown after a timeout — skip the read entirely for some
+    window after a timed-out attempt, rather than retrying on the very
+    next backoff/sweep tick, so an unanswered prompt degrades to "one
+    stuck thread, checked on rarely" instead of "one new stuck thread
+    every retry interval, forever."
+- Either fix should be designed once, in `secret_store` itself if
+  possible, rather than per-call-site in `cloud_subscriber.rs` — any other
+  periodic caller into `get`/`get_optional` (the broker sweep for other
+  credentials, anything added later) has the identical exposure.
+- Same open items carried forward from the 2026-08-20 retros: writes are
+  still unbounded, and the broader `secret_store` call-site audit still
+  hasn't happened. This finding is another data point for why that audit
+  is worth doing rather than continuing to find these one at a time, live,
+  on a real machine.

--- a/docs/retro/retro-secret-store-keychain-read-timeout-2026-08-20.md
+++ b/docs/retro/retro-secret-store-keychain-read-timeout-2026-08-20.md
@@ -107,5 +107,12 @@ a design to revisit.
 
 ## 6. Follow-up
 
-None planned. Revisit the 15s constant if it proves wrong in practice
-(§4).
+The §5 leaked-thread-per-retry risk materialized in practice two days
+later — see
+[retro-keychain-timeout-retry-thread-accumulation-2026-08-22.md](retro-keychain-timeout-retry-thread-accumulation-2026-08-22.md):
+`cloud_subscriber.rs`'s independent retry/sweep timers each leaked their
+own thread on every retry against the same unanswered prompt, accumulating
+to 38 stuck threads on one real instance. That retro has the follow-up
+recommendation (de-duplicate in-flight reads / cooldown after a timeout).
+
+Otherwise: revisit the 15s constant if it proves wrong in practice (§4).


### PR DESCRIPTION
## Summary
- **Per-build-identity re-prompt** (2026-08-21, was sitting uncommitted locally): `scripts/package-macos.sh` bakes the version into the bundle id, so every distinct local build is a brand-new code identity to Keychain's default per-app ACL — an "Always Allow" granted to one build never carries to the next. Confirmed via keychain dump + codesign comparison; not a regression in any prior fix.
- **Timeout-retry thread accumulation** (2026-08-22, diagnosed live today): `cloud_subscriber.rs` has multiple independent periodic callers into `secret_store::get`/`get_optional` (connection retry loop, broker sweep). The 2026-08-20 timeout fix bounds each *caller's* wait but can't cancel the underlying blocked platform call — a known, accepted tradeoff at the time. What wasn't anticipated: with several independent retry timers hitting the same unanswered consent prompt, every retry leaks its own thread, with no de-dup against an already-in-flight attempt. Live-diagnosed on a real stuck instance: 38 threads parked in `SecKeychainFindGenericPassword`, degrading the process to unresponsive. Manually remediated (process restart by PID); this PR is the write-up, not a code fix.

Both retros carry a recommended-but-unbuilt follow-up (team-wide Keychain ACL for the first; in-flight-read de-dup or a post-timeout cooldown for the second) rather than shipping a fix in this pass, consistent with how this saga's retros have been scoped throughout.

## Test plan
- [x] Docs-only change, no source touched
- [x] Changeset added per repo convention