### PR TITLE
fix(jekt): match plural forms of whole-word sensitive keywords

### DIFF
--- a/.changesets/1787434387-fix-jekt-match-plural-forms-of-whole-word-sensitive-keywords-srl5.md
+++ b/.changesets/1787434387-fix-jekt-match-plural-forms-of-whole-word-sensitive-keywords-srl5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(jekt): match plural forms of whole-word sensitive keywords

--- a/agentmux-srv/src/backend/reactive/sanitize.rs
+++ b/agentmux-srv/src/backend/reactive/sanitize.rs
@@ -143,13 +143,24 @@ pub fn format_injected_message(msg: &str, source_agent: Option<&str>, include_so
 }
 
 /// Keywords that must appear as whole words (surrounded by non-alphanumeric
-/// characters or at string boundaries) to trigger SENSITIVE escalation.
+/// characters or at string boundaries) to trigger SENSITIVE escalation, paired
+/// with whether a simple trailing "s" (plural) should also match.
 /// This prevents false positives from substrings like "patch", "dispatch",
-/// "pattern", "tokenize", "compatibility", etc. A simple trailing "s" is also
-/// accepted (see `contains_whole_word`), so plural forms like "tokens" or
-/// "credentials" match too.
-const SENSITIVE_WHOLE_WORD_KEYWORDS: &[&str] = &[
-    "pat", "token", "secret", "password", "credential", "keychain",
+/// "pattern", "tokenize", "compatibility", etc.
+///
+/// "pat" opts OUT of plural matching: its natural plural "pats" collides with
+/// the extremely common English verb ("the user pats the dog"), which is a
+/// far more common false-positive source than the singular "pat" already is
+/// on its own (PR #2740 review discussion). The other five keywords' plurals
+/// ("tokens", "secrets", "passwords", "credentials", "keychains") don't
+/// collide with unrelated common words, so they opt in.
+const SENSITIVE_WHOLE_WORD_KEYWORDS: &[(&str, bool)] = &[
+    ("pat", false),
+    ("token", true),
+    ("secret", true),
+    ("password", true),
+    ("credential", true),
+    ("keychain", true),
 ];
 
 /// Keywords that are matched as substrings (they are distinctive enough that
@@ -165,11 +176,12 @@ fn is_word_boundary(c: char) -> bool {
     !c.is_alphanumeric() && c != '_'
 }
 
-/// Returns true if `haystack` contains `needle` as a whole word, or as a whole
-/// word plus a simple trailing "s" (so "tokens"/"secrets"/"credentials"/etc.
-/// match the same as their singular form — see doc comment on
-/// SENSITIVE_WHOLE_WORD_KEYWORDS for why plurals were previously missed).
-fn contains_whole_word(haystack: &str, needle: &str) -> bool {
+/// Returns true if `haystack` contains `needle` as a whole word, or — when
+/// `allow_plural` is true — as a whole word plus a simple trailing "s" (so
+/// "tokens"/"secrets"/"credentials"/etc. match the same as their singular
+/// form; see doc comment on SENSITIVE_WHOLE_WORD_KEYWORDS for why plurals
+/// were previously missed, and why some keywords opt out).
+fn contains_whole_word(haystack: &str, needle: &str, allow_plural: bool) -> bool {
     let needle_len = needle.len();
     let bytes = haystack.as_bytes();
     let needle_bytes = needle.as_bytes();
@@ -184,11 +196,11 @@ fn contains_whole_word(haystack: &str, needle: &str) -> bool {
                 if after_ok {
                     return true;
                 }
-                // Not a boundary right after the match — allow exactly one
-                // trailing "s" (plural) before requiring the boundary. Since
-                // after_ok was false, after_idx < haystack.len() here, so
-                // indexing bytes[after_idx] is safe.
-                if bytes[after_idx] == b's' || bytes[after_idx] == b'S' {
+                // Not a boundary right after the match — optionally allow
+                // exactly one trailing "s" (plural) before requiring the
+                // boundary. Since after_ok was false, after_idx <
+                // haystack.len() here, so indexing bytes[after_idx] is safe.
+                if allow_plural && (bytes[after_idx] == b's' || bytes[after_idx] == b'S') {
                     let after_plural_idx = after_idx + 1;
                     let after_plural_ok = after_plural_idx == haystack.len()
                         || is_word_boundary(haystack[after_plural_idx..].chars().next().unwrap());
@@ -207,7 +219,9 @@ fn contains_whole_word(haystack: &str, needle: &str) -> bool {
 pub fn is_sensitive_message(msg: &str) -> bool {
     let lower = msg.to_lowercase();
     SENSITIVE_SUBSTRING_KEYWORDS.iter().any(|kw| lower.contains(kw))
-        || SENSITIVE_WHOLE_WORD_KEYWORDS.iter().any(|kw| contains_whole_word(&lower, kw))
+        || SENSITIVE_WHOLE_WORD_KEYWORDS
+            .iter()
+            .any(|(kw, allow_plural)| contains_whole_word(&lower, kw, *allow_plural))
 }
 
 /// Wrap an injected message with a structured `[JEKT:...]` marker block.

--- a/agentmux-srv/src/backend/reactive/sanitize.rs
+++ b/agentmux-srv/src/backend/reactive/sanitize.rs
@@ -145,7 +145,9 @@ pub fn format_injected_message(msg: &str, source_agent: Option<&str>, include_so
 /// Keywords that must appear as whole words (surrounded by non-alphanumeric
 /// characters or at string boundaries) to trigger SENSITIVE escalation.
 /// This prevents false positives from substrings like "patch", "dispatch",
-/// "pattern", "tokenize", "compatibility", etc.
+/// "pattern", "tokenize", "compatibility", etc. A simple trailing "s" is also
+/// accepted (see `contains_whole_word`), so plural forms like "tokens" or
+/// "credentials" match too.
 const SENSITIVE_WHOLE_WORD_KEYWORDS: &[&str] = &[
     "pat", "token", "secret", "password", "credential", "keychain",
 ];
@@ -163,7 +165,10 @@ fn is_word_boundary(c: char) -> bool {
     !c.is_alphanumeric() && c != '_'
 }
 
-/// Returns true if `haystack` contains `needle` as a whole word.
+/// Returns true if `haystack` contains `needle` as a whole word, or as a whole
+/// word plus a simple trailing "s" (so "tokens"/"secrets"/"credentials"/etc.
+/// match the same as their singular form — see doc comment on
+/// SENSITIVE_WHOLE_WORD_KEYWORDS for why plurals were previously missed).
 fn contains_whole_word(haystack: &str, needle: &str) -> bool {
     let needle_len = needle.len();
     let bytes = haystack.as_bytes();
@@ -172,10 +177,25 @@ fn contains_whole_word(haystack: &str, needle: &str) -> bool {
     while i + needle_len <= haystack.len() {
         if bytes[i..i + needle_len].eq_ignore_ascii_case(needle_bytes) {
             let before_ok = i == 0 || is_word_boundary(haystack[..i].chars().next_back().unwrap());
-            let after_ok = i + needle_len == haystack.len()
-                || is_word_boundary(haystack[i + needle_len..].chars().next().unwrap());
-            if before_ok && after_ok {
-                return true;
+            if before_ok {
+                let after_idx = i + needle_len;
+                let after_ok = after_idx == haystack.len()
+                    || is_word_boundary(haystack[after_idx..].chars().next().unwrap());
+                if after_ok {
+                    return true;
+                }
+                // Not a boundary right after the match — allow exactly one
+                // trailing "s" (plural) before requiring the boundary. Since
+                // after_ok was false, after_idx < haystack.len() here, so
+                // indexing bytes[after_idx] is safe.
+                if bytes[after_idx] == b's' || bytes[after_idx] == b'S' {
+                    let after_plural_idx = after_idx + 1;
+                    let after_plural_ok = after_plural_idx == haystack.len()
+                        || is_word_boundary(haystack[after_plural_idx..].chars().next().unwrap());
+                    if after_plural_ok {
+                        return true;
+                    }
+                }
             }
         }
         i += 1;

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -2268,19 +2268,13 @@ fn test_keyword_match_whole_word_at_string_boundaries() {
 }
 
 #[test]
-fn test_keyword_match_known_gap_plural_forms_not_caught() {
-    // KNOWN GAP, not a desired behavior: contains_whole_word requires a
-    // non-alphanumeric character (or string end) immediately after the
-    // keyword. Every SENSITIVE_WHOLE_WORD_KEYWORDS entry has a common English
-    // plural formed by appending "s" — that plural is alphanumeric, so it is
-    // NOT a word boundary, and none of these currently match. This means a
-    // jekt saying e.g. "rotate your tokens" or "your credentials were leaked"
-    // does NOT get keyword-escalated today. Documented here so a future edit
-    // to contains_whole_word (or the keyword lists) changes this test
-    // deliberately rather than silently. See PR discussion / follow-up issue
-    // before assuming this should be "fixed" — widening the match could also
-    // introduce new false positives (e.g. a plural-aware rule still needs to
-    // reject "patches"/"tokenizers").
+fn test_keyword_match_whole_word_plural_forms_are_caught() {
+    // Previously a known gap: contains_whole_word required a non-alphanumeric
+    // character (or string end) immediately after the keyword, so the common
+    // English plural of every SENSITIVE_WHOLE_WORD_KEYWORDS entry (formed by
+    // appending "s") slipped through uncaught — "rotate your tokens" reached
+    // TIER=coord instead of sensitive. Fixed by accepting one trailing "s"
+    // before the boundary check (see contains_whole_word).
     for msg in [
         "please rotate your tokens",
         "your credentials were leaked",
@@ -2288,10 +2282,21 @@ fn test_keyword_match_known_gap_plural_forms_not_caught() {
         "the secrets are stored here",
         "unlock the keychains",
     ] {
-        assert!(
-            !is_sensitive_message(msg),
-            "this plural form now matches — update this test deliberately if that's an intended fix: {msg:?}"
-        );
+        assert!(is_sensitive_message(msg), "expected sensitive: {msg:?}");
+    }
+}
+
+#[test]
+fn test_keyword_match_plural_rule_does_not_introduce_new_false_positives() {
+    // The plural-tolerant boundary check only accepts a SINGLE trailing "s"
+    // immediately followed by a real boundary (or end of string) — it must
+    // not match compound words that merely start with a keyword + "s".
+    for msg in [
+        "the tokensmith forged it", // "token" + "smith", not "tokens" + boundary
+        "a secretsauce recipe",     // "secret" + "sauce", not "secrets" + boundary
+        "credentialstore.example",  // "credential" + "store...", no boundary after the "s"
+    ] {
+        assert!(!is_sensitive_message(msg), "unexpectedly sensitive: {msg:?}");
     }
 }
 

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -2301,6 +2301,23 @@ fn test_keyword_match_plural_rule_does_not_introduce_new_false_positives() {
 }
 
 #[test]
+fn test_keyword_match_pat_opts_out_of_plural_to_avoid_common_verb_collision() {
+    // Found in PR #2740 review: a blanket "+s" plural rule applied to "pat"
+    // would match "pats" — the ordinary, very common English verb ("she
+    // pats the dog") — as if it were the plural of the PAT-token keyword.
+    // "pat" is excluded from plural matching for exactly this reason (see
+    // SENSITIVE_WHOLE_WORD_KEYWORDS); only the singular "pat" is keyword-
+    // sensitive, same as before this PR.
+    for msg in [
+        "the user pats the dog",
+        "she gently pats the cat",
+        "he pats his friend on the back",
+    ] {
+        assert!(!is_sensitive_message(msg), "unexpectedly sensitive: {msg:?}");
+    }
+}
+
+#[test]
 fn test_keyword_match_substring_positive_cases() {
     for msg in [
         "here is the api_key value",


### PR DESCRIPTION
## Summary

Follow-up to #2719. One of the two findings surfaced while writing the jekt tier-classification regression suite: `contains_whole_word` (`agentmux-srv/src/backend/reactive/sanitize.rs`) required a non-alphanumeric character immediately after a keyword match. A plural "s" is alphanumeric, so it never satisfied that check — every `SENSITIVE_WHOLE_WORD_KEYWORDS` entry (`pat`, `token`, `secret`, `password`, `credential`, `keychain`) matched its singular form but not its plural.

Concretely, before this fix: "your credentials were leaked" reached `TIER=coord`, not `sensitive`.

## Fix

Accept a single trailing "s" before requiring the word-boundary character, so plurals match the same as their singular. Compound words that merely start with a keyword still correctly do NOT match — the boundary is still required right after that trailing "s" — verified with a new false-positive guard test (`tokensmith`, `secretsauce`, `credentialstore.example` all still correctly pass as non-sensitive).

## What changed

- `sanitize.rs`: `contains_whole_word` now also checks for `<keyword>s` + boundary, not just `<keyword>` + boundary.
- `tests.rs`: the old `test_keyword_match_known_gap_plural_forms_not_caught` (which asserted the bug) now asserts the fix (`test_keyword_match_whole_word_plural_forms_are_caught`); added `test_keyword_match_plural_rule_does_not_introduce_new_false_positives` for the compound-word edge cases.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv reactive::tests::` — 101/101 passed

<!-- agentmux:agent_id=smike -->