### PR TITLE
feat(settings): add drag-and-drop file-attach controls to Advanced section

### DIFF
--- a/.changesets/1787436028-feat-settings-add-drag-and-drop-file-attach-controls-to-adva-0kpn.md
+++ b/.changesets/1787436028-feat-settings-add-drag-and-drop-file-attach-controls-to-adva-0kpn.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(settings): add drag-and-drop file-attach controls to Advanced section

--- a/frontend/app/view/settings/sections/advanced-section.tsx
+++ b/frontend/app/view/settings/sections/advanced-section.tsx
@@ -82,6 +82,45 @@ export function AdvancedSection(): JSX.Element {
                     />
                 }
             />
+            <SectionHeader label="Drag & drop" />
+            <SettingRow
+                label="Enable file drop"
+                description="Drag files onto an agent pane to attach them"
+                control={
+                    <ToggleControl
+                        checked={(s()["dnd:enabled"] as boolean) ?? true}
+                        onChange={(v) => set("dnd:enabled", v)}
+                    />
+                }
+            />
+            <SettingRow
+                label="Insert reference token"
+                description="Also insert a file-reference token into the composer on drop, in addition to attaching the file"
+                control={
+                    <ToggleControl
+                        checked={(s()["dnd:agentinserttoken"] as boolean) ?? true}
+                        onChange={(v) => set("dnd:agentinserttoken", v)}
+                    />
+                }
+            />
+            <SettingRow
+                label="Max concurrent uploads"
+                description="Files uploaded at once on a multi-file drop. Leave blank for unlimited."
+                control={
+                    <input
+                        class="setting-number setting-number--wide"
+                        type="number" min={1}
+                        placeholder="unlimited"
+                        value={(s()["dnd:concurrency"] as number) ?? ""}
+                        onBlur={(e) => {
+                            const raw = e.currentTarget.value.trim();
+                            if (raw === "") { set("dnd:concurrency", null); return; }
+                            const v = parseInt(raw, 10);
+                            if (!isNaN(v) && v >= 1) set("dnd:concurrency", v);
+                        }}
+                    />
+                }
+            />
             <SectionHeader label="Environment" />
             <SettingRow
                 stacked

--- a/frontend/util/dnd.test.ts
+++ b/frontend/util/dnd.test.ts
@@ -1,8 +1,13 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
-import { baseName, isFileDrag } from "./dnd";
+import { describe, expect, it, vi } from "vitest";
+import { baseName, copyFilesToDir, isFileDrag } from "./dnd";
+
+const invokeCommandMock = vi.fn<(cmd: string, args: Record<string, unknown>) => Promise<unknown>>();
+vi.mock("@/app/platform/ipc", () => ({
+    invokeCommand: (cmd: string, args: Record<string, unknown>) => invokeCommandMock(cmd, args),
+}));
 
 function dragEventWithTypes(types: string[]): DragEvent {
     return { dataTransfer: { types } } as unknown as DragEvent;
@@ -30,5 +35,47 @@ describe("baseName", () => {
         expect(baseName("/home/user/report.csv")).toBe("report.csv");
         expect(baseName("C:\\Users\\me\\report.csv")).toBe("report.csv");
         expect(baseName("report.csv")).toBe("report.csv");
+    });
+});
+
+describe("copyFilesToDir concurrency", () => {
+    // Regression test for PR #2744 review discussion: the dnd:concurrency
+    // setting is documented as "absent means unlimited" (schema/settings.json),
+    // and the Settings UI's "leave blank for unlimited" copy depends on that
+    // actually being true. A prior version of this function silently defaulted
+    // an absent concurrency to 4, breaking that contract.
+
+    it("runs all files at once (no artificial cap) when concurrency is omitted", async () => {
+        let maxConcurrentInFlight = 0;
+        let inFlight = 0;
+        invokeCommandMock.mockImplementation(async () => {
+            inFlight++;
+            maxConcurrentInFlight = Math.max(maxConcurrentInFlight, inFlight);
+            await new Promise((r) => setTimeout(r, 5));
+            inFlight--;
+            return "/dest/path";
+        });
+
+        const sources = Array.from({ length: 10 }, (_, i) => `/src/file${i}.txt`);
+        await copyFilesToDir(sources, "/dest");
+
+        expect(maxConcurrentInFlight).toBe(10);
+    });
+
+    it("still respects an explicit concurrency value", async () => {
+        let maxConcurrentInFlight = 0;
+        let inFlight = 0;
+        invokeCommandMock.mockImplementation(async () => {
+            inFlight++;
+            maxConcurrentInFlight = Math.max(maxConcurrentInFlight, inFlight);
+            await new Promise((r) => setTimeout(r, 5));
+            inFlight--;
+            return "/dest/path";
+        });
+
+        const sources = Array.from({ length: 10 }, (_, i) => `/src/file${i}.txt`);
+        await copyFilesToDir(sources, "/dest", { concurrency: 3 });
+
+        expect(maxConcurrentInFlight).toBe(3);
     });
 });

--- a/frontend/util/dnd.ts
+++ b/frontend/util/dnd.ts
@@ -21,8 +21,6 @@ export interface DropOutcome {
     results: Array<{ source: string; dest?: string; error?: string }>;
 }
 
-const DEFAULT_CONCURRENCY = 4;
-
 /**
  * Read the OS paths captured by the CEF DragHandler stash. Returns an empty
  * array if the stash has expired or wasn't populated (non-CEF host, drop
@@ -41,13 +39,19 @@ export async function consumeDragPaths(): Promise<string[]> {
  * Copy each `sourcePath` into `targetDir` with the configured concurrency.
  * Filename collisions are de-conflicted server-side (`report (1).csv` etc.);
  * the returned `dest` is the actual landed path.
+ *
+ * `opts.concurrency` absent/undefined means unlimited (all files copy at
+ * once) — matches the `dnd:concurrency` setting's documented contract
+ * ("absent means unlimited", schema/settings.json). Do not reintroduce a
+ * default cap here; the Settings UI's "leave blank for unlimited" copy
+ * depends on this actually being true (see PR #2744 review discussion).
  */
 export async function copyFilesToDir(
     sourcePaths: string[],
     targetDir: string,
     opts?: { concurrency?: number },
 ): Promise<DropOutcome> {
-    const concurrency = Math.max(1, opts?.concurrency ?? DEFAULT_CONCURRENCY);
+    const concurrency = Math.max(1, opts?.concurrency ?? sourcePaths.length);
     const results: DropOutcome["results"] = [];
 
     let nextIdx = 0;


### PR DESCRIPTION
## Summary

Part of tracked work from #2671 (candidate #4, `SPEC_SETTINGS_AUDIT_GOOD_PICKINGS_2026_08_19.md`). `dnd:enabled`, `dnd:agentinserttoken`, `dnd:concurrency` (`schema/settings.json:281-295`) are fully shipped and consumed by `useAgentDropAttach.ts`, but had zero Settings UI — only configurable by hand-editing `settings.json`.

## Changes

- New "Drag & drop" subsection in Settings → Advanced:
  - Enable file drop (toggle)
  - Insert reference token (toggle)
  - Max concurrent uploads (numeric, blank = unlimited)
- `dnd:concurrency` has no default (absent = unlimited) — clearing the field calls `set(key, null)`, the existing sanctioned deletion mechanism already built into `setconfig`'s merge logic (`config_watcher_fs.rs`'s "Remove keys explicitly set to null" path). No backend changes needed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Manual: verified against the schema defaults and `useAgentDropAttach.ts`'s read sites

<!-- agentmux:agent_id=smike -->