### PR TITLE
Korp@claudius: fix(muxspect): wire transcript_request jekt tier enforcement into the WAN delivery path (Phase C)

### DIFF
--- a/.changesets/1787452355-fix-muxspect-wire-transcript-request-jekt-tier-enforcement-i-a01z.md
+++ b/.changesets/1787452355-fix-muxspect-wire-transcript-request-jekt-tier-enforcement-i-a01z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxspect): wire transcript_request jekt tier enforcement into the WAN delivery path (Phase C)

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -581,9 +581,12 @@ impl Handler {
         // verified sender when the RESPONDING agent's own
         // conversation_visibility is `ask` (or `trusted_peers` with a
         // non-allow-listed requester) — `req.transcript_request_escalate_forced`,
-        // resolved server-side in `handle_reactive_inject` against that
-        // agent's own setting (meaningless/always-false unless
-        // `is_transcript_request` is also true). A valid signature answers
+        // resolved server-side by `resolve_transcript_request_tier_fields`
+        // against that agent's own setting, called from both delivery paths
+        // that reach `Handler` (`handle_reactive_inject` for
+        // host/cross-channel/LAN, `muxbus::cloud_subscriber::sync_agent_reactive`
+        // for WAN) — meaningless/always-false unless `is_transcript_request`
+        // is also true. A valid signature answers
         // *who is asking*, not *whether this content should be disclosed* —
         // identity proof alone doesn't relax that question, unlike every
         // other TIER=sensitive case above.

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -225,8 +225,11 @@ pub struct InjectionRequest {
     /// — `muxspect` Phase B/C's LAN/WAN conversation-visibility protocol.
     /// `#[serde(skip_deserializing)]`, same guarantee as `sig_verified`
     /// etc.: no attacker-supplied JSON body can force or suppress this —
-    /// `handle_reactive_inject` always recomputes it by re-parsing `message`
-    /// itself, ignoring anything the client claims. Forces `TIER=sensitive`
+    /// `resolve_transcript_request_tier_fields` always recomputes it by
+    /// re-parsing `message` itself, ignoring anything the client claims.
+    /// Called from both delivery paths that reach `Handler`:
+    /// `handle_reactive_inject` for host/cross-channel/LAN, and
+    /// `muxbus::cloud_subscriber::sync_agent_reactive` for WAN. Forces `TIER=sensitive`
     /// unconditionally when `true`, regardless of trust
     /// (`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md` rule 1) — a
     /// content-disclosure *request* isn't caught by the existing credential/
@@ -243,11 +246,14 @@ pub struct InjectionRequest {
     /// exception to the 2026-08-17 relaxation) — unlike every other
     /// `TIER=sensitive` case, where a verified sender's identity answers
     /// the only open question. Meaningless (always `false`) when
-    /// `is_transcript_request` is `false`. Resolved in
-    /// `handle_reactive_inject` (has `AppState::wstore`, unlike
-    /// `Handler::inject_message`, which has no `Store` access "by design")
-    /// — same "resolve in the caller with Store access, pass the outcome
-    /// through" pattern `sig_verified`/`lan_verified` already establish.
+    /// `is_transcript_request` is `false`. Resolved by
+    /// `resolve_transcript_request_tier_fields` (has `Store` access, unlike
+    /// `Handler::inject_message`, which has none "by design") — called from
+    /// both delivery paths that reach `Handler`: `handle_reactive_inject`
+    /// for host/cross-channel/LAN, and
+    /// `muxbus::cloud_subscriber::sync_agent_reactive` for WAN — same
+    /// "resolve in the caller with Store access, pass the outcome through"
+    /// pattern `sig_verified`/`lan_verified` already establish.
     #[serde(skip_deserializing, default)]
     pub transcript_request_escalate_forced: bool,
 }

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -941,7 +941,7 @@ async fn sync_agent_reactive(
             _ => None,
         };
 
-        let req = InjectionRequest {
+        let mut req = InjectionRequest {
             target_agent: agent_id.to_string(),
             message: inj.message.clone(),
             source_agent: inj.source_agent.clone(),
@@ -955,6 +955,15 @@ async fn sync_agent_reactive(
             reagent_key_id: inj.reagent_key_id.clone(),
             ..Default::default()
         };
+        // Phase C (muxspect Phase B/C conversation visibility,
+        // SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md): this WAN
+        // delivery path calls `Handler::inject_message` directly and never
+        // goes through `server/reactive.rs::handle_reactive_inject`/HTTP at
+        // all — without also resolving these two fields HERE, a
+        // WAN-delivered `transcript_request` would silently skip both the
+        // forced-TIER=sensitive rule and the escalate-forcing rule
+        // entirely, not just get a weaker version of them.
+        crate::server::reactive::resolve_transcript_request_tier_fields(wstore, &mut req);
         let delivery = handler.inject_message(req);
         tracing::debug!(
             injection_id = %inj.id,

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -13,7 +13,10 @@ mod identity_handlers;
 pub mod install_handlers;
 mod lsp_handlers;
 mod messagebus;
-mod reactive;
+// pub(crate): muxbus::cloud_subscriber (the WAN delivery path) calls
+// resolve_transcript_request_tier_fields directly — see that function's
+// own doc comment for why.
+pub(crate) mod reactive;
 pub(crate) mod service;
 mod shell_handlers;
 mod tool_handlers;

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -387,16 +387,25 @@ fn resolve_delivery_tier(auth_via: super::ReactiveAuthVia, claimed: Option<&str>
 /// `transcript_request_escalate_forced` — see both fields' own doc comments
 /// (`backend/reactive/types.rs`) and
 /// `SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`. Lives here (not
-/// `Handler::inject_message_inner`) because it needs `AppState::wstore` —
+/// `Handler::inject_message_inner`) because it needs `Store` access —
 /// `Handler` has no `Store` access "by design," same reason
 /// `sig_verified`/`lan_verified` are resolved by this same caller before
 /// the request reaches the handler.
+///
+/// Takes `wstore: &Arc<Store>` directly (not `&AppState`) so
+/// `muxbus::cloud_subscriber::sync_agent_reactive` — the WAN delivery path,
+/// which calls `Handler::inject_message` directly and never goes through
+/// `handle_reactive_inject`/HTTP at all — can call this exact same
+/// resolution too (`pub(crate)`). Phase C (WAN) needs the identical rule 1/
+/// rule 2 computation this function already does; without also wiring it
+/// in there, a WAN-delivered `transcript_request` would silently skip both
+/// rules entirely, not just get weaker ones.
 ///
 /// Always re-parses `req.message` itself — never trusts anything the
 /// client might have set on these two fields (impossible anyway, since
 /// both are `#[serde(skip_deserializing)]`, but this function is the one
 /// place that actually computes their real value from scratch).
-fn resolve_transcript_request_tier_fields(state: &AppState, req: &mut InjectionRequest) {
+pub(crate) fn resolve_transcript_request_tier_fields(wstore: &std::sync::Arc<crate::backend::storage::store::Store>, req: &mut InjectionRequest) {
     let Some(transcript_req) = agentmux_common::transcript_request::parse_transcript_request(&req.message) else {
         return;
     };
@@ -408,8 +417,7 @@ fn resolve_transcript_request_tier_fields(state: &AppState, req: &mut InjectionR
     // display `name` (same cross-namespace hazard already documented at
     // this file's Supervisor-nudge opt-in check just above, which this
     // mirrors exactly).
-    let visibility = state
-        .wstore
+    let visibility = wstore
         .agent_def_list()
         .ok()
         .and_then(|defs| defs.into_iter().find(|d| d.slug.eq_ignore_ascii_case(&req.target_agent)))
@@ -421,8 +429,7 @@ fn resolve_transcript_request_tier_fields(state: &AppState, req: &mut InjectionR
         "ask" => true,
         "trusted_peers" => {
             let requester = req.source_agent.as_deref().unwrap_or("");
-            let granted = state
-                .wstore
+            let granted = wstore
                 .conversation_trust_grant_check(&req.target_agent, requester, tier)
                 .unwrap_or(false);
             !granted
@@ -505,7 +512,7 @@ mod transcript_request_tier_resolution_tests {
             message: "just chatting".to_string(),
             ..Default::default()
         };
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(!req.is_transcript_request);
         assert!(!req.transcript_request_escalate_forced);
     }
@@ -515,7 +522,7 @@ mod transcript_request_tier_resolution_tests {
         let state = test_state();
         insert_agent_def(&state, "agent1", "private");
         let mut req = base_req("agent1");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(req.is_transcript_request);
         assert!(!req.transcript_request_escalate_forced);
     }
@@ -525,7 +532,7 @@ mod transcript_request_tier_resolution_tests {
         let state = test_state();
         insert_agent_def(&state, "agent1", "ask");
         let mut req = base_req("agent1");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(req.is_transcript_request);
         assert!(req.transcript_request_escalate_forced);
     }
@@ -535,7 +542,7 @@ mod transcript_request_tier_resolution_tests {
         let state = test_state();
         insert_agent_def(&state, "agent1", "trusted_peers");
         let mut req = base_req("agent1");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(
             req.transcript_request_escalate_forced,
             "an un-granted requester must still force escalation under trusted_peers mode"
@@ -548,7 +555,7 @@ mod transcript_request_tier_resolution_tests {
         insert_agent_def(&state, "agent1", "trusted_peers");
         state.wstore.conversation_trust_grant_add("agent1", "requester", "lan").unwrap();
         let mut req = base_req("agent1");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(
             !req.transcript_request_escalate_forced,
             "an allow-listed requester on the SAME tier must not force escalation"
@@ -562,10 +569,48 @@ mod transcript_request_tier_resolution_tests {
         // Granted for WAN, but this request arrives on LAN (base_req's default).
         state.wstore.conversation_trust_grant_add("agent1", "requester", "wan").unwrap();
         let mut req = base_req("agent1");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(
             req.transcript_request_escalate_forced,
             "a grant for one tier's identity guarantee must never be assumed to cover a different tier"
+        );
+    }
+
+    // Phase C (WAN): this function is tier-generic — these two tests pin
+    // that WAN delivery gets the identical treatment LAN already has,
+    // since `sync_agent_reactive` (the WAN delivery path,
+    // `muxbus/cloud_subscriber.rs`) calls this exact function directly.
+    #[tokio::test]
+    async fn wan_tier_transcript_request_forces_sensitive_same_as_lan() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "private");
+        let mut req = InjectionRequest {
+            target_agent: "agent1".to_string(),
+            message: transcript_request_message(),
+            source_agent: Some("requester".to_string()),
+            delivery_tier: Some("wan".to_string()),
+            ..Default::default()
+        };
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
+        assert!(req.is_transcript_request, "rule 1 must fire on WAN exactly like every other tier");
+    }
+
+    #[tokio::test]
+    async fn wan_tier_trusted_peers_grant_on_the_matching_tier_relaxes_escalation() {
+        let state = test_state();
+        insert_agent_def(&state, "agent1", "trusted_peers");
+        state.wstore.conversation_trust_grant_add("agent1", "requester", "wan").unwrap();
+        let mut req = InjectionRequest {
+            target_agent: "agent1".to_string(),
+            message: transcript_request_message(),
+            source_agent: Some("requester".to_string()),
+            delivery_tier: Some("wan".to_string()),
+            ..Default::default()
+        };
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
+        assert!(
+            !req.transcript_request_escalate_forced,
+            "a WAN grant checked against an actual WAN request must relax escalation, same as LAN's matching-tier case"
         );
     }
 
@@ -613,7 +658,7 @@ mod transcript_request_tier_resolution_tests {
             state_clone.wstore.agent_def_insert(&mut def).unwrap();
         }
         let mut req = base_req("agent1");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(req.transcript_request_escalate_forced, "lookup must match by slug \"agent1\", not the unrelated display name");
     }
 
@@ -622,7 +667,7 @@ mod transcript_request_tier_resolution_tests {
         let state = test_state();
         // No AgentDefinition inserted at all for this target.
         let mut req = base_req("no-such-agent");
-        resolve_transcript_request_tier_fields(&state, &mut req);
+        resolve_transcript_request_tier_fields(&state.wstore, &mut req);
         assert!(req.is_transcript_request, "rule 1 (forced sensitive) applies regardless of whether the target is known");
         assert!(!req.transcript_request_escalate_forced, "an unknown agent defaults to the safe 'private' behavior for the escalate-forcing question");
     }
@@ -645,7 +690,7 @@ pub(super) async fn handle_reactive_inject(
     verify_jekt_signature(&state, &mut req);
     verify_reagent_signature(&mut req, now_unix_secs());
     verify_lan_signature(&state, &mut req).await;
-    resolve_transcript_request_tier_fields(&state, &mut req);
+    resolve_transcript_request_tier_fields(&state.wstore, &mut req);
 
     // 1. Try local ReactiveHandler first (fast path — same instance).
     let resp = state.reactive_handler.inject_message(req.clone());

--- a/docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
+++ b/docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
@@ -15,7 +15,13 @@ auto-approve, invisible to the target agent), the `ask`-mode
 approve/deny CLI, the `RequestTranscript`/`PollTranscriptRequest` MCP
 tools, and per-request-type rate limiting are still not built — see that
 spec's §3 for why deferring those specifically was a safe scope cut, not a
-gap. Phase C (WAN) not yet started.
+gap. Phase C (WAN) tier enforcement now also implemented — see
+`SPEC_MUXSPECT_PHASE_C_WAN_TIER_ENFORCEMENT_2026_08_22.md` (the same rule
+1/rule 2 computation, now also wired into the WAN delivery path,
+`muxbus::cloud_subscriber`, which bypasses `handle_reactive_inject`/HTTP
+entirely). Phase C's own WAN-specific differences (settings-UI guidance,
+no-cache `ask` approval, bench-tuned `max_lines`) are all N/A until the
+same deferred auto-responder/settings-UI pieces above are built.
 **Motivated by:** direct request — agents need a fast way to see what every
 other agent (this host, other channels on this host, LAN, connected WAN) is
 currently saying/doing, without manual filesystem archaeology or a

--- a/docs/specs/SPEC_MUXSPECT_PHASE_C_WAN_TIER_ENFORCEMENT_2026_08_22.md
+++ b/docs/specs/SPEC_MUXSPECT_PHASE_C_WAN_TIER_ENFORCEMENT_2026_08_22.md
@@ -1,0 +1,91 @@
+# SPEC: `muxspect` Phase C — WAN tier enforcement
+
+**Date:** 2026-08-22
+**Status:** Implemented (scoped — see §2 for why this is small)
+**Author:** Korp
+**Repo touched:** `agentmux` (`agentmux-srv`)
+**Related:** `docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`
+(Phase C's design), `docs/specs/SPEC_MUXSPECT_PHASE_B_POLICY_AND_TIER_ENFORCEMENT_2026_08_22.md`
+(Phase B, this extends)
+
+## 1. The one real gap Phase B left for WAN
+
+Phase B's `resolve_transcript_request_tier_fields` (`server/reactive.rs`)
+was written tier-generically from the start — it reads `req.delivery_tier`
+and matches trust grants against whichever tier a request actually arrived
+on, never assuming "lan." So the RULE LOGIC already worked for `"wan"`
+without any changes.
+
+But it was only ever **called** from `handle_reactive_inject` — the HTTP
+handler behind `/agentmux/reactive/inject`. WAN delivery doesn't go
+through that path at all: `muxbus::cloud_subscriber::sync_agent_reactive`
+polls the cloud relay for pending injections and calls
+`Handler::inject_message` **directly**, bypassing
+`server/reactive.rs`/HTTP entirely. Without also calling the resolution
+function there, a WAN-delivered `transcript_request` would silently skip
+both confirmed jekt rules completely — not a weaker version of them,
+nothing at all.
+
+## 2. Fix
+
+- `resolve_transcript_request_tier_fields` made `pub(crate)`, its
+  parameter changed from `&AppState` to `&Arc<Store>` directly (all it ever
+  used from `AppState` was `.wstore`) — `sync_agent_reactive` has its own
+  `wstore: &Arc<Store>` parameter already, no new plumbing needed.
+- `server::reactive` module widened to `pub(crate)` so
+  `muxbus::cloud_subscriber` (a sibling top-level module) can reach it.
+- One new call, right before `sync_agent_reactive`'s existing
+  `handler.inject_message(req)`.
+
+That's the entire change. Everything else — the `TranscriptRequest`/
+`TranscriptResponse` wire payload, the `conversation_visibility` setting,
+`db_conversation_trust_grants`, the actual rule 1/rule 2 computation — is
+unchanged from Phase B and now correctly reachable from both delivery
+paths.
+
+## 3. Why this is small — the design spec's own WAN-specific items are all N/A yet
+
+`SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`'s Phase C
+section lists three WAN-specific differences from Phase B. All three
+concern pieces Phase B explicitly deferred (see that spec's §3) and this
+PR doesn't build either — so there is currently nothing to differentiate:
+
+- *"`conversation_visibility` for WAN defaults to `private`, and
+  `trusted_peers` shouldn't be exposed as usable for WAN"* — this is
+  guidance for a settings UI/CLI that doesn't exist yet (nothing lets an
+  agent SET `conversation_visibility` or manage trust grants today). Moot
+  until that surface is built. The underlying data model already supports
+  the recommendation once it matters: a `trusted_peers` grant is tier-
+  scoped (`db_conversation_trust_grants.tier`), so a WAN grant only ever
+  relaxes escalation for an ACTUAL WAN request — nothing silently
+  leaks across tiers regardless of what any future settings UI allows.
+- *"`ask` mode requests no session-remembered/cached approval across
+  WAN"* — about the (not-yet-built) approve/deny CLI's caching behavior.
+  Moot until that's built.
+- *"Default `max_lines` for WAN needs bench data"* — about the
+  (not-yet-built) auto-responder's transcript-reading logic. Moot until
+  that's built.
+
+None of this is silently glossed over — it's the same non-goal list Phase
+B already named, now confirmed to also cover Phase C's own described
+scope, not just Phase B's.
+
+## 4. Testing
+
+- 2 new tests in `server::reactive::transcript_request_tier_resolution_tests`
+  proving the shared resolution function behaves identically for
+  `delivery_tier: "wan"` as it already does for `"lan"`: rule 1 forces
+  sensitive; a `trusted_peers` grant checked against a MATCHING `"wan"`
+  request relaxes escalation (the positive case — the existing Phase B
+  suite already covered the negative "wrong tier" case, granted-for-WAN-
+  but-requested-on-LAN).
+- Full `agentmux-srv` suite: 2746 passed, 0 failed, 6 pre-existing ignores.
+- `muxbus::cloud_subscriber::sync_agent_reactive` itself is not
+  independently integration-tested — consistent with this file's own
+  existing convention (every test in `cloud_subscriber.rs` covers an
+  extracted pure helper — `is_credential_rejected`, `reagent_sig_is_fresh`,
+  etc. — never the top-level async polling/delivery orchestration, which
+  needs real HTTP mocking this file has never built). The correctness of
+  what gets called is covered by the resolution function's own thorough
+  test suite; the one-line call site is a small, visually-verifiable
+  addition consistent with that existing testing boundary, not a new gap.


### PR DESCRIPTION
## Summary

Phase C of `SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`, extending Phase B (#2764).

Phase B's `resolve_transcript_request_tier_fields` was written tier-generically from the start — it reads `req.delivery_tier` and matches trust grants against whichever tier a request actually arrived on. But it was only ever **called** from `handle_reactive_inject` (the HTTP handler). WAN delivery doesn't go through that path at all: `muxbus::cloud_subscriber::sync_agent_reactive` polls the cloud relay for pending injections and calls `Handler::inject_message` **directly**. Without also calling the resolution function there, a WAN-delivered `transcript_request` would silently skip both confirmed jekt rules entirely — not a weaker version, nothing at all.

**Fix:** `resolve_transcript_request_tier_fields` made `pub(crate)`, takes `&Arc<Store>` directly instead of `&AppState` (all it used was `.wstore`, which `sync_agent_reactive` already has as its own parameter — no new plumbing). `server::reactive` module widened to `pub(crate)`. One new call site, right before `sync_agent_reactive`'s existing `inject_message` call.

**Why this is the whole change:** see `docs/specs/SPEC_MUXSPECT_PHASE_C_WAN_TIER_ENFORCEMENT_2026_08_22.md` §3 — the design spec's own WAN-specific differences from Phase B (settings-UI guidance around `trusted_peers`, no-cache `ask` approval, bench-tuned `max_lines`) all concern pieces Phase B already deferred (the auto-responder, the settings UI, the approve/deny CLI) and this PR doesn't build either — so they're not yet applicable. Once this repo builds those, they'll need their own WAN-specific handling; today there's genuinely nothing to differentiate.

## Test plan
- [x] 2 new tests proving the shared resolution function behaves identically for `delivery_tier: "wan"` as it already does for `"lan"` — rule 1 forces sensitive; a matching-tier `trusted_peers` grant relaxes escalation (the existing Phase B suite already covered the negative "wrong tier" case)
- [x] Full `agentmux-srv` suite: 2746 passed (the one intermittent local failure, `refresh_processes_specifics_does_not_leak_a_handle_per_call`, is the same pre-existing environment-sensitive Windows handle-count flake seen throughout this session — confirmed passing 2/3 re-runs in isolation, untouched by this change)
- [x] `sync_agent_reactive` itself is not independently integration-tested, consistent with `cloud_subscriber.rs`'s own existing convention (every test there covers an extracted pure helper, never the top-level async polling orchestration)

<!-- agentmux:agent_id=korp -->