### PR TITLE
feat(browser-pane): render real per-site favicons in the bookmarks menu

### DIFF
--- a/.changesets/1787425691-feat-browser-pane-render-real-per-site-favicons-in-the-bookm-k7ok.md
+++ b/.changesets/1787425691-feat-browser-pane-render-real-per-site-favicons-in-the-bookm-k7ok.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(browser-pane): render real per-site favicons in the bookmarks menu

--- a/.changesets/1787425691-feat-browser-pane-render-real-per-site-favicons-in-the-bookm-k7ok.md
+++ b/.changesets/1787425691-feat-browser-pane-render-real-per-site-favicons-in-the-bookm-k7ok.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(browser-pane): render real per-site favicons in the bookmarks menu

--- a/docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md
+++ b/docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md
@@ -283,16 +283,21 @@ dev` + clicking through the feature) — typecheck/unit-test coverage only.
 
 **Deviations from the plan above, decided during implementation:**
 
-- **No live favicon thumbnails in the menu.** `FlyoutMenu`'s default item
-  renderer only supports a FontAwesome icon-name string (`item.icon` is
-  typed `string | JSX.Element`, but `flyoutmenu.tsx`'s render only ever
-  treats it as a string — no existing consumer uses the `JSX.Element`
-  branch). Special-casing a real `<img>` favicon via `renderMenuItem` would
-  be new, unprecedented surface in a shared component for a cosmetic
-  upgrade — every bookmark row instead shows a plain `fa-bookmark` icon,
-  matching how every other menu in the app already renders. `favicon_url`
-  is still captured and stored on each record (harmless, forward-
-  compatible) — just not rendered as an image in v1.
+- **Live favicon thumbnails, added as a same-day follow-up (PR after
+  #2730).** Originally deferred — `FlyoutMenu`'s default item renderer only
+  supports a FontAwesome icon-name string, and `item.icon`'s `JSX.Element`
+  branch (`custom.d.ts:465`) had no existing consumer to confirm the
+  pattern. Revisited on request: `browser-nav-bar.tsx` now passes a
+  `renderMenuItem` override on this menu's `<FlyoutMenu>` — it renders
+  `item.icon` as-is when it's a `JSX.Element` (a small `<BookmarkFavicon>`
+  component wrapping the real `<img src={favicon_url}>`, falling back to a
+  plain globe icon on a missing URL or an `onError` load failure) and falls
+  back to the original `fa-solid fa-fw fa-${icon}` rendering for string
+  icons (the pinned toggle row, loading/empty-state rows). Scoped
+  deliberately to only this menu's icon slot — `checked`/`shortcut`/
+  `subItems` aren't replicated since nothing here uses them yet. Live-
+  verified via CDP against a running `task dev` instance: a real bookmark
+  row renders `<img src="https://agentmux.ai/favicon.ico">`.
 - **No per-row delete for a bookmark other than the current page.**
   `MenuItem` has no secondary-action/trailing-button slot, and nesting a
   submenu (`subItems: [Open, Remove]`) per row would replace "click to

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -172,13 +172,54 @@ export function BrowserNavBar(props: {
     const [bookmarks, setBookmarks] = createSignal<BrowserBookmark[]>([]);
     const [bookmarksLoading, setBookmarksLoading] = createSignal(false);
     const [bookmarksError, setBookmarksError] = createSignal<string | null>(null);
+    // True once loadBookmarks() has resolved successfully at least once in
+    // this pane's lifetime. Gates the "Loading…" placeholder to the very
+    // first fetch only — see loadBookmarks' comment below for why later
+    // opens must NOT flip bookmarksLoading (ReAgent P1, PR #2733).
+    const [hasLoadedBookmarksOnce, setHasLoadedBookmarksOnce] = createSignal(false);
+
+    /** Field-by-field equality, not reference equality — used to decide
+     *  whether a fresh RPC read actually changed anything worth
+     *  re-rendering for (see loadBookmarks below). */
+    const bookmarkListsEqual = (a: BrowserBookmark[], b: BrowserBookmark[]): boolean =>
+        a.length === b.length &&
+        a.every((item, i) => {
+            const other = b[i];
+            return (
+                item.id === other.id &&
+                item.title === other.title &&
+                item.url === other.url &&
+                item.favicon_url === other.favicon_url
+            );
+        });
 
     const loadBookmarks = async () => {
-        setBookmarksLoading(true);
+        // Only show the transient "Loading…" placeholder before the very
+        // first successful load in this pane's lifetime. Every subsequent
+        // menu-open refresh keeps rendering the last-known list while the
+        // fresh fetch resolves in the background — flipping
+        // bookmarksLoading on every open (as this used to, unconditionally)
+        // forced bookmarkMenuItems' createMemo to rebuild a fresh
+        // MenuItem[] (fresh <BookmarkFavicon> elements) TWICE per open, and
+        // since Solid's <For> (inside FlyoutMenu) diffs by reference, that
+        // tore down and remounted every saved bookmark's <img> — reloading
+        // every favicon over the network on every single menu open, not
+        // just the first (ReAgent P1, PR #2733).
+        if (!hasLoadedBookmarksOnce()) setBookmarksLoading(true);
         setBookmarksError(null);
         try {
             const result = await RpcApi.ListBookmarksCommand(TabRpcClient);
-            setBookmarks(result.bookmarks ?? []);
+            const next = result.bookmarks ?? [];
+            // Skip the signal write entirely when nothing actually
+            // changed — keeps the same array/object references so
+            // bookmarkMenuItems' memo doesn't rerun and <For> never
+            // touches the DOM for unchanged rows. A real change (another
+            // window added/removed/edited a bookmark since last open)
+            // still updates normally.
+            if (!bookmarkListsEqual(bookmarks(), next)) {
+                setBookmarks(next);
+            }
+            setHasLoadedBookmarksOnce(true);
         } catch (e) {
             setBookmarksError(`Failed to load bookmarks: ${(e as Error).message ?? e}`);
         } finally {
@@ -242,6 +283,11 @@ export function BrowserNavBar(props: {
     // icon as-is and falls back to the default fa-${icon} rendering for the
     // pinned toggle row / placeholder rows, which still use string icons.
     const bookmarkMenuItems = createMemo<MenuItem[]>(() => {
+        // Only true before the first-ever successful loadBookmarks() call
+        // (see its own comment) — every later menu open keeps rendering
+        // the previous list below instead of bouncing through this branch,
+        // so saved bookmarks' <img> favicons are never torn down and
+        // remounted just because the menu was reopened.
         if (bookmarksLoading()) {
             // No icon here (deliberately): FlyoutMenu's default item
             // renderer only ever applies `fa-solid fa-fw fa-${item.icon}` —

--- a/frontend/app/view/browser/browser-nav-bar.tsx
+++ b/frontend/app/view/browser/browser-nav-bar.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import clsx from "clsx";
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { FlyoutMenu } from "@/app/element/flyoutmenu";
@@ -9,6 +10,33 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { findBookmark, toggleBookmark } from "./browser-bookmarks-logic";
 import type { BrowserViewModel } from "./browser-model";
+
+/**
+ * A saved bookmark's favicon, falling back to the app's existing "no
+ * favicon" convention (a plain globe icon, matching
+ * `BrowserViewModel.viewIcon`/faviconUrlAtom's own empty-string fallback)
+ * when there's no favicon_url, or the image fails to load. A real `<img>`
+ * — not a FontAwesome name — since `MenuItem.icon` is typed
+ * `string | JSX.Element` specifically to allow this; FlyoutMenu's default
+ * item renderer only handles the string case, so this is paired with a
+ * `renderMenuItem` override below that renders a JSX.Element icon as-is.
+ */
+function BookmarkFavicon(props: { faviconUrl: string }): JSX.Element {
+    const [failed, setFailed] = createSignal(false);
+    return (
+        <Show
+            when={props.faviconUrl && !failed()}
+            fallback={<i class="fa-solid fa-fw fa-globe menu-item-icon" aria-hidden="true" />}
+        >
+            <img
+                src={props.faviconUrl}
+                class="menu-item-icon browser-bookmark-favicon"
+                onError={() => setFailed(true)}
+                alt=""
+            />
+        </Show>
+    );
+}
 
 // Compact tag for an Element — used by diag log lines to identify the
 // previous/next active element across focus transitions.
@@ -206,13 +234,13 @@ export function BrowserNavBar(props: {
     // means the "grows to the bottom of the window, then scrolls
     // internally" behavior (computeMenuPosition's size() middleware,
     // frontend/app/util/menu-position.ts) and edge-flip/click-outside-close
-    // come for free — nothing bookmark-specific to build there. `icon`
-    // uses a plain FontAwesome name (consistent with every other menu item
-    // in the app) rather than a live per-site favicon image — FlyoutMenu's
-    // default item renderer only supports FA icon-name strings, and
-    // special-casing an `<img>` via `renderMenuItem` would be new,
-    // unprecedented surface in a shared component for a purely cosmetic
-    // upgrade, not worth it for v1.
+    // come for free — nothing bookmark-specific to build there. Saved-
+    // bookmark rows use a real per-site favicon (`BookmarkFavicon`, a
+    // JSX.Element) rather than a FontAwesome name — FlyoutMenu's default
+    // item renderer only handles the string-icon case, so the `<FlyoutMenu>`
+    // below carries a `renderMenuItem` override that renders a JSX.Element
+    // icon as-is and falls back to the default fa-${icon} rendering for the
+    // pinned toggle row / placeholder rows, which still use string icons.
     const bookmarkMenuItems = createMemo<MenuItem[]>(() => {
         if (bookmarksLoading()) {
             // No icon here (deliberately): FlyoutMenu's default item
@@ -241,7 +269,7 @@ export function BrowserNavBar(props: {
             for (const b of saved) {
                 items.push({
                     label: b.title || b.url,
-                    icon: "bookmark",
+                    icon: <BookmarkFavicon faviconUrl={b.favicon_url ?? ""} />,
                     onClick: () => navigateTo(b.url),
                 });
             }
@@ -280,6 +308,27 @@ export function BrowserNavBar(props: {
                     onOpenChange={(open) => {
                         if (open) void loadBookmarks();
                     }}
+                    // Only the icon slot is customized here — label/onClick/
+                    // divider behavior is identical to FlyoutMenu's default
+                    // rendering. `checked`/`shortcut`/`subItems` are
+                    // deliberately not replicated since this menu never uses
+                    // them (v1 has no folders/radio state) — not a general-
+                    // purpose replacement for the default renderer.
+                    renderMenuItem={(item, menuItemProps) => (
+                        <div {...menuItemProps}>
+                            <Show
+                                when={typeof item.icon !== "string"}
+                                fallback={
+                                    <Show when={item.icon}>
+                                        <i class={clsx("fa-solid fa-fw", `fa-${item.icon}`, "menu-item-icon")} />
+                                    </Show>
+                                }
+                            >
+                                {item.icon as JSX.Element}
+                            </Show>
+                            <span class="label">{item.label}</span>
+                        </div>
+                    )}
                 >
                     <button
                         class="browser-nav-btn"

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -9,6 +9,17 @@
     border-radius: 0;
 }
 
+// Bookmark row favicon in the bookmarks FlyoutMenu — `.menu-item-icon`
+// (flyoutmenu.scss) sizes the icon slot itself (width/margin/opacity);
+// this adds the image-specific sizing an <img> needs that a font-icon
+// doesn't (height, object-fit, no inline whitespace gap).
+.browser-bookmark-favicon {
+    height: 14px;
+    object-fit: contain;
+    display: block;
+    border-radius: 0;
+}
+
 .browser-view {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
Follow-up to #2730 (merged) — the user asked for real favicons in the bookmarks menu instead of a generic icon, which #2730's spec had deliberately deferred pending confirmation this was wanted.

- Bookmark rows now render the actual saved favicon (an `<img>`), falling back to a plain globe icon on a missing `favicon_url` or an `onError` load failure — matches this app's existing "no favicon → globe" convention (`BrowserViewModel.viewIcon`).
- `FlyoutMenu`'s default item renderer only ever templates a FontAwesome name (`fa-solid fa-fw fa-${icon}`) and never handles the `JSX.Element` branch of `MenuItem.icon` (typed but previously unused by any consumer) — this adds a `renderMenuItem` override scoped to just this menu: render `item.icon` as-is when it's a `JSX.Element`, otherwise fall back to the original string-icon rendering (used by the pinned "Bookmark this page" toggle row and the loading/empty-state rows).
- Spec updated (`docs/specs/SPEC_BROWSER_PANE_BOOKMARKS_AND_GO_ICON_2026_08_22.md`) to reflect this as a same-day follow-up rather than a deferred v1 limitation.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npx vitest run frontend/app/view/browser frontend/app/store/browser-pane-state` — 123 passed
- [x] **Live-verified** against a running `task dev` instance via CDP (`Runtime.evaluate` over the CEF remote-debugging port): opened the bookmarks menu, confirmed a real bookmark row renders `<img src="https://agentmux.ai/favicon.ico">`, and the star-toggle row is unaffected (`<i class="fa-solid fa-fw fa-star ...">`).

<!-- agentmux:agent_id=agent3 -->