### PR TITLE
fix(editor): strip Windows' \?\ prefix so live-reload matching works

### DIFF
--- a/.changesets/1787434387-fix-editor-strip-windows-verbatim-prefix-so-live-reload-matc-l5fb.md
+++ b/.changesets/1787434387-fix-editor-strip-windows-verbatim-prefix-so-live-reload-matc-l5fb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): strip Windows' verbatim prefix so live-reload matching works

--- a/frontend/app/store/editor-pane-state-store.test.ts
+++ b/frontend/app/store/editor-pane-state-store.test.ts
@@ -514,15 +514,18 @@ describe("editor-pane-state-store (slice #10, Phase 1A)", () => {
         expect(prefixed).toBe("c:/Users/asafe/AppData/Local/Temp/probe.md");
     });
 
-    it("canonicalizePath strips the \\\\?\\UNC\\ variant for network shares", () => {
+    // Codex P2 on PR #2739: an earlier version of this fix stripped the
+    // \\?\UNC\ prefix but then let the pre-existing doubled-slash collapse
+    // eat the UNC authority marker too, producing "/server/share/..." — a
+    // current-drive-rooted path on Windows, not a usable network path. The
+    // leading "//" must survive so WatchEditorFileCommand/ReadEditorFileCommand
+    // get back something that still actually resolves to the share.
+    it("canonicalizePath strips the \\\\?\\UNC\\ variant while preserving the UNC authority marker", () => {
         const prefixed = canonicalizePath("\\\\?\\UNC\\server\\share\\file.md");
-        // The function's existing (pre-existing, unrelated to this fix)
-        // doubled-slash collapse already reduces a plain UNC path's
-        // leading "\\\\" to a single "/" — this test only pins down that
-        // the \\?\UNC\ prefix itself is stripped consistently with that
-        // existing behavior, not a claim of correct UNC round-tripping.
+        const plainUnc = canonicalizePath("\\\\server\\share\\file.md");
         expect(prefixed.startsWith("\\\\?\\")).toBe(false);
-        expect(prefixed).toBe("/server/share/file.md");
+        expect(prefixed).toBe("//server/share/file.md");
+        expect(prefixed).toBe(plainUnc);
     });
 
     it("slot dispatch path: OpenFile via dispatch updates the snapshot", () => {

--- a/frontend/app/store/editor-pane-state-store.test.ts
+++ b/frontend/app/store/editor-pane-state-store.test.ts
@@ -501,6 +501,30 @@ describe("editor-pane-state-store (slice #10, Phase 1A)", () => {
         expect(canonicalizePath("")).toBe("");
     });
 
+    // Regression for a live-repro'd bug (2026-08-22): Rust's
+    // Path::canonicalize() unconditionally prepends `\\?\` on Windows.
+    // EditorFileWatcher's editor:file_changed WPS event carries that
+    // prefixed path; without stripping it here, it can never compare
+    // equal to a tab's own (never-prefixed) filePath, so live-reload
+    // silently never fires on Windows at all.
+    it("canonicalizePath strips Windows' \\\\?\\ extended-length prefix so it matches the un-prefixed form", () => {
+        const prefixed = canonicalizePath("\\\\?\\C:\\Users\\asafe\\AppData\\Local\\Temp\\probe.md");
+        const unprefixed = canonicalizePath("C:\\Users\\asafe\\AppData\\Local\\Temp\\probe.md");
+        expect(prefixed).toBe(unprefixed);
+        expect(prefixed).toBe("c:/Users/asafe/AppData/Local/Temp/probe.md");
+    });
+
+    it("canonicalizePath strips the \\\\?\\UNC\\ variant for network shares", () => {
+        const prefixed = canonicalizePath("\\\\?\\UNC\\server\\share\\file.md");
+        // The function's existing (pre-existing, unrelated to this fix)
+        // doubled-slash collapse already reduces a plain UNC path's
+        // leading "\\\\" to a single "/" — this test only pins down that
+        // the \\?\UNC\ prefix itself is stripped consistently with that
+        // existing behavior, not a claim of correct UNC round-tripping.
+        expect(prefixed.startsWith("\\\\?\\")).toBe(false);
+        expect(prefixed).toBe("/server/share/file.md");
+    });
+
     it("slot dispatch path: OpenFile via dispatch updates the snapshot", () => {
         registerEditorPane("blk-x");
         const events = dispatch("blk-x", { type: "OpenFile", path: "C:/foo.ts" });

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -242,7 +242,14 @@ export function canonicalizePath(path: string): string {
         p = p.slice(4); // \\?\C:\... -> C:\...
     }
     p = p.replace(/\\/g, "/");
+    // codex P2 on PR #2739: a UNC path's leading "//" (the authority
+    // marker distinguishing \\server\share from a current-drive-rooted
+    // path) must survive the doubled-slash collapse below, or the
+    // \\?\UNC\ strip above is pointless — the result would compare equal
+    // between panes, but be unusable as an actual path to watch/read.
+    const isUnc = p.startsWith("//");
     p = p.replace(/\/{2,}/g, "/");
+    if (isUnc) p = "/" + p;
     // Windows drive letter — lowercase for stable equality.
     if (/^[A-Za-z]:\//.test(p)) {
         p = p[0].toLowerCase() + p.slice(1);

--- a/frontend/app/store/editor-pane-state-store.ts
+++ b/frontend/app/store/editor-pane-state-store.ts
@@ -208,10 +208,25 @@ export interface ReducerResult {
 /**
  * Canonicalize a filesystem path so `C:/x` and `C:\x` resolve to the
  * same tab. Phase 1A approach (cheap, deterministic, no I/O):
+ *   - strip Windows' `\\?\` extended-length ("verbatim") prefix
  *   - normalize backslashes to forward slashes
  *   - collapse repeated slashes
  *   - lowercase the Windows drive letter
  *   - strip a trailing slash (except for a bare "/" or drive root)
+ *
+ * **The `\\?\` strip closes a real live-reload bug**, confirmed by live
+ * repro (2026-08-22): `EditorFileWatcher`'s published `editor:file_changed`
+ * WPS event carries a path produced by Rust's `Path::canonicalize()`,
+ * which on Windows unconditionally prepends `\\?\` (`\\?\UNC\` for a
+ * network share) — well-documented std behavior, and something this
+ * backend's own comments already flag in two other places
+ * (`editor_file_watcher.rs`, `media_file_watcher.rs`) for the backend's
+ * OWN internal path matching. Nothing on the frontend ever produces that
+ * prefix for the same file (a tab's `filePath` is derived from whatever
+ * path was originally requested to open it), so without stripping it
+ * here, `_handleExternalFileChanged`'s `canonicalizePath(rawPath) !==
+ * canonicalizePath(tab.filePath)` comparison NEVER matches — live-reload
+ * silently never fires for any tab, on Windows, unconditionally.
  *
  * Symlink resolution is intentionally out of scope — that requires
  * filesystem I/O which can't sit inside a pure reducer. The saga in
@@ -220,7 +235,13 @@ export interface ReducerResult {
  */
 export function canonicalizePath(path: string): string {
     if (!path) return path;
-    let p = path.replace(/\\/g, "/");
+    let p = path;
+    if (p.startsWith("\\\\?\\UNC\\")) {
+        p = "\\\\" + p.slice(8); // \\?\UNC\server\share\... -> \\server\share\...
+    } else if (p.startsWith("\\\\?\\")) {
+        p = p.slice(4); // \\?\C:\... -> C:\...
+    }
+    p = p.replace(/\\/g, "/");
     p = p.replace(/\/{2,}/g, "/");
     // Windows drive letter — lowercase for stable equality.
     if (/^[A-Za-z]:\//.test(p)) {


### PR DESCRIPTION
## Summary
- Live-confirmed bug: an editor pane opened via the `OpenEditor` MCP tool never picks up an on-disk change made after the pane is open — reproduced end-to-end against a real running instance, confirmed by the repo owner directly checking the pane.
- Root cause: Rust's `Path::canonicalize()` unconditionally prepends the `\?\` extended-length prefix on Windows (`\?\UNC\` for a network share) — well-documented std behavior, and this backend's own comments already flag it in two sibling files (`editor_file_watcher.rs`, `media_file_watcher.rs`) for the backend's own internal path matching. But `EditorFileWatcher`'s published `editor:file_changed` WPS event ships that `\?\`-prefixed path straight to the frontend, and the frontend's `canonicalizePath()` never stripped it. A tab's own `filePath` is never `\?\`-prefixed, so the live-reload comparison in `_handleExternalFileChanged` could never match — silently, unconditionally, on every Windows install.
- Fix: `canonicalizePath()` (`frontend/app/store/editor-pane-state-store.ts`) now strips `\?\` and `\?\UNC\` before its existing normalization.

## Test plan
- [x] Two new regression tests in `editor-pane-state-store.test.ts`, proven to fail without the fix (exact string mismatch) and pass with it restored.
- [x] Full `vitest run` on the file (37 tests) — clean.
- [x] `tsc --noEmit` — clean.
- [x] **Live end-to-end verification**: launched an isolated `task dev` instance from this branch (window titled "agent1", per the repo owner's request), opened a probe file via `OpenEditor`, edited it on disk, confirmed the pane now updates live — repo owner confirmed directly ("yes great it works").

<!-- agentmux:agent_id=agent1 -->