### PR TITLE
fix(muxlog): srv logs honor AGENTMUX_LOG_DIR, fix channels/ glob depth mismatch

### DIFF
--- a/.changesets/1787428853-fix-muxlog-srv-logs-honor-agentmux-log-dir-fix-channels-glob-zj2j.md
+++ b/.changesets/1787428853-fix-muxlog-srv-logs-honor-agentmux-log-dir-fix-channels-glob-zj2j.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxlog): srv logs honor AGENTMUX_LOG_DIR, fix channels/ glob depth mismatch

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -17,6 +17,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 const HOME = os.homedir();
 const AGENTMUX = path.join(HOME, ".agentmux");
@@ -24,19 +25,46 @@ const AGENTMUX = path.join(HOME, ".agentmux");
 // ─── Log discovery ────────────────────────────────────────────────────────────
 // Logs can live in any of these roots (the shared dir alone is NOT enough — dev
 // builds and per-build channels keep their host log in their own data dir):
-//   ~/.agentmux/logs/                                  (shared: srv, launcher, some host)
+//   ~/.agentmux/logs/                                  (shared: launcher, and
+//                                                        srv when AGENTMUX_LOG_DIR
+//                                                        isn't set — see below)
 //   ~/.agentmux/dev/<branch>/<hash>/logs/              (task dev, keyed on branch)
-//   ~/.agentmux/channels/local-*/versions/<v>/.../logs/(portable/per-build)
+//   ~/.agentmux/channels/<channel>/versions/<v>/logs/  (portable/per-build; both
+//                                                        host AND srv as of
+//                                                        agentmux-srv/src/bootstrap.rs
+//                                                        honoring AGENTMUX_LOG_DIR —
+//                                                        see REPORT_MUXSPECT_MUXLOG_
+//                                                        CROSS_CHANNEL_INSPECTION_2026_08_22.md)
+//
+// The confirmed on-disk depth is `versions/<v>/logs` (ONE directory between
+// version and logs — verified against a real running instance's own
+// AGENTMUX_LOG_DIR). An earlier version of this glob assumed TWO directories
+// (`versions/*/*/logs`), which never actually matches that shape — silently
+// finding zero channel-build logs ever, on any platform, the entire time this
+// source existed. Try both depths (cheap — glob() is a handful of readdirSync
+// calls) so a differently-shaped install elsewhere still resolves, deduping by
+// path so a hit on the 1-level pattern doesn't also list on the 2-level one.
 function* logRoots() {
     yield { dir: path.join(AGENTMUX, "logs"), source: "shared" };
     for (const p of glob(path.join(AGENTMUX, "dev", "*", "*", "logs")))
         yield { dir: p, source: "dev:" + p.split(path.sep).at(-3) };
-    for (const p of glob(path.join(AGENTMUX, "channels", "*", "versions", "*", "*", "logs")))
+    const seen = new Set();
+    for (const p of glob(path.join(AGENTMUX, "channels", "*", "versions", "*", "logs"))) {
+        if (seen.has(p)) continue; seen.add(p);
+        yield { dir: p, source: "channel:" + p.split(path.sep).at(-4) };
+    }
+    for (const p of glob(path.join(AGENTMUX, "channels", "*", "versions", "*", "*", "logs"))) {
+        if (seen.has(p)) continue; seen.add(p);
         yield { dir: p, source: "channel:" + p.split(path.sep).at(-5) };
+    }
 }
 
 // Tiny one-level-per-`*` glob (no deps). Only handles `*` path segments.
-function glob(pattern) {
+// Exported (pure, no I/O beyond readdirSync/existsSync — no network, no
+// process.exit) for muxlog.test.mjs, which pins the depth-matching bug fixed
+// in logRoots() below (an earlier version of the channels/ glob pattern had
+// one wildcard segment too many and could never match a real install).
+export function glob(pattern) {
     const parts = pattern.split(path.sep);
     let bases = [parts[0] === "" ? path.sep : parts[0]];
     for (let i = 1; i < parts.length; i++) {
@@ -656,4 +684,9 @@ function main() {
     follow(file, opt);
 }
 
-main();
+// Only run when executed directly (`node muxlog.mjs ...`) — importing this
+// module (muxlog.test.mjs imports `glob`) must not trigger a live tail loop /
+// `process.exit`. Same pattern as muxspect.mjs.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+    main();
+}

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for muxlog.mjs's glob() — pure filesystem reads against a real
+// temp directory tree (no mocking needed, no network, no process.exit). Runs
+// as part of `npm test` (vitest), same discipline as muxspect.test.mjs.
+//
+// Pins the fix in docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
+// §2.2/§2.3: the channels/ log-discovery glob had one wildcard segment more
+// than any real on-disk channel-build layout actually has
+// (`channels/*/versions/*/*/logs` vs. the real `channels/*/versions/*/logs`),
+// so it silently matched zero channel-build logs on every platform, the
+// entire time that source existed — logRoots() now tries both depths.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { glob } from "./muxlog.mjs";
+
+let root;
+
+beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "muxlog-glob-test-"));
+});
+
+afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+function makeDir(...segments) {
+    const p = path.join(root, ...segments);
+    fs.mkdirSync(p, { recursive: true });
+    return p;
+}
+
+describe("muxlog glob", () => {
+    it("matches a literal-only pattern that exists", () => {
+        makeDir("a", "b", "c");
+        expect(glob(path.join(root, "a", "b", "c"))).toEqual([path.join(root, "a", "b", "c")]);
+    });
+
+    it("returns empty for a literal-only pattern that doesn't exist", () => {
+        expect(glob(path.join(root, "nope"))).toEqual([]);
+    });
+
+    it("matches the real 1-level channel-build depth: channels/*/versions/*/logs", () => {
+        const logs = makeDir("channels", "local-main-abc123", "versions", "0.55.19", "logs");
+        const found = glob(path.join(root, "channels", "*", "versions", "*", "logs"));
+        expect(found).toEqual([logs]);
+    });
+
+    it("does NOT match a 2-level layout with the 1-level pattern (proves the depths are genuinely distinct)", () => {
+        makeDir("channels", "local-main-abc123", "versions", "0.55.19", "extra", "logs");
+        const found = glob(path.join(root, "channels", "*", "versions", "*", "logs"));
+        expect(found).toEqual([]);
+    });
+
+    it("matches a 2-level layout with the 2-level pattern (in case some install shape uses it)", () => {
+        const logs = makeDir("channels", "local-main-abc123", "versions", "0.55.19", "extra", "logs");
+        const found = glob(path.join(root, "channels", "*", "versions", "*", "*", "logs"));
+        expect(found).toEqual([logs]);
+    });
+
+    it("matches multiple channels and versions", () => {
+        const a = makeDir("channels", "chan-a", "versions", "0.55.18", "logs");
+        const b = makeDir("channels", "chan-a", "versions", "0.55.19", "logs");
+        const c = makeDir("channels", "chan-b", "versions", "0.55.19", "logs");
+        const found = glob(path.join(root, "channels", "*", "versions", "*", "logs")).sort();
+        expect(found).toEqual([a, b, c].sort());
+    });
+
+    it("a sibling directory (data/cef-cache/runtime) next to logs is never picked up by the logs glob", () => {
+        makeDir("channels", "chan-a", "versions", "0.55.19", "data");
+        makeDir("channels", "chan-a", "versions", "0.55.19", "cef-cache");
+        const logs = makeDir("channels", "chan-a", "versions", "0.55.19", "logs");
+        const found = glob(path.join(root, "channels", "*", "versions", "*", "logs"));
+        expect(found).toEqual([logs]);
+    });
+});

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -276,14 +276,33 @@ pub fn install_crash_guard() -> Option<crate::crash_monitor::CrashHandlerGuard> 
 pub fn init_logging() -> tracing_appender::non_blocking::WorkerGuard {
     use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 
-    // Always log to ~/.agentmux/logs/ so all logs (host + sidecar) land in one
-    // discoverable directory. AGENTMUX_DATA_HOME controls the data dir, not logs.
+    // Prefer AGENTMUX_LOG_DIR (set by the launcher, per-instance-scoped —
+    // agentmux-common::DataPaths::to_env_vars) so srv's log file lands in the
+    // SAME per-channel directory agentmux-cef's host log already uses, and
+    // the same directory the shell-integration pointer lookups
+    // (bash.sh/zsh.sh/fish.fish/pwsh.ps1's `$AGENTMUX_LOG_DIR/current-<target>-
+    // v<version>.path`) already assume both host AND srv write into. Before
+    // this, srv unconditionally wrote to the SHARED ~/.agentmux/logs/ root
+    // regardless of channel — every instance at the same version interleaved
+    // into one file, with no way to attribute a line back to its instance
+    // (see docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
+    // §2.2-2.3). Read inline (not via DataPaths::from_env(), which requires
+    // several other vars to all be present) to match this file's existing
+    // lightweight-env-var-read style for a single value (see the
+    // AGENTMUX_CHANNEL/AGENTMUX_HOME_OVERRIDE reads below) and to keep
+    // working the same as before when AGENTMUX_LOG_DIR isn't set (a
+    // standalone/no-launcher run).
     // Version is embedded in the filename for side-by-side coexistence.
     let version = env!("CARGO_PKG_VERSION");
-    let log_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".agentmux")
-        .join("logs");
+    let log_dir = std::env::var_os("AGENTMUX_LOG_DIR")
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_default()
+                .join(".agentmux")
+                .join("logs")
+        });
     let _ = std::fs::create_dir_all(&log_dir);
 
     // Delete log files older than 7 days to prevent unbounded growth.

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -94,9 +94,12 @@ muxlog srv --since 2026-06-15T23:30 cat        # a time window
 AgentMux logs live in **three** root trees, not one:
 
 ```
-~/.agentmux/logs/                                   shared: sidecar, launcher, some host
-~/.agentmux/dev/<branch>/<hash>/logs/               task dev — keyed on the git branch
-~/.agentmux/channels/local-*/versions/<v>/.../logs/ portable / per-build instances
+~/.agentmux/logs/                                  shared: launcher, and sidecar
+                                                    when AGENTMUX_LOG_DIR isn't set
+~/.agentmux/dev/<branch>/<hash>/logs/              task dev — keyed on the git branch
+~/.agentmux/channels/<channel>/versions/<v>/logs/  portable / per-build instances —
+                                                    both host AND sidecar, as of the
+                                                    sidecar honoring AGENTMUX_LOG_DIR
 ```
 
 The old `muxlog` followed a single version-pinned pointer

--- a/docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
+++ b/docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
@@ -1,0 +1,168 @@
+# Report: muxspect/muxlog cross-channel inspection gaps
+
+Date: 2026-08-22
+Status: draft — findings from a live debugging session, not yet a spec
+
+## 1. Why this exists
+
+While investigating a real live bug (a dispatched Agent-tool subagent never
+appearing in the user's Swarm pane at all — not a naming issue, an absence),
+the debugging process itself turned into a live audit of `muxspect`/`muxlog`:
+every step that should have been "run a diagnostic command" instead required
+manually walking the filesystem, cross-referencing `Get-Process`, reading env
+vars by hand, and guessing which of several candidate log files was the real
+one. That manual process is recorded below verbatim as the evidence base for
+the extensions proposed in §3. The original bug is still **unresolved** —
+see §4.
+
+## 2. Concrete, reproducible gaps found this session
+
+### 2.1 `muxlog swarm` resolved to the wrong (stale) instance's log on the first try
+
+```
+$ node ~/.agentmux/shell/muxlog.mjs swarm --grep "ab786c0dbcfa0a121|71a6b2ae" -n 500
+=== swarm trace: C:\Users\asafe\.agentmux\logs\agentmuxsrv-v0.55.18.log.2026-08-22 ===
+```
+
+`muxlog ls` run moments later showed the actually-freshest srv log was
+`agentmuxsrv-v0.55.19.log.2026-08-22` (age `0s`) — a **different, newer**
+file than the `v0.55.18` one `swarm` silently picked. `discover()`'s own
+sort is `mtime` descending, so on paper `resolveFile("srv", opt)` should
+already have preferred the newer file; in practice the wrong one won. This
+is a real, reproducible correctness gap in the plain `resolveFile()` path
+that `swarm`, `errors`, `auth`, and `bridge` all share.
+
+Contrast with `muxlog phases`, which had this exact class of bug found by
+review (see `resolvePhaseFiles`'s own doc comment, muxlog.mjs:450-511) and
+was fixed by verifying log **content** actually contains the target block
+id, not trusting filename/mtime metadata alone. `swarm`/`errors`/`auth`/
+`bridge` never got that fix — they still trust `discover()[0]` (or the
+`-i`-filtered first match) unconditionally.
+
+### 2.2 No way to select a log by channel
+
+```
+$ node ~/.agentmux/shell/muxlog.mjs swarm -i local-main-b28b7a-b966d418 ...
+# no srv candidates matched — exits with "no srv log found matching '...'"
+```
+
+`$AGENTMUX_CHANNEL` (`local-main-b28b7a-b966d418` in this case) is the one
+identifier an agent or user can always name with certainty — it's in their
+own environment. But `-i` only substring-matches against the discovered
+file's **path**, **source** label, or **version** string
+(`resolveFile`/`muxlog.mjs:335-343`), and srv logs are tagged `source:
+"shared"` uniformly (`logRoots()`, muxlog.mjs:30-36) regardless of which
+channel's srv process actually wrote them. There is currently no query of
+the form "give me the log for *my own* running instance" that's guaranteed
+correct — only best-effort filename heuristics.
+
+### 2.3 Multiple srv processes likely share one log file by version coincidence
+
+The resolved `agentmuxsrv-v0.55.19.log.2026-08-22` file contains several
+`"subagent watcher initialized"` lines clustered within about 40 minutes
+(`18:59:34`, `19:01:29`, `19:01:30`, `19:39:19`, `19:39:20`) — more
+initialization events than this one session should produce, consistent with
+multiple srv processes (this machine had dozens of `agentmux*` processes
+running across portable builds, dev branches, and channels — confirmed via
+`Get-Process`) all logging to the same shared, version-keyed file. No log
+line carries a channel/instance tag to attribute it to a specific process
+after the fact — `muxlog`'s own log-rendering pipeline
+(`renderLine`/`shortTarget`) has no such field to show even if one existed.
+
+### 2.4 `muxspect` is explicitly single-instance by design
+
+Per `docs/MUXSPECT.md` and `muxspect.mjs`'s own header comment: Phase 1 only
+queries "the instance you're already inside," via
+`$AGENTMUX_LOCAL_URL`/`$AGENTMUX_AUTH_KEY` read from the caller's own
+environment. `muxspect conversations`/`conversation <agent>` (Phase A of
+`SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`, merged
+just hours before this session) is the first crack at cross-*channel*
+visibility, but it only covers registered **agents' conversations** — there
+is still no equivalent for "does a different running instance have a
+subagent dispatch/controller matching X."
+
+### 2.5 The just-merged cross-channel feature 404s on the actual running instance
+
+```
+$ node ~/.agentmux/shell/muxspect.mjs conversations
+muxspect: request failed (404): Not Found
+```
+
+`describe <my own block_id>` worked fine against the same instance
+moments later — so the API path and auth are fine in general, but the
+specific route this instance's running `agentmux-srv` binary was built
+before `feat(muxspect): cross-tier conversation visibility, Phase A`
+merged, and nothing told me that. No `muxspect`/`muxlog` command surfaces
+"the srv build you're actually talking to is older than the source tree
+you're reading" — every command's output should probably lead with the
+live instance's own reported version, and `muxspect`/`muxlog` themselves
+could sanity-check that against the newest known feature set instead of
+just failing opaquely on the missing route.
+
+### 2.6 No single command answers "where did this dispatch actually go"
+
+The manual reconstruction this session needed — confirm the subagent's
+`agent-<id>.jsonl` + `.meta.json` were written to
+`projects/<workspace>/<session>/subagents/`, confirm the srv's file watcher
+config matches that path/pattern, find the srv log actually written by the
+right process, grep it for the dispatch/block id — is exactly the kind of
+thing `muxspect`/`muxlog` exist to save someone from doing by hand. Today
+neither tool has a "for dispatch/agent X, tell me its full observed
+lifecycle" command; `muxlog swarm` gets closest but is a raw filtered tail,
+not a correlated answer.
+
+## 3. Proposed extensions
+
+Roughly in the order that unblocks the most downstream value:
+
+1. **Emit a structured instance-identity field on every srv/host log line**
+   (e.g. `channel=<AGENTMUX_CHANNEL>` or a short stable instance id), not
+   just in specific recipes' matchers. This is the actual root fix — `-i`
+   filtering, `phases`' bespoke content-verification resolver, and every
+   other gap in §2.1-2.3 are all workarounds for not having this at the
+   source. Once present, `muxlog -i` can match it directly instead of
+   guessing from file paths.
+2. **Factor `resolvePhaseFiles`'s content-verification logic into a shared
+   resolver** all recipes call, instead of only `phases` having it.
+   `swarm`/`errors`/`auth`/`bridge` inherit the same
+   wrong-instance-resolution risk today.
+3. **A real "list live instances" command** — extend `muxlog ls` (or add
+   `muxspect instances`) to cross-reference actual running processes (PID,
+   port, channel, version — ground truth) against the log files discovered
+   on disk, rather than inferring liveness from log mtimes alone. This
+   would have made the very first step of this session's investigation
+   ("which of these processes/channels is the one I'm actually in")
+   instant instead of manual.
+4. **`muxspect` Phase 2 cross-instance querying** (already planned per
+   `SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md`) — when it lands,
+   prioritize exactly the query this session needed: "which running
+   instance(s), if any, have a controller or subagent dispatch matching
+   block_id/agent X" — discoverable without the caller already knowing the
+   target channel.
+5. **Surface the live instance's own version prominently** in every
+   `muxspect` command's output (not just buried in `list`/`describe`'s
+   process metadata) so a stale-build 404 like §2.5 is self-diagnosing
+   ("you're talking to v0.55.19, this route needs v0.55.20+") instead of a
+   bare 404.
+6. **A correlated dispatch-lifecycle command** —
+   `muxlog swarm --dispatch <id>` or `muxspect dispatch <id>` — that
+   productizes the manual workflow in §2.6: find the subagent's
+   transcript/meta files, confirm the watcher's config covers that path,
+   pull the matching srv log lines (via the shared resolver from #2), and
+   report a single verdict (written → watched → registered → visible, or
+   the exact step where it stopped).
+
+## 4. Open — the original bug
+
+None of the above resolves *why* the test dispatch never appeared in Swarm.
+What's confirmed: the subagent's `agent-ab786c0dbcfa0a121.jsonl` +
+`.meta.json` were written correctly, at the right path, at the right time;
+the backend's file watcher is structurally configured to catch exactly that
+file pattern; and no srv log file located so far (including the
+freshest-available `v0.55.19` one) contains any line mentioning that
+dispatch id or this session's block id. The `session_belongs_to_block` gate
+in the event-processing pipeline (`subagent_watcher/mod.rs`) remains the
+leading suspect for a silent drop, but this could not be confirmed with the
+tooling available today — which is itself the point of this report. Once
+even §3.1 or §3.3 lands, re-running this same repro should give a
+conclusive answer instead of another round of manual log archaeology.


### PR DESCRIPTION
## Summary

Ext 1 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md` (included in this PR for context — findings from a live debugging session where a dispatched subagent never appeared in Swarm, and the diagnostic tools couldn't reliably say why).

Two compounding bugs found together:

1. **agentmux-srv wrote logs to the shared root regardless of channel.** `agentmux-cef` (host) already writes to a per-instance log dir; the shell-integration scripts (`bash.sh`/`zsh.sh`/`fish.fish`/`pwsh.ps1`) already assume `$AGENTMUX_LOG_DIR` holds both host AND srv pointer files. Only srv didn't honor it — every instance at the same version interleaved into one shared file, un-attributable after the fact. Fixed: srv now prefers `$AGENTMUX_LOG_DIR` (same var `agentmux-cef` already uses), falling back to the old shared-dir behavior when unset.

2. **`muxlog.mjs`'s own `channels/` discovery glob had the wrong depth.** `channels/*/versions/*/*/logs` vs. the real on-disk `channels/<channel>/versions/<v>/logs` (confirmed against a real running instance's own `AGENTMUX_LOG_DIR`) — one wildcard segment too many, so it matched **zero** channel-build logs, on any platform, for as long as that source existed. `logRoots()` now tries both depths (deduped).

Together: srv logs now land where `muxlog` can actually find them per-channel, so `muxlog swarm -i <channel>` / `errors -i <channel>` / etc. resolve to the right instance instead of a same-version sibling's interleaved shared log.

## Test plan
- [x] New `muxlog.test.mjs` (7 cases) pins the glob depth-matching fix against a real temp directory tree — `npx vitest run agentmux-srv/src/backend/shellintegration/muxlog.test.mjs` passes
- [x] `cargo check -p agentmux-srv` passes clean
- [ ] Manual verification against a rebuilt portable (can't retroactively fix already-running instances — needs a relaunch on the new binary)

<!-- agentmux:agent_id=korp -->