### PR TITLE
feat(srv): log rebuild_output_idx's start time and duration

### DIFF
--- a/agentmux-srv/src/backend/blockcontroller/shell/indexing.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/indexing.rs
@@ -33,6 +33,17 @@ pub(crate) fn rebuild_output_idx(
     const IDX: &str = "output.idx";
     const WIN: i64 = 1 << 20; // 1 MiB read window
 
+    // Start/duration logging (docs/status/STATUS_CROSS_CHANNEL_AGENT_OPEN_FULL_APP_FREEZE_2026_08_22.md
+    // §7.1): the prior completion-only log recorded a rebuild happened but
+    // not how long it ran for or when it started, so a live incident
+    // couldn't be checked for whether a rebuild's execution window actually
+    // overlapped some other stalled RPC — only that both happened "around
+    // the same time." Kept as a lasting diagnostic, not a one-off debug
+    // print — a slow rebuild is exactly the kind of thing worth being able
+    // to correlate after the fact, the same way `mem_attribution` already is.
+    let started = std::time::Instant::now();
+    tracing::info!(block_id = %block_id, covered = output_size, "output.idx rebuild starting");
+
     // Offsets buffer starts with the covered-size header.
     let mut buf: Vec<u8> = Vec::new();
     buf.extend_from_slice(&output_size.to_le_bytes());
@@ -87,7 +98,13 @@ pub(crate) fn rebuild_output_idx(
     }
     match fs.write_file(block_id, IDX, &buf) {
         Ok(()) => {
-            tracing::info!(block_id = %block_id, lines = line_count, covered = output_size, "output.idx rebuilt");
+            tracing::info!(
+                block_id = %block_id,
+                lines = line_count,
+                covered = output_size,
+                duration_ms = started.elapsed().as_millis() as u64,
+                "output.idx rebuilt"
+            );
             Some(line_count)
         }
         Err(e) => {

--- a/agentmux-srv/src/backend/blockcontroller/shell/indexing.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/indexing.rs
@@ -70,7 +70,23 @@ pub(crate) fn rebuild_output_idx(
     };
 
     while read_pos < output_size as i64 {
-        let (_, chunk) = fs.read_at(block_id, "output", read_pos, WIN).ok()?;
+        let (_, chunk) = match fs.read_at(block_id, "output", read_pos, WIN) {
+            Ok(v) => v,
+            Err(e) => {
+                // codex P2 on #2724: every exit path must log a terminal
+                // event (with duration) — an unmatched "starting" event with
+                // no completion reads as "still running," easy to mistake
+                // for a rebuild that was active throughout an incident when
+                // it actually failed fast and returned immediately.
+                tracing::warn!(
+                    block_id = %block_id,
+                    error = %e,
+                    duration_ms = started.elapsed().as_millis() as u64,
+                    "output.idx rebuild failed: read_at error"
+                );
+                return None;
+            }
+        };
         if chunk.is_empty() {
             break;
         }
@@ -108,7 +124,12 @@ pub(crate) fn rebuild_output_idx(
             Some(line_count)
         }
         Err(e) => {
-            tracing::warn!(block_id = %block_id, error = %e, "output.idx rebuild write failed");
+            tracing::warn!(
+                block_id = %block_id,
+                error = %e,
+                duration_ms = started.elapsed().as_millis() as u64,
+                "output.idx rebuild write failed"
+            );
             None
         }
     }


### PR DESCRIPTION
## Summary

Small, standalone diagnostic improvement split out of the live-debugging
session for `docs/status/STATUS_CROSS_CHANNEL_AGENT_OPEN_FULL_APP_FREEZE_2026_08_22.md`.
The prior completion-only log recorded that a rebuild happened but not how
long it ran or when it started — so correlating a slow RPC against a
concurrent rebuild elsewhere in the process required guessing from
completion timestamps alone (and got that guess wrong once already, in
that doc's own §4 correction).

Kept as a lasting diagnostic (not removed after the debug session) — the
same reasoning `mem_attribution` is kept for.

No behavior change, log-only.

<!-- agentmux:agent_id=agent1 -->