### PR TITLE
chore: release v0.55.21

### DIFF
--- a/.changesets/1787426726-feat-tabs-quick-fork-keybinding-non-claude-fallback-banner-a-vrwl.md
+++ b/.changesets/1787426726-feat-tabs-quick-fork-keybinding-non-claude-fallback-banner-a-vrwl.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tabs): quick-fork keybinding, non-Claude fallback banner, and inherit-identity variant

--- a/.changesets/1787427171-fix-statusbar-stop-double-applying-chrome-zoom-to-status-bar-r5f2.md
+++ b/.changesets/1787427171-fix-statusbar-stop-double-applying-chrome-zoom-to-status-bar-r5f2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): stop double-applying chrome zoom to status bar popovers

--- a/.changesets/1787428853-fix-muxlog-srv-logs-honor-agentmux-log-dir-fix-channels-glob-zj2j.md
+++ b/.changesets/1787428853-fix-muxlog-srv-logs-honor-agentmux-log-dir-fix-channels-glob-zj2j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxlog): srv logs honor AGENTMUX_LOG_DIR, fix channels/ glob depth mismatch

--- a/.changesets/1787429114-fix-muxlog-prefer-caller-s-own-agentmux-channel-over-global--tos2.md
+++ b/.changesets/1787429114-fix-muxlog-prefer-caller-s-own-agentmux-channel-over-global--tos2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxlog): prefer caller's own $AGENTMUX_CHANNEL over global freshest when resolving a log

--- a/.changesets/1787434387-fix-editor-strip-windows-verbatim-prefix-so-live-reload-matc-l5fb.md
+++ b/.changesets/1787434387-fix-editor-strip-windows-verbatim-prefix-so-live-reload-matc-l5fb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): strip Windows' verbatim prefix so live-reload matching works

--- a/.changesets/1787434387-fix-jekt-match-plural-forms-of-whole-word-sensitive-keywords-srl5.md
+++ b/.changesets/1787434387-fix-jekt-match-plural-forms-of-whole-word-sensitive-keywords-srl5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(jekt): match plural forms of whole-word sensitive keywords

--- a/.changesets/1787434874-feat-muxlog-ls-gains-a-live-column-via-real-tcp-liveness-pro-huv1.md
+++ b/.changesets/1787434874-feat-muxlog-ls-gains-a-live-column-via-real-tcp-liveness-pro-huv1.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxlog): ls gains a LIVE column via real TCP liveness probe of each instance's ipc-port

--- a/.changesets/1787435685-docs-claude-pr-title-agent-host-prefix-for-shared-identity-a-te13.md
+++ b/.changesets/1787435685-docs-claude-pr-title-agent-host-prefix-for-shared-identity-a-te13.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(claude): PR title Agent@host prefix for shared-identity agents

--- a/.changesets/1787436028-feat-settings-add-drag-and-drop-file-attach-controls-to-adva-0kpn.md
+++ b/.changesets/1787436028-feat-settings-add-drag-and-drop-file-attach-controls-to-adva-0kpn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(settings): add drag-and-drop file-attach controls to Advanced section

--- a/.changesets/1787436129-feat-muxspect-cross-instance-find-which-channel-has-this-blo-2qw6.md
+++ b/.changesets/1787436129-feat-muxspect-cross-instance-find-which-channel-has-this-blo-2qw6.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxspect): cross-instance find — which channel has this block_id/agent

--- a/.changesets/1787436301-fix-tabs-move-quick-fork-from-the-window-tab-strip-into-the--1mqa.md
+++ b/.changesets/1787436301-fix-tabs-move-quick-fork-from-the-window-tab-strip-into-the--1mqa.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): move quick-fork from the window tab-strip into the per-agent pane, landing forks as a sibling pane tab

--- a/.changesets/1787436504-feat-agent-config-protect-a-pre-existing-project-claude-md-f-xdb8.md
+++ b/.changesets/1787436504-feat-agent-config-protect-a-pre-existing-project-claude-md-f-xdb8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-config): protect a pre-existing project CLAUDE.md from being overwritten

--- a/.changesets/1787436671-feat-settings-add-agent-watchdog-threshold-controls-to-termi-9qat.md
+++ b/.changesets/1787436671-feat-settings-add-agent-watchdog-threshold-controls-to-termi-9qat.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(settings): add agent watchdog threshold controls to Terminal section

--- a/.changesets/1787437319-feat-muxspect-stamp-every-response-with-x-agentmux-srv-versi-njed.md
+++ b/.changesets/1787437319-feat-muxspect-stamp-every-response-with-x-agentmux-srv-versi-njed.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(muxspect): stamp every response with x-agentmux-srv-version, self-diagnosing stale-build 404s

--- a/.changesets/1787438045-feat-muxlog-swarm-d-dispatch-id-filters-prints-a-correlated--0bp7.md
+++ b/.changesets/1787438045-feat-muxlog-swarm-d-dispatch-id-filters-prints-a-correlated--0bp7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxlog): swarm -d/--dispatch <id> filters + prints a correlated match-count verdict

--- a/.changesets/1787438407-feat-settings-add-recording-input-section-voice-engine-confi-9i5s.md
+++ b/.changesets/1787438407-feat-settings-add-recording-input-section-voice-engine-confi-9i5s.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(settings): add Recording/Input section — voice engine config, device picker, test-your-mic

--- a/.changesets/1787439491-fix-voice-redact-groqapikey-from-renderer-fix-engine-switch--0dxc.md
+++ b/.changesets/1787439491-fix-voice-redact-groqapikey-from-renderer-fix-engine-switch--0dxc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(voice): redact groqApiKey from renderer, fix engine-switch/test-cancel bugs

--- a/.changesets/1787439562-fix-agent-stop-agent-unresponsive-from-firing-during-legitim-wokj.md
+++ b/.changesets/1787439562-fix-agent-stop-agent-unresponsive-from-firing-during-legitim-wokj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): stop 'Agent unresponsive' from firing during legitimate context compaction

--- a/.changesets/1787441148-fix-agent-propagate-resumed-session-id-to-shared-cross-chann-x7xr.md
+++ b/.changesets/1787441148-fix-agent-propagate-resumed-session-id-to-shared-cross-chann-x7xr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): propagate resumed session_id to shared cross-channel registry

--- a/.changesets/1787441538-fix-tabs-quick-fork-always-inherits-identity-dropping-the-re-q6iq.md
+++ b/.changesets/1787441538-fix-tabs-quick-fork-always-inherits-identity-dropping-the-re-q6iq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): quick-fork always inherits identity, dropping the redundant second menu item

--- a/.changesets/1787442317-fix-subagent-watcher-watch-the-identity-bound-claude-config--py2b.md
+++ b/.changesets/1787442317-fix-subagent-watcher-watch-the-identity-bound-claude-config--py2b.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(subagent-watcher): watch the identity-bound Claude config dir, not a stale spawn-time snapshot

--- a/.changesets/1787446160-feat-fleet-fleetbroadcast-reaches-cross-channel-lan-wan-targ-r06t.md
+++ b/.changesets/1787446160-feat-fleet-fleetbroadcast-reaches-cross-channel-lan-wan-targ-r06t.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(fleet): FleetBroadcast reaches cross-channel/LAN/WAN targets, not just this instance

--- a/.changesets/1787447023-feat-layout-generalize-the-tab-content-reveal-gate-to-leaf-p-ujpp.md
+++ b/.changesets/1787447023-feat-layout-generalize-the-tab-content-reveal-gate-to-leaf-p-ujpp.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(layout): generalize the tab-content reveal gate to leaf/pane scope, fixing flicker on +, Quick Fork, and Agent History

--- a/.changesets/1787447234-feat-fleet-fleetbulkstop-reaches-cross-channel-targets-not-j-2dg8.md
+++ b/.changesets/1787447234-feat-fleet-fleetbulkstop-reaches-cross-channel-targets-not-j-2dg8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(fleet): FleetBulkStop reaches cross-channel targets, not just this instance

--- a/.changesets/1787451088-feat-muxspect-phase-b-policy-infrastructure-jekt-tier-enforc-3dgi.md
+++ b/.changesets/1787451088-feat-muxspect-phase-b-policy-infrastructure-jekt-tier-enforc-3dgi.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxspect): Phase B policy infrastructure + jekt tier enforcement for transcript_request

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.20"
+version = "0.55.21"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.20"
+version = "0.55.21"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.20"
+version = "0.55.21"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.20"
+version = "0.55.21"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.20"
+version = "0.55.21"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.20"
+version = "0.55.21"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.20"
+version = "0.55.21"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,34 @@
 # AgentMux Version History
 
+## 0.55.21 — 2026-08-22
+
+- feat(tabs): quick-fork keybinding, non-Claude fallback banner, and inherit-identity variant
+- fix(statusbar): stop double-applying chrome zoom to status bar popovers
+- fix(muxlog): srv logs honor AGENTMUX_LOG_DIR, fix channels/ glob depth mismatch
+- fix(muxlog): prefer caller's own $AGENTMUX_CHANNEL over global freshest when resolving a log
+- fix(editor): strip Windows' verbatim prefix so live-reload matching works
+- fix(jekt): match plural forms of whole-word sensitive keywords
+- feat(muxlog): ls gains a LIVE column via real TCP liveness probe of each instance's ipc-port
+- docs(claude): PR title Agent@host prefix for shared-identity agents
+- feat(settings): add drag-and-drop file-attach controls to Advanced section
+- feat(muxspect): cross-instance find — which channel has this block_id/agent
+- fix(tabs): move quick-fork from the window tab-strip into the per-agent pane, landing forks as a sibling pane tab
+- feat(agent-config): protect a pre-existing project CLAUDE.md from being overwritten
+- feat(settings): add agent watchdog threshold controls to Terminal section
+- feat(muxspect): stamp every response with x-agentmux-srv-version, self-diagnosing stale-build 404s
+- feat(muxlog): swarm -d/--dispatch <id> filters + prints a correlated match-count verdict
+- feat(settings): add Recording/Input section — voice engine config, device picker, test-your-mic
+- fix(voice): redact groqApiKey from renderer, fix engine-switch/test-cancel bugs
+- fix(agent): stop 'Agent unresponsive' from firing during legitimate context compaction
+- fix(agent): propagate resumed session_id to shared cross-channel registry
+- fix(tabs): quick-fork always inherits identity, dropping the redundant second menu item
+- fix(subagent-watcher): watch the identity-bound Claude config dir, not a stale spawn-time snapshot
+- feat(fleet): FleetBroadcast reaches cross-channel/LAN/WAN targets, not just this instance
+- feat(layout): generalize the tab-content reveal gate to leaf/pane scope, fixing flicker on +, Quick Fork, and Agent History
+- feat(fleet): FleetBulkStop reaches cross-channel targets, not just this instance
+- feat(muxspect): Phase B policy infrastructure + jekt tier enforcement for transcript_request
+
+
 ## 0.55.20 — 2026-08-22
 
 - feat(mcp): add CaptureWindow tool for cross-instance/OS window screenshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.20",
+  "version": "0.55.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.20",
+      "version": "0.55.21",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.20",
+  "version": "0.55.21",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Consumes 25 pending changesets. `task release -- --as patch` forced a patch bump — the computed bump from the queued changesets was `minor` (several `feat:` entries are included), so those minor-level changes ship under this patch version per the explicit override.

## Version consistency
All 5 required locations agree at `0.55.21`:
- `VERSION_HISTORY.md` top section
- `package.json`
- `Cargo.toml` `[workspace.package].version`
- `Cargo.lock` workspace-member versions
- `package-lock.json` root version

## Test plan
- [x] `git diff --staged` reviewed before commit — only version files + changeset deletions + `VERSION_HISTORY.md` entry
- [x] No source code changes in this PR (release-only)

<!-- agentmux:agent_id=agent1 -->