### PR TITLE
feat(agent-config): protect a pre-existing project CLAUDE.md from overwrite

### DIFF
--- a/.changesets/1787436504-feat-agent-config-protect-a-pre-existing-project-claude-md-f-xdb8.md
+++ b/.changesets/1787436504-feat-agent-config-protect-a-pre-existing-project-claude-md-f-xdb8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-config): protect a pre-existing project CLAUDE.md from being overwritten

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -877,6 +877,120 @@ pub fn write_managed_skill_file_manifest(
     }
 }
 
+// ============================================================
+// CLAUDE.md ownership protection (I/O — see module doc comment)
+// ============================================================
+
+/// First line AgentMux writes on any `CLAUDE.md` it fully owns (freshly
+/// created, or regenerated on every launch since). Its ABSENCE on an
+/// EXISTING file is what marks that file as foreign — predates AgentMux
+/// touching this working directory, or a human replaced AgentMux's file
+/// with their own — and is never overwritten again. See
+/// `docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md`.
+pub const CLAUDE_MD_MANAGED_MARKER: &str = "<!-- agentmux:managed-claude-md -->";
+
+/// AgentMux-owned side file carrying the full Soul+AgentMD+Memory+Skills
+/// composition when the real `CLAUDE.md` is foreign — always safe to
+/// regenerate in place every launch, unlike `CLAUDE.md` itself in that case.
+pub const AGENTMUX_MEMORY_FILENAME: &str = ".claude/AGENTMUX_MEMORY.md";
+
+/// One-time marker recording whether the `@import` line (below) has
+/// already been offered for this working directory. Checked INSTEAD of
+/// re-scanning `CLAUDE.md` content on every launch — without it, a user
+/// who deliberately deletes the import line (opting out of AgentMux
+/// content entirely) would see it silently reappear on their next launch.
+const CLAUDE_MD_OWNERSHIP_MARKER_PATH: &str = ".claude/.agentmux-claude-md-ownership.json";
+
+/// Comment wrapping the `@import` line so its origin — and how to remove
+/// it — is unambiguous to anyone reading a foreign `CLAUDE.md` by hand.
+const CLAUDE_MD_IMPORT_MARKER_COMMENT: &str =
+    "<!-- agentmux:managed-import (safe to delete this line to opt out) -->";
+
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct ClaudeMdOwnershipMarker {
+    import_line_offered: bool,
+}
+
+/// Materialize `generated_content` (the composed Soul+AgentMD+Memory+Skills
+/// `CLAUDE.md` body `build_config_files` already produced) against whatever
+/// is already on disk at `base_path/CLAUDE.md`, WITHOUT ever overwriting a
+/// foreign file's content:
+///
+/// - No file yet, or the existing file starts with
+///   [`CLAUDE_MD_MANAGED_MARKER`]: AgentMux owns it — write `CLAUDE.md`
+///   directly (marker + `generated_content`), exactly as every call site
+///   did unconditionally before this function existed.
+/// - Existing file present WITHOUT the marker: foreign. `CLAUDE.md` itself
+///   is never touched again. `generated_content` instead goes to
+///   [`AGENTMUX_MEMORY_FILENAME`] (always safe to regenerate — it's 100%
+///   AgentMux's own content), pulled in via a single `@import` line
+///   appended to the real `CLAUDE.md` — offered at most once per working
+///   directory (see [`CLAUDE_MD_OWNERSHIP_MARKER_PATH`]'s doc comment).
+///
+/// Best-effort in the same spirit as [`write_managed_skill_file_manifest`]:
+/// an I/O failure on the side-file/marker writes is logged, not
+/// propagated — losing them only means the import line isn't offered (or
+/// the side file isn't refreshed) on this one launch, not a correctness
+/// issue serious enough to fail the whole config-write.
+///
+/// Shared by `agent.open` (`server/app_api/agent_open.rs`) and the
+/// `WriteAgentConfig` "click Launch" path (`server/editor_handlers.rs`) —
+/// per this module's own doc comment, the two config-materializing call
+/// sites that must not drift out of sync. See
+/// `docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md`.
+pub fn write_claude_md_respecting_ownership(
+    base_path: &std::path::Path,
+    generated_content: &str,
+) -> std::io::Result<()> {
+    let claude_md_path = base_path.join("CLAUDE.md");
+    let existing = std::fs::read_to_string(&claude_md_path).ok();
+
+    let agentmux_owns_it = match &existing {
+        None => true,
+        Some(content) => content.starts_with(CLAUDE_MD_MANAGED_MARKER),
+    };
+
+    if agentmux_owns_it {
+        let content = format!("{CLAUDE_MD_MANAGED_MARKER}\n\n{generated_content}");
+        return std::fs::write(&claude_md_path, content);
+    }
+
+    // Foreign file — CLAUDE.md's own content is never touched from here on.
+    let memory_path = base_path.join(AGENTMUX_MEMORY_FILENAME);
+    if let Some(parent) = memory_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&memory_path, generated_content)?;
+
+    let ownership_marker_path = base_path.join(CLAUDE_MD_OWNERSHIP_MARKER_PATH);
+    let already_offered = std::fs::read_to_string(&ownership_marker_path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<ClaudeMdOwnershipMarker>(&s).ok())
+        .map(|m| m.import_line_offered)
+        .unwrap_or(false);
+
+    if !already_offered {
+        let existing_content = existing.unwrap_or_default();
+        let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
+        // Idempotent even on this first offer: don't duplicate if the
+        // import somehow already appears (e.g. a user copied it in by
+        // hand before AgentMux ever ran here).
+        if !existing_content.contains(&import_needle) {
+            let import_block =
+                format!("\n\n{CLAUDE_MD_IMPORT_MARKER_COMMENT}\n{import_needle}\n");
+            std::fs::write(&claude_md_path, format!("{existing_content}{import_block}"))?;
+        }
+        if let Some(parent) = ownership_marker_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let marker_json = serde_json::to_string(&ClaudeMdOwnershipMarker { import_line_offered: true })
+            .unwrap_or_default();
+        std::fs::write(&ownership_marker_path, marker_json)?;
+    }
+
+    Ok(())
+}
+
 /// Best-effort: mint-or-reuse `agent_slug`'s jekt/LAN signing keys
 /// (`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` §2.2,
 /// `SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md` §2.1) and patch them into a
@@ -1466,5 +1580,100 @@ mod tests {
     fn inject_jekt_signing_keys_into_mcp_json_returns_none_on_malformed_json() {
         let store = crate::backend::storage::store::Store::open_in_memory().unwrap();
         assert!(inject_jekt_signing_keys_into_mcp_json("not json", &store, "aria").is_none());
+    }
+
+    // ============================================================
+    // write_claude_md_respecting_ownership
+    // (SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md)
+    // ============================================================
+
+    #[test]
+    fn claude_md_fresh_working_dir_writes_directly_with_the_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        write_claude_md_respecting_ownership(dir.path(), "Soul + AgentMD + Memory + Skills").unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(content.starts_with(CLAUDE_MD_MANAGED_MARKER));
+        assert!(content.contains("Soul + AgentMD + Memory + Skills"));
+        // No foreign-file side effects on the common (fresh dir) path.
+        assert!(!dir.path().join(AGENTMUX_MEMORY_FILENAME).exists());
+    }
+
+    #[test]
+    fn claude_md_agentmux_owned_file_is_freely_regenerated() {
+        let dir = tempfile::tempdir().unwrap();
+        write_claude_md_respecting_ownership(dir.path(), "first version").unwrap();
+        write_claude_md_respecting_ownership(dir.path(), "second version").unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(content.contains("second version"));
+        assert!(!content.contains("first version"), "regeneration must replace, not accumulate");
+    }
+
+    #[test]
+    fn claude_md_foreign_file_content_is_never_touched() {
+        let dir = tempfile::tempdir().unwrap();
+        let human_content = "# My real project\n\nHand-written rules, no AgentMux marker.";
+        std::fs::write(dir.path().join("CLAUDE.md"), human_content).unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "AgentMux's generated content").unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(content.starts_with(human_content), "every byte of the original file must survive, at the start");
+        assert!(!content.contains("AgentMux's generated content"), "generated content must never land in the real file");
+    }
+
+    #[test]
+    fn claude_md_foreign_file_gets_a_side_file_and_one_import_line() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Real project\n").unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "the generated body").unwrap();
+
+        let side_file = std::fs::read_to_string(dir.path().join(AGENTMUX_MEMORY_FILENAME)).unwrap();
+        assert_eq!(side_file, "the generated body");
+
+        let claude_md = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(claude_md.contains(&format!("@{AGENTMUX_MEMORY_FILENAME}")));
+        assert!(claude_md.contains(CLAUDE_MD_IMPORT_MARKER_COMMENT));
+    }
+
+    #[test]
+    fn claude_md_import_line_is_never_duplicated_across_launches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Real project\n").unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "v1").unwrap();
+        write_claude_md_respecting_ownership(dir.path(), "v2").unwrap();
+        write_claude_md_respecting_ownership(dir.path(), "v3").unwrap();
+
+        let claude_md = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
+        assert_eq!(claude_md.matches(&import_needle).count(), 1, "the import line must appear exactly once, no matter how many launches");
+        // The side file, unlike CLAUDE.md, keeps regenerating freely.
+        let side_file = std::fs::read_to_string(dir.path().join(AGENTMUX_MEMORY_FILENAME)).unwrap();
+        assert_eq!(side_file, "v3");
+    }
+
+    #[test]
+    fn claude_md_user_deleted_import_line_is_never_reinserted() {
+        // The whole point of the ownership marker file: once offered, a
+        // user's deliberate removal of the import line must stick.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Real project\n").unwrap();
+        write_claude_md_respecting_ownership(dir.path(), "v1").unwrap();
+
+        // User opts out: deletes the import line by hand.
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Real project\n").unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "v2").unwrap();
+
+        let claude_md = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert_eq!(claude_md, "# Real project\n", "import line must not silently reappear after the user removed it");
+        // The side file still refreshes even though nothing links to it
+        // from CLAUDE.md anymore — harmless, and keeps it ready if the
+        // user re-adds the import line themselves later.
+        let side_file = std::fs::read_to_string(dir.path().join(AGENTMUX_MEMORY_FILENAME)).unwrap();
+        assert_eq!(side_file, "v2");
     }
 }

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -1067,42 +1067,62 @@ pub fn write_claude_md_respecting_ownership(
         return Ok(());
     };
 
-    let already_offered = std::fs::read_to_string(&ownership_marker_path)
-        .ok()
-        .and_then(|s| serde_json::from_str::<ClaudeMdOwnershipMarker>(&s).ok())
-        .map(|m| m.import_line_offered)
-        .unwrap_or(false);
+    if let Some(parent) = ownership_marker_path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::warn!(path = %parent.display(), error = %e, "write_claude_md_respecting_ownership: failed to create dir for ownership marker");
+            return Ok(());
+        }
+    }
 
-    if !already_offered {
-        let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
-        // Idempotent even on this first offer: don't duplicate if the
-        // import somehow already appears (e.g. a user copied it in by
-        // hand before AgentMux ever ran here).
-        if !existing_content.contains(&import_needle) {
-            let import_block =
-                format!("\n\n{CLAUDE_MD_IMPORT_MARKER_COMMENT}\n{import_needle}\n");
-            // True append (never a read-modify-write of the whole file) —
-            // an edit racing this function's earlier read is preserved,
-            // not silently discarded (codex P2 on PR #2747).
-            let append_result = std::fs::OpenOptions::new()
-                .append(true)
-                .open(&claude_md_path)
-                .and_then(|mut f| std::io::Write::write_all(&mut f, import_block.as_bytes()));
-            if let Err(e) = append_result {
-                tracing::warn!(path = %claude_md_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to append the @import line this launch");
-                return Ok(());
+    // Atomic "am I the first to offer this" gate, not a read-then-write
+    // check: `create_new` fails with `AlreadyExists` if another
+    // concurrent call already won this race. Two agents sharing a
+    // working directory (agent_open.rs's shared-workdir fallback,
+    // `~/.agentmux/agents/<slug>`, launching concurrently) previously
+    // could both read "not yet offered" and both append the import
+    // line, duplicating it — the only existing serialization
+    // (`agent_open_lock`) is keyed by agent_id, not by working
+    // directory, so it doesn't cover this case (reagent P2, second
+    // review round on PR #2747). Only the caller whose `create_new`
+    // succeeds proceeds to append; every other caller — including a
+    // genuine concurrent racer, and every later launch once the marker
+    // exists — sees `AlreadyExists` and skips straight past.
+    let marker_json = serde_json::to_string(&ClaudeMdOwnershipMarker { import_line_offered: true })
+        .unwrap_or_default();
+    let create_result = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&ownership_marker_path)
+        .and_then(|mut f| std::io::Write::write_all(&mut f, marker_json.as_bytes()));
+
+    match create_result {
+        Ok(()) => {
+            let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
+            // Idempotent even having won the race: don't duplicate if
+            // the import somehow already appears (e.g. a user copied it
+            // in by hand before AgentMux ever ran here).
+            if !existing_content.contains(&import_needle) {
+                let import_block =
+                    format!("\n\n{CLAUDE_MD_IMPORT_MARKER_COMMENT}\n{import_needle}\n");
+                // True append (never a read-modify-write of the whole
+                // file) — an edit racing this function's earlier read is
+                // preserved, not silently discarded (codex P2 on
+                // PR #2747).
+                let append_result = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&claude_md_path)
+                    .and_then(|mut f| std::io::Write::write_all(&mut f, import_block.as_bytes()));
+                if let Err(e) = append_result {
+                    tracing::warn!(path = %claude_md_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to append the @import line this launch");
+                }
             }
         }
-        if let Some(parent) = ownership_marker_path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                tracing::warn!(path = %parent.display(), error = %e, "write_claude_md_respecting_ownership: failed to create dir for ownership marker");
-                return Ok(());
-            }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Already offered — by us on a prior launch, or a concurrent
+            // racer that won just now. Nothing to do.
         }
-        let marker_json = serde_json::to_string(&ClaudeMdOwnershipMarker { import_line_offered: true })
-            .unwrap_or_default();
-        if let Err(e) = std::fs::write(&ownership_marker_path, marker_json) {
-            tracing::warn!(path = %ownership_marker_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to write ownership marker");
+        Err(e) => {
+            tracing::warn!(path = %ownership_marker_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to create ownership marker");
         }
     }
 
@@ -1795,6 +1815,43 @@ mod tests {
         // The side file, unlike CLAUDE.md, keeps regenerating freely.
         let side_file = std::fs::read_to_string(dir.path().join(AGENTMUX_MEMORY_FILENAME)).unwrap();
         assert_eq!(side_file, "v3");
+    }
+
+    #[test]
+    fn claude_md_concurrent_launches_against_a_shared_workdir_never_duplicate_the_import() {
+        // reagent P2 (second review round) on PR #2747: two agents
+        // sharing a working directory (agent_open.rs's shared-workdir
+        // fallback) launching concurrently previously could both read
+        // "not yet offered" and both append the import line — the only
+        // existing serialization (agent_open_lock) is keyed by
+        // agent_id, not by working directory. Real threads, not a
+        // sequential simulation, to actually exercise the race.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Real project\n").unwrap();
+        let dir_path = dir.path().to_path_buf();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let dir_path = dir_path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait(); // maximize actual overlap
+                    write_claude_md_respecting_ownership(&dir_path, &format!("content-{i}")).unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let claude_md = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
+        assert_eq!(
+            claude_md.matches(&import_needle).count(),
+            1,
+            "8 concurrent launches against the same foreign CLAUDE.md must still produce exactly one import line, not one per racer"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -1024,6 +1024,23 @@ pub fn write_claude_md_respecting_ownership(
     let agentmux_owns_it =
         matches!(&existing, Some(Ok(content)) if content.starts_with(CLAUDE_MD_MANAGED_MARKER));
 
+    // Known, accepted TOCTOU window (codex P2, third review round on
+    // PR #2747): if a foreign CLAUDE.md is created/swapped in between the
+    // read above and this write — e.g. this exact working directory
+    // becoming a real project mid-launch — that unconditional write would
+    // still clobber it once. Not closed here: doing so would need real
+    // file locking (flock/LockFile) across the read-decide-write sequence,
+    // which every other config file this module writes (.mcp.json, skill
+    // files, hooks.json) has the identical unaddressed race against
+    // (agent_open.rs's own "no collision resolution... overwrites
+    // whatever's there" comment, about a directory-level version of the
+    // same class of race). Singling out CLAUDE.md's OWNED-file fast path
+    // for stronger protection than every sibling write in this same
+    // function would be inconsistent scope for what this PR set out to
+    // fix (a stable, at-rest foreign file being clobbered on every
+    // ordinary launch) — narrower and far less likely than that. The
+    // foreign-file branch below (where this PR's actual guarantee lives)
+    // does not have this gap: it never writes CLAUDE.md's own content.
     if agentmux_owns_it || existing.is_none() {
         let content = format!("{CLAUDE_MD_MANAGED_MARKER}\n\n{generated_content}");
         return std::fs::write(&claude_md_path, content);
@@ -1114,6 +1131,18 @@ pub fn write_claude_md_respecting_ownership(
                     .and_then(|mut f| std::io::Write::write_all(&mut f, import_block.as_bytes()));
                 if let Err(e) = append_result {
                     tracing::warn!(path = %claude_md_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to append the @import line this launch");
+                    // Roll back the marker we just created — winning the
+                    // race doesn't mean the offer actually completed. Without
+                    // this, the marker alone would permanently record
+                    // "offered" even though the import line was never
+                    // added, and every later launch's create_new would hit
+                    // AlreadyExists and skip forever, with no retry path
+                    // (reagent P1 + codex, third review round on PR #2747).
+                    // Best-effort: if the removal itself fails, a future
+                    // launch just stays stuck the way it would have been
+                    // without this fix — not worse, and not worth
+                    // escalating a cleanup failure into a launch failure.
+                    let _ = std::fs::remove_file(&ownership_marker_path);
                 }
             }
         }
@@ -1852,6 +1881,41 @@ mod tests {
             1,
             "8 concurrent launches against the same foreign CLAUDE.md must still produce exactly one import line, not one per racer"
         );
+    }
+
+    #[test]
+    fn claude_md_marker_is_rolled_back_when_the_append_fails() {
+        // reagent P1 + codex, third review round on PR #2747: winning the
+        // create_new race must not permanently record "offered" if the
+        // append itself then fails -- otherwise every later launch's
+        // create_new hits AlreadyExists and the import is never offered
+        // again, with no retry path.
+        let dir = tempfile::tempdir().unwrap();
+        let claude_md_path = dir.path().join("CLAUDE.md");
+        std::fs::write(&claude_md_path, "# Real project\n").unwrap();
+
+        // Read-only so the append's .open(...) fails, even though the
+        // read earlier in the function (which only needs read access)
+        // succeeds fine.
+        let mut perms = std::fs::metadata(&claude_md_path).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&claude_md_path, perms).unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "v1").unwrap();
+
+        let marker_path = dir.path().join(CLAUDE_MD_OWNERSHIP_MARKER_PATH);
+        assert!(!marker_path.exists(), "a failed append must roll back the ownership marker so a future launch can retry");
+
+        // Restore write access and confirm a later launch actually succeeds.
+        let mut perms = std::fs::metadata(&claude_md_path).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        std::fs::set_permissions(&claude_md_path, perms).unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "v2").unwrap();
+        let claude_md = std::fs::read_to_string(&claude_md_path).unwrap();
+        let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
+        assert_eq!(claude_md.matches(&import_needle).count(), 1, "retry after the file becomes writable again must succeed");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -911,6 +911,39 @@ struct ClaudeMdOwnershipMarker {
     import_line_offered: bool,
 }
 
+/// Resolve [`AGENTMUX_MEMORY_FILENAME`] and [`CLAUDE_MD_OWNERSHIP_MARKER_PATH`]
+/// against `base_path`, verifying neither escapes it via a symlinked
+/// ancestor (e.g. `.claude` itself existing as a symlink pointing outside
+/// the working directory) — same defense-in-depth the config-file write
+/// loops already apply to their own paths (codex P1 on PR #2747). Both
+/// constants are fixed, not user-controllable, so `safe_join_within_base`
+/// itself can never fail here; the symlink check is the one that matters.
+/// Returns `None` (having already logged why) if either check fails —
+/// callers treat that as "skip the foreign-file side effects this
+/// launch," not a hard error.
+fn resolve_claude_md_side_paths(
+    base_path: &std::path::Path,
+    base_canonical: &std::path::Path,
+) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    let resolve = |relative: &str| -> Option<std::path::PathBuf> {
+        let path = match crate::backend::base::safe_join_within_base(base_path, relative) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(base = %base_path.display(), relative, error = %e, "write_claude_md_respecting_ownership: path resolution failed");
+                return None;
+            }
+        };
+        if let Err(e) = crate::backend::base::verify_no_symlink_escape(&path, base_canonical) {
+            tracing::warn!(path = %path.display(), error = %e, "write_claude_md_respecting_ownership: refusing to write a path that escapes the working directory via a symlink");
+            return None;
+        }
+        Some(path)
+    };
+    let memory_path = resolve(AGENTMUX_MEMORY_FILENAME)?;
+    let ownership_marker_path = resolve(CLAUDE_MD_OWNERSHIP_MARKER_PATH)?;
+    Some((memory_path, ownership_marker_path))
+}
+
 /// Materialize `generated_content` (the composed Soul+AgentMD+Memory+Skills
 /// `CLAUDE.md` body `build_config_files` already produced) against whatever
 /// is already on disk at `base_path/CLAUDE.md`, WITHOUT ever overwriting a
@@ -919,19 +952,54 @@ struct ClaudeMdOwnershipMarker {
 /// - No file yet, or the existing file starts with
 ///   [`CLAUDE_MD_MANAGED_MARKER`]: AgentMux owns it — write `CLAUDE.md`
 ///   directly (marker + `generated_content`), exactly as every call site
-///   did unconditionally before this function existed.
-/// - Existing file present WITHOUT the marker: foreign. `CLAUDE.md` itself
-///   is never touched again. `generated_content` instead goes to
+///   did unconditionally before this function existed. **This is the one
+///   path that still hard-fails on an I/O error** (propagated via `?`,
+///   same as every call site's pre-existing behavior) — AgentMux's own
+///   config file failing to write is a real launch-blocking problem.
+/// - Existing file present WITHOUT the marker, **or present but
+///   unreadable** (permission denied, non-UTF-8 content, transient I/O
+///   error — a `read_to_string` error here must never collapse into "no
+///   file yet," or an unreadable foreign file gets silently clobbered,
+///   defeating this whole function's purpose; reagent P0 + codex P1 on
+///   PR #2747): treated identically as foreign. `CLAUDE.md` itself is
+///   never written to again. `generated_content` instead goes to
 ///   [`AGENTMUX_MEMORY_FILENAME`] (always safe to regenerate — it's 100%
 ///   AgentMux's own content), pulled in via a single `@import` line
 ///   appended to the real `CLAUDE.md` — offered at most once per working
 ///   directory (see [`CLAUDE_MD_OWNERSHIP_MARKER_PATH`]'s doc comment).
+///   If the file is unreadable specifically, the `@import` offer is
+///   skipped for this launch (nothing to safely append to/check
+///   idempotency against) — retried on the next launch.
 ///
-/// Best-effort in the same spirit as [`write_managed_skill_file_manifest`]:
-/// an I/O failure on the side-file/marker writes is logged, not
-/// propagated — losing them only means the import line isn't offered (or
-/// the side file isn't refreshed) on this one launch, not a correctness
-/// issue serious enough to fail the whole config-write.
+/// Everything in the foreign-file branch is best-effort, in the same
+/// spirit as [`write_managed_skill_file_manifest`] and unlike the
+/// AgentMux-owned branch above: an I/O failure writing the side file,
+/// appending the import line, or writing the ownership marker is logged
+/// and this function still returns `Ok(())` — losing one of these only
+/// means the import line isn't offered (or the side file isn't
+/// refreshed) on this one launch, not a correctness issue serious enough
+/// to fail the whole agent launch (codex P1 on PR #2747: the original
+/// version used `?` throughout this branch, contradicting this doc
+/// comment and propagating a side-file write failure into a hard launch
+/// failure).
+///
+/// The `@import` append is a true O_APPEND write
+/// (`OpenOptions::append(true)`), never a read-modify-write of the whole
+/// file — if the foreign file changes between this function's read and
+/// the append (edited by the user or another process mid-launch), a
+/// full-file rewrite would silently discard that intervening edit; a
+/// true append can only ever add bytes at whatever the end happens to be
+/// (codex P2 on PR #2747).
+///
+/// Every new path this function writes ([`AGENTMUX_MEMORY_FILENAME`],
+/// [`CLAUDE_MD_OWNERSHIP_MARKER_PATH`]) is resolved through
+/// [`crate::backend::base::safe_join_within_base`] and verified against
+/// [`crate::backend::base::verify_no_symlink_escape`] before any write —
+/// both constants are fixed, not user-controllable, but `.claude/` itself
+/// could exist as a symlink escaping the working directory, and without
+/// this check a write would silently follow it outside the selected
+/// project (codex P1 on PR #2747, same defense-in-depth the other
+/// config-file write loops already apply to their own paths).
 ///
 /// Shared by `agent.open` (`server/app_api/agent_open.rs`) and the
 /// `WriteAgentConfig` "click Launch" path (`server/editor_handlers.rs`) —
@@ -943,26 +1011,62 @@ pub fn write_claude_md_respecting_ownership(
     generated_content: &str,
 ) -> std::io::Result<()> {
     let claude_md_path = base_path.join("CLAUDE.md");
-    let existing = std::fs::read_to_string(&claude_md_path).ok();
 
-    let agentmux_owns_it = match &existing {
-        None => true,
-        Some(content) => content.starts_with(CLAUDE_MD_MANAGED_MARKER),
+    // `None` = genuinely no file yet. `Some(Ok(content))` = read fine.
+    // `Some(Err(_))` = exists but unreadable — MUST be treated the same
+    // as "foreign," never as "no file yet" (see doc comment above).
+    let existing = match std::fs::read_to_string(&claude_md_path) {
+        Ok(content) => Some(Ok(content)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => Some(Err(e)),
     };
 
-    if agentmux_owns_it {
+    let agentmux_owns_it =
+        matches!(&existing, Some(Ok(content)) if content.starts_with(CLAUDE_MD_MANAGED_MARKER));
+
+    if agentmux_owns_it || existing.is_none() {
         let content = format!("{CLAUDE_MD_MANAGED_MARKER}\n\n{generated_content}");
         return std::fs::write(&claude_md_path, content);
     }
 
-    // Foreign file — CLAUDE.md's own content is never touched from here on.
-    let memory_path = base_path.join(AGENTMUX_MEMORY_FILENAME);
-    if let Some(parent) = memory_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(&memory_path, generated_content)?;
+    // Resolve + symlink-verify the two new paths once, up front — neither
+    // write below proceeds if this fails.
+    let base_canonical = match base_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(path = %base_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to canonicalize base_path; skipping side-file write this launch");
+            return Ok(());
+        }
+    };
+    let Some((memory_path, ownership_marker_path)) =
+        resolve_claude_md_side_paths(base_path, &base_canonical)
+    else {
+        return Ok(());
+    };
 
-    let ownership_marker_path = base_path.join(CLAUDE_MD_OWNERSHIP_MARKER_PATH);
+    // Foreign (or unreadable) file — CLAUDE.md's own content is never
+    // written to from here on. Everything from here down is best-effort
+    // (see doc comment): a failure must not fail the whole agent launch.
+    if let Some(parent) = memory_path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::warn!(path = %parent.display(), error = %e, "write_claude_md_respecting_ownership: failed to create .claude/; side file not written this launch");
+            return Ok(());
+        }
+    }
+    if let Err(e) = std::fs::write(&memory_path, generated_content) {
+        tracing::warn!(path = %memory_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to write AGENTMUX_MEMORY.md this launch");
+        return Ok(());
+    }
+
+    // Unreadable (not just "no marker") — nothing safe to check
+    // idempotency against or append to. Skip the @import offer this
+    // launch; the side file above is still fresh and ready whenever the
+    // file becomes readable again.
+    let Some(Ok(existing_content)) = existing else {
+        tracing::warn!(path = %claude_md_path.display(), "write_claude_md_respecting_ownership: existing CLAUDE.md unreadable; treating as foreign, skipping @import offer this launch");
+        return Ok(());
+    };
+
     let already_offered = std::fs::read_to_string(&ownership_marker_path)
         .ok()
         .and_then(|s| serde_json::from_str::<ClaudeMdOwnershipMarker>(&s).ok())
@@ -970,7 +1074,6 @@ pub fn write_claude_md_respecting_ownership(
         .unwrap_or(false);
 
     if !already_offered {
-        let existing_content = existing.unwrap_or_default();
         let import_needle = format!("@{AGENTMUX_MEMORY_FILENAME}");
         // Idempotent even on this first offer: don't duplicate if the
         // import somehow already appears (e.g. a user copied it in by
@@ -978,14 +1081,29 @@ pub fn write_claude_md_respecting_ownership(
         if !existing_content.contains(&import_needle) {
             let import_block =
                 format!("\n\n{CLAUDE_MD_IMPORT_MARKER_COMMENT}\n{import_needle}\n");
-            std::fs::write(&claude_md_path, format!("{existing_content}{import_block}"))?;
+            // True append (never a read-modify-write of the whole file) —
+            // an edit racing this function's earlier read is preserved,
+            // not silently discarded (codex P2 on PR #2747).
+            let append_result = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&claude_md_path)
+                .and_then(|mut f| std::io::Write::write_all(&mut f, import_block.as_bytes()));
+            if let Err(e) = append_result {
+                tracing::warn!(path = %claude_md_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to append the @import line this launch");
+                return Ok(());
+            }
         }
         if let Some(parent) = ownership_marker_path.parent() {
-            std::fs::create_dir_all(parent)?;
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!(path = %parent.display(), error = %e, "write_claude_md_respecting_ownership: failed to create dir for ownership marker");
+                return Ok(());
+            }
         }
         let marker_json = serde_json::to_string(&ClaudeMdOwnershipMarker { import_line_offered: true })
             .unwrap_or_default();
-        std::fs::write(&ownership_marker_path, marker_json)?;
+        if let Err(e) = std::fs::write(&ownership_marker_path, marker_json) {
+            tracing::warn!(path = %ownership_marker_path.display(), error = %e, "write_claude_md_respecting_ownership: failed to write ownership marker");
+        }
     }
 
     Ok(())
@@ -1621,6 +1739,30 @@ mod tests {
         let content = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
         assert!(content.starts_with(human_content), "every byte of the original file must survive, at the start");
         assert!(!content.contains("AgentMux's generated content"), "generated content must never land in the real file");
+    }
+
+    #[test]
+    fn claude_md_non_utf8_file_is_treated_as_foreign_not_missing() {
+        // reagent P0 + codex P1 on PR #2747: read_to_string(...).ok()
+        // collapsed ANY read error (not just NotFound) into "no file
+        // yet," so a non-UTF-8 (or otherwise unreadable) foreign file
+        // got silently clobbered — the exact data-loss bug this whole
+        // function exists to prevent.
+        let dir = tempfile::tempdir().unwrap();
+        let claude_md_path = dir.path().join("CLAUDE.md");
+        // Invalid UTF-8: a lone continuation byte. read_to_string must
+        // fail on this (not silently lossy-convert it).
+        std::fs::write(&claude_md_path, [0x23, 0x20, 0xFF, 0xFE, 0x0A]).unwrap();
+        let raw_before = std::fs::read(&claude_md_path).unwrap();
+
+        write_claude_md_respecting_ownership(dir.path(), "AgentMux's generated content").unwrap();
+
+        let raw_after = std::fs::read(&claude_md_path).unwrap();
+        assert_eq!(raw_before, raw_after, "an unreadable foreign file's bytes must be completely untouched, not overwritten");
+        // Best-effort side file is still written even though the
+        // @import offer itself is skipped (nothing safe to append to).
+        let side_file = std::fs::read_to_string(dir.path().join(AGENTMUX_MEMORY_FILENAME)).unwrap();
+        assert_eq!(side_file, "AgentMux's generated content");
     }
 
     #[test]

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -840,6 +840,18 @@ pub(super) fn write_agent_config_files(
     crate::backend::agent_config::cleanup_stale_managed_skill_files(base_path, &new_managed_skill_paths);
 
     for file in &config_files {
+        // CLAUDE.md never gets the generic write below — it goes through
+        // ownership-aware materialization instead, which never overwrites
+        // a pre-existing, non-AgentMux-authored file's content. See
+        // docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md.
+        if file.filename == "CLAUDE.md" {
+            if let Err(e) =
+                crate::backend::agent_config::write_claude_md_respecting_ownership(base_path, &file.content)
+            {
+                return Err(format!("failed to write CLAUDE.md: {e}"));
+            }
+            continue;
+        }
         // Same defense-in-depth join as the cleanup pass above.
         let Ok(file_path) = crate::backend::base::safe_join_within_base(base_path, &file.filename)
         else {

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -321,11 +321,20 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Inject global memory bundles into CLAUDE.md so agents
                     // launched from the picker receive the same workspace rules
                     // as agents launched via the agent.open RPC.
-                    let content = if file.path == "CLAUDE.md" {
-                        inject_global_bundles(&file.content, &id_store)
-                    } else {
-                        file.content.clone()
-                    };
+                    if file.path == "CLAUDE.md" {
+                        // Ownership-aware materialization instead of the
+                        // generic write below — never overwrites a
+                        // pre-existing, non-AgentMux-authored file's
+                        // content. See
+                        // docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md.
+                        let content = inject_global_bundles(&file.content, &id_store);
+                        crate::backend::agent_config::write_claude_md_respecting_ownership(
+                            base_path, &content,
+                        )
+                        .map_err(|e| format!("failed to write CLAUDE.md: {e}"))?;
+                        tracing::debug!(path = %file_path.display(), "wrote config file (ownership-aware)");
+                        continue;
+                    }
                     // Create parent directories if needed
                     if let Some(parent) = file_path.parent() {
                         if !parent.exists() {
@@ -333,7 +342,7 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 .map_err(|e| format!("failed to create dir for {}: {e}", file.path))?;
                         }
                     }
-                    std::fs::write(&file_path, &content)
+                    std::fs::write(&file_path, &file.content)
                         .map_err(|e| format!("failed to write {}: {e}", file.path))?;
                     tracing::debug!(path = %file_path.display(), "wrote config file");
                 }

--- a/docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md
+++ b/docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md
@@ -1,0 +1,190 @@
+# Spec: protect a pre-existing project `CLAUDE.md` from AgentMux's overwrite
+
+**Date:** 2026-08-22
+**Author:** Camper
+**Status:** Implemented. The relative `@.claude/AGENTMUX_MEMORY.md` import
+(the design's one open question) was smoke-tested directly against the
+real Claude Code CLI (`claude -p`) before implementation — confirmed
+working as assumed.
+**Motivated by:** direct request, following the Armory "Global Memory" rename
+(`SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md`) — Global Memory
+is supposed to represent "the global rules agents follow," but a project's
+own real, git-tracked `CLAUDE.md` (e.g. this repo's own root `CLAUDE.md`)
+is a second, very real source of exactly that, sitting entirely outside
+AgentMux's system today.
+
+## Problem — confirmed, and worse than a naming gap
+
+`agent_config.rs::build_config_files()` composes `CLAUDE.md` from Soul +
+AgentMD + Memory (Global Memory + per-agent) + a skills index, and both
+call sites that materialize it to disk —
+`agent_open.rs::write_agent_config_files()` (line 859) and
+`editor_handlers.rs`'s `writeagentconfig` handler (line 336, "the actual
+'click Launch' path") — write it with a raw `std::fs::write(&file_path,
+&content)`. **No read of the existing file first, no diff, no backup, no
+warning, no merge.**
+
+The write target — `<agent.working_directory>/CLAUDE.md` — is not an
+AgentMux-owned location. It's confirmed identical to Claude Code's own
+native "project CLAUDE.md" discovery slot
+(`docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md`'s own location
+table). **Any agent launched with its working directory pointed at a real
+project that keeps hand-authored instructions in a root `CLAUDE.md` — this
+repo included — has that file silently, fully replaced on every launch.**
+Uncommitted edits at that moment are unrecoverable outside git.
+
+The one nearby code comment (`agent_open.rs:582-587`, "No collision
+resolution... overwrites whatever's there") is about concurrent AgentMux
+launches racing on the same *synthetic* workdir, not about a pre-existing
+independently-authored file — nobody appears to have reasoned about this
+case for Claude specifically.
+
+**A correct precedent already exists in this codebase, for a different
+provider.** `SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md` §10.2: *"AgentMux
+must not overwrite, merge by string marker into, or claim ownership of an
+existing repository `AGENTS.md`"* — routing AgentMux's content through an
+AgentMux-owned side file (`$CODEX_HOME/agentmux-<id>.config.toml` +
+`--profile`) instead. That design is itself unimplemented ("Slice E... not
+started"), and — the actual gap this spec closes — **was never extended to
+Claude/`CLAUDE.md`, which is the path that's live and actively overwriting
+real files today.**
+
+## Constraints ruled out by research (read before proposing alternatives)
+
+- **`CLAUDE_CONFIG_DIR`-relocated user-level `CLAUDE.md` is not a safe side
+  channel.** It's resolved per identity/account binding, not per agent —
+  multiple unbound agents share one instance-wide directory, and an agent
+  bound to the legacy "Default" migration identity resolves it to the
+  user's real global `~/.claude`. Writing AgentMux content there risks
+  leaking between agents or clobbering the user's own real global config
+  (`identities.rs:80-86`'s own doc comment confirms the Default-bundle case
+  literally resolves to `~/.claude/`).
+- **No `--system-prompt`/`--append-system-prompt` flag is used anywhere in
+  this codebase today.** It's a real Claude Code CLI flag
+  (`docs/research/claude-code-presentation-layer.md` confirms it exists),
+  but introducing it here would be new integration work, not reuse of an
+  existing path — and its compatibility with AgentMux's actual persistent
+  launch mode (`--input-format stream-json --output-format stream-json
+  --permission-prompt-tool stdio`, `providers.rs`'s `persistent_launch_args`)
+  is unverified. Soul/AgentMD/Memory are all funneled into the same
+  `CLAUDE.md` today — there's no existing split to extend.
+- **No project-scoped tier exists in the data model** — `db_bundles` has
+  only a boolean `is_global`, no working-directory/repo column. This spec
+  doesn't add one; it's a file-write-safety fix, not a new memory tier.
+
+Given these, a fully zero-touch fix isn't achievable today without taking
+on unverified `--append-system-prompt` integration risk. §Design below is
+a minimal-touch fix deployable now; §Future work names the zero-touch path
+as a follow-up once that flag's compatibility is verified.
+
+## Design
+
+### Ownership tracking — reuses the existing managed-files philosophy
+
+`agent_config.rs` already has exactly this pattern for skill files:
+`MANAGED_SKILL_FILES_MANIFEST` (`.claude/.agentmux-managed-skill-files.json`)
+tracks which paths AgentMux itself created, so `cleanup_stale_managed_skill_files`
+never deletes a file the user hand-authored outside that manifest. This
+spec applies the same *distinguish AgentMux-authored from user-authored*
+principle to `CLAUDE.md`, via a lighter mechanism suited to tracking a
+single file rather than a dynamic set:
+
+1. **A one-line marker as the first line of any `CLAUDE.md` AgentMux
+   itself writes:** `<!-- agentmux:managed-claude-md -->`. On every write,
+   check the *existing* file first:
+   - **Doesn't exist:** create it as today (full Soul+AgentMD+Memory+Skills
+     composition), with the marker as line 1. No behavior change from
+     today for the common case — a fresh working directory.
+   - **Exists and starts with the marker:** AgentMux wrote it last time.
+     Safe to regenerate in place exactly as today.
+   - **Exists and does NOT start with the marker:** foreign — either
+     predates AgentMux touching this workdir, or a human replaced
+     AgentMux's file with their own. **Never overwrite its content.**
+2. **Foreign-file case: deliver AgentMux's content via a side file +
+   a single idempotent `@import` line**, not a full-file replacement:
+   - Write the full Soul+AgentMD+Memory+Skills composition to an
+     AgentMux-owned file under the same namespace the skill manifest
+     already uses — `.claude/AGENTMUX_MEMORY.md` — freely regenerated on
+     every launch (it's 100% AgentMux's own content, always safe to
+     rewrite).
+   - Append exactly one line to the **end** of the real `CLAUDE.md`,
+     wrapped in a comment so its origin is unambiguous:
+     ```
+     <!-- agentmux:managed-import (safe to delete this line to opt out) -->
+     @.claude/AGENTMUX_MEMORY.md
+     ```
+     via Claude Code's own `@path` import mechanism
+     (`docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md:261-262`
+     confirms `@path` imports are real and already used for the analogous
+     user-level case). **This never touches the user's own content above
+     it** — append-only, and the insertion is idempotent (checked before
+     inserting, never duplicated on repeat launches).
+   - **Respecting an explicit opt-out:** whether the import line has
+     already been offered for this working directory is tracked in a
+     small on-disk marker, `.claude/.agentmux-claude-md-ownership.json`
+     (`{ "import_line_offered": true }`), checked *instead of* re-scanning
+     file content on every launch. Without this, a user who deliberately
+     deletes the import line (opting out of AgentMux content entirely)
+     would see it silently reappear on their next launch — the marker file
+     is what lets AgentMux tell "never offered yet" apart from "offered
+     and removed on purpose," and only ever inserts the line once per
+     working directory.
+
+### Open questions / needs verification before implementation
+
+- **Relative `@path` resolution.** The confirmed example
+  (`@~/.claude/my-instructions.md`) is home-relative; this design needs a
+  plain-relative `@.claude/AGENTMUX_MEMORY.md` resolved against the
+  including file's own directory. Needs a real Claude Code smoke test
+  before shipping — if relative imports don't resolve the way this
+  assumes, the side file may need an absolute path instead (computable at
+  write time either way, no design change, just confirm which form Claude
+  actually expects).
+- **Does the LLM "seeing" the marker comment matter?** An HTML comment is
+  invisible to a Markdown renderer but not to the model reading the raw
+  file — it'll see `<!-- agentmux:managed-claude-md -->` as ordinary text.
+  Harmless (one line of context), just noting it's not truly hidden from
+  the agent the way it would be from a human viewing rendered Markdown.
+
+## Future work — the zero-touch path
+
+If `--append-system-prompt` is verified compatible with AgentMux's
+persistent stream-json launch mode, a follow-up spec could deliver
+Soul/AgentMD/Memory via that flag instead of any file at all for agents
+whose `CLAUDE.md` is foreign — fully eliminating even the one-line
+`@import` touch. That's real, separate integration work (flag plumbing
+through `providers.rs`'s launch-args, verifying it doesn't interact badly
+with `--permission-prompt-tool stdio`) — not bundled here, since this
+spec's fix (stop the active data-loss risk) is deployable now without it.
+
+## Non-goals
+
+- Not building a project-scoped memory tier in the data model — Global
+  Memory and per-agent bundles stay exactly as they are; this only fixes
+  *how* their composed content reaches disk when a foreign `CLAUDE.md`
+  is present.
+- Not implemented for Codex/`AGENTS.md` here — that's
+  `SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md` §10.2's job, already
+  spec'd, separately unimplemented, and out of scope for this Claude-specific
+  fix.
+- Not retroactively repairing any `CLAUDE.md` that's already been
+  overwritten by AgentMux before this ships — no way to distinguish
+  "AgentMux clobbered real content" from "AgentMux legitimately created
+  this from nothing" after the fact without the marker this spec
+  introduces going forward. Recovery for anyone already affected is git
+  history/reflog, same as today.
+
+## Testing
+
+- Unit: `agent_config.rs`'s ownership-detection logic — marker present vs.
+  absent vs. no file at all, each producing the right write behavior.
+- Unit: idempotent import-line insertion — inserting twice must not
+  duplicate the line; a user-deleted import line must not reappear
+  (mocked ownership-marker file state).
+- Integration/manual: launch an agent against a real directory with a
+  hand-authored `CLAUDE.md` (this repo is the natural test case in a
+  throwaway clone — never test against a real checkout in place) and
+  confirm its content is untouched, `.claude/AGENTMUX_MEMORY.md` contains
+  the composed Soul+AgentMD+Memory+Skills content, and Claude Code
+  actually resolves the `@import` (the open question above) — verify with
+  a prompt that only the imported content could answer correctly.


### PR DESCRIPTION
## Summary
Both config-materializing call sites (`agent.open`'s `write_agent_config_files`, and the `WriteAgentConfig` "click Launch" path) wrote `CLAUDE.md` via a raw `std::fs::write` — no read-before-write, no backup, no merge. That path is the exact same slot Claude Code's own project-`CLAUDE.md` discovery uses, so any agent launched with its working directory pointed at a real project with its own hand-authored, git-tracked `CLAUDE.md` had it silently, fully replaced on every launch.

`write_claude_md_respecting_ownership()` fixes this, extending the same "distinguish AgentMux-authored from user-authored" philosophy the existing managed-skill-files manifest already uses:

- AgentMux marks any `CLAUDE.md` it writes with a first-line comment marker. No file yet, or marker present → owned, freely regenerated exactly as before (**zero behavior change for the common case** — a fresh working directory).
- Marker absent on an existing file → foreign, never overwritten. AgentMux's composed content instead goes to an AgentMux-owned side file (`.claude/AGENTMUX_MEMORY.md`), pulled in via one idempotent `@import` line appended to the real file — offered at most once per working directory, and never silently reappears if a user deletes it to opt out.

The relative `@path` import mechanism was smoke-tested directly against the real Claude Code CLI (`claude -p`) before writing any code, not assumed — confirmed it resolves `@.claude/AGENTMUX_MEMORY.md` correctly.

Full design: `docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md`

## Test plan
- [x] 6 new unit tests in `agent_config.rs` covering: fresh dir, AgentMux-owned regeneration, foreign-file content never touched, side-file + import-line creation, no duplicate import across repeated launches, and a user's deliberate opt-out never gets silently reversed.
- [x] All 4 existing `write_agent_config_files_tests` integration tests still pass (skill cleanup, manifest path-traversal defense, MCP blob preservation).
- [x] `cargo check` clean.
- [x] Real Claude Code CLI smoke test confirming the `@path` import mechanism this design depends on actually works as assumed.

<!-- agentmux:agent_id=camper -->