### PR TITLE
Korp@claudius: feat(muxspect): Phase B policy infrastructure + jekt tier enforcement for transcript_request

### DIFF
--- a/.changesets/1787451088-feat-muxspect-phase-b-policy-infrastructure-jekt-tier-enforc-3dgi.md
+++ b/.changesets/1787451088-feat-muxspect-phase-b-policy-infrastructure-jekt-tier-enforc-3dgi.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxspect): Phase B policy infrastructure + jekt tier enforcement for transcript_request

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod layout_types;
 pub mod pagefile;
 pub mod runtime_mode;
 pub mod toolchain_path;
+pub mod transcript_request;
 
 pub use cli::{make_cli_cmd, resolve_cli_spawn_target};
 pub use data_paths::{

--- a/agentmux-common/src/transcript_request.rs
+++ b/agentmux-common/src/transcript_request.rs
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `transcript_request`/`transcript_response` wire payload — `muxspect`
+//! Phase B/C's LAN/WAN conversation-visibility protocol
+//! (docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md,
+//! jekt tier rules confirmed in
+//! docs/specs/SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md).
+//!
+//! There is no structured `msg_type`/content-type field anywhere in the
+//! jekt wire format — every jekt is one opaque `message: String`, and that
+//! field is part of the SIGNED material (`jekt_sign::signed_material`).
+//! Adding a top-level field would mean touching every signer/verifier and
+//! every existing marker-formatting call site for a feature that's
+//! otherwise fully layerable on top. Instead, this payload is JSON-encoded
+//! and carried AS the jekt `message` — the receiving side sniffs for it
+//! (`parse_transcript_request`/`parse_transcript_response`, both `None` for
+//! any ordinary free-text message, so this can never misfire on normal
+//! jekt traffic) before falling through to ordinary message handling.
+//!
+//! Shared between `agentmux-mcp` (constructs a request, sends it as an
+//! ordinary signed jekt via the existing `/agentmux/reactive/inject` path —
+//! no new transport) and `agentmux-srv` (detects an incoming request/
+//! response payload in `Handler::inject_message_inner` and routes it to the
+//! conversation-visibility auto-resolution logic instead of ordinary
+//! delivery).
+
+use serde::{Deserialize, Serialize};
+
+pub const TRANSCRIPT_REQUEST_TYPE: &str = "transcript_request";
+pub const TRANSCRIPT_RESPONSE_TYPE: &str = "transcript_response";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TranscriptRequest {
+    #[serde(rename = "type")]
+    pub msg_type: String,
+    pub request_id: String,
+    pub max_lines: usize,
+}
+
+impl TranscriptRequest {
+    pub fn new(request_id: impl Into<String>, max_lines: usize) -> Self {
+        Self {
+            msg_type: TRANSCRIPT_REQUEST_TYPE.to_string(),
+            request_id: request_id.into(),
+            max_lines,
+        }
+    }
+
+    pub fn to_message(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum TranscriptResponseStatus {
+    Ok { lines: Vec<String> },
+    Denied,
+    Error { error: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TranscriptResponse {
+    #[serde(rename = "type")]
+    pub msg_type: String,
+    pub request_id: String,
+    #[serde(flatten)]
+    pub status: TranscriptResponseStatus,
+}
+
+impl TranscriptResponse {
+    pub fn ok(request_id: impl Into<String>, lines: Vec<String>) -> Self {
+        Self {
+            msg_type: TRANSCRIPT_RESPONSE_TYPE.to_string(),
+            request_id: request_id.into(),
+            status: TranscriptResponseStatus::Ok { lines },
+        }
+    }
+
+    pub fn denied(request_id: impl Into<String>) -> Self {
+        Self {
+            msg_type: TRANSCRIPT_RESPONSE_TYPE.to_string(),
+            request_id: request_id.into(),
+            status: TranscriptResponseStatus::Denied,
+        }
+    }
+
+    pub fn error(request_id: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            msg_type: TRANSCRIPT_RESPONSE_TYPE.to_string(),
+            request_id: request_id.into(),
+            status: TranscriptResponseStatus::Error { error: error.into() },
+        }
+    }
+
+    pub fn to_message(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
+/// Sniff a jekt's raw `message` for a `transcript_request` payload. `None`
+/// for anything else — malformed JSON, valid JSON that isn't this shape, or
+/// ordinary free text — so this can never misclassify normal jekt traffic.
+/// Deliberately checks the `type` discriminant BEFORE fully deserializing
+/// (a message that happens to parse as arbitrary JSON but isn't a
+/// transcript_request must return `None`, not an error).
+pub fn parse_transcript_request(message: &str) -> Option<TranscriptRequest> {
+    let value: serde_json::Value = serde_json::from_str(message).ok()?;
+    if value.get("type")?.as_str()? != TRANSCRIPT_REQUEST_TYPE {
+        return None;
+    }
+    serde_json::from_value(value).ok()
+}
+
+/// Sniff a jekt's raw `message` for a `transcript_response` payload. Same
+/// "never misfire" contract as [`parse_transcript_request`].
+pub fn parse_transcript_response(message: &str) -> Option<TranscriptResponse> {
+    let value: serde_json::Value = serde_json::from_str(message).ok()?;
+    if value.get("type")?.as_str()? != TRANSCRIPT_RESPONSE_TYPE {
+        return None;
+    }
+    serde_json::from_value(value).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trips_through_message_encoding() {
+        let req = TranscriptRequest::new("req-1", 100);
+        let message = req.to_message();
+        let parsed = parse_transcript_request(&message).unwrap();
+        assert_eq!(parsed, req);
+    }
+
+    #[test]
+    fn ordinary_free_text_never_parses_as_a_request() {
+        assert!(parse_transcript_request("just chatting with you").is_none());
+    }
+
+    #[test]
+    fn arbitrary_json_that_isnt_this_shape_never_parses_as_a_request() {
+        assert!(parse_transcript_request(r#"{"type":"something_else","foo":"bar"}"#).is_none());
+        assert!(parse_transcript_request(r#"{"foo":"bar"}"#).is_none());
+        assert!(parse_transcript_request("[1,2,3]").is_none());
+    }
+
+    #[test]
+    fn malformed_json_never_parses_as_a_request_and_never_panics() {
+        assert!(parse_transcript_request("{not json").is_none());
+    }
+
+    #[test]
+    fn ok_response_round_trips() {
+        let resp = TranscriptResponse::ok("req-1", vec!["line 1".to_string(), "line 2".to_string()]);
+        let message = resp.to_message();
+        let parsed = parse_transcript_response(&message).unwrap();
+        assert_eq!(parsed, resp);
+    }
+
+    #[test]
+    fn denied_response_round_trips() {
+        let resp = TranscriptResponse::denied("req-1");
+        let message = resp.to_message();
+        let parsed = parse_transcript_response(&message).unwrap();
+        assert_eq!(parsed, resp);
+    }
+
+    #[test]
+    fn error_response_round_trips() {
+        let resp = TranscriptResponse::error("req-1", "something broke");
+        let message = resp.to_message();
+        let parsed = parse_transcript_response(&message).unwrap();
+        assert_eq!(parsed, resp);
+    }
+
+    #[test]
+    fn a_request_never_parses_as_a_response_and_vice_versa() {
+        let req = TranscriptRequest::new("req-1", 100);
+        assert!(parse_transcript_response(&req.to_message()).is_none());
+        let resp = TranscriptResponse::denied("req-1");
+        assert!(parse_transcript_request(&resp.to_message()).is_none());
+    }
+}

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -199,6 +199,7 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
             model_vendor_base_url: String::new(), // manifest doesn't declare this yet
             auto_continue_enabled: 0,
             memory_id: String::new(),
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -449,6 +450,7 @@ fn reseed_if_needed(
             model_vendor_base_url: String::new(), // manifest doesn't declare this yet
             auto_continue_enabled: 0,
             memory_id: String::new(),
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {
@@ -560,6 +562,7 @@ mod tests {
             auto_continue_enabled: 0,
             model_vendor_base_url: String::new(),
             memory_id: String::new(),
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         };
         wstore.agent_def_insert(&mut def).unwrap();
     }

--- a/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
+++ b/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
@@ -296,6 +296,11 @@ pub fn migrate_promote_template_sessions_v1(
                 model_vendor_base_url: template.model_vendor_base_url.clone(),
                 auto_continue_enabled: 0,
                 memory_id: String::new(),
+                // Safe fail-closed default, not inherited from the template —
+                // same convention as auto_continue_enabled/use_ambient_login
+                // just above (opt-in settings reset, not carried over, on a
+                // fresh instantiation).
+                conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             };
             if let Err(e) = wstore.agent_def_insert(&mut new_def) {
                 tracing::warn!(

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -502,6 +502,7 @@ fn insert_template(
     provider: &str,
 ) -> AgentDefinition {
     let mut def = AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: id.to_string(),
         slug: String::new(),
         name: name.to_string(),
@@ -789,6 +790,7 @@ fn template_promote_does_not_reuse_clone_with_active_zone() {
     // own zone.
     let now = now_ms() as i64;
     let mut user_clone = crate::backend::storage::store::AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: "user-made-clone".to_string(),
         slug: String::new(),
         name: "MyAgent".to_string(),
@@ -899,6 +901,7 @@ fn template_promote_preserves_user_continuation_on_clone() {
     let promote_target_id = format!("template-promote-v1-{}", template.id);
     let now = now_ms() as i64;
     let mut prior_target = crate::backend::storage::store::AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: promote_target_id.clone(),
         slug: String::new(),
         name: "Claude Code".to_string(),
@@ -1001,6 +1004,7 @@ fn template_promote_recovers_partial_copy_at_zone() {
     let promote_target_id = format!("template-promote-v1-{}", template.id);
     let now = now_ms() as i64;
     let mut prior_target = crate::backend::storage::store::AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: promote_target_id.clone(),
         slug: String::new(),
         name: "Claude Code".to_string(),
@@ -1105,6 +1109,7 @@ fn template_promote_promotes_newer_source_over_stale_destination() {
     let promote_target_id = format!("template-promote-v1-{}", template.id);
     let now = now_ms() as i64;
     let mut prior_target = crate::backend::storage::store::AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: promote_target_id.clone(),
         slug: String::new(),
         name: "Claude Code".to_string(),
@@ -1228,6 +1233,7 @@ fn template_promote_idempotent_under_partial_failure_at_archive_move() {
     let promote_target_id = format!("template-promote-v1-{}", template.id);
     let now = now_ms() as i64;
     let mut prior_target = crate::backend::storage::store::AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: promote_target_id.clone(),
         slug: String::new(),
         name: "Maks".to_string(),
@@ -1368,6 +1374,7 @@ fn template_promote_skips_already_user_owned_definitions() {
     // A user-owned definition (is_seeded = 0) with a session — the
     // migration should leave it alone.
     let mut user_def = AgentDefinition {
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
         id: "user-abc".to_string(),
         slug: String::new(),
         name: "My Agent".to_string(),

--- a/agentmux-srv/src/backend/blockcontroller/core.rs
+++ b/agentmux-srv/src/backend/blockcontroller/core.rs
@@ -310,6 +310,7 @@ mod tests {
     /// `definition_id` — field values otherwise irrelevant to these tests.
     fn sample_agent(id: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: id.to_string(),
             name: id.to_string(),

--- a/agentmux-srv/src/backend/history/mod.rs
+++ b/agentmux-srv/src/backend/history/mod.rs
@@ -274,6 +274,7 @@ mod tests {
 
         let store = Store::open_in_memory().unwrap();
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "agent-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -339,6 +340,7 @@ mod tests {
 
     fn insert_test_agent_and_link(store: &Store, agent_id: &str, account_id: &str) {
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: agent_id.to_string(),
             slug: String::new(),
             name: "T".to_string(),

--- a/agentmux-srv/src/backend/native_memory_drift.rs
+++ b/agentmux-srv/src/backend/native_memory_drift.rs
@@ -424,6 +424,7 @@ mod tests {
         let config_b = tempfile::tempdir().unwrap();
         for (id, dir) in [("sweep-agent-a", config_a.path()), ("sweep-agent-b", config_b.path())] {
             let mut def = crate::backend::storage::AgentDefinition {
+                conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 id: id.to_string(),
                 slug: id.to_string(),
                 name: "Test".to_string(),

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -526,11 +526,21 @@ impl Handler {
         // docs/specs/SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md §2.4/§2.5.
         let is_lan_sig_invalid = delivery_tier == "lan" && req.lan_verified == Some(false);
         let is_unverified_sender = req.sig_verified == Some(false);
+        // SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md rule 1: a
+        // transcript_request (muxspect Phase B/C's LAN/WAN conversation-
+        // visibility protocol) is forced sensitive unconditionally, on any
+        // tier, regardless of trust — the existing credential/destructive-
+        // keyword scan (is_sensitive_message) doesn't catch a content-
+        // disclosure *request* at all. `req.is_transcript_request` is
+        // server-computed in `handle_reactive_inject` by re-parsing
+        // `message` itself (never attacker-settable — see its own doc
+        // comment), so this can't be spoofed by a client claiming/denying it.
         let is_sensitive = is_network_tier_sig_invalid
             || is_lan_sig_invalid
             || is_unverified_sender
             || matches!(declared_tier, Some(super::types::JektTier::Sensitive))
-            || is_sensitive_message(&sanitized);
+            || is_sensitive_message(&sanitized)
+            || req.is_transcript_request;
         let effective_tier = if is_sensitive { "sensitive" } else {
             declared_tier.map_or("coord", |t| match t {
                 super::types::JektTier::Info => "info",
@@ -565,7 +575,20 @@ impl Handler {
         let is_cryptographically_verified = req.sig_verified == Some(true)
             || req.reagent_verified == Some(true)
             || req.lan_verified == Some(true);
-        let requires_stop = is_sensitive && !is_cryptographically_verified;
+        // SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md rule 2: the
+        // ONE named exception to the verified-sender relaxation above. A
+        // transcript_request's ESCALATE=required is not relaxed by a
+        // verified sender when the RESPONDING agent's own
+        // conversation_visibility is `ask` (or `trusted_peers` with a
+        // non-allow-listed requester) — `req.transcript_request_escalate_forced`,
+        // resolved server-side in `handle_reactive_inject` against that
+        // agent's own setting (meaningless/always-false unless
+        // `is_transcript_request` is also true). A valid signature answers
+        // *who is asking*, not *whether this content should be disclosed* —
+        // identity proof alone doesn't relax that question, unlike every
+        // other TIER=sensitive case above.
+        let requires_stop = is_sensitive
+            && (!is_cryptographically_verified || req.transcript_request_escalate_forced);
         let priority = req.priority.as_deref().unwrap_or("normal");
 
         // Wrap in JEKT marker block (structured tag + human-readable header).

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -924,6 +924,125 @@ async fn test_handler_inject_lan_clean_content_not_forced_sensitive() {
     assert!(payload.contains("TIER=coord"), "{payload}");
 }
 
+// SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md rule 1: is_transcript_request
+// forces TIER=sensitive unconditionally, even on host delivery with an
+// otherwise-clean message and no declared tier — the one new category
+// alongside declared-sensitive/keyword-match.
+#[tokio::test]
+async fn test_handler_inject_transcript_request_forces_sensitive_tier() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |_block_id: &str, _data: &[u8]| Ok(())));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: r#"{"type":"transcript_request","request_id":"r1","max_lines":50}"#.to_string(),
+        source_agent: Some("korp".to_string()),
+        request_id: Some("req-tr-1".to_string()),
+        delivery_tier: Some("host".to_string()),
+        is_transcript_request: true,
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert_eq!(
+        resp.effective_tier.as_deref(),
+        Some("sensitive"),
+        "a transcript_request must be forced sensitive even on host tier with clean content and no declared tier"
+    );
+}
+
+// Rule 2: a verified sender's identity ordinarily relaxes ESCALATE to
+// `none` (requires_stop == false) — transcript_request is the one named
+// exception WHEN transcript_request_escalate_forced is true (the
+// responding agent's own conversation_visibility is `ask`, or
+// `trusted_peers` with a non-allow-listed requester).
+#[tokio::test]
+async fn test_handler_inject_transcript_request_escalate_forced_survives_a_verified_sender() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |_block_id: &str, _data: &[u8]| Ok(())));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: r#"{"type":"transcript_request","request_id":"r1","max_lines":50}"#.to_string(),
+        source_agent: Some("korp".to_string()),
+        request_id: Some("req-tr-2".to_string()),
+        delivery_tier: Some("lan".to_string()),
+        is_transcript_request: true,
+        transcript_request_escalate_forced: true,
+        lan_verified: Some(true), // cryptographically verified sender
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert_eq!(resp.effective_tier.as_deref(), Some("sensitive"));
+    assert_eq!(
+        resp.requires_stop,
+        Some(true),
+        "transcript_request_escalate_forced must survive a verified sender — unlike every other sensitive-tier case"
+    );
+}
+
+// The mirror-image proof: when transcript_request_escalate_forced is
+// false (the responding agent's own conversation_visibility is `private`
+// or an allow-listed `trusted_peers` requester), a verified sender's
+// identity relaxes ESCALATE to `none` same as any other sensitive-tier
+// case — the exception in rule 2 is opt-in per-response, not blanket for
+// the whole jekt type.
+#[tokio::test]
+async fn test_handler_inject_transcript_request_verified_sender_relaxes_when_not_forced() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |_block_id: &str, _data: &[u8]| Ok(())));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: r#"{"type":"transcript_request","request_id":"r1","max_lines":50}"#.to_string(),
+        source_agent: Some("korp".to_string()),
+        request_id: Some("req-tr-3".to_string()),
+        delivery_tier: Some("lan".to_string()),
+        is_transcript_request: true,
+        transcript_request_escalate_forced: false,
+        lan_verified: Some(true),
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert_eq!(resp.effective_tier.as_deref(), Some("sensitive"), "rule 1 still forces the tier regardless");
+    assert_eq!(
+        resp.requires_stop,
+        Some(false),
+        "an unforced transcript_request from a verified sender relaxes normally, same as any other sensitive case"
+    );
+}
+
+// An unverified sender's transcript_request must still require STOP
+// regardless of transcript_request_escalate_forced — that flag only ever
+// ADDS to the escalation requirement, never removes the ordinary
+// unverified-sender STOP rule every other sensitive jekt already has.
+#[tokio::test]
+async fn test_handler_inject_transcript_request_unverified_sender_still_requires_stop() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |_block_id: &str, _data: &[u8]| Ok(())));
+    handler.register_agent("agent1", "block1", None).unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agent1".to_string(),
+        message: r#"{"type":"transcript_request","request_id":"r1","max_lines":50}"#.to_string(),
+        source_agent: Some("korp".to_string()),
+        request_id: Some("req-tr-4".to_string()),
+        delivery_tier: Some("lan".to_string()),
+        is_transcript_request: true,
+        transcript_request_escalate_forced: false,
+        lan_verified: None, // no signature attempted at all
+        ..Default::default()
+    });
+
+    assert!(resp.success);
+    assert_eq!(resp.requires_stop, Some(true), "an unverified sender must still require STOP, same as any other sensitive jekt");
+}
+
 // Rule 4 (keyword match) is completely unaffected by the narrowing — this is
 // the negative-control proof for LAN specifically.
 #[tokio::test]

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -220,6 +220,36 @@ pub struct InjectionRequest {
     /// (`docs/specs/SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md` §2.4/§2.5).
     #[serde(skip_deserializing, default, skip_serializing_if = "Option::is_none")]
     pub lan_verified: Option<bool>,
+    /// Server-computed: this jekt's `message` is a `transcript_request`
+    /// payload (`agentmux_common::transcript_request::parse_transcript_request`)
+    /// — `muxspect` Phase B/C's LAN/WAN conversation-visibility protocol.
+    /// `#[serde(skip_deserializing)]`, same guarantee as `sig_verified`
+    /// etc.: no attacker-supplied JSON body can force or suppress this —
+    /// `handle_reactive_inject` always recomputes it by re-parsing `message`
+    /// itself, ignoring anything the client claims. Forces `TIER=sensitive`
+    /// unconditionally when `true`, regardless of trust
+    /// (`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md` rule 1) — a
+    /// content-disclosure *request* isn't caught by the existing credential/
+    /// destructive-keyword scan at all.
+    #[serde(skip_deserializing, default)]
+    pub is_transcript_request: bool,
+    /// Server-computed: when `is_transcript_request` is also `true`, whether
+    /// the RESPONDING agent's (`target_agent`'s) own `conversation_visibility`
+    /// setting is `ask`, or `trusted_peers` with a requester not on that
+    /// agent's own allowlist — i.e. a case that genuinely needs a human
+    /// decision, per `SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`
+    /// rule 2. When `true`, `ESCALATE=required` is NOT relaxed to `none`
+    /// even for a cryptographically verified sender (the one named
+    /// exception to the 2026-08-17 relaxation) — unlike every other
+    /// `TIER=sensitive` case, where a verified sender's identity answers
+    /// the only open question. Meaningless (always `false`) when
+    /// `is_transcript_request` is `false`. Resolved in
+    /// `handle_reactive_inject` (has `AppState::wstore`, unlike
+    /// `Handler::inject_message`, which has no `Store` access "by design")
+    /// — same "resolve in the caller with Store access, pass the outcome
+    /// through" pattern `sig_verified`/`lan_verified` already establish.
+    #[serde(skip_deserializing, default)]
+    pub transcript_request_escalate_forced: bool,
 }
 
 /// Response from a message injection attempt.

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -169,6 +169,27 @@ pub struct AgentDefinition {
     /// decision about how the two interact). Schema v19.
     #[serde(default)]
     pub memory_id: String,
+    /// This agent's own disclosure policy for an incoming cross-tier
+    /// `transcript_request` jekt (`muxspect` Phase B/C — LAN/WAN
+    /// conversation visibility, `SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`,
+    /// jekt tier rules confirmed in `SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`).
+    /// One of `"private"` (default — auto-deny, fail-closed), `"trusted_peers"`
+    /// (auto-approve only a requester in `db_conversation_trust_grants`), or
+    /// `"ask"` (force human escalation, never auto-respond). Schema v26.
+    /// Channel-local only, like `model_vendor_base_url`/`memory_id` above —
+    /// deliberately NOT added to `DefinitionRecordV1`'s cross-channel wire
+    /// format yet; a cross-channel-reopened agent starts back at the safe
+    /// `"private"` default rather than carrying a stale value. Known
+    /// limitation, not a bug — same precedent as those two fields.
+    #[serde(default = "default_conversation_visibility")]
+    pub conversation_visibility: String,
+}
+
+/// `AgentDefinition::conversation_visibility`'s serde default — the safe,
+/// fail-closed value for any row/context that doesn't specify one
+/// (including every pre-existing row before this column existed).
+pub fn default_conversation_visibility() -> String {
+    "private".to_string()
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -351,7 +372,8 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id
+                    use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id,
+                    conversation_visibility
              FROM db_agent_definitions
              WHERE is_seeded = 0 AND parent_id = ?1
              ORDER BY updated_at DESC, created_at DESC",
@@ -412,7 +434,8 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id
+                    use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id,
+                    conversation_visibility
              FROM db_agent_definitions
              WHERE id = ?1",
         )?;
@@ -435,7 +458,7 @@ impl Store {
                         accounts, parent_template_id, branch_label, updated_at,
                         user_hidden, container_image, container_volumes, container_name,
                         use_ambient_login, model_vendor_base_url, auto_continue_enabled,
-                        default_memory_id
+                        default_memory_id, conversation_visibility
                  FROM db_agents
                  ORDER BY updated_at DESC, created_at ASC",
             )?;
@@ -496,6 +519,16 @@ impl Store {
             if let Some(existing) = by_id.get(&def.id) {
                 def.model_vendor_base_url = existing.model_vendor_base_url.clone();
                 def.memory_id = existing.memory_id.clone();
+                // conversation_visibility is the identical channel-local-only
+                // case (SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
+                // Phase B/C, jekt rules SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md)
+                // — DefinitionRecordV1 doesn't carry it, so without this the
+                // global overlay would silently reset every agent's
+                // disclosure policy back to "private" on every list read,
+                // even though "private" is a safe fail-closed default (this
+                // preserves the ADMINISTRATOR'S actual configured choice,
+                // not just avoiding a crash).
+                def.conversation_visibility = existing.conversation_visibility.clone();
             }
             by_id.insert(def.id.clone(), def);
         }
@@ -633,9 +666,9 @@ impl Store {
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
              is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
              container_image, container_volumes, container_name, use_ambient_login,
-             model_vendor_base_url, auto_continue_enabled, memory_id)
+             model_vendor_base_url, auto_continue_enabled, memory_id, conversation_visibility)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29)",
+                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30)",
             params![
                 agent.id,
                 agent.slug,
@@ -675,6 +708,7 @@ impl Store {
                 agent.model_vendor_base_url,
                 agent.auto_continue_enabled,
                 agent.memory_id,
+                agent.conversation_visibility,
             ],
         )?;
         // Persist the stamped updated_at before we leave the lock so the
@@ -800,7 +834,8 @@ impl Store {
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_id, branch_label, updated_at,
                         user_hidden, container_image, container_volumes, container_name,
-                        use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id
+                        use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id,
+                        conversation_visibility
                  FROM db_agent_definitions
                  WHERE (lower(trim(name)) = ?1 OR slug = ?2)
                    AND is_seeded = 0
@@ -850,10 +885,10 @@ impl Store {
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
                     is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
                     container_image, container_volumes, container_name, use_ambient_login,
-                    model_vendor_base_url, auto_continue_enabled, memory_id)
+                    model_vendor_base_url, auto_continue_enabled, memory_id, conversation_visibility)
                  VALUES
                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29)",
+                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30)",
                 params![
                     agent.id, agent.slug, agent.name, agent.icon, agent.provider,
                     agent.description, agent.working_directory, agent.shell,
@@ -868,6 +903,7 @@ impl Store {
                     agent.model_vendor_base_url,
                     agent.auto_continue_enabled,
                     agent.memory_id,
+                    agent.conversation_visibility,
                 ],
             )?;
             agent.created_at
@@ -1232,7 +1268,7 @@ impl Store {
                  agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15,
                  container_image=?17, container_volumes=?18, container_name=?19,
                  use_ambient_login=?20, branch_label=?21, model_vendor_base_url=?22,
-                 auto_continue_enabled=?23
+                 auto_continue_enabled=?23, conversation_visibility=?24
                  WHERE id=?16",
                 params![
                     agent.name,
@@ -1258,6 +1294,7 @@ impl Store {
                     agent.branch_label,
                     agent.model_vendor_base_url,
                     agent.auto_continue_enabled,
+                    agent.conversation_visibility,
                 ],
             )?
         };
@@ -2477,6 +2514,7 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
         model_vendor_base_url: row.get(26)?,
         auto_continue_enabled: row.get(27)?,
         memory_id: row.get(28)?,
+        conversation_visibility: row.get(29)?,
     })
 }
 
@@ -2525,6 +2563,7 @@ fn test_agent_def(
         model_vendor_base_url: model_vendor_base_url.to_string(),
         auto_continue_enabled: 0,
         memory_id: String::new(),
+        conversation_visibility: default_conversation_visibility(),
     }
 }
 
@@ -2840,10 +2879,10 @@ mod tests {
                  idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
                  is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
                  container_image, container_volumes, container_name, use_ambient_login,
-                 model_vendor_base_url, auto_continue_enabled, memory_id)
+                 model_vendor_base_url, auto_continue_enabled, memory_id, conversation_visibility)
                  VALUES ('only-in-legacy', 'only-in-legacy', 'OnlyLegacy', '', 'claude', '',
                  '', '', '', 0, 0, 0, 1, 'standalone', '', '', 0, '', '', '', 1, 0, '', '[]', '',
-                 0, '', 0, '')",
+                 0, '', 0, '', 'private')",
                 [],
             )
             .unwrap();

--- a/agentmux-srv/src/backend/storage/conversation_trust_grants.rs
+++ b/agentmux-srv/src/backend/storage/conversation_trust_grants.rs
@@ -1,0 +1,214 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Allowlist for a responding agent's `conversation_visibility: trusted_peers`
+//! mode. See `db_conversation_trust_grants` in migrations.rs
+//! (OBJECT_SCHEMA_VERSION v26) and
+//! docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
+//! Phase B.
+//!
+//! Mirrors `lan_peer_pubkey_pins.rs`'s exact shape (own module, get/set-style
+//! methods, case-insensitive agent_id lookups) — the explicit precedent this
+//! table is modeled on. Distinct concern, though: pubkey pins record an
+//! OBSERVED fact (trust-on-first-use) that must never silently change;
+//! trust grants record an EXPLICIT, revocable decision an agent's owner
+//! makes about who may read that agent's conversation content. A grant can
+//! be added or removed at any time — there is no "first write wins"
+//! invariant here.
+
+use rusqlite::params;
+
+use super::error::StoreError;
+use super::store::Store;
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+impl Store {
+    /// True if `agent_id` has explicitly granted `requester_agent_id` access
+    /// to its conversation content on `tier` ("lan" or "wan"). A grant for
+    /// one tier's cryptographic identity guarantee is never assumed to
+    /// cover another — a caller must check the grant for the ACTUAL tier
+    /// the incoming `transcript_request` arrived on.
+    pub fn conversation_trust_grant_check(
+        &self,
+        agent_id: &str,
+        requester_agent_id: &str,
+        tier: &str,
+    ) -> Result<bool, StoreError> {
+        let agent_key = agent_id.to_lowercase();
+        let requester_key = requester_agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM db_conversation_trust_grants \
+             WHERE agent_id = ?1 AND granted_peer_agent_id = ?2 AND tier = ?3",
+            params![agent_key, requester_key, tier],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Grant `requester_agent_id` access to `agent_id`'s conversation
+    /// content on `tier`. Idempotent — granting an already-granted peer is
+    /// a no-op, not an error or a duplicate row (the compound primary key
+    /// on (agent_id, granted_peer_agent_id, tier) enforces this at the
+    /// schema level too; `INSERT OR REPLACE` keeps this call site simple
+    /// rather than requiring callers to distinguish "insert" from
+    /// "already exists").
+    pub fn conversation_trust_grant_add(
+        &self,
+        agent_id: &str,
+        requester_agent_id: &str,
+        tier: &str,
+    ) -> Result<(), StoreError> {
+        let agent_key = agent_id.to_lowercase();
+        let requester_key = requester_agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO db_conversation_trust_grants \
+             (agent_id, granted_peer_agent_id, tier, granted_at) VALUES (?1, ?2, ?3, ?4)",
+            params![agent_key, requester_key, tier, now_secs()],
+        )?;
+        Ok(())
+    }
+
+    /// Revoke a previously-granted peer. A no-op (not an error) if no such
+    /// grant exists — revoking is idempotent, same as granting.
+    pub fn conversation_trust_grant_revoke(
+        &self,
+        agent_id: &str,
+        requester_agent_id: &str,
+        tier: &str,
+    ) -> Result<(), StoreError> {
+        let agent_key = agent_id.to_lowercase();
+        let requester_key = requester_agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM db_conversation_trust_grants \
+             WHERE agent_id = ?1 AND granted_peer_agent_id = ?2 AND tier = ?3",
+            params![agent_key, requester_key, tier],
+        )?;
+        Ok(())
+    }
+
+    /// List every peer `agent_id` has granted access to, across all tiers —
+    /// for a settings UI/CLI to show the current allowlist.
+    pub fn conversation_trust_grant_list(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<(String, String, i64)>, StoreError> {
+        let agent_key = agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT granted_peer_agent_id, tier, granted_at FROM db_conversation_trust_grants \
+             WHERE agent_id = ?1 ORDER BY granted_at DESC",
+        )?;
+        let rows = stmt.query_map(params![agent_key], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object_store() -> Store {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Store::open(tmp.path()).unwrap()
+    }
+
+    #[test]
+    fn check_returns_false_when_ungranted() {
+        let store = object_store();
+        assert!(!store.conversation_trust_grant_check("korp", "loap", "lan").unwrap());
+    }
+
+    #[test]
+    fn add_then_check_returns_true() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        assert!(store.conversation_trust_grant_check("korp", "loap", "lan").unwrap());
+    }
+
+    #[test]
+    fn grant_is_scoped_to_its_own_tier() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        assert!(
+            !store.conversation_trust_grant_check("korp", "loap", "wan").unwrap(),
+            "a LAN grant must not be assumed to cover WAN — different cryptographic identity guarantee"
+        );
+    }
+
+    #[test]
+    fn grant_is_scoped_to_its_own_responding_agent() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        assert!(
+            !store.conversation_trust_grant_check("agentx", "loap", "lan").unwrap(),
+            "a grant made by one agent must not apply to a different agent's own visibility check"
+        );
+    }
+
+    #[test]
+    fn revoke_removes_the_grant() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        store.conversation_trust_grant_revoke("korp", "loap", "lan").unwrap();
+        assert!(!store.conversation_trust_grant_check("korp", "loap", "lan").unwrap());
+    }
+
+    #[test]
+    fn revoke_of_a_never_granted_peer_is_a_harmless_no_op() {
+        let store = object_store();
+        store.conversation_trust_grant_revoke("korp", "loap", "lan").unwrap();
+        assert!(!store.conversation_trust_grant_check("korp", "loap", "lan").unwrap());
+    }
+
+    #[test]
+    fn granting_twice_is_idempotent() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        let list = store.conversation_trust_grant_list("korp").unwrap();
+        assert_eq!(list.len(), 1, "granting the same peer/tier twice must not duplicate the row");
+    }
+
+    #[test]
+    fn agent_id_lookup_is_case_insensitive() {
+        let store = object_store();
+        store.conversation_trust_grant_add("Korp", "Loap", "lan").unwrap();
+        assert!(store.conversation_trust_grant_check("korp", "loap", "lan").unwrap());
+        assert!(store.conversation_trust_grant_check("KORP", "LOAP", "lan").unwrap());
+    }
+
+    #[test]
+    fn list_returns_every_grant_for_the_agent_across_tiers() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        store.conversation_trust_grant_add("korp", "agentx", "wan").unwrap();
+        let list = store.conversation_trust_grant_list("korp").unwrap();
+        assert_eq!(list.len(), 2);
+        let peers: std::collections::HashSet<_> = list.iter().map(|(p, _, _)| p.clone()).collect();
+        assert_eq!(peers, ["loap", "agentx"].into_iter().map(String::from).collect());
+    }
+
+    #[test]
+    fn list_never_returns_a_different_agents_grants() {
+        let store = object_store();
+        store.conversation_trust_grant_add("korp", "loap", "lan").unwrap();
+        store.conversation_trust_grant_add("agentx", "loap", "lan").unwrap();
+        let list = store.conversation_trust_grant_list("korp").unwrap();
+        assert_eq!(list.len(), 1);
+    }
+}

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -131,6 +131,15 @@ pub(super) fn record_to_agent_definition(rec: &DefinitionRecord) -> AgentDefinit
         // channel's SQLite for this reason; a genuinely global backfill
         // needs this field added to the registry wire format first.
         memory_id: String::new(),
+        // Same known limitation, but the safe direction: DefinitionRecordV1
+        // doesn't carry it yet, so a cross-channel-reopened agent starts
+        // back at the fail-closed "private" default rather than an unset/
+        // empty value — never silently more permissive than intended.
+        // agent_def_list()'s own overlay (agents.rs) preserves the local
+        // row's real value when one exists, same as model_vendor_base_url/
+        // memory_id; this default only applies to a genuinely
+        // never-seen-locally cross-channel agent.
+        conversation_visibility: super::agents::default_conversation_visibility(),
     }
 }
 
@@ -389,6 +398,7 @@ mod tests {
 
     fn local_def(id: &str, name: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: id.to_string(),
             name: name.to_string(),

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -78,7 +78,7 @@ impl Store {
                 created_at, updated_at, is_seeded, user_hidden,
                 container_image, container_volumes, container_name,
                 use_ambient_login, model_vendor_base_url, auto_continue_enabled,
-                default_memory_id
+                default_memory_id, conversation_visibility
              ) VALUES (
                 ?1, ?2, ?3, ?4,
                 ?5, ?6,
@@ -89,7 +89,7 @@ impl Store {
                 ?20, ?21, ?22, ?23,
                 ?24, ?25, ?26,
                 ?27, ?28, ?29,
-                ?30
+                ?30, ?31
              )
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
@@ -118,7 +118,8 @@ impl Store {
                 use_ambient_login = excluded.use_ambient_login,
                 model_vendor_base_url = excluded.model_vendor_base_url,
                 auto_continue_enabled = excluded.auto_continue_enabled,
-                default_memory_id = excluded.default_memory_id",
+                default_memory_id = excluded.default_memory_id,
+                conversation_visibility = excluded.conversation_visibility",
             params![
                 def.id,
                 def.name,
@@ -150,6 +151,7 @@ impl Store {
                 def.model_vendor_base_url,
                 def.auto_continue_enabled,
                 def.memory_id,
+                def.conversation_visibility,
             ],
         )?;
         Ok(())
@@ -647,7 +649,8 @@ impl Store {
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
                     user_hidden, container_image, container_volumes, container_name,
-                    use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id
+                    use_ambient_login, model_vendor_base_url, auto_continue_enabled, memory_id,
+                    conversation_visibility
              FROM db_agent_definitions WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], |row| {
@@ -681,6 +684,7 @@ impl Store {
                 model_vendor_base_url: row.get(26)?,
                 auto_continue_enabled: row.get(27)?,
                 memory_id: row.get(28)?,
+                conversation_visibility: row.get(29)?,
             })
         });
         match result {

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -757,6 +757,7 @@ mod tests {
 
     fn sample_agent(id: &str, slug: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: slug.to_string(),
             name: id.to_string(),

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -802,6 +802,7 @@ mod bundle_ref_tests {
 
     fn insert_agent_with_bundle(store: &Store, id: &str, memory_id: &str) {
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: String::new(),
             name: "Test Agent".to_string(),
@@ -897,6 +898,7 @@ mod bundle_ref_tests {
     fn effective_mcp_servers_is_unaffected_when_agent_has_no_bundle() {
         let store = make_store();
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "agent-no-bundle".to_string(),
             slug: String::new(),
             name: "No Bundle".to_string(),

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -213,7 +213,26 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 8;
 ///        memory-version-history PR, which independently claimed v24 for
 ///        an unrelated table (see that entry above for the same class of
 ///        collision this codebase has hit before, e.g. v20→v22).
-pub const OBJECT_SCHEMA_VERSION: i64 = 25;
+///   v26 — db_agent_definitions.conversation_visibility (TEXT, default
+///        'private') + db_conversation_trust_grants: `muxspect` Phase B/C's
+///        per-agent disclosure policy for an incoming cross-tier
+///        `transcript_request` jekt (LAN/WAN conversation visibility —
+///        docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md,
+///        jekt tier rules confirmed in
+///        docs/specs/SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md).
+///        One of "private" (default, auto-deny)/"trusted_peers" (auto-
+///        approve an allow-listed requester)/"ask" (force human
+///        escalation). Also dual-written to `db_agents` (mirrors
+///        `auto_continue_enabled`'s treatment exactly — a simple per-agent
+///        opt-in-style setting, unlike `memory_id`/`model_vendor_base_url`,
+///        which use a differently-named column there). Deliberately NOT
+///        added to `DefinitionRecordV1`'s cross-channel wire format —
+///        channel-local only, same precedent as those two fields; a
+///        cross-channel-reopened agent starts back at the safe "private"
+///        default. `db_conversation_trust_grants` mirrors
+///        `db_lan_peer_pubkey_pins`'s exact shape (own module,
+///        get/set-style methods, case-insensitive agent_id lookups).
+pub const OBJECT_SCHEMA_VERSION: i64 = 26;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -807,6 +826,24 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             name       TEXT NOT NULL,
             member_ids TEXT NOT NULL DEFAULT '[]',
             created_at INTEGER NOT NULL DEFAULT 0
+        );
+
+        -- v26: allowlist for a responding agent's 'trusted_peers'
+        -- conversation_visibility mode — see OBJECT_SCHEMA_VERSION's v26
+        -- doc comment above. Mirrors db_lan_peer_pubkey_pins's exact shape
+        -- (own module, get/set-style methods, case-insensitive agent_id
+        -- lookups). `agent_id` is the RESPONDING agent (whose transcript
+        -- may be disclosed); `granted_peer_agent_id` is the requester it
+        -- trusts; `tier` records which delivery tier the grant applies to
+        -- ('lan'/'wan') since a grant for one tier's cryptographic
+        -- identity guarantee should not be silently assumed to hold for a
+        -- weaker one.
+        CREATE TABLE IF NOT EXISTS db_conversation_trust_grants (
+            agent_id             TEXT NOT NULL,
+            granted_peer_agent_id TEXT NOT NULL,
+            tier                 TEXT NOT NULL,
+            granted_at           INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (agent_id, granted_peer_agent_id, tier)
         );",
     )?;
 
@@ -888,6 +925,13 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         // comment for why, and OBJECT_SCHEMA_VERSION's v19 entry.
         "ALTER TABLE db_agent_definitions ADD COLUMN memory_id TEXT NOT NULL DEFAULT ''",
         "ALTER TABLE db_agents ADD COLUMN default_memory_id TEXT NOT NULL DEFAULT ''",
+        // v26: muxspect Phase B/C per-agent conversation-disclosure policy —
+        // see OBJECT_SCHEMA_VERSION's v26 doc comment above. Dual-written
+        // to db_agents under the SAME column name (a simple opt-in-style
+        // setting, like auto_continue_enabled above — not a differently-
+        // named-on-db_agents case like memory_id/default_memory_id).
+        "ALTER TABLE db_agent_definitions ADD COLUMN conversation_visibility TEXT NOT NULL DEFAULT 'private'",
+        "ALTER TABLE db_agents ADD COLUMN conversation_visibility TEXT NOT NULL DEFAULT 'private'",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -15,6 +15,7 @@ pub mod agents;
 pub mod agents_consolidate;
 pub mod background_tasks;
 pub mod content;
+pub mod conversation_trust_grants;
 pub mod cron;
 pub mod def_registry_mirror;
 pub mod dual_write;

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -820,6 +820,7 @@ mod effective_skills_tests {
 
     fn insert_agent(store: &Store, id: &str) {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: String::new(),
             name: "Test Agent".to_string(),
@@ -963,6 +964,7 @@ mod effective_skills_tests {
 
     fn insert_agent_with_bundle(store: &Store, id: &str, memory_id: &str) {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: String::new(),
             name: "Test Agent".to_string(),

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -292,6 +292,7 @@
         let store = make_store();
 
         let mut a1 = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "id-a".to_string(),
             slug: String::new(),
             name: "Agent X".to_string(),
@@ -362,6 +363,7 @@
         let store = make_store();
 
         let mut a1 = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "id-a".to_string(),
             slug: "explicit".to_string(),
             name: "First".to_string(),
@@ -427,6 +429,7 @@
 
     fn sample_agent(id: &str, slug: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: slug.to_string(),
             name: id.to_string(),
@@ -2616,6 +2619,7 @@
     fn dual_write_agent_def_insert_seeded_creates_template_row() {
         let store = make_store();
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-dw-seeded".to_string(),
             slug: String::new(),
             name: "Coder".to_string(),
@@ -2659,6 +2663,7 @@
         let store = make_store();
         // Seed the template first so the FK exists in the old table.
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-parent".to_string(),
             slug: String::new(),
             name: "Coder".to_string(),
@@ -2708,6 +2713,7 @@
     fn dual_write_agent_def_update_refreshes_name_in_db_agents() {
         let store = make_store();
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-update".to_string(),
             slug: String::new(),
             name: "Old Name".to_string(),
@@ -2758,6 +2764,7 @@
     fn dual_write_agent_def_update_persists_branch_label_change() {
         let store = make_store();
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "fork-rename-test".to_string(),
             slug: String::new(),
             name: "Fork Name".to_string(),
@@ -2805,6 +2812,7 @@
     fn dual_write_agent_def_delete_removes_db_agents_row() {
         let store = make_store();
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-del".to_string(),
             slug: String::new(),
             name: "Goner".to_string(),
@@ -2846,6 +2854,7 @@
         let store = make_store();
         // Seed template.
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-for-inst".to_string(),
             slug: String::new(),
             name: "Coder".to_string(),
@@ -2935,6 +2944,7 @@
         let store = make_store();
         // Seed a template.
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-folded".to_string(),
             slug: String::new(),
             name: "Coder".to_string(),
@@ -3033,6 +3043,7 @@
     fn dual_write_instance_set_hidden_flips_user_hidden_bit() {
         let store = make_store();
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-hide".to_string(),
             slug: String::new(),
             name: "Coder".to_string(),
@@ -3093,6 +3104,7 @@
     fn dual_write_instance_delete_drops_db_agents_row() {
         let store = make_store();
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-instdel".to_string(),
             slug: String::new(),
             name: "Coder".to_string(),
@@ -3151,6 +3163,7 @@
     fn dual_write_instance_repoint_updates_parent_template_id() {
         let store = make_store();
         let mut tpl_a = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-A".to_string(),
             slug: String::new(),
             name: "A".to_string(),
@@ -3221,6 +3234,7 @@
         let store = make_store();
         for id in &["s1", "s2", "s3"] {
             let mut d = AgentDefinition {
+                conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 id: id.to_string(),
                 slug: String::new(),
                 name: id.to_string(),
@@ -3266,6 +3280,7 @@
         let store = make_store();
         // Seeded template.
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-keep-check".to_string(),
             slug: String::new(),
             name: "TplCheck".to_string(),
@@ -3343,6 +3358,7 @@
         let store = make_store();
         // Template, user-clone def of it, instance on the user-clone.
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-rt".to_string(),
             slug: String::new(),
             name: "Tpl".to_string(),

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -803,6 +803,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -894,6 +895,7 @@ mod tests {
         let identity_store = Arc::new(Store::open_identity_store(identity_store_tmp.path()).unwrap());
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -978,6 +980,7 @@ mod tests {
         // `make_instance` below hardcodes `definition_id: "def-1"` — match it
         // rather than parameterizing a helper shared with other tests.
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1087,6 +1090,7 @@ mod tests {
 
         let store = make_store();
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1157,6 +1161,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1234,6 +1239,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1300,6 +1306,7 @@ mod tests {
     /// (claude) with a configurable ambient opt-in.
     fn gate_def(use_ambient_login: i64) -> crate::backend::storage::store::AgentDefinition {
         crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1538,6 +1545,7 @@ mod tests {
 
         // Agent definition.
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1629,6 +1637,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1695,6 +1704,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1763,6 +1773,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1839,6 +1850,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -1920,6 +1932,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -2022,6 +2035,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -2170,6 +2184,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -2248,6 +2263,7 @@ mod tests {
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -2363,6 +2379,7 @@ mod tests {
         let identity_store = Arc::new(Store::open_identity_store(identity_store_tmp.path()).unwrap());
 
         let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-1".to_string(),
             slug: String::new(),
             name: "T".to_string(),
@@ -2445,6 +2462,7 @@ mod tests {
 
     fn make_agent_def_with_provider(id: &str, provider: &str) -> crate::backend::storage::store::AgentDefinition {
         crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: String::new(),
             name: "T".to_string(),

--- a/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
+++ b/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
@@ -109,6 +109,7 @@ mod tests {
 
     fn make_def(id: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: id.to_string(),
             name: id.to_string(),

--- a/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
+++ b/agentmux-srv/src/migrations/m0020_agent_color_backfill.rs
@@ -157,6 +157,7 @@ mod tests {
 
     fn insert_def(wstore: &Store, name: &str) -> String {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: format!("test-{name}"),
             slug: String::new(),
             name: name.to_string(),

--- a/agentmux-srv/src/migrations/m0021_backfill_agent_bundles.rs
+++ b/agentmux-srv/src/migrations/m0021_backfill_agent_bundles.rs
@@ -254,6 +254,7 @@ mod tests {
 
     fn insert_def(wstore: &Store, name: &str) -> String {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: format!("test-{name}"),
             slug: String::new(),
             name: name.to_string(),
@@ -290,6 +291,7 @@ mod tests {
 
     fn insert_def_with_provider(wstore: &Store, name: &str, provider: &str) -> String {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: format!("test-{name}"),
             slug: String::new(),
             name: name.to_string(),
@@ -525,6 +527,7 @@ mod tests {
             let shared_tmp = tempfile::NamedTempFile::new().unwrap();
             let wstore = Store::open(tmp.path()).unwrap();
             let mut def_a = AgentDefinition {
+                conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 id: "test-twin-a".to_string(),
                 slug: String::new(),
                 name: "Twin".to_string(),

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -137,6 +137,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Supervisor panel (not this RPC) once that ships.
                     auto_continue_enabled: 0,
                     memory_id: String::new(),
+                    conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 // Every agent gets its own dedicated ABF bundle
@@ -264,6 +265,13 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // needs the real value: it's what gets serialized back
                     // to the frontend as the "updated" agent.
                     memory_id: old.memory_id.clone(),
+                    // Not yet exposed by this RPC's own command schema
+                    // (CommandUpdateAgentData has no conversation_visibility
+                    // field) — preserve the existing value, same as
+                    // memory_id just above, rather than silently resetting
+                    // a configured agent back to the default on an
+                    // unrelated name/icon/accounts edit.
+                    conversation_visibility: old.conversation_visibility.clone(),
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -465,6 +473,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     model_vendor_base_url: String::new(),
                     auto_continue_enabled: 0,
                     memory_id: String::new(),
+                    conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
                 wstore.agent_def_provision_and_bind_bundle(&id_store, &mut agent, now);
@@ -607,6 +616,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         model_vendor_base_url: String::new(),
                         auto_continue_enabled: 0,
                         memory_id: String::new(),
+                        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {
@@ -783,6 +793,7 @@ mod tests {
     // seed the imported agent's bundle with the wrong provider.
     fn seed_drifted_agent(state: &AppState, def_id: &str, bundle_id: &str) {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: def_id.to_string(),
             slug: def_id.to_string(),
             name: "Drifted Agent".to_string(),

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -393,6 +393,7 @@ mod recent_sessions_tests {
         // db_agents fold semantics require the seed shape to avoid
         // the collision.
         let def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "def-claude".to_string(),
             slug: "claude-code".to_string(),
             name: "Claude Code".to_string(),
@@ -717,6 +718,7 @@ mod recent_sessions_tests {
 
         // One seeded template + one already-user-owned definition.
         let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "tpl-claude".to_string(),
             slug: String::new(),
             name: "Claude Code".to_string(),
@@ -750,6 +752,7 @@ mod recent_sessions_tests {
         wstore.agent_def_insert(&mut tpl).unwrap();
 
         let mut user_a = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "user-a".to_string(),
             slug: String::new(),
             name: "Maks".to_string(),

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -230,6 +230,11 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     model_vendor_base_url: chosen_model_vendor_base_url,
                     auto_continue_enabled: 0,
                     memory_id: String::new(),
+                    // Fail-closed default, not inherited from the template —
+                    // same convention as auto_start/use_ambient_login/
+                    // auto_continue_enabled above (opt-in settings reset on
+                    // a fresh clone, not carried over).
+                    conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 };
                 wstore
                     .agent_def_insert(&mut new_def)
@@ -449,6 +454,12 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     model_vendor_base_url: source.model_vendor_base_url.clone(),
                     auto_continue_enabled: 0,
                     memory_id: String::new(),
+                    // Fail-closed default, not inherited from source — same
+                    // convention as use_ambient_login/auto_continue_enabled
+                    // above (opt-in settings reset on a fork, not carried
+                    // over, even though other config like container image
+                    // and model vendor IS inherited).
+                    conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
                 };
                 wstore
                     .agent_def_insert(&mut fork)
@@ -630,6 +641,7 @@ mod tests {
     // "claude". A correct clone/fork must carry "claude", not "codex".
     fn seed_drifted_template(state: &AppState, def_id: &str, bundle_id: &str) {
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: def_id.to_string(),
             slug: String::new(),
             name: "Drifted Template".to_string(),

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -71,6 +71,7 @@ mod resolve_vendor_env_override_tests {
 
     fn base_agent(model_vendor_base_url: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "a1".to_string(),
             slug: "a1".to_string(),
             name: "T".to_string(),
@@ -895,6 +896,7 @@ mod write_agent_config_files_tests {
 
     fn make_agent(id: &str, working_directory: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: String::new(),
             name: "Test Agent".to_string(),

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -466,6 +466,7 @@ pub(crate) async fn agent_define_core(
         model_vendor_base_url: cmd_model_vendor_base_url.clone(),
         auto_continue_enabled: 0,
         memory_id: String::new(),
+        conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
     };
 
     // Atomic check-then-insert.
@@ -1169,6 +1170,7 @@ mod memory_version_impl_tests {
 
     fn agent_def(id: &str, working_directory: &str) -> crate::backend::storage::AgentDefinition {
         crate::backend::storage::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: id.to_string(),
             name: "Test Agent".to_string(),
@@ -2580,6 +2582,7 @@ mod identity_self_accounts_tests {
         let state = test_state();
 
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: uuid::Uuid::new_v4().to_string(),
             slug: String::new(),
             name: "test agent".to_string(),
@@ -2654,6 +2657,7 @@ mod identity_self_accounts_tests {
 
         let state = test_state();
         let mut def = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: uuid::Uuid::new_v4().to_string(),
             slug: "agenty".to_string(),
             name: "AgentY".to_string(),

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -1404,6 +1404,7 @@ mod tests {
 
     fn agent_def(id: &str, working_directory: &str) -> AgentDefinition {
         AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: id.to_string(),
             slug: id.to_string(),
             name: "Test Agent".to_string(),
@@ -2159,6 +2160,7 @@ mod tests {
         let state = crate::server::tests::test_state();
         let config_dir = tempfile::tempdir().unwrap();
         let mut def = crate::backend::storage::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
             id: "dup-agent".to_string(),
             slug: "dup-agent".to_string(),
             name: "Test".to_string(),

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -383,6 +383,251 @@ fn resolve_delivery_tier(auth_via: super::ReactiveAuthVia, claimed: Option<&str>
     }
 }
 
+/// Server-side resolution of `InjectionRequest::is_transcript_request` /
+/// `transcript_request_escalate_forced` — see both fields' own doc comments
+/// (`backend/reactive/types.rs`) and
+/// `SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`. Lives here (not
+/// `Handler::inject_message_inner`) because it needs `AppState::wstore` —
+/// `Handler` has no `Store` access "by design," same reason
+/// `sig_verified`/`lan_verified` are resolved by this same caller before
+/// the request reaches the handler.
+///
+/// Always re-parses `req.message` itself — never trusts anything the
+/// client might have set on these two fields (impossible anyway, since
+/// both are `#[serde(skip_deserializing)]`, but this function is the one
+/// place that actually computes their real value from scratch).
+fn resolve_transcript_request_tier_fields(state: &AppState, req: &mut InjectionRequest) {
+    let Some(transcript_req) = agentmux_common::transcript_request::parse_transcript_request(&req.message) else {
+        return;
+    };
+    let _ = transcript_req; // request_id/max_lines belong to the (not-yet-built) auto-responder, not tier resolution.
+    req.is_transcript_request = true;
+
+    // Match on the RESPONDING agent's (target_agent's) own slug — the
+    // stable, AGENTMUX_AGENT_ID-derived identifier, NOT the renameable
+    // display `name` (same cross-namespace hazard already documented at
+    // this file's Supervisor-nudge opt-in check just above, which this
+    // mirrors exactly).
+    let visibility = state
+        .wstore
+        .agent_def_list()
+        .ok()
+        .and_then(|defs| defs.into_iter().find(|d| d.slug.eq_ignore_ascii_case(&req.target_agent)))
+        .map(|d| d.conversation_visibility)
+        .unwrap_or_else(crate::backend::storage::agents::default_conversation_visibility);
+
+    let tier = req.delivery_tier.as_deref().unwrap_or("host");
+    req.transcript_request_escalate_forced = match visibility.as_str() {
+        "ask" => true,
+        "trusted_peers" => {
+            let requester = req.source_agent.as_deref().unwrap_or("");
+            let granted = state
+                .wstore
+                .conversation_trust_grant_check(&req.target_agent, requester, tier)
+                .unwrap_or(false);
+            !granted
+        }
+        // "private" and any unrecognized value: fail-closed on the
+        // ESCALATE-forcing question too — an agent def loaded from a
+        // channel/registry state older than this feature (or IS
+        // genuinely "private") never had a chance to opt into
+        // relaxation, so it gets none. Rule 1's forced TIER=sensitive
+        // still applies regardless (set above) — only this ADDITIONAL
+        // escalate-forcing rule reads "private" as "no need to force it
+        // beyond the ordinary verified-sender relaxation," since a
+        // "private" agent auto-denies (once the responder auto-resolve
+        // is built) and was never going to disclose anything either way.
+        _ => false,
+    };
+}
+
+#[cfg(test)]
+mod transcript_request_tier_resolution_tests {
+    use super::*;
+    use crate::backend::storage::store::AgentDefinition;
+    use crate::server::tests::test_state;
+
+    fn insert_agent_def(state: &AppState, slug: &str, conversation_visibility: &str) {
+        let mut def = AgentDefinition {
+            id: uuid::Uuid::new_v4().to_string(),
+            slug: slug.to_string(),
+            name: slug.to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "standalone".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
+            auto_continue_enabled: 0,
+            memory_id: String::new(),
+            conversation_visibility: conversation_visibility.to_string(),
+        };
+        state.wstore.agent_def_insert(&mut def).unwrap();
+    }
+
+    fn transcript_request_message() -> String {
+        r#"{"type":"transcript_request","request_id":"r1","max_lines":50}"#.to_string()
+    }
+
+    fn base_req(target: &str) -> InjectionRequest {
+        InjectionRequest {
+            target_agent: target.to_string(),
+            message: transcript_request_message(),
+            source_agent: Some("requester".to_string()),
+            delivery_tier: Some("lan".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn ordinary_message_never_sets_either_field() {
+        let state = test_state();
+        let mut req = InjectionRequest {
+            target_agent: "agent1".to_string(),
+            message: "just chatting".to_string(),
+            ..Default::default()
+        };
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(!req.is_transcript_request);
+        assert!(!req.transcript_request_escalate_forced);
+    }
+
+    #[tokio::test]
+    async fn private_visibility_does_not_force_escalate() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "private");
+        let mut req = base_req("agent1");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(req.is_transcript_request);
+        assert!(!req.transcript_request_escalate_forced);
+    }
+
+    #[tokio::test]
+    async fn ask_visibility_forces_escalate() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "ask");
+        let mut req = base_req("agent1");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(req.is_transcript_request);
+        assert!(req.transcript_request_escalate_forced);
+    }
+
+    #[tokio::test]
+    async fn trusted_peers_without_a_grant_forces_escalate() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "trusted_peers");
+        let mut req = base_req("agent1");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(
+            req.transcript_request_escalate_forced,
+            "an un-granted requester must still force escalation under trusted_peers mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn trusted_peers_with_a_matching_grant_does_not_force_escalate() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "trusted_peers");
+        state.wstore.conversation_trust_grant_add("agent1", "requester", "lan").unwrap();
+        let mut req = base_req("agent1");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(
+            !req.transcript_request_escalate_forced,
+            "an allow-listed requester on the SAME tier must not force escalation"
+        );
+    }
+
+    #[tokio::test]
+    async fn trusted_peers_grant_on_a_different_tier_still_forces_escalate() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "trusted_peers");
+        // Granted for WAN, but this request arrives on LAN (base_req's default).
+        state.wstore.conversation_trust_grant_add("agent1", "requester", "wan").unwrap();
+        let mut req = base_req("agent1");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(
+            req.transcript_request_escalate_forced,
+            "a grant for one tier's identity guarantee must never be assumed to cover a different tier"
+        );
+    }
+
+    #[tokio::test]
+    async fn matches_on_slug_not_display_name() {
+        let state = test_state();
+        // Insert with a slug matching the target, but a DIFFERENT display name —
+        // the lookup must key off slug (the stable AGENTMUX_AGENT_ID-derived
+        // identifier), same cross-namespace hazard the Supervisor-nudge
+        // opt-in check just above this function already guards against.
+        let state_clone = &state;
+        {
+            let mut def = AgentDefinition {
+                id: uuid::Uuid::new_v4().to_string(),
+                slug: "agent1".to_string(),
+                name: "Totally Different Display Name".to_string(),
+                icon: String::new(),
+                provider: "claude".to_string(),
+                description: String::new(),
+                working_directory: String::new(),
+                shell: String::new(),
+                provider_flags: String::new(),
+                auto_start: 0,
+                restart_on_crash: 0,
+                idle_timeout_minutes: 0,
+                created_at: 0,
+                agent_type: "standalone".to_string(),
+                environment: String::new(),
+                agent_bus_id: String::new(),
+                is_seeded: 0,
+                accounts: String::new(),
+                parent_id: String::new(),
+                branch_label: String::new(),
+                updated_at: 0,
+                user_hidden: 0,
+                container_image: String::new(),
+                container_volumes: "[]".to_string(),
+                container_name: String::new(),
+                use_ambient_login: 0,
+                model_vendor_base_url: String::new(),
+                auto_continue_enabled: 0,
+                memory_id: String::new(),
+                conversation_visibility: "ask".to_string(),
+            };
+            state_clone.wstore.agent_def_insert(&mut def).unwrap();
+        }
+        let mut req = base_req("agent1");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(req.transcript_request_escalate_forced, "lookup must match by slug \"agent1\", not the unrelated display name");
+    }
+
+    #[tokio::test]
+    async fn unknown_target_agent_fails_closed_to_private_defaults() {
+        let state = test_state();
+        // No AgentDefinition inserted at all for this target.
+        let mut req = base_req("no-such-agent");
+        resolve_transcript_request_tier_fields(&state, &mut req);
+        assert!(req.is_transcript_request, "rule 1 (forced sensitive) applies regardless of whether the target is known");
+        assert!(!req.transcript_request_escalate_forced, "an unknown agent defaults to the safe 'private' behavior for the escalate-forcing question");
+    }
+}
+
 pub(super) async fn handle_reactive_inject(
     State(state): State<AppState>,
     Extension(auth_via): Extension<super::ReactiveAuthVia>,
@@ -400,6 +645,7 @@ pub(super) async fn handle_reactive_inject(
     verify_jekt_signature(&state, &mut req);
     verify_reagent_signature(&mut req, now_unix_secs());
     verify_lan_signature(&state, &mut req).await;
+    resolve_transcript_request_tier_fields(&state, &mut req);
 
     // 1. Try local ReactiveHandler first (fast path — same instance).
     let resp = state.reactive_handler.inject_message(req.clone());

--- a/docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
+++ b/docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
@@ -4,8 +4,18 @@
 **Author:** Camper
 **Status:** Phase A implemented. Phase B/C's CLAUDE.md jekt rule change
 confirmed live 2026-08-22 — see `SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`
-and `CLAUDE.md`'s jekt security rules section. Phase B/C implementation
-tracked separately, not yet built.
+and `CLAUDE.md`'s jekt security rules section. Phase B's policy
+infrastructure and jekt-rule enforcement are now implemented — see
+`SPEC_MUXSPECT_PHASE_B_POLICY_AND_TIER_ENFORCEMENT_2026_08_22.md`
+(`conversation_visibility` setting, `db_conversation_trust_grants`, the
+`transcript_request`/`transcript_response` wire payload, and the actual
+`TIER=sensitive`/`ESCALATE=required` computation this whole spec exists to
+gate). The auto-resolve short-circuit (private auto-deny / trusted_peers
+auto-approve, invisible to the target agent), the `ask`-mode
+approve/deny CLI, the `RequestTranscript`/`PollTranscriptRequest` MCP
+tools, and per-request-type rate limiting are still not built — see that
+spec's §3 for why deferring those specifically was a safe scope cut, not a
+gap. Phase C (WAN) not yet started.
 **Motivated by:** direct request — agents need a fast way to see what every
 other agent (this host, other channels on this host, LAN, connected WAN) is
 currently saying/doing, without manual filesystem archaeology or a

--- a/docs/specs/SPEC_MUXSPECT_PHASE_B_POLICY_AND_TIER_ENFORCEMENT_2026_08_22.md
+++ b/docs/specs/SPEC_MUXSPECT_PHASE_B_POLICY_AND_TIER_ENFORCEMENT_2026_08_22.md
@@ -1,0 +1,158 @@
+# SPEC: `muxspect` Phase B — policy infrastructure + jekt tier enforcement
+
+**Date:** 2026-08-22
+**Status:** Implemented (scoped — see §3 for what's deferred)
+**Author:** Korp
+**Repo touched:** `agentmux` (`agentmux-srv`, `agentmux-common`)
+**Related:** `docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`
+(the design this implements a slice of), `docs/specs/SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`
+(the confirmed jekt rules this enforces)
+
+## 1. What shipped
+
+The confirmed jekt rules for `transcript_request` need real infrastructure
+to mean anything: a place to store each agent's disclosure policy, a wire
+format for the request/response pair, and the actual escalation-computation
+wiring. This PR ships all three, fully tested, plus the trust-grant table
+Phase B's `trusted_peers` mode needs — everything **except** the pieces
+that build ON TOP of correct tiering (see §3).
+
+### 1.1 `conversation_visibility` (schema v26)
+
+New column on `db_agent_definitions` (+ dual-written to `db_agents`,
+mirroring `auto_continue_enabled`'s treatment — a simple per-agent
+opt-in-style setting). One of `"private"` (default, fail-closed) /
+`"trusted_peers"` / `"ask"`. Channel-local only, like
+`model_vendor_base_url`/`memory_id` — deliberately not added to
+`DefinitionRecordV1`'s cross-channel wire format; a cross-channel-reopened
+agent starts back at the safe `"private"` default rather than carrying a
+stale value (`def_registry_mirror.rs`, `agent_def_list()`'s own overlay
+preserves the local row's real value when one exists, same precedent as
+those two fields).
+
+### 1.2 `db_conversation_trust_grants`
+
+New table, mirroring `db_lan_peer_pubkey_pins`'s exact shape (own module
+`conversation_trust_grants.rs`, get/set-style methods, case-insensitive
+agent_id lookups) — the explicit precedent
+`SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md` named.
+`(agent_id, granted_peer_agent_id, tier)` — a grant is tier-scoped: one
+tier's cryptographic identity guarantee is never assumed to cover another.
+
+### 1.3 Wire payload (`agentmux-common::transcript_request`)
+
+`TranscriptRequest`/`TranscriptResponse`, JSON-encoded and carried AS a
+jekt's existing `message: String` field — there is no structured
+`msg_type` anywhere in the jekt wire format (`message` is part of the
+signed material every signer/verifier already depends on; adding a
+top-level field would mean touching all of them for a feature that's
+otherwise fully layerable on top). `parse_transcript_request`/
+`parse_transcript_response` sniff for the shape and return `None` for
+anything else — malformed JSON, unrelated JSON, or ordinary free text —
+so this can never misclassify normal jekt traffic.
+
+### 1.4 Escalation-rule enforcement (the security-critical core)
+
+Two new server-computed fields on `InjectionRequest`
+(`is_transcript_request`, `transcript_request_escalate_forced`) —
+`#[serde(skip_deserializing)]`, same guarantee as `sig_verified`/
+`lan_verified`: no attacker-supplied JSON body can set or suppress them.
+
+- `resolve_transcript_request_tier_fields` (`server/reactive.rs`) runs in
+  `handle_reactive_inject`, right after signature verification, before the
+  request reaches `Handler::inject_message` (which has no `Store` access
+  "by design" — same reason `sig_verified`/`lan_verified` are resolved by
+  this same caller). Re-parses `message` itself; looks up the RESPONDING
+  agent (`target_agent`) by **slug**, not display name (the same
+  cross-namespace hazard this file's own Supervisor-nudge opt-in check
+  already guards against, mirrored exactly); for `trusted_peers`, checks
+  `db_conversation_trust_grants` against the actual delivery tier.
+- `Handler::inject_message_inner` (`backend/reactive/handler.rs`):
+  `is_transcript_request` ORs into the existing `is_sensitive` computation
+  (rule 1 — unconditional force, any tier, any trust); `requires_stop`
+  becomes `is_sensitive && (!is_cryptographically_verified ||
+  transcript_request_escalate_forced)` (rule 2 — the one named exception to
+  the 2026-08-17 verified-sender relaxation).
+
+## 2. Design decisions worth calling out
+
+- **Fail-closed on every branch.** An unknown target agent, a agent
+  definition load error, or an unrecognized `conversation_visibility`
+  value all resolve `transcript_request_escalate_forced` to whatever is
+  SAFER — for the escalate-forcing question specifically, "private-like"
+  (no forcing beyond the ordinary rule) is the correct fail-closed
+  behavior, because rule 1's forced `TIER=sensitive` already applies
+  regardless and a genuinely "private" or not-yet-configured agent was
+  never going to auto-disclose anything once §3's auto-responder exists —
+  there's no scenario where failing this lookup open would leak content.
+- **Layering, not a new transport.** No new HTTP endpoint, no new signing
+  scheme — a `transcript_request` rides the exact same
+  `/agentmux/reactive/inject` path, signing, and cross-tier delivery
+  cascade every ordinary jekt already uses. The only new logic is
+  detection + tier computation.
+
+## 3. Explicitly deferred — not silently incomplete
+
+**The "invisible auto-resolve" convenience layer is not built.** Per the
+design spec, `private` should auto-deny and `trusted_peers` (when granted)
+should auto-approve **without the target agent's own pane ever seeing the
+raw request**. This PR does not build that short-circuit. Today, EVERY
+`transcript_request` — regardless of the responding agent's configured
+mode — is delivered into that agent's pane like any other jekt, correctly
+tiered (`TIER=sensitive` always; `ESCALATE=required` surviving a verified
+sender specifically when the mode is `ask` or an un-granted
+`trusted_peers` requester).
+
+This is a deliberate, safety-conscious scope cut, not an oversight:
+
+- The confirmed jekt rules (the actual reason this needed a repo-owner
+  conversation) are fully and correctly enforced regardless of whether
+  auto-resolve exists. Building the rules first, correctly, independent of
+  the UX convenience layer, means the security-critical piece isn't
+  entangled with — or gated behind — the larger remaining feature.
+- "Always visible to a human/agent" is strictly MORE cautious than
+  "sometimes silently auto-resolved" — deferring the silent path never
+  creates a gap; at worst it means `private`-mode agents see a request
+  they'll eventually be able to auto-deny invisibly, and have to deny it
+  by hand meanwhile (a UX rough edge, not a disclosure risk).
+- `db_conversation_trust_grants` and the visibility-mode lookup are ALREADY
+  built and tested (§1.2, §1.4) — the auto-responder is "wire the existing
+  pieces into a short-circuit before `inject_message`," not new plumbing.
+
+**Also deferred, per the original design spec's own scope (unchanged from
+`SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`):**
+- `muxspect conversation-requests` (list/approve/deny CLI for `ask` mode).
+- `RequestTranscript`/`PollTranscriptRequest` MCP tools (the requester
+  side — nothing constructs/sends a `transcript_request` yet).
+- Per-source-agent rate limiting specific to `transcript_request` (the
+  existing global 10/sec `RateLimiter` still applies to ALL injections,
+  including these, but a dedicated narrower limit isn't built).
+- Phase C (WAN) — tracked separately.
+
+## 4. Testing
+
+- `agentmux-common::transcript_request`: 8 unit tests — round-trips for
+  request/ok/denied/error responses; ordinary free text and unrelated JSON
+  never misparse as either shape; malformed JSON never panics; a request
+  never parses as a response and vice versa.
+- `backend::storage::conversation_trust_grants`: 10 unit tests — check/add/
+  revoke/list, tier scoping, per-agent scoping, case-insensitivity,
+  idempotent granting, idempotent revoking of a never-granted peer.
+- `backend::reactive::tests` (handler-level): 4 new tests — rule 1 forces
+  sensitive even on host tier with clean content; rule 2's forced
+  escalation survives a verified sender; the mirror-image case (not
+  forced) still relaxes normally for a verified sender; an unverified
+  sender still requires stop regardless of the forced-escalate flag.
+- `server::reactive::transcript_request_tier_resolution_tests`
+  (caller-level, real `Store`): 8 new tests — ordinary messages never set
+  either field; `private`/`ask`/`trusted_peers` (granted and un-granted)
+  resolve correctly; a grant is tier-scoped (a LAN grant doesn't cover
+  WAN); lookup matches by slug, not display name; an unknown target agent
+  fails closed.
+- Full `agentmux-srv` suite: 2744 passed, 0 failed, 6 pre-existing ignores.
+  Full `agentmux-common` suite: 161 passed, 0 failed.
+- Schema migration: `db_agent_definitions`/`db_agents` ALTER + new
+  `db_conversation_trust_grants` CREATE TABLE, both idempotent
+  (duplicate-column/IF-NOT-EXISTS tolerant), verified via the full existing
+  `backend::storage::agents` test suite (99 tests) passing unchanged after
+  the schema bump.

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -411,6 +411,17 @@ declare global {
          * see ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md §3.1.
          */
         memory_id?: string;
+        /**
+         * This agent's own disclosure policy for an incoming cross-tier
+         * `transcript_request` jekt (`muxspect` Phase B/C — LAN/WAN
+         * conversation visibility). One of "private" (default,
+         * auto-deny) / "trusted_peers" (auto-approve an allow-listed
+         * requester) / "ask" (force human escalation). Channel-local
+         * only, like model_vendor_base_url/memory_id above — a
+         * cross-channel-reopened agent starts back at the safe
+         * "private" default. Schema v26.
+         */
+        conversation_visibility?: string;
     };
 
     // ── v6: identity, instance, junction ────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the confirmed jekt rules (`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`) for `SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`'s Phase B (LAN conversation visibility). Full writeup in `docs/specs/SPEC_MUXSPECT_PHASE_B_POLICY_AND_TIER_ENFORCEMENT_2026_08_22.md`.

**Ships (schema v26):**
- `conversation_visibility` per-agent setting (`private`/`trusted_peers`/`ask`), dual-written to `db_agents`, deliberately channel-local (not added to the cross-channel registry wire format — same precedent as `model_vendor_base_url`/`memory_id`).
- `db_conversation_trust_grants` table + CRUD module, mirroring `db_lan_peer_pubkey_pins`'s exact shape (the explicit precedent the design spec named).
- `transcript_request`/`transcript_response` wire payload (`agentmux-common`) — JSON-encoded inside a jekt's existing `message` field. No new transport: there's no structured `msg_type` anywhere in the jekt wire format (`message` is part of the signed material every signer/verifier depends on), so this rides the exact same `/agentmux/reactive/inject` signing + cross-tier delivery cascade every ordinary jekt already uses.
- **The actual `TIER=sensitive`/`ESCALATE=required` computation** — the security-critical reason this needed a repo-owner conversation in the first place: two new server-computed `InjectionRequest` fields (`#[serde(skip_deserializing)]`, same guarantee as `sig_verified`/`lan_verified` — no attacker-supplied body can set or suppress them), resolved in `handle_reactive_inject` (has `Store` access, unlike `Handler`) and wired into `Handler::inject_message_inner`'s existing tier logic.

**Explicitly deferred, not silently incomplete** (see spec §3): the invisible auto-resolve short-circuit (`private` auto-deny / `trusted_peers` auto-approve without the target agent's own pane ever seeing the raw request), the `ask`-mode approve/deny CLI, the `RequestTranscript`/`PollTranscriptRequest` MCP tools, and per-request-type rate limiting. Every `transcript_request` is delivered visibly today, correctly tiered — strictly MORE cautious than the deferred silent-resolution path, never a disclosure gap. `db_conversation_trust_grants` and the visibility lookup are already built and tested; the auto-responder is "wire the existing pieces into a short-circuit," not new plumbing.

Also updates `frontend/types/gotypes.d.ts` (hand-maintained `AgentDefinition` mirror) for the new field.

## Test plan
- [x] 8 wire-payload tests (`agentmux-common::transcript_request`) — round-trips, never misparses ordinary/unrelated content, never panics on malformed JSON
- [x] 10 trust-grant tests — check/add/revoke/list, tier scoping, per-agent scoping, case-insensitivity, idempotency
- [x] 4 handler-level tier tests — rule 1 forces sensitive unconditionally; rule 2's forced escalation survives a verified sender; the mirror-image (not forced) still relaxes normally; an unverified sender still requires stop regardless
- [x] 8 caller-level resolution tests (real `Store`) — every visibility mode; tier-scoped grants; slug-vs-display-name lookup; fail-closed on an unknown target agent
- [x] Full workspace suite: 2744 (srv) + 161 (common) + 5 (integration) + 7 (subprocess_io) passed, 0 failed

<!-- agentmux:agent_id=korp -->