### PR TITLE
feat(armory): rename Memories/Native Memory to Global/Personal Memory

### DIFF
--- a/.changesets/1787426829-feat-armory-rename-memories-native-memory-to-global-personal-4pnf.md
+++ b/.changesets/1787426829-feat-armory-rename-memories-native-memory-to-global-personal-4pnf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(armory): rename Memories/Native Memory to Global/Personal Memory, reposition below Accounts

--- a/docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md
+++ b/docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md
@@ -1,0 +1,82 @@
+# Spec: Armory rail — "Global Memory" / "Personal Memory" rename + reposition
+
+**Date:** 2026-08-22
+**Author:** Camper
+**Status:** Implemented
+**Motivated by:** direct request — abstract away, for the user, that the
+Armory currently exposes two structurally different backing systems under
+confusing names; present a single "Memory" concept split by scope instead.
+
+## Problem
+
+The Armory rail had three memory-adjacent tabs with names that don't
+describe what they actually are, discovered while investigating this
+request:
+
+| Rail id | Old label | What it actually is |
+|---|---|---|
+| `memory` | "Memories" | `GlobalBrainManager` — workspace-wide sections (`is_global` Memory bundles) composed into every agent's `CLAUDE.md` at launch |
+| `native_memory` | "Native Memory" | Per-agent version history over the harness's own native memory files (currently Claude Code's `MEMORY.md`/topic files) |
+| `bundles` | "ABF" | The actual Armory Bundle Format CRUD — an agent's capability stack (instructions, context files, MCP servers, skills, provider/model) |
+
+"Memories" and "ABF" both being memory-shaped-but-different, plus a third
+"Native Memory" tab at the opposite end of the rail, made the distinction
+illegible to a user who hasn't read the specs behind each one.
+
+## Design
+
+Two tabs renamed to reflect the one thing users actually need to know —
+scope (workspace-wide vs. per-agent) — not which backend system answers
+it:
+
+- `memory` (`GlobalBrainManager`): **"Memories" → "Global Memory"**
+- `native_memory` (native memory history): **"Native Memory" → "Personal Memory"**
+
+Repositioned so both sit together, directly below Accounts:
+
+```
+Before: Accounts, Memories, Skills, MCP Servers, ABF, Native Memory
+After:  Accounts, Global Memory, Personal Memory, Skills, MCP Servers, ABF
+```
+
+**`ABF` is explicitly out of scope** (confirmed directly) — it keeps its
+current tab, label, and position. This is a rename + reorder only, not a
+data-model unification: `Global Memory` and `Personal Memory` remain two
+separate backing systems under the hood (`is_global` Memory bundles vs.
+native memory files) — see
+`docs/reports/REPORT_ARMORY_STASH_MEMORY_SYNC_STATUS_2026_08_07.md` and
+`docs/specs/archive/SPEC_MEMORY_IDENTITY_ARCH_2026_06_19.md` for why that
+separation itself stays as-is. Only the section ids stay stable
+internally (`memory`, `native_memory`) — they're persisted in
+`block.meta["armory:section"]`; renaming the *label* doesn't touch a
+user's already-selected tab, renaming the *id* would have stranded it
+back to "accounts."
+
+**Write access:** confirmed both Global Memory and Personal Memory are
+(and stay) writable by both the human and the agent — this rename doesn't
+reintroduce or imply the older "bundles are human-only, native memory is
+agent-only" governance split described in the docs above. Neither
+component's own UI copy claimed otherwise; nothing needed to change on
+that front.
+
+## Files changed
+
+- `frontend/app/view/armory/armory-model.ts` — `ARMORY_SECTION_LABELS`.
+- `frontend/app/view/armory/armory-view.tsx` — `RAIL` array order, plus a
+  short tooltip on each memory tab clarifying scope (workspace-wide vs.
+  per-agent) at a glance.
+- `frontend/app/view/armory/armory-view.test.tsx` — updated the two
+  existing label/order assertions, added one new label assertion for the
+  Personal Memory rename (the prior test suite only ever asserted the
+  Global Memory side of a rename, since "Native Memory" had never been
+  renamed before).
+
+## Non-goals
+
+- No change to `ABF`.
+- No data-model change — `Global Memory` and `Personal Memory` are not
+  merged, bridged, or given a new shared table. Purely a rail-level
+  rename + reorder.
+- No change to either pane's own component (`GlobalBrainManager`,
+  `NativeMemoryManager`) beyond what the rename required (none — neither
+  had the old label as literal text in its own JSX).

--- a/frontend/app/view/agent/components/AgentNativeMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNativeMemoryModal.tsx
@@ -299,7 +299,7 @@ export const AgentNativeMemoryModal = (props: AgentNativeMemoryModalProps): JSX.
 
             <PrimitiveListDetail
                 showDetail={inDetail()}
-                backLabel="Memories"
+                backLabel="Personal Memory"
                 onBack={() => model.clearSelection()}
                 list={listView}
                 detail={detailView}

--- a/frontend/app/view/agent/components/AgentStashModal.tsx
+++ b/frontend/app/view/agent/components/AgentStashModal.tsx
@@ -13,7 +13,13 @@
  *                   New bindings are created from the agent-launch flow;
  *                   see that component's own doc comment for why this tab
  *                   is not a create/edit surface.
- *   - Memory      — the native-memory browser (AgentNativeMemoryModal).
+ *   - Personal Memory — the native-memory browser (AgentNativeMemoryModal),
+ *                   same feature/RPCs as the Armory rail's "Personal
+ *                   Memory" tab (native-memory-manager.tsx) — this is the
+ *                   per-agent entry point, that one the cross-agent entry
+ *                   point, one source of truth either way. Labels kept in
+ *                   sync deliberately — see
+ *                   docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md.
  *   - MCP Servers — the standalone MCP Server primitive (AgentMcpModal).
  *   - Skills      — the standalone Skill primitive (AgentSkillsModal).
  *   - Startup     — select an existing Bundle as Session Context's
@@ -65,7 +71,7 @@ export const AgentStashModal = (props: AgentStashModalProps): JSX.Element => {
     // primitive yet).
     const tabs: StashTabDef[] = [
         { id: "accounts", label: "Accounts", icon: "key" },
-        { id: "memory", label: "Memories", icon: "brain" },
+        { id: "memory", label: "Personal Memory", icon: "brain" },
         { id: "mcp", label: "MCP Servers", icon: "plug" },
         { id: "skills", label: "Skills", icon: "wand-magic-sparkles" },
         // layer-group: same icon armory-view.tsx's RAIL uses for "ABF" —

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -6,11 +6,18 @@ import { useBlockAtom } from "@/app/store/global";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, type Accessor } from "solid-js";
 
-// "native_memory" deliberately does NOT reuse the word "memory" — that's
-// already the (confusingly-named, legacy) section id for the global-brain
-// tab below, distinct from a bundle's own "bundles" section (whose backing
-// component, MemoryManager, is itself a naming leftover — see
+// Section ids are internal and stay stable across renames (they're
+// persisted in block.meta["armory:section"] — changing an id would strand
+// a user's previously-selected tab back to "accounts"). "memory" is the
+// global-brain tab (label "Global Memory" below); "native_memory" is the
+// per-agent tab (label "Personal Memory" below) — both distinct from a
+// bundle's own "bundles" section (label "ABF"; its backing component,
+// MemoryManager, is itself a naming leftover — see
 // docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3).
+// "Global Memory"/"Personal Memory" abstract away, for the user, that these
+// are two structurally different backing systems (is_global Memory bundles
+// vs. the harness's own native memory files) — see
+// docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md.
 export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles" | "native_memory";
 
 // Label text only (not icon/tooltip, which stay armory-view.tsx's own
@@ -20,11 +27,11 @@ export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles"
 // too, so the two can never drift out of sync.
 export const ARMORY_SECTION_LABELS: Record<ArmorySection, string> = {
     accounts: "Accounts",
-    memory: "Memories",
+    memory: "Global Memory",
     skills: "Skills",
     mcp: "MCP Servers",
     bundles: "ABF",
-    native_memory: "Native Memory",
+    native_memory: "Personal Memory",
 };
 
 function isArmorySection(v: unknown): v is ArmorySection {

--- a/frontend/app/view/armory/armory-view.test.tsx
+++ b/frontend/app/view/armory/armory-view.test.tsx
@@ -9,10 +9,17 @@
  * §1/§2/§3) removed the "Identities" tab (folded into the agent-pane's own
  * Identity tab — see agent-identity-links-panel.test.tsx), renamed "Memory"
  * to "Memories", and reordered the rail to
- * Accounts, Memories, Skills, MCP Servers, ABF. These tests guard the
- * rail contents directly; `ArmorySection`'s type-level rejection of
- * `"identities"` is checked at compile time below (no runtime assertion
- * needed for that part).
+ * Accounts, Memories, Skills, MCP Servers, ABF.
+ *
+ * docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md renamed
+ * "Memories" to "Global Memory" and "Native Memory" to "Personal Memory",
+ * and moved Personal Memory up to sit right below Global Memory (both now
+ * adjacent, just below Accounts) — one user-facing "Memory" concept split
+ * by scope, abstracting away the two structurally different backing
+ * systems. Current rail order: Accounts, Global Memory, Personal Memory,
+ * Skills, MCP Servers, ABF. These tests guard the rail contents directly;
+ * `ArmorySection`'s type-level rejection of `"identities"` is checked at
+ * compile time below (no runtime assertion needed for that part).
  */
 
 import { createSignal } from "solid-js";
@@ -101,17 +108,24 @@ describe("ArmoryView rail", () => {
         expect(container.querySelector(".bundle-manager-pane--identity")).not.toBeInTheDocument();
     });
 
-    it("labels the brain tab 'Memories' (renamed from 'Memory')", () => {
+    it("labels the brain tab 'Global Memory' (renamed from 'Memories')", () => {
         renderArmory();
-        expect(screen.getAllByText("Memories").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Global Memory").length).toBeGreaterThan(0);
+        expect(screen.queryByText("Memories")).not.toBeInTheDocument();
         expect(screen.queryByText("Memory")).not.toBeInTheDocument();
     });
 
-    it("orders the rail as Accounts, Memories, Skills, MCP Servers, ABF, Native Memory", () => {
+    it("labels the native-memory tab 'Personal Memory' (renamed from 'Native Memory')", () => {
+        renderArmory();
+        expect(screen.getAllByText("Personal Memory").length).toBeGreaterThan(0);
+        expect(screen.queryByText("Native Memory")).not.toBeInTheDocument();
+    });
+
+    it("orders the rail as Accounts, Global Memory, Personal Memory, Skills, MCP Servers, ABF", () => {
         renderArmory();
         const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
         const labels = Array.from(rail.querySelectorAll("button span")).map((el) => el.textContent);
-        expect(labels).toEqual(["Accounts", "Memories", "Skills", "MCP Servers", "ABF", "Native Memory"]);
+        expect(labels).toEqual(["Accounts", "Global Memory", "Personal Memory", "Skills", "MCP Servers", "ABF"]);
     });
 });
 

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -15,13 +15,18 @@ import { NativeMemoryManager } from "@/app/view/native-memory/native-memory-mana
 import { ARMORY_SECTION_LABELS, type ArmorySection, type ArmoryViewModel } from "./armory-model";
 import "./armory-view.scss";
 
+// Global Memory + Personal Memory sit together right below Accounts,
+// deliberately adjacent — the user-facing framing is one "Memory" concept
+// split in two by scope (workspace-wide vs. per-agent), not two unrelated
+// features that happen to share a rail. See
+// docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md.
 const RAIL: { id: ArmorySection; label: string; tooltip?: string; icon: string }[] = [
     { id: "accounts", label: ARMORY_SECTION_LABELS.accounts, icon: "key" },
-    { id: "memory",   label: ARMORY_SECTION_LABELS.memory,   icon: "brain" },
+    { id: "memory",   label: ARMORY_SECTION_LABELS.memory,   tooltip: "Workspace-wide — composes into every agent's CLAUDE.md", icon: "brain" },
+    { id: "native_memory", label: ARMORY_SECTION_LABELS.native_memory, tooltip: "Per-agent — version history, diff and revert", icon: "clock-rotate-left" },
     { id: "skills",   label: ARMORY_SECTION_LABELS.skills,   icon: "wand-magic-sparkles" },
     { id: "mcp",      label: ARMORY_SECTION_LABELS.mcp,      icon: "plug" },
     { id: "bundles",  label: ARMORY_SECTION_LABELS.bundles,  tooltip: "Armory Bundle Format (ABF)", icon: "layer-group" },
-    { id: "native_memory", label: ARMORY_SECTION_LABELS.native_memory, tooltip: "Per-agent memory version history — diff and revert", icon: "clock-rotate-left" },
 ];
 
 export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Element {


### PR DESCRIPTION
## Summary
Abstracts away, for the user, that these are two structurally different backing systems — presents one "Memory" concept split by scope instead:

- "Memories" (`GlobalBrainManager`, workspace-wide, composes into every agent's `CLAUDE.md`) → **"Global Memory"**
- "Native Memory" (per-agent version history) → **"Personal Memory"**

Repositioned so both sit together, directly below Accounts: `Accounts, Global Memory, Personal Memory, Skills, MCP Servers, ABF`.

`ABF` (the actual bundle/capability-stack CRUD) is confirmed out of scope — untouched. Section ids stay stable internally (persisted in `block.meta["armory:section"]`) — only labels/order changed, so no existing user's selected tab gets stranded. Both sections remain writable by both agent and human, unchanged — this rename doesn't reintroduce the older "bundles are human-only, native memory is agent-only" governance split from the docs.

Full design: `docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md`

## Test plan
- [x] `armory-view.test.tsx` — updated rail-order + label assertions (15 tests pass), added a new assertion for the Personal Memory rename.
- [x] `tsc --noEmit` clean, zero errors.

<!-- agentmux:agent_id=camper -->