### PR TITLE
Korp@claudius: feat(fleet): FleetBulkStop reaches cross-channel targets, not just this instance

### DIFF
--- a/.changesets/1787447234-feat-fleet-fleetbulkstop-reaches-cross-channel-targets-not-j-2dg8.md
+++ b/.changesets/1787447234-feat-fleet-fleetbulkstop-reaches-cross-channel-targets-not-j-2dg8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(fleet): FleetBulkStop reaches cross-channel targets, not just this instance

--- a/agentmux-srv/src/server/app_api/fleet.rs
+++ b/agentmux-srv/src/server/app_api/fleet.rs
@@ -135,7 +135,7 @@ fn register_fleet_bulk_stop(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let cmd: CommandFleetBulkStopData = serde_json::from_value(data)
                     .map_err(|e| format!("fleet.bulk-stop: {e}"))?;
-                let result = fleet_bulk_stop_impl(&state, cmd.targets, cmd.signal.as_deref(), cmd.staged);
+                let result = fleet_bulk_stop_impl(&state, cmd.targets, cmd.signal.as_deref(), cmd.staged).await;
                 Ok(Some(serde_json::to_value(&result).unwrap()))
             })
         }),
@@ -161,7 +161,71 @@ const FLEET_BULK_STOP_AUDIT_ACTION: &str = "fleet.bulk-stop";
 /// unattempted — tripping the threshold on the LAST batch (nothing left to
 /// skip) must not report "aborted early" when the full list actually ran
 /// (reagent P2, same review).
-pub(crate) fn fleet_bulk_stop_impl(
+/// Look up `block_id` in the shared cross-channel registry (this host,
+/// other channels — same registry `server/reactive.rs`'s inject cascade
+/// tier-2b already reads) and forward a stop request over loopback HTTP to
+/// that channel's own srv (`/agentmux/agent/stop`), using its own
+/// `auth_key` from the registry entry — identical trust model to the
+/// inject cascade's own cross-channel forward (same host, same user).
+///
+/// Returns `None` when `block_id` isn't in the shared registry at all, or
+/// every matching entry is filtered out (not loopback, or a stale
+/// self-entry pointing at THIS instance) — the caller falls through to the
+/// normal local "not running" error in that case, same message as before
+/// this feature existed. `Some((agent_name, outcome))` otherwise.
+pub(crate) async fn forward_stop_to_shared_channel(
+    state: &AppState,
+    block_id: &str,
+    signal: Option<&str>,
+) -> Option<(String, Result<(), String>)> {
+    let shared_dir = crate::registry::resolve_shared_reactive_dir()?;
+    let entry = crate::backend::reactive::registry::list_all_shared(&shared_dir)
+        .into_iter()
+        .find(|e| e.block_id == block_id)?;
+
+    let is_loopback = entry.local_url.starts_with("http://127.0.0.1")
+        || entry.local_url.starts_with("http://localhost")
+        || entry.local_url.starts_with("http://[::1]");
+    if !is_loopback || entry.local_url == state.local_web_url {
+        return None;
+    }
+
+    let url = format!("{}/agentmux/agent/stop", entry.local_url);
+    let mut req = state.http_client.post(&url).json(&serde_json::json!({
+        "block_id": block_id,
+        "signal": signal,
+    }));
+    if !entry.auth_key.is_empty() {
+        req = req.header("X-AuthKey", &entry.auth_key);
+    }
+    let outcome = async {
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("cross-channel forward failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("cross-channel forward: HTTP {}", resp.status()));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("cross-channel forward: response parse failed: {e}"))?;
+        if body.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            Ok(())
+        } else {
+            Err(body
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("cross-channel forward failed")
+                .to_string())
+        }
+    }
+    .await;
+
+    Some((entry.agent_id, outcome))
+}
+
+pub(crate) async fn fleet_bulk_stop_impl(
     state: &AppState,
     targets: Vec<String>,
     signal: Option<&str>,
@@ -177,14 +241,21 @@ pub(crate) fn fleet_bulk_stop_impl(
         let batch_len = batch.len();
         let mut batch_failures = 0usize;
         for block_id in batch {
-            let target_agent = state
-                .reactive_handler
-                .get_agent_by_block(&block_id)
-                .map(|a| a.agent_id)
-                .unwrap_or_else(|| block_id.clone());
             let request_id = uuid::Uuid::new_v4().to_string();
-            match stop_one_agent_block(&block_id, signal) {
-                Ok(_) => {
+            // Local (this instance's own in-process controller registry)
+            // first — unchanged, fast path. Only reach for the shared
+            // cross-channel registry when nothing local matches
+            // (REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md
+            // §3.2 — this was host-tier-only before).
+            let (target_agent, outcome) = match state.reactive_handler.get_agent_by_block(&block_id) {
+                Some(agent) => (agent.agent_id, stop_one_agent_block(&block_id, signal).map(|_| ())),
+                None => match forward_stop_to_shared_channel(state, &block_id, signal).await {
+                    Some((agent_name, outcome)) => (agent_name, outcome),
+                    None => (block_id.clone(), stop_one_agent_block(&block_id, signal).map(|_| ())),
+                },
+            };
+            match outcome {
+                Ok(()) => {
                     state.reactive_handler.log_fleet_action_audit(
                         None, &target_agent, &block_id, FLEET_BULK_STOP_AUDIT_ACTION,
                         true, None, &request_id,

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -26,7 +26,13 @@ use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
 
 mod agent_open;
-mod agent_io;
+// pub(crate): `server/mod.rs`'s `/agentmux/agent/stop` handler (the
+// cross-channel bulk-stop forward target,
+// SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md) calls
+// `stop_one_agent_block` directly — same function `fleet_bulk_stop_impl`
+// already uses for a LOCAL target, reused rather than duplicated for a
+// forwarded one.
+pub(crate) mod agent_io;
 mod agent_define;
 /// Re-exported so the human-facing creation/edit RPC handlers
 /// (`server::agent_handlers::template`/`core`) can reuse the same

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -528,6 +528,16 @@ pub fn build_router(state: AppState) -> Router {
         // scoping — fleet actions target OTHER agents' panes by design, so
         // "own pane only" doesn't apply here the way it does to `ui/*`.
         .route("/api/v1/fleet/bulk-stop", post(handle_fleet_bulk_stop))
+        // Cross-channel bulk-stop forward target
+        // (SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md): when
+        // `fleet_bulk_stop_impl` can't find a target block_id in ITS OWN
+        // in-process controller registry, it checks the shared
+        // cross-channel registry and forwards here — same trust model as
+        // `/agentmux/reactive/inject`'s own cross-channel forward (same
+        // host, same user, the target channel's own auth_key from the
+        // shared registry). Loopback-only by construction: the caller only
+        // ever forwards to a `local_url` it already verified is loopback.
+        .route("/agentmux/agent/stop", post(handle_agent_stop_forward))
         .route("/api/messaging/status", get(messaging_handlers::handle_status))
         .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
         .route("/api/messaging/telegram/send", post(messaging_handlers::handle_telegram_send))
@@ -1132,8 +1142,30 @@ async fn handle_fleet_bulk_stop(
     State(state): State<AppState>,
     Json(req): Json<crate::backend::rpc_types::CommandFleetBulkStopData>,
 ) -> impl IntoResponse {
-    let result = app_api::fleet::fleet_bulk_stop_impl(&state, req.targets, req.signal.as_deref(), req.staged);
+    let result = app_api::fleet::fleet_bulk_stop_impl(&state, req.targets, req.signal.as_deref(), req.staged).await;
     (StatusCode::OK, Json(result)).into_response()
+}
+
+#[derive(serde::Deserialize)]
+struct AgentStopForwardRequest {
+    block_id: String,
+    signal: Option<String>,
+}
+
+/// `POST /agentmux/agent/stop` — the cross-channel bulk-stop forward
+/// target. See `fleet_bulk_stop_impl`'s doc comment for the caller side;
+/// this is just `stop_one_agent_block` run against THIS instance's own
+/// (in-process) controller registry, for a target the CALLING channel
+/// couldn't find in its own — same one-hop-forward shape as
+/// `/agentmux/reactive/inject`'s cross-channel tier, no further forwarding.
+async fn handle_agent_stop_forward(
+    State(_state): State<AppState>,
+    Json(req): Json<AgentStopForwardRequest>,
+) -> impl IntoResponse {
+    match app_api::agent_io::stop_one_agent_block(&req.block_id, req.signal.as_deref()) {
+        Ok(result) => (StatusCode::OK, Json(serde_json::json!({ "success": true, "result": result }))).into_response(),
+        Err(e) => (StatusCode::OK, Json(serde_json::json!({ "success": false, "error": e }))).into_response(),
+    }
 }
 
 #[derive(serde::Deserialize)]

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -2664,15 +2664,15 @@ mod fleet_tests {
         assert_eq!(good_outcome_count, 1, "the registered target must produce exactly one outcome");
     }
 
-    fn stop_result(state: &AppState, targets: Vec<String>, staged: Option<StagePlanInput>) -> FleetActionResult {
-        fleet_bulk_stop_impl(state, targets, None, staged)
+    async fn stop_result(state: &AppState, targets: Vec<String>, staged: Option<StagePlanInput>) -> FleetActionResult {
+        fleet_bulk_stop_impl(state, targets, None, staged).await
     }
 
     #[tokio::test]
     async fn bulk_stop_reports_a_failure_per_target_with_no_live_controller() {
         let state = test_state();
         let targets = vec!["blk-a".to_string(), "blk-b".to_string(), "blk-c".to_string()];
-        let result = stop_result(&state, targets.clone(), None);
+        let result = stop_result(&state, targets.clone(), None).await;
 
         assert!(result.succeeded.is_empty());
         assert_eq!(result.failed.len(), 3);
@@ -2697,7 +2697,7 @@ mod fleet_tests {
             &state,
             targets.clone(),
             Some(StagePlanInput { batch_size: 2, max_fail_percentage: 50 }),
-        );
+        ).await;
 
         assert!(result.aborted_early);
         assert!(result.succeeded.is_empty());
@@ -2725,7 +2725,7 @@ mod fleet_tests {
             &state,
             targets.clone(),
             Some(StagePlanInput { batch_size: 2, max_fail_percentage: 100 }),
-        );
+        ).await;
 
         assert!(!result.aborted_early);
         assert_eq!(result.failed.len(), 5);
@@ -2748,7 +2748,7 @@ mod fleet_tests {
             &state,
             targets.clone(),
             Some(StagePlanInput { batch_size: 5, max_fail_percentage: 50 }),
-        );
+        ).await;
 
         assert_eq!(result.failed.len(), 5, "every target was still attempted");
         for f in &result.failed {
@@ -2780,7 +2780,7 @@ mod fleet_tests {
         let block_id = format!("fleet-audit-block-{unique}");
         state.reactive_handler.register_agent(&agent_id, &block_id, None).unwrap();
 
-        let _ = stop_result(&state, vec![block_id.clone()], None);
+        let _ = stop_result(&state, vec![block_id.clone()], None).await;
         let matching: Vec<_> = state
             .reactive_handler
             .get_audit_log(10_000)
@@ -2893,6 +2893,208 @@ mod fleet_tests {
             .unwrap()
             .unwrap();
         assert!(!resp.error.is_empty(), "updating a nonexistent group must error, not silently no-op");
+    }
+
+    // ── Cross-channel bulk-stop forward
+    // (SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md) ──────────────────
+
+    use crate::server::app_api::fleet::forward_stop_to_shared_channel;
+
+    /// Serializes every test in this sub-block that mutates the
+    /// process-global `AGENTMUX_HOME_OVERRIDE` env var (which
+    /// `resolve_shared_reactive_dir` reads) — same lock already used
+    /// elsewhere in this crate for this exact var (e.g.
+    /// `identity::resolver::inject`'s tests), not a new one, per
+    /// `test_support::ISOLATED_AUTH_ENV_LOCK`'s own doc comment about
+    /// avoiding a proliferation of module-local locks around shared env
+    /// vars.
+    fn home_override_guard() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_support::ISOLATED_AUTH_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Write an `AgentEntry` directly (not via `registry::write_shared`,
+    /// which always stamps `local_auth_key()` — a process-global `OnceLock`
+    /// this test can't control) so tests can assert on a SPECIFIC auth_key
+    /// value being forwarded. Layout only needs to satisfy
+    /// `list_all_shared`'s generic "any `*.json` file under a subdirectory
+    /// of `shared_dir`" walk, not `write_shared`'s own path convention.
+    fn write_raw_shared_entry(
+        shared_dir: &std::path::Path,
+        agent_id: &str,
+        local_url: &str,
+        block_id: &str,
+        auth_key: &str,
+    ) {
+        let dir = shared_dir.join(agent_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let entry = crate::backend::reactive::registry::AgentEntry {
+            agent_id: agent_id.to_string(),
+            local_url: local_url.to_string(),
+            block_id: block_id.to_string(),
+            pid: std::process::id(),
+            updated_at: 0,
+            auth_key: auth_key.to_string(),
+            channel: "test-channel".to_string(),
+            registration_nonce: 0,
+        };
+        std::fs::write(dir.join("test-channel.json"), serde_json::to_string(&entry).unwrap()).unwrap();
+    }
+
+    /// Fake `/agentmux/agent/stop` responder — records the `X-AuthKey`
+    /// header it received (or `None`) and returns `response_body` verbatim.
+    /// Mirrors `spawn_fake_browser_api`'s established pattern (raw TCP +
+    /// hand-built HTTP response — no real CEF host needed).
+    async fn spawn_fake_agent_stop_endpoint(
+        response_body: &'static str,
+    ) -> (String, std::sync::Arc<std::sync::Mutex<Option<String>>>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let received_auth: std::sync::Arc<std::sync::Mutex<Option<String>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let received_auth_clone = received_auth.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else { return };
+                let received_auth = received_auth_clone.clone();
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 4096];
+                    let Ok(n) = stream.read(&mut buf).await else { return };
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    let auth = req
+                        .lines()
+                        .find_map(|l| l.strip_prefix("X-AuthKey: ").or_else(|| l.strip_prefix("x-authkey: ")))
+                        .map(|v| v.trim_end_matches('\r').to_string());
+                    *received_auth.lock().unwrap() = auth;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), received_auth)
+    }
+
+    #[tokio::test]
+    async fn forward_stop_returns_none_when_shared_registry_has_no_matching_entry() {
+        let _guard = home_override_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        let state = test_state();
+
+        let result = forward_stop_to_shared_channel(&state, "no-such-block", None).await;
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+
+        assert!(result.is_none(), "no matching shared entry must fall through to the caller's local-error path");
+    }
+
+    #[tokio::test]
+    async fn forward_stop_ignores_a_non_loopback_entry() {
+        let _guard = home_override_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        let shared_dir = tmp.path().join("shared").join("agents").join("reactive");
+        let unique = uuid::Uuid::new_v4();
+        let block_id = format!("blk-remote-{unique}");
+        // A real IP, not loopback — must never be treated as a same-host
+        // cross-channel peer (this is the same defense-in-depth check
+        // `server/reactive.rs`'s inject cascade already applies).
+        write_raw_shared_entry(&shared_dir, "remote-agent", "http://203.0.113.5:9999", &block_id, "some-key");
+        let state = test_state();
+
+        let result = forward_stop_to_shared_channel(&state, &block_id, None).await;
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+
+        assert!(result.is_none(), "a non-loopback entry must never be forwarded to");
+    }
+
+    #[tokio::test]
+    async fn forward_stop_ignores_a_stale_self_entry() {
+        let _guard = home_override_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        let shared_dir = tmp.path().join("shared").join("agents").join("reactive");
+        let unique = uuid::Uuid::new_v4();
+        let block_id = format!("blk-self-{unique}");
+        let mut state = test_state();
+        state.local_web_url = "http://127.0.0.1:12345".to_string();
+        // An entry whose local_url IS this instance's own — a stale
+        // self-registration from a prior crash, not a real peer.
+        write_raw_shared_entry(&shared_dir, "self-agent", &state.local_web_url.clone(), &block_id, "some-key");
+
+        let result = forward_stop_to_shared_channel(&state, &block_id, None).await;
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+
+        assert!(result.is_none(), "a stale self-entry must never be forwarded to (would be forwarding to itself)");
+    }
+
+    #[tokio::test]
+    async fn forward_stop_succeeds_against_a_real_loopback_peer_with_its_own_auth_key() {
+        let _guard = home_override_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        let shared_dir = tmp.path().join("shared").join("agents").join("reactive");
+        let unique = uuid::Uuid::new_v4();
+        let block_id = format!("blk-peer-{unique}");
+        let (peer_url, received_auth) =
+            spawn_fake_agent_stop_endpoint(r#"{"success":true,"result":{"block_id":"x","status":"done"}}"#).await;
+        write_raw_shared_entry(&shared_dir, "peer-agent", &peer_url, &block_id, "peer-secret-key");
+        let state = test_state();
+
+        let result = forward_stop_to_shared_channel(&state, &block_id, None).await;
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+
+        let (agent_name, outcome) = result.expect("a loopback entry must be forwarded to");
+        assert_eq!(agent_name, "peer-agent");
+        assert!(outcome.is_ok(), "a success:true response must resolve Ok: {outcome:?}");
+        assert_eq!(
+            received_auth.lock().unwrap().as_deref(),
+            Some("peer-secret-key"),
+            "the peer's OWN auth_key (from the registry entry) must be sent, not this instance's"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_stop_propagates_a_peer_side_failure() {
+        let _guard = home_override_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        let shared_dir = tmp.path().join("shared").join("agents").join("reactive");
+        let unique = uuid::Uuid::new_v4();
+        let block_id = format!("blk-fail-{unique}");
+        let (peer_url, _received_auth) =
+            spawn_fake_agent_stop_endpoint(r#"{"success":false,"error":"NOT_RUNNING: no controller for block x"}"#).await;
+        write_raw_shared_entry(&shared_dir, "peer-agent", &peer_url, &block_id, "peer-secret-key");
+        let state = test_state();
+
+        let result = forward_stop_to_shared_channel(&state, &block_id, None).await;
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+
+        let (_agent_name, outcome) = result.expect("a loopback entry must still be forwarded to");
+        let err = outcome.expect_err("a success:false response must resolve Err");
+        assert!(err.contains("NOT_RUNNING"), "the peer's own error text must propagate: {err}");
+    }
+
+    #[tokio::test]
+    async fn bulk_stop_reaches_a_target_only_present_in_the_shared_cross_channel_registry() {
+        let _guard = home_override_guard();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+        let shared_dir = tmp.path().join("shared").join("agents").join("reactive");
+        let unique = uuid::Uuid::new_v4();
+        let block_id = format!("blk-e2e-{unique}");
+        let (peer_url, _received_auth) =
+            spawn_fake_agent_stop_endpoint(r#"{"success":true,"result":{"block_id":"x","status":"done"}}"#).await;
+        write_raw_shared_entry(&shared_dir, "peer-agent-e2e", &peer_url, &block_id, "peer-secret-key");
+        let state = test_state();
+
+        let result = fleet_bulk_stop_impl(&state, vec![block_id.clone()], None, None).await;
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+
+        assert_eq!(result.succeeded, vec![block_id], "a target absent from THIS instance's own registry, but present cross-channel, must succeed via the forward — not fail with NOT_RUNNING");
+        assert!(result.failed.is_empty());
     }
 }
 

--- a/docs/specs/SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md
+++ b/docs/specs/SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md
@@ -1,0 +1,102 @@
+# SPEC: `FleetBulkStop` reaches cross-channel targets; LAN/WAN deliberately deferred
+
+**Date:** 2026-08-22
+**Status:** Implemented (cross-channel only)
+**Author:** Korp
+**Repo touched:** `agentmux` (`agentmux-srv/src/server/app_api/fleet.rs`, `server/mod.rs`, `server/app_api/mod.rs`)
+**Diagnosis:** `docs/reports/REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md` §3.2
+**Related:** `SPEC_FLEET_BROADCAST_CROSS_TIER_TARGETING_2026_08_22.md` (the sibling fix this follows)
+
+## 1. Problem
+
+`fleet_bulk_stop_impl` resolved every target purely via
+`state.reactive_handler.get_agent_by_block` — this instance's own
+in-process controller registry. A `host.cross_channel` target (a different
+channel on the same host, visible via `FleetList`/`DiscoverAgents`, with a
+real `block_id` in the same namespace) always failed with "no registered
+agent for this block," identical to a genuinely-unknown block_id — even
+though the block is live, just owned by a sibling process on the same
+machine.
+
+## 2. Fix — cross-channel only
+
+Unlike `FleetBroadcast`, bulk-stop involves **no jekt signing at all**
+(same module doc comment, unchanged) — so there's no signing-locality
+reason to keep the fix client-side. This is fixed once, at the single
+shared choke point (`fleet_bulk_stop_impl`), covering BOTH the WS-RPC
+(Swarm UI) and HTTP (`FleetBulkStop` MCP tool) callers identically.
+
+- When a target isn't found in the local controller registry, look it up
+  in the shared cross-channel registry (`registry::list_all_shared` — the
+  same mechanism `server/reactive.rs`'s inject cascade tier-2b already
+  uses) by `block_id`.
+- If found, and the entry is loopback (same defense-in-depth check the
+  inject cascade already applies) and isn't a stale self-entry, forward an
+  authenticated HTTP stop request to a new endpoint,
+  `POST /agentmux/agent/stop`, on that channel's own srv — using ITS OWN
+  `auth_key` from the registry entry, not this instance's. Same one-hop,
+  same-host, same-user trust model as the existing inject forward; no new
+  trust primitive.
+- If the shared registry has no matching entry either, falls through to
+  the original `stop_one_agent_block` call — same exact "NOT_RUNNING"
+  error a genuinely-unknown block_id always produced. No regression for
+  the common case.
+- `fleet_bulk_stop_impl` is now `async` (previously synchronous) to allow
+  the forward's HTTP round-trip; both call sites (`register_fleet_bulk_stop`
+  WS-RPC handler, `handle_fleet_bulk_stop` HTTP handler) now `.await` it.
+  `app_api::agent_io` module visibility widened to `pub(crate)` so the new
+  `/agentmux/agent/stop` handler (in `server/mod.rs`) can call
+  `stop_one_agent_block` directly — the exact same function the local path
+  already used, reused rather than duplicated for the forwarded case.
+
+## 3. LAN/WAN — deliberately deferred, not silently dropped
+
+Extending bulk-stop past cross-channel needs a genuinely new primitive:
+per `REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md` §2,
+**no remote-command bus exists on any tier today** — jekt is
+message-only (free-text injection into a conversation stream), never a
+structured "run this" verb. A LAN/WAN remote-stop would mean designing and
+shipping a brand-new authenticated destructive-action protocol, not
+reusing something that already exists the way the cross-channel fix does.
+
+Two additional reasons this isn't attempted here:
+
+- **LAN** could plausibly reuse the LAN Ed25519 signing infrastructure
+  (`SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md`) for a new `stop_request`/
+  `stop_response` message pair — architecturally sound, but a genuinely new
+  message type with its own tier/escalation semantics deserves its own
+  dedicated design pass (e.g.: should a cryptographically-verified LAN
+  sender's stop request skip human escalation the way `ESCALATE=none`
+  already works for messaging, or does a destructive remote action always
+  warrant `ESCALATE=required` regardless of verification? — not a decision
+  to fold into this PR's scope).
+- **WAN** is currently blocked on the exact same infrastructure gap as
+  general WAN agent-to-agent jekt signing (audit §4.1): no non-reagent WAN
+  sender is cryptographically verifiable today, and that's real
+  `agentmux-cloud`/`shared-infrastructure` work (Cognito M2M redesign), not
+  something buildable from this repo. Building WAN bulk-stop without that
+  would mean either trusting an unverified WAN sender with a destructive
+  action (precisely the kind of gap this whole audit exists to close, not
+  add to) or inventing a parallel, one-off WAN trust mechanism that
+  duplicates the already-planned redesign.
+
+Both are flagged as real, visible follow-ups — not silently assumed
+covered by this PR's title.
+
+## 4. Testing
+
+- `forward_stop_to_shared_channel`: 4 new unit tests — returns `None` for
+  no matching entry; returns `None` for a non-loopback entry (security);
+  returns `None` for a stale self-entry; succeeds against a real loopback
+  peer (spawned via a raw-TCP fake responder, mirroring the existing
+  `spawn_fake_browser_api` pattern) and asserts the PEER's own `auth_key`
+  is what gets sent, not this instance's; propagates a peer-side failure
+  response's error text.
+- `fleet_bulk_stop_impl`: 1 new end-to-end test — a target present only in
+  the shared cross-channel registry (absent from this instance's own)
+  succeeds via the forward, not "NOT_RUNNING."
+- Full `agentmux-srv` suite: 2721/2722 passed (the one failure,
+  `refresh_processes_specifics_does_not_leak_a_handle_per_call`, is an
+  unrelated, environment-sensitive Windows handle-count check — confirmed
+  to pass in isolation, reproduces the same way with or without this
+  change, and touches no code this PR modifies).


### PR DESCRIPTION
## Summary

Item §3.2 of `docs/reports/REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md`, sibling fix to #2759 (FleetBroadcast).

`fleet_bulk_stop_impl` resolved every target purely via this instance's own in-process controller registry. A `host.cross_channel` target (a different channel on the same host, real `block_id`, visible via `FleetList`) always failed with "no registered agent for this block" — even though the block is live, just owned by a sibling process on the same machine.

**Fix**, at the single shared choke point (`fleet_bulk_stop_impl` — unlike broadcast, bulk-stop involves no jekt signing at all, so there's no signing-locality reason to keep this client-side; this covers both the WS-RPC/Swarm-UI and HTTP/MCP-tool callers identically):
- When a target isn't in the local registry, check the shared cross-channel registry (same mechanism `server/reactive.rs`'s inject cascade tier-2b already uses) and forward an authenticated stop request to that channel's own srv (new `POST /agentmux/agent/stop` endpoint), using **its own** `auth_key` from the registry — same one-hop, same-host, same-user trust model as the existing inject forward, no new trust primitive.
- Falls through to the original `NOT_RUNNING` error when nothing matches anywhere — no regression for the common case.
- `fleet_bulk_stop_impl` is now `async`; both call sites updated to `.await` it.

**LAN/WAN deliberately deferred, not silently dropped** (see the spec's §3): per the audit, no remote-command bus exists on any tier today — jekt is message-only. Reaching LAN/WAN for bulk-stop means designing a genuinely new authenticated destructive-action protocol, not reusing something that already exists the way cross-channel does. WAN specifically is blocked on the same Cognito redesign as general WAN jekt signing (real `agentmux-cloud`/`shared-infrastructure` work, out of this repo's scope). LAN is architecturally feasible via the existing LAN Ed25519 signing, but a new message type's tier/escalation semantics (should a verified LAN sender's stop request skip human escalation, or does a destructive remote action always warrant it regardless of verification?) deserves its own dedicated design pass, not a rushed addition here.

## Test plan
- [x] 4 new unit tests for `forward_stop_to_shared_channel`: no matching entry → `None`; non-loopback entry ignored (security); stale self-entry ignored; succeeds against a real loopback peer (raw-TCP fake responder, mirrors the existing `spawn_fake_browser_api` pattern) and asserts the **peer's own** `auth_key` is sent, not this instance's; propagates a peer-side failure's error text
- [x] 1 new end-to-end test: a target present only in the shared cross-channel registry succeeds via the forward
- [x] Full `agentmux-srv` suite: 2721/2722 passed — the one failure (`refresh_processes_specifics_does_not_leak_a_handle_per_call`) is an unrelated, environment-sensitive Windows handle-count check, confirmed to pass in isolation and untouched by this PR

<!-- agentmux:agent_id=korp -->