### PR TITLE
fix(agent-pane): "modelit" typo in the New Agent hint text

### DIFF
--- a/.changesets/1787425657-fix-agent-pane-modelit-typo-in-the-new-agent-hint-text-xm4g.md
+++ b/.changesets/1787425657-fix-agent-pane-modelit-typo-in-the-new-agent-hint-text-xm4g.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): modelit typo in the New Agent hint text

--- a/frontend/app/view/agent/components/AgentCard.test.tsx
+++ b/frontend/app/view/agent/components/AgentCard.test.tsx
@@ -12,8 +12,15 @@
 import { cleanup, render, screen } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const providerLogoSpy = vi.fn();
-const dualProviderLogoSpy = vi.fn();
+// vi.mock(...) calls below are hoisted above these — and above the
+// AgentCard import that triggers module resolution — so the spies
+// referenced inside the mock factories must be created via vi.hoisted()
+// too, or the factories close over a still-temporal-dead-zone binding
+// (codex P1 on PR #2731).
+const { providerLogoSpy, dualProviderLogoSpy } = vi.hoisted(() => ({
+    providerLogoSpy: vi.fn(),
+    dualProviderLogoSpy: vi.fn(),
+}));
 
 // Real ProviderLogo/DualProviderLogo import raw SVG assets vitest can't
 // resolve without a transformer (same reasoning as MyAgentsList.test.tsx's

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -274,6 +274,14 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         const hint = await screen.findByTestId("agent-templates-hint");
         expect(hint).toHaveTextContent("harness");
         expect(hint).toHaveTextContent("model");
+        // Regression guard: a JSX line break directly after a </strong>
+        // closing tag drops the whitespace entirely instead of preserving
+        // it, rendering "model" and "it" concatenated as "modelit" — a
+        // substring check for "model" alone doesn't catch this (it's
+        // still a substring of "modelit"). Assert the exact word boundary
+        // instead.
+        expect(hint.textContent).toContain("model it uses next");
+        expect(hint.textContent).not.toMatch(/model[a-z]/i);
     });
 
     it("clicks on a template open the create-from-template modal", async () => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -919,8 +919,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         </div>
                         <p class="agent-picker-templates-hint" data-testid="agent-templates-hint">
                             Each card is a <strong>harness</strong> (the CLI that runs the agent, e.g. Claude Code,
-                            Codex) — you'll pick which <strong>model</strong>
-                            it uses next.
+                            Codex) — you'll pick which <strong>model</strong> it uses next.
                         </p>
                         <div class="agent-picker-list" data-testid="agent-templates-list">
                             <For each={templates()}>


### PR DESCRIPTION
## Summary
Follow-up to #2731 — that PR's auto-merge fired on the pre-fix commit due to a race between reagent's approval and a fix I was still pushing, so this typo shipped to `main` for a short window. This PR is exactly the fix commit that PR was supposed to include.

- The hint text's `</strong>` closing tag was directly followed by a line break before "it uses next" — JSX drops whitespace entirely at that exact tag-to-text boundary instead of preserving it, rendering "model" and "it" concatenated as **"modelit"** (user-reported, confirmed live on `main`).
- Fixed by keeping `</strong>` and "it" on the same source line with a real space between.
- The existing hint test's substring checks (`toHaveTextContent("model")`) didn't catch this — "model" is still a substring of "modelit" — strengthened to assert the actual word boundary.
- Also includes the fix for codex P1 on #2731: `AgentCard.test.tsx`'s mock spies now use `vi.hoisted()` since `vi.mock(...)` is hoisted above plain top-level `const` declarations.

## Test plan
- [x] All 24 tests in `AgentPicker.test.tsx` + `AgentCard.test.tsx` pass, including the new word-boundary assertion.
- [x] Confirmed the bug is present in current `main` (`git show origin/main:...AgentPicker.tsx` shows the unfixed `</strong>\n it uses next.` line break) before this fix.

<!-- agentmux:agent_id=camper -->