### PR TITLE
[Manoz@Area54] chore: release v0.55.20

### DIFF
--- a/.changesets/1787346377-feat-mcp-add-capturewindow-tool-for-cross-instance-os-window-xarw.md
+++ b/.changesets/1787346377-feat-mcp-add-capturewindow-tool-for-cross-instance-os-window-xarw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): add CaptureWindow tool for cross-instance/OS window screenshots

--- a/.changesets/1787367568-feat-muxspect-cross-tier-conversation-visibility-phase-a-hos-jes7.md
+++ b/.changesets/1787367568-feat-muxspect-cross-tier-conversation-visibility-phase-a-hos-jes7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxspect): cross-tier conversation visibility Phase A — host + cross-channel

--- a/.changesets/1787386695-test-jekt-add-regression-tests-for-tier-classification-keywo-v21l.md
+++ b/.changesets/1787386695-test-jekt-add-regression-tests-for-tier-classification-keywo-v21l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(jekt): add regression tests for tier-classification keyword matching and marker rendering

--- a/.changesets/1787412644-fix-srv-stop-fswatchpool-s-health-sweep-leaking-a-file-semap-1lf1.md
+++ b/.changesets/1787412644-fix-srv-stop-fswatchpool-s-health-sweep-leaking-a-file-semap-1lf1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): stop FsWatchPool's health sweep leaking a File+Semaphore handle pair per tick

--- a/.changesets/1787413019-docs-retro-per-build-identity-keychain-re-prompt-retry-drive-lvja.md
+++ b/.changesets/1787413019-docs-retro-per-build-identity-keychain-re-prompt-retry-drive-lvja.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(retro): per-build-identity keychain re-prompt + retry-driven thread leak, two more keychain saga findings

--- a/.changesets/1787414854-fix-agent-fork-carries-conversation-history-flat-lineage-nam-cinn.md
+++ b/.changesets/1787414854-fix-agent-fork-carries-conversation-history-flat-lineage-nam-cinn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): fork carries conversation history + flat lineage naming

--- a/.changesets/1787416051-fix-agent-pane-refresh-activity-dock-subagent-rows-on-abando-ves3.md
+++ b/.changesets/1787416051-fix-agent-pane-refresh-activity-dock-subagent-rows-on-abando-ves3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): refresh Activity Dock subagent rows on abandon so restarts don't show stale 'running' entries

--- a/.changesets/1787417655-feat-tabs-quick-fork-a-tab-into-a-new-tab-with-full-independ-9beq.md
+++ b/.changesets/1787417655-feat-tabs-quick-fork-a-tab-into-a-new-tab-with-full-independ-9beq.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tabs): quick-fork a tab into a new tab with full independent identity

--- a/.changesets/1787418543-feat-srv-retention-gc-for-native-memory-version-history-8e0o.md
+++ b/.changesets/1787418543-feat-srv-retention-gc-for-native-memory-version-history-8e0o.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): retention/GC for native memory version history

--- a/.changesets/1787419367-feat-agent-pane-tier-3-predictive-countdown-before-auto-comp-2cwp.md
+++ b/.changesets/1787419367-feat-agent-pane-tier-3-predictive-countdown-before-auto-comp-2cwp.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): Tier 3 predictive countdown before auto-compact

--- a/.changesets/1787423206-feat-browser-pane-add-global-bookmarks-icon-go-button-wtuj.md
+++ b/.changesets/1787423206-feat-browser-pane-add-global-bookmarks-icon-go-button-wtuj.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser-pane): add global bookmarks + icon Go button

--- a/.changesets/1787424964-fix-agent-pane-new-agent-heading-harness-only-template-card--44ym.md
+++ b/.changesets/1787424964-fix-agent-pane-new-agent-heading-harness-only-template-card--44ym.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): New Agent heading + harness-only template card icons

--- a/.changesets/1787425657-fix-agent-pane-modelit-typo-in-the-new-agent-hint-text-xm4g.md
+++ b/.changesets/1787425657-fix-agent-pane-modelit-typo-in-the-new-agent-hint-text-xm4g.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): modelit typo in the New Agent hint text

--- a/.changesets/1787425691-feat-browser-pane-render-real-per-site-favicons-in-the-bookm-k7ok.md
+++ b/.changesets/1787425691-feat-browser-pane-render-real-per-site-favicons-in-the-bookm-k7ok.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser-pane): render real per-site favicons in the bookmarks menu

--- a/.changesets/1787426829-feat-armory-rename-memories-native-memory-to-global-personal-4pnf.md
+++ b/.changesets/1787426829-feat-armory-rename-memories-native-memory-to-global-personal-4pnf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): rename Memories/Native Memory to Global/Personal Memory, reposition below Accounts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.19"
+version = "0.55.20"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.19"
+version = "0.55.20"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.19"
+version = "0.55.20"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.19"
+version = "0.55.20"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.19"
+version = "0.55.20"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.19"
+version = "0.55.20"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.19"
+version = "0.55.20"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,24 @@
 # AgentMux Version History
 
+## 0.55.20 — 2026-08-22
+
+- feat(mcp): add CaptureWindow tool for cross-instance/OS window screenshots
+- feat(muxspect): cross-tier conversation visibility Phase A — host + cross-channel
+- test(jekt): add regression tests for tier-classification keyword matching and marker rendering
+- fix(srv): stop FsWatchPool's health sweep leaking a File+Semaphore handle pair per tick
+- docs(retro): per-build-identity keychain re-prompt + retry-driven thread leak, two more keychain saga findings
+- fix(agent): fork carries conversation history + flat lineage naming
+- fix(agent-pane): refresh Activity Dock subagent rows on abandon so restarts don't show stale 'running' entries
+- feat(tabs): quick-fork a tab into a new tab with full independent identity
+- feat(srv): retention/GC for native memory version history
+- feat(agent-pane): Tier 3 predictive countdown before auto-compact
+- feat(browser-pane): add global bookmarks + icon Go button
+- fix(agent-pane): New Agent heading + harness-only template card icons
+- fix(agent-pane): modelit typo in the New Agent hint text
+- feat(browser-pane): render real per-site favicons in the bookmarks menu
+- feat(armory): rename Memories/Native Memory to Global/Personal Memory, reposition below Accounts
+
+
 ## 0.55.19 — 2026-08-21
 
 - feat(agent-pane): live dispatch cards for Agent/Task/Workflow tool calls in the transcript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.19",
+  "version": "0.55.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.19",
+      "version": "0.55.20",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.19",
+  "version": "0.55.20",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 15 pending changesets. **Forced patch bump** (`task release -- --as patch`) per explicit request, overriding the computed `minor` (6 of the 15 changesets are `minor`-level) — those changes still ship, just under a patch version number rather than triggering a minor bump.

0.55.19 → 0.55.20

## Changes shipping in this release

- feat(mcp): add CaptureWindow tool for cross-instance/OS window screenshots
- feat(muxspect): cross-tier conversation visibility Phase A — host + cross-channel
- test(jekt): add regression tests for tier-classification keyword matching and marker rendering
- fix(srv): stop FsWatchPool's health sweep leaking a File+Semaphore handle pair per tick
- docs(retro): per-build-identity keychain re-prompt + retry-driven thread leak, two more keychain saga findings
- fix(agent): fork carries conversation history + flat lineage naming
- fix(agent-pane): refresh Activity Dock subagent rows on abandon so restarts don't show stale 'running' entries
- feat(tabs): quick-fork a tab into a new tab with full independent identity
- feat(srv): retention/GC for native memory version history
- feat(agent-pane): Tier 3 predictive countdown before auto-compact
- feat(browser-pane): add global bookmarks + icon Go button
- fix(agent-pane): New Agent heading + harness-only template card icons
- fix(agent-pane): modelit typo in the New Agent hint text
- feat(browser-pane): render real per-site favicons in the bookmarks menu
- feat(armory): rename Memories/Native Memory to Global/Personal Memory, reposition below Accounts

## Test plan

- [x] `task release -- --as patch` completed cleanly, all 5 version locations (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) agree at 0.55.20
- [x] All 15 changesets consumed and deleted
- [x] No source changes in this PR — version/changelog bump only

<!-- agentmux:agent_id=manoz -->