### PR TITLE
fix(agent): fork actually carries conversation history + flat lineage naming

### DIFF
--- a/.changesets/1787414854-fix-agent-fork-carries-conversation-history-flat-lineage-nam-cinn.md
+++ b/.changesets/1787414854-fix-agent-fork-carries-conversation-history-flat-lineage-nam-cinn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): fork carries conversation history + flat lineage naming

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -26,6 +26,64 @@ use crate::backend::storage::{AgentDefinition, AgentContent, AgentSkill};
 
 use super::super::AppState;
 
+/// Resolve a definition's **fork**-lineage root by walking `parent_id`.
+///
+/// `parent_id` is overloaded in this schema: `agentdefcreatefromtemplate`
+/// sets it to the *template's* id for every freshly-instantiated user
+/// agent (see that handler below), not just `forkagentdefinition`'s actual
+/// forks — so two unrelated agents both created fresh from the same
+/// template share a `parent_id`, but are not forks of each other. The one
+/// field that reliably distinguishes an actual fork is `branch_label`:
+/// `forkagentdefinition` always sets it (non-empty); `agentdefcreatefromtemplate`
+/// always leaves it empty. Walk upward only while the current node is
+/// itself a fork (non-empty `branch_label`); stop at the first non-fork
+/// ancestor (a template, or a first-generation user agent) — that's the
+/// lineage's root for fork-counting purposes. Confirmed bug this fixes
+/// (Codex's review of PR #2721, docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
+/// §2): the naming rule requires a flat, lineage-wide counter ("AgentX #2"
+/// → "AgentX #3"), but the previous `parent_id == source_id` filter only
+/// counted immediate children, so forking a fork produced "AgentX #2 #2".
+fn fork_lineage_root_id(defs: &[AgentDefinition], start_id: &str) -> String {
+    let mut current = start_id.to_string();
+    loop {
+        match defs.iter().find(|a| a.id == current) {
+            Some(def) if !def.branch_label.is_empty() && !def.parent_id.is_empty() => {
+                current = def.parent_id.clone();
+            }
+            _ => return current,
+        }
+    }
+}
+
+/// Build the flat, lineage-wide "#N" auto-suggestion for forking `source`.
+///
+/// Two bugs, both from the same root cause (no lineage-root resolution),
+/// fixed together: (1) the existing-fork count must include every fork
+/// anywhere in the lineage, not just `source`'s immediate children —
+/// otherwise forking a fork undercounts and can repeat a number; (2) the
+/// suggested name must be built from the lineage **root's** name, not
+/// `source`'s own (possibly already-suffixed) name — otherwise forking
+/// "AgentX #2" produces "AgentX #2 #3" instead of the flat "AgentX #3"
+/// `SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` §4.5
+/// requires. If the root can't be found (should not happen — `source`
+/// itself is always in `defs`), falls back to `source`'s own name rather
+/// than panicking.
+fn suggest_fork_name(defs: &[AgentDefinition], source: &AgentDefinition) -> String {
+    let root_id = fork_lineage_root_id(defs, &source.id);
+    let root_name = defs
+        .iter()
+        .find(|a| a.id == root_id)
+        .map(|a| a.name.as_str())
+        .unwrap_or(source.name.as_str());
+    let existing_fork_count = defs
+        .iter()
+        .filter(|a| {
+            a.is_seeded == 0 && !a.branch_label.is_empty() && fork_lineage_root_id(defs, &a.id) == root_id
+        })
+        .count();
+    format!("{root_name} #{}", existing_fork_count + 2)
+}
+
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // agentdefcreatefromtemplate → clone a seeded template into a new
     // user-owned definition (Phase 1 two-tier picker —
@@ -340,13 +398,10 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .unwrap_or(0);
 
                 // branch_label is the fork's full display name when provided.
-                // When empty, auto-generate "Name #N" based on existing fork count.
+                // When empty, auto-generate a flat, lineage-wide "Name #N"
+                // (see suggest_fork_name's doc comment).
                 let fork_name = if cmd.branch_label.is_empty() {
-                    let existing_fork_count = all_defs
-                        .iter()
-                        .filter(|a| a.parent_id == cmd.source_id && a.is_seeded == 0)
-                        .count();
-                    format!("{} #{}", source.name, existing_fork_count + 2)
+                    suggest_fork_name(&all_defs, &source)
                 } else {
                     cmd.branch_label.clone()
                 };
@@ -470,11 +525,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .find(|a| a.id == cmd.source_id)
                     .ok_or_else(|| format!("forkagentdefinitionsuggest: source not found: {}", cmd.source_id))?;
 
-                let existing_fork_count = all
-                    .iter()
-                    .filter(|a| a.parent_id == cmd.source_id && a.is_seeded == 0)
-                    .count();
-                let suggested_label = format!("{} #{}", source.name, existing_fork_count + 2);
+                let suggested_label = suggest_fork_name(&all, source);
 
                 let result = ForkAgentDefinitionSuggestResult { suggested_label };
                 Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
@@ -679,5 +730,70 @@ mod tests {
             fork.provider, "claude",
             "fork must carry the source's REAL (bundle-resolved) provider, not the drifted `codex` column"
         );
+    }
+
+    // #2721 Phase 1 (Codex's review) — the auto-suggested name must be a
+    // flat, lineage-wide counter off the ROOT's name, not the immediate
+    // parent's (possibly already-suffixed) name. Forking a fork used to
+    // produce "Drifted Template #2 #2" (immediate-parent-only count) or
+    // even "Drifted Template #2 #3" (root-based count, but still built off
+    // the parent's own name) — the correct result is the flat
+    // "Drifted Template #3".
+    #[tokio::test]
+    async fn forking_a_fork_produces_a_flat_lineage_wide_name() {
+        let state = test_state();
+        seed_bundle(&state, "bundle-claude", "claude");
+        seed_drifted_template(&state, "root-1", "bundle-claude");
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+
+        let fork_once = |engine: &Arc<WshRpcEngine>, source_id: &str| {
+            engine.handle_message(RpcMessage {
+                command: COMMAND_FORK_AGENT_DEFINITION.to_string(),
+                reqid: "req".to_string(),
+                data: Some(serde_json::json!({ "source_id": source_id, "branch_label": "" })),
+                ..Default::default()
+            });
+        };
+
+        fork_once(&engine, "root-1");
+        let resp1 = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp1.error.is_empty(), "unexpected error: {}", resp1.error);
+        let fork1: AgentDefinition = serde_json::from_value(resp1.data.expect("expected result data")).unwrap();
+        assert_eq!(fork1.name, "Drifted Template #2");
+
+        fork_once(&engine, &fork1.id);
+        let resp2 = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp2.error.is_empty(), "unexpected error: {}", resp2.error);
+        let fork2: AgentDefinition = serde_json::from_value(resp2.data.expect("expected result data")).unwrap();
+        assert_eq!(
+            fork2.name, "Drifted Template #3",
+            "forking a fork must produce a flat, lineage-wide name — not \"#2 #2\" (immediate-parent-only \
+             count) or \"#2 #3\" (root-based count off the parent's own already-suffixed name)"
+        );
+
+        // The suggest RPC (used to preview the name before the user
+        // confirms) must agree with what an actual fork would produce.
+        engine.handle_message(RpcMessage {
+            command: COMMAND_FORK_AGENT_DEFINITION_SUGGEST.to_string(),
+            reqid: "req-suggest".to_string(),
+            data: Some(serde_json::json!({ "source_id": fork2.id })),
+            ..Default::default()
+        });
+        let resp3 = tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp3.error.is_empty(), "unexpected error: {}", resp3.error);
+        let suggestion: ForkAgentDefinitionSuggestResult =
+            serde_json::from_value(resp3.data.expect("expected result data")).unwrap();
+        assert_eq!(suggestion.suggested_label, "Drifted Template #4");
     }
 }

--- a/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
@@ -314,7 +314,7 @@ is narrower and different from the original draft's Phase 1:
 
 | Phase | Deliverable | Depends on |
 |---|---|---|
-| **1** | Fix the two confirmed bugs blocking correctness even for the *existing* fork flow: (a) wire `continueSessionId`/`forkSession: true` into the fork path's `launchAgentDefinition` call (§2 — currently missing entirely), (b) fix `template.rs`'s fork-count filter to walk the lineage root instead of the immediate parent (§4.5) | — |
+| **1** ✅ | Fix the two confirmed bugs blocking correctness even for the *existing* fork flow: (a) wire `continueSessionId`/`forkSession: true` into the fork path's `launchAgentDefinition` call (§2 — currently missing entirely), (b) fix `template.rs`'s fork-count filter to walk the lineage root instead of the immediate parent (§4.5) — **landed**, also fixed a third bug found while implementing (b): the suggested name was built from the immediate parent's own name, not the lineage root's, so even a correctly-counted fork of a fork produced "AgentX #2 #3" instead of the flat "AgentX #3" | — |
 | **2** | Wire the quick-fork action itself: `NewTab` (capture the returned tab id) → `launchAgentDefinition(forkedDef, {continueSessionId, forkSession: true, ...}, newTabId)` — explicit tab id, not ambient active-tab state (§4.1) | Phase 1 |
 | **3** | UX polish: right-click affordance, keybinding, auto tab title, non-Claude fallback messaging | Phase 2 |
 | **4** | Long-press/confirmation variant exposing the identity choice (§5) | Phase 2 |

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -22,6 +22,7 @@ import { realAccountIdOrEmpty } from "./identity-carry-over";
 import { refreshAccountCache } from "@/app/view/identity/identity-model";
 import { dimAgentColor, isValidAgentColor, pickAgentColor } from "./agent-color";
 import { parseSeedZoom } from "./agent-zoom-seed";
+import { resolveForkSessionArgs } from "./fork-session-args";
 import { HISTORY_TAB_FOR_META_KEY, openOrFocusHistoryTab } from "./open-history-tab";
 
 export class AgentViewModel implements ViewModel {
@@ -414,16 +415,14 @@ export class AgentViewModel implements ViewModel {
             cliArgs.push(...agent.provider_flags.split(/\s+/).filter(Boolean));
         }
         // In-pane tabs, Phase 4 — see LaunchOverrides.forkSession's own doc
-        // comment. Review finding: `--fork-session` is Claude Code CLI
-        // syntax, validated ONLY for Claude
-        // (SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §6.4's empirical
-        // gate) — gating on "any provider with a resumeFlag" wrongly also
-        // matched gemini (`-r`) and muxcode (`--resume`), passing an
-        // unsupported flag to CLIs that were never validated to accept it.
-        // Every other provider (including those two) silently falls back
-        // to "fork = fresh definition, fresh start" — no flag, no error,
-        // exactly the graceful fallback §6.4 called for.
-        if (overrides?.forkSession && provider.id === "claude") {
+        // comment, and fork-session-args.ts's doc comment for the two real
+        // bugs (reagent + Codex, PR #2725) this resolution now guards
+        // against. `--fork-session` is Claude Code CLI syntax, validated
+        // ONLY for Claude (SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15
+        // §6.4's empirical gate) — every other provider falls back to a
+        // true fresh start (no session id at all, not a plain resume).
+        const forkSessionArgs = resolveForkSessionArgs(overrides, provider.id);
+        if (forkSessionArgs.appendForkFlag) {
             cliArgs.push("--fork-session");
         }
 
@@ -592,7 +591,11 @@ export class AgentViewModel implements ViewModel {
             // ensures any session id the CLI later emits on stdout
             // overrides whatever value lands here on subsequent
             // turns.
-            const continueSid = overrides?.continueSessionId?.trim() ?? "";
+            // See fork-session-args.ts / forkSessionArgs above — already
+            // resolved the fork-vs-plain-reattach session id, including
+            // dropping it entirely when a fork was requested for a
+            // provider that can't fork-session (Codex's review of #2725).
+            const continueSid = forkSessionArgs.continueSessionId;
 
             // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md):
             // seed term:zoom from the agent's saved ui:zoom (already loaded

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -157,16 +157,26 @@ vi.mock("./MyAgentsList", () => {
         agent_created_at: 0,
         started_at: 0,
     };
+    // reagent's review of PR #2725 — a row whose agent is open but hasn't
+    // emitted a CLI session id yet (session_id empty). Forking this must
+    // not request a session fork at all (no session to fork from).
+    const forkSourceRowNoSession = { ...forkSourceRow, session_id: "" };
     return {
         MyAgentsList: (props: any) => (
             <div data-testid="my-agents-list-mock" data-name-filter={props.nameFilter?.() ?? ""}>
                 {/* Fires the real onFork prop (AgentPicker.tsx's handleFork) with
-                    a fixed fixture row — MyAgentsList's own multi-step
+                    fixed fixture rows — MyAgentsList's own multi-step
                     fork-prompt UI (prompt -> naming -> confirm) is out of scope
                     for this file; this exercises the function under test
                     directly. */}
                 <button data-testid="fork-trigger" onClick={() => props.onFork?.(forkSourceRow, "X #2")}>
                     fork
+                </button>
+                <button
+                    data-testid="fork-trigger-no-session"
+                    onClick={() => props.onFork?.(forkSourceRowNoSession, "X #2")}
+                >
+                    fork (no session)
                 </button>
             </div>
         ),
@@ -429,6 +439,27 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         expect(launchedDef.id).toBe("forked-def");
         expect(overrides.continueSessionId).toBe("sid-parent-123");
         expect(overrides.forkSession).toBe(true);
+    });
+
+    // reagent's review of PR #2725 — a row whose agent hasn't emitted a
+    // CLI session id yet must not request a session fork at all (nothing
+    // to fork from); omitting both fields lets launchAgentDefinition fall
+    // back to its normal fresh-start defaults instead of forcing a bare
+    // --fork-session with no session, or a false "forkSession: true" that
+    // implies a carryover that can't actually happen.
+    it("handleFork omits continueSessionId/forkSession when the row has no session id yet", async () => {
+        const forkedDef = baseDef({ id: "forked-def", slug: "x-2", name: "X #2", parent_id: "user-maks" });
+        vi.mocked(RpcApi.ForkAgentDefinitionCommand).mockResolvedValue(forkedDef);
+
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const forkTrigger = await screen.findByTestId("fork-trigger-no-session");
+        fireEvent.click(forkTrigger);
+
+        await waitFor(() => expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1));
+        const [, overrides] = model.launchAgentDefinition.mock.calls[0];
+        expect(overrides.continueSessionId).toBeUndefined();
+        expect(overrides.forkSession).toBeUndefined();
     });
 
     // #2594 — AgentPicker's install-check/prereq-probe/cache-invalidation

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -47,6 +47,8 @@ vi.mock("@/app/store/rpc-api", () => {
         AgentDefUnhideCommand: vi.fn().mockResolvedValue({ ok: true }),
         AgentDefListHiddenTemplatesCommand: vi.fn().mockResolvedValue([]),
         ListMemoriesCommand: vi.fn().mockResolvedValue([]),
+        // Fork flow (#2721 Phase 1 — continueSessionId/forkSession wiring).
+        ForkAgentDefinitionCommand: vi.fn(),
     };
     return { RpcApi };
 });
@@ -131,11 +133,45 @@ vi.mock("./HiddenTemplatesSection", () => ({
     HiddenTemplatesSection: () => null,
 }));
 
-vi.mock("./MyAgentsList", () => ({
-    MyAgentsList: (props: any) => (
-        <div data-testid="my-agents-list-mock" data-name-filter={props.nameFilter?.() ?? ""} />
-    ),
-}));
+vi.mock("./MyAgentsList", () => {
+    // Defined inline (not module-scope) so vi.mock's top-of-file hoisting
+    // doesn't read the fixture before its declaration runs — same reasoning
+    // as the ContextMenuModel mock above.
+    const forkSourceRow = {
+        instance_id: "inst-user-maks",
+        instance_name: "Maks",
+        definition_id: "user-maks",
+        definition_name: "Maks",
+        provider: "claude",
+        working_directory: "",
+        identity_id: "",
+        identity_name: "",
+        memory_id: "",
+        memory_name: "",
+        block_id_hint: "",
+        session_id: "sid-parent-123",
+        preview: "",
+        node_count: 0,
+        last_active_at: 0,
+        has_snapshot: false,
+        agent_created_at: 0,
+        started_at: 0,
+    };
+    return {
+        MyAgentsList: (props: any) => (
+            <div data-testid="my-agents-list-mock" data-name-filter={props.nameFilter?.() ?? ""}>
+                {/* Fires the real onFork prop (AgentPicker.tsx's handleFork) with
+                    a fixed fixture row — MyAgentsList's own multi-step
+                    fork-prompt UI (prompt -> naming -> confirm) is out of scope
+                    for this file; this exercises the function under test
+                    directly. */}
+                <button data-testid="fork-trigger" onClick={() => props.onFork?.(forkSourceRow, "X #2")}>
+                    fork
+                </button>
+            </div>
+        ),
+    };
+});
 
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { AgentPicker } from "./AgentPicker";
@@ -368,6 +404,31 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         await req.onCreatedAndLaunch("new-def-id", "id-work", "mem-notes", "Mary", "host", "");
         const [, overrides] = model.launchAgentDefinition.mock.calls[0];
         expect(overrides.model).toBeUndefined();
+    });
+
+    // #2721 Phase 1 — forking used to clone only the agent *definition* and
+    // start a brand-new conversation, silently dropping the whole point of
+    // a fork (the parent's history). continueSessionId + forkSession are
+    // what makes launchAgentDefinition append --fork-session so the new
+    // block resumes-then-diverges instead of starting fresh.
+    it("handleFork carries the parent session forward via continueSessionId + forkSession", async () => {
+        const forkedDef = baseDef({ id: "forked-def", slug: "x-2", name: "X #2", parent_id: "user-maks" });
+        vi.mocked(RpcApi.ForkAgentDefinitionCommand).mockResolvedValue(forkedDef);
+
+        const model = makeMockModel();
+        render(() => <AgentPicker model={model as any} />);
+        const forkTrigger = await screen.findByTestId("fork-trigger");
+        fireEvent.click(forkTrigger);
+
+        await waitFor(() => expect(model.launchAgentDefinition).toHaveBeenCalledTimes(1));
+        expect(RpcApi.ForkAgentDefinitionCommand).toHaveBeenCalledWith(
+            {},
+            { source_id: "user-maks", branch_label: "X #2" }
+        );
+        const [launchedDef, overrides] = model.launchAgentDefinition.mock.calls[0];
+        expect(launchedDef.id).toBe("forked-def");
+        expect(overrides.continueSessionId).toBe("sid-parent-123");
+        expect(overrides.forkSession).toBe(true);
     });
 
     // #2594 — AgentPicker's install-check/prereq-probe/cache-invalidation

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -413,10 +413,18 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 // "fork" (SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md §2).
                 // `forkSession: true` is what makes launchAgentDefinition
                 // append `--fork-session` (Claude only; every other
-                // provider ignores it and falls back to fresh-start, same
-                // as `continueSessionId` alone would do without it).
-                continueSessionId: row.session_id ?? "",
-                forkSession: true,
+                // provider's launchAgentDefinition ignores both fields and
+                // falls back to a true fresh start — reagent + Codex's
+                // review of PR #2725 found that used to not hold: passing
+                // `forkSession` with an empty session id pushed a bare
+                // `--fork-session` with nothing to resume from, and for a
+                // non-Claude provider `continueSessionId` alone (with
+                // `forkSession` silently ignored) resumed the SAME live
+                // session as the parent instead of falling back — both
+                // fixed at the source in launchAgentDefinition, and guarded
+                // here too: only request a fork when there's an actual
+                // session to fork from.
+                ...(row.session_id ? { continueSessionId: row.session_id, forkSession: true } : {}),
             });
         } finally {
             setLaunching(null);

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -406,6 +406,17 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     (await refreshAccountCache()).map((a) => a.id)
                 ),
                 memoryId: row.memory_id,
+                // Carry the parent conversation's history forward — without
+                // these two, forking only clones the agent *definition*
+                // (config/instructions/skills) and starts a brand new
+                // conversation, silently dropping the whole point of a
+                // "fork" (SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md §2).
+                // `forkSession: true` is what makes launchAgentDefinition
+                // append `--fork-session` (Claude only; every other
+                // provider ignores it and falls back to fresh-start, same
+                // as `continueSessionId` alone would do without it).
+                continueSessionId: row.session_id ?? "",
+                forkSession: true,
             });
         } finally {
             setLaunching(null);

--- a/frontend/app/view/agent/fork-session-args.test.ts
+++ b/frontend/app/view/agent/fork-session-args.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { resolveForkSessionArgs } from "./fork-session-args";
+
+describe("resolveForkSessionArgs", () => {
+    it("plain reattach (no forkSession) resumes any provider unaffected", () => {
+        for (const providerId of ["claude", "codex", "gemini", "muxcode"]) {
+            expect(resolveForkSessionArgs({ continueSessionId: "sid-1" }, providerId)).toEqual({
+                continueSessionId: "sid-1",
+                appendForkFlag: false,
+            });
+        }
+    });
+
+    it("no overrides at all resolves to a plain fresh start for any provider", () => {
+        expect(resolveForkSessionArgs(undefined, "claude")).toEqual({
+            continueSessionId: "",
+            appendForkFlag: false,
+        });
+    });
+
+    it("Claude fork with a real session id appends the flag and keeps the session id", () => {
+        expect(resolveForkSessionArgs({ continueSessionId: "sid-1", forkSession: true }, "claude")).toEqual({
+            continueSessionId: "sid-1",
+            appendForkFlag: true,
+        });
+    });
+
+    // reagent's review of PR #2725: a fork requested with no session to
+    // fork from must not push a bare --fork-session flag.
+    it("Claude fork with an empty session id does not append the flag", () => {
+        expect(resolveForkSessionArgs({ continueSessionId: "", forkSession: true }, "claude")).toEqual({
+            continueSessionId: "",
+            appendForkFlag: false,
+        });
+        expect(resolveForkSessionArgs({ forkSession: true }, "claude")).toEqual({
+            continueSessionId: "",
+            appendForkFlag: false,
+        });
+    });
+
+    // Codex's review of PR #2725: a fork requested for a non-Claude
+    // provider must fall back to a true fresh start, not a plain resume
+    // of the parent's live session.
+    it("non-Claude fork drops the session id entirely rather than plain-resuming", () => {
+        for (const providerId of ["codex", "gemini", "muxcode"]) {
+            expect(resolveForkSessionArgs({ continueSessionId: "sid-1", forkSession: true }, providerId)).toEqual({
+                continueSessionId: "",
+                appendForkFlag: false,
+            });
+        }
+    });
+});

--- a/frontend/app/view/agent/fork-session-args.ts
+++ b/frontend/app/view/agent/fork-session-args.ts
@@ -1,0 +1,49 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Fork-session argument resolution — extracted out of
+// agent-model.ts::launchAgentDefinition (SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
+// Phase 1) so this contract has its own unit tests instead of living
+// inline in a large function. Two real bugs were found here, in the same
+// spot, one review round apart (PR #2725, reagent + Codex) — a strong
+// signal this logic deserved direct coverage, not just indirect coverage
+// via a mocked integration test.
+
+/**
+ * Resolve fork-session behavior for a launch: whether to append the
+ * `--fork-session` CLI flag, and whether to actually seed a session id to
+ * resume from at all.
+ *
+ * `--fork-session` is Claude Code CLI syntax, validated only for Claude
+ * (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15.md` §6.4's empirical
+ * gate) — every other provider must fall back to a true fresh start, not
+ * a plain resume of `continueSessionId`. Two failure modes fixed here:
+ *
+ * - A fork requested (`forkSession: true`) for a non-Claude provider used
+ *   to still seed `continueSessionId`, silently resuming the exact same
+ *   live session the fork's source was still driving — not a fresh start
+ *   (Codex's review of PR #2725). Fixed: when a fork is requested but the
+ *   provider doesn't support it, `continueSessionId` is dropped entirely.
+ * - A fork requested with no actual session to fork from (empty
+ *   `continueSessionId`) used to still push a bare `--fork-session` flag
+ *   with nothing to resume (reagent's review of PR #2725). Fixed: the
+ *   flag is only appended when there's a real session id to pair it with.
+ */
+export function resolveForkSessionArgs(
+    overrides: { continueSessionId?: string; forkSession?: boolean } | undefined,
+    providerId: string
+): { continueSessionId: string; appendForkFlag: boolean } {
+    const continueSessionId = overrides?.continueSessionId?.trim() ?? "";
+    const forkSessionSupported = providerId === "claude";
+    if (overrides?.forkSession && !forkSessionSupported) {
+        // Fork requested, but this provider can't fork-session — a plain
+        // resume of the parent's live session is worse than a fresh
+        // start, so drop the session id entirely rather than fall back
+        // to it.
+        return { continueSessionId: "", appendForkFlag: false };
+    }
+    return {
+        continueSessionId,
+        appendForkFlag: !!overrides?.forkSession && forkSessionSupported && continueSessionId !== "",
+    };
+}


### PR DESCRIPTION
## Summary

Implements `SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md` Phase 1 — two confirmed bugs in the already-shipped fork flow (`AgentPicker.tsx`'s fork prompt → `ForkAgentDefinitionCommand`), found while writing that spec and verified against real code during PR #2721's review round with reagent and Codex.

**Bug 1 — forking doesn't carry conversation history.** `handleFork` mints a forked `AgentDefinition` (config/instructions/skills clone via `ForkAgentDefinitionCommand`) but never set `continueSessionId`/`forkSession` on the `launchAgentDefinition` call — so every "fork" silently started a brand-new conversation, despite `--fork-session` being empirically validated as working back in June (`SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15` §6.4). Fixed by wiring both through, mirroring how `handleReattach` already does it for plain resume a few lines above.

**Bug 2 — fork-of-a-fork naming.** `template.rs`'s auto-naming ("Name #N") counted only a source's immediate children (`parent_id == source_id`), so forking a fork produced "AgentX #2 #2" instead of the flat "AgentX #3" the naming spec (`SPEC_AGENT_NAMING_AND_ADDRESSING_HOST_LAN_WAN_2026_08_22.md` §4.5) requires. This needed care: `parent_id` is overloaded in this schema — `agentdefcreatefromtemplate` also sets it (to the template's id) for every freshly-instantiated agent, so a naive "walk `parent_id` to the root" fix would wrongly merge unrelated agents created from the same template into one lineage. Fixed by walking only while the current node is itself a fork (non-empty `branch_label` — the one field that actually distinguishes a real fork from a template-instantiation) to find the true lineage root, then counting *and naming* off that root. Naming off the root mattered too — a correctly-*counted* fork-of-a-fork still produced "AgentX #2 #3" when the name was built from the immediate parent's own already-suffixed name instead of the root's.

## Test plan

- [x] New frontend test: `AgentPicker.test.tsx` — `handleFork` sets `continueSessionId`/`forkSession: true` (20/20 tests pass, `npx vitest run`).
- [x] New backend test: `template.rs` — forking a fork produces a flat, lineage-wide name via both the real fork RPC and the suggest-preview RPC (`cargo test -p agentmux-srv --bin agentmux-srv agent_handlers::template::`, 3/3 pass).
- [x] Compiles clean, no new warnings.

<!-- agentmux:agent_id=agentx -->