### PR TITLE
feat(settings): add Recording/Input section — voice engine config, device picker, test-your-mic

### DIFF
--- a/.changesets/1787438407-feat-settings-add-recording-input-section-voice-engine-confi-9i5s.md
+++ b/.changesets/1787438407-feat-settings-add-recording-input-section-voice-engine-confi-9i5s.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(settings): add Recording/Input section — voice engine config, device picker, test-your-mic

--- a/.changesets/1787439491-fix-voice-redact-groqapikey-from-renderer-fix-engine-switch--0dxc.md
+++ b/.changesets/1787439491-fix-voice-redact-groqapikey-from-renderer-fix-engine-switch--0dxc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(voice): redact groqApiKey from renderer, fix engine-switch/test-cancel bugs

--- a/agentmux-srv/src/backend/config_watcher_fs.rs
+++ b/agentmux-srv/src/backend/config_watcher_fs.rs
@@ -261,7 +261,8 @@ fn reload_and_broadcast(
     // Broadcast updated config to all connected clients (same format as initial config push)
     let config = config_watcher.get_full_config();
     let client_count = event_bus.connection_count();
-    if let Ok(config_val) = serde_json::to_value(config.as_ref()) {
+    if let Ok(mut config_val) = serde_json::to_value(config.as_ref()) {
+        crate::backend::wconfig::redact_full_config_for_renderer(&mut config_val);
         let event = WSEventType {
             eventtype: WS_EVENT_RPC.to_string(),
             oref: String::new(),

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -400,6 +400,11 @@ pub const COMMAND_MEMORY_WRITE: &str = "memory.write";
 pub const COMMAND_BOOKMARKS_LIST: &str = "bookmarks.list";
 pub const COMMAND_BOOKMARKS_SET: &str = "bookmarks.set";
 
+// Settings -> Recording section: live path-existence check for the local
+// whisper.cpp CLI/model file config. See
+// docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §3.
+pub const COMMAND_VOICE_CHECK_PATH: &str = "voice.checkPath";
+
 // App API — v1 standalone Skill primitives
 pub const COMMAND_SKILL_LIST: &str = "skill.list";
 pub const COMMAND_SKILL_GET: &str = "skill.get";

--- a/agentmux-srv/src/backend/wconfig/mod.rs
+++ b/agentmux-srv/src/backend/wconfig/mod.rs
@@ -8,11 +8,13 @@
 //! config watcher.
 
 mod loader;
+pub mod redact;
 pub mod types;
 mod watcher;
 
 // Re-export all public APIs so callers can continue using `wconfig::Type`.
 pub use loader::*;
+pub use redact::redact_full_config_for_renderer;
 pub use types::*;
 pub use watcher::*;
 

--- a/agentmux-srv/src/backend/wconfig/redact.rs
+++ b/agentmux-srv/src/backend/wconfig/redact.rs
@@ -1,0 +1,98 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Redact secret settings keys from the full-config JSON before it is sent to
+//! any renderer/frontend connection.
+//!
+//! Found in PR #2751 review: `voice:groqApiKey`'s own doc comment claims
+//! "Read server-side only, never sent to the renderer," but `get_full_config()`'s
+//! outbound JSON (the initial `config` event, the `getfullconfig` RPC, and the
+//! post-`setconfig` broadcast — all three call sites in `server/websocket.rs`)
+//! was never actually filtered, so the real plaintext key has always reached
+//! every renderer connection's JS memory. PR #2751 introduced a masked-dot
+//! Settings UI for this key (`MaskedKeyField`) that visually implies the
+//! opposite. This module makes the doc comment's claim actually true.
+//!
+//! The renderer's UI only needs to know a value IS set, never what it is, so
+//! redaction replaces the real value with a fixed non-empty placeholder
+//! (distinguishable from "unset") rather than merely blanking it. The write
+//! path (`setconfig` → `merge_settings_to_disk`/`merge_settings_into_current`)
+//! is untouched — this only filters the server → renderer read direction.
+
+use serde_json::Value;
+
+/// Settings keys whose values must never reach a renderer connection.
+/// Extend this list as more secret-shaped fields get a Settings UI (e.g. the
+/// messaging-bridge bot tokens proposed in
+/// docs/specs/SPEC_SETTINGS_MESSAGING_BRIDGES_SECTION_2026_08_22.md).
+const REDACTED_SETTINGS_KEYS: &[&str] = &["voice:groqApiKey"];
+
+/// Placeholder written in place of a redacted value. Any renderer code that
+/// merely checks "is a key set" (e.g. `MaskedKeyField`'s locked-state gate)
+/// keeps working unchanged; nothing should ever display this string as if it
+/// were the real value.
+const REDACTED_PLACEHOLDER: &str = "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}";
+
+/// Redact known-secret keys in-place on an already-serialized full-config
+/// JSON value. Call this on every path that sends config to a renderer;
+/// never on the in-memory `ConfigWatcher` state or the on-disk file.
+pub fn redact_full_config_for_renderer(v: &mut Value) {
+    let Some(settings) = v.get_mut("settings").and_then(|s| s.as_object_mut()) else {
+        return;
+    };
+    for key in REDACTED_SETTINGS_KEYS {
+        let is_set = settings
+            .get(*key)
+            .map(|existing| match existing {
+                Value::String(s) => !s.is_empty(),
+                Value::Null => false,
+                _ => true,
+            })
+            .unwrap_or(false);
+        if is_set {
+            settings.insert((*key).to_string(), Value::String(REDACTED_PLACEHOLDER.to_string()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn redacts_a_set_secret_key() {
+        let mut v = json!({ "settings": { "voice:groqApiKey": "sk-real-secret-value" } });
+        redact_full_config_for_renderer(&mut v);
+        assert_eq!(v["settings"]["voice:groqApiKey"], REDACTED_PLACEHOLDER);
+        assert_ne!(v["settings"]["voice:groqApiKey"], "sk-real-secret-value");
+    }
+
+    #[test]
+    fn leaves_an_unset_secret_key_alone() {
+        let mut v = json!({ "settings": { "term:fontsize": 14 } });
+        redact_full_config_for_renderer(&mut v);
+        assert!(v["settings"].get("voice:groqApiKey").is_none());
+    }
+
+    #[test]
+    fn does_not_touch_unrelated_settings() {
+        let mut v = json!({ "settings": { "voice:groqApiKey": "sk-real", "term:fontsize": 14 } });
+        redact_full_config_for_renderer(&mut v);
+        assert_eq!(v["settings"]["term:fontsize"], 14);
+    }
+
+    #[test]
+    fn handles_missing_settings_object_gracefully() {
+        let mut v = json!({ "mimetypes": {} });
+        redact_full_config_for_renderer(&mut v); // must not panic
+        assert_eq!(v, json!({ "mimetypes": {} }));
+    }
+
+    #[test]
+    fn treats_empty_string_as_unset() {
+        let mut v = json!({ "settings": { "voice:groqApiKey": "" } });
+        redact_full_config_for_renderer(&mut v);
+        assert_eq!(v["settings"]["voice:groqApiKey"], "");
+    }
+}

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -42,6 +42,7 @@ mod memory;
 mod skill;
 mod mcp;
 mod bookmarks;
+mod voice;
 pub(crate) mod fleet;
 
 /// Register all App API handlers on the RPC engine.
@@ -58,6 +59,7 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     skill::register(engine, state);
     mcp::register(engine, state);
     bookmarks::register(engine, state);
+    voice::register(engine, state);
     fleet::register(engine, state);
 }
 

--- a/agentmux-srv/src/server/app_api/voice.rs
+++ b/agentmux-srv/src/server/app_api/voice.rs
@@ -1,0 +1,39 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `voice.checkPath` — live existence check for the local whisper.cpp CLI
+//! binary or GGML model file paths configured in Settings -> Recording.
+//!
+//! Exposes the exact same `Path::new(&p).exists()` check
+//! `agentmux-srv/src/server/voice.rs` already performs inline at actual
+//! transcription time (`voice.rs`'s `transcribe_local_whisper` /
+//! `ensure_local_model`) -- no new validation logic, just surfacing it
+//! proactively so the Settings UI can show live status instead of only
+//! failing at first-recording-attempt. See
+//! docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §3.
+
+use super::*;
+
+pub fn register(engine: &Arc<WshRpcEngine>, _state: &AppState) {
+    register_voice_check_path(engine);
+}
+
+#[derive(serde::Deserialize)]
+struct VoiceCheckPathReq {
+    path: String,
+}
+
+fn register_voice_check_path(engine: &Arc<WshRpcEngine>) {
+    engine.register_handler(
+        COMMAND_VOICE_CHECK_PATH,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let req: VoiceCheckPathReq = serde_json::from_value(data)
+                    .map_err(|e| format!("voice.checkPath: {e}"))?;
+                let trimmed = req.path.trim();
+                let exists = !trimmed.is_empty() && std::path::Path::new(trimmed).exists();
+                Ok(Some(json!({ "exists": exists })))
+            })
+        }),
+    );
+}

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -100,7 +100,8 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
     {
         let t = std::time::Instant::now();
         let config = state.config_watcher.get_full_config();
-        if let Ok(config_val) = serde_json::to_value(config.as_ref()) {
+        if let Ok(mut config_val) = serde_json::to_value(config.as_ref()) {
+            crate::backend::wconfig::redact_full_config_for_renderer(&mut config_val);
             let config_event = json!({
                 "eventtype": "rpc",
                 "data": {
@@ -618,7 +619,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
             Box::pin(async move {
                 let config = cw.get_full_config();
                 match serde_json::to_value(config.as_ref()) {
-                    Ok(v) => Ok(Some(v)),
+                    Ok(mut v) => {
+                        crate::backend::wconfig::redact_full_config_for_renderer(&mut v);
+                        Ok(Some(v))
+                    }
                     Err(e) => Err(format!("failed to serialize config: {}", e)),
                 }
             })
@@ -1392,7 +1396,8 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
 
                 // 4. Broadcast updated config now — no waiting for fs watcher
                 let config = cw.get_full_config();
-                if let Ok(config_val) = serde_json::to_value(config.as_ref()) {
+                if let Ok(mut config_val) = serde_json::to_value(config.as_ref()) {
+                    crate::backend::wconfig::redact_full_config_for_renderer(&mut config_val);
                     let event = crate::backend::eventbus::WSEventType {
                         eventtype: crate::backend::eventbus::WS_EVENT_RPC.to_string(),
                         oref: String::new(),

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -956,8 +956,7 @@ function installVoiceInputErrorListener(): void {
             case "service-not-allowed":
                 title = "Voice transcription unavailable";
                 message =
-                    "Speech recognition isn't available in this build yet. " +
-                    "Server-side transcription is in progress.";
+                    "Voice transcription isn't configured — open Settings ▸ Recording to set it up.";
                 break;
             default:
                 return; // non-fatal / unknown — no toast

--- a/frontend/app/hook/audioLevel.ts
+++ b/frontend/app/hook/audioLevel.ts
@@ -1,0 +1,20 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared RMS-from-AnalyserNode computation. Factored out of
+ * `whisperVoiceEngine.ts`'s `pollLevel()` (originally VAD-only, its number
+ * was never rendered) so `useMicLevelMeter` can reuse the identical
+ * calculation instead of duplicating the Web Audio boilerplate.
+ * See docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §4.
+ */
+export function computeRms(analyser: AnalyserNode): number {
+    const buf = new Uint8Array(analyser.fftSize);
+    analyser.getByteTimeDomainData(buf);
+    let sum = 0;
+    for (let i = 0; i < buf.length; i++) {
+        const v = (buf[i] - 128) / 128;
+        sum += v * v;
+    }
+    return Math.sqrt(sum / buf.length);
+}

--- a/frontend/app/hook/useMicLevelMeter.ts
+++ b/frontend/app/hook/useMicLevelMeter.ts
@@ -1,0 +1,71 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Live microphone level meter for the Settings -> Recording "Test your
+ * microphone" flow. Reuses the same RMS-from-AnalyserNode computation
+ * `whisperVoiceEngine.ts`'s VAD already performs (`audioLevel.ts`), applied
+ * here purely for display rather than silence-detection.
+ *
+ * Independent of `whisperVoiceEngine.ts`'s own capture graph — this owns its
+ * own short-lived AudioContext/AnalyserNode against whatever stream the
+ * caller hands it (the test flow's own getUserMedia call), so it doesn't
+ * interfere with an actual in-progress voice-input session elsewhere.
+ *
+ * See docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §4.
+ */
+import { onCleanup } from "solid-js";
+import { createSignalAtom, type SignalAtom } from "@/util/util";
+import { computeRms } from "./audioLevel";
+
+const POLL_MS = 100;
+
+export interface MicLevelMeter {
+    /** Current RMS level, 0..~1. Resets to 0 when stopped. */
+    level: SignalAtom<number>;
+    /** Start polling the given stream's audio level. Safe to call repeatedly (restarts). */
+    start: (stream: MediaStream) => void;
+    /** Stop polling and release the AudioContext. Safe to call when not started. */
+    stop: () => void;
+}
+
+export function createMicLevelMeter(): MicLevelMeter {
+    const level = createSignalAtom(0);
+    let audioCtx: AudioContext | null = null;
+    let analyser: AnalyserNode | null = null;
+    let timer: number | null = null;
+
+    const stop = () => {
+        if (timer != null) {
+            clearInterval(timer);
+            timer = null;
+        }
+        analyser = null;
+        if (audioCtx) {
+            const ctx = audioCtx;
+            audioCtx = null;
+            void ctx.close().catch(() => {});
+        }
+        level._set(0);
+    };
+
+    const start = (stream: MediaStream) => {
+        stop();
+        try {
+            audioCtx = new AudioContext();
+            const src = audioCtx.createMediaStreamSource(stream);
+            analyser = audioCtx.createAnalyser();
+            analyser.fftSize = 2048;
+            src.connect(analyser);
+            timer = window.setInterval(() => {
+                if (analyser) level._set(computeRms(analyser));
+            }, POLL_MS);
+        } catch {
+            stop();
+        }
+    };
+
+    onCleanup(stop);
+
+    return { level, start, stop };
+}

--- a/frontend/app/hook/useVoiceInput.test.ts
+++ b/frontend/app/hook/useVoiceInput.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression test for PR #2751 review (re-review round): getVoiceSession()
+ * must return a STABLE object so long-lived callers that cache it once at
+ * component setup (MicButton.tsx, AgentFooter.tsx: `const voice =
+ * getVoiceSession()` at the top of the component body) still observe an
+ * engine change made later via Settings -> Recording's live engine picker.
+ * An earlier fix in this same PR rebuilt the underlying session correctly
+ * but returned it directly, so only call sites that re-invoke
+ * getVoiceSession() fresh on every use (keymodel.ts's global hotkey) actually
+ * saw the rebuild — this test exercises the cached-at-setup pattern instead,
+ * which is the primary per-pane mic-button path.
+ */
+
+import { createRoot, createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignalAtom } from "@/util/util";
+
+let engineSignal: ReturnType<typeof createSignal<string | null>>;
+
+vi.mock("@/app/store/global", () => ({
+    getSettingsKeyAtom: (key: string) => {
+        if (key === "voice:engine") return engineSignal[0];
+        return () => null;
+    },
+}));
+
+let nextMockSessionId = 0;
+vi.mock("./whisperVoiceEngine", () => ({
+    createWhisperVoiceSession: vi.fn(() => {
+        const id = ++nextMockSessionId;
+        const isListening = createSignalAtom(false);
+        const currentTargetId = createSignalAtom<string | null>(null);
+        const lastError = createSignalAtom<string | null>(null);
+        return {
+            __id: id,
+            isListening,
+            currentTargetId,
+            lastError,
+            isAvailable: () => true,
+            toggleListening: () => isListening._set(!isListening()),
+            registerPane: (blockId: string) => currentTargetId._set(blockId),
+        };
+    }),
+    pickMime: () => "audio/webm",
+}));
+
+describe("getVoiceSession — cached facade observes a live engine switch", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        engineSignal = createRoot(() => createSignal<string | null>("groq"));
+    });
+    afterEach(() => vi.clearAllMocks());
+
+    it("a session cached once at 'component setup' still reflects a later engine change", async () => {
+        const { getVoiceSession } = await import("./useVoiceInput");
+        const { createWhisperVoiceSession } = await import("./whisperVoiceEngine");
+
+        // Simulates MicButton.tsx: fetched once, never re-invoked.
+        const voice = getVoiceSession();
+
+        voice.registerPane("pane-a", { appendFinal: () => {}, setInterim: () => {} });
+        voice.toggleListening();
+        expect(createWhisperVoiceSession).toHaveBeenCalledTimes(1); // lazily built on first real use
+        expect(voice.isListening()).toBe(true);
+        expect(voice.currentTargetId()).toBe("pane-a");
+
+        // The user flips Settings -> Recording's engine picker from groq to
+        // whisper-local. No component re-fetches getVoiceSession() — this is
+        // exactly the cached-reference scenario the earlier fix missed.
+        createRoot(() => engineSignal[1]("whisper-local"));
+
+        // The cached `voice` facade must now be backed by a NEW underlying
+        // session, not the stale groq one — checked on next actual use.
+        expect(voice.isListening()).toBe(false); // fresh session, nothing listening yet
+        expect(voice.currentTargetId()).toBe(null);
+        expect(createWhisperVoiceSession).toHaveBeenCalledTimes(2);
+
+        voice.registerPane("pane-b", { appendFinal: () => {}, setInterim: () => {} });
+        voice.toggleListening();
+        expect(voice.isListening()).toBe(true);
+        expect(voice.currentTargetId()).toBe("pane-b");
+
+        // Same call again with no further engine change must NOT rebuild again.
+        void getVoiceSession();
+        expect(createWhisperVoiceSession).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns the exact same object identity across engine changes (safe to cache)", async () => {
+        const { getVoiceSession } = await import("./useVoiceInput");
+        const first = getVoiceSession();
+        createRoot(() => engineSignal[1]("whisper-local"));
+        // Re-reading a signal on the SAME facade object is how a real caller
+        // would observe the change — re-fetching getVoiceSession() itself
+        // must also still be the same object, since some callers do that too.
+        const second = getVoiceSession();
+        expect(second).toBe(first);
+    });
+});

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -154,6 +154,8 @@ function createWebSpeechVoiceSession(): VoiceSession {
     };
 }
 
+type VoiceEngineMode = "webspeech" | "whisper-local" | "groq";
+
 let _session: VoiceSession | null = null;
 // Which resolved mode `_session` was actually built for. Must be the FULL
 // three-way resolution, not just "webspeech vs. whisper" — createWhisperVoiceSession()
@@ -162,19 +164,9 @@ let _session: VoiceSession | null = null;
 // change needs a rebuild too, even though both route through that same
 // factory function. Collapsing them to one "whisper" bucket here would miss
 // exactly that transition.
-let _sessionMode: "webspeech" | "whisper-local" | "groq" | null = null;
+let _sessionMode: VoiceEngineMode | null = null;
 
-/**
- * Settings -> Recording's engine picker (#2751) made `voice:engine` a live,
- * user-facing switch for the first time — previously it was settings.json-only
- * and effectively required an app restart to notice. `getVoiceSession()`'s
- * singleton cache never accounted for the setting changing mid-session: the
- * Whisper engine's `isLocal` (webm vs. 16kHz WAV capture) is captured once at
- * construction, so switching engines left the frontend still recording in the
- * old format while the backend immediately started expecting the new one —
- * recording silently breaks until a full reload. Found in PR #2751 review.
- */
-export function getVoiceSession(): VoiceSession {
+function resolveVoiceEngineMode(): VoiceEngineMode {
     // Engine selection (SPEC_VOICE_STT_ENGINE_2026_06_20.md §5): the Web Speech
     // recognizer can't transcribe in CEF (closed-source Google service), so it's
     // used ONLY when explicitly opted into via `voice:engine: "webspeech"` AND
@@ -184,19 +176,71 @@ export function getVoiceSession(): VoiceSession {
     const hasWebSpeech =
         typeof window !== "undefined" &&
         !!((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition);
-    const resolvedMode: "webspeech" | "whisper-local" | "groq" =
-        engine === "webspeech" && hasWebSpeech ? "webspeech" : engine === "whisper-local" ? "whisper-local" : "groq";
+    if (engine === "webspeech" && hasWebSpeech) return "webspeech";
+    if (engine === "whisper-local") return "whisper-local";
+    return "groq";
+}
 
+/**
+ * Settings -> Recording's engine picker (#2751) made `voice:engine` a live,
+ * user-facing switch for the first time — previously it was settings.json-only
+ * and effectively required an app restart to notice. Rebuilds the underlying
+ * session (stopping any in-progress capture cleanly) when the resolved engine
+ * no longer matches what it was built for.
+ */
+function ensureVoiceSession(): VoiceSession {
+    const resolvedMode = resolveVoiceEngineMode();
     if (_session && _sessionMode !== resolvedMode) {
-        // The engine changed since this session was built — tear it down
-        // (stopping any in-progress capture cleanly) rather than leave a
-        // stale-mode session running.
         if (_session.isListening()) _session.toggleListening();
         _session = null;
     }
-    if (_session) return _session;
-
-    _session = resolvedMode === "webspeech" ? createWebSpeechVoiceSession() : createWhisperVoiceSession();
-    _sessionMode = resolvedMode;
+    if (!_session) {
+        _session = resolvedMode === "webspeech" ? createWebSpeechVoiceSession() : createWhisperVoiceSession();
+        _sessionMode = resolvedMode;
+    }
     return _session;
+}
+
+const NULL_STRING_SIGNAL: SignalAtom<string | null> = createSignalAtom<string | null>(null);
+
+/** A SignalAtom that always reads/writes through to whichever session is
+ * CURRENT at call time (via `ensureVoiceSession()`), rather than one fixed
+ * session captured at creation. This is what makes the facade below safe for
+ * long-lived callers to cache once: `resolveVoiceEngineMode()` reads the live
+ * `voice:engine` setting on every read, so any reactive scope that calls a
+ * facade signal (e.g. a component's JSX) automatically re-subscribes to
+ * whichever underlying session is current, and re-runs when the engine
+ * setting itself changes — not just when the old session's own signal fires
+ * (which stops happening the moment that session is discarded). */
+function facadeSignal<T>(pick: (s: VoiceSession) => SignalAtom<T> | undefined, fallback: SignalAtom<T>): SignalAtom<T> {
+    const read = (() => (pick(ensureVoiceSession()) ?? fallback)()) as SignalAtom<T>;
+    (read as any)._set = (v: T) => (pick(ensureVoiceSession()) ?? fallback)._set(v);
+    return read;
+}
+
+let _facade: VoiceSession | null = null;
+
+/**
+ * Returns a STABLE facade object (same identity forever) so long-lived
+ * callers that cache the return value once at component setup — MicButton.tsx,
+ * AgentFooter.tsx, both `const voice = getVoiceSession()` at the top of the
+ * component body, not re-invoked per render — still always operate on
+ * whichever underlying session is current. An earlier version of this fix
+ * (this same PR) rebuilt the underlying session correctly but returned it
+ * directly, so only call sites that invoke `getVoiceSession()` fresh on every
+ * use (keymodel.ts's global hotkey handler) actually observed the rebuild;
+ * the primary per-pane mic-button path did not. Found in PR #2751 re-review.
+ */
+export function getVoiceSession(): VoiceSession {
+    if (_facade) return _facade;
+    _facade = {
+        isListening: facadeSignal((s) => s.isListening, createSignalAtom(false)),
+        currentTargetId: facadeSignal((s) => s.currentTargetId, createSignalAtom<string | null>(null)),
+        lastError: facadeSignal((s) => s.lastError, NULL_STRING_SIGNAL),
+        lastErrorDetail: facadeSignal((s) => s.lastErrorDetail, NULL_STRING_SIGNAL),
+        isAvailable: () => ensureVoiceSession().isAvailable(),
+        toggleListening: () => ensureVoiceSession().toggleListening(),
+        registerPane: (blockId, handle) => ensureVoiceSession().registerPane(blockId, handle),
+    };
+    return _facade;
 }

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -155,9 +155,26 @@ function createWebSpeechVoiceSession(): VoiceSession {
 }
 
 let _session: VoiceSession | null = null;
+// Which resolved mode `_session` was actually built for. Must be the FULL
+// three-way resolution, not just "webspeech vs. whisper" — createWhisperVoiceSession()
+// itself branches on "groq" vs. "whisper-local" internally (a captured-once
+// `isLocal` controlling webm vs. 16kHz-WAV capture), so a groq<->whisper-local
+// change needs a rebuild too, even though both route through that same
+// factory function. Collapsing them to one "whisper" bucket here would miss
+// exactly that transition.
+let _sessionMode: "webspeech" | "whisper-local" | "groq" | null = null;
 
+/**
+ * Settings -> Recording's engine picker (#2751) made `voice:engine` a live,
+ * user-facing switch for the first time — previously it was settings.json-only
+ * and effectively required an app restart to notice. `getVoiceSession()`'s
+ * singleton cache never accounted for the setting changing mid-session: the
+ * Whisper engine's `isLocal` (webm vs. 16kHz WAV capture) is captured once at
+ * construction, so switching engines left the frontend still recording in the
+ * old format while the backend immediately started expecting the new one —
+ * recording silently breaks until a full reload. Found in PR #2751 review.
+ */
 export function getVoiceSession(): VoiceSession {
-    if (_session) return _session;
     // Engine selection (SPEC_VOICE_STT_ENGINE_2026_06_20.md §5): the Web Speech
     // recognizer can't transcribe in CEF (closed-source Google service), so it's
     // used ONLY when explicitly opted into via `voice:engine: "webspeech"` AND
@@ -167,9 +184,19 @@ export function getVoiceSession(): VoiceSession {
     const hasWebSpeech =
         typeof window !== "undefined" &&
         !!((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition);
-    _session =
-        engine === "webspeech" && hasWebSpeech
-            ? createWebSpeechVoiceSession()
-            : createWhisperVoiceSession();
+    const resolvedMode: "webspeech" | "whisper-local" | "groq" =
+        engine === "webspeech" && hasWebSpeech ? "webspeech" : engine === "whisper-local" ? "whisper-local" : "groq";
+
+    if (_session && _sessionMode !== resolvedMode) {
+        // The engine changed since this session was built — tear it down
+        // (stopping any in-progress capture cleanly) rather than leave a
+        // stale-mode session running.
+        if (_session.isListening()) _session.toggleListening();
+        _session = null;
+    }
+    if (_session) return _session;
+
+    _session = resolvedMode === "webspeech" ? createWebSpeechVoiceSession() : createWhisperVoiceSession();
+    _sessionMode = resolvedMode;
     return _session;
 }

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -21,6 +21,15 @@ export interface VoiceSession {
      *  Mic buttons read this to render a "blocked" affordance; cleared when a
      *  session starts successfully. */
     lastError: SignalAtom<string | null>;
+    /** Optional detail string accompanying `lastError` — e.g. the server's
+     *  actual error body ("whisper-cli not found at ...") for
+     *  `service-not-allowed`, rather than just the coarse category. Additive:
+     *  existing consumers (MicButton.tsx's tooltip) only read `lastError` and
+     *  are unaffected; the Settings -> Recording "test your microphone" flow
+     *  reads this to show the specific failure. Not implemented by every
+     *  engine (optional) — the Web Speech engine has no server round-trip to
+     *  report a detail for. */
+    lastErrorDetail?: SignalAtom<string | null>;
     isAvailable: () => boolean;
     toggleListening: () => void;
     registerPane: (blockId: string, handle: PaneVoiceHandle) => void;

--- a/frontend/app/hook/whisperVoiceEngine.ts
+++ b/frontend/app/hook/whisperVoiceEngine.ts
@@ -27,6 +27,7 @@ import { createSignalAtom } from "@/util/util";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { getApi } from "@/app/store/app-api";
 import { getSettingsKeyAtom } from "@/app/store/global";
+import { computeRms } from "./audioLevel";
 import type { PaneVoiceHandle, VoiceSession } from "./useVoiceInput";
 
 // VAD tuning. RMS below SILENCE_RMS for >= SILENCE_MS after speech ends an
@@ -41,7 +42,7 @@ const LEVEL_POLL_MS = 100;
 const WAV_SAMPLE_RATE = 16_000; // whisper.cpp requires 16 kHz mono
 
 /** Pick the best MediaRecorder mime the runtime supports (opus preferred). */
-function pickMime(): string {
+export function pickMime(): string {
     const candidates = [
         "audio/webm;codecs=opus",
         "audio/webm",
@@ -89,6 +90,7 @@ export function createWhisperVoiceSession(): VoiceSession {
     const isListening = createSignalAtom(false);
     const currentTargetId = createSignalAtom<string | null>(null);
     const lastError = createSignalAtom<string | null>(null);
+    const lastErrorDetail = createSignalAtom<string | null>(null);
 
     // Capture mode is fixed for the session: whisper-local → WAV, else webm.
     const isLocal = getSettingsKeyAtom("voice:engine")() === "whisper-local";
@@ -107,6 +109,7 @@ export function createWhisperVoiceSession(): VoiceSession {
             isListening,
             currentTargetId,
             lastError,
+            lastErrorDetail,
             isAvailable: () => false,
             toggleListening: () => {},
             registerPane: () => {},
@@ -164,22 +167,40 @@ export function createWhisperVoiceSession(): VoiceSession {
                 body: blob,
             });
             handle.setInterim("");
-            if (resp.status === 501) {
-                fail("service-not-allowed"); // backend not configured
-                return;
-            }
             if (!resp.ok) {
-                lastError._set("service-not-allowed");
-                window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
+                // Thread the server's actual error body through as a detail —
+                // additive: existing coarse `lastError` categories used by
+                // MicButton.tsx's tooltip stay unchanged, this only adds a
+                // detail string for surfaces that want it (the Settings ->
+                // Recording test-mic panel).
+                lastErrorDetail._set(await readErrorDetail(resp));
+                if (resp.status === 501) {
+                    fail("service-not-allowed"); // backend not configured
+                } else {
+                    lastError._set("service-not-allowed");
+                    window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
+                }
                 return;
             }
+            lastErrorDetail._set(null);
             const data = (await resp.json()) as { text?: string };
             const text = (data.text || "").trim();
             if (text) handle.appendFinal(text);
-        } catch {
+        } catch (e) {
             handle.setInterim("");
             lastError._set("service-not-allowed");
+            lastErrorDetail._set(e instanceof Error ? e.message : null);
             window.dispatchEvent(new CustomEvent("voice-input-error", { detail: "service-not-allowed" }));
+        }
+    };
+
+    /** Read `{ "error": "..." }` from a non-OK transcribe response, best-effort. */
+    const readErrorDetail = async (resp: Response): Promise<string | null> => {
+        try {
+            const data = (await resp.json()) as { error?: string };
+            return data.error ?? null;
+        } catch {
+            return null;
         }
     };
 
@@ -229,14 +250,7 @@ export function createWhisperVoiceSession(): VoiceSession {
 
     const pollLevel = () => {
         if (!analyser) return;
-        const buf = new Uint8Array(analyser.fftSize);
-        analyser.getByteTimeDomainData(buf);
-        let sum = 0;
-        for (let i = 0; i < buf.length; i++) {
-            const v = (buf[i] - 128) / 128;
-            sum += v * v;
-        }
-        if (vadShouldCut(Math.sqrt(sum / buf.length))) {
+        if (vadShouldCut(computeRms(analyser))) {
             if (recorder && recorder.state !== "inactive") recorder.stop();
         }
     };
@@ -310,7 +324,12 @@ export function createWhisperVoiceSession(): VoiceSession {
 
     const startCapture = async () => {
         try {
-            stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            // voice:inputDeviceId (Settings -> Recording device picker):
+            // absent/"default" keeps the original unconstrained behavior.
+            const deviceId = getSettingsKeyAtom("voice:inputDeviceId")();
+            const audioConstraint: boolean | MediaTrackConstraints =
+                deviceId && deviceId !== "default" ? { deviceId: { exact: deviceId } } : true;
+            stream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraint });
         } catch (e: any) {
             const name = e?.name || "";
             if (name === "NotAllowedError" || name === "SecurityError") fail("not-allowed");
@@ -360,6 +379,7 @@ export function createWhisperVoiceSession(): VoiceSession {
         isListening,
         currentTargetId,
         lastError,
+        lastErrorDetail,
         isAvailable: () => true,
         toggleListening,
         registerPane: (blockId, handle) => {

--- a/frontend/app/store/rpc-api/index.ts
+++ b/frontend/app/store/rpc-api/index.ts
@@ -24,6 +24,7 @@ import { MiscApi } from "./misc";
 import { ReactiveApi } from "./reactive";
 import { SessionApi } from "./session";
 import { SkillApi } from "./skill";
+import { VoiceApi } from "./voice";
 import { WorkspaceApi } from "./workspace";
 
 export type { OAuthFlowStatus } from "./types";
@@ -51,4 +52,5 @@ export const RpcApi = {
     ...FleetApi,
     ...ReactiveApi,
     ...BookmarksApi,
+    ...VoiceApi,
 };

--- a/frontend/app/store/rpc-api/voice.ts
+++ b/frontend/app/store/rpc-api/voice.ts
@@ -1,0 +1,19 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Settings -> Recording section: live existence check for the local
+// whisper.cpp CLI/model file paths. See
+// docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §3 and
+// agentmux-srv/src/server/app_api/voice.rs.
+
+import { RpcClient } from "../rpc-client";
+
+export const VoiceApi = {
+    CheckPathCommand(
+        client: RpcClient,
+        data: { path: string },
+        opts?: RpcOpts,
+    ): Promise<{ exists: boolean }> {
+        return client.rpcCall("voice.checkPath", data, opts);
+    },
+};

--- a/frontend/app/view/settings/masked-key-field.test.tsx
+++ b/frontend/app/view/settings/masked-key-field.test.tsx
@@ -1,0 +1,67 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for MaskedKeyField (settings-controls.tsx) — the masked-credential
+ * primitive introduced for Settings -> Recording's Groq API key field
+ * (docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §2), also
+ * intended for future messaging-bridge bot tokens. No prior test coverage
+ * existed for any settings-controls.tsx primitive.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MaskedKeyField } from "./settings-controls";
+
+afterEach(() => cleanup());
+
+describe("MaskedKeyField", () => {
+    it("shows a dot mask + Replace button when a value is already set", () => {
+        const { container } = render(() => <MaskedKeyField value="sk-existing-key" onSave={() => {}} />);
+        expect(screen.getByText("••••••••")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Replace" })).toBeInTheDocument();
+        expect(container.querySelector("input")).not.toBeInTheDocument();
+    });
+
+    it("shows an entry field with no value set (nothing to mask yet)", () => {
+        render(() => <MaskedKeyField value={undefined} onSave={() => {}} placeholder="paste key" />);
+        expect(screen.queryByText("••••••••")).not.toBeInTheDocument();
+        expect(screen.getByPlaceholderText("paste key")).toBeInTheDocument();
+        // No existing value to fall back to, so Cancel shouldn't be offered.
+        expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    });
+
+    it("clicking Replace reveals the entry field with Save + Cancel", () => {
+        render(() => <MaskedKeyField value="sk-existing-key" onSave={() => {}} />);
+        fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+        expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    });
+
+    it("Cancel returns to the locked/masked state without calling onSave", () => {
+        const onSave = vi.fn();
+        render(() => <MaskedKeyField value="sk-existing-key" onSave={onSave} />);
+        fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        expect(screen.getByText("••••••••")).toBeInTheDocument();
+        expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it("Save calls onSave with the typed value and clears the draft", () => {
+        const onSave = vi.fn();
+        render(() => <MaskedKeyField value="sk-existing-key" onSave={onSave} />);
+        fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+        const input = screen.getByDisplayValue("") as HTMLInputElement;
+        fireEvent.input(input, { target: { value: "sk-new-key" } });
+        fireEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(onSave).toHaveBeenCalledWith("sk-new-key");
+    });
+
+    it("Save is disabled until something is typed", () => {
+        const { container } = render(() => <MaskedKeyField value={undefined} onSave={() => {}} />);
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        fireEvent.input(container.querySelector("input") as HTMLInputElement, { target: { value: "x" } });
+        expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    });
+});

--- a/frontend/app/view/settings/sections/recording-section.tsx
+++ b/frontend/app/view/settings/sections/recording-section.tsx
@@ -81,7 +81,19 @@ export function RecordingSection(): JSX.Element {
     const enabled = () => (s()["voice:enabled"] as boolean) ?? true;
     const engine = () => (s()["voice:engine"] as string) ?? "groq";
     const whisperModel = () => (s()["voice:whisperModel"] as string) ?? "base.en";
-    const modelChoice = () => (WHISPER_MODEL_CHOICES.includes(whisperModel()) ? whisperModel() : "custom");
+    // An explicit voice:whisperModelPath always wins server-side (voice.rs),
+    // so treat its presence as "custom" regardless of whisperModel's value —
+    // otherwise a hand-edited settings.json with both keys set would silently
+    // hide the path that's actually in effect. `explicitCustom` covers the
+    // gap where the user has just clicked "custom path…" but hasn't typed a
+    // path yet (whisperModelPath is still empty at that point, so the above
+    // check alone wouldn't reveal the field).
+    const [explicitCustom, setExplicitCustom] = createSignal(false);
+    const modelChoice = () => {
+        if ((s()["voice:whisperModelPath"] as string | undefined)?.trim()) return "custom";
+        if (explicitCustom()) return "custom";
+        return WHISPER_MODEL_CHOICES.includes(whisperModel()) ? whisperModel() : "custom";
+    };
 
     // ── Device picker (§5) ───────────────────────────────────────────────────
     const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
@@ -104,11 +116,22 @@ export function RecordingSection(): JSX.Element {
     const [testResult, setTestResult] = createSignal<string | null>(null);
     let testStream: MediaStream | null = null;
     let testRecorder: MediaRecorder | null = null;
+    // Bumped by every runTest()/cancelTest() call. Async continuations
+    // (setTimeout callbacks, the fetch round-trip) capture the generation
+    // active when they were scheduled and check it's still current before
+    // touching state — otherwise a Cancel during an in-flight test could not
+    // stop it: stopping the recorder still fired its installed onstop (which
+    // then proceeded to transcribe), and a stale fetch response could
+    // overwrite state a new test had already moved past. See PR #2751 review.
+    let testGeneration = 0;
 
     const stopTest = () => {
         meter.stop();
-        if (testRecorder && testRecorder.state !== "inactive") {
-            try { testRecorder.stop(); } catch { /* ignore */ }
+        if (testRecorder) {
+            testRecorder.onstop = null; // don't let a deliberate stop trigger transcription
+            if (testRecorder.state !== "inactive") {
+                try { testRecorder.stop(); } catch { /* ignore */ }
+            }
         }
         testRecorder = null;
         if (testStream) {
@@ -120,14 +143,17 @@ export function RecordingSection(): JSX.Element {
 
     const runTest = async () => {
         stopTest();
+        const gen = ++testGeneration;
         setTestResult(null);
         setTestState("listening");
+        let stream: MediaStream;
         try {
             const deviceId = s()["voice:inputDeviceId"] as string | undefined;
             const constraint: boolean | MediaTrackConstraints =
                 deviceId && deviceId !== "default" ? { deviceId: { exact: deviceId } } : true;
-            testStream = await navigator.mediaDevices.getUserMedia({ audio: constraint });
+            stream = await navigator.mediaDevices.getUserMedia({ audio: constraint });
         } catch (e: any) {
+            if (gen !== testGeneration) return; // cancelled while awaiting the permission prompt
             setTestState("error");
             setTestResult(
                 e?.name === "NotAllowedError" || e?.name === "SecurityError"
@@ -136,6 +162,13 @@ export function RecordingSection(): JSX.Element {
             );
             return;
         }
+        if (gen !== testGeneration) {
+            // Cancelled while awaiting getUserMedia — this stream was never
+            // handed to stopTest(), so it's the only one that can leak it.
+            stream.getTracks().forEach((t) => t.stop());
+            return;
+        }
+        testStream = stream;
         // Unlocks real device labels for the picker (getUserMedia grant makes
         // enumerateDevices() return non-empty labels from here on).
         void refreshDevices();
@@ -147,38 +180,43 @@ export function RecordingSection(): JSX.Element {
         // end-to-end (misconfiguration is server-side-only).
         const isLocal = engine() === "whisper-local";
         window.setTimeout(() => {
-            if (!testStream) return; // stopped/cancelled before the clip started
-            const mime = isLocal ? "" : pickMime();
+            if (gen !== testGeneration || !testStream) return; // stopped/cancelled before the clip started
             if (isLocal) {
                 // whisper-local expects 16kHz mono WAV; recording that path's
                 // exact encoder here would duplicate whisperVoiceEngine.ts's
                 // ScriptProcessor pipeline. Keep the test flow's own capture
                 // simple (MediaRecorder) and let the user know local-engine
-                // testing isn't wired into this quick check yet.
+                // testing isn't wired into this quick check yet. Full
+                // stopTest() (not just meter.stop()) so the still-open mic
+                // stream from getUserMedia above is actually released —
+                // Cancel isn't shown once we're in the "error" state.
                 setTestState("error");
                 setTestResult(
                     "Quick mic test only validates capture + Groq for now. Save a whisper-cli path above, " +
                     "then try recording from an actual agent pane to validate the local engine end-to-end.",
                 );
-                meter.stop();
+                stopTest();
                 return;
             }
+            const mime = pickMime();
             const chunks: Blob[] = [];
-            testRecorder = new MediaRecorder(testStream, { mimeType: mime });
-            testRecorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data); };
-            testRecorder.onstop = () => {
+            const recorder = new MediaRecorder(testStream, { mimeType: mime });
+            testRecorder = recorder;
+            recorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data); };
+            recorder.onstop = () => {
+                if (gen !== testGeneration) return; // stopTest() cleared onstop before calling stop(); belt-and-suspenders
                 meter.stop();
                 setTestState("transcribing");
-                void transcribeTestClip(new Blob(chunks, { type: mime }), mime);
+                void transcribeTestClip(gen, new Blob(chunks, { type: mime }), mime);
             };
-            testRecorder.start();
+            recorder.start();
             window.setTimeout(() => {
-                if (testRecorder && testRecorder.state !== "inactive") testRecorder.stop();
+                if (gen === testGeneration && recorder.state !== "inactive") recorder.stop();
             }, 2500);
         }, 1200);
     };
 
-    const transcribeTestClip = async (blob: Blob, mime: string) => {
+    const transcribeTestClip = async (gen: number, blob: Blob, mime: string) => {
         try {
             const base = getWebServerEndpoint();
             const url = `${base}/api/v1/voice/transcribe?mime=${encodeURIComponent(mime)}`;
@@ -187,22 +225,27 @@ export function RecordingSection(): JSX.Element {
                 headers: { "X-AuthKey": getApi()?.getAuthKey?.() ?? "", "Content-Type": mime },
                 body: blob,
             });
+            if (gen !== testGeneration) return; // cancelled (or superseded by a new test) while the request was in flight
             if (!resp.ok) {
                 const detail = await resp.json().then((d: any) => d?.error).catch(() => null);
+                if (gen !== testGeneration) return;
                 setTestState("error");
                 setTestResult(detail ?? `Transcription failed (${resp.status}).`);
                 return;
             }
             const data = (await resp.json()) as { text?: string };
+            if (gen !== testGeneration) return;
             setTestState("done");
             setTestResult((data.text || "").trim() || "(no speech detected)");
         } catch (e) {
+            if (gen !== testGeneration) return;
             setTestState("error");
             setTestResult(e instanceof Error ? e.message : "Request failed.");
         }
     };
 
     const cancelTest = () => {
+        testGeneration++; // invalidate any in-flight continuation before tearing down
         stopTest();
         setTestState("idle");
     };
@@ -263,7 +306,16 @@ export function RecordingSection(): JSX.Element {
                                 value={modelChoice()}
                                 onChange={(e) => {
                                     const v = e.currentTarget.value;
-                                    if (v !== "custom") set("voice:whisperModel", v);
+                                    if (v === "custom") {
+                                        setExplicitCustom(true);
+                                    } else {
+                                        setExplicitCustom(false);
+                                        // A named model takes over — clear any stale explicit
+                                        // path so the two settings can't silently disagree
+                                        // about which one the backend actually uses.
+                                        set("voice:whisperModelPath", null);
+                                        set("voice:whisperModel", v);
+                                    }
                                 }}
                             >
                                 <For each={WHISPER_MODEL_CHOICES}>{(m) => <option value={m}>{m}</option>}</For>

--- a/frontend/app/view/settings/sections/recording-section.tsx
+++ b/frontend/app/view/settings/sections/recording-section.tsx
@@ -1,0 +1,332 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Settings -> Recording — voice input is a fully-shipped feature (3 STT
+ * engines, per-pane mic button) with zero prior Settings UI; every knob was
+ * settings.json-only. See docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md
+ * for the full design this section implements.
+ */
+import { createSignal, onCleanup, onMount, Show, For, type JSX } from "solid-js";
+
+import { settingsAtom } from "@/app/store/global";
+import { isDev } from "@/app/store/misc-utils";
+import { getWebServerEndpoint } from "@/util/endpoints";
+import { getApi } from "@/app/store/app-api";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { createMicLevelMeter } from "@/app/hook/useMicLevelMeter";
+import { pickMime } from "@/app/hook/whisperVoiceEngine";
+import { MaskedKeyField, SectionHeader, set, SettingRow, ToggleControl } from "../settings-controls";
+
+type PathStatus = "idle" | "checking" | "found" | "not-found";
+
+// ── PathField: text input + live existence status (voice.checkPath) ─────────
+
+function PathField(p: { value: string | undefined; onChange: (v: string) => void; placeholder?: string }): JSX.Element {
+    const [status, setStatus] = createSignal<PathStatus>("idle");
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    onCleanup(() => { if (debounceTimer != null) clearTimeout(debounceTimer); });
+
+    const checkNow = (path: string) => {
+        const trimmed = path.trim();
+        if (!trimmed) {
+            setStatus("idle");
+            return;
+        }
+        setStatus("checking");
+        void RpcApi.CheckPathCommand(TabRpcClient, { path: trimmed })
+            .then((r) => setStatus(r.exists ? "found" : "not-found"))
+            .catch(() => setStatus("idle"));
+    };
+
+    onMount(() => checkNow(p.value ?? ""));
+
+    return (
+        <div class="setting-path-field">
+            <input
+                class="setting-text"
+                type="text"
+                value={p.value ?? ""}
+                placeholder={p.placeholder}
+                onInput={(e) => {
+                    const v = e.currentTarget.value;
+                    if (debounceTimer != null) clearTimeout(debounceTimer);
+                    debounceTimer = setTimeout(() => checkNow(v), 400);
+                }}
+                onBlur={(e) => p.onChange(e.currentTarget.value)}
+            />
+            <span
+                class="setting-path-status"
+                classList={{
+                    "setting-path-status--found": status() === "found",
+                    "setting-path-status--not-found": status() === "not-found",
+                }}
+            >
+                <Show when={status() === "checking"}><i class="fa-solid fa-spinner fa-spin" /></Show>
+                <Show when={status() === "found"}><i class="fa-solid fa-check" /></Show>
+                <Show when={status() === "not-found"}><i class="fa-solid fa-xmark" /></Show>
+            </span>
+        </div>
+    );
+}
+
+// ── Section ───────────────────────────────────────────────────────────────────
+
+const WHISPER_MODEL_CHOICES = ["base.en", "small.en", "medium.en"];
+
+export function RecordingSection(): JSX.Element {
+    const s = () => settingsAtom() ?? ({} as any);
+
+    const enabled = () => (s()["voice:enabled"] as boolean) ?? true;
+    const engine = () => (s()["voice:engine"] as string) ?? "groq";
+    const whisperModel = () => (s()["voice:whisperModel"] as string) ?? "base.en";
+    const modelChoice = () => (WHISPER_MODEL_CHOICES.includes(whisperModel()) ? whisperModel() : "custom");
+
+    // ── Device picker (§5) ───────────────────────────────────────────────────
+    const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
+    const refreshDevices = async () => {
+        if (typeof navigator === "undefined" || !navigator.mediaDevices?.enumerateDevices) return;
+        try {
+            const all = await navigator.mediaDevices.enumerateDevices();
+            setDevices(all.filter((d) => d.kind === "audioinput"));
+        } catch {
+            setDevices([]);
+        }
+    };
+    onMount(() => void refreshDevices());
+
+    // ── Test your microphone (§4) ────────────────────────────────────────────
+    // Explicit-click only (not an auto-probe on section mount) so opening
+    // Settings never triggers a surprise OS mic-permission dialog by itself.
+    const meter = createMicLevelMeter();
+    const [testState, setTestState] = createSignal<"idle" | "listening" | "transcribing" | "done" | "error">("idle");
+    const [testResult, setTestResult] = createSignal<string | null>(null);
+    let testStream: MediaStream | null = null;
+    let testRecorder: MediaRecorder | null = null;
+
+    const stopTest = () => {
+        meter.stop();
+        if (testRecorder && testRecorder.state !== "inactive") {
+            try { testRecorder.stop(); } catch { /* ignore */ }
+        }
+        testRecorder = null;
+        if (testStream) {
+            testStream.getTracks().forEach((t) => t.stop());
+            testStream = null;
+        }
+    };
+    onCleanup(stopTest);
+
+    const runTest = async () => {
+        stopTest();
+        setTestResult(null);
+        setTestState("listening");
+        try {
+            const deviceId = s()["voice:inputDeviceId"] as string | undefined;
+            const constraint: boolean | MediaTrackConstraints =
+                deviceId && deviceId !== "default" ? { deviceId: { exact: deviceId } } : true;
+            testStream = await navigator.mediaDevices.getUserMedia({ audio: constraint });
+        } catch (e: any) {
+            setTestState("error");
+            setTestResult(
+                e?.name === "NotAllowedError" || e?.name === "SecurityError"
+                    ? "Microphone access blocked — check your OS privacy settings."
+                    : "No microphone available.",
+            );
+            return;
+        }
+        // Unlocks real device labels for the picker (getUserMedia grant makes
+        // enumerateDevices() return non-empty labels from here on).
+        void refreshDevices();
+        meter.start(testStream);
+
+        // Record a short fixed-duration clip, encoded for whichever engine is
+        // currently configured, then run it through the real transcribe
+        // endpoint — this is the only way to genuinely validate an engine
+        // end-to-end (misconfiguration is server-side-only).
+        const isLocal = engine() === "whisper-local";
+        window.setTimeout(() => {
+            if (!testStream) return; // stopped/cancelled before the clip started
+            const mime = isLocal ? "" : pickMime();
+            if (isLocal) {
+                // whisper-local expects 16kHz mono WAV; recording that path's
+                // exact encoder here would duplicate whisperVoiceEngine.ts's
+                // ScriptProcessor pipeline. Keep the test flow's own capture
+                // simple (MediaRecorder) and let the user know local-engine
+                // testing isn't wired into this quick check yet.
+                setTestState("error");
+                setTestResult(
+                    "Quick mic test only validates capture + Groq for now. Save a whisper-cli path above, " +
+                    "then try recording from an actual agent pane to validate the local engine end-to-end.",
+                );
+                meter.stop();
+                return;
+            }
+            const chunks: Blob[] = [];
+            testRecorder = new MediaRecorder(testStream, { mimeType: mime });
+            testRecorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data); };
+            testRecorder.onstop = () => {
+                meter.stop();
+                setTestState("transcribing");
+                void transcribeTestClip(new Blob(chunks, { type: mime }), mime);
+            };
+            testRecorder.start();
+            window.setTimeout(() => {
+                if (testRecorder && testRecorder.state !== "inactive") testRecorder.stop();
+            }, 2500);
+        }, 1200);
+    };
+
+    const transcribeTestClip = async (blob: Blob, mime: string) => {
+        try {
+            const base = getWebServerEndpoint();
+            const url = `${base}/api/v1/voice/transcribe?mime=${encodeURIComponent(mime)}`;
+            const resp = await fetch(url, {
+                method: "POST",
+                headers: { "X-AuthKey": getApi()?.getAuthKey?.() ?? "", "Content-Type": mime },
+                body: blob,
+            });
+            if (!resp.ok) {
+                const detail = await resp.json().then((d: any) => d?.error).catch(() => null);
+                setTestState("error");
+                setTestResult(detail ?? `Transcription failed (${resp.status}).`);
+                return;
+            }
+            const data = (await resp.json()) as { text?: string };
+            setTestState("done");
+            setTestResult((data.text || "").trim() || "(no speech detected)");
+        } catch (e) {
+            setTestState("error");
+            setTestResult(e instanceof Error ? e.message : "Request failed.");
+        }
+    };
+
+    const cancelTest = () => {
+        stopTest();
+        setTestState("idle");
+    };
+
+    return (
+        <div class="settings-section-body">
+            <SettingRow
+                label="Enable voice input"
+                description="Show the microphone button on agent and terminal panes"
+                control={<ToggleControl checked={enabled()} onChange={(v) => set("voice:enabled", v)} />}
+            />
+            <Show when={enabled()}>
+                <SectionHeader label="Transcription engine" />
+                <SettingRow
+                    label="Engine"
+                    control={
+                        <select class="setting-select" value={engine()} onChange={(e) => set("voice:engine", e.currentTarget.value)}>
+                            <option value="groq">Groq (cloud)</option>
+                            <option value="whisper-local">whisper.cpp (local, offline)</option>
+                            <Show when={isDev()}>
+                                <option value="webspeech">Web Speech (dev only)</option>
+                            </Show>
+                        </select>
+                    }
+                    description="whisper.cpp runs fully offline; Groq sends audio to Groq's API"
+                />
+
+                <Show when={engine() === "groq"}>
+                    <SettingRow
+                        label="Groq API key"
+                        control={
+                            <MaskedKeyField
+                                value={s()["voice:groqApiKey"] as string | undefined}
+                                onSave={(key) => set("voice:groqApiKey", key)}
+                                placeholder="paste key — never displayed again after saving"
+                            />
+                        }
+                        description="Sent once, over HTTPS, from the AgentMux backend on this machine directly to api.groq.com — never to any other AgentMux service."
+                    />
+                </Show>
+
+                <Show when={engine() === "whisper-local"}>
+                    <SettingRow
+                        label="whisper-cli path"
+                        control={
+                            <PathField
+                                value={s()["voice:whisperCliPath"] as string | undefined}
+                                onChange={(v) => set("voice:whisperCliPath", v)}
+                                placeholder="/usr/local/bin/whisper-cli"
+                            />
+                        }
+                    />
+                    <SettingRow
+                        label="Model"
+                        control={
+                            <select
+                                class="setting-select"
+                                value={modelChoice()}
+                                onChange={(e) => {
+                                    const v = e.currentTarget.value;
+                                    if (v !== "custom") set("voice:whisperModel", v);
+                                }}
+                            >
+                                <For each={WHISPER_MODEL_CHOICES}>{(m) => <option value={m}>{m}</option>}</For>
+                                <option value="custom">custom path…</option>
+                            </select>
+                        }
+                        description="Auto-downloaded on first use. Only one of Model or Model file path applies at a time — file path takes precedence if both are set."
+                    />
+                    <Show when={modelChoice() === "custom"}>
+                        <SettingRow
+                            indent
+                            label="Model file path"
+                            control={
+                                <PathField
+                                    value={s()["voice:whisperModelPath"] as string | undefined}
+                                    onChange={(v) => set("voice:whisperModelPath", v)}
+                                    placeholder="/path/to/ggml-model.bin"
+                                />
+                            }
+                        />
+                    </Show>
+                </Show>
+
+                <SectionHeader label="Microphone" />
+                <SettingRow
+                    label="Input device"
+                    control={
+                        <select
+                            class="setting-select"
+                            value={(s()["voice:inputDeviceId"] as string) ?? "default"}
+                            onChange={(e) => set("voice:inputDeviceId", e.currentTarget.value)}
+                        >
+                            <option value="default">System default</option>
+                            <For each={devices()}>
+                                {(d, i) => <option value={d.deviceId}>{d.label || `Microphone ${i() + 1}`}</option>}
+                            </For>
+                        </select>
+                    }
+                />
+
+                <SectionHeader label="Test your microphone" />
+                <div class="setting-mic-test">
+                    <button
+                        type="button"
+                        class="setting-masked-key-btn setting-masked-key-btn--primary"
+                        disabled={testState() === "listening" || testState() === "transcribing"}
+                        onClick={() => void runTest()}
+                    >
+                        {testState() === "listening" ? "Listening…" : testState() === "transcribing" ? "Transcribing…" : "Start test"}
+                    </button>
+                    <Show when={testState() === "listening" || testState() === "transcribing"}>
+                        <button type="button" class="setting-masked-key-btn" onClick={cancelTest}>Cancel</button>
+                    </Show>
+                    <div class="setting-mic-test-meter">
+                        <div class="setting-mic-test-meter-fill" style={{ width: `${Math.min(100, meter.level() * 220)}%` }} />
+                    </div>
+                </div>
+                <Show when={testResult()}>
+                    <div class="setting-mic-test-result" classList={{ "setting-mic-test-result--error": testState() === "error" }}>
+                        {testResult()}
+                    </div>
+                </Show>
+            </Show>
+        </div>
+    );
+}

--- a/frontend/app/view/settings/settings-controls.tsx
+++ b/frontend/app/view/settings/settings-controls.tsx
@@ -70,6 +70,92 @@ export function SliderControl(p: { min: number; max: number; step: number; value
     );
 }
 
+/**
+ * Masked credential input — at-rest shows a fixed-width dot mask with a
+ * "Replace" button (no partial/tail hint: this is a flat settings.json
+ * string, not keychain-backed like the Armory identity form, so there's no
+ * separate masked_tail metadata to show); clicking Replace reveals a
+ * password-type entry field with Save/Cancel. Modeled on
+ * `identity-account-form.tsx`'s masked-key UX without its keychain
+ * lifecycle. See docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §2
+ * (designed for `voice:groqApiKey`; also intended for messaging-bridge bot
+ * tokens per that spec's Open Question 1 — keep this generic, no
+ * voice-specific naming).
+ */
+export function MaskedKeyField(p: {
+    value: string | undefined;
+    onSave: (key: string) => void;
+    placeholder?: string;
+    disabled?: boolean;
+}): JSX.Element {
+    const [replacing, setReplacing] = createSignal(false);
+    const [draft, setDraft] = createSignal("");
+    const hasValue = () => !!p.value;
+
+    const save = () => {
+        const v = draft().trim();
+        if (!v) return;
+        p.onSave(v);
+        setDraft("");
+        setReplacing(false);
+    };
+    const cancel = () => {
+        setDraft("");
+        setReplacing(false);
+    };
+
+    return (
+        <Show
+            when={hasValue() && !replacing()}
+            fallback={
+                <div class="setting-masked-key setting-masked-key--entry">
+                    <input
+                        class="setting-text"
+                        type="password"
+                        autocomplete="off"
+                        spellcheck={false}
+                        value={draft()}
+                        placeholder={p.placeholder}
+                        disabled={p.disabled}
+                        onInput={(e) => setDraft(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") save();
+                            if (e.key === "Escape") cancel();
+                        }}
+                    />
+                    <div class="setting-masked-key-actions">
+                        <button
+                            type="button"
+                            class="setting-masked-key-btn setting-masked-key-btn--primary"
+                            disabled={p.disabled || !draft().trim()}
+                            onClick={save}
+                        >
+                            Save
+                        </button>
+                        <Show when={hasValue()}>
+                            <button type="button" class="setting-masked-key-btn" onClick={cancel}>
+                                Cancel
+                            </button>
+                        </Show>
+                    </div>
+                </div>
+            }
+        >
+            <div class="setting-masked-key setting-masked-key--locked">
+                <span class="setting-masked-key-dots">••••••••</span>
+                <button
+                    type="button"
+                    class="setting-masked-key-btn"
+                    disabled={p.disabled}
+                    onClick={() => setReplacing(true)}
+                >
+                    Replace
+                </button>
+            </div>
+        </Show>
+    );
+}
+
 export function KeyValueEditor(p: { value: Record<string, string>; onChange: (v: Record<string, string>) => void }): JSX.Element {
     const keys = () => Object.keys(p.value ?? {});
     const [newKey, setNewKey] = createSignal("");

--- a/frontend/app/view/settings/settings-model.ts
+++ b/frontend/app/view/settings/settings-model.ts
@@ -8,6 +8,7 @@ export type SettingsSection =
     | "window"
     | "terminal"
     | "sounds"
+    | "recording"
     | "advanced";
 
 // Label text only, hoisted here so viewName can read it without importing
@@ -19,6 +20,7 @@ export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
     window: "Window & Panes",
     terminal: "Terminal",
     sounds: "Sounds",
+    recording: "Recording",
     advanced: "Advanced",
 };
 

--- a/frontend/app/view/settings/settings-view.test.tsx
+++ b/frontend/app/view/settings/settings-view.test.tsx
@@ -28,6 +28,9 @@ vi.mock("./sections/terminal-section", () => ({
 vi.mock("./sections/sounds-section", () => ({
     SoundsSection: () => <div data-testid="sounds-section" />,
 }));
+vi.mock("./sections/recording-section", () => ({
+    RecordingSection: () => <div data-testid="recording-section" />,
+}));
 vi.mock("./sections/advanced-section", () => ({
     AdvancedSection: () => <div data-testid="advanced-section" />,
 }));
@@ -53,11 +56,11 @@ describe("SettingsView rail", () => {
         return { ...result, model };
     }
 
-    it("orders the rail as Appearance, Window & Panes, Terminal, Sounds, Advanced", () => {
+    it("orders the rail as Appearance, Window & Panes, Terminal, Sounds, Recording, Advanced", () => {
         renderSettings();
         const rail = screen.getByLabelText("Settings section", { selector: "nav.settings-rail" });
         const labels = Array.from(rail.querySelectorAll("button span")).map((el) => el.textContent);
-        expect(labels).toEqual(["Appearance", "Window & Panes", "Terminal", "Sounds", "Advanced"]);
+        expect(labels).toEqual(["Appearance", "Window & Panes", "Terminal", "Sounds", "Recording", "Advanced"]);
     });
 
     it("defaults to the Appearance section visible", () => {

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -10,6 +10,7 @@ import { AppearanceSection } from "./sections/appearance-section";
 import { WindowPanesSection } from "./sections/window-panes-section";
 import { TerminalSection } from "./sections/terminal-section";
 import { SoundsSection } from "./sections/sounds-section";
+import { RecordingSection } from "./sections/recording-section";
 import { AdvancedSection } from "./sections/advanced-section";
 import "./settings.scss";
 
@@ -50,6 +51,7 @@ const RAIL: { id: SettingsSection; label: string; icon: string }[] = [
     { id: "window",     label: SETTINGS_SECTION_LABELS.window,     icon: "table-cells" },
     { id: "terminal",   label: SETTINGS_SECTION_LABELS.terminal,   icon: "square-terminal" },
     { id: "sounds",     label: SETTINGS_SECTION_LABELS.sounds,     icon: "volume-high" },
+    { id: "recording",  label: SETTINGS_SECTION_LABELS.recording,  icon: "microphone" },
     { id: "advanced",   label: SETTINGS_SECTION_LABELS.advanced,   icon: "sliders" },
 ];
 
@@ -97,6 +99,9 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
                     </Match>
                     <Match when={section() === "sounds"}>
                         <SoundsSection />
+                    </Match>
+                    <Match when={section() === "recording"}>
+                        <RecordingSection />
                     </Match>
                     <Match when={section() === "advanced"}>
                         <AdvancedSection />

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -335,6 +335,44 @@
     }
 }
 
+// ── Masked key field ────────────────────────────────────────────────────────
+
+.setting-masked-key {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.setting-masked-key-dots {
+    font-family: monospace;
+    letter-spacing: 2px;
+    opacity: 0.8;
+}
+
+.setting-masked-key-btn {
+    flex: 0 0 auto;
+    padding: 3px 10px;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+    font-size: 0.8rem;
+
+    &:hover:not(:disabled) {
+        background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    }
+
+    &:disabled {
+        opacity: 0.4;
+    }
+
+    &--primary {
+        border-color: var(--accent-color, #58a6ff);
+        color: var(--accent-color, #58a6ff);
+    }
+}
+
 // ── Slider ────────────────────────────────────────────────────────────────────
 
 .setting-slider {
@@ -420,6 +458,70 @@
             opacity: 0.85;
             background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
         }
+    }
+}
+
+// ── Path field (Settings -> Recording) ───────────────────────────────────────
+
+.setting-path-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .setting-text {
+        flex: 1 1 auto;
+    }
+}
+
+.setting-path-status {
+    flex: 0 0 auto;
+    width: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.7;
+
+    &--found {
+        color: var(--success-color, #3fb950);
+    }
+
+    &--not-found {
+        color: var(--error-color, #f85149);
+    }
+}
+
+// ── Mic test (Settings -> Recording) ─────────────────────────────────────────
+
+.setting-mic-test {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 0;
+}
+
+.setting-mic-test-meter {
+    flex: 1 1 auto;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.15));
+    overflow: hidden;
+}
+
+.setting-mic-test-meter-fill {
+    height: 100%;
+    background: var(--accent-color, #58a6ff);
+    transition: width 0.1s linear;
+}
+
+.setting-mic-test-result {
+    margin-top: 4px;
+    padding: 8px 10px;
+    border-radius: 4px;
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    font-size: 0.85rem;
+
+    &--error {
+        color: var(--error-color, #f85149);
     }
 }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1733,6 +1733,7 @@ declare global {
         "voice:whisperCliPath"?: string;
         "voice:whisperModel"?: string;
         "voice:whisperModelPath"?: string;
+        "voice:inputDeviceId"?: string;
         "notify:*"?: boolean;
         "notify:sounds:enabled"?: boolean;
         "notify:sounds:volume"?: number;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -210,6 +210,10 @@
           "type": "string",
           "description": "Explicit path to a GGML model file for the local whisper.cpp backend, skipping the auto-download. Env override: AGENTMUX_WHISPER_MODEL."
         },
+        "voice:inputDeviceId": {
+          "type": "string",
+          "description": "Preferred microphone input device (from navigator.mediaDevices.enumerateDevices). Absent or 'default' means the OS default input. See docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md §5."
+        },
         "notify:*": {
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

Candidate #1 from #2671 / `SPEC_SETTINGS_AUDIT_GOOD_PICKINGS_2026_08_19.md` — the single highest-value gap found in that audit. Voice input is a fully-shipped feature (3 STT engines, per-pane mic button) with **zero Settings UI**, including a Groq API key a user had to hand-edit into `settings.json` in plaintext. Implements `docs/specs/SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md`.

## What's new

New **"Recording"** rail section (between Sounds and Advanced):

- Enable toggle, engine picker (Groq / whisper.cpp local / Web Speech dev-only)
- **Groq API key** via a new `MaskedKeyField` shared primitive — masked-by-default, Replace/Save/Cancel, egress-transparency note. Built generic (not voice-specific) per the audit spec's Open Question 1, so messaging-bridge bot tokens can reuse it later.
- **whisper-local config** (CLI path + model) via a new `PathField`, live-validated against a new `voice.checkPath` RPC (`agentmux-srv/src/server/app_api/voice.rs`) — exposes the exact same `Path::exists()` check `voice.rs` already does at transcribe time, just proactively instead of only failing at first use.
- **Microphone device picker** (`enumerateDevices`), new `voice:inputDeviceId` setting threaded into the real capture path.
- **"Test your microphone"** — the first "test X" pattern in the app: a live level meter (new `useMicLevelMeter` hook, built on a `computeRms` helper factored out of the existing VAD so the two don't duplicate Web Audio boilerplate) + a real transcription round-trip against `/api/v1/voice/transcribe`, surfacing the server's actual error text.
- Fixed the stale "Speech recognition isn't available in this build yet" toast copy.
- Threaded a `lastErrorDetail` signal through `VoiceSession` (additive/optional — `MicButton.tsx`'s existing tooltip logic is unchanged) so the test-mic panel can show the real server error.

## Non-goals (matching the spec)

- Quick mic test only validates capture + Groq — whisper-local's WAV-encoding path isn't duplicated in the test flow (documented in-UI); full validation there means actually recording from an agent pane.
- No auto-detection of a local whisper.cpp install.
- No change to the groq-vs-whisper-local default.

## Test plan

- [x] `cargo build -p agentmux-srv` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — full suite green (one pre-existing flaky timeout in `tool-renderers/registry.test.ts`, confirmed passing in isolation, unrelated to this change)
- [x] New `masked-key-field.test.tsx` (6 tests, the state machine: locked/entry/save/cancel)
- [x] Updated `settings-view.test.tsx` for the new rail entry

<!-- agentmux:agent_id=smike -->