### PR TITLE
fix(tabs): quick-fork always inherits identity, dropping the redundant second menu item

### DIFF
--- a/.changesets/1787441538-fix-tabs-quick-fork-always-inherits-identity-dropping-the-re-q6iq.md
+++ b/.changesets/1787441538-fix-tabs-quick-fork-always-inherits-identity-dropping-the-re-q6iq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): quick-fork always inherits identity, dropping the redundant second menu item

--- a/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
+++ b/docs/specs/SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
@@ -324,12 +324,32 @@ so no LAN/WAN qualifier is ever shown — that only becomes relevant if a
 future capability forks directly onto a remote peer, at which point the
 naming spec's tiering (§4.1 there) already covers it without change here.
 
-## 5. Identity: resolving the open question prior specs left unsettled
+## 5. Identity: resolving the open question prior specs left unsettled — **revised 2026-08-22**
 
 **Routing/signing identity (`AGENTMUX_AGENT_ID`, jekt key) is never shared** — this
 falls out of forking the definition regardless of any choice made here (§2). The
 only real decision is **credential identity** (Armory account bindings /
-`db_agent_identity_links`):
+`db_agent_identity_links`).
+
+> **Second correction (2026-08-22, repo-owner-directed).** The original
+> table below described the "inherit" option as "copy rows" and framed it
+> as a meaningfully riskier alternative to "unbound." That premise was
+> wrong: `LinkAgentIdentityCommand` never copies a credential — it only
+> inserts a `db_agent_identity_links` row pointing at an `account_id`. The
+> actual credential (OAuth config dir or keychain entry) lives at a path
+> keyed by `account_id` alone (`identities_dir().join(account_id)`), so
+> *any* agent linked to that account — whether via the fork's own new link
+> or the parent's pre-existing one — reads and writes the exact same
+> shared credential. There is no independent, "safer" copy to withhold by
+> defaulting to unbound; "inherit" and "unbound" aren't a
+> risk/no-risk pair, they're "point the fork at the same shared resource"
+> vs. "don't." Given that, offering both as separate menu actions added a
+> decision with no real safety difference on the other side of it.
+> **Corrected: quick-fork always inherits the source's own bound account,
+> unconditionally** — the second "Quick-fork (inherit identity)" menu
+> entry from Phase 4 was removed; there is now exactly one "Quick-fork"
+> action. The table and "Decision" text immediately below are kept for the
+> historical record of the original (superseded) reasoning.
 
 | Option | Behavior | Risk |
 |---|---|---|
@@ -337,12 +357,13 @@ only real decision is **credential identity** (Armory account bindings /
 | **Unbound (default, recommended)** | Forked agent starts with no Armory bindings, same as any newly-created definition; falls back to the global, non-identity-bound `provider_auth_dir()` path (`agent_open.rs`), matching what a plain agent spawn already does today | Fork may not be able to push/PR under the same identity as the parent without a manual re-bind step |
 | **Explicit choice at fork time** | The long-press/confirmation variant (§4.3) lets the user pick "same identity" or "unbound" per-fork | Adds one decision to the non-default path only — doesn't slow down the common case |
 
-**Decision: unbound by default, explicit opt-in to inherit.** Matches this
-codebase's existing default-secure posture elsewhere (e.g. Armory account
-isolation defaulting to isolated-by-channel per `SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`)
-and avoids a "quick" action having a non-obvious credential-sharing side effect.
-A user who explicitly wants the clone to act as the same GitHub identity opts in
-via the confirmation variant, not the default one-click path.
+**Original decision (superseded): unbound by default, explicit opt-in to inherit.**
+Matches this codebase's existing default-secure posture elsewhere (e.g. Armory
+account isolation defaulting to isolated-by-channel per
+`SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md`) and avoids a "quick"
+action having a non-obvious credential-sharing side effect. A user who
+explicitly wants the clone to act as the same GitHub identity opts in via the
+confirmation variant, not the default one-click path.
 
 ## 6. Phasing
 
@@ -355,7 +376,7 @@ is narrower and different from the original draft's Phase 1:
 | **1** ✅ | Fix the two confirmed bugs blocking correctness even for the *existing* fork flow: (a) wire `continueSessionId`/`forkSession: true` into the fork path's `launchAgentDefinition` call (§2 — currently missing entirely), (b) fix `template.rs`'s fork-count filter to walk the lineage root instead of the immediate parent (§4.5) — **landed**, also fixed a third bug found while implementing (b): the suggested name was built from the immediate parent's own name, not the lineage root's, so even a correctly-counted fork of a fork produced "AgentX #2 #3" instead of the flat "AgentX #3" | — |
 | **2** ✅ (destination corrected 2026-08-22) | Wire the quick-fork action itself. **Originally shipped landing the fork in a brand-new top-level window tab** (`WorkspaceService.CreateTab`) triggered from the window tab-strip's own right-click menu; **corrected per the notice at the top of this document** to land as a new sibling block pushed onto the SOURCE pane's own `blockStack` (`pushBlockOntoStack` — the same primitive `open-history-tab.ts`'s "Agent History" entry and the pane tab strip's own "+" already use), triggered from `AgentViewModel.getBodyContextMenuItems` right next to "Agent History". The launch reuses `this.launchAgentDefinition` directly (the method's own view-model instance, since the trigger now lives inside that same class) via its pre-existing `targetBlockId` override param — no `targetTabId` override needed post-correction, since the destination never leaves the current window tab. | Phase 1 |
 | **3** ✅ | The non-Claude fallback note: `quick-fork.ts`'s `quickForkAgent` sets `FORK_NO_HISTORY_FALLBACK_META_KEY` on the new block once launch succeeds when the fork's effective provider doesn't support `--fork-session` and there was a session to lose; `ForkProviderFallbackBanner` (`agent-view.tsx`) reads it, cloned from `AgentDisconnectedBanner`'s no-dismiss-button pattern since there's no seam to push a synthesized message into the new pane's conversation before its own stream mounts. **The `Cmd:Shift:t` keybinding and the tab-strip "+" split-button from the original draft were both removed/dropped as part of the destination correction** — see §4.3. | Phase 2 |
-| **4** ✅ | Confirmation variant exposing the identity choice (§5): a second "Quick-fork (inherit identity)" entry in the body context menu alongside the default quick-fork, calling `quickForkAgent(this, {inheritIdentity: true})`. Resolves the SOURCE definition's own bound account via `ListAgentIdentitiesCommand` (`db_agent_identity_links`), filtered to the fork's own canonical effective provider via `lastLinkedAccountId` (`provider-id-aliases.ts`) — not a raw `.find()` (two review rounds on PR #2735 caught, respectively, taking the wrong-provider link and taking the wrong ROW among same-provider links when a canonical + legacy-alias row both exist). | Phase 2 |
+| **4** ✅ (simplified 2026-08-22) | **Originally shipped** as a confirmation variant exposing the identity choice (§5): a second "Quick-fork (inherit identity)" entry in the body context menu alongside the default quick-fork. **Corrected per §5's second correction notice** — the "unbound" vs. "inherit" choice was never actually a safety trade-off (binding doesn't copy the credential either way), so the second menu entry was removed; `quickForkAgent` now always resolves and inherits the SOURCE definition's own bound account via `ListAgentIdentitiesCommand` (`db_agent_identity_links`), filtered to the fork's own canonical effective provider via `lastLinkedAccountId` (`provider-id-aliases.ts`) — not a raw `.find()` (two review rounds on PR #2735 caught, respectively, taking the wrong-provider link and taking the wrong ROW among same-provider links when a canonical + legacy-alias row both exist). | Phase 2 |
 
 Phase 1 is **not optional polish** — without it, quick-fork (and the existing
 in-pane fork prompt) both silently produce fresh-start clones with no

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -822,10 +822,6 @@ export class AgentViewModel implements ViewModel {
                 label: "Quick-fork",
                 click: () => void quickForkAgent(this),
             },
-            {
-                label: "Quick-fork (inherit identity)",
-                click: () => void quickForkAgent(this, { inheritIdentity: true }),
-            },
             { type: "separator" },
         ];
     }

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -819,7 +819,7 @@ export class AgentViewModel implements ViewModel {
                 click: () => void openOrFocusHistoryTab({ currentBlockId: this.blockId, agentId }),
             },
             {
-                label: "Quick-fork",
+                label: "Quick Fork",
                 click: () => void quickForkAgent(this),
             },
             { type: "separator" },

--- a/frontend/app/view/agent/quick-fork.test.ts
+++ b/frontend/app/view/agent/quick-fork.test.ts
@@ -103,7 +103,8 @@ describe("quickForkAgent", () => {
         expect(forkAgentDefinitionCommand).not.toHaveBeenCalled();
     });
 
-    it("forks the definition, pushes the new block onto THIS pane's own stack (not a new window tab), and launches with history carryover + unbound identity", async () => {
+    it("forks the definition, pushes the new block onto THIS pane's own stack (not a new window tab), and launches with history carryover", async () => {
+        listAgentIdentitiesCommand.mockResolvedValue([{ account_id: "acct-1", provider: "claude" }]);
         const result = await quickForkAgent(model);
 
         expect(forkAgentDefinitionCommand).toHaveBeenCalledWith(
@@ -123,7 +124,9 @@ describe("quickForkAgent", () => {
         expect(forkedDef).toEqual({ id: "forked-def", name: "X #2", agent_type: "host" });
         expect(overrides.continueSessionId).toBe("sid-parent");
         expect(overrides.forkSession).toBe(true);
-        expect(overrides.accountId).toBe("");
+        // Always inherits the source's own bound account (spec §5, revised
+        // 2026-08-22) — no separate unbound/opt-in variant.
+        expect(overrides.accountId).toBe("acct-1");
         expect(targetBlockId).toBe("new-block-1");
         expect(targetTabId).toBe("tab-1");
         expect(result).toBe(true);
@@ -247,10 +250,14 @@ describe("quickForkAgent", () => {
         expect(launchAgentDefinition).not.toHaveBeenCalled();
     });
 
-    describe("opts.inheritIdentity", () => {
-        it("resolves the source definition's bound account for the fork's own provider and passes it as accountId", async () => {
+    // Spec §5 (revised 2026-08-22): always inherit the source's own bound
+    // account — there's no separate "unbound" variant to opt out into,
+    // since binding never copies the underlying credential anyway (it's
+    // shared by account_id regardless of which agent links to it).
+    describe("identity inheritance", () => {
+        it("resolves the source definition's bound account for the fork's own provider and passes it as accountId, unconditionally", async () => {
             listAgentIdentitiesCommand.mockResolvedValue([{ account_id: "acct-1", provider: "claude" }]);
-            await quickForkAgent(model, { inheritIdentity: true });
+            await quickForkAgent(model);
             expect(listAgentIdentitiesCommand).toHaveBeenCalledWith(
                 expect.anything(),
                 { agent_id: "source-def" },
@@ -264,7 +271,7 @@ describe("quickForkAgent", () => {
                 { account_id: "github-acct", provider: "github" },
                 { account_id: "claude-acct", provider: "claude" },
             ]);
-            await quickForkAgent(model, { inheritIdentity: true });
+            await quickForkAgent(model);
             const overrides = launchAgentDefinition.mock.calls[0][1];
             expect(overrides.accountId).toBe("claude-acct");
         });
@@ -274,22 +281,24 @@ describe("quickForkAgent", () => {
                 { account_id: "acct-alias", provider: "claude-code" },
                 { account_id: "acct-canonical", provider: "claude" },
             ]);
-            await quickForkAgent(model, { inheritIdentity: true });
+            await quickForkAgent(model);
             const overrides = launchAgentDefinition.mock.calls[0][1];
             expect(overrides.accountId).toBe("acct-canonical");
         });
 
-        it("falls back to unbound (best-effort, not thrown) when ListAgentIdentitiesCommand rejects", async () => {
+        it("falls back to empty (best-effort, not thrown) when ListAgentIdentitiesCommand rejects", async () => {
             listAgentIdentitiesCommand.mockRejectedValue(new Error("boom"));
-            const result = await quickForkAgent(model, { inheritIdentity: true });
+            const result = await quickForkAgent(model);
             expect(result).toBe(true);
             const overrides = launchAgentDefinition.mock.calls[0][1];
             expect(overrides.accountId).toBe("");
         });
 
-        it("does not resolve identity at all when inheritIdentity is not set", async () => {
+        it("falls back to empty when the source has no linked identity at all", async () => {
+            listAgentIdentitiesCommand.mockResolvedValue([]);
             await quickForkAgent(model);
-            expect(listAgentIdentitiesCommand).not.toHaveBeenCalled();
+            const overrides = launchAgentDefinition.mock.calls[0][1];
+            expect(overrides.accountId).toBe("");
         });
     });
 

--- a/frontend/app/view/agent/quick-fork.test.ts
+++ b/frontend/app/view/agent/quick-fork.test.ts
@@ -190,7 +190,7 @@ describe("quickForkAgent", () => {
         launchAgentDefinition.mockResolvedValue(false);
         await quickForkAgent(model);
         expect(pushNotification).toHaveBeenCalledWith(
-            expect.objectContaining({ type: "error", title: "Quick-fork failed" }),
+            expect.objectContaining({ type: "error", title: "Quick Fork failed" }),
         );
     });
 
@@ -225,7 +225,7 @@ describe("quickForkAgent", () => {
         expect(await quickForkAgent(model)).toBe(false);
         expect(closeBlockInStack).toHaveBeenCalledWith(expect.anything(), "node-1", "new-block-1");
         expect(pushNotification).toHaveBeenCalledWith(
-            expect.objectContaining({ type: "error", title: "Quick-fork failed" }),
+            expect.objectContaining({ type: "error", title: "Quick Fork failed" }),
         );
     });
 
@@ -286,12 +286,24 @@ describe("quickForkAgent", () => {
             expect(overrides.accountId).toBe("acct-canonical");
         });
 
-        it("falls back to empty (best-effort, not thrown) when ListAgentIdentitiesCommand rejects", async () => {
+        // Codex's review of PR #2756: silently proceeding unbound on a
+        // lookup failure would let launchAgentDefinition report success
+        // while the backend's OAuth layer-3 spawn gate blocks the new
+        // agent's actual first turn (no resolved binding at all) --
+        // contradicting quick-fork's own "always inherits identity"
+        // promise. Aborts the whole fork instead, same cleanup +
+        // notification path as any other mid-flight failure.
+        it("aborts the fork (cleans up the pushed block, notifies) when ListAgentIdentitiesCommand rejects, rather than proceeding unbound", async () => {
             listAgentIdentitiesCommand.mockRejectedValue(new Error("boom"));
             const result = await quickForkAgent(model);
-            expect(result).toBe(true);
-            const overrides = launchAgentDefinition.mock.calls[0][1];
-            expect(overrides.accountId).toBe("");
+            expect(result).toBe(false);
+            expect(launchAgentDefinition).not.toHaveBeenCalled();
+            // No block was ever created at this point — nothing to clean up.
+            expect(closeBlockInStack).not.toHaveBeenCalled();
+            expect(deleteBlock).not.toHaveBeenCalled();
+            expect(pushNotification).toHaveBeenCalledWith(
+                expect.objectContaining({ type: "error", title: "Quick Fork failed" }),
+            );
         });
 
         it("falls back to empty when the source has no linked identity at all", async () => {

--- a/frontend/app/view/agent/quick-fork.ts
+++ b/frontend/app/view/agent/quick-fork.ts
@@ -65,15 +65,24 @@ export interface QuickForkModel {
  * Full independent identity (new `AgentDefinition`, never shares
  * `AGENTMUX_AGENT_ID` or a jekt signing key with the source, per
  * `template.rs`'s `forkagentdefinition` handler), conversation history
- * carried forward via `continueSessionId`/`forkSession`, Armory/credential
- * identity left **unbound by default** (spec §5) unless `opts.inheritIdentity`
- * is explicitly set — sourced from the SOURCE definition's own bound account
- * via `ListAgentIdentitiesCommand`, filtered to the fork's own canonical
- * effective provider through `lastLinkedAccountId` (NOT a raw `.find()` —
- * `db_agent_identity_links` can hold both a canonical and a legacy-alias row
- * for the same provider at once; `lastLinkedAccountId`'s own doc comment
- * covers why the LAST such row, not the first, matches the real backend
- * spawn resolver).
+ * carried forward via `continueSessionId`/`forkSession`.
+ *
+ * Always inherits the source's own bound Armory account (spec §5, revised
+ * 2026-08-22) — sourced via `ListAgentIdentitiesCommand`, filtered to the
+ * fork's own canonical effective provider through `lastLinkedAccountId`
+ * (NOT a raw `.find()` — `db_agent_identity_links` can hold both a
+ * canonical and a legacy-alias row for the same provider at once;
+ * `lastLinkedAccountId`'s own doc comment covers why the LAST such row, not
+ * the first, matches the real backend spawn resolver). There is no
+ * meaningfully "safer, unbound" alternative to offer as a separate action:
+ * binding never copies the underlying credential — `LinkAgentIdentityCommand`
+ * only inserts a `db_agent_identity_links` row; the actual OAuth config dir
+ * / keychain entry lives at a path keyed by `account_id`
+ * (`identities_dir().join(account_id)`), so every agent linked to that
+ * account already reads and writes the exact same shared credential
+ * regardless of whether the fork or the source requested the link. The
+ * original two-button design (unbound-by-default + an opt-in "inherit
+ * identity" variant) was removed for this reason.
  *
  * When the fork's effective provider (resolved through its bound bundle,
  * same as `launchAgentDefinition` itself does) doesn't support
@@ -89,10 +98,7 @@ export interface QuickForkModel {
  *   self-contained-failure-handling convention (this has no wrapping caller
  *   of its own to push a notification on `false`).
  */
-export async function quickForkAgent(
-    model: QuickForkModel,
-    opts?: { inheritIdentity?: boolean },
-): Promise<boolean> {
+export async function quickForkAgent(model: QuickForkModel): Promise<boolean> {
     const meta = WOS.getObjectValue<Block>(WOS.makeORef("block", model.blockId))?.meta;
     const definitionId = meta?.["agentId"] as string | undefined;
     if (!definitionId) {
@@ -157,20 +163,19 @@ export async function quickForkAgent(
         const canonicalForkProvider = resolveProviderAlias(effectiveProvider);
         const provider = PROVIDERS[effectiveProvider] ?? PROVIDERS[canonicalForkProvider];
 
-        // Spec §5 decision: unbound by default, not the source's bound
-        // account — a "quick" one-click action shouldn't silently fan out
-        // credential access to a second agent. opts.inheritIdentity opts
-        // in, looking up the SOURCE's own bound link directly.
+        // Spec §5 (revised 2026-08-22): always inherit the source's own
+        // bound account — see this function's doc comment for why an
+        // "unbound" alternative wouldn't actually be a safer/different
+        // option (binding never copies the credential; it's shared by
+        // account_id regardless of who links to it).
         let accountId = "";
-        if (opts?.inheritIdentity) {
-            try {
-                const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
-                    agent_id: definitionId,
-                });
-                accountId = lastLinkedAccountId(links, provider?.id ?? canonicalForkProvider) ?? "";
-            } catch (e: any) {
-                Logger.warn("quick-fork", "failed to resolve source identity to inherit", { error: String(e) });
-            }
+        try {
+            const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
+                agent_id: definitionId,
+            });
+            accountId = lastLinkedAccountId(links, provider?.id ?? canonicalForkProvider) ?? "";
+        } catch (e: any) {
+            Logger.warn("quick-fork", "failed to resolve source identity to inherit", { error: String(e) });
         }
 
         // Non-Claude fallback note — only relevant when there was actually

--- a/frontend/app/view/agent/quick-fork.ts
+++ b/frontend/app/view/agent/quick-fork.ts
@@ -168,15 +168,20 @@ export async function quickForkAgent(model: QuickForkModel): Promise<boolean> {
         // "unbound" alternative wouldn't actually be a safer/different
         // option (binding never copies the credential; it's shared by
         // account_id regardless of who links to it).
-        let accountId = "";
-        try {
-            const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
-                agent_id: definitionId,
-            });
-            accountId = lastLinkedAccountId(links, provider?.id ?? canonicalForkProvider) ?? "";
-        } catch (e: any) {
-            Logger.warn("quick-fork", "failed to resolve source identity to inherit", { error: String(e) });
-        }
+        //
+        // A lookup failure here is NOT swallowed into "proceed unbound"
+        // (Codex's review of PR #2756): the backend's OAuth-class layer-3
+        // spawn gate (`identity/resolver/inject.rs`) blocks a definition
+        // with no resolved binding at all, unless it opted into ambient
+        // login — so an unresolved lookup would let `launchAgentDefinition`
+        // report success while the new agent can never actually spawn its
+        // first turn, silently contradicting quick-fork's own "always
+        // inherits identity" promise. Rethrown into the outer catch, which
+        // already handles cleanup + notification identically.
+        const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
+            agent_id: definitionId,
+        });
+        const accountId = lastLinkedAccountId(links, provider?.id ?? canonicalForkProvider) ?? "";
 
         // Non-Claude fallback note — only relevant when there was actually
         // a session to lose (an empty sessionId is already a fresh start
@@ -228,7 +233,7 @@ export async function quickForkAgent(model: QuickForkModel): Promise<boolean> {
             // wrong (Codex's second-round review of PR #2746).
             pushNotification({
                 icon: "fa-triangle-exclamation",
-                title: "Quick-fork failed",
+                title: "Quick Fork failed",
                 message: "The forked agent could not be launched.",
                 timestamp: new Date().toISOString(),
                 type: "error",
@@ -257,7 +262,7 @@ export async function quickForkAgent(model: QuickForkModel): Promise<boolean> {
         await cleanupPushedBlock();
         pushNotification({
             icon: "fa-triangle-exclamation",
-            title: "Quick-fork failed",
+            title: "Quick Fork failed",
             message: e instanceof Error ? e.message : String(e),
             timestamp: new Date().toISOString(),
             type: "error",


### PR DESCRIPTION
## Summary
Repo-owner feedback on the merged quick-fork feature: the "unbound by default, explicit inherit-identity opt-in" design (spec §5 / Phase 4, two menu items: "Quick-fork" and "Quick-fork (inherit identity)") was based on a wrong premise.

Verified directly against the backend: `LinkAgentIdentityCommand` (`agentmux-srv/src/server/agent_handlers/identity.rs:559-580`) never copies a credential — it only inserts a `db_agent_identity_links` row (`agent_id`, `account_id`, `provider`). The actual credential (OAuth config dir or keychain entry) lives at a path keyed by `account_id` alone (`identities_dir().join(account_id)`), so *any* agent linked to that account — the fork's own new link or the parent's pre-existing one — reads and writes the exact same shared credential. There's no independent, safer copy that "unbound by default" was actually withholding; "inherit" and "unbound" were never a real risk/no-risk pair.

Given that, offering both as separate menu actions added a decision with no safety difference on the other side of it.

- `quickForkAgent` now always resolves and inherits the source's own bound account, unconditionally — removed the `opts` parameter entirely.
- `getBodyContextMenuItems` now has one "Quick-fork" entry, not two.
- Spec doc (`SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md` §5, phasing table) updated with a correction notice; original reasoning kept for the historical record.

## Test plan
- [x] `npx vitest run` — full suite green (2949 passed), 1 pre-existing/unrelated flaky timeout in `tool-renderers/registry.test.ts`
- [x] `quick-fork.test.ts` updated: removed the opt-out test, renamed the describe block to "identity inheritance", added a "no linked identity at all" case
- [x] `npx tsc --noEmit` clean

<!-- agentmux:agent_id=agentx -->