### PR TITLE
feat(srv): retention/GC for native memory version history

### DIFF
--- a/.changesets/1787418543-feat-srv-retention-gc-for-native-memory-version-history-8e0o.md
+++ b/.changesets/1787418543-feat-srv-retention-gc-for-native-memory-version-history-8e0o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): retention/GC for native memory version history

--- a/.changesets/1787418543-feat-srv-retention-gc-for-native-memory-version-history-8e0o.md
+++ b/.changesets/1787418543-feat-srv-retention-gc-for-native-memory-version-history-8e0o.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(srv): retention/GC for native memory version history

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -22,6 +22,7 @@ pub mod editor_file_watcher;
 pub mod fs_watch;
 pub mod media_file_watcher;
 pub mod native_memory_drift;
+pub mod native_memory_retention;
 pub mod ijson;
 pub mod docsite;
 pub mod eventbus;

--- a/agentmux-srv/src/backend/native_memory_retention.rs
+++ b/agentmux-srv/src/backend/native_memory_retention.rs
@@ -1,0 +1,148 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Retention/GC for `db_agent_native_memory_versions` — closes §7.1 of
+//! docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md,
+//! left open in v1 ("no pruning is proposed... flag if unbounded growth is
+//! a concern"). Operator-confirmed policy (2026-08-22): hybrid age +
+//! min-count floor — a version is pruned only once it is BOTH older than
+//! [`MAX_AGE_MS`] AND ranked beyond the [`MIN_KEEP`] most-recent versions
+//! for its `(agent_id, filename)`. The floor exists so an agent that
+//! rarely touches a given memory file never loses its entire history just
+//! because every version happens to be old; the age bound exists so a
+//! hyperactive agent's frequently-rewritten file doesn't grow unbounded
+//! just because every version happens to be recent. See
+//! `agent_native_memory_versions.rs::agent_native_memory_version_prune`
+//! for the actual query.
+//!
+//! Runs as its own periodic background sweep, started once at server
+//! startup alongside `native_memory_drift`'s detection sweeps (a sibling
+//! concern, not the same one — drift *detects* out-of-band writes,
+//! retention *prunes* old versions regardless of source). Deliberately a
+//! much slower cadence than drift detection's 30s: pruning is housekeeping,
+//! not latency-sensitive — nothing is waiting on a stale version's removal
+//! the way a reviewer is waiting to see a drifted write show up.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::backend::storage::store::Store;
+
+/// Pruning is housekeeping, not latency-sensitive — once a day is generous
+/// enough that growth stays bounded without adding meaningful DB load.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Keep at least this many most-recent versions per `(agent_id, filename)`,
+/// regardless of age.
+pub(crate) const MIN_KEEP: u32 = 50;
+
+/// Beyond `MIN_KEEP`, prune versions older than this.
+pub(crate) const MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
+
+/// One pass: prune every `(agent_id, filename)` pair that has any recorded
+/// version history. Returns the number of version rows deleted (for
+/// logging; tests assert on it directly). A failure listing targets or
+/// pruning one file is logged and does not stop the sweep from covering
+/// everything else — matches `native_memory_drift`'s own per-item error
+/// handling.
+pub(crate) fn prune_once(id_store: &Store) -> usize {
+    let targets = match id_store.agent_native_memory_version_list_distinct_files() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "native_memory_retention: failed to list files needing pruning");
+            return 0;
+        }
+    };
+
+    let mut pruned = 0;
+    for (agent_id, filename) in targets {
+        match id_store.agent_native_memory_version_prune(&agent_id, &filename, MIN_KEEP, MAX_AGE_MS) {
+            Ok(0) => {}
+            Ok(n) => {
+                pruned += n;
+                tracing::info!(agent_id, filename, pruned = n, "native_memory_retention: pruned old versions");
+            }
+            Err(e) => tracing::warn!(agent_id, filename, error = %e, "native_memory_retention: prune failed"),
+        }
+    }
+    pruned
+}
+
+/// Start the periodic sweep. Call once at server startup with the store
+/// version history is recorded in. Returns immediately — runs as a
+/// spawned background task for the process lifetime (no shutdown handle;
+/// srv itself owns the process lifetime, same as `native_memory_drift::spawn`).
+pub fn spawn(id_store: Arc<Store>) {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(SWEEP_INTERVAL);
+        loop {
+            tick.tick().await;
+            prune_once(&id_store);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn shared_store() -> Store {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Store::open_shared(tmp.path()).unwrap()
+    }
+
+    const DAY_MS: i64 = 24 * 60 * 60 * 1000;
+
+    fn backdate(store: &Store, version_id: &str, days_ago: i64) {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        let conn = store.conn().lock().unwrap();
+        conn.execute(
+            "UPDATE db_agent_native_memory_versions SET created_at = ?1 WHERE id = ?2",
+            params![now_ms - days_ago * DAY_MS, version_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prune_once_covers_every_file_with_recorded_history() {
+        let store = shared_store();
+        for (agent_id, filename) in [("agent-1", "a.md"), ("agent-1", "b.md"), ("agent-2", "a.md")] {
+            for i in 0..(MIN_KEEP + 3) {
+                let v = store
+                    .agent_native_memory_version_insert(agent_id, filename, &format!("v{i}"), "human", "{}", "")
+                    .unwrap();
+                backdate(&store, &v.id, 200); // past MAX_AGE_MS
+            }
+        }
+
+        let pruned = prune_once(&store);
+        assert_eq!(pruned, 3 * 3, "3 excess versions per file, across 3 distinct files");
+
+        for (agent_id, filename) in [("agent-1", "a.md"), ("agent-1", "b.md"), ("agent-2", "a.md")] {
+            assert_eq!(
+                store.agent_native_memory_version_list(agent_id, filename).unwrap().len(),
+                MIN_KEEP as usize
+            );
+        }
+    }
+
+    #[test]
+    fn prune_once_is_a_no_op_when_nothing_qualifies() {
+        let store = shared_store();
+        store
+            .agent_native_memory_version_insert("agent-1", "MEMORY.md", "v1", "human", "{}", "")
+            .unwrap();
+        assert_eq!(prune_once(&store), 0);
+        assert_eq!(store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_once_returns_zero_when_no_version_history_exists_at_all() {
+        let store = shared_store();
+        assert_eq!(prune_once(&store), 0);
+    }
+}

--- a/agentmux-srv/src/backend/storage/agent_native_memory_versions.rs
+++ b/agentmux-srv/src/backend/storage/agent_native_memory_versions.rs
@@ -335,6 +335,53 @@ impl Store {
         }
     }
 
+    /// Every distinct `(agent_id, filename)` pair with at least one recorded
+    /// version — the retention sweep's (`native_memory_retention.rs`) work
+    /// list, so it doesn't need its own separate source of "which files
+    /// have history" (the version table itself is authoritative for that).
+    pub fn agent_native_memory_version_list_distinct_files(&self) -> Result<Vec<(String, String)>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT DISTINCT agent_id, filename FROM db_agent_native_memory_versions")?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Prune old versions of `(agent_id, filename)` per the hybrid
+    /// age + min-count-floor retention policy
+    /// (`native_memory_retention.rs`, spec §7.1): a version is deleted only
+    /// if it is BOTH older than `max_age_ms` AND ranked beyond the
+    /// `min_keep` most-recent versions for this file — so a rarely-touched
+    /// file never loses its entire history purely because every version
+    /// happens to be old, and a hyperactive file never grows unbounded
+    /// purely because every version happens to be recent. Returns the
+    /// number of rows deleted.
+    pub fn agent_native_memory_version_prune(
+        &self,
+        agent_id: &str,
+        filename: &str,
+        min_keep: u32,
+        max_age_ms: i64,
+    ) -> Result<usize, StoreError> {
+        let cutoff = now_ms() - max_age_ms;
+        let conn = self.conn.lock().unwrap();
+        let deleted = conn.execute(
+            "DELETE FROM db_agent_native_memory_versions
+             WHERE id IN (
+                 SELECT id FROM (
+                     SELECT id, created_at,
+                            ROW_NUMBER() OVER (ORDER BY created_at DESC, rowid DESC) AS rn
+                     FROM db_agent_native_memory_versions
+                     WHERE agent_id = ?1 AND filename = ?2
+                 )
+                 WHERE rn > ?3 AND created_at < ?4
+             )",
+            params![agent_id, filename, min_keep, cutoff],
+        )?;
+        Ok(deleted)
+    }
+
     /// Read one version's full content by id — for diff/revert, which need
     /// exactly one or two full bodies, not a whole file's history.
     pub fn agent_native_memory_version_get(
@@ -619,5 +666,131 @@ mod tests {
         assert!(first.is_some());
         assert_eq!(second, None, "a second call observing the same already-recorded content must be a no-op");
         assert_eq!(store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap().len(), 1);
+    }
+
+    const DAY_MS: i64 = 24 * 60 * 60 * 1000;
+
+    /// Test-only helper: backdate a version's `created_at` directly (the
+    /// public insert API always stamps `now_ms()` — retention policy can
+    /// only be exercised against real elapsed time otherwise, which would
+    /// make these tests either slow or flaky).
+    fn backdate(store: &Store, version_id: &str, days_ago: i64) {
+        let conn = store.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE db_agent_native_memory_versions SET created_at = ?1 WHERE id = ?2",
+            params![now_ms() - days_ago * DAY_MS, version_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prune_leaves_a_file_with_fewer_versions_than_the_floor_untouched() {
+        let store = shared_store();
+        for i in 0..5 {
+            let v = store
+                .agent_native_memory_version_insert("agent-1", "MEMORY.md", &format!("v{i}"), "human", "{}", "")
+                .unwrap();
+            backdate(&store, &v.id, 1000); // ancient, but under the count floor
+        }
+        let deleted = store.agent_native_memory_version_prune("agent-1", "MEMORY.md", 50, 90 * DAY_MS).unwrap();
+        assert_eq!(deleted, 0);
+        assert_eq!(store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap().len(), 5);
+    }
+
+    #[test]
+    fn prune_keeps_the_min_keep_newest_versions_even_when_all_are_old() {
+        let store = shared_store();
+        for i in 0..8 {
+            let v = store
+                .agent_native_memory_version_insert("agent-1", "MEMORY.md", &format!("v{i}"), "human", "{}", "")
+                .unwrap();
+            backdate(&store, &v.id, 1000);
+        }
+        let deleted = store.agent_native_memory_version_prune("agent-1", "MEMORY.md", 3, 90 * DAY_MS).unwrap();
+        assert_eq!(deleted, 5, "floor of 3 must survive out of 8, even though every version is ancient");
+        let remaining = store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap();
+        assert_eq!(remaining.len(), 3);
+        // The 3 survivors must be the newest 3 (v5, v6, v7 — insertion order).
+        assert_eq!(remaining[0].content_hash, content_hash("v7"));
+        assert_eq!(remaining[1].content_hash, content_hash("v6"));
+        assert_eq!(remaining[2].content_hash, content_hash("v5"));
+    }
+
+    #[test]
+    fn prune_leaves_a_version_beyond_the_floor_alone_if_it_is_still_young() {
+        let store = shared_store();
+        // 5 versions, all inserted "now" (age 0) — none old enough to prune,
+        // even with a floor of 1 that would otherwise expose 4 of them.
+        for i in 0..5 {
+            store
+                .agent_native_memory_version_insert("agent-1", "MEMORY.md", &format!("v{i}"), "human", "{}", "")
+                .unwrap();
+        }
+        let deleted = store.agent_native_memory_version_prune("agent-1", "MEMORY.md", 1, 90 * DAY_MS).unwrap();
+        assert_eq!(deleted, 0, "young versions must survive regardless of the count floor");
+        assert_eq!(store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap().len(), 5);
+    }
+
+    #[test]
+    fn prune_deletes_only_versions_both_beyond_the_floor_and_past_the_age_cutoff() {
+        let store = shared_store();
+        // 5 old versions (beyond a floor of 2, past the age cutoff) + 2 kept
+        // by the floor (also old, but protected by min_keep) — mixing both
+        // guards in one file to prove they combine with AND, not OR.
+        let mut ids = Vec::new();
+        for i in 0..7 {
+            let v = store
+                .agent_native_memory_version_insert("agent-1", "MEMORY.md", &format!("v{i}"), "human", "{}", "")
+                .unwrap();
+            backdate(&store, &v.id, 100); // past a 90-day cutoff
+            ids.push(v.id);
+        }
+        let deleted = store.agent_native_memory_version_prune("agent-1", "MEMORY.md", 2, 90 * DAY_MS).unwrap();
+        assert_eq!(deleted, 5);
+        assert_eq!(store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn prune_scopes_to_the_requested_agent_and_filename_only() {
+        let store = shared_store();
+        let v_a = store
+            .agent_native_memory_version_insert("agent-1", "MEMORY.md", "a", "human", "{}", "")
+            .unwrap();
+        backdate(&store, &v_a.id, 200);
+        let v_b = store
+            .agent_native_memory_version_insert("agent-2", "MEMORY.md", "b", "human", "{}", "")
+            .unwrap();
+        backdate(&store, &v_b.id, 200);
+
+        let deleted = store.agent_native_memory_version_prune("agent-1", "MEMORY.md", 0, 90 * DAY_MS).unwrap();
+        assert_eq!(deleted, 1);
+        assert!(store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap().is_empty());
+        assert_eq!(store.agent_native_memory_version_list("agent-2", "MEMORY.md").unwrap().len(), 1, "a different agent's version must be untouched");
+    }
+
+    #[test]
+    fn list_distinct_files_returns_each_agent_filename_pair_once() {
+        let store = shared_store();
+        store.agent_native_memory_version_insert("agent-1", "a.md", "v1", "human", "{}", "").unwrap();
+        store.agent_native_memory_version_insert("agent-1", "a.md", "v2", "human", "{}", "").unwrap();
+        store.agent_native_memory_version_insert("agent-1", "b.md", "v1", "human", "{}", "").unwrap();
+        store.agent_native_memory_version_insert("agent-2", "a.md", "v1", "human", "{}", "").unwrap();
+
+        let mut files = store.agent_native_memory_version_list_distinct_files().unwrap();
+        files.sort();
+        assert_eq!(
+            files,
+            vec![
+                ("agent-1".to_string(), "a.md".to_string()),
+                ("agent-1".to_string(), "b.md".to_string()),
+                ("agent-2".to_string(), "a.md".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_distinct_files_is_empty_when_no_versions_exist() {
+        let store = shared_store();
+        assert!(store.agent_native_memory_version_list_distinct_files().unwrap().is_empty());
     }
 }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -85,6 +85,10 @@ async fn main() {
     // docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.5.
     backend::native_memory_drift::spawn(state.fs_watch_pool.clone(), state.wstore.clone(), state.id_store.clone());
 
+    // Retention/GC for native-memory version history — see
+    // docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §7.1.
+    backend::native_memory_retention::spawn(state.id_store.clone());
+
     // Start persistent cron scheduler — load enabled jobs from DB, fire any
     // that missed their window (FIRE_ONCE_NOW), schedule all for future fires.
     state.cron_scheduler.start().await;

--- a/docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md
+++ b/docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md
@@ -626,10 +626,21 @@ distinct from the Armory-shaped work this spec actually does.
 
 ## 7. Open questions for the human operator
 
-1. **Retention/GC.** Should old versions ever be pruned (age-based,
-   count-based per file), or retained forever? No pruning is proposed in
-   v1 (§4.1) — flag if unbounded growth is a concern for long-lived agents
-   with frequent memory writes.
+1. **Retention/GC — RESOLVED (2026-08-22, operator-confirmed).** Hybrid
+   age + min-count floor: a version is pruned only once it is both older
+   than 90 days AND ranked beyond the 50 most-recent versions for its
+   `(agent_id, filename)` — so a rarely-touched file never loses its
+   entire history purely because every version happens to be old, and a
+   hyperactive file never grows unbounded purely because every version
+   happens to be recent. Implemented as
+   `Store::agent_native_memory_version_prune` (single SQL statement using
+   `ROW_NUMBER() OVER`, `agentmux-srv/src/backend/storage/agent_native_memory_versions.rs`)
+   plus a new daily background sweep,
+   `agentmux-srv/src/backend/native_memory_retention.rs` (`MIN_KEEP = 50`,
+   `MAX_AGE_MS = 90 days`), spawned once at startup in `main.rs` alongside
+   `native_memory_drift`'s own sweeps. Deliberately a much slower cadence
+   (24h) than drift detection's 30s — pruning is housekeeping, not
+   latency-sensitive.
 2. **Should a `source: 'jekt'` write ever be blocked outright** (not just
    flagged) when the triggering jekt's `TIER=sensitive` with
    `ESCALATE=required` per the current jekt trust rules — i.e., should


### PR DESCRIPTION
## Summary
- Closes `SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md` §7.1, an open operator question in the original spec ("no pruning is proposed in v1... flag if unbounded growth is a concern").
- Operator-confirmed policy (2026-08-22): hybrid age + min-count floor — a version is pruned only once it is **both** older than 90 days **and** ranked beyond the 50 most-recent versions for its `(agent_id, filename)`. This protects a rarely-touched file's full history from age-only pruning, and caps a hyperactive file's growth that a count-only floor wouldn't bound in time.
- New `Store::agent_native_memory_version_prune` (single `ROW_NUMBER() OVER`-based SQL statement) plus a new daily background sweep (`agentmux-srv/src/backend/native_memory_retention.rs`), spawned once at startup alongside `native_memory_drift`'s own detection sweeps — a much slower cadence (24h vs. 30s) since pruning is housekeeping, not latency-sensitive.

## Test plan
- [x] New unit tests for `agent_native_memory_version_prune`/`agent_native_memory_version_list_distinct_files` (22 tests total in that module) — floor-only, age-only, both-combined, and per-agent/file scoping cases.
- [x] New unit tests for `native_memory_retention::prune_once` (multi-file sweep coverage, no-op cases).
- [x] Proved test discrimination: reverted the count-floor guard in the SQL, confirmed 3 tests fail with the exact expected signature, restored, confirmed clean.
- [x] Full suite: `cargo test -p agentmux-srv --bin agentmux-srv -- --test-threads=1` — 2653 passed, 0 failed.
- [x] `cargo build -p agentmux-srv --bin agentmux-srv` — clean, confirms `main.rs` wiring compiles.

<!-- agentmux:agent_id=agent1 -->