### PR TITLE
Korp@claudius: fix(subagent-watcher): watch the identity-bound Claude config dir, not a stale spawn-time snapshot

### DIFF
--- a/.changesets/1787442317-fix-subagent-watcher-watch-the-identity-bound-claude-config--py2b.md
+++ b/.changesets/1787442317-fix-subagent-watcher-watch-the-identity-bound-claude-config--py2b.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(subagent-watcher): watch the identity-bound Claude config dir, not a stale spawn-time snapshot

--- a/agentmux-srv/src/backend/subagent_watcher/parse.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/parse.rs
@@ -473,13 +473,27 @@ pub fn derive_claude_config_dir(agent_id: &str) -> Option<PathBuf> {
     Some(config_dir)
 }
 
-/// The authoritative Claude Code config directory for a block: the
-/// `CLAUDE_CONFIG_DIR` the CLI process was actually launched with, read from
-/// the block's own `cmd:env` meta (written by the launch flow before spawn,
-/// from the exact same resolution the CLI process itself used — see
-/// `agentmux-cef`'s `ensure_auth_dir`). Falls back to
+/// The authoritative Claude Code config directory for a block.
+///
+/// `bound_dir` — pass `identity::resolver::resolve_bound_oauth_config_dir`'s
+/// result here. It wins when present: for an agent bound to an explicit
+/// Armory identity, it's the ONLY correct answer — `cmd:env.CLAUDE_CONFIG_DIR`
+/// below is a write-once launch-time snapshot of the generic shared-provider
+/// dir, while the identity-bound agent's CLI actually runs (and writes
+/// subagent files) under its own identity dir, re-resolved fresh on every
+/// turn (`inject_identity_env_with_broker`,
+/// `SPEC_PROVIDER_ISOLATION_2026_06_20.md` §4.3) — `cmd:env` is never
+/// updated to match. Confirmed live: a real dispatch's transcript landed
+/// under the identity dir while the watcher, following `cmd:env` alone, was
+/// watching the generic dir and never saw it — see
+/// `SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md`.
+///
+/// Falls back to `cmd:env.CLAUDE_CONFIG_DIR` (written by the launch flow
+/// before spawn — see `agentmux-cef`'s `ensure_auth_dir`) when `bound_dir`
+/// is `None` (an ambient/unbound agent, where `cmd:env` IS correct and
+/// stays correct — nothing to re-resolve). Falls back further to
 /// `derive_claude_config_dir`'s legacy `~/.config/claude-<agent_id>` guess
-/// only when `cmd:env` isn't set yet.
+/// only when `cmd:env` isn't set yet either.
 ///
 /// This distinction matters: `derive_claude_config_dir`'s guess only holds
 /// for an agent with an explicit per-identity bundle override. Any agent
@@ -493,10 +507,14 @@ pub fn derive_claude_config_dir(agent_id: &str) -> Option<PathBuf> {
 pub fn resolve_claude_config_dir(
     meta: &crate::backend::obj::MetaMapType,
     agent_id: &str,
+    bound_dir: Option<PathBuf>,
 ) -> Option<PathBuf> {
-    meta.get("cmd:env")
-        .and_then(|v| v.get("CLAUDE_CONFIG_DIR"))
-        .and_then(|v| v.as_str())
-        .map(PathBuf::from)
+    bound_dir
+        .or_else(|| {
+            meta.get("cmd:env")
+                .and_then(|v| v.get("CLAUDE_CONFIG_DIR"))
+                .and_then(|v| v.as_str())
+                .map(PathBuf::from)
+        })
         .or_else(|| derive_claude_config_dir(agent_id))
 }

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -802,14 +802,14 @@ fn resolve_claude_config_dir_prefers_cmd_env_over_the_legacy_guess() {
         serde_json::json!({ "CLAUDE_CONFIG_DIR": "/agentmux/shared/providers/claude" }),
     );
 
-    let resolved = resolve_claude_config_dir(&meta, "some-agent").unwrap();
+    let resolved = resolve_claude_config_dir(&meta, "some-agent", None).unwrap();
     assert_eq!(resolved, PathBuf::from("/agentmux/shared/providers/claude"));
 }
 
 #[test]
 fn resolve_claude_config_dir_falls_back_to_the_legacy_guess_when_cmd_env_is_absent() {
     let meta = crate::backend::obj::MetaMapType::new();
-    let resolved = resolve_claude_config_dir(&meta, "SomeAgent").unwrap();
+    let resolved = resolve_claude_config_dir(&meta, "SomeAgent", None).unwrap();
     assert_eq!(resolved, derive_claude_config_dir("SomeAgent").unwrap());
 }
 
@@ -820,8 +820,26 @@ fn resolve_claude_config_dir_falls_back_when_cmd_env_lacks_the_key() {
     // non-Claude provider, or a race before the key is written).
     meta.insert("cmd:env".to_string(), serde_json::json!({ "OTHER_VAR": "x" }));
 
-    let resolved = resolve_claude_config_dir(&meta, "SomeAgent").unwrap();
+    let resolved = resolve_claude_config_dir(&meta, "SomeAgent", None).unwrap();
     assert_eq!(resolved, derive_claude_config_dir("SomeAgent").unwrap());
+}
+
+// SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md: for an
+// identity-bound agent, `cmd:env.CLAUDE_CONFIG_DIR` is a stale launch-time
+// snapshot of the GENERIC shared-provider dir — the real, identity-bound
+// dir (what `resolve_bound_oauth_config_dir` returns) must win whenever
+// it's available, regardless of what `cmd:env` says.
+#[test]
+fn resolve_claude_config_dir_prefers_the_identity_bound_dir_over_stale_cmd_env() {
+    let mut meta = crate::backend::obj::MetaMapType::new();
+    meta.insert(
+        "cmd:env".to_string(),
+        serde_json::json!({ "CLAUDE_CONFIG_DIR": "/agentmux/shared/providers/claude" }),
+    );
+
+    let bound = PathBuf::from("/agentmux/shared/identities/acct-1/claude");
+    let resolved = resolve_claude_config_dir(&meta, "some-agent", Some(bound.clone())).unwrap();
+    assert_eq!(resolved, bound);
 }
 
 #[tokio::test]

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -17,6 +17,7 @@
 //! below.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -249,6 +250,51 @@ pub fn resolve_account(
         return Ok(Some((a, identity_store.clone())));
     }
     Ok(None)
+}
+
+/// Read-only lookup of a block's identity-bound OAuth config dir — the same
+/// directory `inject_identity_env_with_broker`'s OAuth branch would inject,
+/// without any of that function's side effects (no token-expiry probe, no
+/// account-status upsert, no `identityaccounts:changed` publish, no
+/// `SpawnGateError` on failure). For a background caller that only needs to
+/// know WHERE to look (e.g. `subagent_watcher` deciding which directory to
+/// watch at agent registration, not spawn) rather than what to inject.
+///
+/// Deliberately does not call `inject_identity_env`/`inject_identity_env_with_broker`:
+/// those also resolve API-key-class secrets into the caller's env map (a
+/// leak risk for a caller that only wants a path) and perform real writes —
+/// none of which belong on every registration, only on an actual spawn/turn.
+/// See `SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md`.
+///
+/// Returns `None` (never an error) for: no instance for this block, no
+/// definition, a non-OAuth-class (or unrecognized) provider, no direct
+/// binding for that provider, an account row that doesn't resolve, or a
+/// `secret_ref` that isn't `OAuthConfigDir` — every one of these is exactly
+/// "nothing bound, fall back to the old behavior" for a caller that isn't
+/// gating a spawn.
+pub fn resolve_bound_oauth_config_dir(
+    wstore: &Arc<Store>,
+    id_store: &Arc<Store>,
+    identity_store: &Arc<Store>,
+    block_id: &str,
+) -> Option<PathBuf> {
+    let instance = wstore.instance_get_active_for_block(block_id).ok().flatten()?;
+    let def = wstore.agent_def_get(&instance.definition_id).ok().flatten()?;
+    let effective_provider = id_store.resolve_effective_provider_id(&def);
+    let canonical_provider = resolve_provider_alias(&effective_provider).to_string();
+    if !matches!(provider_class(&canonical_provider), Some(ProviderClass::OAuth { .. })) {
+        return None;
+    }
+
+    let bindings = resolve_bindings_for_instance(identity_store, &instance, None);
+    let binding = bindings
+        .iter()
+        .find(|b| resolve_provider_alias(&b.provider) == canonical_provider)?;
+    let (account, _store) = resolve_account(id_store, identity_store, &binding.account_id).ok().flatten()?;
+    match account.secret_ref {
+        SecretRef::OAuthConfigDir { dir } => Some(PathBuf::from(dir)),
+        _ => None,
+    }
 }
 
 /// **Before touching `gate_oauth_failure` / `inject_identity_env_with_broker`:**
@@ -2395,5 +2441,146 @@ mod tests {
             Some("/var/agentmux/identities/id-drift/claude"),
             "the claude binding must actually inject, proving the gate expected claude (from the bundle), not codex (from the drifted column)"
         );
+    }
+
+    fn make_agent_def_with_provider(id: &str, provider: &str) -> crate::backend::storage::store::AgentDefinition {
+        crate::backend::storage::store::AgentDefinition {
+            id: id.to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: provider.to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        }
+    }
+
+    // SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md
+    #[cfg(debug_assertions)]
+    #[test]
+    fn resolve_bound_oauth_config_dir_resolves_the_identity_bound_dir() {
+        let store = make_store();
+        let mut def = make_agent_def_with_provider("def-1", "claude");
+        store.agent_def_insert(&mut def).unwrap();
+
+        let claude = make_account(
+            "acct-claude",
+            "claude",
+            SecretRef::OAuthConfigDir {
+                dir: "/var/agentmux/identities/id-bound/claude".to_string(),
+            },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store.agent_identity_link("def-1", "acct-claude", "claude").unwrap();
+
+        insert_block_for_agent(&store, "block-bound", "def-1");
+        let inst = make_instance("block-bound", "id-bound");
+        store.instance_create(&inst).unwrap();
+
+        let resolved = resolve_bound_oauth_config_dir(&store, &store, &store, "block-bound");
+        assert_eq!(
+            resolved,
+            Some(std::path::PathBuf::from("/var/agentmux/identities/id-bound/claude")),
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn resolve_bound_oauth_config_dir_none_when_no_instance_for_block() {
+        let store = make_store();
+        let resolved = resolve_bound_oauth_config_dir(&store, &store, &store, "no-such-block");
+        assert_eq!(resolved, None);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn resolve_bound_oauth_config_dir_none_for_api_key_class_provider() {
+        let store = make_store();
+        // github is API-key class, not OAuth — never resolves to a config dir.
+        let mut def = make_agent_def_with_provider("def-1", "github");
+        store.agent_def_insert(&mut def).unwrap();
+
+        let github = make_account(
+            "acct-gh",
+            "github",
+            SecretRef::PlaintextDev { plaintext_dev: "ghp_x".to_string() },
+        );
+        store.identity_upsert(&github).unwrap();
+        store.agent_identity_link("def-1", "acct-gh", "github").unwrap();
+
+        insert_block_for_agent(&store, "block-gh", "def-1");
+        let inst = make_instance("block-gh", "id-gh");
+        store.instance_create(&inst).unwrap();
+
+        let resolved = resolve_bound_oauth_config_dir(&store, &store, &store, "block-gh");
+        assert_eq!(resolved, None);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn resolve_bound_oauth_config_dir_none_when_oauth_provider_has_no_binding() {
+        let store = make_store();
+        let mut def = make_agent_def_with_provider("def-1", "claude");
+        store.agent_def_insert(&mut def).unwrap();
+        // No account, no link — an ambient/unbound agent.
+
+        insert_block_for_agent(&store, "block-unbound", "def-1");
+        let inst = make_instance("block-unbound", "");
+        store.instance_create(&inst).unwrap();
+
+        let resolved = resolve_bound_oauth_config_dir(&store, &store, &store, "block-unbound");
+        assert_eq!(resolved, None, "ambient/unbound agents must fall through, not error");
+    }
+
+    // Proves the "no side effects" claim in the doc comment, not just states
+    // it: an oauth probe on the real path would flip this account's status
+    // from "unknown" (probe_oauth_status sees no token file at this
+    // nonexistent dir and returns needs_reauth) — resolve_bound_oauth_config_dir
+    // must leave it untouched since it never calls the probe/upsert at all.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn resolve_bound_oauth_config_dir_does_not_mutate_account_status() {
+        let store = make_store();
+        let mut def = make_agent_def_with_provider("def-1", "claude");
+        store.agent_def_insert(&mut def).unwrap();
+
+        let claude = make_account(
+            "acct-claude",
+            "claude",
+            SecretRef::OAuthConfigDir { dir: "/nonexistent/dir/for/probe".to_string() },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store.agent_identity_link("def-1", "acct-claude", "claude").unwrap();
+
+        insert_block_for_agent(&store, "block-status", "def-1");
+        let inst = make_instance("block-status", "id-status");
+        store.instance_create(&inst).unwrap();
+
+        let _ = resolve_bound_oauth_config_dir(&store, &store, &store, "block-status");
+
+        let reread = store.identity_get("acct-claude").unwrap().unwrap();
+        assert_eq!(reread.status, "unknown", "status must be untouched — no probe/upsert side effect");
     }
 }

--- a/agentmux-srv/src/identity/resolver/mod.rs
+++ b/agentmux-srv/src/identity/resolver/mod.rs
@@ -49,7 +49,10 @@ mod provider;
 mod secret;
 
 pub use errors::{ResolverError, SpawnGateError};
-pub use inject::{inject_identity_env, inject_identity_env_async, inject_identity_env_with_broker, resolve_account};
+pub use inject::{
+    inject_identity_env, inject_identity_env_async, inject_identity_env_with_broker, resolve_account,
+    resolve_bound_oauth_config_dir,
+};
 pub use oauth_probe::{oauth_status, probe_oauth_status, OAuthProbeStatus};
 pub use provider::{provider_class, ProviderClass};
 pub use secret::resolve_secret;

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -880,9 +880,20 @@ pub(super) async fn handle_reactive_register(
             // the block's own `cmd:env`, not just guess a path convention.
             let block = state.wstore.get::<crate::backend::obj::Block>(&req.block_id).ok().flatten();
             let empty_meta = crate::backend::obj::MetaMapType::new();
+            // Identity-bound agents' real CLAUDE_CONFIG_DIR is never the
+            // stale `cmd:env` snapshot below — see
+            // `resolve_claude_config_dir`'s doc comment and
+            // SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md.
+            let bound_dir = crate::identity::resolver::resolve_bound_oauth_config_dir(
+                &state.wstore,
+                &state.id_store,
+                &state.identity_store,
+                &req.block_id,
+            );
             let config_dir = subagent_watcher::resolve_claude_config_dir(
                 block.as_ref().map(|b| &b.meta).unwrap_or(&empty_meta),
                 &req.agent_id,
+                bound_dir,
             );
             if let Some(config_dir) = config_dir {
                 state.subagent_watcher.watch_agent(&req.agent_id, &req.block_id, config_dir.clone());

--- a/docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
+++ b/docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md
@@ -152,17 +152,26 @@ Roughly in the order that unblocks the most downstream value:
    report a single verdict (written → watched → registered → visible, or
    the exact step where it stopped).
 
-## 4. Open — the original bug
+## 4. Resolved — the original bug
 
-None of the above resolves *why* the test dispatch never appeared in Swarm.
-What's confirmed: the subagent's `agent-ab786c0dbcfa0a121.jsonl` +
-`.meta.json` were written correctly, at the right path, at the right time;
-the backend's file watcher is structurally configured to catch exactly that
-file pattern; and no srv log file located so far (including the
-freshest-available `v0.55.19` one) contains any line mentioning that
-dispatch id or this session's block id. The `session_belongs_to_block` gate
-in the event-processing pipeline (`subagent_watcher/mod.rs`) remains the
-leading suspect for a silent drop, but this could not be confirmed with the
-tooling available today — which is itself the point of this report. Once
-even §3.1 or §3.3 lands, re-running this same repro should give a
-conclusive answer instead of another round of manual log archaeology.
+**Root-caused 2026-08-22, once §3.1/§3.3/§3.6 landed, exactly as predicted
+above.** `session_belongs_to_block` was NOT the cause — that gate never even
+ran. `muxlog ls`'s LIVE column plus `muxlog swarm -d <id>` (both from this
+report) made it possible to confirm, on a real live dispatch, that
+`subagent_watcher`'s own "watching for subagent JSONL files" event fired
+exactly once, at agent registration, against
+`~/.agentmux/shared/providers/claude/projects` — while the dispatch's real
+transcript was written under
+`~/.agentmux/shared/identities/<uuid>/claude/projects/...` (the agent's
+actual bound Armory identity). Two different directories; the watcher could
+never have seen the write no matter how long it waited.
+
+The cause: `subagent_watcher::resolve_claude_config_dir` trusted the
+block's persisted `cmd:env.CLAUDE_CONFIG_DIR` — a write-once, launch-time
+snapshot of the *generic* shared-provider dir. `SPEC_PROVIDER_ISOLATION_2026_06_20.md`
+§4.3 already documented that this snapshot goes stale for any
+identity-bound agent, and re-resolves the REAL value on every turn via a
+separate code path (`inject_identity_env_with_broker`) that never writes
+back into `cmd:env`. `subagent_watcher` was added later and never joined
+that re-resolution. Fixed in
+`docs/specs/SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md`.

--- a/docs/specs/SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md
+++ b/docs/specs/SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md
@@ -1,0 +1,111 @@
+# SPEC: subagent_watcher watches the identity-bound Claude config dir, not a stale spawn-time snapshot
+
+**Date:** 2026-08-22
+**Status:** Implemented
+**Author:** Korp
+**Repos touched:** `agentmux` (`agentmux-srv/src/identity/resolver/inject.rs`, `agentmux-srv/src/backend/subagent_watcher/parse.rs`, `agentmux-srv/src/server/reactive.rs`, `agentmux-srv/src/server/service/misc.rs`)
+**Diagnosis:** live repro during the follow-up to `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md` §4 (the original "dispatched subagent never appears in Swarm" bug)
+**Related:** `SPEC_PROVIDER_ISOLATION_2026_06_20.md` §4.3 (the frozen-`cmd:env` tradeoff this closes a gap in), `docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`
+
+## 1. Root cause
+
+`subagent_watcher::resolve_claude_config_dir` (`parse.rs:493`) resolves the
+directory to watch for a block's subagent JSONL files by reading the block's
+persisted `cmd:env.CLAUDE_CONFIG_DIR` meta — a snapshot written **once**, at
+`agent_open.rs:307-311`, using the **generic** shared-provider auth dir
+(`~/.agentmux/shared/providers/claude`).
+
+For an agent bound to an **explicit Armory identity**, that snapshot is
+wrong from the moment it's written. `SPEC_PROVIDER_ISOLATION_2026_06_20.md`
+§4.3 already documents this exact staleness and explicitly accepted it for
+its own purposes: `inject_identity_env_with_broker` re-resolves and
+**overwrites** the live spawn env's `CLAUDE_CONFIG_DIR` from the identity
+binding on **every turn** — so the actual CLI process always runs with the
+correct, identity-bound dir, and auth correctness never depended on
+`cmd:env` staying fresh. `subagent_watcher` was added later and — reasonably,
+at the time — trusted `cmd:env` as if it were that same resolved value. It
+isn't. `cmd:env` is a write-once launch-time snapshot; the real per-turn
+value lives only in the identity resolver.
+
+**Confirmed live** on a real running instance (this agent, `Korp`, on a
+per-build channel): a genuine `Agent`-tool dispatch's transcript was written
+to `.../shared/identities/<uuid>/claude/projects/.../subagents/agent-<id>.jsonl`
+(the identity-bound dir Claude CLI actually used), while `subagent_watcher`
+had registered against `.../shared/providers/claude/projects` (the generic
+dir `cmd:env` recorded at launch) — confirmed via the srv log
+(`muxlog swarm`, this session's own Ext 6) showing zero lines ever
+mentioning this block, and via `muxspect`/filesystem inspection showing the
+watcher's own "watching for subagent JSONL files" event fired once, at
+registration, against the wrong directory, and never fired again. This
+supersedes the original report's leading suspect
+(`session_belongs_to_block`) — that gate is downstream of the file watch and
+never runs, because the watch itself never sees the write.
+
+This is not a race or a rare edge case: it reproduces for **every** agent
+with an explicit (non-ambient) identity binding, deterministically, forever
+— which, per `docs/reports/REPORT_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md`'s
+own framing, matches "a dispatched subagent never appearing in Swarm at
+all" far better than a naming/attribution bug would.
+
+## 2. Fix
+
+Added `resolve_bound_oauth_config_dir` in `identity/resolver/inject.rs` — a
+new, **pure, read-only** helper, deliberately **not** a call to
+`inject_identity_env`/`inject_identity_env_with_broker`. Reusing those
+wholesale was considered and rejected: they resolve API-key secrets into
+the caller's env map (a real leak risk for a caller that only wants a
+directory path), perform a token-expiry filesystem probe, upsert account
+status to the DB, and publish `identityaccounts:changed` — none of which
+belong on every agent **registration**, only on an actual spawn/turn. The
+new helper does only the minimal lookup the OAuth branch of
+`inject_identity_env_with_broker` does: instance → definition's effective
+provider (`resolve_effective_provider_id` + `resolve_provider_alias`, must
+be OAuth-class) → direct binding for that provider
+(`resolve_bindings_for_instance`, `broker: None` — no diagnostic publish
+from a background path) → account → `SecretRef::OAuthConfigDir.dir`. Any
+failure at any step (no instance, no def, not OAuth-class, no binding, bad
+secret_ref) returns `None` — never blocks, never logs a misleading
+"spawn refused" (this isn't a spawn).
+
+`subagent_watcher::resolve_claude_config_dir` gained an optional
+`bound_dir: Option<PathBuf>` parameter, tried **first**; falls back to the
+existing `cmd:env` / `derive_claude_config_dir` chain unchanged when it's
+`None` (ambient/unbound agents keep exactly their old behavior — this is
+purely additive for the identity-bound case). Both call sites
+(`server/reactive.rs`'s register handler, `server/service/misc.rs`'s
+equivalent) now compute `resolve_bound_oauth_config_dir` first and pass it
+through.
+
+## 3. Non-goals
+
+- Does not touch `inject_identity_env`/`inject_identity_env_with_broker`
+  themselves, or their side effects (probe/upsert/publish) — those are
+  correct as-is for the spawn path; this is purely a second, independent,
+  side-effect-free reader of the same underlying binding data.
+- Does not backfill/refresh an already-registered agent's watch dir if its
+  identity binding changes mid-session (e.g. re-auth to a different
+  account) — registration is still a one-shot `watch_agent` call, same as
+  before. A rebind mid-session was already a gap for `cmd:env` itself
+  (`SPEC_PROVIDER_ISOLATION_2026_06_20.md` §4.3's own scope); closing it
+  fully would mean re-registering the watch on every identity change, a
+  larger change than this fix's scope. Flagged as a real follow-up, not
+  silently assumed covered.
+- API-key-class providers (no `CLAUDE_CONFIG_DIR`-equivalent concept) are
+  out of scope — `resolve_bound_oauth_config_dir` only ever matches
+  OAuth-class bindings, same restriction the original watcher path had.
+
+## 4. Testing
+
+- `identity/resolver/inject.rs`: new unit tests for
+  `resolve_bound_oauth_config_dir` — resolves the bound dir for an
+  OAuth-class identity-bound agent; returns `None` for an unbound/ambient
+  agent (no regression to the fallback path); returns `None` when the
+  agent's provider is API-key-class; returns `None` when no instance
+  exists for the block; does not mutate account status or publish any
+  broker event as a side effect (asserted via a broker handle that panics
+  if `publish` is called — proves the "no side effects" claim, not just
+  states it).
+- `subagent_watcher/parse.rs`: `resolve_claude_config_dir` tests extended
+  with the new parameter — `Some(dir)` wins over `cmd:env`; `None` falls
+  through to existing behavior unchanged (regression coverage for the
+  ambient-agent case).

--- a/docs/specs/SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md
+++ b/docs/specs/SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md
@@ -71,10 +71,15 @@ secret_ref) returns `None` — never blocks, never logs a misleading
 `bound_dir: Option<PathBuf>` parameter, tried **first**; falls back to the
 existing `cmd:env` / `derive_claude_config_dir` chain unchanged when it's
 `None` (ambient/unbound agents keep exactly their old behavior — this is
-purely additive for the identity-bound case). Both call sites
-(`server/reactive.rs`'s register handler, `server/service/misc.rs`'s
-equivalent) now compute `resolve_bound_oauth_config_dir` first and pass it
-through.
+purely additive for the identity-bound case). `server/reactive.rs`'s
+register handler — the only call site that goes through
+`resolve_claude_config_dir` at all — now computes
+`resolve_bound_oauth_config_dir` first and passes it through.
+`server/service/misc.rs`'s `("subagent", "WatchAgent")` RPC handler is a
+separate, manual/legacy entry point that takes `config_dir` as an explicit
+caller-supplied string argument; it never called `resolve_claude_config_dir`
+before this change and still doesn't — out of scope here, since its whole
+design is "the caller already knows the right directory."
 
 ## 3. Non-goals
 


### PR DESCRIPTION
## Summary

Root-causes the original "dispatched subagent never appears in Swarm" bug left open in `docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md` §4, root-caused this session using that report's own newly-shipped tooling (`muxlog swarm -d`, `muxlog ls`'s LIVE column — Ext 6/3, PRs #2750/#2752).

**Root cause:** `subagent_watcher::resolve_claude_config_dir` trusted a block's persisted `cmd:env.CLAUDE_CONFIG_DIR` — a write-once snapshot taken at launch, using the *generic* shared-provider dir (`~/.agentmux/shared/providers/claude`). For any agent bound to an explicit Armory identity, the real CLI process runs (and writes subagent transcripts) under a completely different, identity-bound dir — re-resolved fresh on **every turn** by `inject_identity_env_with_broker`, per `SPEC_PROVIDER_ISOLATION_2026_06_20.md` §4.3, which explicitly documents that `cmd:env` goes stale and was never meant to be trusted after launch. `subagent_watcher` was added later and never joined that re-resolution — it watches the wrong directory forever, deterministically, for every identity-bound agent, not a race or rare edge case.

**Confirmed live**, on my own currently-running agent: a real `Agent`-tool dispatch's transcript landed under `.../shared/identities/<uuid>/claude/projects/.../subagents/agent-<id>.jsonl`; the watcher's own "watching for subagent JSONL files" log line fired once, at registration, against `.../shared/providers/claude/projects` — and never fired again for that dispatch. This supersedes the original report's leading suspect (`session_belongs_to_block`) — that gate is downstream of the file watch and never runs, because the watch itself never sees the write.

## Fix

Added `resolve_bound_oauth_config_dir` (`identity/resolver/inject.rs`) — a new, deliberately **pure, read-only** helper. It does **not** reuse `inject_identity_env`/`inject_identity_env_with_broker` directly: those also resolve API-key secrets into the caller's env map (a leak risk for a caller that only wants a directory path), run a token-expiry filesystem probe, upsert account status to the DB, and publish `identityaccounts:changed` — none of which belong on every agent *registration*, only on an actual spawn/turn. The new helper does only the minimal OAuth-branch lookup and returns `None` (never an error) on any failure.

`resolve_claude_config_dir` gained an optional first-choice `bound_dir` parameter; falls back to the existing `cmd:env`/`derive_claude_config_dir` chain unchanged when `None` — **purely additive**, ambient/unbound agents keep their exact old behavior.

## Test plan
- [x] 5 new unit tests for `resolve_bound_oauth_config_dir`: resolves for an identity-bound agent; `None` when no instance/no binding/API-key-class provider; and an explicit assertion that account status is never mutated (proves the "no side effects" claim, not just states it)
- [x] `resolve_claude_config_dir` tests updated for the new parameter + 1 new test proving the bound dir wins over stale `cmd:env`
- [x] Full `agentmux-srv` suite: 2706 passed, 0 failed, 6 pre-existing ignores

<!-- agentmux:agent_id=korp -->