### PR TITLE
feat(browser-pane): add global bookmarks + icon Go button

### DIFF
--- a/.changesets/1787423206-feat-browser-pane-add-global-bookmarks-icon-go-button-wtuj.md
+++ b/.changesets/1787423206-feat-browser-pane-add-global-bookmarks-icon-go-button-wtuj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(browser-pane): add global bookmarks + icon Go button

--- a/agentmux-srv/src/backend/bookmarks_store.rs
+++ b/agentmux-srv/src/backend/bookmarks_store.rs
@@ -1,0 +1,172 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Browser-pane bookmarks — a flat list of saved URLs, deliberately stored
+//! under `shared_dir` (`~/.agentmux/shared/browser-bookmarks.json`) rather
+//! than `settings.json`. `settings.json` isolation is whole-file only (see
+//! `docs/specs/SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19.md` §6 — per-key
+//! tiering was considered and rejected there), so a key inside it can't stay
+//! global while the rest of the file is channel-isolated. `shared_dir` is
+//! this codebase's existing mechanism for data that must always be global
+//! regardless of channel/isolation flags — the same directory already backs
+//! the agent registry, transcripts, and `provider_auth_dir()`. See
+//! `docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// One saved bookmark. `favicon_url` and `created_at` are best-effort —
+/// absent on any record written before a field was added, so both default
+/// on deserialize rather than failing the whole list over one old entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BrowserBookmark {
+    pub id: String,
+    pub title: String,
+    pub url: String,
+    #[serde(default)]
+    pub favicon_url: String,
+    #[serde(default)]
+    pub created_at: i64,
+}
+
+const BOOKMARKS_FILE_NAME: &str = "browser-bookmarks.json";
+
+/// Resolves the shared, cross-channel bookmarks file path. Returns `None`
+/// when `DataPaths` can't resolve (CI / unusual env) — mirrors
+/// `providers_handlers.rs`'s own `DataPaths::from_env()` best-effort
+/// fallback, so callers stay best-effort too rather than erroring the whole
+/// nav bar over an environment that never has this info anyway.
+pub fn bookmarks_file_path() -> Option<PathBuf> {
+    agentmux_common::DataPaths::from_env().map(|p| p.shared_dir.join(BOOKMARKS_FILE_NAME))
+}
+
+/// Read the bookmarks list. A missing file is "no bookmarks yet", not an
+/// error — every fresh install/environment starts here. A present-but-
+/// unparseable file IS an error: silently resetting to an empty list would
+/// look exactly like the user's saved bookmarks vanished, so this fails
+/// loud instead (matches this codebase's general preference for warning
+/// over silent data loss, e.g. the ABF import path's warning-budget
+/// conventions).
+pub fn read_bookmarks(path: &Path) -> Result<Vec<BrowserBookmark>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| format!("read bookmarks: {e}"))?;
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str(&content).map_err(|e| format!("parse bookmarks: {e}"))
+}
+
+/// Write the whole bookmarks list, replacing whatever was there before —
+/// the same wholesale-replace shape as `widget:pinned`'s `SetConfigCommand`
+/// convention, just pointed at this dedicated file instead of
+/// `settings.json`. Writes to a per-call unique temp file then renames over
+/// the real path, so a crash or concurrent write never leaves a
+/// half-written, corrupt `browser-bookmarks.json` behind (mirrors the
+/// tmp-then-rename pattern used for native-memory file writes in
+/// `bundle_import_for_agent_impl`). Two windows writing at the same instant
+/// still race at the whole-file level — last write wins, no merge — an
+/// accepted limitation, not something this function tries to solve.
+pub fn write_bookmarks(path: &Path, bookmarks: &[BrowserBookmark]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+    }
+    let json = serde_json::to_string_pretty(bookmarks).map_err(|e| format!("serialize bookmarks: {e}"))?;
+    let tmp = path.with_file_name(format!(
+        ".{BOOKMARKS_FILE_NAME}.{}.tmp",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::write(&tmp, &json).map_err(|e| format!("write bookmarks: {e}"))?;
+    std::fs::rename(&tmp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename bookmarks: {e}")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bookmark(id: &str, url: &str) -> BrowserBookmark {
+        BrowserBookmark {
+            id: id.to_string(),
+            title: format!("Title for {id}"),
+            url: url.to_string(),
+            favicon_url: String::new(),
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn missing_file_reads_as_empty_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(BOOKMARKS_FILE_NAME);
+        assert_eq!(read_bookmarks(&path).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn empty_file_reads_as_empty_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(BOOKMARKS_FILE_NAME);
+        std::fs::write(&path, "").unwrap();
+        assert_eq!(read_bookmarks(&path).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(BOOKMARKS_FILE_NAME);
+        let bookmarks = vec![
+            bookmark("b1", "https://example.com"),
+            bookmark("b2", "https://agentmux.ai"),
+        ];
+        write_bookmarks(&path, &bookmarks).unwrap();
+        assert_eq!(read_bookmarks(&path).unwrap(), bookmarks);
+    }
+
+    #[test]
+    fn write_creates_missing_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join(BOOKMARKS_FILE_NAME);
+        write_bookmarks(&path, &[bookmark("b1", "https://example.com")]).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn write_overwrites_a_previous_list_wholesale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(BOOKMARKS_FILE_NAME);
+        write_bookmarks(&path, &[bookmark("b1", "https://example.com")]).unwrap();
+        write_bookmarks(&path, &[bookmark("b2", "https://agentmux.ai")]).unwrap();
+        assert_eq!(read_bookmarks(&path).unwrap(), vec![bookmark("b2", "https://agentmux.ai")]);
+    }
+
+    #[test]
+    fn corrupt_json_fails_loud_instead_of_silently_resetting_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(BOOKMARKS_FILE_NAME);
+        std::fs::write(&path, "{not valid json").unwrap();
+        let err = read_bookmarks(&path).unwrap_err();
+        assert!(err.contains("parse bookmarks"));
+    }
+
+    #[test]
+    fn old_record_missing_favicon_and_created_at_still_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(BOOKMARKS_FILE_NAME);
+        std::fs::write(&path, r#"[{"id":"b1","title":"T","url":"https://example.com"}]"#).unwrap();
+        let bookmarks = read_bookmarks(&path).unwrap();
+        assert_eq!(
+            bookmarks,
+            vec![BrowserBookmark {
+                id: "b1".to_string(),
+                title: "T".to_string(),
+                url: "https://example.com".to_string(),
+                favicon_url: String::new(),
+                created_at: 0,
+            }]
+        );
+    }
+}

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -6,6 +6,7 @@ pub mod agent_color;
 pub mod agent_config;
 pub mod agent_session;
 pub mod blockcontroller;
+pub mod bookmarks_store;
 pub mod bundle_export;
 pub mod bundle_import;
 pub mod bundle_validate;

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -395,6 +395,11 @@ pub const COMMAND_MEMORY_LIST: &str = "memory.list";
 pub const COMMAND_MEMORY_READ: &str = "memory.read";
 pub const COMMAND_MEMORY_WRITE: &str = "memory.write";
 
+// Browser-pane bookmarks — a global (shared_dir-backed, not settings.json)
+// flat list. See docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md.
+pub const COMMAND_BOOKMARKS_LIST: &str = "bookmarks.list";
+pub const COMMAND_BOOKMARKS_SET: &str = "bookmarks.set";
+
 // App API — v1 standalone Skill primitives
 pub const COMMAND_SKILL_LIST: &str = "skill.list";
 pub const COMMAND_SKILL_GET: &str = "skill.get";

--- a/agentmux-srv/src/server/app_api/bookmarks.rs
+++ b/agentmux-srv/src/server/app_api/bookmarks.rs
@@ -1,0 +1,98 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `bookmarks.list` / `bookmarks.set` — the browser pane's saved-URL list.
+//! Deliberately a thin wrapper over `backend::bookmarks_store`: no `Store`/
+//! sqlite involvement, no per-agent scoping — see
+//! `docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md` for why
+//! this is a dedicated `shared_dir` file instead of the ABF/`db_bundles`
+//! pattern the rest of this directory mostly follows.
+
+use super::*;
+use crate::backend::bookmarks_store::{self, BrowserBookmark};
+
+pub fn register(engine: &Arc<WshRpcEngine>, _state: &AppState) {
+    register_bookmarks_list(engine);
+    register_bookmarks_set(engine);
+}
+
+/// `None` from `bookmarks_file_path()` means `DataPaths` couldn't resolve
+/// (unusual/CI env, same fallback `providers_handlers.rs` already accepts
+/// for `provider_auth_dir()`) — best-effort empty list rather than an RPC
+/// error, so a missing data-dir environment doesn't break the whole nav bar.
+fn bookmarks_list_impl() -> Result<Vec<BrowserBookmark>, String> {
+    let Some(path) = bookmarks_store::bookmarks_file_path() else {
+        return Ok(Vec::new());
+    };
+    bookmarks_store::read_bookmarks(&path)
+}
+
+fn register_bookmarks_list(engine: &Arc<WshRpcEngine>) {
+    engine.register_handler(
+        COMMAND_BOOKMARKS_LIST,
+        Box::new(move |_data, _ctx| {
+            Box::pin(async move {
+                let bookmarks = bookmarks_list_impl()?;
+                Ok(Some(json!({ "bookmarks": bookmarks })))
+            })
+        }),
+    );
+}
+
+#[derive(serde::Deserialize)]
+struct BookmarksSetReq {
+    bookmarks: Vec<BrowserBookmark>,
+}
+
+fn register_bookmarks_set(engine: &Arc<WshRpcEngine>) {
+    engine.register_handler(
+        COMMAND_BOOKMARKS_SET,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let req: BookmarksSetReq = serde_json::from_value(data)
+                    .map_err(|e| format!("bookmarks.set: {e}"))?;
+                // Unlike bookmarks.list's best-effort empty fallback, a SET
+                // with nowhere to durably land must fail loudly — silently
+                // no-oping here would tell the caller a bookmark was saved
+                // when it wasn't (see the spec's "shared_dir can't be
+                // resolved" unhappy-path entry).
+                let path = bookmarks_store::bookmarks_file_path()
+                    .ok_or_else(|| "bookmarks.set: could not resolve the shared data directory".to_string())?;
+                bookmarks_store::write_bookmarks(&path, &req.bookmarks)?;
+                Ok(Some(json!({ "bookmarks": req.bookmarks })))
+            })
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_req_deserializes_a_bookmarks_array() {
+        let data = json!({
+            "bookmarks": [
+                {"id": "b1", "title": "T", "url": "https://example.com"}
+            ]
+        });
+        let req: BookmarksSetReq = serde_json::from_value(data).unwrap();
+        assert_eq!(
+            req.bookmarks,
+            vec![BrowserBookmark {
+                id: "b1".to_string(),
+                title: "T".to_string(),
+                url: "https://example.com".to_string(),
+                favicon_url: String::new(),
+                created_at: 0,
+            }]
+        );
+    }
+
+    #[test]
+    fn set_req_rejects_missing_bookmarks_field() {
+        let data = json!({});
+        let result: Result<BookmarksSetReq, _> = serde_json::from_value(data);
+        assert!(result.is_err());
+    }
+}

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -41,6 +41,7 @@ mod bundle;
 mod memory;
 mod skill;
 mod mcp;
+mod bookmarks;
 pub(crate) mod fleet;
 
 /// Register all App API handlers on the RPC engine.
@@ -56,6 +57,7 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     memory::register(engine, state);
     skill::register(engine, state);
     mcp::register(engine, state);
+    bookmarks::register(engine, state);
     fleet::register(engine, state);
 }
 

--- a/docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md
+++ b/docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md
@@ -1,0 +1,343 @@
+# SPEC — Browser pane: bookmarks (design exploration) + Go-button icon (quick tweak)
+
+**Date:** 2026-08-22
+**Type:** Two asks bundled in one doc — (1) a small presentational fix, ready to
+implement; (2) a design exploration for a bigger feature, **not yet approved
+for implementation**.
+**Status:** Draft
+**Scope:** `frontend/app/view/browser/` (nav bar, view model), `frontend/app/store/browser-pane-state/`, potentially `settings.json`/`agentmux-srv` config plumbing for part 2.
+
+---
+
+## Part 1 — Replace the "Go" text button with an icon (ready to implement)
+
+### Current state
+
+`BrowserNavBar` (`frontend/app/view/browser/browser-nav-bar.tsx:117-193`) renders
+four controls: Back (`←`), Forward (`→`), Reload (`↻`) — all single-glyph,
+icon-only, with a `title=` tooltip for accessibility — and then a text-labeled
+`Go` button (line 190):
+
+```tsx
+<button class="browser-nav-btn browser-go-btn" onClick={handleNavigate}>Go</button>
+```
+
+This is already the outlier in its own row: three icon buttons and one text
+button. `browser-view.scss:54-58` gives it bespoke sizing (`width: auto; padding: 0 10px`)
+that the other three buttons don't need (fixed 28×28, `browser-view.scss:31-52`).
+
+The app's general icon convention is FontAwesome via a shared helper
+(`clsx(\`fa fa-solid fa-${icon}\`, ...)`, `frontend/util/util.ts:60`), used
+throughout menus, the command palette, file tree, etc. Back/Forward/Reload
+predate that convention and use raw Unicode glyphs instead — not a pattern
+worth extending, just a pre-existing inconsistency. FontAwesome's CSS is
+already bundled (`public/fontawesome/css/fontawesome.min.css`), so using it
+here costs nothing new.
+
+### What icon
+
+The address bar in this app is an omnibox, not a pure search box:
+`handleNavigate` (`browser-nav-bar.tsx:55-80`) and `BrowserViewModel.navigate`
+(`browser-model.ts:540-568`) both treat the input as a URL when it looks like
+one and fall back to a Google search only otherwise. Icon research (NN/g and
+general UI-icon guidance) draws a consistent line between the two available
+metaphors: a magnifying glass signals "search," an arrow signals "navigate /
+submit to a destination." Since navigation is the primary action here even
+in the search-fallback case, an arrow reads correctly in both cases and a
+magnifying glass would mis-set expectations for the common URL case.
+
+**Recommendation:** `fa-solid fa-arrow-right` (a plain right-pointing arrow).
+Keep `title="Go"` (or `"Navigate"`) on the button — icon-only affordances
+need a discoverable label for users who haven't memorized the icon yet, and
+this repo's own Back/Forward/Reload already establish `title=` as the
+convention for exactly that.
+
+### Change
+
+- `browser-nav-bar.tsx:190`: swap the text child for an `<i class="fa fa-solid fa-arrow-right" />`, add `title="Go"`.
+- `browser-view.scss:54-58` (`.browser-go-btn`): drop the `width: auto; padding: 0 10px; font-size: 12px` overrides so it falls back to the shared 28×28 `.browser-nav-btn` sizing, matching the other three buttons.
+
+### Risk
+
+Presentational only — no model/state/IPC changes. Safe as a standalone, tiny
+PR, independent of Part 2 below.
+
+---
+
+## Part 2 — Bookmarks (exploration only — not a commitment to build)
+
+### Why this section is "explore," not "build"
+
+This exact repo already tried a bookmark feature once and removed it —
+`docs/specs/SPEC_REMOVE_BOOKMARKS_2026_06_11.md` (2026-06-11), a "bookmark
+this message" feature in the agent-pane feed. It was deleted for two
+reasons: (1) it hijacked a right-click surface users expected to show the
+standard pane context menu (split/float/close), silently hiding those
+actions; (2) actual usage never justified the added surface area (a panel,
+a hook, a keyboard shortcut, a per-row visual indicator, all for one
+feature). That was a different kind of bookmark (annotating a chat message,
+not saving a URL) so the lesson isn't "don't build bookmarks" — it's
+**don't take over an existing interaction surface, and start at the
+smallest useful surface area, not the fullest one.** Both constraints shape
+the proposal below.
+
+### Relevant current architecture
+
+- **The nav bar is real DOM**; the page content area is not. Per
+  `docs/specs/SPEC_NATIVE_BROWSER_PANE_2026_04_17.md`, a browser pane's
+  content is a native `CefBrowserView` overlay, not a DOM subtree — that's
+  why right-clicking *inside a page* still shows Chromium's own native menu
+  today (`docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md`
+  is a still-unimplemented Draft proposing to fix that). A bookmark toggle
+  belongs in the nav bar, which is ordinary DOM (`browser-nav-bar.tsx`) —
+  no native-overlay complications, unlike anything scoped to page content.
+- **`showControlsAtom`** (`browser-model.ts:355`) hides the entire nav bar
+  for widget-style panes — `agentmux-srv/src/config/widgets.json` sets
+  `"browser:show_controls": false` for the Discord/Slack/Telegram/WhatsApp
+  widgets (lines ~139-188). A bookmark button must respect the same flag:
+  no bookmark UI on those panes, consistent with hiding back/forward/reload
+  there today.
+- **Multi-tab state already exists in the reducer** but not yet in the UI.
+  `frontend/app/store/browser-pane-state/types.ts` defines a full
+  `BrowserTab` (`url`, `title`, `faviconUrl`, per-tab loading/history state)
+  and the reducer already handles `OpenTab`/`CloseTab`/`SwitchTab`/etc. —
+  but `browser-view.tsx` renders no tab strip yet (per comments in
+  `browser-model.ts`, e.g. "Phase 1A: diagnostic-only... Phase 1B's tab
+  strip lands..."). Practically: today one pane = one URL, so a bookmark
+  button can read `model.urlAtom()` / `model.titleAtom()` /
+  `model.faviconUrlAtom()` directly. Building it against the model's
+  existing accessors (rather than something pane-global) means it keeps
+  working unchanged once a tab strip ships and "current URL" becomes
+  per-active-tab.
+- **`recentlyClosed`** (`browser-pane-state/types.ts:88-93`,
+  `{url, title, closedAt}`, capped at 10) is the closest existing shape to a
+  bookmark record, but it's per-pane, in-memory reducer state — it disappears
+  on pane close and was never meant to be shared globally. Confirms bookmarks
+  need their own, separate, global store — nothing existing already covers it.
+
+### Where would bookmarks live? (persistence — the key open decision)
+
+**`settings.json` is the wrong home, on reflection.** It was the first
+instinct (see the now-superseded settings-blob option below) because it's
+the lightest-weight precedent for "an ordered list of small records," via
+`"widget:pinned"` (`frontend/app/window/action-widgets-config.ts:37,109`,
+written through the generic `RpcApi.SetConfigCommand`). But `settings.json`
+isolation is **whole-file, not per-key** — per
+`docs/specs/SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19.md` §6, per-key
+tiering ("some settings global, some isolated") was explicitly considered
+and rejected: *"the whole-file isolation the auth precedent uses is
+simpler, has no 'did we remember to list this key' failure mode."* There is
+no supported way to make one key in `settings.json` behave differently from
+the rest of the file. Since we specifically want bookmarks to stay global
+(including on `dev-<branch>`/`local-*` channels, for a usable dev
+experience — losing your bookmark list every time you `task dev` a new
+branch defeats the point of the feature), putting them in `settings.json`
+means fighting the file's own design principle, not using it.
+
+**Better fit: `shared_dir` — the mechanism this codebase already uses for
+"must always be global, regardless of channel."** `DataPaths.shared_dir`
+(`agentmux-common/src/data_paths.rs:122,215`, resolved once as
+`root.join("shared")`, exported as `AGENTMUX_SHARED_DIR`) sits as a
+**sibling** of `channels/`/`dev/`/`versions/` — no channel switch or
+isolation flag touches it, because it isn't reached through
+`instance_dir`/`config_dir` at all. This is exactly what already backs the
+things in this app that are deliberately global no matter what channel or
+isolation setting is active:
+
+- Agent registry — `~/.agentmux/shared/agents/registry/<uuid>.json` (`docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`)
+- Conversation transcripts (same doc)
+- Provider auth — `provider_auth_dir()` (`data_paths.rs:445`, `shared_dir.join("providers").join(...)`) — CLAUDE.md notes this "always resolves auth... regardless of isolation," the same guarantee bookmarks want
+
+**Recommendation:** store bookmarks as their own small file under
+`shared_dir` — e.g. `~/.agentmux/shared/browser-bookmarks.json`, a flat JSON
+array of `{id, title, url, faviconUrl}` — resolved independently of
+`resolve_settings_dir()`/channel logic entirely, not a `settings.json` key.
+Concretely this needs: a tiny new read/write helper (mirrors
+`provider_auth_dir()`'s shape, not a full sqlite migration), and either (a)
+a couple of new RPC commands (`bookmarks.list`/`bookmarks.set`, following
+the same thin-wrapper shape as `bundle.rs`'s registration but pointed at
+this file instead of `db_bundles`), or (b) — if the generic config RPC can
+be taught to accept a path override — reusing `SetConfigCommand`'s wire
+shape but not its storage target. Either way it's still much lighter than
+the ABF/`db_bundles` route (no migration, no versioned table, no
+import/export machinery) while actually satisfying "global including
+during dev," which the settings-blob route cannot.
+
+The ABF/`db_bundles` route (full sqlite table + migration + `Store` methods
++ dedicated RPC file, e.g. `agentmux-srv/src/backend/storage/migrations.rs:1290`,
+`memory_bundles.rs`, `app_api/bundle.rs`) remains the fallback if bookmarks
+later grow folders/nesting, per-record versioning, or import/export — not
+needed for v1.
+
+One thing to flag explicitly: `shared_dir`-backed bookmarks would be global
+on **every** channel, including `stable` — there's no "global in dev, still
+somehow scoped in prod" middle ground in this mechanism, any more than
+provider auth has one. That matches what a personal bookmark list should
+probably do anyway (nobody wants a separate bookmark set per release
+channel), but it's worth confirming that's the intended behavior, not an
+accidental side effect of picking this mechanism.
+
+### Proposed UI (v1 scope, if approved)
+
+**One button, one menu — not a separate star + dropdown.** A single
+bookmarks button sits in `browser-nav-bar.tsx` between Reload and the
+address bar (`browser-nav-bar.tsx:132-136`, right before the `<input
+class="browser-address-bar">` at line 137). Clicking it opens a menu
+containing:
+
+1. A pinned first row — "★ Bookmark this page" / "★ Remove bookmark"
+   (label/state flips based on whether the active tab's URL is already
+   saved) — acting on `model.urlAtom()`/`titleAtom()`/`faviconUrlAtom()`.
+2. A separator, then every saved bookmark as a menu item (favicon → icon,
+   title → label, click → `model.navigate(url)` + close the menu).
+
+**Reuse `FlyoutMenu` directly — do not build a new menu component.**
+`frontend/app/element/flyoutmenu.tsx` is the same primitive already behind
+the hamburger menu, the widget bar's "More" dropdown, and right-click
+context menus, so using it here is a DRY win, not just a style match:
+
+- Its `MenuItem` shape (`frontend/types/custom.d.ts:463-477`) already
+  supports `icon`, `label`, `onClick`, `divider` (for the separator above),
+  and `checked` (could show a check/star state on the pinned first row) —
+  no new prop shape to invent.
+- **"Expands to the bottom of the window, then scrolls" is already built
+  in, not something to implement.** `FlyoutMenu`'s positioning goes through
+  `computeMenuPosition` (`frontend/app/util/menu-position.ts:228-296`),
+  whose `size()` middleware measures `availableHeight` down to the window's
+  paintable-area boundary and returns it as `maxHeight`
+  (`menu-position.ts:279`); `styleToString`
+  (`frontend/app/element/flyoutmenu.tsx:38-44`) applies that as
+  `max-height:${maxHeight}px; overflow-y:auto` on the menu's own root. Every
+  existing `FlyoutMenu` consumer already gets "grow until it hits the
+  window edge, then scroll internally" for free — the bookmarks menu needs
+  zero new positioning/scrolling code, only a long-enough item list to
+  actually exercise it.
+- Horizontal overflow (menu opened near the window's right edge) and
+  avoiding native browser-pane overlays are likewise already handled by the
+  same `flip()`/`shift()`/`avoidNativePanes` machinery every other
+  `FlyoutMenu` menu gets (`menu-position.ts`, `flyoutmenu.tsx:100-111`) —
+  nothing bookmarks-specific to add there either.
+
+**No folders, tags, or import/export in v1.** A flat, most-recent-first (or
+manually reorderable) list. This deliberately avoids the classic
+"bookmarks bar overflows after ~10 items" trap current browser-UX critiques
+call out (a flat scrollable dropdown — see above — scales considerably
+further before folders become necessary) and avoids re-adding the
+surface-area-without-proven-value problem the removed feature ran into.
+`MenuItem.subItems` (nested submenus) stays available on the type if
+folders are ever added later, but nothing in v1 uses it.
+
+**Respect `showControlsAtom`** — no bookmark button at all on widget-style
+panes (Discord/Slack/Telegram/WhatsApp), matching existing nav-bar
+visibility for back/forward/reload/address-bar.
+
+### Unhappy paths
+
+Explicitly worked through per-scenario, since "reuse the existing menu"
+answers the layout/scrolling questions but not the data/state ones:
+
+| Scenario | Behavior |
+|---|---|
+| **Zero bookmarks saved** | Menu opens with just the pinned "Bookmark this page" row and no separator/list below it (an empty list under a separator would read as a rendering glitch, not "you have none yet") — show a muted "No bookmarks yet" row instead of an empty gap. |
+| **Hundreds of bookmarks** | `FlyoutMenu`'s internal scroll (above) keeps the menu usable, but a plain scroll through hundreds of unfiltered rows is a real UX cliff — out of scope for v1 (flat list is the explicit v1 boundary), but worth a documented threshold: if usage data shows this happening, the next increment is a filter/search input pinned above the scrollable list, not folders. |
+| **Bookmarking the same URL twice** | Toggle, not append-only: the pinned row's click handler checks whether the active URL already has an entry (by exact URL match) and removes it instead of inserting a duplicate. Prevents an ever-growing list of identical entries from repeated toggling. |
+| **Very long title or URL** | Menu items must truncate with an ellipsis (existing `.menu-item .label` CSS likely already does this for other long menu labels — verify, don't assume, during implementation) rather than wrapping and blowing out the fixed-width menu. |
+| **Favicon fails to load / bookmark predates a favicon** | Fall back to the existing globe icon convention already used elsewhere in the browser pane (`viewIcon = () => "globe"`, `browser-model.ts:89`) — never a broken-image glyph in the menu. |
+| **Two windows/panes editing bookmarks concurrently** | v1 has no live cross-window sync (see persistence section — no wave-event broadcast, matching `MemoryViewModel`'s and `GlobalBrainViewModel`'s existing "does not subscribe... the manager is the only writer in practice" precedent). A menu opened before another window's edit lands shows a stale snapshot until closed and reopened. Acceptable for personal-bookmark scope; flagged here rather than silently assumed away. |
+| **Two windows write at the exact same instant** | Last write wins (whole-file overwrite, no merge) — the earlier window's edit can be silently lost. Same accepted risk class as any other single-JSON-file store in this app; not solved by this feature, just inherited. |
+| **`shared_dir` can't be resolved** (unusual/CI environment, per `providers_handlers.rs`'s own `DataPaths::from_env()` fallback precedent) | `bookmarks.list` returns an empty list rather than erroring the whole nav bar; the bookmark-toggle action should visibly fail (e.g. a toast/error, not a silent no-op) so the user isn't left thinking their bookmark saved when it didn't. |
+| **Bookmarks file exists but is corrupt/unparseable JSON** | Fail loud on `bookmarks.list` (surface the parse error) rather than silently discarding the user's saved list — matches this codebase's general preference for warning over silent data loss (e.g. the ABF import path's warning-budget conventions) over quietly resetting to empty, which would look like the data vanished. |
+| **Active tab has no URL yet** (blank/fresh pane) | Originally planned as "disabled, not hidden" — reverted during implementation once it turned out `MenuItem` has no `disabled` field at all. The row is omitted entirely in this case instead (falls back to "No bookmarks yet" if the list is also empty); rare and brief in practice since panes navigate to `DEFAULT_BROWSER_URL` almost immediately. |
+| **Menu open, then the pane itself closes/navigates away underneath it** | `FlyoutMenu`'s existing outside-click-to-close (`flyoutmenu.tsx:126-133`) and Solid's unmount-on-dispose already tear the menu down; no bookmarks-specific handling needed, but worth a manual check during implementation since this menu is anchored inside a per-pane component, unlike the window-global hamburger menu. |
+| **Keyboard-only user** | `FlyoutMenu` itself has no `Escape`-to-close handler today (only outside-click) — confirmed by grepping for `Escape` handling in `frontend/app/element/`, which turns up `modal.tsx` and `popover-menu.tsx` but not `flyoutmenu.tsx`. This is a pre-existing gap shared by every current `FlyoutMenu` consumer (hamburger menu, widget bar, context menus) — not something to silently fix as a side effect of adding bookmarks, but worth flagging explicitly since a keyboard user has no way to dismiss this menu without a mouse click today. Candidate follow-up, not a v1 blocker.
+
+### Non-goals for v1 (explicitly out of scope)
+
+- Folders/tags — defer until a flat list is demonstrably insufficient.
+- Import/export (e.g. Chrome bookmarks HTML).
+- Cross-device sync via muxbus — no existing channel carries user data like
+  this today; out of scope until one does.
+- Bookmarking inside the widget-style chat panes (Discord/Slack/etc.) — nav
+  chrome is hidden there by design.
+
+### Sequencing
+
+**Status: both parts implemented (2026-08-22).** `cargo test -p agentmux-srv`
+(2647 tests) and the frontend `vitest` suite (2855+ tests, plus a clean
+`tsc --noEmit`) pass. Not yet manually verified in a running app (`task
+dev` + clicking through the feature) — typecheck/unit-test coverage only.
+
+1. ~~Ship Part 1 (Go-button icon).~~ Done —
+   `frontend/app/view/browser/browser-nav-bar.tsx`,
+   `frontend/app/view/browser/browser-view.scss`.
+2. ~~Backend: `~/.agentmux/shared/browser-bookmarks.json` read/write helper
+   + `bookmarks.list`/`bookmarks.set` RPC commands.~~ Done —
+   `agentmux-srv/src/backend/bookmarks_store.rs`,
+   `agentmux-srv/src/server/app_api/bookmarks.rs`, constants in
+   `rpc_types/commands.rs`, registered in `app_api/mod.rs`.
+3. ~~Frontend: RPC wrapper, bookmarks button + `FlyoutMenu` wiring.~~ Done —
+   `frontend/app/store/rpc-api/bookmarks.ts`, spliced into `RpcApi`
+   (`rpc-api/index.ts`); toggle/dedupe logic extracted to the pure, unit-
+   tested `frontend/app/view/browser/browser-bookmarks-logic.ts`
+   (`toggleBookmark`/`findBookmark`); wired into `browser-nav-bar.tsx`.
+
+**Deviations from the plan above, decided during implementation:**
+
+- **No live favicon thumbnails in the menu.** `FlyoutMenu`'s default item
+  renderer only supports a FontAwesome icon-name string (`item.icon` is
+  typed `string | JSX.Element`, but `flyoutmenu.tsx`'s render only ever
+  treats it as a string — no existing consumer uses the `JSX.Element`
+  branch). Special-casing a real `<img>` favicon via `renderMenuItem` would
+  be new, unprecedented surface in a shared component for a cosmetic
+  upgrade — every bookmark row instead shows a plain `fa-bookmark` icon,
+  matching how every other menu in the app already renders. `favicon_url`
+  is still captured and stored on each record (harmless, forward-
+  compatible) — just not rendered as an image in v1.
+- **No per-row delete for a bookmark other than the current page.**
+  `MenuItem` has no secondary-action/trailing-button slot, and nesting a
+  submenu (`subItems: [Open, Remove]`) per row would replace "click to
+  navigate" with "hover to reveal, then click" as the primary interaction —
+  a worse tradeoff for the common case. v1 supports removing a bookmark
+  only by revisiting that URL and toggling it off again. A real, accepted
+  limitation for this pass — same "start smallest" discipline as the
+  no-folders decision above, not an oversight.
+- **No native "disabled" state for the pinned toggle row.** `MenuItem` has
+  no `disabled` field, so the originally-planned "Bookmark this page" row
+  is disabled-with-reason when the active tab has no URL yet — instead,
+  the row is omitted entirely in that case (falls back to "No bookmarks
+  yet" if the list is also empty). In practice this state is rare and
+  brief (every pane navigates to `DEFAULT_BROWSER_URL` almost immediately
+  after construction).
+- **Bookmark-save failures surface via the button itself** (a red icon
+  tint + the failure text in the button's `title` tooltip), not the page
+  error banner in `browser-view.tsx` — that banner is `model.errorAtom()`,
+  scoped to page-load failures and cleared on the next navigation; a
+  bookmark-save failure is a different lifecycle and would look wrong
+  riding along on it.
+
+---
+
+## References
+
+- `frontend/app/view/browser/browser-nav-bar.tsx`
+- `frontend/app/view/browser/browser-model.ts`
+- `frontend/app/view/browser/browser-view.scss`
+- `frontend/app/store/browser-pane-state/types.ts`
+- `frontend/app/window/action-widgets-config.ts` (`widget:pinned` precedent — superseded for this feature, see persistence section)
+- `frontend/app/element/flyoutmenu.tsx`, `frontend/app/element/popover-menu.tsx`
+- `frontend/app/util/menu-position.ts` (`computeMenuPosition` — the grow-to-window-edge-then-scroll primitive `FlyoutMenu` already uses)
+- `frontend/types/custom.d.ts` (`MenuItem` shape)
+- `frontend/util/util.ts` (FontAwesome icon-class helper)
+- `agentmux-srv/src/server/providers_handlers.rs` (`DataPaths::from_env()` best-effort fallback precedent)
+- `agentmux-srv/src/config/widgets.json`
+- `agentmux-common/src/data_paths.rs` (`shared_dir`/`AGENTMUX_SHARED_DIR`, `provider_auth_dir()` — the recommended persistence precedent)
+- `agentmux-srv/src/backend/storage/migrations.rs`, `memory_bundles.rs`,
+  `agentmux-srv/src/server/app_api/bundle.rs` (ABF/`db_bundles` — fallback route only)
+- `docs/specs/SPEC_REMOVE_BOOKMARKS_2026_06_11.md` (prior-art / lesson learned)
+- `docs/specs/SPEC_NATIVE_BROWSER_PANE_2026_04_17.md`
+- `docs/specs/SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md`
+- `docs/specs/SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19.md` (why settings.json doesn't fit — whole-file-only isolation, no per-key tiering)
+- `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` (`shared_dir` precedent for agent registry/transcripts)
+- Web research: NN/g on magnifying-glass-vs-label search affordances
+  (nngroup.com/articles/magnifying-glass-icon); browser bookmarks-bar UX
+  critique (bookmarker.cc/blog/browser-bookmark-bar-alternative)

--- a/frontend/app/store/rpc-api/bookmarks.ts
+++ b/frontend/app/store/rpc-api/bookmarks.ts
@@ -1,0 +1,31 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Browser pane bookmarks — a global (shared_dir-backed) flat list, not
+// per-agent or per-channel. See
+// docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md and
+// agentmux-srv/src/server/app_api/bookmarks.rs.
+
+import { RpcClient } from "../rpc-client";
+
+export const BookmarksApi = {
+    ListBookmarksCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<{ bookmarks: BrowserBookmark[] }> {
+        return client.rpcCall("bookmarks.list", data, opts);
+    },
+
+    /** Wholesale replace — same shape as `SetConfigCommand`'s
+     *  merge-the-whole-value convention, just against the dedicated
+     *  bookmarks file instead of settings.json. Callers read-modify-write
+     *  the full list (see the nav bar's toggle/add/remove logic). */
+    SetBookmarksCommand(
+        client: RpcClient,
+        data: { bookmarks: BrowserBookmark[] },
+        opts?: RpcOpts,
+    ): Promise<{ bookmarks: BrowserBookmark[] }> {
+        return client.rpcCall("bookmarks.set", data, opts);
+    },
+};

--- a/frontend/app/store/rpc-api/index.ts
+++ b/frontend/app/store/rpc-api/index.ts
@@ -13,6 +13,7 @@
 
 import { AgentApi } from "./agent";
 import { BlockApi } from "./block";
+import { BookmarksApi } from "./bookmarks";
 import { BundleImportApi } from "./bundle";
 import { FileApi } from "./file";
 import { FleetApi } from "./fleet";
@@ -49,4 +50,5 @@ export const RpcApi = {
     ...BundleImportApi,
     ...FleetApi,
     ...ReactiveApi,
+    ...BookmarksApi,
 };

--- a/frontend/app/view/browser/browser-bookmarks-logic.test.ts
+++ b/frontend/app/view/browser/browser-bookmarks-logic.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { findBookmark, toggleBookmark } from "./browser-bookmarks-logic";
+
+function bookmark(id: string, url: string, title = "T"): BrowserBookmark {
+    return { id, title, url, favicon_url: "", created_at: 0 };
+}
+
+describe("findBookmark", () => {
+    it("returns undefined for an empty list", () => {
+        expect(findBookmark([], "https://example.com")).toBeUndefined();
+    });
+
+    it("finds an exact URL match", () => {
+        const list = [bookmark("b1", "https://example.com")];
+        expect(findBookmark(list, "https://example.com")?.id).toBe("b1");
+    });
+
+    it("does not match a different URL", () => {
+        const list = [bookmark("b1", "https://example.com")];
+        expect(findBookmark(list, "https://example.com/other")).toBeUndefined();
+    });
+});
+
+describe("toggleBookmark", () => {
+    it("adds a new bookmark when the URL isn't already saved", () => {
+        const next = toggleBookmark([], {
+            url: "https://example.com",
+            title: "Example",
+            faviconUrl: "https://example.com/favicon.ico",
+            newId: () => "generated-id",
+            now: () => 1000,
+        });
+        expect(next).toEqual([
+            {
+                id: "generated-id",
+                title: "Example",
+                url: "https://example.com",
+                favicon_url: "https://example.com/favicon.ico",
+                created_at: 1000,
+            },
+        ]);
+    });
+
+    it("removes the existing bookmark when the URL is already saved (toggle off)", () => {
+        const existing = [bookmark("b1", "https://example.com"), bookmark("b2", "https://other.com")];
+        const next = toggleBookmark(existing, {
+            url: "https://example.com",
+            title: "Example",
+            faviconUrl: "",
+            newId: () => "unused",
+            now: () => 1000,
+        });
+        expect(next).toEqual([bookmark("b2", "https://other.com")]);
+    });
+
+    it("never produces two entries for the same URL (repeated toggling doesn't duplicate)", () => {
+        let list: BrowserBookmark[] = [];
+        const opts = { url: "https://example.com", title: "Example", faviconUrl: "", newId: () => "b1", now: () => 1000 };
+        list = toggleBookmark(list, opts); // add
+        list = toggleBookmark(list, opts); // remove
+        list = toggleBookmark(list, opts); // add again
+        expect(list.filter((b) => b.url === "https://example.com")).toHaveLength(1);
+    });
+
+    it("falls back to the URL as the title when no page title is available yet", () => {
+        const next = toggleBookmark([], {
+            url: "https://example.com",
+            title: "",
+            faviconUrl: "",
+            newId: () => "b1",
+            now: () => 1000,
+        });
+        expect(next[0].title).toBe("https://example.com");
+    });
+});

--- a/frontend/app/view/browser/browser-bookmarks-logic.ts
+++ b/frontend/app/view/browser/browser-bookmarks-logic.ts
@@ -1,0 +1,46 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Pure bookmark list transforms, extracted out of browser-nav-bar.tsx so
+// the toggle/dedupe logic is directly unit-testable without rendering the
+// Solid component. See
+// docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md.
+
+/** Exact-URL lookup — bookmarks are deduped by URL, not by id. */
+export function findBookmark(list: BrowserBookmark[], url: string): BrowserBookmark | undefined {
+    return list.find((b) => b.url === url);
+}
+
+export interface ToggleBookmarkInput {
+    url: string;
+    title: string;
+    faviconUrl: string;
+    /** Injected so this stays pure/testable — no direct crypto.randomUUID() call. */
+    newId: () => string;
+    /** Injected so this stays pure/testable — no direct Date.now() call. */
+    now: () => number;
+}
+
+/**
+ * Add-or-remove the given URL from the list, keyed by exact URL match so
+ * repeated toggling of the same page never produces duplicate entries
+ * (append-only would). Falls back to the URL itself as the title when no
+ * page title is available yet (e.g. toggled before the title-change event
+ * has landed).
+ */
+export function toggleBookmark(list: BrowserBookmark[], input: ToggleBookmarkInput): BrowserBookmark[] {
+    const existing = findBookmark(list, input.url);
+    if (existing) {
+        return list.filter((b) => b.id !== existing.id);
+    }
+    return [
+        ...list,
+        {
+            id: input.newId(),
+            title: input.title || input.url,
+            url: input.url,
+            favicon_url: input.faviconUrl,
+            created_at: input.now(),
+        },
+    ];
+}

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -56,6 +56,29 @@ export function BrowserNavBar(props: {
         if (modelUrl !== addressBar()) setAddressBar(modelUrl);
     });
 
+    // Shared tail of "actually go somewhere": update model + address-bar
+    // state AND drive the real native CEF pane (via IPC when the pane
+    // already exists, or by creating it for the first time). Extracted so
+    // the bookmark-click path (below) can't drift from the address-bar
+    // submit path the way it did before this was pulled out — a bookmark
+    // click used to call only `model.navigate()`, which updates reducer
+    // state/block-meta but never told the actual CEF pane to navigate, so
+    // the address bar changed while the displayed page didn't (reagentx/
+    // Codex review, PR #2730).
+    const navigateTo = (url: string) => {
+        model.navigate(url);
+        setAddressBar(url);
+
+        if (props.paneCreated()) {
+            invokeCommand("browser_pane_navigate", {
+                block_id: model.blockId,
+                url,
+            }).catch((e: any) => model.onError(`Navigation failed: ${e}`));
+        } else {
+            props.createPane(url);
+        }
+    };
+
     const handleNavigate = () => {
         const url = addressBar().trim();
         diag(`input-submit value=${JSON.stringify(url)}`);
@@ -70,17 +93,7 @@ export function BrowserNavBar(props: {
             }
         }
 
-        model.navigate(normalized);
-        setAddressBar(normalized);
-
-        if (props.paneCreated()) {
-            invokeCommand("browser_pane_navigate", {
-                block_id: model.blockId,
-                url: normalized,
-            }).catch((e: any) => model.onError(`Navigation failed: ${e}`));
-        } else {
-            props.createPane(normalized);
-        }
+        navigateTo(normalized);
     };
 
     const handleAddressKeyDown = (e: KeyboardEvent) => {
@@ -219,9 +232,7 @@ export function BrowserNavBar(props: {
                 items.push({
                     label: b.title || b.url,
                     icon: "bookmark",
-                    onClick: () => {
-                        model.navigate(b.url);
-                    },
+                    onClick: () => navigateTo(b.url),
                 });
             }
         } else if (items.length > 0) {

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -1,9 +1,13 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
+import { FlyoutMenu } from "@/app/element/flyoutmenu";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { findBookmark, toggleBookmark } from "./browser-bookmarks-logic";
 import type { BrowserViewModel } from "./browser-model";
 
 // Compact tag for an Element — used by diag log lines to identify the
@@ -114,6 +118,121 @@ export function BrowserNavBar(props: {
         onCleanup(() => unsub?.());
     });
 
+    // Browser pane bookmarks — a global (shared_dir-backed) flat list, NOT
+    // per-pane block meta. See
+    // docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md.
+    // Deliberately re-fetched on every menu open (not once on mount) rather
+    // than kept live via a wave-event subscription — matches this
+    // codebase's existing MemoryViewModel/GlobalBrainViewModel precedent
+    // ("does not subscribe... the manager is the only writer in
+    // practice"). A menu opened before another window's edit lands still
+    // shows a stale snapshot until closed and reopened — an accepted v1
+    // limitation, not something this component tries to solve.
+    const [bookmarks, setBookmarks] = createSignal<BrowserBookmark[]>([]);
+    const [bookmarksLoading, setBookmarksLoading] = createSignal(false);
+    const [bookmarksError, setBookmarksError] = createSignal<string | null>(null);
+
+    const loadBookmarks = async () => {
+        setBookmarksLoading(true);
+        setBookmarksError(null);
+        try {
+            const result = await RpcApi.ListBookmarksCommand(TabRpcClient);
+            setBookmarks(result.bookmarks ?? []);
+        } catch (e) {
+            setBookmarksError(`Failed to load bookmarks: ${(e as Error).message ?? e}`);
+        } finally {
+            setBookmarksLoading(false);
+        }
+    };
+
+    // Optimistic write with rollback — the menu already closed by the time
+    // this resolves (FlyoutMenu closes on any item click), so a failure
+    // needs its own visible surface rather than silently reopening the
+    // menu. `bookmarksError` surfaces via the bookmark button itself (title
+    // tooltip + a red icon tint, below) rather than the page-load error
+    // banner in browser-view.tsx — that banner is `model`'s own
+    // `errorAtom`/`LoadFailed` state for page navigation failures, a
+    // different concern that gets cleared on the next navigation; a
+    // bookmark-save failure shouldn't ride along on that lifecycle. See the
+    // spec's "shared_dir can't be resolved" unhappy path — a write that
+    // didn't land must not look like it succeeded.
+    const persistBookmarks = async (next: BrowserBookmark[]) => {
+        const previous = bookmarks();
+        setBookmarks(next);
+        try {
+            await RpcApi.SetBookmarksCommand(TabRpcClient, { bookmarks: next });
+        } catch (e) {
+            setBookmarks(previous);
+            setBookmarksError(`Failed to save bookmarks: ${(e as Error).message ?? e}`);
+        }
+    };
+
+    // Exact-URL match, not append-only — repeatedly toggling the same page
+    // must flip between saved/unsaved, never pile up duplicate entries.
+    // The actual add/remove decision is in the pure, directly-unit-tested
+    // browser-bookmarks-logic.ts (toggleBookmark/findBookmark) — this
+    // component only wires it to the model's live signals and the RPC.
+    const currentBookmark = createMemo(() => findBookmark(bookmarks(), model.urlAtom()));
+
+    const toggleCurrentBookmark = () => {
+        const url = model.urlAtom();
+        if (!url) return;
+        void persistBookmarks(
+            toggleBookmark(bookmarks(), {
+                url,
+                title: model.titleAtom(),
+                faviconUrl: model.faviconUrlAtom() ?? "",
+                newId: () => crypto.randomUUID(),
+                now: () => Date.now(),
+            }),
+        );
+    };
+
+    // FlyoutMenu — the same primitive behind the hamburger menu, the widget
+    // bar's "More" dropdown, and right-click context menus. Reusing it
+    // means the "grows to the bottom of the window, then scrolls
+    // internally" behavior (computeMenuPosition's size() middleware,
+    // frontend/app/util/menu-position.ts) and edge-flip/click-outside-close
+    // come for free — nothing bookmark-specific to build there. `icon`
+    // uses a plain FontAwesome name (consistent with every other menu item
+    // in the app) rather than a live per-site favicon image — FlyoutMenu's
+    // default item renderer only supports FA icon-name strings, and
+    // special-casing an `<img>` via `renderMenuItem` would be new,
+    // unprecedented surface in a shared component for a purely cosmetic
+    // upgrade, not worth it for v1.
+    const bookmarkMenuItems = createMemo<MenuItem[]>(() => {
+        if (bookmarksLoading()) {
+            return [{ label: "Loading…", icon: "spinner" }];
+        }
+        const items: MenuItem[] = [];
+        if (model.urlAtom()) {
+            items.push({
+                label: currentBookmark() ? "Remove Bookmark" : "Bookmark This Page",
+                icon: "star",
+                onClick: toggleCurrentBookmark,
+            });
+        }
+        const saved = bookmarks();
+        if (saved.length > 0) {
+            if (items.length > 0) items.push({ label: "", divider: true });
+            for (const b of saved) {
+                items.push({
+                    label: b.title || b.url,
+                    icon: "bookmark",
+                    onClick: () => {
+                        model.navigate(b.url);
+                    },
+                });
+            }
+        } else if (items.length > 0) {
+            items.push({ label: "", divider: true });
+            items.push({ label: "No bookmarks yet", icon: "bookmark" });
+        } else {
+            items.push({ label: "No bookmarks yet", icon: "bookmark" });
+        }
+        return items;
+    });
+
     return (
         <Show when={model.showControlsAtom()}>
             <div class="browser-nav-bar">
@@ -134,6 +253,24 @@ export function BrowserNavBar(props: {
                     onClick={() => invokeCommand("browser_pane_reload", { block_id: model.blockId }).catch(() => {})}
                     title="Reload"
                 >{"↻"}</button>
+                <FlyoutMenu
+                    items={bookmarkMenuItems()}
+                    placement="bottom-start"
+                    onOpenChange={(open) => {
+                        if (open) void loadBookmarks();
+                    }}
+                >
+                    <button
+                        class="browser-nav-btn"
+                        title={bookmarksError() ? `Bookmarks: ${bookmarksError()}` : "Bookmarks"}
+                    >
+                        <i
+                            class="fa fa-solid fa-bookmark"
+                            classList={{ "browser-bookmark-btn-error": !!bookmarksError() }}
+                            aria-hidden="true"
+                        />
+                    </button>
+                </FlyoutMenu>
                 <input
                     ref={addressInputRef}
                     class="browser-address-bar"
@@ -187,7 +324,9 @@ export function BrowserNavBar(props: {
                     }}
                     placeholder="Enter URL or search..."
                 />
-                <button class="browser-nav-btn browser-go-btn" onClick={handleNavigate}>Go</button>
+                <button class="browser-nav-btn browser-go-btn" onClick={handleNavigate} title="Go">
+                    <i class="fa fa-solid fa-arrow-right" aria-hidden="true" />
+                </button>
             </div>
         </Show>
     );

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -215,7 +215,17 @@ export function BrowserNavBar(props: {
     // upgrade, not worth it for v1.
     const bookmarkMenuItems = createMemo<MenuItem[]>(() => {
         if (bookmarksLoading()) {
-            return [{ label: "Loading…", icon: "spinner" }];
+            // No icon here (deliberately): FlyoutMenu's default item
+            // renderer only ever applies `fa-solid fa-fw fa-${item.icon}` —
+            // there's no way to also pair in `fa-spin` through that field,
+            // so a `fa-spinner` icon would render static/non-animating and
+            // look broken next to every other spinner in this codebase
+            // (which is always fa-spinner + fa-spin together, e.g.
+            // swarm-view.tsx:757, toolchain-view.tsx:322). A label-only row
+            // for this brief, local-file-read loading state is honest
+            // rather than a fake, non-spinning spinner (ReAgent re-review,
+            // PR #2730).
+            return [{ label: "Loading…" }];
         }
         const items: MenuItem[] = [];
         if (model.urlAtom()) {

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -51,10 +51,8 @@
     }
 }
 
-.browser-go-btn {
-    width: auto;
-    padding: 0 10px;
-    font-size: 12px;
+.browser-bookmark-btn-error {
+    color: var(--error-color, #e5484d);
 }
 
 .browser-address-bar {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -488,6 +488,19 @@ declare global {
         updated_at: number;
     };
 
+    // ── Browser pane bookmarks ───────────────────────────────────────────
+    // agentmux-srv/src/backend/bookmarks_store.rs — a global (shared_dir,
+    // NOT settings.json — see the spec for why) flat list, not per-agent
+    // or per-channel. See
+    // docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md.
+    type BrowserBookmark = {
+        id: string;
+        title: string;
+        url: string;
+        favicon_url?: string;
+        created_at?: number;
+    };
+
     // ── Armory Bundle Format (ABF) import, Phase 3 ──────────────────────
     // agentmux-srv/src/server/app_api/bundle.rs — bundle.import.preview /
     // bundle.import.commit. See docs/specs/SPEC_ABF_IMPORT_UI_PHASE3_2026_08_02.md.


### PR DESCRIPTION
## Summary
- Adds a bookmarks button to the browser pane nav bar (between Reload and the address bar), opening a `FlyoutMenu` (reusing the same menu primitive as the hamburger menu / widget bar / right-click menus) with a "Bookmark this page" toggle + the saved bookmark list.
- Bookmarks persist to a new, global (cross-channel) `~/.agentmux/shared/browser-bookmarks.json` file rather than `settings.json` — `settings.json` isolation is whole-file-only per `SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19`, so a key inside it can't stay global while the rest of the file is channel-isolated. `shared_dir` is this codebase's existing escape hatch for data that must always be global (agent registry, transcripts, provider auth) — reused here so bookmarks survive across `task dev` branches and local package builds instead of resetting per channel.
- Replaces the nav bar's text "Go" button with an icon-only `fa-arrow-right` button, matching the icon-only Back/Forward/Reload buttons already in the same row.

## Design doc
`docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md` — full analysis, prior-art (a previous message-bookmark feature was removed for scope-creep reasons, `SPEC_REMOVE_BOOKMARKS_2026_06_11`), persistence-mechanism tradeoffs, and a documented unhappy-paths table (empty list, corrupt file, concurrent writes, favicon-load failure, keyboard-only dismissal gap in `FlyoutMenu`, etc.).

## What's new
- `agentmux-srv/src/backend/bookmarks_store.rs` — atomic (tmp+rename) read/write of the shared bookmarks file; missing file → empty list, corrupt file → loud error (never silently discards).
- `agentmux-srv/src/server/app_api/bookmarks.rs` — `bookmarks.list` / `bookmarks.set` RPC handlers.
- `frontend/app/store/rpc-api/bookmarks.ts` — RPC wrapper, spliced into `RpcApi`.
- `frontend/app/view/browser/browser-bookmarks-logic.ts` — pure toggle/dedupe-by-URL logic, unit-tested independently of the Solid component.
- `frontend/app/view/browser/browser-nav-bar.tsx` — the bookmarks button + menu wiring, plus the Go-icon swap.

## Test plan
- [x] `cargo test -p agentmux-srv` — 2647 passed (includes new `bookmarks_store`/`app_api::bookmarks` unit tests)
- [x] `npx vitest run` — full frontend suite passes (one unrelated pre-existing flaky timeout in `tool-renderers/registry.test.ts`, confirmed unrelated and passes in isolation)
- [x] `tsc --noEmit` clean
- [ ] Manual click-through in a running app (`task dev`) — not yet done, worth doing before merge

<!-- agentmux:agent_id=agent3 -->