### PR TITLE
Korp@claudius: feat(muxspect): cross-instance find — which channel has this block_id/agent

### DIFF
--- a/.changesets/1787436129-feat-muxspect-cross-instance-find-which-channel-has-this-blo-2qw6.md
+++ b/.changesets/1787436129-feat-muxspect-cross-instance-find-which-channel-has-this-blo-2qw6.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxspect): cross-instance find — which channel has this block_id/agent

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -54,6 +54,17 @@ Usage:
                                   name — resolves host first, then
                                   cross-channel (other AgentMux channels on
                                   this same host); does not reach LAN/WAN
+  muxspect find <block_id_or_agent> [--json]
+                                  which running instance(s), if any, have a
+                                  controller/dispatch matching this block id
+                                  or agent name — checks this instance first,
+                                  then every other channel via the shared
+                                  reactive registry (no forwarded call unless
+                                  a channel actually matches). A UUID-shaped
+                                  query is sent as block_id; anything else as
+                                  agent name (SPEC_MUXSPECT_CROSS_INSTANCE_
+                                  FIND_2026_08_22.md, Ext 4 of REPORT_MUXSPECT_
+                                  MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md)
   muxspect verify-sender <agent_name> [--json]
                                   is an agent named <agent_name> currently
                                   REGISTERED, and via what tier (spawner /
@@ -360,6 +371,41 @@ function renderConversation(data) {
     for (const l of lines) console.log(l);
 }
 
+// `find <block_id_or_agent>` — Ext 4 of REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_
+// INSPECTION_2026_08_22.md / SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md.
+// `results` is empty when nothing matched anywhere — a legitimate "not
+// found on this host, in any known channel" answer, not an error.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function renderFind(data) {
+    const { block_id, agent } = data.query ?? {};
+    console.log(`query: ${block_id ? `block_id=${block_id}` : `agent=${agent}`}`);
+    const results = data.results ?? [];
+    if (results.length === 0) {
+        console.log("\nnot found on this host, in any known channel.");
+        return;
+    }
+    console.log(`\nfound in ${results.length} place${results.length === 1 ? "" : "s"}:`);
+    for (const r of results) {
+        console.log(`\n--- ${r.tier}${r.channel ? ` (${r.channel})` : ""} ---`);
+        console.log(`  block_id: ${r.block_id}`);
+        if (r.agent_id) console.log(`  agent_id: ${r.agent_id}`);
+        if (r.tier === "host" && r.process_status) {
+            console.log(`  lifecycle: ${r.process_status.lifecycle ?? "unknown"}`);
+            console.log(`  controller_type: ${r.process_status.controller_type ?? "(none)"}`);
+        }
+        if (r.tier === "cross-channel") {
+            if (r.describe) {
+                const ps = r.describe.process_status ?? {};
+                console.log(`  lifecycle: ${ps.lifecycle ?? "unknown"}`);
+                console.log(`  controller_type: ${ps.controller_type ?? "(none)"}`);
+            } else {
+                console.log(`  (matched in the shared registry, but the forwarded describe call didn't respond in time — channel may be busy or gone)`);
+            }
+        }
+    }
+}
+
 function renderDock(data) {
     console.log(`block_id: ${data.block_id}`);
     const nodes = data.nodes ?? [];
@@ -481,6 +527,18 @@ async function main() {
         const data = await apiGet(url, authKey, `/agentmux/reactive/transcript?agent=${encodeURIComponent(agentName)}`);
         if (json) console.log(JSON.stringify(data, null, 2));
         else renderConversation(data);
+        return;
+    }
+
+    if (cmd === "find") {
+        const query = blockId; // parseArgs puts the sole positional arg here
+        if (!query) fail("find requires a block_id or agent name — 'muxspect find <block_id_or_agent>'");
+        const isBlockId = UUID_RE.test(query);
+        const params = isBlockId ? `block_id=${encodeURIComponent(query)}` : `agent=${encodeURIComponent(query)}`;
+        const data = await apiGet(url, authKey, `/api/v1/muxspect/find?${params}`);
+        if (json) console.log(JSON.stringify(data, null, 2));
+        else renderFind(data);
+        if ((data.results ?? []).length === 0) process.exitCode = 1;
         return;
     }
 

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -57,14 +57,19 @@ Usage:
   muxspect find <block_id_or_agent> [--json]
                                   which running instance(s), if any, have a
                                   controller/dispatch matching this block id
-                                  or agent name — checks this instance first,
-                                  then every other channel via the shared
-                                  reactive registry (no forwarded call unless
-                                  a channel actually matches). A UUID-shaped
-                                  query is sent as block_id; anything else as
-                                  agent name (SPEC_MUXSPECT_CROSS_INSTANCE_
-                                  FIND_2026_08_22.md, Ext 4 of REPORT_MUXSPECT_
-                                  MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md)
+                                  or agent name — checks this instance first
+                                  (ANY controller type), then every other
+                                  channel via the shared reactive registry
+                                  (agent-registered blocks ONLY on the
+                                  cross-channel tier — a non-agent controller,
+                                  e.g. a plain shell, in another channel isn't
+                                  findable by block_id there). No forwarded
+                                  call unless a channel actually matches. A
+                                  UUID-shaped query is sent as block_id;
+                                  anything else as agent name
+                                  (SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md,
+                                  Ext 4 of REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_
+                                  INSPECTION_2026_08_22.md)
   muxspect verify-sender <agent_name> [--json]
                                   is an agent named <agent_name> currently
                                   REGISTERED, and via what tier (spawner /
@@ -377,17 +382,29 @@ function renderConversation(data) {
 // found on this host, in any known channel" answer, not an error.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// `found: false` (cross-channel only) means the shared registry pointed at
+// a channel, but the forwarded describe's own lifecycle came back "unknown"
+// — the remote ProcessBroker has no controller for this block_id at all,
+// i.e. the registry entry was fresh enough to survive the staleness filter
+// srv-side but the block itself is already gone. Shown, not hidden — but
+// not counted toward "genuinely found" for the summary line or exit code.
 function renderFind(data) {
     const { block_id, agent } = data.query ?? {};
     console.log(`query: ${block_id ? `block_id=${block_id}` : `agent=${agent}`}`);
     const results = data.results ?? [];
+    const live = results.filter((r) => r.found !== false);
     if (results.length === 0) {
         console.log("\nnot found on this host, in any known channel.");
         return;
     }
-    console.log(`\nfound in ${results.length} place${results.length === 1 ? "" : "s"}:`);
+    if (live.length === 0) {
+        console.log(`\nnot found — ${results.length} registry match${results.length === 1 ? "" : "es"} pointed at a channel, but the block is already gone there.`);
+    } else {
+        console.log(`\nfound in ${live.length} place${live.length === 1 ? "" : "s"}:`);
+    }
     for (const r of results) {
-        console.log(`\n--- ${r.tier}${r.channel ? ` (${r.channel})` : ""} ---`);
+        const staleNote = r.found === false ? " — gone (registry match, but remote lifecycle is 'unknown')" : "";
+        console.log(`\n--- ${r.tier}${r.channel ? ` (${r.channel})` : ""}${staleNote} ---`);
         console.log(`  block_id: ${r.block_id}`);
         if (r.agent_id) console.log(`  agent_id: ${r.agent_id}`);
         if (r.tier === "host" && r.process_status) {
@@ -538,7 +555,11 @@ async function main() {
         const data = await apiGet(url, authKey, `/api/v1/muxspect/find?${params}`);
         if (json) console.log(JSON.stringify(data, null, 2));
         else renderFind(data);
-        if ((data.results ?? []).length === 0) process.exitCode = 1;
+        // A cross-channel result with found:false (registry match, but the
+        // remote lifecycle reads "unknown" — the block is already gone
+        // there) doesn't count as a genuine find for exit-code purposes.
+        const genuinelyFound = (data.results ?? []).some((r) => r.found !== false);
+        if (!genuinelyFound) process.exitCode = 1;
         return;
     }
 

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -125,6 +125,30 @@ describe("muxspect parseArgs", () => {
         expect(r.blockId).toBe("AgentA");
         expect(r.json).toBe(true);
     });
+
+    // Ext 4 (SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md) — 'find' parses
+    // like 'conversation'/'describe': single positional lands in blockId, no
+    // 'sub' shape needed. The UUID-vs-agent-name dispatch itself lives in
+    // main() (query string routing, not argv parsing) — out of scope for
+    // this pure parser, covered instead by manual/integration verification.
+    it("'find <query>' parses like describe (query lands in blockId)", () => {
+        const r = parseArgs(["find", "71a6b2ae-b651-43aa-aed4-6121f24fd713"]);
+        expect(r.cmd).toBe("find");
+        expect(r.blockId).toBe("71a6b2ae-b651-43aa-aed4-6121f24fd713");
+    });
+
+    it("'find <agent_name>' parses the same way for a non-UUID query", () => {
+        const r = parseArgs(["find", "Korp"]);
+        expect(r.cmd).toBe("find");
+        expect(r.blockId).toBe("Korp");
+    });
+
+    it("'find <query> --json' still resolves the query, flag anywhere", () => {
+        const r = parseArgs(["find", "--json", "Korp"]);
+        expect(r.cmd).toBe("find");
+        expect(r.blockId).toBe("Korp");
+        expect(r.json).toBe(true);
+    });
 });
 
 // SPEC_MUXSPECT_VERIFY_SENDER_2026_08_21.md tier 0 — checked before any

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -460,6 +460,12 @@ pub fn build_router(state: AppState) -> Router {
         // own environment, no new IPC).
         .route("/api/v1/muxspect/list", get(muxspect_handlers::handle_muxspect_list))
         .route("/api/v1/muxspect/describe", get(muxspect_handlers::handle_muxspect_describe))
+        // Cross-instance lookup — Ext 4 of
+        // docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md.
+        // Checks this instance first, then every other channel via the shared
+        // reactive registry (same mechanism `conversations` below already
+        // uses) — see the handler's own doc comment.
+        .route("/api/v1/muxspect/find", get(muxspect_handlers::handle_muxspect_find))
         // Dock diagnosis/remediation extension (2026-08-06 spec) — `dock` is
         // read-only like the two routes above; `dock/clear` is this module's
         // first mutating route (narrowly scoped — see the handler's own doc

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -253,6 +253,36 @@ pub struct MuxspectFindQuery {
 /// same block_id/agent name somehow exists in more than one place at once
 /// (a real, worth-surfacing anomaly, not something to silently collapse to
 /// the first match).
+///
+/// **Cross-channel `block_id` scope (reagent P2 on PR #2745):** the
+/// cross-channel tier only searches the shared `AgentEntry` registry —
+/// agent-registered blocks. A plain shell/terminal block, or any other
+/// non-agent controller, in a DIFFERENT channel is not findable by
+/// `block_id` here (the host tier above has no such limit — it searches
+/// this instance's FULL `ProcessBroker::list()`, any controller type).
+/// Reaching a non-agent controller cross-channel would need a remote
+/// `/api/v1/muxspect/list`-style forward-and-filter, not just a registry
+/// lookup — out of scope for this change; see
+/// `SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md`'s Non-goals.
+///
+/// True when a forwarded `describe` response's `process_status.lifecycle`
+/// reads `"unknown"` — `broker::process::Lifecycle::Unknown`'s own doc
+/// comment: "no controller found for this block_id at all." A `None`
+/// input (the forward itself failed/timed out) is NOT the same as this —
+/// deliberately returns `false` for that case, since "we couldn't ask" is
+/// not the same claim as "we asked and it's confirmed gone." Pure
+/// (extracted from the async handler above) for direct unit testing —
+/// reagent P1 on PR #2745 found the un-extracted inline version reported
+/// "found": true unconditionally, with no test coverage of the "gone but
+/// still registered" case at all.
+fn describe_lifecycle_is_unknown(describe: Option<&serde_json::Value>) -> bool {
+    describe
+        .and_then(|d| d.get("process_status"))
+        .and_then(|ps| ps.get("lifecycle"))
+        .and_then(|l| l.as_str())
+        == Some("unknown")
+}
+
 pub async fn handle_muxspect_find(
     State(state): State<AppState>,
     Query(q): Query<MuxspectFindQuery>,
@@ -297,6 +327,23 @@ pub async fn handle_muxspect_find(
 
     // Cross-channel tier — AgentEntry already carries block_id/agent_id, so
     // matching costs zero network calls; only a match gets forwarded.
+    //
+    // reagent P1 on PR #2745: an earlier version unconditionally reported
+    // "found": true for any registry match, even a possibly-stale one whose
+    // owning agent/block already exited but hasn't been evicted from the
+    // shared registry yet — reported as a successful match with CLI exit
+    // code 0. Two checks now guard against that, mirroring the sibling
+    // handle_muxspect_verify_sender's staleness handling in this same file:
+    //   1. should_evict_on_forward_failure(&entry) (reused verbatim from
+    //      backend::reactive::registry — the exact function the registry's
+    //      OWN eviction logic uses, checking both real PID liveness and
+    //      FORWARD_FAILURE_GRACE_MS age) filters out entries already known
+    //      to be stale, before wasting a network call on them.
+    //   2. Even a fresh-looking entry can point at a block the remote
+    //      ProcessBroker no longer knows about (lifecycle: "unknown" — see
+    //      broker::process::Lifecycle's doc comment: "No controller found
+    //      for this block_id at all"). A successful forward with that
+    //      lifecycle is reported with "found": false, not true.
     if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
         let local_url = state.local_web_url.clone();
         let matches: Vec<_> = crate::backend::reactive::registry::list_all_shared(&shared_dir)
@@ -306,6 +353,7 @@ pub async fn handle_muxspect_find(
                 q.block_id.as_deref().is_some_and(|b| b == e.block_id)
                     || q.agent.as_deref().is_some_and(|name| e.agent_id.eq_ignore_ascii_case(name))
             })
+            .filter(|e| !crate::backend::reactive::registry::should_evict_on_forward_failure(e))
             .collect();
 
         let mut join_set = tokio::task::JoinSet::new();
@@ -328,12 +376,14 @@ pub async fn handle_muxspect_find(
                     _ => None, // timeout/connect/parse failure: still report the match, just without detail
                 };
 
+                let lifecycle_unknown = describe_lifecycle_is_unknown(describe.as_ref());
+
                 json!({
                     "tier": "cross-channel",
                     "channel": entry.channel,
                     "block_id": entry.block_id,
                     "agent_id": entry.agent_id,
-                    "found": true,
+                    "found": !lifecycle_unknown,
                     "describe": describe,
                 })
             });
@@ -1080,6 +1130,37 @@ mod tests {
             "error": {"message": message}
         })
         .to_string()
+    }
+
+    // reagent P1 on PR #2745 — pins describe_lifecycle_is_unknown, the
+    // pure piece extracted from handle_muxspect_find's cross-channel
+    // staleness check.
+    #[test]
+    fn describe_lifecycle_is_unknown_true_for_lifecycle_unknown() {
+        let describe = json!({ "process_status": { "lifecycle": "unknown" } });
+        assert!(describe_lifecycle_is_unknown(Some(&describe)));
+    }
+
+    #[test]
+    fn describe_lifecycle_is_unknown_false_for_a_real_lifecycle() {
+        for lifecycle in ["running", "idle", "done", "error"] {
+            let describe = json!({ "process_status": { "lifecycle": lifecycle } });
+            assert!(!describe_lifecycle_is_unknown(Some(&describe)), "lifecycle={lifecycle}");
+        }
+    }
+
+    #[test]
+    fn describe_lifecycle_is_unknown_false_when_the_forward_itself_failed() {
+        // None (the describe call timed out/errored) is NOT the same claim
+        // as "confirmed gone" — "we couldn't ask" must not read as "unknown".
+        assert!(!describe_lifecycle_is_unknown(None));
+    }
+
+    #[test]
+    fn describe_lifecycle_is_unknown_false_for_malformed_or_missing_fields() {
+        assert!(!describe_lifecycle_is_unknown(Some(&json!({}))));
+        assert!(!describe_lifecycle_is_unknown(Some(&json!({ "process_status": {} }))));
+        assert!(!describe_lifecycle_is_unknown(Some(&json!({ "process_status": { "lifecycle": 123 } }))));
     }
 
     #[test]

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -216,6 +216,142 @@ pub async fn handle_muxspect_describe(
     .into_response()
 }
 
+#[derive(serde::Deserialize)]
+pub struct MuxspectFindQuery {
+    pub block_id: Option<String>,
+    pub agent: Option<String>,
+}
+
+/// `GET /api/v1/muxspect/find?block_id=X` or `?agent=X` — Ext 4 of
+/// `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`:
+/// "which running instance(s), if any, have a controller or subagent
+/// dispatch matching block_id/agent X" — the query that debugging session
+/// needed and had no tool for, ending in manual filesystem/env-var
+/// archaeology across every channel by hand.
+///
+/// Checks THIS instance first (host tier, no network) via the same
+/// `ProcessBroker::list()` `handle_muxspect_list` uses (so "found" here
+/// means the same thing `muxspect list` would show, not a different
+/// existence check invented for this endpoint) and, for an `agent` query,
+/// `reactive_handler.list_agents()` (same source `handle_muxspect_conversations`'s
+/// host tier and `verify-sender` use).
+///
+/// Then checks every OTHER channel via the shared reactive registry
+/// (`resolve_shared_reactive_dir` + `list_all_shared` — the exact mechanism
+/// `handle_muxspect_conversations`'s cross-channel tier already uses, see
+/// that handler's own doc comment for the security rationale) WITHOUT any
+/// network call at all for basic existence: `AgentEntry` already carries
+/// `block_id`/`agent_id`/`channel`/`local_url`, so a match there already
+/// answers "which channel" before any forwarding happens. Only a MATCHED
+/// cross-channel entry gets a forwarded `describe` call (same
+/// single-forwarded-hop / timeout discipline as the conversations handler)
+/// to fill in process/controller detail — unmatched channels cost nothing.
+///
+/// Always 200 — zero results is a legitimate answer ("not found on this
+/// host, in any known channel"), not an error, same posture as every other
+/// handler in this file. `results` can have more than one entry only if the
+/// same block_id/agent name somehow exists in more than one place at once
+/// (a real, worth-surfacing anomaly, not something to silently collapse to
+/// the first match).
+pub async fn handle_muxspect_find(
+    State(state): State<AppState>,
+    Query(q): Query<MuxspectFindQuery>,
+) -> impl IntoResponse {
+    if q.block_id.as_deref().unwrap_or("").is_empty() && q.agent.as_deref().unwrap_or("").is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "provide block_id or agent" })),
+        )
+            .into_response();
+    }
+
+    let mut results: Vec<serde_json::Value> = Vec::new();
+    let own_channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+
+    // Host tier — no network, same source handle_muxspect_list/
+    // handle_muxspect_conversations already use.
+    for status in state.process_broker.list() {
+        let block_matches = q.block_id.as_deref().is_some_and(|b| b == status.block_id);
+        let agent_matches = q
+            .agent
+            .as_deref()
+            .and_then(|name| {
+                state
+                    .reactive_handler
+                    .list_agents()
+                    .into_iter()
+                    .find(|r| r.block_id == status.block_id && r.agent_id.eq_ignore_ascii_case(name))
+            })
+            .is_some();
+        if !block_matches && !agent_matches {
+            continue;
+        }
+        results.push(json!({
+            "tier": "host",
+            "channel": own_channel,
+            "block_id": status.block_id,
+            "found": true,
+            "process_status": &status,
+        }));
+    }
+
+    // Cross-channel tier — AgentEntry already carries block_id/agent_id, so
+    // matching costs zero network calls; only a match gets forwarded.
+    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+        let local_url = state.local_web_url.clone();
+        let matches: Vec<_> = crate::backend::reactive::registry::list_all_shared(&shared_dir)
+            .into_iter()
+            .filter(|e| e.channel != own_channel && e.local_url != local_url)
+            .filter(|e| {
+                q.block_id.as_deref().is_some_and(|b| b == e.block_id)
+                    || q.agent.as_deref().is_some_and(|name| e.agent_id.eq_ignore_ascii_case(name))
+            })
+            .collect();
+
+        let mut join_set = tokio::task::JoinSet::new();
+        for entry in matches {
+            let http_client = state.http_client.clone();
+            join_set.spawn(async move {
+                let fetch = http_client
+                    .get(format!("{}/api/v1/muxspect/describe", entry.local_url))
+                    .header("X-AuthKey", &entry.auth_key)
+                    .query(&[("block_id", entry.block_id.as_str())])
+                    .send();
+
+                let describe = match tokio::time::timeout(
+                    std::time::Duration::from_millis(CROSS_CHANNEL_PREVIEW_TIMEOUT_MS),
+                    fetch,
+                )
+                .await
+                {
+                    Ok(Ok(resp)) if resp.status().is_success() => resp.json::<serde_json::Value>().await.ok(),
+                    _ => None, // timeout/connect/parse failure: still report the match, just without detail
+                };
+
+                json!({
+                    "tier": "cross-channel",
+                    "channel": entry.channel,
+                    "block_id": entry.block_id,
+                    "agent_id": entry.agent_id,
+                    "found": true,
+                    "describe": describe,
+                })
+            });
+        }
+        while let Some(res) = join_set.join_next().await {
+            if let Ok(value) = res {
+                results.push(value);
+            }
+        }
+    }
+
+    Json(json!({
+        "query": { "block_id": q.block_id, "agent": q.agent },
+        "results": results,
+    }))
+    .into_response()
+}
+
 /// A `ToolNode`'s status stays `"running"` this long (matches the
 /// frontend's own `TOOL_PROMOTION_MS`, `frontend/app/view/agent/activity/
 /// tool-adapter.ts`) before it's eligible to be flagged `stuck` here — a

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -269,20 +269,20 @@ pub async fn handle_muxspect_find(
     let own_channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
 
     // Host tier — no network, same source handle_muxspect_list/
-    // handle_muxspect_conversations already use.
+    // handle_muxspect_conversations already use. list_agents() (mutex lock +
+    // full clone of the agent map) is fetched ONCE here, not once per block
+    // inside the loop below — reagent P2 on PR #2745 caught the original
+    // version paying that cost per block, unnecessary repeated
+    // locking/cloning that scaled with block count, matching how
+    // handle_muxspect_conversations's own host tier already does it.
+    let agents = state.reactive_handler.list_agents();
     for status in state.process_broker.list() {
         let block_matches = q.block_id.as_deref().is_some_and(|b| b == status.block_id);
-        let agent_matches = q
-            .agent
-            .as_deref()
-            .and_then(|name| {
-                state
-                    .reactive_handler
-                    .list_agents()
-                    .into_iter()
-                    .find(|r| r.block_id == status.block_id && r.agent_id.eq_ignore_ascii_case(name))
-            })
-            .is_some();
+        let agent_matches = q.agent.as_deref().is_some_and(|name| {
+            agents
+                .iter()
+                .any(|r| r.block_id == status.block_id && r.agent_id.eq_ignore_ascii_case(name))
+        });
         if !block_matches && !agent_matches {
             continue;
         }

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -36,6 +36,7 @@ node ~/.agentmux/shell/muxspect.mjs dock <block_id>
 node ~/.agentmux/shell/muxspect.mjs dock clear <block_id> <node_id>
 node ~/.agentmux/shell/muxspect.mjs conversations
 node ~/.agentmux/shell/muxspect.mjs conversation <agent>
+node ~/.agentmux/shell/muxspect.mjs find <block_id_or_agent>
 node ~/.agentmux/shell/muxspect.mjs help
 ```
 
@@ -97,6 +98,25 @@ This is Phase A of `docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_
 — it does not reach LAN or WAN conversation content (Phase B/C, not yet
 built, and gated on an explicit repo-owner-confirmed addition to
 `CLAUDE.md`'s jekt security rules before they can be).
+
+## Finding which instance has a block/agent (`find`)
+
+`find <block_id_or_agent>` answers "which running instance(s), if any, have
+a controller or subagent dispatch matching this" — checks this instance
+first, then every other channel via the shared reactive registry, with a
+forwarded lookup only for a channel that actually matches (no network calls
+wasted on channels that don't). A UUID-shaped argument is sent as a
+`block_id` query; anything else as an `agent` name query.
+
+```bash
+muxspect find 71a6b2ae-b651-43aa-aed4-6121f24fd713
+muxspect find Korp
+```
+
+An empty result is a legitimate answer — "not found on this host, in any
+known channel" — not an error. Same LAN/WAN boundary as `conversations`
+above (host + cross-channel only). See
+`docs/specs/SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md`.
 
 ## What it can and can't see
 

--- a/docs/specs/SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md
+++ b/docs/specs/SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md
@@ -71,3 +71,13 @@ to the first match.
   module only covers pure helpers like `classify_last_error_source`/
   `last_error_frame`). Relies on code-review + the mirrored pattern's
   existing track record instead.
+- **Cross-channel `block_id` search only covers agent-registered blocks**
+  (reagent P2 on PR #2745). It reads the shared `AgentEntry` registry, not
+  a remote channel's full controller inventory — a plain shell/terminal
+  block, or any other non-agent controller, in a *different* channel is
+  not findable by `block_id` on the cross-channel tier (the host tier has
+  no such limit — it searches this instance's full `ProcessBroker::list()`,
+  any controller type). Reaching a non-agent controller cross-channel would
+  need a remote `/api/v1/muxspect/list`-style forward-and-filter call, a
+  bigger change than a registry lookup; left for a follow-up if it turns
+  out to matter in practice.

--- a/docs/specs/SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md
+++ b/docs/specs/SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md
@@ -1,0 +1,73 @@
+# SPEC: `muxspect find` — cross-instance block/agent lookup
+
+**Date:** 2026-08-22
+**Status:** Implemented
+**Author:** Korp
+**Repos touched:** `agentmux` (`agentmux-srv/src/server/muxspect_handlers.rs`,
+`agentmux-srv/src/server/mod.rs`, `agentmux-srv/src/backend/shellintegration/muxspect.mjs`)
+**Related:** Ext 4 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`;
+builds on the cross-channel fan-out mechanism `SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`
+(Phase A) already shipped for `muxspect conversations`.
+
+## 1. Problem
+
+`muxspect` (Phase 1, `SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md`)
+only ever queries the instance the caller is already inside — it cannot
+answer "does a *different* running instance have a controller or subagent
+dispatch matching this block id / agent name." A live debugging session
+needed exactly this question answered and had no tool for it: confirming
+which of several running channels actually owned a given block id took
+manually reading `$AGENTMUX_*` env vars, walking `~/.agentmux/channels/*/versions/*/data`
+by hand, and cross-referencing `Get-Process` output — the report's whole
+motivating example.
+
+## 2. What ships
+
+`GET /api/v1/muxspect/find?block_id=X` or `?agent=X`, and the matching CLI
+command `muxspect find <block_id_or_agent>`.
+
+1. **Host tier (no network):** checks `state.process_broker.list()` — the
+   same source `handle_muxspect_list` already uses — for a matching
+   `block_id`, and (for an `agent` query) cross-references
+   `state.reactive_handler.list_agents()` the same way
+   `handle_muxspect_conversations`'s host tier already does.
+2. **Cross-channel tier:** reads the shared reactive registry
+   (`crate::registry::resolve_shared_reactive_dir` +
+   `backend::reactive::registry::list_all_shared` — the exact mechanism
+   `handle_muxspect_conversations`'s cross-channel tier already uses, see
+   that handler's own doc comment for the security rationale). Each
+   `AgentEntry` already carries `block_id`/`agent_id`/`channel`/`local_url`,
+   so **matching costs zero network calls** — only a channel whose entry
+   actually matches the query gets a forwarded `describe` call (same
+   single-hop / `CROSS_CHANNEL_PREVIEW_TIMEOUT_MS` timeout discipline as the
+   conversations handler) to fill in process/controller detail.
+
+The CLI dispatches by shape: a UUID-looking query is sent as `block_id`,
+anything else as `agent` — no separate flags needed for the common case of
+"I don't remember which one this is, I just have the string."
+
+Always 200; an empty `results` array is a legitimate "not found on this
+host, in any known channel" answer, same posture as every other handler in
+this file (not an error). More than one result is possible and, if it
+happens, is a real anomaly worth surfacing rather than silently collapsing
+to the first match.
+
+## 3. Non-goals / limitations
+
+- **LAN/WAN tiers are not reached.** Same Phase A boundary
+  `muxspect conversations` already has — no remote-read protocol exists for
+  those tiers yet.
+- **Not tested against a live rebuilt instance in this change.** Verifying
+  this specific endpoint end-to-end (the way Ext 1 and Ext 3 were verified
+  against this session's actual running instance) requires a full
+  srv rebuild + relaunch, since the currently-running binary predates this
+  route. Verified instead via `cargo check`, the CLI's `parseArgs` unit
+  tests, and direct mirroring of `handle_muxspect_conversations`'s
+  already-proven fan-out pattern — flagged here rather than silently
+  presented as more thoroughly checked than it is.
+- Does not add a dedicated Rust-side unit/integration test for the handler
+  itself (no existing precedent for testing the async, `AppState`-composing
+  handlers in this file in isolation — the file's existing `#[cfg(test)]`
+  module only covers pure helpers like `classify_last_error_source`/
+  `last_error_frame`). Relies on code-review + the mirrored pattern's
+  existing track record instead.


### PR DESCRIPTION
## Summary

Ext 4 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`. `SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md`.

`muxspect` (Phase 1) only ever queries the instance the caller is already inside — it cannot answer "does a *different* running instance have a controller/dispatch matching this block id or agent name." The live debugging session that produced the report needed exactly this and had no tool for it.

New `GET /api/v1/muxspect/find?block_id=X` or `?agent=X`, and matching CLI `muxspect find <block_id_or_agent>`:

- **Host tier** (no network): `state.process_broker.list()`, cross-referenced against `reactive_handler.list_agents()` for agent-name queries.
- **Cross-channel tier**: reads the shared reactive registry (`resolve_shared_reactive_dir` + `list_all_shared` — the exact mechanism `handle_muxspect_conversations` already uses). Each entry already carries `block_id`/`agent_id`/`channel`/`local_url`, so matching costs **zero** network calls — only an actual match gets a forwarded `describe` call for detail.

CLI dispatches by shape: UUID-looking query → `block_id`; anything else → `agent`.

## Known limitations (called out in the spec, not hidden)
- Not verified against a live rebuilt instance — would need a full srv rebuild+relaunch. Verified instead via `cargo check`, CLI unit tests, and direct mirroring of `handle_muxspect_conversations`'s already-proven pattern.
- No dedicated Rust unit/integration test for the handler itself — no existing precedent in this file for testing its async, `AppState`-composing handlers in isolation.

## Test plan
- [x] `cargo check -p agentmux-srv` passes clean
- [x] 3 new `parseArgs` cases (`find <uuid>`, `find <agent>`, flag-anywhere) — 25/25 passing in `muxspect.test.mjs`
- [ ] Live end-to-end verification (blocked on a rebuild — see limitations above)

<!-- agentmux:agent_id=korp -->