### PR TITLE
Korp@claudius: feat(muxlog): ls gains a LIVE column via real TCP liveness probe of each instance's ipc-port

### DIFF
--- a/.changesets/1787434874-feat-muxlog-ls-gains-a-live-column-via-real-tcp-liveness-pro-huv1.md
+++ b/.changesets/1787434874-feat-muxlog-ls-gains-a-live-column-via-real-tcp-liveness-pro-huv1.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxlog): ls gains a LIVE column via real TCP liveness probe of each instance's ipc-port

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -14,6 +14,7 @@
 // One tested implementation does discovery + JSON rendering + filtering uniformly.
 
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
@@ -207,8 +208,63 @@ function follow(file, opt) {
     }, 400);
 }
 
+// ─── liveness ─────────────────────────────────────────────────────────────────
+// A log's mtime says "something was written recently," not "this instance is
+// running right now" — the two look identical for a process that just died.
+// agentmux-cef already writes a real, checkable liveness signal per instance:
+// `<data-dir>/ipc-port-<hash>` (agentmux-launcher/src/second_instance.rs),
+// containing `port:token` for the host's cross-window IPC listener. We don't
+// replicate the launcher's FNV-1a dir_hash to compute the exact filename —
+// glob for any `ipc-port-*` in the sibling `data` dir instead, cheaper and
+// forward-compatible if the hash scheme ever changes. A raw TCP connect (no
+// HTTP/token exchange — we're not actually forwarding an IPC call, just
+// confirming something is listening) is enough: nothing binds a dead
+// process's port, so a refused/timed-out connect means genuinely gone, not
+// just quiet.
+//
+// Exported (pure logic split from the fs/net I/O) for muxlog.test.mjs.
+export function siblingDataDir(logDir) {
+    if (path.basename(logDir) !== "logs") return null;
+    return path.join(path.dirname(logDir), "data");
+}
+
+function probePort(port, timeoutMs = 300) {
+    return new Promise((resolve) => {
+        let done = false;
+        const finish = (alive) => {
+            if (done) return;
+            done = true;
+            sock.destroy();
+            resolve(alive);
+        };
+        const sock = net.createConnection({ host: "127.0.0.1", port, timeout: timeoutMs });
+        sock.once("connect", () => finish(true));
+        sock.once("timeout", () => finish(false));
+        sock.once("error", () => finish(false));
+    });
+}
+
+// "live" | "dead" | "?" — "?" means genuinely unknown (no sibling data dir,
+// no port file, or unreadable/malformed contents), never a liveness verdict
+// of its own. Async — the only I/O-bound piece of muxlog; every caller
+// awaits a Promise.all of these so probes for different instances run
+// concurrently instead of serially piling up 300ms timeouts.
+export async function checkLiveness(logDir) {
+    const dataDir = siblingDataDir(logDir);
+    if (!dataDir) return "?";
+    let entries;
+    try { entries = fs.readdirSync(dataDir); } catch { return "?"; }
+    const portFile = entries.find((n) => n.startsWith("ipc-port-"));
+    if (!portFile) return "?";
+    let contents;
+    try { contents = fs.readFileSync(path.join(dataDir, portFile), "utf8"); } catch { return "?"; }
+    const port = parseInt(contents.trim().split(":")[0], 10);
+    if (!Number.isFinite(port) || port <= 0 || port > 65535) return "?";
+    return (await probePort(port)) ? "live" : "dead";
+}
+
 // ─── ls ───────────────────────────────────────────────────────────────────────
-function listInstances() {
+async function listInstances() {
     const seen = new Set();
     const rows = [];
     for (const e of discover("host").concat(discover("srv"), discover("launcher"))) {
@@ -217,12 +273,16 @@ function listInstances() {
     }
     rows.sort((a, b) => b.mtime - a.mtime);
     if (!rows.length) { console.log("No AgentMux logs found under ~/.agentmux."); return; }
-    console.log(`${"TARGET".padEnd(9)}${"VERSION".padEnd(9)}${"SOURCE".padEnd(22)}${"AGE".padEnd(8)}${"SIZE".padEnd(8)}PATH`);
-    for (const e of rows) {
+    const live = await Promise.all(rows.map((e) => checkLiveness(path.dirname(e.file))));
+    console.log(`${"TARGET".padEnd(9)}${"VERSION".padEnd(9)}${"SOURCE".padEnd(22)}${"LIVE".padEnd(6)}${"AGE".padEnd(8)}${"SIZE".padEnd(8)}PATH`);
+    rows.forEach((e, i) => {
         console.log(
             e.target.padEnd(9) + e.version.padEnd(9) + e.source.slice(0, 21).padEnd(22) +
-            age(e.mtime).padEnd(8) + human(e.size).padEnd(8) + e.file,
+            live[i].padEnd(6) + age(e.mtime).padEnd(8) + human(e.size).padEnd(8) + e.file,
         );
+    });
+    if (live.every((v) => v === "?")) {
+        console.log(`\nLIVE column is '?' for everything — this host has no findable ipc-port-* files (older builds predating this feature, or none of these are agentmux-cef host instances).`);
     }
 }
 function age(ms) {
@@ -694,12 +754,12 @@ Options (any position):
   --since <ts>  only lines at/after ISO <ts> (e.g. 2026-06-15T23:30)
   --raw         emit the original NDJSON   --verbose  include structured fields`;
 
-function main() {
+async function main() {
     const { opt, pos } = parse(process.argv.slice(2));
     const cmd = pos[0] || "host";
 
     if (cmd === "help" || cmd === "-h" || cmd === "--help") { console.log(HELP); return; }
-    if (cmd === "ls") { listInstances(); return; }
+    if (cmd === "ls") { await listInstances(); return; }
     if (cmd === "mem" || cmd === "doctor") { memDoctor(); return; }
 
     if (cmd === "errors") {
@@ -802,7 +862,12 @@ function main() {
 
 // Only run when executed directly (`node muxlog.mjs ...`) — importing this
 // module (muxlog.test.mjs imports `glob`) must not trigger a live tail loop /
-// `process.exit`. Same pattern as muxspect.mjs.
+// `process.exit`. Same pattern as muxspect.mjs. `main` is async now (the
+// `ls` recipe awaits liveness probes) — `.catch` surfaces a rejected
+// promise as a visible error instead of an unhandled-rejection warning.
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-    main();
+    main().catch((e) => {
+        console.error(`muxlog: ${e?.message ?? String(e)}`);
+        process.exit(1);
+    });
 }

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -6,7 +6,7 @@
 // data for the other two — no mocking needed, no network, no process.exit).
 // Runs as part of `npm test` (vitest), same discipline as muxspect.test.mjs.
 //
-// Pins two fixes from docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
+// Pins three fixes/features from docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
 // - §2.2/§2.3: the channels/ log-discovery glob had one wildcard segment more
 //   than any real on-disk channel-build layout actually has
 //   (`channels/*/versions/*/*/logs` vs. the real `channels/*/versions/*/logs`),
@@ -17,12 +17,17 @@
 //   `swarm` resolved to a stale same-version sibling's log on the very first
 //   live repro. `pickCandidate` now prefers a candidate matching the
 //   caller's own $AGENTMUX_CHANNEL when no explicit `-i` is given.
+// - Ext 3: `muxlog ls` inferred liveness from log mtime alone (a dead
+//   process's log looks identical to a live-but-idle one). checkLiveness()
+//   TCP-probes the real `ipc-port-*` file agentmux-cef already writes per
+//   instance.
 
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { filterByInstance, glob, matchesOwnChannel, pickCandidate } from "./muxlog.mjs";
+import { checkLiveness, filterByInstance, glob, matchesOwnChannel, pickCandidate, siblingDataDir } from "./muxlog.mjs";
 
 let root;
 
@@ -222,4 +227,81 @@ describe("muxlog matchesOwnChannel", () => {
     function normalizeCandFor(source, file) {
         return { file, source, version: "" };
     }
+});
+
+describe("muxlog siblingDataDir", () => {
+    it("swaps a trailing 'logs' segment for 'data'", () => {
+        const logs = path.join("channels", "chan-a", "versions", "0.55.19", "logs");
+        const data = path.join("channels", "chan-a", "versions", "0.55.19", "data");
+        expect(siblingDataDir(logs)).toBe(data);
+    });
+
+    it("returns null for a directory that isn't named 'logs'", () => {
+        expect(siblingDataDir(path.join("channels", "chan-a", "versions", "0.55.19", "data"))).toBeNull();
+    });
+});
+
+describe("muxlog checkLiveness", () => {
+    let root;
+    let server;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), "muxlog-liveness-test-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+        server?.close();
+        server = undefined;
+    });
+
+    function makeInstance() {
+        const logDir = path.join(root, "logs");
+        const dataDir = path.join(root, "data");
+        fs.mkdirSync(logDir, { recursive: true });
+        fs.mkdirSync(dataDir, { recursive: true });
+        return { logDir, dataDir };
+    }
+
+    function listenOnEphemeralPort() {
+        return new Promise((resolve) => {
+            server = net.createServer();
+            server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+        });
+    }
+
+    it("returns '?' when there's no sibling data dir at all", async () => {
+        const logDir = path.join(root, "logs");
+        fs.mkdirSync(logDir, { recursive: true });
+        // no "data" dir created
+        expect(await checkLiveness(logDir)).toBe("?");
+    });
+
+    it("returns '?' when the data dir exists but has no ipc-port-* file", async () => {
+        const { logDir } = makeInstance();
+        expect(await checkLiveness(logDir)).toBe("?");
+    });
+
+    it("returns '?' for a malformed port file (no ':' separator, or non-numeric port)", async () => {
+        const { logDir, dataDir } = makeInstance();
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), "not-a-port-file");
+        expect(await checkLiveness(logDir)).toBe("?");
+    });
+
+    it("returns 'live' when something is actually listening on the recorded port", async () => {
+        const { logDir, dataDir } = makeInstance();
+        const port = await listenOnEphemeralPort();
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("live");
+    });
+
+    it("returns 'dead' when the recorded port has nothing listening on it", async () => {
+        const { logDir, dataDir } = makeInstance();
+        // Bind then immediately close — the port is very likely free again,
+        // and nothing else in this test process will grab it in between.
+        const port = await listenOnEphemeralPort();
+        await new Promise((resolve) => server.close(resolve));
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("dead");
+    });
 });


### PR DESCRIPTION
## Summary

Ext 3 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`.

**Stacked on #2741 (Ext 2)** — this branches from `korp/muxlog-own-channel-preference`, not `main`, since it extends the same file. Once #2741 merges and its branch is deleted, GitHub should auto-retarget this PR to `main`.

A log's mtime says "something was written recently," not "this instance is running right now" — the two look identical for a process that died right after its last log line. `agentmux-cef` already writes a real, checkable liveness signal per instance: `<data-dir>/ipc-port-<hash>` (`agentmux-launcher/src/second_instance.rs`), containing `port:token` for the host's cross-window IPC listener.

`checkLiveness(logDir)` finds the sibling `data` dir, globs for any `ipc-port-*` file (doesn't replicate the launcher's FNV-1a hash — just finds whatever's there), and does a raw TCP connect to the recorded port with a short timeout. Returns `"live" | "dead" | "?"` (genuinely unknown, never a false "confirmed dead").

`muxlog ls` now shows this as a **LIVE** column, probing every listed instance concurrently.

## Test plan
- [x] 7 new test cases (`siblingDataDir` + `checkLiveness`, the latter against a real ephemeral TCP listener) — 47/47 passing overall in this file's suite
- [x] **Verified end-to-end against this machine's real running instances**, not just unit tests: both live channel-build instances correctly show `live`; dev-mode/shared entries show `?` (honest — dev builds don't appear to write the same ipc-port file)

<!-- agentmux:agent_id=korp -->