### PR TITLE
Camper@claudius: fix(agent): make cross-channel resume session_id a live pointer, not write-once

### DIFF
--- a/.changesets/1787441148-fix-agent-propagate-resumed-session-id-to-shared-cross-chann-x7xr.md
+++ b/.changesets/1787441148-fix-agent-propagate-resumed-session-id-to-shared-cross-chann-x7xr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): propagate resumed session_id to shared cross-channel registry

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1643,6 +1643,7 @@ impl Store {
             )?;
         }
         self.registry_upsert_if_named(inst);
+        self.registry_propagate_continuation_session_id(inst);
         // Mirror new instance into db_agents.
         self.agents_dual_write_instance_create(inst)?;
         Ok(())
@@ -2131,6 +2132,7 @@ impl Store {
         let fresh = self.instance_get(id)?;
         if let Some(f) = &fresh {
             self.registry_upsert_if_named(f);
+            self.registry_propagate_continuation_session_id(f);
             // Mirror update to db_agents.
             self.agents_dual_write_instance_update(f)?;
         }
@@ -2173,6 +2175,7 @@ impl Store {
             // mirror exact.
             if let Ok(Some(fresh)) = self.instance_get(&inst.id) {
                 self.registry_upsert_if_named(&fresh);
+                self.registry_propagate_continuation_session_id(&fresh);
                 // Mirror status fields to db_agents.
                 self.agents_dual_write_instance_update(&fresh)?;
             }

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1643,7 +1643,14 @@ impl Store {
             )?;
         }
         self.registry_upsert_if_named(inst);
-        self.registry_propagate_continuation_session_id(inst);
+        // A freshly created row's session_id is never a genuine capture —
+        // production always creates continuations with session_id = ""
+        // (see registry_propagate_continuation_session_id's doc comment).
+        // Skip so we don't clobber the chain root's still-valid registry
+        // pointer with an empty one on every ordinary "Continue agent".
+        if !inst.session_id.is_empty() {
+            self.registry_propagate_continuation_session_id(inst);
+        }
         // Mirror new instance into db_agents.
         self.agents_dual_write_instance_create(inst)?;
         Ok(())
@@ -2132,7 +2139,18 @@ impl Store {
         let fresh = self.instance_get(id)?;
         if let Some(f) = &fresh {
             self.registry_upsert_if_named(f);
-            self.registry_propagate_continuation_session_id(f);
+            // Only propagate when THIS call actually targeted session_id —
+            // `upd.session_id` is `None` for e.g. a bare status change, in
+            // which case `f.session_id` just reflects whatever the row
+            // already had (possibly still empty, pre-first-capture) and
+            // propagating it would clobber a valid root pointer for no
+            // reason. `Some("")` (poison_resume's deliberate stale-resume
+            // clear) and `Some(real_sid)` (a genuine capture) both DO mean
+            // this call wrote session_id and must propagate either way —
+            // see registry_propagate_continuation_session_id's doc comment.
+            if upd.session_id.is_some() {
+                self.registry_propagate_continuation_session_id(f);
+            }
             // Mirror update to db_agents.
             self.agents_dual_write_instance_update(f)?;
         }

--- a/agentmux-srv/src/backend/storage/registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/registry_mirror.rs
@@ -218,4 +218,83 @@ impl Store {
             }
         }
     }
+
+    /// Propagate a fresh `session_id` onto the chain-root registry record
+    /// when `inst` is a **continuation** row (`parent_instance_id` set).
+    ///
+    /// `registry_upsert_if_named` above deliberately excludes continuation
+    /// rows from the mirror (see its filter comment — kept symmetric with
+    /// `instance_list_named`'s legacy dropdown mode so a resume chain
+    /// doesn't fragment into N registry files). That's correct for most
+    /// fields, but it leaves the registry's `session_id` — the ONE field a
+    /// cross-channel/cross-build reader consults to `--resume` this agent —
+    /// stuck at whatever the chain head had when first mirrored, never
+    /// updated by any later resume. Root cause of
+    /// docs/retro/retro-agent-resumed-9-day-stale-session-2026-08-22.md:
+    /// reopening the agent in a different channel silently resumed a
+    /// stale-but-valid session instead of the live one.
+    ///
+    /// Read-modify-write against the existing root record (never
+    /// constructs a partial one — `Registry::upsert`'s merge overwrites
+    /// every field present in the struct). Best-effort: logs and returns
+    /// on any lookup/write failure, since the SQLite write already
+    /// succeeded and remains authoritative.
+    pub(super) fn registry_propagate_continuation_session_id(&self, inst: &AgentInstance) {
+        if inst.parent_instance_id.is_empty() {
+            return; // chain head — already covered by registry_upsert_if_named.
+        }
+        let Some(reg) = self.shared_agent_registry() else {
+            return;
+        };
+        let root_id = self.find_chain_root_id(inst);
+        if root_id == inst.id {
+            return;
+        }
+        let mut rec = match reg.get(&root_id) {
+            Ok(Some(rec)) => rec,
+            Ok(None) => return, // root was never named/mirrored — nothing to update.
+            Err(e) => {
+                tracing::warn!(
+                    instance_id = %inst.id,
+                    root_id = %root_id,
+                    error = %e,
+                    "registry: failed to read chain-root record for session_id propagation"
+                );
+                return;
+            }
+        };
+        let fresh_session_id = empty_to_none(&inst.session_id);
+        if rec.data.session_id == fresh_session_id {
+            return; // already current — skip the write.
+        }
+        rec.data.session_id = fresh_session_id;
+        rec.schema_version = rec.data.min_schema_version().max(rec.schema_version);
+        if let Err(e) = reg.upsert(&rec) {
+            tracing::warn!(
+                instance_id = %inst.id,
+                root_id = %root_id,
+                error = %e,
+                "registry: failed to propagate continuation session_id to chain root"
+            );
+        }
+    }
+
+    /// Walk `parent_instance_id` upward from `inst` to find the chain
+    /// root — the row with no parent, or an orphan whose parent no longer
+    /// exists (mirrors `instance_list_named`'s recursive-CTE orphan-as-root
+    /// anchor). Bounded to guard against a corrupted cyclic chain; real
+    /// chains are a handful of user-driven resumes deep.
+    fn find_chain_root_id(&self, inst: &AgentInstance) -> String {
+        let mut current = inst.clone();
+        for _ in 0..64 {
+            if current.parent_instance_id.is_empty() {
+                return current.id;
+            }
+            match self.instance_get(&current.parent_instance_id) {
+                Ok(Some(parent)) => current = parent,
+                _ => return current.id, // orphan: parent missing/unreadable.
+            }
+        }
+        current.id
+    }
 }

--- a/agentmux-srv/src/backend/storage/registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/registry_mirror.rs
@@ -243,6 +243,20 @@ impl Store {
         if inst.parent_instance_id.is_empty() {
             return; // chain head — already covered by registry_upsert_if_named.
         }
+        if inst.session_id.is_empty() {
+            // No live session_id captured on THIS row yet. `instance_create`
+            // calls this on every new continuation, and `createagentinstance`
+            // always creates one with session_id = "" (the RPC's
+            // `CommandCreateAgentInstanceData` has no session_id field at
+            // all — it's only ever set later via a genuine capture). If we
+            // propagated an empty value here, every ordinary "Continue
+            // agent" click would immediately clobber the chain root's still-
+            // valid registry session_id with None before the new
+            // continuation's own id is ever captured — reagent P1 on PR
+            // #2755, a self-inflicted regression of the exact field this
+            // fix exists to make more reliable.
+            return;
+        }
         let Some(reg) = self.shared_agent_registry() else {
             return;
         };
@@ -280,10 +294,23 @@ impl Store {
     }
 
     /// Walk `parent_instance_id` upward from `inst` to find the chain
-    /// root — the row with no parent, or an orphan whose parent no longer
-    /// exists (mirrors `instance_list_named`'s recursive-CTE orphan-as-root
-    /// anchor). Bounded to guard against a corrupted cyclic chain; real
-    /// chains are a handful of user-driven resumes deep.
+    /// root — the row with no parent. Bounded to guard against a
+    /// corrupted cyclic chain; real chains are a handful of user-driven
+    /// resumes deep.
+    ///
+    /// When a lookup misses locally, returns `current.parent_instance_id`
+    /// (the id we couldn't resolve), NOT `current.id`. Two cases produce a
+    /// local miss and both want that: (1) the id is a genuinely orphaned
+    /// continuation (its head was hard-deleted, no FK cascade) — the
+    /// registry has no file for it either, so the caller's `reg.get`
+    /// harmlessly no-ops; (2) the id is the chain root living in a
+    /// DIFFERENT channel's local SQLite — this store never has that row,
+    /// but the shared registry still does, under exactly this id. That
+    /// second case is the primary scenario this propagation exists for
+    /// (reopening an agent in another channel/build): `current.id` is a
+    /// continuation's own id, which never has a registry file (reagent P1
+    /// on PR #2755 — the original fallback made cross-channel propagation
+    /// always no-op, defeating the fix for its own target case).
     fn find_chain_root_id(&self, inst: &AgentInstance) -> String {
         let mut current = inst.clone();
         for _ in 0..64 {
@@ -292,7 +319,7 @@ impl Store {
             }
             match self.instance_get(&current.parent_instance_id) {
                 Ok(Some(parent)) => current = parent,
-                _ => return current.id, // orphan: parent missing/unreadable.
+                _ => return current.parent_instance_id.clone(),
             }
         }
         current.id

--- a/agentmux-srv/src/backend/storage/registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/registry_mirror.rs
@@ -239,23 +239,22 @@ impl Store {
     /// every field present in the struct). Best-effort: logs and returns
     /// on any lookup/write failure, since the SQLite write already
     /// succeeded and remains authoritative.
+    ///
+    /// Callers decide WHETHER to invoke this at all based on whether
+    /// `inst.session_id` reflects a genuine write, not just this
+    /// function — an empty `session_id` is ambiguous in isolation: it can
+    /// mean "never captured yet" (a fresh continuation — must NOT
+    /// propagate, would clobber a still-valid root pointer, reagent P1 on
+    /// PR #2755) or "deliberately cleared" (`poison_resume`'s stale-resume
+    /// handling, via `persist_session_id(block_id, "", ...)` on an
+    /// EXISTING row — MUST propagate, otherwise the shared registry keeps
+    /// serving a session_id already proven dead, reagent P1 round 2). Only
+    /// the caller knows which case it's in (create vs. an explicit
+    /// `InstanceUpdate.session_id` write), so this function itself never
+    /// special-cases emptiness — it always mirrors whatever it's given.
     pub(super) fn registry_propagate_continuation_session_id(&self, inst: &AgentInstance) {
         if inst.parent_instance_id.is_empty() {
             return; // chain head — already covered by registry_upsert_if_named.
-        }
-        if inst.session_id.is_empty() {
-            // No live session_id captured on THIS row yet. `instance_create`
-            // calls this on every new continuation, and `createagentinstance`
-            // always creates one with session_id = "" (the RPC's
-            // `CommandCreateAgentInstanceData` has no session_id field at
-            // all — it's only ever set later via a genuine capture). If we
-            // propagated an empty value here, every ordinary "Continue
-            // agent" click would immediately clobber the chain root's still-
-            // valid registry session_id with None before the new
-            // continuation's own id is ever captured — reagent P1 on PR
-            // #2755, a self-inflicted regression of the exact field this
-            // fix exists to make more reliable.
-            return;
         }
         let Some(reg) = self.shared_agent_registry() else {
             return;

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -2395,6 +2395,103 @@
             "no registry file should be created when the chain root was never named/mirrored");
     }
 
+    #[test]
+    fn continuation_create_with_empty_session_id_does_not_clobber_root() {
+        // Reagent P1 on PR #2755: `createagentinstance`'s real RPC handler
+        // always creates a fresh continuation row with session_id = "" (no
+        // session_id field on CommandCreateAgentInstanceData at all — it's
+        // only ever set later via a genuine capture). Every ordinary
+        // "Continue agent" click must NOT clobber the chain root's
+        // still-valid registry session_id with None before the new
+        // continuation captures its own.
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let head = make_named_inst("inst-head3", "demoNoClobber", &agents_root);
+        store.instance_create(&head).unwrap();
+        use crate::backend::storage::InstanceUpdate;
+        store
+            .instance_update_partial(
+                "inst-head3",
+                &InstanceUpdate { session_id: Some("sess-still-valid".into()), ..Default::default() },
+            )
+            .unwrap();
+        assert_eq!(
+            reg.get("inst-head3").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-still-valid")
+        );
+
+        // Matches the real RPC handler: a brand new continuation row with
+        // an empty session_id (default from make_named_inst).
+        let mut cont = make_named_inst("inst-cont3", "demoNoClobber", &agents_root);
+        cont.parent_instance_id = "inst-head3".to_string();
+        assert_eq!(cont.session_id, "", "precondition: matches real creation shape");
+        store.instance_create(&cont).unwrap();
+
+        assert_eq!(
+            reg.get("inst-head3").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-still-valid"),
+            "creating a fresh (session-less) continuation must not clobber the root's live session_id"
+        );
+    }
+
+    #[test]
+    fn continuation_session_id_propagates_when_chain_root_lives_in_another_channel() {
+        // Reagent P1 on PR #2755: the primary scenario this whole fix
+        // exists for is cross-channel — the chain root's SQLite row lives
+        // in a DIFFERENT channel's local store, so `instance_get` on the
+        // parent id always misses locally. `find_chain_root_id` must still
+        // resolve to that (unreachable-locally-but-registry-valid) parent
+        // id, not fall back to the continuation's own id (which never has
+        // a registry file, silently defeating the whole fix).
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        // Seed a registry record for a "foreign" root with NO matching
+        // local SQLite row — simulates a root instance that lives in
+        // another channel's own database.
+        reg.upsert(&crate::registry::NamedAgentRecord {
+            schema_version: crate::registry::MAX_SUPPORTED_SCHEMA,
+            data: crate::registry::NamedAgentRecordV1 {
+                instance_id: "inst-foreign-root".to_string(),
+                instance_name: "crossChannelAgent".to_string(),
+                definition_id: "def-mirror".to_string(),
+                identity_id: None,
+                memory_id: None,
+                session_id: Some("sess-stale-from-other-channel".to_string()),
+                working_dir: "crossChannelAgent-fixture".to_string(),
+                source_agents_base: None,
+                created_at_ms: 100,
+                last_launched_at_ms: 100,
+                created_by_version: "0.55.18".to_string(),
+                last_launched_by_version: "0.55.18".to_string(),
+            },
+        })
+        .unwrap();
+        assert!(
+            store.instance_get("inst-foreign-root").unwrap().is_none(),
+            "precondition: root has no local SQLite row (lives in another channel)"
+        );
+
+        // This channel resumes the agent: a new local continuation row
+        // pointing at the foreign root, with a freshly captured session_id.
+        let mut cont = make_named_inst("inst-local-cont", "crossChannelAgent", &agents_root);
+        cont.parent_instance_id = "inst-foreign-root".to_string();
+        cont.session_id = "sess-fresh-this-channel".to_string();
+        store.instance_create(&cont).unwrap();
+
+        assert!(
+            reg.get("inst-local-cont").unwrap().is_none(),
+            "the local continuation itself must never get its own registry file"
+        );
+        assert_eq!(
+            reg.get("inst-foreign-root").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-fresh-this-channel"),
+            "propagation must reach the foreign root's registry record even though \
+             it has no local SQLite row"
+        );
+    }
+
     // ----------------------------------------------------------------
     // Phase 3a — db_agents dual-write coverage
     // ----------------------------------------------------------------

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -2492,6 +2492,92 @@
         );
     }
 
+    #[test]
+    fn continuation_explicit_session_id_clear_propagates_to_root() {
+        // Reagent P1 round 2 on PR #2755: `poison_resume`'s stale-resume
+        // handling deliberately clears an EXISTING continuation's
+        // session_id to "" (persist_session_id(block_id, "", ...) when a
+        // --resume is confirmed dead — persistent.rs:2384). That's a
+        // genuine, intentional write, not "never captured yet" — it MUST
+        // reach the shared registry, or another channel keeps getting
+        // handed a session_id already proven unreachable.
+        use crate::backend::storage::InstanceUpdate;
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let head = make_named_inst("inst-head-clear", "demoClear", &agents_root);
+        store.instance_create(&head).unwrap();
+        store
+            .instance_update_partial(
+                "inst-head-clear",
+                &InstanceUpdate { session_id: Some("sess-1".into()), ..Default::default() },
+            )
+            .unwrap();
+
+        let mut cont = make_named_inst("inst-cont-clear", "demoClear", &agents_root);
+        cont.parent_instance_id = "inst-head-clear".to_string();
+        cont.session_id = "sess-2".to_string();
+        store.instance_create(&cont).unwrap();
+        assert_eq!(
+            reg.get("inst-head-clear").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-2")
+        );
+
+        // The continuation's --resume is confirmed dead: explicit clear.
+        store
+            .instance_update_partial(
+                "inst-cont-clear",
+                &InstanceUpdate { session_id: Some(String::new()), ..Default::default() },
+            )
+            .unwrap();
+        assert_eq!(
+            reg.get("inst-head-clear").unwrap().unwrap().data.session_id,
+            None,
+            "a deliberate clear on an existing continuation must propagate to the root"
+        );
+    }
+
+    #[test]
+    fn continuation_unrelated_field_update_does_not_touch_root_session_id() {
+        // A status-only update on a continuation (session_id untouched,
+        // `InstanceUpdate.session_id` is `None`) must NOT re-propagate
+        // whatever the row's session_id currently happens to be — if it's
+        // still empty (pre-first-capture), that would clobber the root's
+        // valid pointer for a completely unrelated field change.
+        use crate::backend::storage::InstanceUpdate;
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let head = make_named_inst("inst-head-unrelated", "demoUnrelated", &agents_root);
+        store.instance_create(&head).unwrap();
+        store
+            .instance_update_partial(
+                "inst-head-unrelated",
+                &InstanceUpdate { session_id: Some("sess-root-valid".into()), ..Default::default() },
+            )
+            .unwrap();
+
+        // Continuation created session-less (matches real creation shape).
+        let mut cont = make_named_inst("inst-cont-unrelated", "demoUnrelated", &agents_root);
+        cont.parent_instance_id = "inst-head-unrelated".to_string();
+        store.instance_create(&cont).unwrap();
+        assert_eq!(cont.session_id, "");
+
+        // An unrelated status update — session_id is NOT part of this call.
+        store
+            .instance_update_partial(
+                "inst-cont-unrelated",
+                &InstanceUpdate { status: Some("stopped".into()), ..Default::default() },
+            )
+            .unwrap();
+
+        assert_eq!(
+            reg.get("inst-head-unrelated").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-root-valid"),
+            "an update that doesn't touch session_id must not clobber the root's pointer"
+        );
+    }
+
     // ----------------------------------------------------------------
     // Phase 3a — db_agents dual-write coverage
     // ----------------------------------------------------------------

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -2287,6 +2287,115 @@
     }
 
     // ----------------------------------------------------------------
+    // Cross-channel resume: continuation session_id propagation
+    // (docs/retro/retro-agent-resumed-9-day-stale-session-2026-08-22.md)
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn continuation_session_id_propagates_to_chain_root_registry_record() {
+        // registry_upsert_if_named excludes continuation rows from the
+        // mirror entirely (avoids fragmenting one resume chain into N
+        // registry files). Without propagation, a resume's fresh
+        // session_id never reaches the registry record another
+        // channel/build actually reads for `--resume` — this is the exact
+        // bug from the retro. The head's OWN registry file must carry the
+        // continuation's session_id after the resume.
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let head = make_named_inst("inst-head", "demoResume", &agents_root);
+        store.instance_create(&head).unwrap();
+        assert_eq!(
+            reg.get("inst-head").unwrap().unwrap().data.session_id,
+            None,
+            "precondition: head created with no session_id"
+        );
+
+        let mut cont = make_named_inst("inst-cont", "demoResume", &agents_root);
+        cont.parent_instance_id = "inst-head".to_string();
+        cont.session_id = "sess-resumed-1".to_string();
+        store.instance_create(&cont).unwrap();
+
+        // The continuation itself must NOT get its own registry file
+        // (would fragment the picker into duplicate entries).
+        assert!(reg.get("inst-cont").unwrap().is_none());
+        assert_eq!(
+            reg.get("inst-head").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-resumed-1"),
+            "head's registry record must reflect the continuation's session_id"
+        );
+
+        // A later session_id update on the SAME continuation row (e.g. a
+        // fresh capture mid-turn, not a brand new resume) must also
+        // propagate — this is the `instance_update_partial` path
+        // `persist_session_id` actually calls.
+        use crate::backend::storage::InstanceUpdate;
+        store
+            .instance_update_partial(
+                "inst-cont",
+                &InstanceUpdate { session_id: Some("sess-resumed-2".into()), ..Default::default() },
+            )
+            .unwrap();
+        assert_eq!(
+            reg.get("inst-head").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-resumed-2"),
+            "a later session_id update on the continuation must also propagate to the head"
+        );
+    }
+
+    #[test]
+    fn continuation_session_id_propagation_walks_multi_hop_chain() {
+        // head -> cont1 -> cont2: cont2's session_id must land on the
+        // ORIGINAL head's registry record, not cont1's (cont1 never got
+        // its own registry file either).
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let head = make_named_inst("inst-head2", "demoChain", &agents_root);
+        store.instance_create(&head).unwrap();
+
+        let mut cont1 = make_named_inst("inst-cont1", "demoChain", &agents_root);
+        cont1.parent_instance_id = "inst-head2".to_string();
+        cont1.session_id = "sess-1".to_string();
+        store.instance_create(&cont1).unwrap();
+
+        let mut cont2 = make_named_inst("inst-cont2", "demoChain", &agents_root);
+        cont2.parent_instance_id = "inst-cont1".to_string();
+        cont2.session_id = "sess-2".to_string();
+        store.instance_create(&cont2).unwrap();
+
+        assert!(reg.get("inst-cont1").unwrap().is_none());
+        assert!(reg.get("inst-cont2").unwrap().is_none());
+        assert_eq!(
+            reg.get("inst-head2").unwrap().unwrap().data.session_id.as_deref(),
+            Some("sess-2"),
+            "multi-hop chain must resolve all the way to the original head"
+        );
+    }
+
+    #[test]
+    fn continuation_session_id_propagation_noop_when_root_never_mirrored() {
+        // Head row's own instance_name is empty (never mirrored — no
+        // registry file exists for it at all). Propagation must no-op,
+        // not error or create a stray file.
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+
+        let mut head = make_named_inst("inst-unnamed-head", "demoUnnamed", &agents_root);
+        head.instance_name = String::new();
+        store.instance_create(&head).unwrap();
+        assert!(reg.get("inst-unnamed-head").unwrap().is_none());
+
+        let mut cont = make_named_inst("inst-unnamed-cont", "demoUnnamed", &agents_root);
+        cont.parent_instance_id = "inst-unnamed-head".to_string();
+        cont.session_id = "sess-orphan".to_string();
+        store.instance_create(&cont).unwrap();
+
+        assert!(reg.list_active().unwrap().is_empty(),
+            "no registry file should be created when the chain root was never named/mirrored");
+    }
+
+    // ----------------------------------------------------------------
     // Phase 3a — db_agents dual-write coverage
     // ----------------------------------------------------------------
 

--- a/agentmux-srv/src/registry/store.rs
+++ b/agentmux-srv/src/registry/store.rs
@@ -136,6 +136,22 @@ impl Registry {
         self.active_path(instance_id).exists()
     }
 
+    /// Read a single active record by id, without scanning the whole
+    /// tree. `Ok(None)` when there's no active file for `instance_id`
+    /// (never checks `retired/`). Callers that need to patch a single
+    /// field (e.g. propagating a fresh `session_id`) must read-modify-
+    /// upsert via this rather than constructing a partial record —
+    /// `upsert`'s merge overwrites every field present in the struct,
+    /// so a partially-populated record would clobber the rest with
+    /// defaults.
+    pub fn get(&self, instance_id: &str) -> Result<Option<NamedAgentRecord>, RegistryError> {
+        let path = self.active_path(instance_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(read_and_validate(&path, instance_id)?))
+    }
+
     /// Whether a record exists in either active or retired. Used by
     /// migration to skip already-tombstoned records (avoid
     /// resurrecting a user's deliberate "Forget agent" via a

--- a/agentmux-srv/src/registry/tests.rs
+++ b/agentmux-srv/src/registry/tests.rs
@@ -52,6 +52,29 @@ fn upsert_update_replaces_known_fields() {
 }
 
 #[test]
+fn get_returns_none_for_missing_record() {
+    let (_t, reg) = fresh();
+    assert!(reg.get("nope").unwrap().is_none());
+}
+
+#[test]
+fn get_returns_existing_active_record() {
+    let (_t, reg) = fresh();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    let got = reg.get("aaa").unwrap().unwrap();
+    assert_eq!(got.data.instance_name, "demo");
+    assert_eq!(got.data.last_launched_at_ms, 100);
+}
+
+#[test]
+fn get_does_not_see_retired_records() {
+    let (_t, reg) = fresh();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    reg.retire("aaa").unwrap();
+    assert!(reg.get("aaa").unwrap().is_none());
+}
+
+#[test]
 fn retire_then_unretire_round_trips() {
     let (_t, reg) = fresh();
     reg.upsert(&record("aaa", "demo", 100)).unwrap();

--- a/docs/retro/retro-agent-resumed-9-day-stale-session-2026-08-22.md
+++ b/docs/retro/retro-agent-resumed-9-day-stale-session-2026-08-22.md
@@ -1,0 +1,215 @@
+# Retro: Reopening a Persistent Agent Silently Resumed a Session 9 Days Stale
+
+**Date:** 2026-08-22
+**Severity:** High — no data loss on disk, but the user was talking to an
+agent that believed it was 9 days in the past, had no memory of ~9 days of
+real intervening work (4+ merged PRs), and generated a status summary
+describing work that never happened in its own timeline. No error or
+warning was ever surfaced.
+**Observed by:** the user, directly — noticed the agent ("Camper")
+responded with a summary of unrelated work (Warden Supervisor /
+harness-model-vendor-decoupling / a fabricated-sounding "Antigravity"
+provider) when the actual most recent conversation had been about the
+Agent Picker / Armory rename / CLAUDE.md ownership protection work.
+**Related:** `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
+(root-caused the underlying mechanism two days before this incident),
+PR #2693 / #2699 (partial fix, merged the day before this incident), PR
+#1479 (introduced `session_backfill.rs`, whose intended cross-channel
+continuity guarantee this bug defeats).
+
+---
+
+## TL;DR
+
+The user closed this agent ("Camper") while it was running in an older
+AgentMux build, then reopened the same named agent in a freshly-launched
+`0.55.20` portable build — a different channel, per this repo's per-build
+data isolation. On reopen, the CLI was `--resume`d against the shared
+cross-channel registry's `session_id` for Camper. That value was written
+**once**, the very first time `backfill_session_ids` ever ran for this
+record, and has never been refreshed since — a known, previously
+root-caused defect
+(`STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`). In this
+incident the stale id happened to point at a **real, still-valid session
+file** from 2026-08-13 (right after this agent's own PR #2558 merged) —
+9 days and roughly 4 more real merged PRs before "now." Because that
+session file genuinely exists and is genuinely readable, the CLI's
+`--resume` call **succeeded**, not failed. The user saw a fully coherent,
+plausible-looking conversation resume — just one frozen 9 days in the
+past — with zero errors, warnings, or any other signal that anything was
+wrong.
+
+This is a **new manifestation of an old, only-partially-fixed bug class**:
+the fix that landed the day before this incident (#2693/#2699) only
+covers the case where the stale `--resume` is **confirmed unreachable**
+(the CLI rejects it outright). It does nothing for the case reproduced
+here, where the stale id is still a perfectly valid, resumable session —
+just not the *latest* one. That's a strictly worse failure mode: a
+rejected resume at least produces a WARN in the srv log; a stale-but-valid
+resume produces nothing at all.
+
+---
+
+## What happened, in the user's words
+
+> "you picked up on a bad history .. i were not working on antigravity ..
+> this is what you last said: [a summary of merged PRs #2715, #2731,
+> #2732, #2734, #2747 — muxspect Phase A, Agent Picker cleanup, Armory
+> rename, CLAUDE.md ownership protection] ... but this is an opportunity
+> to fix this .. first of all, it still takes a long time for an existing
+> agent to load ... and while it is loading, it is showing garbage, like
+> old long-running processes that are s[t]ock[ed]. Then the actual
+> conversation that loads is wrong ... note, i closed the previous agent
+> in an older version and opened it here, in 55.20 a portable instance"
+
+The agent's own working context, at the time this was raised, was a long
+conversation that ended with PR #2558 ("feat(agent): expose model vendor
+/ custom endpoint UI + add Antigravity harness") — real work, genuinely
+merged, but from **2026-08-13**. The agent had no memory of anything after
+that point and, when asked "are you there?", responded as if #2558 were
+the most recent thing that had happened.
+
+## Confirming this wasn't a hallucination — ground-truthing against real git history
+
+Before proposing any fix, the actual merge timestamps of both the agent's
+own remembered PRs and the user-described PRs were checked directly
+against GitHub (`gh pr view <n> --json mergedAt`), not trusted from either
+party's memory:
+
+| PR | Title | Merged |
+|---|---|---|
+| #2552–2557 | Warden Supervisor build-out (this agent's session) | 2026-08-12 22:14 → 2026-08-13 00:16 |
+| #2558 | harness/model-vendor UI + Antigravity (this agent's session) | 2026-08-13 07:04 |
+| #2715 | muxspect Phase A | 2026-08-22 03:21 |
+| #2731 / #2732 | Agent Picker heading/typo fixes | 2026-08-22 18:57 / 19:08 |
+| #2734 | Armory rename (Memories → Global/Personal Memory) | 2026-08-22 19:33 |
+| #2747 | CLAUDE.md ownership protection | 2026-08-22 22:43 |
+
+Both sets of PRs are 100% real — the same agent identity/conversation
+genuinely did all of them, in that order, over roughly 9 real days. This
+was never two conversations colliding; it's one continuous conversation
+whose active context got rolled back by ~9 days on reopen. Corroborating
+evidence from the agent's own transcript: a `currentDate` system message
+early in the resumed context read `2026-08-22` (correct), then partway
+through — right around a `task changeset` invocation — a *different*
+system message announced "the date has changed, today is now
+2026-08-13" (the clock moved **backward**), consistent with the harness
+re-deriving "now" from a resumed session whose own embedded state was
+frozen at that earlier date.
+
+## Root cause
+
+Traced directly against `STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
+(written 2026-08-20, two days before this incident) and confirmed still
+accurate against the current `agentmux-srv/src/backend/session_backfill.rs`
+on `main` as of this writing:
+
+1. Two independent, non-synchronized places track "this agent's session
+   id": the local, per-channel `db_agent_instances.session_id` (kept
+   genuinely live by `persist_session_id`, but never leaves its own
+   channel's SQLite file), and the shared, cross-channel `Registry`
+   record's `session_id` — the one place a *different* channel/instance
+   actually reads when deciding what to `--resume`.
+2. The shared registry's `session_id` is populated by
+   `session_backfill::backfill_session_ids`, whose own doc comment says
+   plainly: *"Idempotent (skips records that already carry a non-empty
+   id)."* Confirmed still true on `main` (`agentmux-srv/src/backend/session_backfill.rs:125`,
+   `continue; // already wired`). Nothing in production code ever
+   re-validates or refreshes an already-non-empty registry `session_id`
+   against what's actually live.
+3. **Net effect (unchanged since 2026-08-20):** the shared registry's
+   `session_id` for any long-running named agent is only ever as good as
+   the *first* value it happened to get, with no self-healing and no
+   user-visible warning, for however long the agent keeps running
+   continuously in its original channel.
+
+### Why the existing fix (#2693 / #2699, merged the day before this incident) didn't help here
+
+PR #2693 added `find_recovery_session_id` / `find_largest_session_for_working_dir`:
+when a `--resume <sid>` attempt is **confirmed unreachable** (the CLI
+rejects it, srv logs a WARN), the retry now scans on-disk sessions for the
+largest one instead of unconditionally starting blank. This is a real,
+well-tested improvement over the pre-#2693 behavior (unconditional blank
+fallback) — but it is gated entirely on a **confirmed failure**.
+
+In this incident, the stale registry `session_id` pointed at a session
+file from 2026-08-13 that **still exists and is still perfectly readable**
+— it's a real, complete, coherent 9-day-old conversation, not a corrupt or
+missing file. The CLI's `--resume` call against it **succeeds**. There is
+no WARN, no retry, no fallback path triggered at all — `retry_after_resume_failure`
+and its new recovery logic never run, because nothing failed. The pane
+simply, silently, successfully resumes into the wrong (stale but valid)
+conversation. This is a **strictly harder case to detect** than the one
+#2693 fixed: a failed resume at least leaves a log trail; a
+stale-but-successful resume leaves none.
+
+This matches recommendation #1 from the original status doc, explicitly
+flagged there as *"not implemented here"*:
+
+> "Make the shared registry `session_id` a live pointer, not a
+> write-once value... or that record should stop being trusted as
+> authoritative and instead be recomputed fresh... whenever a `--resume`
+> attempt is about to be made rather than relying on a value that might
+> be arbitrarily old."
+
+That recommendation is still open on `main` as of this retro.
+
+## Secondary observation (lower confidence, not independently confirmed this session)
+
+The user also reported: *"it still takes a long time for an existing
+agent to load... and while it is loading, it is showing garbage, like old
+long-running processes that are stuck."* This wasn't traced with the same
+rigor as the session-resume issue above (no live repro / log access this
+session), but two prior, related fixes are worth checking against for a
+possible regression or an uncovered edge case, since both are exactly
+"stale process/task state visible in the UI":
+
+- `retro-stuck-background-dock-timer-2026-08-10.md` (issue #2518, fixed
+  by #2519/#2520) — Activity Dock rows stuck showing "running" forever
+  for backgrounded calls that actually finished synchronously.
+- PR #2726 (`fix(agent-pane): refresh Activity Dock subagent rows on
+  subagent:abandoned`) — a related staleness fix for subagent rows
+  specifically.
+
+Whether the "stuck processes during load" the user saw is a recurrence of
+one of these, a new variant, or an artifact of the SAME stale-session-resume
+sequence (e.g. the pane briefly rendering process/tracker state left over
+from before the resume-vs-fresh decision resolves) is not established
+here and needs its own live reproduction.
+
+## Recommended fix direction
+
+Implement the status doc's recommendation #1, since recommendation #2
+(#2693's on-disk fallback) is now confirmed insufficient on its own:
+
+1. Stop treating the shared registry's `session_id` as authoritative once
+   written. Either propagate `persist_session_id`'s local, genuinely-live
+   writes to the shared cross-channel record on every real capture (not
+   just the one-time backfill), or re-derive the resume target fresh
+   (largest on-disk session for the agent's working dir) every time a
+   `--resume` is about to be attempted from a *different* channel than
+   the one that last wrote it, rather than trusting a value that may be
+   arbitrarily old.
+2. Surface *something* to the user when a persistent agent resumes into a
+   session whose captured timestamp is suspiciously old relative to the
+   pane's own "last active" metadata — even a passive banner ("Resumed a
+   session last active 9 days ago") would have made this immediately
+   legible instead of requiring a manual PR-timestamp audit to catch.
+3. Separately: this agent's own status-summary behavior compounded the
+   problem — asked "are you there?", it answered confidently from stale
+   context with no hedge ("no open PRs, everything's merged and clean")
+   instead of any signal of uncertainty about how much time had passed.
+   Not a code fix, but worth noting: a resumed agent has no reliable way
+   to know its own context is stale unless the product tells it so (point
+   2 above would help this too).
+
+## What this is NOT
+
+- Not data loss. Every real PR from both halves of the conversation is
+  genuinely merged and on `main`; nothing was overwritten or lost on
+  disk. The only thing "lost" was this one pane's *active working
+  context* for ~9 days of the conversation, until the user caught it.
+- Not caused by this session's own work. The `camper/harness-model-vendor-ui`
+  branch and PR #2558 were real, correctly scoped, and are unaffected by
+  this bug — they're simply the point in time the stale resume rolled
+  back to.


### PR DESCRIPTION
## Summary

Root-caused after the agent's own pane resumed a 9-day-stale session on
reopen in a fresh channel (see the retro this PR adds:
`docs/retro/retro-agent-resumed-9-day-stale-session-2026-08-22.md`).

This ties directly to an already-documented, only-partially-fixed bug:
`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
found that the shared cross-channel registry's `session_id` is written
**once** (`session_backfill::backfill_session_ids`, explicitly idempotent —
skips any record that already carries a non-empty value, forever) and never
refreshed after that, even though the *local* per-channel
`db_agent_instances.session_id` stays genuinely live.

PR #2693/#2699 partially addressed this — but only for the case where a
stale `--resume <sid>` is **confirmed unreachable** (the CLI rejects it
outright), falling back to a largest-on-disk-session scan. This incident is
the harder, still-open case: the stale registry id pointed at a session
file that **still exists and is still valid** — so the CLI resume
**succeeds**, silently, with no WARN, no retry, and no fallback ever
triggered. The pane simply, quietly resumes the wrong (stale-but-valid)
conversation.

## Fix (in progress on this branch)

Implementing status doc recommendation #1: make the shared registry
`session_id` a live pointer instead of a write-once value, by propagating
`persist_session_id`'s already-live local writes to the shared
cross-channel registry record on every genuine capture — not just the
one-time backfill.

Opening this as a draft now per the plan (retro first, fix in the same PR);
will push the implementation as follow-up commits.

<!-- agentmux:agent_id=camper -->