### PR TITLE
Korp@claudius: feat(muxspect): stamp every response with x-agentmux-srv-version, self-diagnosing stale-build 404s

### DIFF
--- a/.changesets/1787437319-feat-muxspect-stamp-every-response-with-x-agentmux-srv-versi-njed.md
+++ b/.changesets/1787437319-feat-muxspect-stamp-every-response-with-x-agentmux-srv-versi-njed.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(muxspect): stamp every response with x-agentmux-srv-version, self-diagnosing stale-build 404s

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -99,6 +99,20 @@ function requireEnv() {
     return { url, authKey };
 }
 
+// Ext 5 of docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
+// this session hit `muxspect conversations` 404ing because the running srv
+// predated that route, with nothing saying so — every response now carries
+// an `x-agentmux-srv-version` header (server/mod.rs's version_header
+// middleware) stamping the instance's own version. Printed to STDERR (not
+// stdout) on every call so it never pollutes piped/parsed `--json` output,
+// and folded into the error message specifically for a 404 — the one status
+// a version mismatch is most likely to explain.
+export function logSrvVersion(resp) {
+    const v = resp.headers.get("x-agentmux-srv-version");
+    if (v) console.error(`[srv v${v}]`);
+    return v;
+}
+
 async function apiGet(url, authKey, urlPath) {
     let resp;
     try {
@@ -106,9 +120,14 @@ async function apiGet(url, authKey, urlPath) {
     } catch (e) {
         fail(`could not reach ${url} — instance unreachable (${e.message})`);
     }
+    const srvVersion = logSrvVersion(resp);
     if (!resp.ok) {
         const body = await resp.text().catch(() => "");
-        fail(`request failed (${resp.status}): ${body || resp.statusText}`);
+        const versionHint =
+            resp.status === 404 && srvVersion
+                ? ` (this instance is running srv v${srvVersion} — a 404 here may mean it predates this command; check you're not talking to a stale build)`
+                : "";
+        fail(`request failed (${resp.status}): ${body || resp.statusText}${versionHint}`);
     }
     return resp.json();
 }
@@ -129,9 +148,14 @@ async function apiPost(url, authKey, urlPath, body) {
     } catch (e) {
         fail(`could not reach ${url} — instance unreachable (${e.message})`);
     }
+    const srvVersion = logSrvVersion(resp);
     if (!resp.ok) {
         const respBody = await resp.text().catch(() => "");
-        fail(`request failed (${resp.status}): ${respBody || resp.statusText}`);
+        const versionHint =
+            resp.status === 404 && srvVersion
+                ? ` (this instance is running srv v${srvVersion} — a 404 here may mean it predates this command; check you're not talking to a stale build)`
+                : "";
+        fail(`request failed (${resp.status}): ${respBody || resp.statusText}${versionHint}`);
     }
     return resp.json();
 }

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -12,8 +12,8 @@
 // after the positional command/block_id, and the original (raw-index)
 // parser silently misbehaved depending on which side they landed on.
 
-import { describe, expect, it } from "vitest";
-import { checkSpawnerTier, parseArgs } from "./muxspect.mjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkSpawnerTier, logSrvVersion, parseArgs } from "./muxspect.mjs";
 
 describe("muxspect parseArgs", () => {
     it("no args defaults to 'list'", () => {
@@ -164,5 +164,42 @@ describe("muxspect checkSpawnerTier", () => {
 
     it("returns null for a non-dev channel (e.g. plain 'stable')", () => {
         expect(checkSpawnerTier("AgentA", { AGENTMUX_CHANNEL: "stable" })).toBeNull();
+    });
+});
+
+// Ext 5 (docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md):
+// every response carries an x-agentmux-srv-version header (server/mod.rs's
+// version_header middleware); logSrvVersion reads it and prints to stderr
+// so a stale-build 404 is self-diagnosing instead of a bare, unexplained
+// one. console.error is mocked (not asserted on message text — that's
+// rendering detail) purely to keep test output clean; the return value is
+// what callers (apiGet/apiPost's 404 version-hint) actually depend on.
+describe("muxspect logSrvVersion", () => {
+    let errSpy;
+
+    beforeEach(() => {
+        errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        errSpy.mockRestore();
+    });
+
+    function fakeResponse(headerValue) {
+        return { headers: { get: (name) => (name === "x-agentmux-srv-version" ? headerValue : null) } };
+    }
+
+    it("returns the version string when the header is present", () => {
+        expect(logSrvVersion(fakeResponse("0.55.19"))).toBe("0.55.19");
+    });
+
+    it("logs to console.error (not stdout) when the header is present", () => {
+        logSrvVersion(fakeResponse("0.55.19"));
+        expect(errSpy).toHaveBeenCalledOnce();
+    });
+
+    it("returns undefined/falsy and logs nothing when the header is absent (older srv build)", () => {
+        expect(logSrvVersion(fakeResponse(null))).toBeFalsy();
+        expect(errSpy).not.toHaveBeenCalled();
     });
 });

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -559,11 +559,32 @@ pub fn build_router(state: AppState) -> Router {
             .post(crate::messaging::whatsapp::handle_inbound),
     );
 
+    // Ext 5 of docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
+    // stamp every response with this instance's own version, so a stale-
+    // build 404 (this session hit exactly this: `muxspect conversations`
+    // 404ing because the running srv predated that route, with nothing
+    // saying so) is self-diagnosing instead of a bare, unexplained 404.
+    // Captured by value (not via AppState extraction) so this applies to
+    // EVERY route uniformly, including the unauthenticated health/webhook
+    // ones, without needing `AppState: Clone`.
+    let version_for_header = state.version.clone();
+    let version_header = axum::middleware::from_fn(move |req: axum::extract::Request, next: axum::middleware::Next| {
+        let version = version_for_header.clone();
+        async move {
+            let mut response = next.run(req).await;
+            if let Ok(value) = axum::http::HeaderValue::from_str(&version) {
+                response.headers_mut().insert("x-agentmux-srv-version", value);
+            }
+            response
+        }
+    });
+
     Router::new()
         .merge(health)
         .merge(whatsapp_webhooks)
         .merge(lan_forward_routes)
         .merge(authed_routes)
+        .layer(version_header)
         .layer(cors)
         .with_state(state)
 }

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -138,3 +138,13 @@ mechanism for one instance to answer a state query from outside itself
 except the path `muxspect` already uses (env-inherited token, same as
 `agentmux-mcp`). Reaching a *different* instance needs a real
 discovery+auth story that doesn't exist yet — planned as Phase 2.
+
+## Every response carries the instance's own version
+
+Every `muxspect` call prints `[srv vX.Y.Z]` to stderr — the running
+instance's own version, read from the `x-agentmux-srv-version` response
+header every route sets. A 404 specifically gets a version hint folded
+into the failure message: a stale local build predating whatever command
+you just ran looks exactly like a missing route otherwise (a real gap this
+session hit live — `muxspect conversations` 404ing against an
+un-rebuilt instance). See `docs/specs/SPEC_MUXSPECT_SRV_VERSION_HEADER_2026_08_22.md`.

--- a/docs/specs/SPEC_MUXSPECT_SRV_VERSION_HEADER_2026_08_22.md
+++ b/docs/specs/SPEC_MUXSPECT_SRV_VERSION_HEADER_2026_08_22.md
@@ -1,0 +1,63 @@
+# SPEC: `x-agentmux-srv-version` response header
+
+**Date:** 2026-08-22
+**Status:** Implemented
+**Author:** Korp
+**Repos touched:** `agentmux` (`agentmux-srv/src/server/mod.rs`,
+`agentmux-srv/src/backend/shellintegration/muxspect.mjs`)
+**Related:** Ext 5 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`
+
+## 1. Problem
+
+Live, during the same debugging session that produced the report:
+`muxspect conversations` returned a bare `404 Not Found` against the
+actual running instance, because the running `agentmux-srv` binary
+predated the route (the feature had just merged to `main` but this
+instance hadn't been rebuilt yet). Nothing in the response said so — the
+404 looked identical to "route genuinely doesn't exist" and "this build is
+just old," and diagnosing which one required manually cross-referencing
+the source tree against the running binary's version by hand.
+
+## 2. Change
+
+Every HTTP response from `agentmux-srv` now carries an
+`x-agentmux-srv-version` header stamping the instance's own
+`CARGO_PKG_VERSION`. Implemented as a small `axum::middleware::from_fn`
+layer in `build_router` (`agentmux-srv/src/server/mod.rs`), applied to the
+whole router — health/webhook routes included — so it's universal rather
+than requiring every individual handler to set it. The version string is
+captured by value from `AppState.version` before the layer closure, so no
+`AppState: Clone` bound is needed.
+
+`muxspect.mjs`'s `apiGet`/`apiPost` read the header on every call and:
+- Print it to **stderr** (`[srv v0.55.19]`) — deliberately not stdout, so
+  it never pollutes piped/parsed `--json` output.
+- On a **404 specifically**, fold a hint into the failure message: "this
+  instance is running srv vX.Y.Z — a 404 here may mean it predates this
+  command; check you're not talking to a stale build." 404 is singled out
+  because a version mismatch is the most plausible explanation for that
+  specific status, versus e.g. a 400 (bad request) or 500 (real server
+  error) where the version is much less likely to be the story.
+
+## 3. Non-goals
+
+- Does not add version-skew *enforcement* (refusing to talk to a
+  mismatched instance) — purely diagnostic, matching every other
+  `muxspect` command's read-only posture.
+- Does not attempt to compare the caller's own build version against the
+  server's — the CLI core (`muxspect.mjs`) doesn't carry its own version
+  identity separately from whatever srv deployed it next to.
+- Does not backfill this into already-running instances — like every
+  other Rust change in this report, it only takes effect once an instance
+  is rebuilt and relaunched on the new binary.
+
+## 4. Testing
+
+- `logSrvVersion()` (the header-read/log function) is pure enough to unit
+  test directly: 3 cases (header present → returns + logs; header absent
+  → returns falsy + logs nothing) using a fake `Response`-shaped object,
+  with `console.error` mocked via `vi.spyOn` so test output stays clean.
+- Not verified against a live rebuilt instance for the same reason as Ext 4
+  (`SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md` §3) — would need a
+  full srv rebuild + relaunch. Verified via `cargo check` and the CLI unit
+  tests instead.


### PR DESCRIPTION
## Summary

Ext 5 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`. `SPEC_MUXSPECT_SRV_VERSION_HEADER_2026_08_22.md`.

Live during this same debugging session: `muxspect conversations` 404'd against the actual running instance because the running srv binary predated that route (merged to `main`, but this instance hadn't been rebuilt yet). Nothing said so — the 404 looked identical to "route genuinely doesn't exist."

Every response now carries `x-agentmux-srv-version` (a small `axum::middleware::from_fn` layer in `build_router`, applied to the whole router including health/webhook routes). `muxspect.mjs` prints it to **stderr** on every call (`[srv v0.55.19]` — never stdout, so `--json` output stays clean), and folds a hint into a 404's failure message specifically, since a version mismatch is the most plausible explanation for that one status.

## Test plan
- [x] `cargo check -p agentmux-srv` passes clean
- [x] 3 new cases for `logSrvVersion` (header present/absent, logs vs. doesn't) — 25/25 passing overall
- [ ] Live end-to-end verification (blocked on a rebuild, same as Ext 4 — see spec's Non-goals)

<!-- agentmux:agent_id=korp -->