### PR TITLE
fix(agent): stop "Agent unresponsive" from firing during legitimate context compaction

### DIFF
--- a/.changesets/1787439562-fix-agent-stop-agent-unresponsive-from-firing-during-legitim-wokj.md
+++ b/.changesets/1787439562-fix-agent-stop-agent-unresponsive-from-firing-during-legitim-wokj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): stop 'Agent unresponsive' from firing during legitimate context compaction

--- a/agentmux-srv/src/backend/blockcontroller/health.rs
+++ b/agentmux-srv/src/backend/blockcontroller/health.rs
@@ -210,6 +210,18 @@ impl HealthMonitor {
         let now = Instant::now();
         inner.last_output_ts = now;
         inner.last_meaningful_ts = now;
+        // codex P2 on PR #2754: reset unconditionally (both directions), same
+        // reasoning as last_output_ts/last_meaningful_ts above — a turn
+        // boundary must never carry a stale `compacting=true` forward. Without
+        // this, a process that crashes/is cancelled mid-compaction (no
+        // compact_boundary frame ever arrives to clear it via
+        // is_compact_boundary_frame's own call site) leaves `compacting`
+        // stuck true, silently suppressing the NEXT turn's normal 30s/120s
+        // watchdog until the unrelated 600s ceiling — or, if that ceiling has
+        // already elapsed, making the next turn immediately Dead before it's
+        // even produced any output.
+        inner.compacting = false;
+        inner.compacting_started_ts = None;
         if active {
             inner.errors.reset();
             inner.exit_code = None;
@@ -247,6 +259,12 @@ impl HealthMonitor {
         inner.last_meaningful_ts = now;
         inner.errors.reset();
         inner.exit_code = None;
+        // codex P2 on PR #2754: same reset as set_active_turn — a fresh turn
+        // must never inherit a stale `compacting=true` left over from a prior
+        // turn that crashed/was cancelled mid-compaction (no compact_boundary
+        // frame ever arrived to clear it the normal way).
+        inner.compacting = false;
+        inner.compacting_started_ts = None;
         drop(inner);
         tracing::info!(
             block_id = %self.block_id,
@@ -263,6 +281,17 @@ impl HealthMonitor {
         let mut inner = self.inner.lock().unwrap();
         inner.active_turn = false;
         inner.exit_code = Some(exit_code);
+        // codex P2 on PR #2754: a process that exits (crashes, is killed,
+        // exits normally) mid-compaction never gets a compact_boundary frame
+        // to clear `compacting` the normal way — reset it here too, so a
+        // later respawn on this same monitor (persistent/subprocess
+        // controllers reuse one HealthMonitor across turns) doesn't inherit
+        // a stale compacting state. `evaluate_and_transition` below still
+        // classifies purely off `exit_code` regardless (its very first
+        // check), so this has no effect on THIS transition — it's a
+        // safety net for whatever reuses this monitor next.
+        inner.compacting = false;
+        inner.compacting_started_ts = None;
         drop(inner);
         tracing::info!(block_id = %self.block_id, exit_code, "[health] turn_active flip (process exited)");
         self.evaluate_and_transition();
@@ -1168,5 +1197,138 @@ mod tests {
         assert_eq!(history.len(), 1, "must publish an AgentFailure even when Dead was reached via the compacting ceiling");
         let data = history[0].data.clone().expect("failure payload must be present");
         assert_eq!(data.get("code").and_then(|v| v.as_str()), Some("unresponsive"));
+    }
+
+    /// Regression for reagent P1 (PR #2754 review): the REAL production call
+    /// ordering at every controller's stdout-reader loop is
+    /// `record_output(meaningful)` THEN (if `compact_boundary`)
+    /// `set_compacting(false)` — not the reverse. Calling
+    /// `set_compacting(false)` first would re-evaluate against a
+    /// still-stale `last_meaningful_ts` (routinely >120s for any
+    /// compaction long enough to have needed this fix at all), transiently
+    /// computing `Dead` and publishing "Agent unresponsive" for one tick,
+    /// immediately self-cleared a moment later by `record_output`'s own
+    /// re-evaluation — a flicker at exactly the moment this fix exists to
+    /// prevent, and the earlier version of this PR had exactly that bug.
+    /// Exercises the real ordering end-to-end (not `set_compacting`/
+    /// `record_output` in isolation, which the original test suite did and
+    /// which is why this regression wasn't caught the first time) and
+    /// asserts NO `AgentFailure` — not even a transient one — is ever
+    /// published.
+    #[test]
+    fn real_call_ordering_never_flickers_unresponsive_when_compaction_ends() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let monitor = HealthMonitor::new("test-block-compact-ordering".to_string(), Some(broker.clone()), None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        // A compaction that ran well past DEAD_SECS before compact_boundary
+        // arrived — the real-world shape (a real captured example took
+        // 231.6s vs. the 120s threshold).
+        {
+            let mut inner = monitor.inner.lock().unwrap();
+            inner.last_meaningful_ts = Instant::now() - Duration::from_secs(HealthMonitor::DEAD_SECS + 50);
+        }
+
+        let frame = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "compactMetadata": { "trigger": "auto" },
+        });
+        let (meaningful, _error) = classify_output_line(&frame);
+        // The exact sequence every controller's stdout-reader loop now uses.
+        monitor.record_output(meaningful);
+        if is_compact_boundary_frame(&frame) {
+            monitor.set_compacting(false);
+        }
+
+        assert_eq!(monitor.inner.lock().unwrap().current_health, AgentHealth::Healthy);
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_AGENT_FAILURE,
+            "block:test-block-compact-ordering",
+            10,
+        );
+        assert!(
+            history.is_empty(),
+            "no AgentFailure — not even a transient publish+clear pair — may fire when compaction ends: {history:?}"
+        );
+    }
+
+    // ---- Stale `compacting` cleared at turn/process boundaries (codex P2, PR #2754) ----
+    //
+    // If a process crashes, is cancelled, or otherwise exits mid-compaction,
+    // no `compact_boundary` frame ever arrives to clear `compacting` the
+    // normal way (`is_compact_boundary_frame` + `set_compacting(false)`).
+    // persistent/subprocess controllers reuse ONE `HealthMonitor` across
+    // turns, so without an explicit reset at every turn/process boundary, a
+    // later, entirely unrelated turn on the same monitor would silently
+    // inherit `compacting=true` — suppressing its normal 30s/120s watchdog
+    // until the unrelated 600s ceiling, or (if that ceiling had already
+    // elapsed) making it immediately `Dead` before it produced any output.
+
+    #[test]
+    fn set_exited_clears_a_stale_compacting_flag() {
+        let monitor = HealthMonitor::new("test-block-exit-clears-compacting".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        assert!(monitor.is_compacting());
+
+        monitor.set_exited(1);
+        assert!(!monitor.is_compacting(), "a process exit mid-compaction must clear the stale compacting flag");
+    }
+
+    #[test]
+    fn set_active_turn_clears_a_stale_compacting_flag_from_a_prior_turn() {
+        let monitor = HealthMonitor::new("test-block-turn-clears-compacting".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        assert!(monitor.is_compacting());
+
+        // A fresh turn starting on the same reused monitor, with no
+        // compact_boundary frame having ever arrived to clear the prior
+        // turn's compacting flag the normal way.
+        monitor.set_active_turn(true);
+        assert!(
+            !monitor.is_compacting(),
+            "a new turn must never inherit a stale compacting flag from a prior, never-cleanly-ended turn"
+        );
+    }
+
+    #[test]
+    fn mark_turn_active_clears_a_stale_compacting_flag_from_a_prior_turn() {
+        let monitor = HealthMonitor::new("test-block-mark-clears-compacting".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        assert!(monitor.is_compacting());
+
+        monitor.mark_turn_active_returning_was_active();
+        assert!(!monitor.is_compacting());
+    }
+
+    /// End-to-end version of the scenario codex's finding warned about: a
+    /// turn dies mid-compaction (process exits, no compact_boundary), then a
+    /// genuinely hung NEW turn starts on the same reused monitor — it must
+    /// still be caught by the NORMAL 120s threshold, not silently protected
+    /// by the stale 600s compacting ceiling for up to 10 minutes.
+    #[test]
+    fn a_new_turn_after_a_crashed_compaction_uses_the_normal_dead_threshold_not_the_stale_ceiling() {
+        let monitor = HealthMonitor::new("test-block-post-crash-turn".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        monitor.set_exited(1); // crash mid-compaction, no compact_boundary ever arrived
+
+        monitor.set_active_turn(true); // a fresh, unrelated turn starts
+        {
+            let mut inner = monitor.inner.lock().unwrap();
+            // Well past the NORMAL 120s threshold, but nowhere near the
+            // compacting-only 600s ceiling — if the stale flag had survived,
+            // this would incorrectly still read Healthy.
+            inner.last_meaningful_ts = Instant::now() - Duration::from_secs(HealthMonitor::DEAD_SECS + 1);
+        }
+        monitor.check();
+        assert_eq!(
+            monitor.inner.lock().unwrap().current_health,
+            AgentHealth::Dead,
+            "a genuinely silent new turn must be caught by the normal 120s threshold, not shielded by a stale compacting ceiling"
+        );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/health.rs
+++ b/agentmux-srv/src/backend/blockcontroller/health.rs
@@ -129,6 +129,16 @@ struct HealthMonitorInner {
     errors: ErrorTracker,
     exit_code: Option<i32>,
     last_error: Option<String>,
+    /// True while a known-legitimate long-silence operation (currently:
+    /// Claude Code context compaction) is confirmed in progress — see
+    /// `set_compacting`'s own doc comment.
+    compacting: bool,
+    /// When `compacting` last flipped to `true`. `None` when not compacting.
+    /// Drives `COMPACTING_DEAD_SECS`, a separate and much longer ceiling than
+    /// the normal `STALL_SECS`/`DEAD_SECS` silence thresholds — so a
+    /// compaction that itself hangs is still eventually caught, instead of
+    /// `compacting=true` suppressing the detector forever.
+    compacting_started_ts: Option<Instant>,
 }
 
 /// Per-block agent health monitor.
@@ -153,6 +163,15 @@ impl HealthMonitor {
     const STALL_SECS: u64 = 30;
     /// Dead threshold: no meaningful output for 120s during active turn.
     const DEAD_SECS: u64 = 120;
+    /// Dead threshold while `compacting` — a real captured Claude Code
+    /// compaction took 231.6s (`docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md`
+    /// §2), nearly double `DEAD_SECS`; Claude Code emits zero intermediate
+    /// output for the whole duration (same spec's §7 Tier 4), so `DEAD_SECS`
+    /// alone reliably false-positives on a legitimate compaction. 600s is
+    /// ~2.6x the one real observed duration — generous enough to cover a
+    /// much larger context's compaction without disabling the detector
+    /// outright. See docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md.
+    const COMPACTING_DEAD_SECS: u64 = 600;
     /// Error window duration.
     const ERROR_WINDOW_SECS: u64 = 300; // 5 minutes
     /// Transient error count threshold for degraded.
@@ -175,6 +194,8 @@ impl HealthMonitor {
                 errors: ErrorTracker::new(Duration::from_secs(Self::ERROR_WINDOW_SECS)),
                 exit_code: None,
                 last_error: None,
+                compacting: false,
+                compacting_started_ts: None,
             }),
             broker,
             wstore,
@@ -266,6 +287,32 @@ impl HealthMonitor {
         }
     }
 
+    /// Suspend (`true`) or resume (`false`) the normal `STALL_SECS`/
+    /// `DEAD_SECS` silence thresholds for a known-legitimate long-silence
+    /// operation — currently only Claude Code context compaction, which
+    /// produces zero intermediate output for well over `DEAD_SECS` on a
+    /// large context (see `COMPACTING_DEAD_SECS`'s own doc comment).
+    /// `COMPACTING_DEAD_SECS` still applies while `compacting`, so an
+    /// operation that hangs mid-compaction is eventually still caught
+    /// rather than suppressing the detector forever.
+    ///
+    /// Deliberately does NOT touch `last_meaningful_ts` — resuming
+    /// (`false`) re-arms the normal thresholds against whatever silence has
+    /// already elapsed, not a fresh grace period. A compaction that ends
+    /// into an already-stale stream (e.g. the process died independently
+    /// during compaction) should be judged on its own merits, not handed
+    /// unearned extra time.
+    ///
+    /// See docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md.
+    pub fn set_compacting(&self, compacting: bool) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.compacting = compacting;
+        inner.compacting_started_ts = if compacting { Some(Instant::now()) } else { None };
+        drop(inner);
+        tracing::info!(block_id = %self.block_id, compacting, "[health] compacting flip");
+        self.evaluate_and_transition();
+    }
+
     /// Called when an error is detected in the output stream.
     pub fn record_error(&self, class: ErrorClass, message: String) {
         let mut inner = self.inner.lock().unwrap();
@@ -278,6 +325,13 @@ impl HealthMonitor {
     /// Whether there's an active turn in progress.
     pub fn is_active_turn(&self) -> bool {
         self.inner.lock().unwrap().active_turn
+    }
+
+    /// Whether a confirmed-legitimate long-silence operation (compaction) is
+    /// currently suppressing the normal Stalled/Dead thresholds — see
+    /// `set_compacting`'s own doc comment.
+    pub fn is_compacting(&self) -> bool {
+        self.inner.lock().unwrap().compacting
     }
 
     /// Periodic health check — call this every ~5 seconds while a turn is active.
@@ -444,6 +498,21 @@ impl HealthMonitor {
             return AgentHealth::Idle;
         }
 
+        // Confirmed-legitimate long silence (context compaction) — skip the
+        // normal Stalled/Dead thresholds, but still bounded by a much more
+        // generous ceiling in case the compaction itself hangs. See
+        // `set_compacting`'s own doc comment.
+        if inner.compacting {
+            let compacting_silence = inner
+                .compacting_started_ts
+                .map(|t| t.elapsed())
+                .unwrap_or_default();
+            if compacting_silence > Duration::from_secs(Self::COMPACTING_DEAD_SECS) {
+                return AgentHealth::Dead;
+            }
+            return AgentHealth::Healthy;
+        }
+
         // Check output silence
         let silence = inner.last_meaningful_ts.elapsed();
         if silence > Duration::from_secs(Self::DEAD_SECS) {
@@ -482,6 +551,18 @@ impl HealthMonitor {
                         .last_error
                         .clone()
                         .unwrap_or_else(|| "Fatal error detected".to_string())
+                } else if inner.compacting {
+                    // Reached Dead via COMPACTING_DEAD_SECS, not the normal
+                    // silence check — report elapsed time since compaction
+                    // started, not since the last real output line (which
+                    // could be arbitrarily older and would misleadingly
+                    // understate/overstate how long the compaction itself
+                    // has been running).
+                    let secs = inner
+                        .compacting_started_ts
+                        .map(|t| t.elapsed().as_secs())
+                        .unwrap_or(0);
+                    format!("Compaction unresponsive for {}s", secs)
                 } else {
                     let secs = inner.last_meaningful_ts.elapsed().as_secs();
                     format!("Unresponsive for {}s", secs)
@@ -506,6 +587,25 @@ impl HealthMonitor {
             broker.publish(wps_event);
         }
     }
+}
+
+/// Whether a parsed NDJSON line is Claude Code's `compact_boundary` system
+/// frame — the signal that a context compaction has just finished. Callers
+/// that classify raw output lines for `record_output` should also check
+/// this and call `HealthMonitor::set_compacting(false)` when it's true, so
+/// the silence-suppression armed by the earlier `PreCompact` hook signal
+/// (`compaction_started`) is torn down the moment compaction genuinely
+/// ends — not left dangling until the next unrelated health check. See
+/// docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md.
+///
+/// Deliberately permissive about the frame's OTHER fields (unlike the
+/// translator's own `compact_boundary` handling in `claude.rs`, which
+/// requires a well-formed `compactMetadata` to emit a real event) — this
+/// check only needs "compaction is over," not the metadata, so a
+/// malformed/partial frame still correctly clears `compacting`.
+pub fn is_compact_boundary_frame(parsed: &serde_json::Value) -> bool {
+    parsed.get("type").and_then(|v| v.as_str()) == Some("system")
+        && parsed.get("subtype").and_then(|v| v.as_str()) == Some("compact_boundary")
 }
 
 // ---- Error classifier for NDJSON lines ----
@@ -886,5 +986,187 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ---- Compaction false-positive fix (SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22) ----
+
+    #[test]
+    fn is_compact_boundary_frame_matches_the_real_frame_shape() {
+        // Real shape captured in SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md §2 —
+        // deliberately includes fields this check doesn't care about (compactMetadata),
+        // matching this fn's own "permissive about other fields" doc comment.
+        let frame = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "content": "Conversation compacted",
+            "level": "info",
+            "compactMetadata": { "trigger": "manual", "durationMs": 231_606 },
+        });
+        assert!(is_compact_boundary_frame(&frame));
+    }
+
+    #[test]
+    fn is_compact_boundary_frame_rejects_other_system_subtypes_and_other_frame_types() {
+        assert!(!is_compact_boundary_frame(&serde_json::json!({"type": "system", "subtype": "other_thing"})));
+        assert!(!is_compact_boundary_frame(&serde_json::json!({"type": "system"})));
+        assert!(!is_compact_boundary_frame(&serde_json::json!({"type": "result", "subtype": "compact_boundary"})));
+        assert!(!is_compact_boundary_frame(&serde_json::json!({})));
+    }
+
+    fn inner_with(
+        active_turn: bool,
+        last_meaningful_secs_ago: u64,
+        compacting: bool,
+        compacting_started_secs_ago: Option<u64>,
+    ) -> HealthMonitorInner {
+        HealthMonitorInner {
+            current_health: AgentHealth::Healthy,
+            active_turn,
+            last_output_ts: Instant::now(),
+            last_meaningful_ts: Instant::now() - Duration::from_secs(last_meaningful_secs_ago),
+            errors: ErrorTracker::new(Duration::from_secs(HealthMonitor::ERROR_WINDOW_SECS)),
+            exit_code: None,
+            last_error: None,
+            compacting,
+            compacting_started_ts: compacting_started_secs_ago.map(|s| Instant::now() - Duration::from_secs(s)),
+        }
+    }
+
+    /// The core fix: a turn silent for well over `DEAD_SECS` must NOT be
+    /// classified `Dead` while `compacting` is true — this is exactly the
+    /// shape a real Claude Code auto-compaction produces (zero output for
+    /// well over 120s, per the spec's own captured 231.6s example).
+    #[test]
+    fn compacting_suppresses_dead_despite_a_last_meaningful_ts_far_past_dead_secs() {
+        let inner = inner_with(true, HealthMonitor::DEAD_SECS + 100, true, Some(60));
+        assert_eq!(HealthMonitor::compute_health(&inner), AgentHealth::Healthy);
+    }
+
+    /// Also suppresses the intermediate `Stalled` classification, not just `Dead`.
+    #[test]
+    fn compacting_suppresses_stalled_too() {
+        let inner = inner_with(true, HealthMonitor::STALL_SECS + 5, true, Some(5));
+        assert_eq!(HealthMonitor::compute_health(&inner), AgentHealth::Healthy);
+    }
+
+    /// The safety ceiling: compaction itself hanging past `COMPACTING_DEAD_SECS`
+    /// must still eventually reach `Dead` — `compacting=true` is a suppression
+    /// of the NORMAL thresholds, not a permanent exemption from ever being
+    /// flagged unresponsive.
+    #[test]
+    fn compacting_still_reaches_dead_once_the_compacting_ceiling_is_exceeded() {
+        let inner = inner_with(true, 1, true, Some(HealthMonitor::COMPACTING_DEAD_SECS + 1));
+        assert_eq!(HealthMonitor::compute_health(&inner), AgentHealth::Dead);
+    }
+
+    /// Comfortably under the ceiling must not be Dead — deliberately not an
+    /// exact-boundary check (`compacting_started_ts.elapsed()` always ticks
+    /// forward slightly between test setup and the `compute_health` call
+    /// below, so asserting the exact instant of the threshold against a
+    /// real monotonic clock is inherently flaky; `- 1` leaves comfortable
+    /// margin while still proving the check is `>`, not `>=`).
+    #[test]
+    fn compacting_just_under_the_ceiling_is_not_yet_dead() {
+        let inner = inner_with(true, 1, true, Some(HealthMonitor::COMPACTING_DEAD_SECS - 1));
+        assert_eq!(HealthMonitor::compute_health(&inner), AgentHealth::Healthy);
+    }
+
+    /// Not compacting: behavior is completely unchanged from before this fix —
+    /// the normal DEAD_SECS threshold still applies exactly as it always did.
+    #[test]
+    fn non_compacting_turn_is_unaffected_by_the_compacting_fields_existing() {
+        let inner = inner_with(true, HealthMonitor::DEAD_SECS + 1, false, None);
+        assert_eq!(HealthMonitor::compute_health(&inner), AgentHealth::Dead);
+    }
+
+    /// `set_compacting(true)` immediately suppresses Dead even when
+    /// `last_meaningful_ts` is already stale past `DEAD_SECS` — the live,
+    /// through-the-public-API path (not just the pure `compute_health` unit
+    /// tests above).
+    #[test]
+    fn set_compacting_true_immediately_suppresses_an_already_stale_turn() {
+        let monitor = HealthMonitor::new("test-block-compacting-1".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        {
+            let mut inner = monitor.inner.lock().unwrap();
+            inner.last_meaningful_ts = Instant::now() - Duration::from_secs(HealthMonitor::DEAD_SECS + 1);
+        }
+        monitor.set_compacting(true);
+        assert!(monitor.is_compacting());
+        assert_eq!(monitor.inner.lock().unwrap().current_health, AgentHealth::Healthy);
+    }
+
+    /// `set_compacting(false)` must NOT reset `last_meaningful_ts` — resuming
+    /// re-arms the normal thresholds against whatever silence has ALREADY
+    /// elapsed, not a fresh grace period. A compaction that "ends" (or whose
+    /// signal is cleared for any reason) into an already-dead-silent stream
+    /// must still be judged Dead immediately, not given another free 120s.
+    #[test]
+    fn set_compacting_false_grants_no_fresh_grace_period() {
+        let monitor = HealthMonitor::new("test-block-compacting-2".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        {
+            let mut inner = monitor.inner.lock().unwrap();
+            inner.last_meaningful_ts = Instant::now() - Duration::from_secs(HealthMonitor::DEAD_SECS + 1);
+        }
+        monitor.set_compacting(true);
+        assert_eq!(monitor.inner.lock().unwrap().current_health, AgentHealth::Healthy);
+
+        monitor.set_compacting(false);
+        assert!(!monitor.is_compacting());
+        assert_eq!(
+            monitor.inner.lock().unwrap().current_health,
+            AgentHealth::Dead,
+            "resuming must re-evaluate against the already-stale last_meaningful_ts immediately"
+        );
+    }
+
+    /// A real `compact_boundary` frame arriving while `compacting` is true
+    /// must clear it — the wiring each controller's stdout-reader loop uses
+    /// (`is_compact_boundary_frame` + `set_compacting(false)`), exercised
+    /// here at the `HealthMonitor` level (per-controller wiring itself is
+    /// mechanical and not independently tested).
+    #[test]
+    fn compact_boundary_frame_detection_pairs_with_set_compacting_false() {
+        let monitor = HealthMonitor::new("test-block-compacting-3".to_string(), None, None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        assert!(monitor.is_compacting());
+
+        let frame = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "compactMetadata": { "trigger": "auto" },
+        });
+        assert!(is_compact_boundary_frame(&frame));
+        monitor.set_compacting(false);
+        assert!(!monitor.is_compacting());
+    }
+
+    /// Reaching Dead via the compacting ceiling (not the normal silence path)
+    /// must still publish a real `AgentFailure` (code `unresponsive`) — the
+    /// escape hatch is scoped to false positives, not to hiding a genuine
+    /// hang that happens to occur mid-compaction.
+    #[test]
+    fn compacting_ceiling_dead_still_publishes_an_unresponsive_failure() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let monitor = HealthMonitor::new("test-block-compacting-dead".to_string(), Some(broker.clone()), None, None);
+        monitor.set_active_turn(true);
+        monitor.set_compacting(true);
+        {
+            let mut inner = monitor.inner.lock().unwrap();
+            inner.compacting_started_ts = Some(Instant::now() - Duration::from_secs(HealthMonitor::COMPACTING_DEAD_SECS + 1));
+        }
+        monitor.check();
+
+        assert_eq!(monitor.inner.lock().unwrap().current_health, AgentHealth::Dead);
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_AGENT_FAILURE,
+            "block:test-block-compacting-dead",
+            1,
+        );
+        assert_eq!(history.len(), 1, "must publish an AgentFailure even when Dead was reached via the compacting ceiling");
+        let data = history[0].data.clone().expect("failure payload must be present");
+        assert_eq!(data.get("code").and_then(|v| v.as_str()), Some("unresponsive"));
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -249,6 +249,18 @@ pub trait Controller: Send + Sync {
     /// override [`agent_id`](Controller::agent_id) either.
     fn set_agent_id(&self, _id: Option<String>) {}
 
+    /// This controller's `HealthMonitor`, if it owns one. Default `None`,
+    /// mirroring [`agent_id`](Controller::agent_id)'s default-None pattern
+    /// — only controller types actually wired to a `HealthMonitor`
+    /// (persistent, host_spawn/subprocess, container_spawn) override this.
+    /// Used by `handle_wps_publish` (`server/mod.rs`) to forward a
+    /// `compaction_started` WPS event into the right block's health
+    /// monitor — see
+    /// docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md.
+    fn health_monitor(&self) -> Option<Arc<health::HealthMonitor>> {
+        None
+    }
+
     /// Downcast support for concrete controller types.
     fn as_any(&self) -> &dyn Any;
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -32,7 +32,7 @@ use super::{
     STATUS_RUNNING,
 };
 use super::core;
-use super::health::{classify_output_line, HealthMonitor};
+use super::health::{classify_output_line, is_compact_boundary_frame, HealthMonitor};
 use super::persistent_resume;
 use crate::backend::eventbus::EventBus;
 use crate::backend::storage::filestore::FileStore;
@@ -2579,6 +2579,9 @@ impl PersistentSubprocessController {
                         }
                     }
                     let (meaningful, _error) = classify_output_line(&parsed);
+                    if is_compact_boundary_frame(&parsed) {
+                        health_read.set_compacting(false);
+                    }
                     health_read.record_output(meaningful);
                     let is_result_frame =
                         parsed.get("type").and_then(|v| v.as_str()) == Some("result");
@@ -3709,6 +3712,10 @@ impl Controller for PersistentSubprocessController {
 
     fn set_agent_id(&self, id: Option<String>) {
         *self.agent_id.lock().unwrap() = id;
+    }
+
+    fn health_monitor(&self) -> Option<Arc<HealthMonitor>> {
+        Some(Arc::clone(&self.health_monitor))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -2579,10 +2579,24 @@ impl PersistentSubprocessController {
                         }
                     }
                     let (meaningful, _error) = classify_output_line(&parsed);
+                    // reagent P1: record_output must run BEFORE set_compacting(false)
+                    // here, not after. set_compacting(false) leaves last_meaningful_ts
+                    // untouched (by design — see its own doc comment) and immediately
+                    // re-evaluates health; evaluating against a last_meaningful_ts still
+                    // stale from before compaction started (routinely >120s for any
+                    // compaction that actually needed this fix) computes Dead and
+                    // publishes "Agent unresponsive" for one tick, self-clearing the
+                    // instant record_output's own re-evaluation runs — a transient
+                    // flicker at exactly the moment this fix exists to prevent.
+                    // Calling record_output first refreshes last_meaningful_ts to now
+                    // (compact_boundary is itself classified "meaningful" by
+                    // classify_output_line's default arm) while still compacting, so
+                    // set_compacting(false)'s own re-evaluation sees fresh output and
+                    // never dips through Dead at all.
+                    health_read.record_output(meaningful);
                     if is_compact_boundary_frame(&parsed) {
                         health_read.set_compacting(false);
                     }
-                    health_read.record_output(meaningful);
                     let is_result_frame =
                         parsed.get("type").and_then(|v| v.as_str()) == Some("result");
                     // Claude's turn-ending marker. Persistent mode never exits

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -468,6 +468,9 @@ impl SubprocessController {
 
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
             let (meaningful, error) = health::classify_output_line(&parsed);
+            if health::is_compact_boundary_frame(&parsed) {
+                health.set_compacting(false);
+            }
             health.record_output(meaningful);
             if let Some((class, msg)) = error {
                 health.record_error(class, msg);

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -468,10 +468,14 @@ impl SubprocessController {
 
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
             let (meaningful, error) = health::classify_output_line(&parsed);
+            // reagent P1 (same finding as persistent.rs, mirrored here):
+            // record_output must run before set_compacting(false) — see
+            // persistent.rs's own comment on this exact ordering for the
+            // full explanation.
+            health.record_output(meaningful);
             if health::is_compact_boundary_frame(&parsed) {
                 health.set_compacting(false);
             }
-            health.record_output(meaningful);
             if let Some((class, msg)) = error {
                 health.record_error(class, msg);
             }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -315,10 +315,18 @@ impl SubprocessController {
                         // terminal `result` frame for failure classification.
                         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
                             let (meaningful, error) = classify_output_line(&parsed);
+                            // reagent P1 (same finding as persistent.rs, mirrored
+                            // here): record_output must run before
+                            // set_compacting(false), or its re-evaluation sees a
+                            // still-stale last_meaningful_ts and transiently
+                            // publishes/clears "Agent unresponsive" right at the
+                            // moment compaction ends — see persistent.rs's own
+                            // comment on this exact ordering for the full
+                            // explanation.
+                            health_read.record_output(meaningful);
                             if is_compact_boundary_frame(&parsed) {
                                 health_read.set_compacting(false);
                             }
-                            health_read.record_output(meaningful);
                             if let Some((class, msg)) = error {
                                 health_read.record_error(class, msg);
                             }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -18,8 +18,8 @@ use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::backend::blockcontroller::{
-    core, health::classify_output_line, publish_controller_status, session_stats, shell,
-    DEFAULT_GRACEFUL_KILL_WAIT_MS, STATUS_DONE, STATUS_RUNNING,
+    core, health::{classify_output_line, is_compact_boundary_frame}, publish_controller_status,
+    session_stats, shell, DEFAULT_GRACEFUL_KILL_WAIT_MS, STATUS_DONE, STATUS_RUNNING,
 };
 use crate::backend::wps;
 
@@ -315,6 +315,9 @@ impl SubprocessController {
                         // terminal `result` frame for failure classification.
                         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
                             let (meaningful, error) = classify_output_line(&parsed);
+                            if is_compact_boundary_frame(&parsed) {
+                                health_read.set_compacting(false);
+                            }
                             health_read.record_output(meaningful);
                             if let Some((class, msg)) = error {
                                 health_read.record_error(class, msg);

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/mod.rs
@@ -417,6 +417,10 @@ impl Controller for SubprocessController {
         &self.block_id
     }
 
+    fn health_monitor(&self) -> Option<Arc<HealthMonitor>> {
+        Some(Arc::clone(&self.health_monitor))
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -771,6 +771,29 @@ async fn handle_wps_publish(
     State(state): State<AppState>,
     Json(req): Json<WpsPublishRequest>,
 ) -> impl IntoResponse {
+    // Forward `compaction_started` into the target block's own
+    // `HealthMonitor` before the generic broadcast below, so the
+    // silence-based Unresponsive detector stops counting silence the
+    // instant Claude Code's `PreCompact` hook fires (`agentmux-bashwrap
+    // precompact`) — see
+    // docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md.
+    // Best-effort and silent: an unknown/unregistered block id, a
+    // controller type with no health monitor (default `None` — see
+    // `Controller::health_monitor`'s own doc comment), or any other event
+    // name is simply a no-op here. This must never fail or delay the
+    // publish itself — the hook that triggers it is explicitly
+    // "never block/delay the operation for observability" (see
+    // `agentmux-bashwrap/src/precompact.rs`'s module doc comment).
+    if req.event == "compaction_started" {
+        if let Some(block_id) = req.scopes.iter().find_map(|s| s.strip_prefix("block:")) {
+            if let Some(controller) = crate::backend::blockcontroller::get_controller(block_id) {
+                if let Some(health) = controller.health_monitor() {
+                    health.set_compacting(true);
+                }
+            }
+        }
+    }
+
     let event = crate::backend::wps::WaveEvent {
         event: req.event,
         scopes: req.scopes,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1237,6 +1237,130 @@ async fn wps_publish_omits_persist_defaults_to_zero() {
     assert_eq!(resp.status(), StatusCode::OK);
 }
 
+// ---- compaction_started -> HealthMonitor wiring (SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22) ----
+
+/// Minimal test double: the only thing that matters is `health_monitor()`
+/// returning a real, inspectable `HealthMonitor`. Every other `Controller`
+/// method is a harmless no-op, mirroring `blockcontroller::mod`'s own
+/// `CountingController` test-double pattern.
+struct CompactionTestController {
+    block_id: String,
+    health: std::sync::Arc<crate::backend::blockcontroller::health::HealthMonitor>,
+}
+
+impl crate::backend::blockcontroller::Controller for CompactionTestController {
+    fn start(
+        &self,
+        _: crate::backend::obj::MetaMapType,
+        _: Option<serde_json::Value>,
+        _: bool,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+    fn stop(&self, _graceful: bool, _new_status: &str) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_runtime_status(&self) -> crate::backend::blockcontroller::BlockControllerRuntimeStatus {
+        crate::backend::blockcontroller::BlockControllerRuntimeStatus {
+            blockid: self.block_id.clone(),
+            ..Default::default()
+        }
+    }
+    fn send_input(
+        &self,
+        _: crate::backend::blockcontroller::BlockInputUnion,
+        _: Option<u64>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+    fn controller_type(&self) -> &str {
+        "test-compaction"
+    }
+    fn block_id(&self) -> &str {
+        &self.block_id
+    }
+    fn health_monitor(&self) -> Option<std::sync::Arc<crate::backend::blockcontroller::health::HealthMonitor>> {
+        Some(std::sync::Arc::clone(&self.health))
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// A `compaction_started` publish for a block with a registered controller
+/// must reach that controller's own `HealthMonitor::set_compacting(true)` —
+/// the actual production wiring path (`agentmux-bashwrap precompact` → this
+/// HTTP endpoint → `get_controller` → `health_monitor()`), exercised
+/// end-to-end through the real router rather than calling `set_compacting`
+/// directly.
+#[tokio::test]
+async fn wps_publish_compaction_started_marks_the_target_blocks_health_monitor_compacting() {
+    let block_id = "test-compaction-wired-block";
+    let health = std::sync::Arc::new(crate::backend::blockcontroller::health::HealthMonitor::new(
+        block_id.to_string(),
+        None,
+        None,
+        None,
+    ));
+    let controller = std::sync::Arc::new(CompactionTestController {
+        block_id: block_id.to_string(),
+        health: health.clone(),
+    });
+    crate::backend::blockcontroller::register_controller(block_id, controller);
+
+    assert!(!health.is_compacting(), "precondition: not compacting yet");
+
+    let app = test_router();
+    let body = serde_json::json!({
+        "event": "compaction_started",
+        "scopes": [format!("block:{block_id}")],
+        "persist": 0,
+        "data": { "trigger": "auto", "sessionId": "sess-1", "startedAt": "2026-08-22T00:00:00Z" }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/wps/publish")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(health.is_compacting(), "compaction_started must reach the target block's HealthMonitor");
+
+    crate::backend::blockcontroller::delete_controller(block_id);
+}
+
+/// A `compaction_started` publish for a block with NO registered controller
+/// (unknown/stale block id) must still succeed — this is best-effort
+/// observability wiring, matching the `PreCompact` hook's own "never
+/// fail/delay the operation" contract; a missing controller must never turn
+/// into an HTTP error.
+#[tokio::test]
+async fn wps_publish_compaction_started_for_an_unregistered_block_is_a_harmless_no_op() {
+    // Deliberately never registered — assert_ne against the registry isn't
+    // needed; get_controller returning None is exactly the case under test.
+    let block_id = "test-compaction-unregistered-block-xyz";
+    assert!(crate::backend::blockcontroller::get_controller(block_id).is_none());
+
+    let app = test_router();
+    let body = serde_json::json!({
+        "event": "compaction_started",
+        "scopes": [format!("block:{block_id}")],
+        "persist": 0,
+        "data": { "trigger": "manual", "sessionId": "", "startedAt": "2026-08-22T00:00:00Z" }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/wps/publish")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "an unregistered block id must not fail the publish");
+}
+
 // ---- First-class agent API (SPEC_AGENT_API_FIRST_CLASS_SURFACE) ----
 
 /// `GET /api/v1/self` resolves the seeded agent block to its tab / window /

--- a/docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md
+++ b/docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md
@@ -1,0 +1,160 @@
+# Spec: Stop "Agent unresponsive" From Firing During Legitimate Context Compaction
+
+**Date:** 2026-08-22
+**Repo:** agentmuxai/agentmux
+**Trigger:** operator report — the "Agent unresponsive" banner (with its "Restart" recovery action) appears in the agent pane during context compaction, and "other times it's not supposed to."
+
+**Implementation status:** Not started. This document proposes the design; it does not change code.
+
+---
+
+## 1. Problem
+
+`HealthMonitor` (`agentmux-srv/src/backend/blockcontroller/health.rs`) classifies an active turn as `Dead` — and publishes an `AgentFailure` with `code: "unresponsive"`, `title: "Agent unresponsive"` (`publish_unresponsive_failure`) — whenever no "meaningful" NDJSON line has arrived from the CLI subprocess for `DEAD_SECS` (120s). The frontend (`useAgentFailure.ts` → `failure-accessory.ts`) renders this as a dismissible banner offering a **Restart** action that kills and respawns the controller process.
+
+This detector was built (`docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md` §2.7/§4, 2026-07-27) specifically to catch a **genuinely wedged CLI subprocess** — one that has stopped producing any output at all while still holding the process alive. It is purely a silence timer: it has no concept of *why* the process is silent, only *how long*.
+
+Three weeks later, `docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md` shipped real compaction visibility (Tiers 1-3, most recently 2026-08-22) — a `PreCompact` hook fires the instant Claude Code begins compacting, and a `compact_boundary` NDJSON frame arrives once it finishes, carrying the real elapsed duration. **The spec's own captured real-world example records a compaction that took 231.6 seconds** — very nearly double `DEAD_SECS`. During that entire window, Claude Code emits **zero** NDJSON output (confirmed by the same spec's own Tier 4 section: "Compaction is a single opaque LLM call producing a summary; there is no intermediate progress event at the protocol level ... Claude Code's own interactive TUI shows only a spinner + elapsed time during compaction, never a percentage").
+
+These two features were built independently, three weeks apart, and never made aware of each other:
+
+- The frontend's own pane state (`agent-pane-state/reducer.ts`) tracks a `compacting` flag and shows a "Compacting… Ns" readout in `AgentComposerStrip.tsx` — it correctly knows nothing is wrong.
+- `HealthMonitor`, running in the same `agentmux-srv` process, has **no visibility into that flag at all**. It only watches raw stdout bytes. Once `last_meaningful_ts` is more than 120s stale — which any auto-compaction on a large context routinely exceeds — it transitions to `Dead` and fires the failure banner, **while the pane is simultaneously showing "Compacting…" right above it.**
+
+This is a straightforward, structural gap, not a mystery: the health monitor was never told compaction is a valid reason for extended silence.
+
+### 1.1 "Other times it's not supposed to" — scope of this document
+
+The operator's report also names other, unspecified occasions. Investigation for this spec found **no second confirmed cause** — no other code path in this repo currently tells `HealthMonitor` about a legitimate long-silence operation, so nothing else *could* be suppressing a false positive today. The most likely additional candidate, based on what's currently in the repo, is a long-running `Task`/subagent dispatch (`docs/specs/SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md` / `docs/reports/REPORT_AGENT_TRANSCRIPT_DISPATCH_CARDS_2026_08_19.md`, merged 2026-08-20) — a parent turn blocked on a `Task` tool call could plausibly also go silent on its own stdout for an extended stretch while the sub-dispatch runs. **This is speculative, not verified** — unlike compaction, there is no captured real-world duration and no structural reason yet to believe a hung `Task` tool call should be treated differently from a hung `Bash` call (the original detector's whole purpose). Recommend confirming with `muxlog srv grep "agent health transition"` whether `Dead` transitions correlate with `Task` dispatches before deciding whether they need the same treatment, or whether flagging a slow dispatch really is correct behavior. §4 below is deliberately scoped to the confirmed compaction cause only, but designed so a second confirmed cause is cheap to add later without redesigning the mechanism.
+
+## 2. Root cause, precisely
+
+`compute_health()` (`health.rs`):
+
+```rust
+// Check output silence
+let silence = inner.last_meaningful_ts.elapsed();
+if silence > Duration::from_secs(Self::DEAD_SECS) {      // 120s
+    return AgentHealth::Dead;
+}
+if silence > Duration::from_secs(Self::STALL_SECS) {     // 30s
+    return AgentHealth::Stalled;
+}
+```
+
+`last_meaningful_ts` only advances when `record_output(meaningful: true)` is called, which only happens when a line actually arrives on stdout. During compaction, no line arrives — `PreCompact` fires over a **separate channel** (an HTTP POST from the standalone `agentmux-bashwrap precompact` process to `/agentmux/wps/publish`, event `compaction_started`; see `agentmux-bashwrap/src/precompact.rs` / `wps_client.rs`), and `compact_boundary` arrives on stdout **only after compaction finishes** — i.e. after the false positive would already have fired.
+
+Concretely, on a session whose auto-compaction takes ~230s (the spec's own real example): `Healthy → Stalled` at +30s, `Stalled → Dead` at +120s (publishing "Agent unresponsive" / Restart), then ~110s later the real `compact_boundary` frame lands, is classified as "meaningful" by `classify_output_line`'s default arm (it doesn't special-case `type: "system"`), and `record_output(true)` silently self-heals `Dead → Healthy` (`clear_unresponsive_failure`, per the existing self-heal handling built for a *different* reason in the 07-27 report). **The banner appears and then disappears on its own** roughly 90-100 seconds later, mid-compaction, for no actual problem — exactly matching the report.
+
+## 3. Design
+
+### 3.1 New primitive: a suppressible/extendable silence timer, not a compaction special case
+
+Add a `compacting: bool` (plus `compacting_started_ts: Option<Instant>`) to `HealthMonitorInner`, and a new public method:
+
+```rust
+/// Suspend the normal Stalled/Dead silence thresholds — a known-legitimate
+/// long-silence operation (currently: context compaction) is in progress.
+/// A separate, more generous ceiling (`COMPACTING_DEAD_SECS`) still applies,
+/// so a compaction that itself hangs is eventually caught.
+pub fn set_compacting(&self, compacting: bool) { ... }
+```
+
+`compute_health()` gains one branch, evaluated before the existing `STALL_SECS`/`DEAD_SECS` checks:
+
+```rust
+if inner.active_turn {
+    if inner.compacting {
+        let compacting_silence = inner.compacting_started_ts
+            .map(|t| t.elapsed())
+            .unwrap_or_default();
+        if compacting_silence > Duration::from_secs(Self::COMPACTING_DEAD_SECS) {
+            return AgentHealth::Dead; // compaction itself has hung — still worth flagging
+        }
+        return AgentHealth::Healthy;
+    }
+    // ... existing STALL_SECS / DEAD_SECS checks, unchanged
+}
+```
+
+Named and scoped as a general "suppress the silence timer for a confirmed reason" primitive (not `set_compacting_because_reasons`) so a second confirmed cause (§1.1) is a second call site, not a redesign. Deliberately **not** introducing a new `AgentHealth::Compacting` enum variant for v1 — `AgentHealthEvent`'s own comment already notes it "has no frontend subscriber" today, so there's no consumer that benefits from a finer-grained state, and it avoids touching the `AgentHealth::as_str()`/`make_detail()` match arms and any downstream type unions for zero user-visible gain. Revisit only if `agenthealth` gets a real subscriber later.
+
+**`COMPACTING_DEAD_SECS` — open question for the operator to confirm before implementation.** Proposed default: 600s (10 minutes) — roughly 2.6× the one real captured duration (231.6s), generous enough to comfortably cover a much larger context's compaction without being effectively infinite.
+
+### 3.2 Wiring "compaction started" → `set_compacting(true)`
+
+`agentmux-bashwrap precompact` already POSTs `{event: "compaction_started", scopes: ["block:<id>"], persist: 0, data: {...}}` to `/agentmux/wps/publish`, handled generically by `handle_wps_publish` (`agentmux-srv/src/server/mod.rs:743`), which today just forwards to `state.broker.publish(...)` with no per-event special-casing.
+
+Add a narrow special case in that handler: when `req.event == "compaction_started"`, parse the block id out of `req.scopes` (`"block:<id>"`, the same convention `health.rs` itself publishes under), look it up via the existing global registry `blockcontroller::get_controller(block_id)` (`agentmux-srv/src/backend/blockcontroller/mod.rs:264`), and call into its health monitor. This requires one small addition to the `Controller` trait:
+
+```rust
+/// This controller's health monitor, if it owns one. Default `None` —
+/// only controller types wired to a `HealthMonitor` override this
+/// (persistent, host_spawn/subprocess, container_spawn). Mirrors the
+/// existing `agent_id()` default-None pattern on this trait.
+fn health_monitor(&self) -> Option<Arc<HealthMonitor>> {
+    None
+}
+```
+
+The generic publish path stays generic and cheap for every other event (a string compare + a registry lookup only for this one event name); nothing about the WPS publish/broadcast behavior itself changes, so the frontend's own `compaction_started` subscription (`useCompactionStream.ts`) is unaffected.
+
+### 3.3 Wiring "compaction ended" → `set_compacting(false)`
+
+`compact_boundary` arrives as a normal line on the same stdout stream `classify_output_line`/`record_output` already read from. Three call sites already parse each raw JSON line for exactly this purpose and would each gain one check immediately alongside the existing one:
+
+- `agentmux-srv/src/backend/blockcontroller/persistent.rs:2581-2582`
+- `agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs:317-318`
+- `agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs:470-471`
+
+```rust
+let (meaningful, _error) = classify_output_line(&parsed);
+if parsed.get("type").and_then(|v| v.as_str()) == Some("system")
+    && parsed.get("subtype").and_then(|v| v.as_str()) == Some("compact_boundary")
+{
+    health_read.set_compacting(false);
+}
+health_read.record_output(meaningful);
+```
+
+`acp.rs` is deliberately **not** touched — it never classifies raw JSON at all (`record_output(true)` unconditionally per its own comment) and ACP is not the Claude Code stream-json path the compaction feature targets, matching the original compaction spec's own explicit provider scoping (§5: "Doesn't fix: other providers").
+
+**Safety net if `compact_boundary` never arrives** (compaction hook fired but the process then genuinely died, or the CLI crashed mid-compaction): covered by §3.1's `COMPACTING_DEAD_SECS` ceiling — `compacting` never gets cleared, so after 10 minutes it still correctly reaches `Dead`, unlike leaving `compacting` permanently sticky.
+
+### 3.4 What does NOT change
+
+- `STALL_SECS`/`DEAD_SECS` (30s/120s) for the non-compacting case — untouched. This is not a general loosening of the unresponsive detector, only a scoped exemption for a specific, protocol-confirmed legitimate cause.
+- The frontend's existing `compacting` pane flag / "Compacting… Ns" UX (§4.2-4.3 of the compaction spec) — untouched; this fix operates one layer down, in the backend health monitor, and the two states simply stop contradicting each other.
+- `classify_output_line`'s own classification of `compact_boundary` as "meaningful" (§2's self-heal path) — still correct and still fires; it's just no longer the *only* thing standing between a long compaction and a spurious banner.
+
+## 4. Rollout shape
+
+Additive and low-risk:
+- New `HealthMonitorInner` fields default `false`/`None` — a controller that never calls `set_compacting` behaves byte-for-byte as today.
+- New `Controller::health_monitor()` trait method has a default (`None`) — every controller type that doesn't override it is unaffected; adding the override to three concrete types is mechanical.
+- `handle_wps_publish`'s new special case only touches behavior for `req.event == "compaction_started"`; every other event's publish path is unchanged.
+
+## 5. Test plan (for whoever implements this)
+
+- `health.rs` unit tests (existing style, `Instant`-based, no real sleeps): `compute_health` returns `Healthy` while `compacting=true` even with `last_meaningful_ts` far in the past; returns `Dead` once `compacting_started_ts` exceeds `COMPACTING_DEAD_SECS` even while still `compacting=true`; `set_compacting(false)` immediately re-arms the normal `STALL_SECS`/`DEAD_SECS` checks against whatever `last_meaningful_ts` already is (don't silently reset it — a compaction that ends into an *already*-stale stream should still be judged on its own silence, not get a fresh 120s grace period for free).
+- Integration-shaped test on one of the three wired controllers (mirroring `dead_transition_publishes_unresponsive_failure`'s style): feed a synthetic `compact_boundary` line through the stdout-handling path and assert `set_compacting(false)` fires (i.e. the controller's health monitor no longer reports `compacting`).
+- `handle_wps_publish`: a `compaction_started` publish for a `block_id` with a registered controller reaches that controller's `HealthMonitor::set_compacting(true)`; a `compaction_started` publish for an unknown/unregistered block id is a no-op, not an error (mirrors the hook's own "never fail the operation" philosophy) — `handle_wps_publish` must still `200 OK` either way, since this is best-effort observability wiring, not a contract the hook depends on.
+- Manual/live verification: trigger `/compact` on a real Claude Code session with a large enough context that compaction visibly runs past 120s (or temporarily lower `COMPACTING_DEAD_SECS` for testing), confirm the pane shows only "Compacting… Ns" throughout with no "Agent unresponsive" banner, and confirm a genuinely killed process during that window still eventually surfaces the banner once `COMPACTING_DEAD_SECS` elapses.
+
+## 6. Open questions for the operator
+
+1. Confirm or adjust the proposed `COMPACTING_DEAD_SECS` = 600s ceiling (§3.1).
+2. Whether to investigate the `Task`/subagent-dispatch hypothesis (§1.1) now, or wait and see if it recurs after the compaction fix ships — since compaction may well have been the entirety of "other times."
+3. Whether a real `AgentHealth::Compacting` state (vs. reusing `Healthy`) is wanted for future observability, given `agenthealth`'s current "no frontend subscriber" status (§3.1).
+
+---
+
+## Sources
+
+- `agentmux-srv/src/backend/blockcontroller/health.rs` — the detector itself
+- `docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md` §2.7/§4 — original design intent and incident history for the Unresponsive/Restart feature
+- `docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md` — compaction visibility feature this spec closes a gap against, including the real 231.6s captured duration and the "no intermediate progress signal" finding (§7 Tier 4)
+- `agentmux-bashwrap/src/precompact.rs`, `agentmux-bashwrap/src/wps_client.rs` — `PreCompact` hook → `compaction_started` WPS publish
+- `agentmux-srv/src/server/mod.rs` (`handle_wps_publish`), `agentmux-srv/src/backend/blockcontroller/mod.rs` (`get_controller`, `Controller` trait) — proposed wiring points
+- `agentmux-srv/src/backend/blockcontroller/persistent.rs`, `subprocess/host_spawn.rs`, `subprocess/container_spawn.rs` — existing `classify_output_line`/`record_output` call sites, proposed `compact_boundary` interception points
+- `frontend/app/view/agent/hooks/useAgentFailure.ts`, `frontend/app/view/agent/failure/failure-accessory.ts` — where "Agent unresponsive" is actually rendered


### PR DESCRIPTION
## Summary

`HealthMonitor`'s silence-based Unresponsive/Restart detector fires after 120s with no output on an active turn. Claude Code context compaction is a single opaque LLM call producing zero intermediate output — the repo's own compaction spec captured a real example taking 231.6s, nearly double that threshold — so a normal auto-compaction routinely trips the detector while the pane is simultaneously showing "Compacting…", then self-heals ~90s later once the real `compact_boundary` frame lands. The two features (unresponsive detection, 07-27; compaction visibility, 07-31) were built three weeks apart and never made aware of each other.

Full root-cause analysis and design: `docs/specs/SPEC_UNRESPONSIVE_FALSE_POSITIVE_DURING_COMPACTION_2026_08_22.md`.

## Changes

- `HealthMonitor` gains a `compacting` flag that suspends the normal 30s/120s Stalled/Dead thresholds while true, bounded by a separate, much more generous 600s ceiling — so a genuine hang mid-compaction is still eventually caught, not permanently hidden.
- `set_compacting(false)` deliberately does NOT reset `last_meaningful_ts` — resuming re-arms the normal thresholds against whatever silence has already elapsed, not a fresh grace period.
- New `Controller::health_monitor()` trait accessor (default `None`, overridden by the three controller types that own a `HealthMonitor`) + a small special case in `handle_wps_publish` forwards the existing `compaction_started` WPS event (already published by the `PreCompact` hook) into the target block's health monitor.
- New `is_compact_boundary_frame()` check at each of the three controller stdout-reader loops that already classify raw NDJSON lines — clears `compacting` the instant the real `compact_boundary` frame arrives.
- `ACP` controllers are deliberately untouched — not the Claude Code stream-json path the compaction feature targets, matching the original compaction spec's own provider scoping.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2689 passed, 0 failed (one pre-existing, unrelated, already-tracked flaky handle-count test on this machine skipped — `docs/status/STATUS_SRV_SECTION_HANDLE_LEAK_LIVE_RECURRENCE_2026_08_19.md`)
- [x] New unit tests in `health.rs`: compacting suppresses Stalled/Dead despite stale output; the 600s ceiling still reaches Dead; exactly-under-ceiling stays Healthy; non-compacting behavior is byte-for-byte unchanged; `set_compacting(false)` grants no fresh grace period; a Dead reached via the ceiling still publishes a real `AgentFailure`
- [x] New integration tests in `server/tests.rs`: a `compaction_started` publish reaches the target block's `HealthMonitor`; an unregistered block id is a harmless no-op, never an HTTP error

<!-- agentmux:agent_id=agent1 -->