### PR TITLE
Korp@claudius: docs(claude): PR title Agent@host prefix for shared-identity agents

### DIFF
--- a/.changesets/1787435685-docs-claude-pr-title-agent-host-prefix-for-shared-identity-a-te13.md
+++ b/.changesets/1787435685-docs-claude-pr-title-agent-host-prefix-for-shared-identity-a-te13.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(claude): PR title Agent@host prefix for shared-identity agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,15 @@ git push -u origin feature-name
 # say which agent opened the PR, so without this tag your review
 # notifications are silently dropped. Always include it regardless, so you
 # don't have to track which case you're in.
-scripts/gh-agent.sh pr create --title "Feature" --body "$(cat <<EOF
+#
+# If gh-agent.sh fell back to GenericAgentX-<host> (see below), ALSO prepend
+# the PR TITLE with "<AgentName>@<host>: " (natural casing, e.g. "Korp@claudius:")
+# — the body tag is machine-read only, so a human scanning the PR list still
+# can't tell shared-identity agents apart without opening each PR. See
+# SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md. Standard-identity agents
+# (own dedicated PAT/App account, or a registered named peer account) skip
+# this — their username already disambiguates them in the list.
+scripts/gh-agent.sh pr create --title "${AGENTMUX_AGENT_ID}@$(hostname): Feature" --body "$(cat <<EOF
 Description of the change.
 
 <!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->
@@ -341,6 +349,14 @@ attributes your PRs/comments to the wrong account.
 Since `GH_TOKEN` is resolved fresh on every call, this always reflects whichever
 agent is currently running — no login/logout step needed, and nothing to keep in
 sync when a new dedicated PAT is registered for you later.
+
+**If step 3 fired (shared `GenericAgentX-<host>` fallback, not your own dedicated
+PAT):** prepend your PR title with `<AgentName>@<host>: ` — see the PR-create
+example above and `SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md`. The body tag
+already handles automated review routing for this case; the title prefix is
+the human-readable counterpart, since every shared-identity PR otherwise shows
+the same generic author in the PR list with no way to tell agents apart at a
+glance.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,13 +311,22 @@ git push -u origin feature-name
 # notifications are silently dropped. Always include it regardless, so you
 # don't have to track which case you're in.
 #
-# If gh-agent.sh fell back to GenericAgentX-<host> (see below), ALSO prepend
-# the PR TITLE with "<AgentName>@<host>: " (natural casing, e.g. "Korp@claudius:")
-# — the body tag is machine-read only, so a human scanning the PR list still
+# Standard identity (your own dedicated PAT/App account, or a registered
+# named peer account) — plain title, no prefix:
+scripts/gh-agent.sh pr create --title "Feature" --body "$(cat <<EOF
+Description of the change.
+
+<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->
+EOF
+)"
+
+# Shared identity ONLY — gh-agent.sh fell back to GenericAgentX-<host> (see
+# "Which GitHub account am I acting as?" below): ALSO prepend the PR TITLE
+# with "<AgentName>@<host>: " (natural casing, e.g. "Korp@claudius:") — the
+# body tag above is machine-read only, so a human scanning the PR list still
 # can't tell shared-identity agents apart without opening each PR. See
-# SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md. Standard-identity agents
-# (own dedicated PAT/App account, or a registered named peer account) skip
-# this — their username already disambiguates them in the list.
+# SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md. Do NOT use this form if you
+# have a dedicated PAT — your username already disambiguates you in the list.
 scripts/gh-agent.sh pr create --title "${AGENTMUX_AGENT_ID}@$(hostname): Feature" --body "$(cat <<EOF
 Description of the change.
 

--- a/docs/specs/SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md
+++ b/docs/specs/SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md
@@ -1,0 +1,101 @@
+# SPEC: PR title `Agent@host` prefix for shared-identity agents
+
+**Date:** 2026-08-22
+**Status:** Implemented
+**Author:** Korp
+**Repos touched:** `agentmux` (this doc + `CLAUDE.md` agent-facing policy)
+**Related:** `SPEC_AGENT_DETECTION_PRIORITY_2026_08_07.md` (the existing
+`<!-- agentmux:agent_id=... -->` body-tag mechanism this change complements,
+does not replace)
+
+## 1. Problem
+
+`SPEC_AGENT_DETECTION_PRIORITY_2026_08_07.md` already solves *automated*
+review-notification routing for an agent pushing under the shared
+`GenericAgentX-<host>` fallback account (`CLAUDE.md`'s "Which GitHub account
+am I acting as?" — the identity `scripts/gh-agent.sh` falls back to when an
+agent has no dedicated PAT registered): the PR-body tag tells the webhook
+consumer exactly which agent to notify, even though the GitHub *username* on
+the PR is the same shared account regardless of which agent actually opened
+it.
+
+That mechanism is invisible to a **human**, though. Someone scanning
+`github.com/agentmuxai/agentmux/pulls` sees a flat list of titles and author
+avatars — every PR opened by a shared-identity agent shows the identical
+generic author (`GenericAgentX-asaf`, or whichever host-suffixed variant),
+with no way to tell which agent opened which PR without clicking into each
+one individually to read its body tag. Confirmed live: this session's own
+PRs (#2738, #2741, #2742) were all opened this way, indistinguishable from
+each other in the PR list by author alone.
+
+## 2. Change
+
+Any agent operating under a **shared, non-dedicated** GitHub identity (in
+practice: `scripts/gh-agent.sh` resolved the `gh-token-genericagentx`
+fallback key, not a `gh-token-<your-id>` dedicated one) must prepend its PR
+**title** with:
+
+```
+<AgentName>@<host>: <normal title>
+```
+
+Example, this session:
+
+```
+Korp@claudius: fix(muxlog): srv logs honor AGENTMUX_LOG_DIR, fix channels/ glob depth mismatch
+```
+
+- `<AgentName>` — `$AGENTMUX_AGENT_ID` in its natural/display casing (e.g.
+  `Korp`), **not** lowercased. This is a deliberate, visible difference from
+  the body tag's `${AGENTMUX_AGENT_ID,,}` convention: the tag is a
+  machine-matched string (lowercasing keeps it a stable, unambiguous key);
+  the title prefix is read by a human, where natural casing is the whole
+  point.
+- `<host>` — this machine's hostname (`$HOSTNAME` on bash/zsh/fish,
+  `$COMPUTERNAME` on Windows — confirmed identical value on a real machine
+  during this session: `claudius`).
+
+**Agents with a standard identity are exempt** — a dedicated numbered
+PAT/App account (`Agent3-<host>`) or a registered named peer account
+(`korp-asaf`), per `SPEC_AGENT_DETECTION_PRIORITY_2026_08_07.md`'s exact
+terminology. Their GitHub username already disambiguates them at a glance in
+the PR list — the same exception the body tag already carries, extended
+here to the title for the same reason.
+
+## 3. Why the title, not just the existing body tag
+
+The two mechanisms solve different problems and both are required together,
+not one replacing the other:
+
+| | Body tag | Title prefix |
+|---|---|---|
+| Reader | Machine (webhook consumer) | Human (PR list, notifications, git log) |
+| Purpose | Route review notifications to the right agent | Let a human tell agents apart without opening each PR |
+| Format | `${AGENTMUX_AGENT_ID,,}` (lowercase, exact-match key) | `$AGENTMUX_AGENT_ID` (natural casing, for reading) |
+| Status | Already implemented, already correct | New as of this spec |
+
+## 4. How to determine your own values
+
+Both are already-available environment values — no new plumbing:
+- `$AGENTMUX_AGENT_ID` — injected at agent spawn, same source the body tag
+  already reads.
+- Host — `$HOSTNAME` (bash/zsh/fish) or `$COMPUTERNAME` (Windows); both
+  resolve to the same value on a given machine.
+
+## 5. Non-goals
+
+- Does not change `SPEC_AGENT_DETECTION_PRIORITY_2026_08_07.md`'s routing
+  logic or the body-tag mechanism in any way — both still required,
+  unchanged.
+- Does not apply to standard-identity agents (own dedicated PAT/App account
+  or registered named peer account).
+- Does not retroactively rename already-*merged* PRs (not worth the
+  history churn) — see §6 for what to do with PRs that were still *open* at
+  the time this convention landed.
+
+## 6. Migration for PRs open at the time of this change
+
+This session had two open shared-identity PRs at the time this spec was
+written (#2741, #2742) — both retitled with the `Korp@claudius:` prefix as
+part of landing this change, rather than left inconsistent with the new
+convention going forward.


### PR DESCRIPTION
## Summary

New spec: `SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md`.

`SPEC_AGENT_DETECTION_PRIORITY_2026_08_07.md`'s PR-body tag already solves *automated* review-notification routing for an agent pushing under the shared `GenericAgentX-<host>` fallback account — but it's invisible to a **human** scanning `github.com/.../pulls`: every such PR shows the identical generic author, with no way to tell which agent opened which PR without opening each one to read its body tag. Confirmed live this session: PRs #2738/#2741/#2742 were all indistinguishable by author alone.

Agents on a shared identity now also prepend their PR **title** with `<AgentName>@<host>: ` (natural casing — e.g. `Korp@claudius:`, deliberately distinct from the body tag's lowercased machine-matched string). Standard-identity agents (own dedicated PAT/App account, or a registered named peer account) are exempt — same exception the body tag already has.

Retitled #2741 and #2742 (both still open) to match. This PR follows its own new convention.

## Test plan
- N/A — documentation + policy change only, no code

<!-- agentmux:agent_id=korp -->