### PR TITLE
feat(agent-pane): Tier 3 predictive countdown before auto-compact

### DIFF
--- a/.changesets/1787419367-feat-agent-pane-tier-3-predictive-countdown-before-auto-comp-2cwp.md
+++ b/.changesets/1787419367-feat-agent-pane-tier-3-predictive-countdown-before-auto-comp-2cwp.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): Tier 3 predictive countdown before auto-compact

--- a/docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md
+++ b/docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md
@@ -4,7 +4,7 @@
 **Repo:** agentmuxai/agentmux
 **Trigger:** investigating AgentA's long compaction stretch (see `REPORT_AGENTA_AUTH_AUDIT_AND_COMPACTION_2026-07-31.md`) required reconstructing *when* compaction happened from git commit timestamps — AgentMux itself couldn't answer that question directly. This spec is about closing that gap structurally.
 
-**Implementation status:** Tier 1 (live "compaction started" signal + status) and Tier 2 (elapsed-time counter) — plus the backend §4.1 fix they depend on — have shipped. Tier 3 (predictive countdown enhancement) and Tier 4 (estimated progress bar) are explicit follow-ups, not yet built; see §7. §4.2's original hook-mechanism sketch ("write a sentinel line to a pipe" / "curl a loopback endpoint") has been superseded by the concrete implementation described in §4.2 below — kept updated to match what actually shipped rather than left as a stale sketch.
+**Implementation status:** Tier 1 (live "compaction started" signal + status), Tier 2 (elapsed-time counter), and Tier 3 (predictive countdown) — plus the backend §4.1 fix they depend on — have shipped. Tier 4 (estimated progress bar) is the remaining explicit follow-up, not yet built; see §7. §4.2's original hook-mechanism sketch ("write a sentinel line to a pipe" / "curl a loopback endpoint") has been superseded by the concrete implementation described in §4.2 below — kept updated to match what actually shipped rather than left as a stale sketch.
 
 ---
 
@@ -143,9 +143,15 @@ The `PreCompact` hook (§4.2) fires synchronously the moment compaction begins. 
 
 A stopwatch starts on the `PreCompact` signal and stops when the `compact_boundary` event (§2) arrives — real elapsed time, not an estimate, since both endpoints are genuine events. The live client-side reading is superseded by the backend's authoritative `durationMs` once the real event lands.
 
-### Tier 3 — predictive count-down *before* compaction starts — NOT YET IMPLEMENTED (follow-up)
+### Tier 3 — predictive count-down *before* compaction starts — SHIPPED (2026-08-22)
 
-Partially built already (Tier 0). The gap is presentation, not data: `compactionThreshold(contextWindow) − currentTokens` is already computable every turn; it just isn't surfaced as explicit countdown language ("~4.2k tokens until auto-compact") or escalated into a proactive banner as the `critical` band is crossed — today it's a number you have to hover to see. Important limitation: this only predicts the `auto` trigger. A `manual` `/compact` (typed by the user or invoked by the agent itself) can happen at any fill level and is fundamentally unpredictable — the countdown should be labeled as applying to auto-compaction only, not a guarantee of when compaction will occur.
+Frontend-only, exactly as scoped: `compactionThreshold(contextWindow) − currentTokens` (already computable every turn since Tier 0) is now surfaced as explicit countdown language, inline and hover-independent — `~4.2k to auto-compact`, rendered next to the existing `12.1k / 64k` context text in `AgentComposerStrip.tsx` once the fill level reaches the `mid` band or above (silent below that — not worth calling out yet). The hover tooltip (`contextTitle()`) also gained the same remaining-count line, so the full-precision and compact readings agree.
+
+**Escalation at the `critical` band**, implemented as a strengthened inline treatment rather than a new standalone banner component: the countdown text gains a bold weight and a leading `⚠` glyph (`.agent-composer-strip-ctx-countdown--critical` in `_composer-strip.scss`), layered on top of the pulsing red color the `critical` band's `ctx` text already had. A genuinely separate full-width banner (matching `AgentDisconnectedBanner.tsx`'s pattern) was considered and deliberately not built — this strip's own file-header comment already documents its tiered-wrap responsive layout as fragile/hand-tuned, and a new mounted row would need its own container-query wiring to avoid fighting that; the strengthened-inline-text approach delivers the same "hard to miss once critical" outcome without that risk. Revisit if a real banner is wanted later.
+
+**Labeled as auto-compaction-only, as required**: both the inline countdown's tooltip and the main tooltip's added line state explicitly that this predicts only the CLI's own auto-compact point — a manual `/compact` can happen at any fill level and is not predicted by this countdown.
+
+Test coverage: `AgentComposerStrip.test.tsx` (band gating, critical escalation class, zero-clamp past the threshold, tooltip wording) — proved discriminating by temporarily stubbing `compactionCountdownText` to always return `null` and confirming 4 of 7 tests fail with the expected signature, then restoring.
 
 ### Tier 4 — percent-complete of the compaction operation itself — NOT YET IMPLEMENTED (follow-up)
 

--- a/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
@@ -23,6 +23,10 @@ afterEach(() => {
 const baseProps = {
     logOpen: false,
     onToggleLog: () => {},
+    // The countdown is Claude-only (compactionThreshold() hard-codes
+    // Claude Code's own auto-compact buffer) — most tests below want it
+    // enabled; the provider-gating test overrides this explicitly.
+    providerId: "claude",
 };
 
 describe("AgentComposerStrip — Tier 3 predictive countdown", () => {
@@ -78,5 +82,22 @@ describe("AgentComposerStrip — Tier 3 predictive countdown", () => {
         ));
         const countdownEl = container.querySelector(".agent-composer-strip-ctx-countdown");
         expect(countdownEl?.getAttribute("title")).toMatch(/manual \/compact can happen at any fill level/);
+    });
+
+    // Regression for Codex P2 on PR #2729: compactionThreshold() hard-codes
+    // Claude Code's own ~33K auto-compact buffer. A non-Claude provider
+    // that happens to report Claude-shaped message_start usage (e.g. a
+    // muxcode-catalog entry) must not get an invented countdown against a
+    // threshold that was never verified for it.
+    it("suppresses the countdown for a non-Claude provider even in the critical band", () => {
+        render(() => (
+            <AgentComposerStrip
+                {...baseProps}
+                providerId="codex"
+                contextTokens={155_000}
+                contextWindow={200_000}
+            />
+        ));
+        expect(screen.queryByText(/to auto-compact/)).toBeNull();
     });
 });

--- a/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Coverage for the Tier 3 predictive-countdown addition
+ * (docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md §7) —
+ * explicit "~Nk to auto-compact" text, surfaced inline once the fill level
+ * reaches the mid band, escalating visually at the critical band. Not a
+ * full component smoke test — AgentComposerStrip's other zones (controls,
+ * turn/session stats, Shell toggle) are exercised elsewhere; this file is
+ * scoped to the countdown behavior this change actually adds.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AgentComposerStrip } from "./AgentComposerStrip";
+
+afterEach(() => {
+    cleanup();
+});
+
+const baseProps = {
+    logOpen: false,
+    onToggleLog: () => {},
+};
+
+describe("AgentComposerStrip — Tier 3 predictive countdown", () => {
+    it("renders no countdown text when the window is unknown", () => {
+        render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={10_000} contextWindow={undefined} />
+        ));
+        expect(screen.queryByText(/to auto-compact/)).toBeNull();
+    });
+
+    it("renders no countdown text in the low band", () => {
+        // compactionThreshold(200_000) = 167_000; 10_000 / 167_000 ≈ 6% — low band.
+        render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={10_000} contextWindow={200_000} />
+        ));
+        expect(screen.queryByText(/to auto-compact/)).toBeNull();
+    });
+
+    it("renders explicit countdown text once the mid band is reached", () => {
+        // threshold = 167_000; 50% of that ≈ 83_500 — mid band.
+        render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={90_000} contextWindow={200_000} />
+        ));
+        expect(screen.getByText(/~77k to auto-compact/)).toBeInTheDocument();
+    });
+
+    it("does not apply the critical escalation class in the mid band", () => {
+        const { container } = render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={90_000} contextWindow={200_000} />
+        ));
+        expect(container.querySelector(".agent-composer-strip-ctx-countdown--critical")).toBeNull();
+    });
+
+    it("applies the critical escalation class once the critical band is crossed", () => {
+        // threshold = 167_000; 90% of that ≈ 150_300 — critical band.
+        const { container } = render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={155_000} contextWindow={200_000} />
+        ));
+        expect(screen.getByText(/to auto-compact/)).toBeInTheDocument();
+        expect(container.querySelector(".agent-composer-strip-ctx-countdown--critical")).not.toBeNull();
+    });
+
+    it("clamps the countdown at zero once past the threshold, never going negative", () => {
+        render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={200_000} contextWindow={200_000} />
+        ));
+        expect(screen.getByText(/~0 to auto-compact/)).toBeInTheDocument();
+    });
+
+    it("the tooltip states this predicts auto-compaction only, not a manual /compact", () => {
+        const { container } = render(() => (
+            <AgentComposerStrip {...baseProps} contextTokens={90_000} contextWindow={200_000} />
+        ));
+        const countdownEl = container.querySelector(".agent-composer-strip-ctx-countdown");
+        expect(countdownEl?.getAttribute("title")).toMatch(/manual \/compact can happen at any fill level/);
+    });
+});

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -249,10 +249,20 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     // Tier 3 — explicit countdown, visible inline (not hover-gated) once
     // the fill level is worth calling out. null below the mid band, or
     // whenever the window itself is unknown (nothing to count down from).
+    //
+    // Gated to Claude only (Codex P2 on PR #2729): `compactionThreshold()`
+    // hard-codes Claude Code's own ~33K auto-compact buffer
+    // (context-window.ts's own doc comment). A non-Claude provider that
+    // happens to report Claude-shaped `message_start` usage (e.g. a
+    // `muxcode`-catalog entry) would otherwise get an invented countdown
+    // against a threshold that has never been verified for it — the same
+    // reason `canCompact()` below already restricts the manual-compact
+    // button to Claude.
     const ctxCountdownText = (): string | null => {
         const t = props.contextTokens;
         const w = props.contextWindow;
         if (t == null || t <= 0 || w == null) return null;
+        if (props.providerId !== "claude") return null;
         return compactionCountdownText(t, w);
     };
 

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -23,7 +23,10 @@
  * In flow order:
  *   1. AgentRuntimeDropup (single Mode · Model · Effort trigger)
  *   2. tokens (↑in ↓out) · elapsed
- *   3. ⚙N process badge · context text (12.1k / 64k) · auth tag · HOST/SANDBOX
+ *   3. ⚙N process badge · context text (12.1k / 64k) · countdown text
+ *      (mid band+, "~4.2k to auto-compact" — Tier 3 of
+ *      SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md §7) · auth tag ·
+ *      HOST/SANDBOX
  *      tag + Shell toggle (paired as one unit, same day, per direct user
  *      request — HOST/SANDBOX moved out of the controls zone to sit
  *      immediately left of Shell)
@@ -69,11 +72,31 @@ function contextTitle(tokens: number, contextWindow: number | undefined): string
         return `Context: ${formatExactNumber(tokens)} tokens`;
     }
     const pct = ((tokens / contextWindow) * 100).toFixed(1);
+    const remaining = Math.max(0, compactionThreshold(contextWindow) - tokens);
     return (
         `Context window: ${formatExactNumber(tokens)} / ${formatExactNumber(contextWindow)} tokens (${pct}%)\n` +
         `This is the total conversation history sent to the model on each turn.\n` +
-        `Auto-compacts around ${formatExactNumber(compactionThreshold(contextWindow))} tokens.`
+        `Auto-compacts around ${formatExactNumber(compactionThreshold(contextWindow))} tokens ` +
+        `(≈${formatExactNumber(remaining)} tokens left).\n` +
+        `Applies to auto-compaction only — a manual /compact can happen at any fill level.`
     );
+}
+
+/**
+ * Tier 3 of docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md
+ * §7 — explicit countdown language, surfaced inline (not hover-gated) once
+ * the fill level is worth calling out (mid band and above). Predicts only
+ * the `auto` trigger: `compactionThreshold(window) − tokens` is the
+ * distance to the CLI's own auto-compact point, computable every turn
+ * (Tier 0's groundwork) — a manual `/compact` can happen at any fill level
+ * and is fundamentally unpredictable, so this must never be read as "the"
+ * time compaction will happen, only as "no sooner than."
+ */
+function compactionCountdownText(tokens: number, window: number): string | null {
+    const band = ctxBand(tokens, window);
+    if (band === "low") return null;
+    const remaining = Math.max(0, compactionThreshold(window) - tokens);
+    return `~${formatCompactNumber(remaining)} to auto-compact`;
 }
 
 // ── Props ──────────────────────────────────────────────────────────────────
@@ -223,6 +246,16 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
         return `${formatCompactNumber(t)} / ${formatCompactNumber(w)}`;
     };
 
+    // Tier 3 — explicit countdown, visible inline (not hover-gated) once
+    // the fill level is worth calling out. null below the mid band, or
+    // whenever the window itself is unknown (nothing to count down from).
+    const ctxCountdownText = (): string | null => {
+        const t = props.contextTokens;
+        const w = props.contextWindow;
+        if (t == null || t <= 0 || w == null) return null;
+        return compactionCountdownText(t, w);
+    };
+
     // Only offer manual compaction for Claude (the only provider this has
     // been verified against — see onCompact's doc comment), only once
     // there's something to compact, and not while a turn is already in
@@ -302,6 +335,15 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                         }
                     >
                         {ctxText()}
+                    </span>
+                </Show>
+                <Show when={ctxCountdownText()}>
+                    <span
+                        class={`agent-composer-strip-ctx-countdown ${ctxClass()}`}
+                        classList={{ "agent-composer-strip-ctx-countdown--critical": ctxClass().endsWith("critical") }}
+                        title="Applies to auto-compaction only — a manual /compact can happen at any fill level."
+                    >
+                        {ctxCountdownText()}
                     </span>
                 </Show>
                 <Show when={props.providerId === "claude" && props.onCompact != null && ctxText() != null}>

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -488,6 +488,32 @@
     50%       { opacity: 0.4; }
 }
 
+// Tier 3 countdown text ("~4.2k to auto-compact") — reuses
+// `.agent-composer-strip-ctx--{band}`'s own color-band classes for the
+// same coloring (deliberately, so the countdown text and the raw context
+// text always agree on color without duplicating the band→color mapping);
+// this block adds only what's specific to the countdown span itself.
+.agent-composer-strip-ctx-countdown {
+    font-family: var(--termfontfamily, monospace);
+    font-size: 10px;
+    white-space: nowrap;
+    opacity: 0.8;
+
+    // Proactive escalation once the critical band is crossed (spec §7 Tier
+    // 3) — bold weight + a leading warning glyph, layered on top of the
+    // pulse animation `.agent-composer-strip-ctx--critical` already
+    // applies (reused above), rather than a separate full-width banner
+    // element that would need its own container-query wiring in this
+    // already-fragile tiered-wrap layout (see file header comment).
+    &--critical {
+        font-weight: 600;
+
+        &::before {
+            content: "⚠ ";
+        }
+    }
+}
+
 // Logged-in/out tag — sits between the context text and the Shell toggle.
 // Simple dot + label, same neutral-chrome-with-a-color-accent treatment as
 // the process badge above rather than a loud filled pill, so it doesn't


### PR DESCRIPTION
## Summary
- Ships Tier 3 of `SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md` §7 — the last documented gap here was presentation, not data: `compactionThreshold(contextWindow) - currentTokens` was already computable every turn, but only visible as a number behind a hover tooltip.
- `AgentComposerStrip.tsx` now shows explicit inline countdown text (`~4.2k to auto-compact`) next to the existing context readout, once the fill level reaches the `mid` band or above.
- Escalates at the `critical` band with a bold weight + leading `⚠` glyph, layered on the band's existing pulsing red color — considered and deliberately skipped a new standalone banner component (like `AgentDisconnectedBanner.tsx`) to avoid destabilizing this strip's already-fragile, hand-tuned tiered-wrap responsive layout (its own file header calls this out).
- Labeled everywhere (inline tooltip + main context tooltip) as predicting **auto-compaction only** — a manual `/compact` can happen at any fill level and isn't predicted by this.

## Test plan
- [x] New `AgentComposerStrip.test.tsx` (7 tests): band gating (silent below mid), correct remaining-token math, critical-band escalation class, zero-clamp past the threshold, tooltip wording.
- [x] Proved test discrimination: stubbed `compactionCountdownText` to always return `null`, confirmed 4 of 7 tests fail with the expected signature, restored, confirmed clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 2933 passed, 1 pre-existing unrelated timeout flake (passes in isolation), 21 unrelated pre-existing failures from an untracked `amramebgi/` scratch directory's missing `joi` dependency (not touched by this change).

<!-- agentmux:agent_id=agent1 -->