### PR TITLE
Korp@claudius: fix(editor): align markdown preview scrollbar to the pane edge, matching source mode

### DIFF
--- a/.changesets/1787460096-fix-editor-align-markdown-preview-scrollbar-to-the-pane-edge-1bjf.md
+++ b/.changesets/1787460096-fix-editor-align-markdown-preview-scrollbar-to-the-pane-edge-1bjf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): align markdown preview scrollbar to the pane edge, matching source mode

--- a/docs/specs/SPEC_EDITOR_MARKDOWN_PREVIEW_SCROLLBAR_ALIGNMENT_2026_08_22.md
+++ b/docs/specs/SPEC_EDITOR_MARKDOWN_PREVIEW_SCROLLBAR_ALIGNMENT_2026_08_22.md
@@ -1,0 +1,117 @@
+# SPEC: Editor pane — align markdown preview's scrollbar with source mode
+
+**Date:** 2026-08-22
+**Status:** Draft
+**Author:** Korp
+**Repo touched:** `agentmux` (`frontend`)
+**Related:** `frontend/app/view/editor/editor-view.tsx`, `frontend/app/view/editor/editor-view.scss`,
+`frontend/app/element/markdown.tsx`, `frontend/app/element/markdown.scss`,
+`docs/specs/SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md` (the
+established house precedent for this exact failure mode — see §2)
+
+## 1. Problem
+
+In the Editor pane's markdown Source mode, the scrollbar sits flush against
+the pane's right edge (CodeMirror's native scrollbar, no ancestor padding).
+In Preview mode, the scrollbar looks misplaced — it renders inset from the
+true edge, floating inside a padding gutter instead of hugging the pane
+border the way Source mode's does.
+
+## 2. Root cause
+
+Source mode (`editor-view.tsx:890-896`, `editor-view.scss:557-561`):
+`.editor-codemirror` has no padding anywhere in its ancestor chain.
+CodeMirror's own `.cm-scroller` is the sole scroll container, so its native
+scrollbar paints flush against the pane's true right edge.
+
+Preview mode (`editor-view.tsx:905-916`) nests two scroll containers instead
+of one:
+
+- `.editor-preview-content` (`editor-view.scss:581-589`) — `overflow-y: auto`
+  **and** `padding: 16px 24px`, wrapping...
+- `<Markdown>`'s own `.markdown > .content` (`markdown.tsx:317-343`,
+  `markdown.scss:19-38`) — `overflow: scroll`, converted at mount
+  (`markdown.tsx:299-304`) into an OverlayScrollbars-managed viewport (the
+  library that renders the visible track/thumb).
+
+Because the 16px/24px padding lives on the **outer** `.editor-preview-content`
+wrapper rather than on the element OverlayScrollbars actually manages, the
+entire `.markdown` box — and with it the visible OverlayScrollbars track —
+is inset 24px from the pane's true right edge. The outer `overflow-y: auto`
+is also redundant: `.content` already owns real scrolling, so the outer
+wrapper is a second, unnecessary scroll container that exists only to hold
+the padding.
+
+Track width/color are not the issue — `--os-size: 7px` (`app.scss:142`)
+already matches the native `*::-webkit-scrollbar { width: 7px }`
+(`app.scss:87-90`), and both pull thumb colors from the same
+`--scrollbar-thumb-color` tokens. This is purely a positioning bug, not a
+styling mismatch.
+
+This is the same failure mode `SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md`
+already diagnosed and fixed for the agent pane's tool-call previews: a
+scrollbar always renders at its own owning element's border box, unaffected
+by that element's own padding — so any padding placed on an *ancestor* of
+the scroll-owning box pushes the scrollbar (track and all) inboard of the
+visible surface's true edge. That spec's fix was to zero the ancestor's
+padding and re-home the inset onto the scroll-owning element itself
+(`.agent-tool-panel` → `.agent-tool-overlay-log`). The same technique
+applies here regardless of OverlayScrollbars vs. a native `::-webkit-scrollbar`
+— it's ordinary CSS box-model behavior, not a library-specific quirk.
+
+## 3. Fix
+
+Move the padding off the outer wrapper and onto the element OverlayScrollbars
+actually hosts, using the `contentClass` prop `<Markdown>` already exposes
+for exactly this kind of per-consumer scoping (`markdown.tsx:72,99,322,327`
+— currently declared but unused by any caller). OverlayScrollbars reads
+padding declared on its host element and renders it as inner content inset
+while keeping the scrollbar track anchored to the host's true border box —
+so applying the padding this way keeps the same visual text inset while
+letting the scrollbar sit flush, matching Source mode.
+
+Changes:
+
+1. **`editor-view.scss:581-589`** (`.editor-preview-content`) — drop
+   `padding: 16px 24px` and the now-redundant `overflow-y: auto`. It becomes
+   a plain flex sizing wrapper (`flex: 1 1 auto`), no longer a scroll
+   container or padding holder.
+2. **`editor-view.tsx:914`** — pass a new `contentClass="editor-preview-markdown-content"`
+   prop to `<Markdown textAtom={() => liveDoc()} />`, so the padding lands
+   on `.content` (the OverlayScrollbars host) scoped to this one call site
+   only — not on `.markdown-content-inner` or any other global class shared
+   by every other `<Markdown>` consumer (agent chat, tool-call output, etc.).
+3. **`editor-view.scss`** — add:
+   ```scss
+   .editor-preview-markdown-content {
+       padding: 16px 24px;
+   }
+   ```
+
+No changes needed to `markdown.tsx`/`markdown.scss` — `contentClass` is
+already wired through to `.content` for this exact purpose.
+
+## 4. Why this is scoped correctly
+
+- `contentClass` only ever applies to the one `.content` div OverlayScrollbars
+  manages for the instance it's passed to (`cn("content", contentClassName)`)
+  — every other `<Markdown>` render site in the app (none of which currently
+  pass `contentClass`) is untouched.
+- `.editor-preview-content` is used at exactly one call site
+  (`editor-view.tsx:913`), so narrowing its CSS to a plain flex wrapper has
+  no other blast radius.
+- Track/thumb size and color are untouched — this only changes where the
+  padding lives, not `--os-size` or any scrollbar-color token.
+
+## 5. Testing plan
+
+- Manual: open a markdown file in the Editor pane, switch to Preview and
+  Split modes, confirm the scrollbar sits flush against the pane's right
+  edge in both, matching Source mode's CodeMirror scrollbar position.
+- Manual: confirm the rendered markdown text still has its original
+  16px/24px visual inset (no regression to reading comfort/line length).
+- Manual: confirm scrolling still works (drag thumb, wheel, keyboard) with
+  the padding relocated.
+- Manual: spot-check another `<Markdown>` consumer (e.g. an agent chat
+  message) to confirm its scrollbar/padding is unaffected, since
+  `.editor-preview-markdown-content` is scoped to the editor's call site only.

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -579,13 +579,25 @@
 }
 
 .editor-preview-content {
+    // No padding/overflow here — a scrollbar always renders at its owning
+    // element's own border box, unaffected by that element's own padding.
+    // Padding on this wrapper (an ancestor of the actual scroll-owning
+    // `.content` box inside <Markdown>) pushed the scrollbar inboard of the
+    // pane's true edge instead of flush against it like source mode's
+    // CodeMirror scrollbar. Same failure mode + fix as
+    // SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md — the inset is
+    // re-homed onto `.editor-preview-markdown-content` below, which targets
+    // `.content` (the OverlayScrollbars-managed scroll owner) directly.
     flex: 1 1 auto;
-    overflow-y: auto;
-    padding: 16px 24px;
+    min-height: 0;
 
     .markdown {
         font-size: var(--markdown-font-size, 14px);
     }
+}
+
+.editor-preview-markdown-content {
+    padding: 16px 24px;
 }
 
 // ── LSP install banner (Phase 1 of SPEC_EDITOR_LSP_AND_THEMES) ────────

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -911,7 +911,10 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                                 }
                             >
                                 <div class="editor-preview-content">
-                                    <Markdown textAtom={() => liveDoc()} />
+                                    <Markdown
+                                        textAtom={() => liveDoc()}
+                                        contentClass="editor-preview-markdown-content"
+                                    />
                                 </div>
                             </div>
                         </Show>


### PR DESCRIPTION
## Summary

The Editor pane's markdown **Source** mode scrollbar (CodeMirror's native
scrollbar) sits flush against the pane's right edge — no ancestor has
padding. The **Preview** mode scrollbar (OverlayScrollbars, hosted on
`<Markdown>`'s `.content` div) instead rendered inset ~24px from the true
edge, looking misplaced.

**Root cause:** the 16px/24px padding lived on `.editor-preview-content`,
an *ancestor* of the actual scroll-owning box — a scrollbar always renders
at its own owning element's border box, unaffected by that element's own
padding, so padding on an ancestor pushes the whole scroll box (and its
scrollbar) inboard.

This is the identical failure mode `SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md`
already diagnosed and fixed for the agent pane's tool-call previews. Same
technique here: move the inset off the ancestor and onto the scroll-owning
element itself, using `<Markdown>`'s existing (previously unused)
`contentClass` prop to target its `.content` div directly — scoped to this
one call site, so no other `<Markdown>` consumer (agent chat, tool output,
etc.) is affected.

Spec: `docs/specs/SPEC_EDITOR_MARKDOWN_PREVIEW_SCROLLBAR_ALIGNMENT_2026_08_22.md`

## Changes

- `frontend/app/view/editor/editor-view.scss` — `.editor-preview-content`
  drops its padding + now-redundant `overflow-y: auto`; new
  `.editor-preview-markdown-content` rule carries the same `16px 24px`
  inset, scoped via `contentClass`.
- `frontend/app/view/editor/editor-view.tsx` — passes
  `contentClass="editor-preview-markdown-content"` to `<Markdown>`.

## Verification

- `npx tsc --noEmit` — clean.
- `npx stylelint frontend/app/view/editor/editor-view.scss` — no new
  findings (13 pre-existing issues elsewhere in the file, none on the
  touched lines).
- **Not yet visually verified live** — my current pane runs a prebuilt
  portable snapshot with no hot reload for this branch, and spinning up a
  fresh `task dev` instance wasn't practical in this session. The fix is a
  well-understood CSS box-model change (scrollbars render at their owning
  element's border box, independent of that element's own padding) and
  mirrors an already-shipped, proven fix for the same failure mode
  elsewhere in this app — but a manual visual pass (open a `.md` file,
  compare Source vs Preview scrollbar position) before merge is recommended.

<!-- agentmux:agent_id=korp -->