### PR TITLE
feat(settings): add agent watchdog threshold controls to Terminal section

### DIFF
--- a/.changesets/1787436671-feat-settings-add-agent-watchdog-threshold-controls-to-termi-9qat.md
+++ b/.changesets/1787436671-feat-settings-add-agent-watchdog-threshold-controls-to-termi-9qat.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(settings): add agent watchdog threshold controls to Terminal section

--- a/frontend/app/view/settings/sections/terminal-section.tsx
+++ b/frontend/app/view/settings/sections/terminal-section.tsx
@@ -144,6 +144,36 @@ export function TerminalSection(): JSX.Element {
                     }
                 />
             </Show>
+            <SettingRow
+                label="Agent max runtime"
+                description="Hours before the watchdog kills a long-running agent pane. 0 = no limit."
+                control={
+                    <input
+                        class="setting-number setting-number--wide"
+                        type="number" min={0} step={0.5}
+                        value={(s()["term:agentmaxruntimehours"] as number) ?? 0}
+                        onBlur={(e) => {
+                            const v = parseFloat(e.currentTarget.value);
+                            if (!isNaN(v) && v >= 0) set("term:agentmaxruntimehours", v);
+                        }}
+                    />
+                }
+            />
+            <SettingRow
+                label="Agent idle timeout"
+                description="Minutes of PTY silence before the watchdog kills an idle agent pane. 0 = no limit."
+                control={
+                    <input
+                        class="setting-number setting-number--wide"
+                        type="number" min={0}
+                        value={(s()["term:agentidletimeoutmins"] as number) ?? 0}
+                        onBlur={(e) => {
+                            const v = parseFloat(e.currentTarget.value);
+                            if (!isNaN(v) && v >= 0) set("term:agentidletimeoutmins", v);
+                        }}
+                    />
+                }
+            />
         </div>
     );
 }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1518,6 +1518,8 @@ declare global {
         "term:transparency"?: number;
         "term:allowbracketedpaste"?: boolean;
         "term:shiftenternewline"?: boolean;
+        "term:agentmaxruntimehours"?: number;
+        "term:agentidletimeoutmins"?: number;
         "term:conndebug"?: string;
         "markdown:fontsize"?: number;
         "markdown:fixedfontsize"?: number;
@@ -1690,6 +1692,8 @@ declare global {
         "term:shiftenternewline"?: boolean;
         "term:predictiveecho"?: boolean;
         "term:predictiveecho:thresholdms"?: number;
+        "term:agentmaxruntimehours"?: number;
+        "term:agentidletimeoutmins"?: number;
         "cmd:env"?: {[key: string]: string};
         "blockheader:*"?: boolean;
         "blockheader:showblockids"?: boolean;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -65,6 +65,18 @@
         "term:predictiveecho:thresholdms": {
           "type": "number"
         },
+        "term:agentmaxruntimehours": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0,
+          "description": "Maximum wall-clock runtime (hours) before the watchdog kills an agent pane. 0 (default) disables the limit."
+        },
+        "term:agentidletimeoutmins": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0,
+          "description": "Minutes of PTY silence before the watchdog kills an idle agent pane. 0 (default) disables the limit."
+        },
         "cmd:env": {
           "additionalProperties": {
             "type": "string"


### PR DESCRIPTION
## Summary

Part of tracked work from #2671 (candidate #2, `SPEC_SETTINGS_AUDIT_GOOD_PICKINGS_2026_08_19.md`). `term:agentmaxruntimehours` / `term:agentidletimeoutmins` (`agentmux-srv/src/backend/wconfig/types.rs:91-99`) are a real, live safety feature — `watchdog.rs`'s 60s poll loop kills any agent pane exceeding a configured max wall-clock runtime or PTY-idle duration — but had zero discoverability.

**Re-verified before implementing**: `SPEC_SETTINGS_PANE_COMPLETION_2026_07_14.md` previously claimed these fields were removed entirely, and the audit spec flagged this as needing a fresh check. Confirmed both fields are live in `types.rs` and consumed in `watchdog.rs` today.

## Changes

- `schema/settings.json` + `frontend/types/gotypes.d.ts`: added the two previously-undocumented keys (matching the format of neighboring `term:*` entries)
- Two new numeric `SettingRow`s in Settings → Terminal, "0 = no limit" per the existing doc comments — no backend changes, both fields already round-trip through the generic settings merge path

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Manual: confirmed field names/defaults exactly match `types.rs`'s serde rename attributes

<!-- agentmux:agent_id=smike -->