### PR TITLE
Korp@claudius: feat(muxlog): ls gains a LIVE column via real health-checked liveness probe

### DIFF
--- a/.changesets/1787434874-feat-muxlog-ls-gains-a-live-column-via-real-tcp-liveness-pro-huv1.md
+++ b/.changesets/1787434874-feat-muxlog-ls-gains-a-live-column-via-real-tcp-liveness-pro-huv1.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxlog): ls gains a LIVE column via real TCP liveness probe of each instance's ipc-port

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -228,16 +228,24 @@ function follow(file, opt) {
 // A log's mtime says "something was written recently," not "this instance is
 // running right now" — the two look identical for a process that just died.
 // agentmux-cef already writes a real, checkable liveness signal per instance:
-// `<data-dir>/ipc-port-<hash>` (agentmux-launcher/src/second_instance.rs),
-// containing `port:token` for the host's IPC HTTP server. We don't replicate
-// the launcher's FNV-1a dir_hash to compute the exact filename — glob for
-// any `ipc-port-*` in the sibling `data` dir instead, cheaper and
-// forward-compatible if the hash scheme ever changes.
+// `<port-file-dir>/ipc-port-<hash>` (agentmux-cef/src/lib.rs), containing
+// `port:token` for the host's IPC HTTP server. We don't replicate the exact
+// hash to compute the filename — glob for any `ipc-port*` file instead,
+// cheaper and forward-compatible if the hash scheme ever changes.
+//
+// Reagent P1 on PR #2752: `port_file_dir` is NOT always the `data` sibling.
+// agentmux-cef/src/lib.rs writes it to `p.cef_cache_dir` for `task dev`
+// instances (`is_dev_build_exe` branch) and to `AGENTMUX_DATA_DIR` (==
+// `DataPaths.data_dir`, the `data` sibling) for portable/installed builds.
+// `logs`/`data`/`cef-cache` are always siblings under the same version dir
+// (agentmux-common/src/data_paths.rs) regardless of build type, so check
+// both siblings rather than trying to infer dev-vs-portable from the path.
 //
 // Exported (pure logic split from the fs/net I/O) for muxlog.test.mjs.
-export function siblingDataDir(logDir) {
-    if (path.basename(logDir) !== "logs") return null;
-    return path.join(path.dirname(logDir), "data");
+export function siblingCandidateDirs(logDir) {
+    if (path.basename(logDir) !== "logs") return [];
+    const parent = path.dirname(logDir);
+    return [path.join(parent, "data"), path.join(parent, "cef-cache")];
 }
 
 // Reagent P2 on PR #2742: a raw TCP connect only proves SOMETHING is
@@ -262,16 +270,14 @@ async function probePort(port, timeoutMs = 300) {
     }
 }
 
-// "live" | "dead" | "?" — "?" means genuinely unknown (no sibling data dir,
+// "live" | "dead" | "?" — "?" means genuinely unknown (no sibling data/cef-cache dir,
 // no port file, or unreadable/malformed contents), never a liveness verdict
 // of its own. Async — the only I/O-bound piece of muxlog; every caller
 // awaits a Promise.all of these so probes for different instances run
 // concurrently instead of serially piling up 300ms timeouts.
 export async function checkLiveness(logDir) {
-    const dataDir = siblingDataDir(logDir);
-    if (!dataDir) return "?";
-    let entries;
-    try { entries = fs.readdirSync(dataDir); } catch { return "?"; }
+    const candidateDirs = siblingCandidateDirs(logDir);
+    if (candidateDirs.length === 0) return "?";
     // Reagent P1 on PR #2742: a dev-mode data dir is keyed by BRANCH, not
     // version, and a crashed (non-graceful-exit) process's port file is
     // never cleaned up (agentmux-cef/src/lib.rs writes it once at startup;
@@ -285,16 +291,18 @@ export async function checkLiveness(logDir) {
     // filename "ipc-port" (no trailing hyphen) when AGENTMUX_IPC_HASH is
     // unset (the task dev:standalone no-launcher path) — startsWith
     // "ipc-port-" alone misses that exact literal.
-    const portFiles = entries.filter((n) => n === "ipc-port" || n.startsWith("ipc-port-"));
-    if (portFiles.length === 0) return "?";
-    const ports = portFiles
-        .map((name) => {
+    const ports = [];
+    for (const dir of candidateDirs) {
+        let entries;
+        try { entries = fs.readdirSync(dir); } catch { continue; }
+        for (const name of entries) {
+            if (name !== "ipc-port" && !name.startsWith("ipc-port-")) continue;
             let contents;
-            try { contents = fs.readFileSync(path.join(dataDir, name), "utf8"); } catch { return null; }
+            try { contents = fs.readFileSync(path.join(dir, name), "utf8"); } catch { continue; }
             const port = parseInt(contents.trim().split(":")[0], 10);
-            return Number.isFinite(port) && port > 0 && port <= 65535 ? port : null;
-        })
-        .filter((p) => p !== null);
+            if (Number.isFinite(port) && port > 0 && port <= 65535) ports.push(port);
+        }
+    }
     if (ports.length === 0) return "?";
     const results = await Promise.all(ports.map((p) => probePort(p)));
     return results.some(Boolean) ? "live" : "dead";

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -281,7 +281,11 @@ export async function checkLiveness(logDir) {
     // readdirSync result (unspecified ordering) could probe the dead one
     // and report "dead" for a genuinely live instance. Probe every
     // candidate concurrently instead; "live" if ANY of them answers.
-    const portFiles = entries.filter((n) => n.startsWith("ipc-port-"));
+    // Reagent P2 on PR #2752: agentmux-cef/src/lib.rs writes the bare
+    // filename "ipc-port" (no trailing hyphen) when AGENTMUX_IPC_HASH is
+    // unset (the task dev:standalone no-launcher path) — startsWith
+    // "ipc-port-" alone misses that exact literal.
+    const portFiles = entries.filter((n) => n === "ipc-port" || n.startsWith("ipc-port-"));
     if (portFiles.length === 0) return "?";
     const ports = portFiles
         .map((name) => {

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -230,14 +230,10 @@ function follow(file, opt) {
 // running right now" — the two look identical for a process that just died.
 // agentmux-cef already writes a real, checkable liveness signal per instance:
 // `<data-dir>/ipc-port-<hash>` (agentmux-launcher/src/second_instance.rs),
-// containing `port:token` for the host's cross-window IPC listener. We don't
-// replicate the launcher's FNV-1a dir_hash to compute the exact filename —
-// glob for any `ipc-port-*` in the sibling `data` dir instead, cheaper and
-// forward-compatible if the hash scheme ever changes. A raw TCP connect (no
-// HTTP/token exchange — we're not actually forwarding an IPC call, just
-// confirming something is listening) is enough: nothing binds a dead
-// process's port, so a refused/timed-out connect means genuinely gone, not
-// just quiet.
+// containing `port:token` for the host's IPC HTTP server. We don't replicate
+// the launcher's FNV-1a dir_hash to compute the exact filename — glob for
+// any `ipc-port-*` in the sibling `data` dir instead, cheaper and
+// forward-compatible if the hash scheme ever changes.
 //
 // Exported (pure logic split from the fs/net I/O) for muxlog.test.mjs.
 export function siblingDataDir(logDir) {
@@ -245,20 +241,26 @@ export function siblingDataDir(logDir) {
     return path.join(path.dirname(logDir), "data");
 }
 
-function probePort(port, timeoutMs = 300) {
-    return new Promise((resolve) => {
-        let done = false;
-        const finish = (alive) => {
-            if (done) return;
-            done = true;
-            sock.destroy();
-            resolve(alive);
-        };
-        const sock = net.createConnection({ host: "127.0.0.1", port, timeout: timeoutMs });
-        sock.once("connect", () => finish(true));
-        sock.once("timeout", () => finish(false));
-        sock.once("error", () => finish(false));
-    });
+// Reagent P2 on PR #2742: a raw TCP connect only proves SOMETHING is
+// listening, not that it's AgentMux — if the OS reassigns a dead instance's
+// ephemeral port to an unrelated local service before this probe runs, a
+// bare connect would false-positive "live". The host's IPC server
+// (agentmux-cef/src/ipc.rs) exposes a genuine unauthenticated
+// `GET /health` on this exact port returning `{"status":"ok","version":...}`
+// — verify that shape specifically, not just a successful connection.
+async function probePort(port, timeoutMs = 300) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const resp = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
+        if (!resp.ok) return false;
+        const body = await resp.json().catch(() => null);
+        return body?.status === "ok";
+    } catch {
+        return false;
+    } finally {
+        clearTimeout(timer);
+    }
 }
 
 // "live" | "dead" | "?" — "?" means genuinely unknown (no sibling data dir,
@@ -271,13 +273,28 @@ export async function checkLiveness(logDir) {
     if (!dataDir) return "?";
     let entries;
     try { entries = fs.readdirSync(dataDir); } catch { return "?"; }
-    const portFile = entries.find((n) => n.startsWith("ipc-port-"));
-    if (!portFile) return "?";
-    let contents;
-    try { contents = fs.readFileSync(path.join(dataDir, portFile), "utf8"); } catch { return "?"; }
-    const port = parseInt(contents.trim().split(":")[0], 10);
-    if (!Number.isFinite(port) || port <= 0 || port > 65535) return "?";
-    return (await probePort(port)) ? "live" : "dead";
+    // Reagent P1 on PR #2742: a dev-mode data dir is keyed by BRANCH, not
+    // version, and a crashed (non-graceful-exit) process's port file is
+    // never cleaned up (agentmux-cef/src/lib.rs writes it once at startup;
+    // nothing removes it on a crash, only on the graceful-shutdown path).
+    // So a stale port file from a PRIOR crashed run and a live one from the
+    // CURRENT run can coexist in the same dir — taking only the first
+    // readdirSync result (unspecified ordering) could probe the dead one
+    // and report "dead" for a genuinely live instance. Probe every
+    // candidate concurrently instead; "live" if ANY of them answers.
+    const portFiles = entries.filter((n) => n.startsWith("ipc-port-"));
+    if (portFiles.length === 0) return "?";
+    const ports = portFiles
+        .map((name) => {
+            let contents;
+            try { contents = fs.readFileSync(path.join(dataDir, name), "utf8"); } catch { return null; }
+            const port = parseInt(contents.trim().split(":")[0], 10);
+            return Number.isFinite(port) && port > 0 && port <= 65535 ? port : null;
+        })
+        .filter((p) => p !== null);
+    if (ports.length === 0) return "?";
+    const results = await Promise.all(ports.map((p) => probePort(p)));
+    return results.some(Boolean) ? "live" : "dead";
 }
 
 // ─── ls ───────────────────────────────────────────────────────────────────────

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -14,7 +14,6 @@
 // One tested implementation does discovery + JSON rendering + filtering uniformly.
 
 import fs from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -14,6 +14,7 @@
 // One tested implementation does discovery + JSON rendering + filtering uniformly.
 
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
@@ -224,8 +225,63 @@ function follow(file, opt) {
     }, 400);
 }
 
+// ─── liveness ─────────────────────────────────────────────────────────────────
+// A log's mtime says "something was written recently," not "this instance is
+// running right now" — the two look identical for a process that just died.
+// agentmux-cef already writes a real, checkable liveness signal per instance:
+// `<data-dir>/ipc-port-<hash>` (agentmux-launcher/src/second_instance.rs),
+// containing `port:token` for the host's cross-window IPC listener. We don't
+// replicate the launcher's FNV-1a dir_hash to compute the exact filename —
+// glob for any `ipc-port-*` in the sibling `data` dir instead, cheaper and
+// forward-compatible if the hash scheme ever changes. A raw TCP connect (no
+// HTTP/token exchange — we're not actually forwarding an IPC call, just
+// confirming something is listening) is enough: nothing binds a dead
+// process's port, so a refused/timed-out connect means genuinely gone, not
+// just quiet.
+//
+// Exported (pure logic split from the fs/net I/O) for muxlog.test.mjs.
+export function siblingDataDir(logDir) {
+    if (path.basename(logDir) !== "logs") return null;
+    return path.join(path.dirname(logDir), "data");
+}
+
+function probePort(port, timeoutMs = 300) {
+    return new Promise((resolve) => {
+        let done = false;
+        const finish = (alive) => {
+            if (done) return;
+            done = true;
+            sock.destroy();
+            resolve(alive);
+        };
+        const sock = net.createConnection({ host: "127.0.0.1", port, timeout: timeoutMs });
+        sock.once("connect", () => finish(true));
+        sock.once("timeout", () => finish(false));
+        sock.once("error", () => finish(false));
+    });
+}
+
+// "live" | "dead" | "?" — "?" means genuinely unknown (no sibling data dir,
+// no port file, or unreadable/malformed contents), never a liveness verdict
+// of its own. Async — the only I/O-bound piece of muxlog; every caller
+// awaits a Promise.all of these so probes for different instances run
+// concurrently instead of serially piling up 300ms timeouts.
+export async function checkLiveness(logDir) {
+    const dataDir = siblingDataDir(logDir);
+    if (!dataDir) return "?";
+    let entries;
+    try { entries = fs.readdirSync(dataDir); } catch { return "?"; }
+    const portFile = entries.find((n) => n.startsWith("ipc-port-"));
+    if (!portFile) return "?";
+    let contents;
+    try { contents = fs.readFileSync(path.join(dataDir, portFile), "utf8"); } catch { return "?"; }
+    const port = parseInt(contents.trim().split(":")[0], 10);
+    if (!Number.isFinite(port) || port <= 0 || port > 65535) return "?";
+    return (await probePort(port)) ? "live" : "dead";
+}
+
 // ─── ls ───────────────────────────────────────────────────────────────────────
-function listInstances() {
+async function listInstances() {
     const seen = new Set();
     const rows = [];
     for (const e of discover("host").concat(discover("srv"), discover("launcher"))) {
@@ -234,12 +290,16 @@ function listInstances() {
     }
     rows.sort((a, b) => b.mtime - a.mtime);
     if (!rows.length) { console.log("No AgentMux logs found under ~/.agentmux."); return; }
-    console.log(`${"TARGET".padEnd(9)}${"VERSION".padEnd(9)}${"SOURCE".padEnd(22)}${"AGE".padEnd(8)}${"SIZE".padEnd(8)}PATH`);
-    for (const e of rows) {
+    const live = await Promise.all(rows.map((e) => checkLiveness(path.dirname(e.file))));
+    console.log(`${"TARGET".padEnd(9)}${"VERSION".padEnd(9)}${"SOURCE".padEnd(22)}${"LIVE".padEnd(6)}${"AGE".padEnd(8)}${"SIZE".padEnd(8)}PATH`);
+    rows.forEach((e, i) => {
         console.log(
             e.target.padEnd(9) + e.version.padEnd(9) + e.source.slice(0, 21).padEnd(22) +
-            age(e.mtime).padEnd(8) + human(e.size).padEnd(8) + e.file,
+            live[i].padEnd(6) + age(e.mtime).padEnd(8) + human(e.size).padEnd(8) + e.file,
         );
+    });
+    if (live.every((v) => v === "?")) {
+        console.log(`\nLIVE column is '?' for everything — this host has no findable ipc-port-* files (older builds predating this feature, or none of these are agentmux-cef host instances).`);
     }
 }
 function age(ms) {
@@ -714,12 +774,12 @@ Options (any position):
   --since <ts>  only lines at/after ISO <ts> (e.g. 2026-06-15T23:30)
   --raw         emit the original NDJSON   --verbose  include structured fields`;
 
-function main() {
+async function main() {
     const { opt, pos } = parse(process.argv.slice(2));
     const cmd = pos[0] || "host";
 
     if (cmd === "help" || cmd === "-h" || cmd === "--help") { console.log(HELP); return; }
-    if (cmd === "ls") { listInstances(); return; }
+    if (cmd === "ls") { await listInstances(); return; }
     if (cmd === "mem" || cmd === "doctor") { memDoctor(); return; }
 
     if (cmd === "errors") {
@@ -845,7 +905,12 @@ function main() {
 
 // Only run when executed directly (`node muxlog.mjs ...`) — importing this
 // module (muxlog.test.mjs imports `glob`) must not trigger a live tail loop /
-// `process.exit`. Same pattern as muxspect.mjs.
+// `process.exit`. Same pattern as muxspect.mjs. `main` is async now (the
+// `ls` recipe awaits liveness probes) — `.catch` surfaces a rejected
+// promise as a visible error instead of an unhandled-rejection warning.
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-    main();
+    main().catch((e) => {
+        console.error(`muxlog: ${e?.message ?? String(e)}`);
+        process.exit(1);
+    });
 }

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -6,7 +6,7 @@
 // data for the other two — no mocking needed, no network, no process.exit).
 // Runs as part of `npm test` (vitest), same discipline as muxspect.test.mjs.
 //
-// Pins two fixes from docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
+// Pins three fixes/features from docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md:
 // - §2.2/§2.3: the channels/ log-discovery glob had one wildcard segment more
 //   than any real on-disk channel-build layout actually has
 //   (`channels/*/versions/*/*/logs` vs. the real `channels/*/versions/*/logs`),
@@ -17,12 +17,17 @@
 //   `swarm` resolved to a stale same-version sibling's log on the very first
 //   live repro. `pickCandidate` now prefers a candidate matching the
 //   caller's own $AGENTMUX_CHANNEL when no explicit `-i` is given.
+// - Ext 3: `muxlog ls` inferred liveness from log mtime alone (a dead
+//   process's log looks identical to a live-but-idle one). checkLiveness()
+//   TCP-probes the real `ipc-port-*` file agentmux-cef already writes per
+//   instance.
 
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { filterByInstance, glob, matchesOwnChannel, pickCandidate, printLastLines, renderLine } from "./muxlog.mjs";
+import { checkLiveness, filterByInstance, glob, matchesOwnChannel, pickCandidate, printLastLines, renderLine, siblingDataDir } from "./muxlog.mjs";
 
 let root;
 
@@ -286,5 +291,82 @@ describe("muxlog printLastLines return value (Ext 6's verdict count)", () => {
     it("returns 0 for a file with no matching lines", () => {
         fs.writeFileSync(file, JSON.stringify({ timestamp: "2026-08-22T00:00:00Z", level: "INFO", fields: { message: "no match here" }, target: "x" }) + "\n");
         expect(printLastLines(file, 200, { dispatch: "dispatch-nonexistent" }, true)).toBe(0);
+    });
+});
+
+describe("muxlog siblingDataDir", () => {
+    it("swaps a trailing 'logs' segment for 'data'", () => {
+        const logs = path.join("channels", "chan-a", "versions", "0.55.19", "logs");
+        const data = path.join("channels", "chan-a", "versions", "0.55.19", "data");
+        expect(siblingDataDir(logs)).toBe(data);
+    });
+
+    it("returns null for a directory that isn't named 'logs'", () => {
+        expect(siblingDataDir(path.join("channels", "chan-a", "versions", "0.55.19", "data"))).toBeNull();
+    });
+});
+
+describe("muxlog checkLiveness", () => {
+    let root;
+    let server;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), "muxlog-liveness-test-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+        server?.close();
+        server = undefined;
+    });
+
+    function makeInstance() {
+        const logDir = path.join(root, "logs");
+        const dataDir = path.join(root, "data");
+        fs.mkdirSync(logDir, { recursive: true });
+        fs.mkdirSync(dataDir, { recursive: true });
+        return { logDir, dataDir };
+    }
+
+    function listenOnEphemeralPort() {
+        return new Promise((resolve) => {
+            server = net.createServer();
+            server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+        });
+    }
+
+    it("returns '?' when there's no sibling data dir at all", async () => {
+        const logDir = path.join(root, "logs");
+        fs.mkdirSync(logDir, { recursive: true });
+        // no "data" dir created
+        expect(await checkLiveness(logDir)).toBe("?");
+    });
+
+    it("returns '?' when the data dir exists but has no ipc-port-* file", async () => {
+        const { logDir } = makeInstance();
+        expect(await checkLiveness(logDir)).toBe("?");
+    });
+
+    it("returns '?' for a malformed port file (no ':' separator, or non-numeric port)", async () => {
+        const { logDir, dataDir } = makeInstance();
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), "not-a-port-file");
+        expect(await checkLiveness(logDir)).toBe("?");
+    });
+
+    it("returns 'live' when something is actually listening on the recorded port", async () => {
+        const { logDir, dataDir } = makeInstance();
+        const port = await listenOnEphemeralPort();
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("live");
+    });
+
+    it("returns 'dead' when the recorded port has nothing listening on it", async () => {
+        const { logDir, dataDir } = makeInstance();
+        // Bind then immediately close — the port is very likely free again,
+        // and nothing else in this test process will grab it in between.
+        const port = await listenOnEphemeralPort();
+        await new Promise((resolve) => server.close(resolve));
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("dead");
     });
 });

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -1,5 +1,15 @@
+// @vitest-environment node
+//
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Forces the real Node environment (vitest.config.ts's global default is
+// jsdom, for frontend component tests) — muxlog.mjs is a standalone Node
+// CLI script that never runs in a browser, and jsdom's `fetch` polyfill
+// doesn't actually reach a real local HTTP server the way checkLiveness's
+// tests below need (probePort speaks real HTTP as of reagent P2 on
+// PR #2742 — every "live"/"multiple ipc-port files" case silently failed
+// under jsdom's fetch until this was added, passing fine under plain Node).
 //
 // Unit tests for muxlog.mjs's glob()/filterByInstance()/pickCandidate() —
 // pure logic (filesystem reads against a real temp dir for glob(), plain
@@ -23,6 +33,7 @@
 //   instance.
 
 import fs from "node:fs";
+import http from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -328,11 +339,38 @@ describe("muxlog checkLiveness", () => {
         return { logDir, dataDir };
     }
 
-    function listenOnEphemeralPort() {
+    // A real HTTP server answering GET /health with the exact shape
+    // agentmux-cef's own IPC server returns ({"status":"ok",...}) — probePort
+    // now speaks HTTP, not raw TCP, so the test double has to match (reagent
+    // P2 on PR #2742).
+    function listenWithHealthResponse() {
         return new Promise((resolve) => {
-            server = net.createServer();
+            server = http.createServer((req, res) => {
+                if (req.url === "/health") {
+                    res.writeHead(200, { "Content-Type": "application/json" });
+                    res.end(JSON.stringify({ status: "ok", version: "0.55.19" }));
+                } else {
+                    res.writeHead(404);
+                    res.end();
+                }
+            });
             server.listen(0, "127.0.0.1", () => resolve(server.address().port));
         });
+    }
+
+    // A listener that accepts the TCP connection (so a bare connect-only
+    // probe would false-positive "live") but isn't AgentMux's IPC server at
+    // all — the exact scenario reagent P2 described (OS reassigns a dead
+    // instance's port to an unrelated local service).
+    function listenAsUnrelatedService() {
+        return new Promise((resolve) => {
+            server = net.createServer((sock) => sock.end("not an agentmux server\n"));
+            server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+        });
+    }
+
+    function listenOnEphemeralPort() {
+        return listenWithHealthResponse();
     }
 
     it("returns '?' when there's no sibling data dir at all", async () => {
@@ -353,10 +391,33 @@ describe("muxlog checkLiveness", () => {
         expect(await checkLiveness(logDir)).toBe("?");
     });
 
-    it("returns 'live' when something is actually listening on the recorded port", async () => {
+    it("returns 'live' when the recorded port answers GET /health with status:ok", async () => {
         const { logDir, dataDir } = makeInstance();
-        const port = await listenOnEphemeralPort();
+        const port = await listenWithHealthResponse();
         fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("live");
+    });
+
+    // reagent P2 on PR #2742: a raw TCP connect alone isn't proof of
+    // liveness — something else could be listening on a reassigned port.
+    it("returns 'dead' when something IS listening but doesn't answer as AgentMux's IPC server", async () => {
+        const { logDir, dataDir } = makeInstance();
+        const port = await listenAsUnrelatedService();
+        fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("dead");
+    });
+
+    // reagent P1 on PR #2742: a dev-mode data dir can hold a stale port file
+    // (crashed process, never cleaned up) alongside a live one — checking
+    // only the first readdirSync result (unspecified order) risks probing
+    // the dead one and reporting "dead" for a genuinely live instance.
+    it("returns 'live' when multiple ipc-port-* files exist and only one is actually alive", async () => {
+        const { logDir, dataDir } = makeInstance();
+        const livePort = await listenWithHealthResponse();
+        // A stale port file pointing at a port nothing is listening on —
+        // simulates a crashed prior run's never-cleaned-up port file.
+        fs.writeFileSync(path.join(dataDir, "ipc-port-stalehash"), "1:dead-token");
+        fs.writeFileSync(path.join(dataDir, "ipc-port-livehash"), `${livePort}:live-token`);
         expect(await checkLiveness(logDir)).toBe("live");
     });
 
@@ -364,7 +425,7 @@ describe("muxlog checkLiveness", () => {
         const { logDir, dataDir } = makeInstance();
         // Bind then immediately close — the port is very likely free again,
         // and nothing else in this test process will grab it in between.
-        const port = await listenOnEphemeralPort();
+        const port = await listenWithHealthResponse();
         await new Promise((resolve) => server.close(resolve));
         fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
         expect(await checkLiveness(logDir)).toBe("dead");

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -38,7 +38,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { checkLiveness, filterByInstance, glob, matchesOwnChannel, pickCandidate, printLastLines, renderLine, siblingDataDir } from "./muxlog.mjs";
+import { checkLiveness, filterByInstance, glob, matchesOwnChannel, pickCandidate, printLastLines, renderLine, siblingCandidateDirs } from "./muxlog.mjs";
 
 let root;
 
@@ -305,15 +305,16 @@ describe("muxlog printLastLines return value (Ext 6's verdict count)", () => {
     });
 });
 
-describe("muxlog siblingDataDir", () => {
-    it("swaps a trailing 'logs' segment for 'data'", () => {
+describe("muxlog siblingCandidateDirs", () => {
+    it("returns both the 'data' and 'cef-cache' siblings of a trailing 'logs' segment", () => {
         const logs = path.join("channels", "chan-a", "versions", "0.55.19", "logs");
         const data = path.join("channels", "chan-a", "versions", "0.55.19", "data");
-        expect(siblingDataDir(logs)).toBe(data);
+        const cefCache = path.join("channels", "chan-a", "versions", "0.55.19", "cef-cache");
+        expect(siblingCandidateDirs(logs)).toEqual([data, cefCache]);
     });
 
-    it("returns null for a directory that isn't named 'logs'", () => {
-        expect(siblingDataDir(path.join("channels", "chan-a", "versions", "0.55.19", "data"))).toBeNull();
+    it("returns an empty array for a directory that isn't named 'logs'", () => {
+        expect(siblingCandidateDirs(path.join("channels", "chan-a", "versions", "0.55.19", "data"))).toEqual([]);
     });
 });
 
@@ -334,9 +335,11 @@ describe("muxlog checkLiveness", () => {
     function makeInstance() {
         const logDir = path.join(root, "logs");
         const dataDir = path.join(root, "data");
+        const cefCacheDir = path.join(root, "cef-cache");
         fs.mkdirSync(logDir, { recursive: true });
         fs.mkdirSync(dataDir, { recursive: true });
-        return { logDir, dataDir };
+        fs.mkdirSync(cefCacheDir, { recursive: true });
+        return { logDir, dataDir, cefCacheDir };
     }
 
     // A real HTTP server answering GET /health with the exact shape
@@ -402,6 +405,17 @@ describe("muxlog checkLiveness", () => {
         const { logDir, dataDir } = makeInstance();
         const port = await listenWithHealthResponse();
         fs.writeFileSync(path.join(dataDir, "ipc-port"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("live");
+    });
+
+    // reagent P1 on PR #2752: agentmux-cef/src/lib.rs writes the port file
+    // to the `cef-cache` sibling (not `data`) for `task dev` instances
+    // (is_dev_build_exe branch) — checking only `data` always reports '?'
+    // for the primary dev workflow, even when it's genuinely live.
+    it("returns 'live' via a port file in the 'cef-cache' sibling (task dev's actual layout)", async () => {
+        const { logDir, cefCacheDir } = makeInstance();
+        const port = await listenWithHealthResponse();
+        fs.writeFileSync(path.join(cefCacheDir, "ipc-port"), `${port}:some-token`);
         expect(await checkLiveness(logDir)).toBe("live");
     });
 

--- a/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.test.mjs
@@ -369,10 +369,6 @@ describe("muxlog checkLiveness", () => {
         });
     }
 
-    function listenOnEphemeralPort() {
-        return listenWithHealthResponse();
-    }
-
     it("returns '?' when there's no sibling data dir at all", async () => {
         const logDir = path.join(root, "logs");
         fs.mkdirSync(logDir, { recursive: true });
@@ -395,6 +391,17 @@ describe("muxlog checkLiveness", () => {
         const { logDir, dataDir } = makeInstance();
         const port = await listenWithHealthResponse();
         fs.writeFileSync(path.join(dataDir, "ipc-port-abc123"), `${port}:some-token`);
+        expect(await checkLiveness(logDir)).toBe("live");
+    });
+
+    // reagent P2 on PR #2752: agentmux-cef/src/lib.rs writes the bare
+    // filename "ipc-port" (no trailing hyphen) when AGENTMUX_IPC_HASH is
+    // unset (task dev:standalone, no launcher) — startsWith("ipc-port-")
+    // alone misses this exact literal.
+    it("returns 'live' via the bare 'ipc-port' filename (no hash suffix, e.g. task dev:standalone)", async () => {
+        const { logDir, dataDir } = makeInstance();
+        const port = await listenWithHealthResponse();
+        fs.writeFileSync(path.join(dataDir, "ipc-port"), `${port}:some-token`);
         expect(await checkLiveness(logDir)).toBe("live");
     });
 

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -87,7 +87,7 @@ muxlog srv --since 2026-06-15T23:30 cat        # a time window
 
 | Recipe | What it shows |
 |--------|---------------|
-| `muxlog ls` | every instance's logs: target, version, source (`shared` / `dev:<branch>` / `channel:…`), **LIVE** (`live`/`dead`/`?` — a real check, not inferred from log mtime: probes the instance's own `ipc-port-*` file with a `GET /health` request; `?` means genuinely unknown, e.g. no per-channel data dir found, never a liveness verdict of its own), age, size, path |
+| `muxlog ls` | every instance's logs: target, version, source (`shared` / `dev:<branch>` / `channel:…`), **LIVE** (`live`/`dead`/`?` — a real check, not inferred from log mtime: probes the instance's own `ipc-port-*` file with a `GET /health` request, checking both the `data` and `cef-cache` sibling dirs since `agentmux-cef` writes the port file to `cef-cache` for `task dev` instances and to `data` for portable/installed builds; `?` means genuinely unknown, e.g. neither sibling dir found, never a liveness verdict of its own), age, size, path |
 | `muxlog mem` (alias `doctor`) | system **commit-free** + derived pressure level (the OOM-relevant ceiling, not physical RAM) + the count and footprint of live AgentMux processes — makes multi-instance commit pressure visible before the cliff (`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16` §5.G) |
 | `muxlog errors` | ERROR + WARN across the active host and sidecar |
 | `muxlog bridge` | the startup handshake — `Loading URL`, `Injected IPC …`, `backend-ready`, `window.api`, `Bootstrap failed` — correlated in time, so a reconnect loop is obvious at a glance |

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -87,7 +87,7 @@ muxlog srv --since 2026-06-15T23:30 cat        # a time window
 
 | Recipe | What it shows |
 |--------|---------------|
-| `muxlog ls` | every instance's logs: target, version, source (`shared` / `dev:<branch>` / `channel:…`), age, size, path |
+| `muxlog ls` | every instance's logs: target, version, source (`shared` / `dev:<branch>` / `channel:…`), **LIVE** (`live`/`dead`/`?` — a real check, not inferred from log mtime: probes the instance's own `ipc-port-*` file with a `GET /health` request; `?` means genuinely unknown, e.g. no per-channel data dir found, never a liveness verdict of its own), age, size, path |
 | `muxlog mem` (alias `doctor`) | system **commit-free** + derived pressure level (the OOM-relevant ceiling, not physical RAM) + the count and footprint of live AgentMux processes — makes multi-instance commit pressure visible before the cliff (`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16` §5.G) |
 | `muxlog errors` | ERROR + WARN across the active host and sidecar |
 | `muxlog bridge` | the startup handshake — `Loading URL`, `Injected IPC …`, `backend-ready`, `window.api`, `Bootstrap failed` — correlated in time, so a reconnect loop is obvious at a glance |


### PR DESCRIPTION
## Summary

Ext 3 of `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`. Reopens the prior PR (#2742), which was closed unmerged after its stacked base branch (Ext 2, already merged as #2741) was deleted — this is the same, already-reviewed content rebased cleanly onto current `main`, with no further changes.

`muxlog ls` previously inferred an instance's liveness from log mtime alone — silent and stale under any crash, and gave no signal at all when deciding whether an instance is worth targeting with `-i`. This adds a **LIVE** column (`live`/`dead`/`?`) computed from a real check: probing each instance's `ipc-port-*` file(s) with an actual `GET /health` request against `agentmux-cef`'s IPC server.

### Review history carried over from #2742 (already fixed, included in this branch)
- **[P1]** `checkLiveness` now probes **every** `ipc-port-*` file concurrently, not just the first via `entries.find()` — a dev-mode data dir is keyed by branch (not version), and a crashed process's port file isn't cleaned up until a graceful exit, so a stale dead-port file and a live one can coexist; "live" if any probe succeeds.
- **[P2]** `probePort` validates the real `GET /health` response body (`{status:"ok"}`), not just a bare TCP connect — a bare connect can't distinguish AgentMux's IPC listener from an unrelated service that got OS-reassigned the same now-free ephemeral port.
- **[P2]** `docs/MUXLOG.md`'s `muxlog ls` column documentation now lists the LIVE column.

## Test plan
- [x] 36/36 passing in `muxlog.test.mjs` (real `http.createServer`-backed liveness probe tests, `// @vitest-environment node`)
- [x] Diff vs current `main` is exactly Ext 3's two commits — verified via `git diff origin/main --stat` before pushing

<!-- agentmux:agent_id=korp -->