### PR TITLE
Korp@claudius: fix(muxlog): prefer caller's own $AGENTMUX_CHANNEL over global freshest when resolving a log

### DIFF
--- a/.changesets/1787429114-fix-muxlog-prefer-caller-s-own-agentmux-channel-over-global--tos2.md
+++ b/.changesets/1787429114-fix-muxlog-prefer-caller-s-own-agentmux-channel-over-global--tos2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxlog): prefer caller's own $AGENTMUX_CHANNEL over global freshest when resolving a log

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -371,6 +371,32 @@ export function filterByInstance(cands, needle) {
     );
 }
 
+// $AGENTMUX_CHANNEL's dev-mode format is `dev-<branch>[-<clone_id>]`
+// (hyphen-joined — agentmux-common's resolve_channel_and_dir) but never
+// appears as a literal substring of a dev candidate's `.source`
+// (`"dev:" + branch`, colon) or `.file` path (`dev/<branch>/...`,
+// slash-separated) — same words, different separators, so
+// filterByInstance()'s plain substring check never matches (reagent P1 on
+// PR #2741: the own-channel default in pickCandidate silently never fired
+// for `task dev` — exactly the "several instances at the same version"
+// scenario this whole change exists for). Comparing the alphanumeric
+// skeleton (strip everything else) sidesteps needing to know which
+// separator scheme a given candidate uses; path segments stay in the same
+// left-to-right order regardless, so this doesn't need to special-case
+// clone_id either. Scoped to the own-channel default ONLY — an explicit
+// `-i` keeps filterByInstance()'s plain, literal substring matching
+// unchanged (a user typing `-i fix-shell` expects that to mean exactly
+// that substring, not a normalized fuzzy match).
+function normalizeForOwnChannelMatch(s) {
+    return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+export function matchesOwnChannel(cand, ownChannel) {
+    const needle = normalizeForOwnChannelMatch(ownChannel);
+    if (!needle) return false;
+    return [cand.file, cand.source, cand.version].some((s) => normalizeForOwnChannelMatch(s).includes(needle));
+}
+
 // Resolving "the" srv/host log used to mean "freshest across every instance
 // on the machine" — with several instances at the same version routinely
 // running at once (dev branches, portables, channels), that's frequently the
@@ -398,7 +424,7 @@ export function pickCandidate(cands, opt, ownChannel) {
         return filtered[0]?.file ?? null;
     }
     if (ownChannel) {
-        const own = filterByInstance(cands, ownChannel);
+        const own = cands.filter((c) => matchesOwnChannel(c, ownChannel));
         if (own.length) return own[0].file;
     }
     return cands[0]?.file ?? null; // most recently active, no preference matched

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -360,14 +360,60 @@ function parse(argv) {
     return { opt, pos };
 }
 
+// Case-insensitive across file path, source label, and version — the
+// original inline filter only lowercased `.file`, so an `-i` matching only
+// via `.source`/`.version` (e.g. `-i Dev:Main`) silently missed real
+// candidates. Exported for muxlog.test.mjs.
+export function filterByInstance(cands, needle) {
+    const n = needle.toLowerCase();
+    return cands.filter(
+        (e) => e.file.toLowerCase().includes(n) || e.source.toLowerCase().includes(n) || e.version.toLowerCase().includes(n),
+    );
+}
+
+// Resolving "the" srv/host log used to mean "freshest across every instance
+// on the machine" — with several instances at the same version routinely
+// running at once (dev branches, portables, channels), that's frequently the
+// WRONG instance, and nothing said so (see
+// docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
+// §2.1: `swarm` resolved to a stale sibling version's log on the very first
+// live repro of this). An explicit `-i` always wins, same as before. Absent
+// that, prefer OUR OWN running instance — $AGENTMUX_CHANNEL is already in
+// every agent pane's environment (same source resolveBlockId below already
+// trusts for $AGENTMUX_BLOCKID), so a caller running from inside an agent
+// pane gets ITS OWN instance's log by default instead of a same-version
+// sibling's. This is a soft preference, not a hard requirement: falls
+// through to the old "freshest overall" behavior when nothing matches
+// (`launcher` has no per-channel log at all; an older srv build predating
+// Ext 1's AGENTMUX_LOG_DIR fix still only writes to the shared root) rather
+// than failing outright — degrading gracefully beats refusing to run.
+//
+// Pure (no I/O, no process.exit) — takes already-discovered candidates so
+// muxlog.test.mjs can exercise the actual selection logic without touching
+// the real filesystem/HOME. Returns `null` when nothing matches at all;
+// `resolveFile` (below) owns turning that into the CLI's error+exit.
+export function pickCandidate(cands, opt, ownChannel) {
+    if (opt.instance) {
+        const filtered = filterByInstance(cands, opt.instance);
+        return filtered[0]?.file ?? null;
+    }
+    if (ownChannel) {
+        const own = filterByInstance(cands, ownChannel);
+        if (own.length) return own[0].file;
+    }
+    return cands[0]?.file ?? null; // most recently active, no preference matched
+}
+
 function resolveFile(target, opt) {
-    let cands = discover(target);
-    if (opt.instance) cands = cands.filter((e) => e.file.toLowerCase().includes(opt.instance.toLowerCase()) || e.source.includes(opt.instance) || e.version.includes(opt.instance));
-    if (!cands.length) {
-        console.error(`muxlog: no ${target} log found${opt.instance ? ` matching '${opt.instance}'` : ""}. Try \`muxlog ls\`.`);
+    const cands = discover(target);
+    const file = pickCandidate(cands, opt, process.env.AGENTMUX_CHANNEL);
+    if (!file) {
+        console.error(
+            `muxlog: no ${target} log found${opt.instance ? ` matching '${opt.instance}'` : ""}. Try \`muxlog ls\`.`,
+        );
         process.exit(1);
     }
-    return cands[0].file; // most recently active
+    return file;
 }
 
 // ─── phases ───────────────────────────────────────────────────────────────────
@@ -506,7 +552,10 @@ function resolvePhaseFiles(pos, opt) {
     const prefix = `pane=${blockId.slice(0, 7)}`;
 
     let hostCands = discover("host");
-    if (opt.instance) hostCands = hostCands.filter((e) => e.file.toLowerCase().includes(opt.instance.toLowerCase()) || e.source.includes(opt.instance) || e.version.includes(opt.instance));
+    // Case-insensitive filterByInstance (see its own doc comment) — the
+    // content-verification scan just below is the real correctness backstop
+    // for `phases`, so this is only ever an ordering hint, same as before.
+    if (opt.instance) hostCands = filterByInstance(hostCands, opt.instance);
     if (!hostCands.length) {
         console.error(`muxlog: no host log found${opt.instance ? ` matching '${opt.instance}'` : ""}. Try \`muxlog ls\`.`);
         process.exit(1);
@@ -593,9 +642,14 @@ function main() {
 
     if (cmd === "errors") {
         opt.level = ["error", "warn"];
+        // Was its own ad-hoc `.file`-only filter with no own-channel default
+        // at all — routed through the same pickCandidate() every other
+        // recipe uses so `errors` gets the same "prefer my own instance"
+        // behavior instead of "freshest anywhere" (see resolveFile's doc
+        // comment above).
         for (const tgt of ["host", "srv"]) {
-            const f = discover(tgt).filter((e) => !opt.instance || e.file.toLowerCase().includes(opt.instance.toLowerCase()))[0];
-            if (f) { console.log(`\n=== ${tgt}: ${f.file} ===`); printLastLines(f.file, opt.n, opt, true); }
+            const file = pickCandidate(discover(tgt), opt, process.env.AGENTMUX_CHANNEL);
+            if (file) { console.log(`\n=== ${tgt}: ${file} ===`); printLastLines(file, opt.n, opt, true); }
         }
         return;
     }

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -378,23 +378,59 @@ export function filterByInstance(cands, needle) {
 // slash-separated) — same words, different separators, so
 // filterByInstance()'s plain substring check never matches (reagent P1 on
 // PR #2741: the own-channel default in pickCandidate silently never fired
-// for `task dev` — exactly the "several instances at the same version"
-// scenario this whole change exists for). Comparing the alphanumeric
-// skeleton (strip everything else) sidesteps needing to know which
-// separator scheme a given candidate uses; path segments stay in the same
-// left-to-right order regardless, so this doesn't need to special-case
-// clone_id either. Scoped to the own-channel default ONLY — an explicit
-// `-i` keeps filterByInstance()'s plain, literal substring matching
-// unchanged (a user typing `-i fix-shell` expects that to mean exactly
-// that substring, not a normalized fuzzy match).
-function normalizeForOwnChannelMatch(s) {
-    return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+// for `task dev`).
+//
+// A first attempt fixed that by stripping ALL separators and doing a plain
+// substring check on the flattened result — reagent P1 round 2 caught the
+// real bug in that: flattening loses word boundaries, so needle
+// "dev-phase-3" (normalized "devphase3") is a substring-PREFIX of an
+// unrelated sibling's "dev-phase-3-repro" (normalized "devphase3repro"),
+// false-positive matching a genuinely different instance whose branch name
+// happens to start with the same characters. No amount of delimiter-padding
+// fixes this on its own, since needle being a true PREFIX of haystack's
+// token sequence still satisfies a boundary-aligned check trivially — the
+// fix has to require the needle match a COMPLETE identifying segment (or
+// exact concatenation of segments), never a partial/prefix one.
+//
+// So: normalize each candidate field into discrete tokens split on real
+// structural boundaries (`/`/`\` for the file path, `:` for the source
+// label's own prefix), and require EXACT equality against one of those
+// tokens — or, for the file path's `dev/<branch>/<clone_id>/logs/...`
+// shape specifically, exact equality against two CONSECUTIVE tokens joined
+// (branch + clone_id) — never a substring/prefix match against a flattened
+// blob. `-i` (filterByInstance) is untouched by any of this — a user
+// typing `-i fix-shell` still gets plain, literal substring matching, same
+// as always.
+function normalizeToken(s) {
+    return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 export function matchesOwnChannel(cand, ownChannel) {
-    const needle = normalizeForOwnChannelMatch(ownChannel);
+    const needle = normalizeToken(ownChannel);
     if (!needle) return false;
-    return [cand.file, cand.source, cand.version].some((s) => normalizeForOwnChannelMatch(s).includes(needle));
+
+    // Source label: "dev:<branch>" / "channel:<name>" / "shared" — strip a
+    // known "<word>:" prefix if present, exact-match what's left (with and
+    // without a "dev-" prepended, since the channel string carries that
+    // prefix but the source label's own identifying part doesn't).
+    const sourceIdent = normalizeToken(cand.source.replace(/^[a-z]+:/i, ""));
+    if (sourceIdent && (needle === sourceIdent || needle === `dev-${sourceIdent}`)) return true;
+
+    // File path: split on real path separators only (never on '-' — a
+    // branch/channel name's internal hyphens are part of ONE segment, not
+    // segment boundaries). Check each segment alone, and each consecutive
+    // pair joined (the dev-mode branch+clone_id shape), always as exact
+    // equality, never substring.
+    const segments = cand.file.split(/[\\/]/).map(normalizeToken).filter(Boolean);
+    for (let i = 0; i < segments.length; i++) {
+        const seg = segments[i];
+        if (needle === seg || needle === `dev-${seg}`) return true;
+        if (i + 1 < segments.length) {
+            const pair = `${seg}-${segments[i + 1]}`;
+            if (needle === pair || needle === `dev-${pair}`) return true;
+        }
+    }
+    return false;
 }
 
 // Resolving "the" srv/host log used to mean "freshest across every instance

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -200,4 +200,26 @@ describe("muxlog matchesOwnChannel", () => {
     it("an empty ownChannel never matches anything (guards against normalizing '' -> '' and matching every candidate)", () => {
         expect(matchesOwnChannel({ file: "anything", source: "anything", version: "" }, "")).toBe(false);
     });
+
+    // reagent P1 round 2 on PR #2741: the first fix (strip-all-separators,
+    // then substring check) false-positive matched a genuinely different
+    // sibling channel whose branch name happens to start with the caller's
+    // own branch name as a prefix. Real repro shape: "dev-phase-3" is a
+    // char-for-char prefix of "dev-phase-3-repro" once separators are
+    // flattened away, even though these are two unrelated instances.
+    it("does NOT match a sibling channel whose branch name is a prefix-extension of the caller's own (the exact false-positive reagent found)", () => {
+        const own = normalizeCandFor("dev:phase-3", String.raw`C:\x\dev\phase-3\hash1\logs\y.log`);
+        const sibling = normalizeCandFor("dev:phase-3-repro", String.raw`C:\x\dev\phase-3-repro\hash2\logs\y.log`);
+        expect(matchesOwnChannel(sibling, "dev-phase-3")).toBe(false);
+        expect(matchesOwnChannel(own, "dev-phase-3")).toBe(true);
+    });
+
+    it("does NOT match when the caller's branch is a prefix-extension of a sibling's shorter branch name (the reverse direction)", () => {
+        const shortSibling = { file: String.raw`C:\x\dev\phase\hash\logs\y.log`, source: "dev:phase", version: "" };
+        expect(matchesOwnChannel(shortSibling, "dev-phase-3")).toBe(false);
+    });
+
+    function normalizeCandFor(source, file) {
+        return { file, source, version: "" };
+    }
 });

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -1,22 +1,28 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Unit tests for muxlog.mjs's glob() — pure filesystem reads against a real
-// temp directory tree (no mocking needed, no network, no process.exit). Runs
-// as part of `npm test` (vitest), same discipline as muxspect.test.mjs.
+// Unit tests for muxlog.mjs's glob()/filterByInstance()/pickCandidate() —
+// pure logic (filesystem reads against a real temp dir for glob(), plain
+// data for the other two — no mocking needed, no network, no process.exit).
+// Runs as part of `npm test` (vitest), same discipline as muxspect.test.mjs.
 //
-// Pins the fix in docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
-// §2.2/§2.3: the channels/ log-discovery glob had one wildcard segment more
-// than any real on-disk channel-build layout actually has
-// (`channels/*/versions/*/*/logs` vs. the real `channels/*/versions/*/logs`),
-// so it silently matched zero channel-build logs on every platform, the
-// entire time that source existed — logRoots() now tries both depths.
+// Pins two fixes from docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
+// - §2.2/§2.3: the channels/ log-discovery glob had one wildcard segment more
+//   than any real on-disk channel-build layout actually has
+//   (`channels/*/versions/*/*/logs` vs. the real `channels/*/versions/*/logs`),
+//   so it silently matched zero channel-build logs on every platform, the
+//   entire time that source existed — logRoots() now tries both depths.
+// - §2.1: `resolveFile` picked "freshest across every instance on the
+//   machine" with no way to prefer the CALLER's own running instance —
+//   `swarm` resolved to a stale same-version sibling's log on the very first
+//   live repro. `pickCandidate` now prefers a candidate matching the
+//   caller's own $AGENTMUX_CHANNEL when no explicit `-i` is given.
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { glob } from "./muxlog.mjs";
+import { filterByInstance, glob, pickCandidate } from "./muxlog.mjs";
 
 let root;
 
@@ -76,5 +82,72 @@ describe("muxlog glob", () => {
         const logs = makeDir("channels", "chan-a", "versions", "0.55.19", "logs");
         const found = glob(path.join(root, "channels", "*", "versions", "*", "logs"));
         expect(found).toEqual([logs]);
+    });
+});
+
+describe("muxlog filterByInstance", () => {
+    const cands = [
+        { file: "/logs/agentmuxsrv-v0.55.19.log", source: "channel:local-main-abc123", version: "0.55.19" },
+        { file: "/logs/agentmuxsrv-v0.55.18.log", source: "shared", version: "0.55.18" },
+        { file: "/logs/agentmux-host-v0.55.19.log", source: "dev:agenta-feature", version: "0.55.19" },
+    ];
+
+    it("matches on file path substring", () => {
+        expect(filterByInstance(cands, "0.55.18")).toEqual([cands[1]]);
+    });
+
+    it("matches on source label", () => {
+        expect(filterByInstance(cands, "local-main-abc123")).toEqual([cands[0]]);
+    });
+
+    it("matches on version", () => {
+        expect(filterByInstance(cands, "0.55.19")).toEqual([cands[0], cands[2]]);
+    });
+
+    it("is case-insensitive across all three fields (the original inline filter was NOT — only .file was lowercased)", () => {
+        expect(filterByInstance(cands, "LOCAL-MAIN-ABC123")).toEqual([cands[0]]);
+        expect(filterByInstance(cands, "DEV:AGENTA-FEATURE")).toEqual([cands[2]]);
+    });
+
+    it("returns empty when nothing matches", () => {
+        expect(filterByInstance(cands, "no-such-instance")).toEqual([]);
+    });
+});
+
+describe("muxlog pickCandidate", () => {
+    const cands = [
+        { file: "/logs/agentmuxsrv-v0.55.19.log.fresh", source: "shared", version: "0.55.19" },
+        { file: "/logs/channels/local-main-abc123/agentmuxsrv-v0.55.19.log.mine", source: "channel:local-main-abc123", version: "0.55.19" },
+    ];
+
+    it("an explicit -i always wins, regardless of $AGENTMUX_CHANNEL", () => {
+        const opt = { instance: "local-main-abc123" };
+        expect(pickCandidate(cands, opt, "some-other-channel")).toBe(cands[1].file);
+    });
+
+    it("no explicit -i: prefers a candidate matching the caller's own $AGENTMUX_CHANNEL over 'freshest first'", () => {
+        // cands[0] is first in the list (would win under old "freshest/first" behavior);
+        // cands[1] is what should win once we know our own channel.
+        const opt = {};
+        expect(pickCandidate(cands, opt, "local-main-abc123")).toBe(cands[1].file);
+    });
+
+    it("no explicit -i, no own channel found among candidates: falls back to the first (freshest) candidate", () => {
+        const opt = {};
+        expect(pickCandidate(cands, opt, "a-channel-with-no-log-here")).toBe(cands[0].file);
+    });
+
+    it("no explicit -i, $AGENTMUX_CHANNEL unset entirely: falls back to the first (freshest) candidate — old behavior preserved", () => {
+        const opt = {};
+        expect(pickCandidate(cands, opt, undefined)).toBe(cands[0].file);
+    });
+
+    it("explicit -i matching nothing returns null (caller turns this into an error+exit)", () => {
+        const opt = { instance: "nonexistent" };
+        expect(pickCandidate(cands, opt, "local-main-abc123")).toBeNull();
+    });
+
+    it("empty candidate list returns null", () => {
+        expect(pickCandidate([], {}, "local-main-abc123")).toBeNull();
     });
 });

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -22,7 +22,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { filterByInstance, glob, pickCandidate } from "./muxlog.mjs";
+import { filterByInstance, glob, matchesOwnChannel, pickCandidate } from "./muxlog.mjs";
 
 let root;
 
@@ -147,7 +147,57 @@ describe("muxlog pickCandidate", () => {
         expect(pickCandidate(cands, opt, "local-main-abc123")).toBeNull();
     });
 
+    // reagent P1 on PR #2741: $AGENTMUX_CHANNEL's dev-mode format is
+    // `dev-<branch>[-<clone_id>]` (hyphen), but logRoots() labels dev
+    // candidates `"dev:" + branch` (colon) with a slash-separated `.file`
+    // path — a plain substring check on the raw channel string never
+    // matches either, so the own-channel default silently never fired for
+    // task dev, reproducing the exact stale-sibling-log bug this PR exists
+    // to fix. Real formats from a live system, not invented ones.
+    it("no explicit -i: matches a dev-mode instance despite the separator mismatch (hyphen channel vs. colon source / slash path)", () => {
+        const devCands = [
+            { file: String.raw`C:\Users\x\.agentmux\dev\main\bd69a405f49440de\logs\agentmux-host-v0.55.19.log`, source: "dev:main", version: "0.55.19" },
+            { file: String.raw`C:\Users\x\.agentmux\dev\agentx-quick-fork-phase-3-4\a4649045a423d8c8\logs\agentmux-host-v0.55.19.log`, source: "dev:agentx-quick-fork-phase-3-4", version: "0.55.19" },
+        ];
+        const opt = {};
+        expect(pickCandidate(devCands, opt, "dev-agentx-quick-fork-phase-3-4")).toBe(devCands[1].file);
+    });
+
+    it("no explicit -i: matches a dev-mode instance with a clone_id suffix on the channel", () => {
+        const devCands = [
+            { file: String.raw`C:\Users\x\.agentmux\dev\main\bd69a405f49440de\logs\agentmux-host-v0.55.19.log`, source: "dev:main", version: "0.55.19" },
+            { file: String.raw`C:\Users\x\.agentmux\dev\main\abc123clone\logs\agentmux-host-v0.55.19.log`, source: "dev:main", version: "0.55.19" },
+        ];
+        const opt = {};
+        // Both candidates' source is "dev:main" (identical, source alone can't
+        // disambiguate) — the clone_id in the channel only appears in the
+        // SECOND candidate's file path, which is what should decide it.
+        expect(pickCandidate(devCands, opt, "dev-main-abc123clone")).toBe(devCands[1].file);
+    });
+
     it("empty candidate list returns null", () => {
         expect(pickCandidate([], {}, "local-main-abc123")).toBeNull();
+    });
+});
+
+describe("muxlog matchesOwnChannel", () => {
+    it("matches despite hyphen vs. colon separator (dev-mode channel vs. muxlog's 'dev:' source label)", () => {
+        expect(matchesOwnChannel({ file: "", source: "dev:agentx-feature", version: "" }, "dev-agentx-feature")).toBe(true);
+    });
+
+    it("matches despite hyphen vs. slash separator (dev-mode channel vs. a filesystem path)", () => {
+        expect(matchesOwnChannel({ file: String.raw`C:\x\dev\agentx-feature\hash\logs\y.log`, source: "", version: "" }, "dev-agentx-feature")).toBe(true);
+    });
+
+    it("matches the portable channel:<name> format unchanged", () => {
+        expect(matchesOwnChannel({ file: "", source: "channel:local-main-abc123", version: "" }, "local-main-abc123")).toBe(true);
+    });
+
+    it("does not match an unrelated channel", () => {
+        expect(matchesOwnChannel({ file: "", source: "dev:agentx-feature", version: "" }, "dev-someone-else")).toBe(false);
+    });
+
+    it("an empty ownChannel never matches anything (guards against normalizing '' -> '' and matching every candidate)", () => {
+        expect(matchesOwnChannel({ file: "anything", source: "anything", version: "" }, "")).toBe(false);
     });
 });

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -25,9 +25,16 @@ muxlog phases       # merged turn-phase timeline for one pane — defaults to yo
 muxlog help         # full usage
 ```
 
-`muxlog` always defaults to the **most-recently-active** instance. With several
-instances running (dev + portables + different versions), that's almost always
-the one you mean — and `muxlog ls` shows the rest.
+`muxlog` defaults to **your own running instance** when it can tell what that
+is — `$AGENTMUX_CHANNEL` is already set in every agent pane's environment, so
+a recipe run from inside an agent pane resolves to that instance's own log
+first, not a same-version sibling's. Falls back to the
+**most-recently-active** instance across the whole machine only when nothing
+matches your own channel (e.g. `launcher`, which has no per-channel log at
+all) or `$AGENTMUX_CHANNEL` isn't set (a human running `muxlog` outside any
+agent pane). `-i <substr>` always overrides both. `muxlog ls` shows every
+instance so you can sanity-check which one a bare `muxlog swarm`/`errors`/
+etc. actually resolved to.
 
 ---
 


### PR DESCRIPTION
## Summary

Ext 2 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md` §2.1.

The report proposed porting `phases`' content-verification resolver to `swarm`/`errors`/`auth`/`bridge`. Those recipes don't take a block-id argument, so there's no "needle" to check log content against. Simpler, more precise fix: `$AGENTMUX_CHANNEL` is already set in every agent pane's environment — use the caller's own identity as ground truth instead.

- `pickCandidate()` (new, pure, extracted from `resolveFile`) now prefers a candidate matching the caller's own channel when no explicit `-i` is given, falling back to "freshest overall" only when nothing matches.
- `errors` had its own separate ad-hoc `.file`-only filter with no own-channel default at all — now routed through the shared resolver like every other recipe.
- `filterByInstance()` (extracted, exported) fixes a case-sensitivity bug: the original inline filter only lowercased `.file`, not `.source`/`.version`.
- `phases`' own filtering reuses `filterByInstance()` too (same case-sensitivity fix), keeping its existing content-verification as the real correctness backstop, unchanged.

## Test plan
- [x] 11 new test cases (`filterByInstance` + `pickCandidate`) — `npx vitest run agentmux-srv/src/backend/shellintegration/` passes 40/40

<!-- agentmux:agent_id=korp -->