### PR TITLE
Camper@claudius: fix(agent): stop Activity Dock flashing stale shell rows on pane load

### DIFF
--- a/.changesets/1787461233-fix-agent-stop-activity-dock-flashing-stale-shell-rows-on-pa-a8zk.md
+++ b/.changesets/1787461233-fix-agent-stop-activity-dock-flashing-stale-shell-rows-on-pa-a8zk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): stop Activity Dock flashing stale shell rows on pane load

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -285,6 +285,12 @@ pub struct CommandShellStopData {
     pub shell_id: String,
 }
 
+/// Data for ShellStatusCommand — query a shell's current running state by id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandShellStatusData {
+    pub shell_id: String,
+}
+
 /// A file to write as part of agent config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfigFile {

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -104,6 +104,11 @@ pub const COMMAND_AGENT_STOP: &str = "agentstop";
 pub const COMMAND_SHELL_EXEC: &str = "shellexec";
 /// Stop a running persistent shell node (Phase 3) — UI stop button.
 pub const COMMAND_SHELL_STOP: &str = "shellstop";
+/// Query a persistent shell node's current running state (Phase 3) —
+/// used by useShellNodeStream to resolve a `shell_node_create` replay's
+/// TRUE current status instead of assuming "running" (see
+/// docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md).
+pub const COMMAND_SHELL_STATUS: &str = "shellstatus";
 pub const COMMAND_WRITE_AGENT_CONFIG: &str = "writeagentconfig";
 pub const COMMAND_RESOLVE_CLI: &str = "resolvecli";
 pub const COMMAND_CHECK_CLI_AUTH: &str = "checkcliauth";

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -115,7 +115,13 @@ impl ShellSessionRegistry {
     // the Broker, unlike this registry) purges their `shell:<id>` persisted
     // WaveEvent history so the broker's persist_map key set stays bounded
     // in step with this registry's own MAX_EXITED_STATUS cap.
-    fn register_full(
+    //
+    // `pub(crate)` (rather than private) so `server::shell_handlers`'s own
+    // tests can seed a running/exited shell directly, without spawning a
+    // real child process, to exercise the `shellstatus` RPC handler's JSON
+    // shape end-to-end for both branches — the same pre-tested primitive
+    // this module's own tests already use, not duplicated logic.
+    pub(crate) fn register_full(
         &self,
         shell_id: String,
         stop_tx: oneshot::Sender<()>,

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -226,11 +226,32 @@ impl ShellSessionRegistry {
     }
 
     /// Return a snapshot of the shell's status. Returns `running: false` if unknown.
+    /// Existing, documented contract for `POST /api/v1/shell/status` (the MCP
+    /// `ShellStatus` tool) — do not change: an agent calling this for an id
+    /// it doesn't recognize expects a plain "not running" answer, not an error.
     pub fn get_status(&self, shell_id: &str) -> ShellStatusInfo {
         self.status_map.lock()
             .get(shell_id)
             .map(|arc| arc.lock().clone())
             .unwrap_or_default()
+    }
+
+    /// Like [`Self::get_status`], but `None` when no entry exists at all —
+    /// distinguishing "genuinely unknown" from "known, and not running."
+    ///
+    /// Needed by the `shellstatus` RPC command (unlike the MCP tool above,
+    /// which is fine collapsing "unknown" into "not running"): `register_full`
+    /// only runs after the runner task spawns the child process, but
+    /// `shell_node_create` is published to the frontend BEFORE that task is
+    /// even scheduled (`handle_shell_create` in server/mod.rs). A caller that
+    /// checks status immediately after seeing `shell_node_create` can race
+    /// ahead of registration — reagent P1 on PR #2770: collapsing that race
+    /// window into `running: false` was indistinguishable from a genuinely
+    /// already-exited shell, so a fast, still-registering, genuinely LIVE
+    /// shell (e.g. a real `task dev`) could be shown as failed in the
+    /// Activity Dock for its entire run.
+    pub(crate) fn get_status_if_known(&self, shell_id: &str) -> Option<ShellStatusInfo> {
+        self.status_map.lock().get(shell_id).map(|arc| arc.lock().clone())
     }
 
     /// List every currently-RUNNING shell across all blocks — the Swarm

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::{
-    COMMAND_SHELL_EXEC, COMMAND_SHELL_STOP,
-    CommandShellExecData, ShellExecResult, CommandShellStopData,
+    COMMAND_SHELL_EXEC, COMMAND_SHELL_STOP, COMMAND_SHELL_STATUS,
+    CommandShellExecData, ShellExecResult, CommandShellStopData, CommandShellStatusData,
 };
 use crate::backend::base::{expand_home_dir_safe, msys_to_windows_path};
 
@@ -27,6 +27,31 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let stopped = registry.stop(&req.shell_id);
                 tracing::info!(shell_id = %req.shell_id, stopped, "shellstop");
                 Ok(Some(serde_json::json!({ "stopped": stopped })))
+            })
+        }),
+    );
+
+    // shellstatus → query a shell's current running state. Used by
+    // useShellNodeStream to resolve the TRUE status of a shell whose
+    // `shell_node_create` event is being replayed on pane mount/reconnect
+    // (persist:64 ring), instead of assuming "running" — the frontend can't
+    // otherwise tell a live spawn apart from a replay of an already-long-
+    // exited shell, which was flashing stale rows in the Activity Dock.
+    // See docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md.
+    let shell_sessions_status = state.shell_sessions.clone();
+    engine.register_handler(
+        COMMAND_SHELL_STATUS,
+        Box::new(move |data, _ctx| {
+            let registry = shell_sessions_status.clone();
+            Box::pin(async move {
+                let req: CommandShellStatusData = serde_json::from_value(data)
+                    .map_err(|e| format!("shellstatus: {e}"))?;
+                let s = registry.get_status(&req.shell_id);
+                Ok(Some(serde_json::json!({
+                    "running": s.running,
+                    "exit_code": s.exit_code,
+                    "line_count": s.line_count,
+                })))
             })
         }),
     );
@@ -348,4 +373,79 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::rpc_types::RpcMessage;
+    use crate::backend::shell_node::ShellStatusInfo;
+    use parking_lot::Mutex;
+
+    // Seed a shell status directly (mirrors shell_node.rs's own
+    // register_running_for_block/register_exited test helpers) — avoids
+    // spawning a real child process just to exercise the RPC handler's
+    // JSON shape.
+    fn seed_status(state: &AppState, shell_id: &str, running: bool, exit_code: Option<i32>) {
+        let (tx, _rx) = tokio::sync::oneshot::channel::<()>();
+        let status = Arc::new(Mutex::new(ShellStatusInfo {
+            running,
+            exit_code,
+            line_count: 3,
+            ..Default::default()
+        }));
+        state.shell_sessions.register_full(shell_id.to_string(), tx, None, status);
+    }
+
+    async fn call_shellstatus(state: &AppState, shell_id: &str) -> serde_json::Value {
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register_shell_handlers(&engine, state);
+        engine.handle_message(RpcMessage {
+            command: "shellstatus".to_string(),
+            reqid: "req-shellstatus".to_string(),
+            data: Some(serde_json::json!({ "shell_id": shell_id })),
+            ..Default::default()
+        });
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(1), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        resp.data.unwrap()
+    }
+
+    #[tokio::test]
+    async fn shellstatus_reports_running_shell() {
+        let state = crate::server::tests::test_state();
+        seed_status(&state, "sh-running", true, None);
+        let data = call_shellstatus(&state, "sh-running").await;
+        assert_eq!(data["running"], serde_json::json!(true));
+        assert_eq!(data["line_count"], serde_json::json!(3));
+        assert!(data.get("exit_code").map_or(true, |v| v.is_null()));
+    }
+
+    #[tokio::test]
+    async fn shellstatus_reports_exited_shell_with_exit_code() {
+        let state = crate::server::tests::test_state();
+        seed_status(&state, "sh-exited", false, Some(0));
+        let data = call_shellstatus(&state, "sh-exited").await;
+        assert_eq!(data["running"], serde_json::json!(false));
+        assert_eq!(data["exit_code"], serde_json::json!(0));
+    }
+
+    #[tokio::test]
+    async fn shellstatus_reports_exited_err_shell() {
+        let state = crate::server::tests::test_state();
+        seed_status(&state, "sh-failed", false, Some(1));
+        let data = call_shellstatus(&state, "sh-failed").await;
+        assert_eq!(data["running"], serde_json::json!(false));
+        assert_eq!(data["exit_code"], serde_json::json!(1));
+    }
+
+    #[tokio::test]
+    async fn shellstatus_unknown_id_reports_not_running_no_exit_code() {
+        let state = crate::server::tests::test_state();
+        let data = call_shellstatus(&state, "sh-never-existed").await;
+        assert_eq!(data["running"], serde_json::json!(false));
+        assert!(data.get("exit_code").map_or(true, |v| v.is_null()));
+    }
 }

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -38,6 +38,13 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // otherwise tell a live spawn apart from a replay of an already-long-
     // exited shell, which was flashing stale rows in the Activity Dock.
     // See docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md.
+    //
+    // Reports `known: false` (rather than collapsing into `running: false`,
+    // like the MCP-facing HTTP route does) when no registry entry exists yet
+    // — the shell may simply not have finished spawning/registering (see
+    // `get_status_if_known`'s doc comment for the exact race this closes:
+    // reagent P1 on PR #2770, a genuinely live shell misreported as already
+    // exited). The frontend treats `known: false` as "don't correct."
     let shell_sessions_status = state.shell_sessions.clone();
     engine.register_handler(
         COMMAND_SHELL_STATUS,
@@ -46,12 +53,20 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let req: CommandShellStatusData = serde_json::from_value(data)
                     .map_err(|e| format!("shellstatus: {e}"))?;
-                let s = registry.get_status(&req.shell_id);
-                Ok(Some(serde_json::json!({
-                    "running": s.running,
-                    "exit_code": s.exit_code,
-                    "line_count": s.line_count,
-                })))
+                match registry.get_status_if_known(&req.shell_id) {
+                    Some(s) => Ok(Some(serde_json::json!({
+                        "known": true,
+                        "running": s.running,
+                        "exit_code": s.exit_code,
+                        "line_count": s.line_count,
+                    }))),
+                    None => Ok(Some(serde_json::json!({
+                        "known": false,
+                        "running": false,
+                        "exit_code": null,
+                        "line_count": 0,
+                    }))),
+                }
             })
         }),
     );
@@ -418,6 +433,7 @@ mod tests {
         let state = crate::server::tests::test_state();
         seed_status(&state, "sh-running", true, None);
         let data = call_shellstatus(&state, "sh-running").await;
+        assert_eq!(data["known"], serde_json::json!(true));
         assert_eq!(data["running"], serde_json::json!(true));
         assert_eq!(data["line_count"], serde_json::json!(3));
         assert!(data.get("exit_code").map_or(true, |v| v.is_null()));
@@ -428,6 +444,7 @@ mod tests {
         let state = crate::server::tests::test_state();
         seed_status(&state, "sh-exited", false, Some(0));
         let data = call_shellstatus(&state, "sh-exited").await;
+        assert_eq!(data["known"], serde_json::json!(true));
         assert_eq!(data["running"], serde_json::json!(false));
         assert_eq!(data["exit_code"], serde_json::json!(0));
     }
@@ -437,14 +454,24 @@ mod tests {
         let state = crate::server::tests::test_state();
         seed_status(&state, "sh-failed", false, Some(1));
         let data = call_shellstatus(&state, "sh-failed").await;
+        assert_eq!(data["known"], serde_json::json!(true));
         assert_eq!(data["running"], serde_json::json!(false));
         assert_eq!(data["exit_code"], serde_json::json!(1));
     }
 
+    // Reagent P1 on PR #2770: a shell with no registry entry at all — either
+    // a genuinely unknown id, OR (the actual race that motivated this)
+    // `shell_node_create` was published but the runner hasn't reached
+    // `register_full` yet (still spawning the child process). Both look
+    // identical to this handler, and BOTH must report `known: false`, not
+    // the same shape as a genuinely exited shell — otherwise a live shell
+    // caught in that race gets misreported as failed for its entire run
+    // (ShellChunkAppend never restores a status once set).
     #[tokio::test]
-    async fn shellstatus_unknown_id_reports_not_running_no_exit_code() {
+    async fn shellstatus_unknown_id_reports_known_false() {
         let state = crate::server::tests::test_state();
         let data = call_shellstatus(&state, "sh-never-existed").await;
+        assert_eq!(data["known"], serde_json::json!(false));
         assert_eq!(data["running"], serde_json::json!(false));
         assert!(data.get("exit_code").map_or(true, |v| v.is_null()));
     }

--- a/docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md
+++ b/docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md
@@ -1,11 +1,13 @@
 # Retro: Activity Dock flashes stale shell rows on every pane load
 
 **Date:** 2026-08-22
-**Severity:** Low — cosmetic only, no data loss, nothing re-executed. But it's
-the second time this exact symptom has been reported by the user (first as
-"old long-running processes that are socked" while diagnosing a separate
-cross-channel resume bug, then again directly during manual verification of
-that bug's fix).
+**Severity:** Low for the original bug — cosmetic only, no data loss, nothing
+re-executed. It's the second time this exact symptom has been reported by the
+user (first as "old long-running processes that are socked" while diagnosing
+a separate cross-channel resume bug, then again directly during manual
+verification of that bug's fix). Note the FIX's first draft briefly
+introduced something more severe — see "Review findings" below — caught and
+closed before merge.
 **Observed by:** Camper (Claude agent), reported directly by the user during
 manual testing of PR #2755: "what about the dock items? they show and then
 disappear."
@@ -174,11 +176,60 @@ longer the ONLY path to a correct status.
   both correctly no-op; clean exit, nonzero exit, and missing-exit-code all
   map to the right terminal status/exit code.
 
-Full verification: `cargo test -p agentmux-srv` (2691 passed, 0 failed, up
-from 2687 before this fix), `npx tsc --noEmit` (clean), `npx vitest run`
-(2965 passed; one unrelated `tool-renderers/registry.test.ts` timeout
-confirmed as a pre-existing flake under full-suite parallel load — passes
-cleanly in isolation, no relation to this change).
+Full verification: `cargo test -p agentmux-srv` (2750 passed, 0 failed),
+`npx tsc --noEmit` (clean), `npx vitest run` (2965 passed; one unrelated
+`tool-renderers/registry.test.ts` timeout confirmed as a pre-existing flake
+under full-suite parallel load — passes cleanly in isolation, no relation to
+this change).
+
+---
+
+## Review findings (PR #2770)
+
+ReAgent's review of the initial fix caught a real regression before merge —
+worse than the bug this PR set out to fix, and correctly blocked it:
+
+**P1 — a genuinely live shell could be misreported as failed for its entire
+run.** `handle_shell_create` (`server/mod.rs`) publishes `shell_node_create`
+to the frontend, then `tokio::spawn`s the runner task fire-and-forget —
+`ShellSessionRegistry::register_full` (the call that actually creates the
+registry entry `get_status` reads) only happens once that task reaches it,
+AFTER spawning the real child process. There is no ordering guarantee
+between "frontend receives shell_node_create and fires its status check"
+and "runner reaches register_full." If the status RPC round-trip completed
+first, `get_status` returned its "unknown" default (`running: false,
+exit_code: None`) — byte-for-byte identical to the shape a genuinely
+already-exited shell produces. `shellStatusCorrection` then pushed a false
+`exited-err` correction for a real, live, freshly-spawned shell (e.g. an
+actual `task dev`). Since nothing in the reducer ever restores a status
+once set (`ShellChunkAppend` only appends log content, never flips status
+back), that shell would show as failed in the Activity Dock for its ENTIRE
+real run, until/unless it happened to exit for real later.
+
+**Fix:** added `ShellSessionRegistry::get_status_if_known`, returning
+`Option<ShellStatusInfo>` — `None` when no registry entry exists at all,
+distinct from `Some(status)` with `running: false`. The existing
+`get_status` (used by the MCP-facing `POST /api/v1/shell/status` HTTP
+route) is untouched — that route's documented contract already treats an
+unrecognized id as "not running," which is the correct answer for an agent
+calling `ShellStatus` on an id it made up, and changing it would be a
+breaking change to an unrelated caller. The NEW `shellstatus` RPC command
+(the only consumer that needs the three-way distinction) reports a `known`
+boolean; `known: false` means "don't correct" — the frontend's
+`shellStatusCorrection` now takes `{ known, running, exit_code? }` and
+returns `null` (no correction) whenever `!known`, exactly like it already
+did for a fully-failed RPC call. This closes the race safely: a live shell
+caught mid-registration now correctly falls back to "stay running, let the
+real exit-chunk replay correct it later if needed" — the same degraded-but-
+safe behavior this PR started from for the narrow cases it doesn't fully
+eliminate (see Prevention/Follow-ups below), rather than a false positive.
+
+Added 1 backend test (`shellstatus_unknown_id_reports_known_false`,
+replacing the now-redundant original unknown-id test) confirming `known:
+false` for any id without a registry entry, and updated all existing
+backend/frontend tests for the new `known` field. Re-verified: `cargo test
+-p agentmux-srv` (2750 passed), `npx tsc --noEmit` (clean), `npx vitest run`
+(new shellStatusCorrection tests: 5/5 passed).
 
 ---
 

--- a/docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md
+++ b/docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md
@@ -1,0 +1,214 @@
+# Retro: Activity Dock flashes stale shell rows on every pane load
+
+**Date:** 2026-08-22
+**Severity:** Low — cosmetic only, no data loss, nothing re-executed. But it's
+the second time this exact symptom has been reported by the user (first as
+"old long-running processes that are socked" while diagnosing a separate
+cross-channel resume bug, then again directly during manual verification of
+that bug's fix).
+**Observed by:** Camper (Claude agent), reported directly by the user during
+manual testing of PR #2755: "what about the dock items? they show and then
+disappear."
+**Related specs:** `SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md`,
+`SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md`
+**Related retros:** `retro-agent-resumed-9-day-stale-session-2026-08-22.md`
+(the cross-channel resume bug this was discovered while verifying — a
+different bug, same session, same user-reported "old garbage on load"
+language)
+
+---
+
+## TL;DR
+
+Reopening an agent pane briefly showed old, already-finished shell commands
+in the Activity Dock as if they were live and running, then made them vanish
+a moment later. Confirmed by direct user testing (not a hypothesis): the
+flash happened right on pane load, and the items shown were "old/unfamiliar"
+— not current activity. Root cause: `shell_node_create`, the WPS event the
+frontend uses to learn about a persistent shell, is published exactly once
+per shell and replayed verbatim (persist:64 ring) on every pane
+mount/reconnect, for every shell in the block's recent history — including
+ones that finished hours or days ago. The event payload carries no status
+field, so the frontend always built a `ShellNode` with `status: "running"`
+regardless of whether it was a genuinely live spawn or a replay of a
+long-dead shell. The correction — an "exit" event replayed from that same
+shell's own separate `shell:<id>` ring — arrives moments later via an
+independent subscribe+replay round trip, at which point the Activity Dock's
+existing departure-flash animation plays and the row disappears. Fixed by
+adding a `shellstatus` RPC command that queries the shell's TRUE current
+state (already tracked server-side in `ShellSessionRegistry`) and firing it
+immediately after every `shell_node_create`, correcting the dock the instant
+the (much cheaper) status lookup resolves — in practice almost always before
+the "running" row the create event queued has painted at all. Node creation
+itself is unchanged (still always "running" at that point) specifically to
+avoid introducing any new risk of a chunk/exit event racing ahead of its
+node's own existence in the document.
+
+---
+
+## What Happened
+
+### The report
+
+Mid-session, right after manually verifying the (unrelated) cross-channel
+resume fix in PR #2755 by reopening an agent pane, the user asked directly:
+
+> "ok, I tried it with Agent2 and it was faster .. but what about the dock
+> items? they show and then disappear"
+
+This echoed almost verbatim the very first complaint that had kicked off
+this whole session's cross-channel-resume investigation: "it is showing
+garbage, like old long-running processes that are socked." That earlier
+retro flagged the dock symptom as a **lower-confidence, unconfirmed**
+secondary observation and explicitly deferred investigating it. This session
+picked it back up on the user's direct follow-up.
+
+Before proposing any fix, two clarifying questions confirmed this wasn't the
+dock's own intended behavior (terminal rows are *supposed* to fade out after
+a retention window — that's a feature, not a bug):
+
+- **Timing:** "Right on open/load" — not after sitting visible for a while.
+- **Content:** "Old/unfamiliar" — not current, recent activity.
+
+Both answers ruled out the benign explanation and confirmed the same failure
+class the original bug report described.
+
+### Finding the mechanism
+
+`frontend/app/view/agent/components/ActivityDock.tsx` renders shell/subagent/
+tool rows derived from the document's `nodes()`. Shell nodes specifically are
+**not** part of the persisted document-history snapshot at all (confirmed:
+zero references to "shell" in `parseHistoryLines.ts`) — they're reconstructed
+entirely from a live WPS event stream, `useShellNodeStream.ts`.
+
+That stream subscribes to a block-scoped `shell_node_create` event with
+`persist: 64` (`agentmux-srv/src/server/mod.rs`'s `handle_shell_create`) —
+meaning the last 64 creation events for this block replay to any new
+subscriber, by design, "so multiple shells in a pane all replay on WS
+reconnect / pane remount" (the mechanism's own doc comment). Each replay is
+handled identically to a live spawn:
+
+```ts
+const node: ShellNode = {
+    ...
+    status: "running",   // ALWAYS — the event payload has no status field
+    spawnedAt: d.timestamp ?? Date.now(),
+    ...
+};
+opts.queue.pushShellCreate(node);
+subscribeShellScope(shellId);   // establishes this shell's OWN per-shell ring
+```
+
+For an already-long-exited shell, the correction only ever arrives via that
+shell's own separate `shell:<id>` ring (`persist: 1024`), which carries its
+`exit` chunk. Subscribing to it is a **second, independent** subscribe+
+replay round trip — not simultaneous with the create event's own replay.
+Concretely, on every pane load with any shell history: create-event replay
+lands first → dock renders the row as "running" → moments later the
+per-shell exit-event replay lands → `ShellStatusUpdate` flips it to
+terminal → the dock's existing `EXIT_FLASH_MS` departure animation plays →
+the row disappears. Exactly "shows on load, old/unfamiliar, then
+disappears."
+
+This was independently confirmed by tracing the exact code paths (not
+inferred from behavior alone): `handle_shell_create` publishes
+`shell_node_create` with no status field, ever, for the shell's entire
+lifetime; `ShellSessionRegistry` (the actual source of truth for a shell's
+live/exited state) was never consulted by the frontend at creation time at
+all.
+
+---
+
+## The Fix
+
+Added a `shellstatus` RPC command
+(`agentmux-srv/src/backend/rpc_types/{block,commands}.rs`,
+`server/shell_handlers.rs`) that thinly wraps the already-existing, already-
+tested `ShellSessionRegistry::get_status` — the same registry the HTTP-only
+`POST /api/v1/shell/status` route (used by the MCP server) already reads,
+just exposed on the RPC channel the frontend actually uses.
+
+`useShellNodeStream.ts`'s `shell_node_create` handler now fires
+`ShellStatusCommand` immediately after queuing the node (still always
+created as `"running"` first — unchanged from before) and after establishing
+the per-shell subscription. If the check reports the shell already exited,
+it immediately pushes a correction via the **same, already-tested**
+`pushShellExit` → `ShellStatusUpdate` path the real exit-chunk replay would
+eventually use anyway — just arriving via a much cheaper single-registry-
+lookup round trip instead of a full subscribe+ring-replay one, so in
+practice it wins the race and the "running" row this pushShellCreate just
+queued never actually paints.
+
+**Deliberately did NOT change node-creation ordering.** An earlier draft of
+this fix tried to defer `pushShellCreate` itself behind the status check —
+i.e., don't insert the node at all until we know its real status. Rejected
+before landing: `subscribeShellScope` (which starts loading this shell's own
+chunk/exit ring in parallel) is called synchronously either way, and
+`ShellChunkAppend`/`ShellStatusUpdate` are no-ops in the reducer when they
+can't find a matching node id. Deferring creation would have raced the two
+independent async round trips (the status check vs. the chunk-ring replay)
+against each other with no ordering guarantee, risking silently dropping a
+shell's captured output if the ring replay won that race and arrived before
+the node existed — trading a cosmetic flash for a real data-loss risk. The
+shipped fix avoids this entirely: creation is always synchronous and
+unchanged, and the status check only ever adds a *faster corrective*
+follow-up on the existing, safe path.
+
+The proxy `exitedAt` used for the correction (the shell's own creation
+timestamp — `ShellStatusResponse` doesn't carry a real exit time) is
+intentionally approximate: for the case this fixes (a shell that finished
+long ago), it's already far outside the dock's retention window either way,
+so the row renders as invisible the instant the correction lands. The real
+`exitedAt`/exit code are refined moments later regardless, once the shell's
+own exit-chunk replay arrives on its own — same as before this fix, just no
+longer the ONLY path to a correct status.
+
+**Tests:**
+- Backend (`server/shell_handlers.rs`, 4 new): the `shellstatus` RPC handler
+  reports `running: true` for a live shell, `exited-ok`-shaped data (exit
+  code 0) and `exited-err`-shaped data (nonzero code) for exited shells, and
+  `running: false` / no exit code for an unknown id — exercised through the
+  real `WshRpcEngine` dispatch path, not just the underlying registry call.
+- Frontend (`useShellNodeStream.test.ts`, 5 new): the pure
+  `shellStatusCorrection` decision function — still-running and failed-check
+  both correctly no-op; clean exit, nonzero exit, and missing-exit-code all
+  map to the right terminal status/exit code.
+
+Full verification: `cargo test -p agentmux-srv` (2691 passed, 0 failed, up
+from 2687 before this fix), `npx tsc --noEmit` (clean), `npx vitest run`
+(2965 passed; one unrelated `tool-renderers/registry.test.ts` timeout
+confirmed as a pre-existing flake under full-suite parallel load — passes
+cleanly in isolation, no relation to this change).
+
+---
+
+## What This Is NOT
+
+- Not a re-execution or duplication of any shell command — purely a display
+  artifact. The shell's actual process lifecycle (`ShellNodeRunner`,
+  `ShellSessionRegistry`) was never affected by this bug.
+- Not the same bug as `retro-agent-resumed-9-day-stale-session-2026-08-22.md`
+  — that was a backend session-id resume correctness bug (a wrong
+  conversation resuming), fixed in PR #2755. This is a frontend display-
+  timing bug (a right conversation, with a cosmetically-wrong dock flash) —
+  the two were reported by the user in very similar language ("old...
+  garbage"/"old long-running processes") because both manifest as stale-
+  looking state on pane load, but they are unrelated code paths with
+  unrelated fixes.
+- Not a data-loss risk introduced by the fix itself — see "Deliberately did
+  NOT change node-creation ordering" above for why the safer, slightly less
+  aggressive design was chosen over a naive "just don't render until we
+  know the real status" approach.
+
+## Prevention / Follow-ups
+
+- Not tracked as a further issue: the fix reduces the flash window to
+  "however long a single registry lookup takes" rather than eliminating it
+  by a hard guarantee — a sufficiently slow/contended status RPC could in
+  principle still lose the race against a fast chunk-ring replay and let one
+  frame paint. Given the cosmetic-only severity and that a guaranteed fix
+  would require either a new "pending" ShellNode status variant (rippling
+  through the dock's status union and retention logic) or reworking the WPS
+  persist-ring replay itself to carry live status, this was judged
+  disproportionate for what is now a much-narrower remaining window rather
+  than a near-certain flash on every load.

--- a/docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md
+++ b/docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md
@@ -231,6 +231,48 @@ backend/frontend tests for the new `known` field. Re-verified: `cargo test
 -p agentmux-srv` (2750 passed), `npx tsc --noEmit` (clean), `npx vitest run`
 (new shellStatusCorrection tests: 5/5 passed).
 
+**Round 3 — P1, same underlying pattern, a different pair of racers.**
+ReAgent's re-review of the round-2 commit (and, per its own report,
+matching a finding chatgpt-codex-connector had already left on the same
+line) caught that the fix STILL had an unguarded race: the synthesized
+`ShellStatusCommand` correction and the shell's REAL exit/stop event
+(delivered independently via the already-subscribed `shell:<id>` chunk
+ring) have no ordering guarantee relative to EACH OTHER either. If the real
+event won that race — the shell genuinely exits or is stopped by the user
+before the status RPC resolves — the correction callback still fired
+unconditionally once its promise settled, overwriting the already-correct
+row (right status, including `"stopped"`, which `ShellStatusResponse` has
+no way to express at all — only `exited-ok`/`exited-err`; and the real
+exact `exitedAt`) with a stale, less-accurate synthesized one (wrong
+status, `exitedAt` hardcoded to `spawnedAt`). `ShellStatusUpdate` in the
+reducer overwrites a node's status unconditionally, so nothing would have
+undone the corruption on its own.
+
+**Fix:** a `reallyResolved` `Set<string>` in the hook's closure, populated
+the instant a shell's real exit/stop event lands (`handleShellChunk`'s
+`exit` branch). The correction callback checks it FIRST, before applying
+anything: if the real event already landed, skip — trust it, never
+overwrite. Safe by construction under JS's single-threaded execution model:
+the check and the (conditional) push both run synchronously within the
+same callback invocation, so no other event handler can interleave between
+"check the set" and "act on it." The reverse order (correction lands first,
+real event arrives later) was already safe without this guard — the real
+event's own unconditional overwrite is exactly the desired behavior when
+authoritative data arrives after a synthesized guess.
+
+Added a genuine ordering test (`useShellNodeStream.test.ts`, new
+`describe` block, mocking `waveEventSubscribe`/`ShellStatusCommand` and
+controlling the status-RPC promise's resolution timing directly) proving
+the guard actually suppresses the stale correction — not merely that the
+two happen to agree: the test resolves the status check with a
+DELIBERATELY wrong "already exited, code 1" reading after the real
+`stopped` event has already landed, and asserts `pushShellExit` was still
+called exactly once (the real one). A second test confirms the correction
+still applies normally when it resolves with no real event racing it at
+all. Re-verified: `cargo test -p agentmux-srv` (2750 passed), `npx tsc
+--noEmit` (clean), `npx vitest run` (7/7 in this file, including the 2 new
+ordering tests).
+
 ---
 
 ## What This Is NOT

--- a/frontend/app/store/rpc-api/agent.ts
+++ b/frontend/app/store/rpc-api/agent.ts
@@ -384,6 +384,20 @@ export const AgentApi = {
         return client.rpcCall("shellstop", data, opts);
     },
 
+    // Query a persistent shell node's TRUE current running state. Used by
+    // useShellNodeStream to resolve a replayed `shell_node_create` event
+    // (persist:64 ring, fires on every pane mount/reconnect for every shell
+    // in the block's recent history) instead of assuming "running" — the
+    // create event itself carries no status, so without this the dock
+    // briefly shows every already-long-exited shell as live on load.
+    ShellStatusCommand(
+        client: RpcClient,
+        data: { shell_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ running: boolean; exit_code?: number; line_count: number }> {
+        return client.rpcCall("shellstatus", data, opts);
+    },
+
     AgentStopCommand(client: RpcClient, data: CommandAgentStopData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("agentstop", data, opts);
     },

--- a/frontend/app/store/rpc-api/agent.ts
+++ b/frontend/app/store/rpc-api/agent.ts
@@ -390,11 +390,18 @@ export const AgentApi = {
     // in the block's recent history) instead of assuming "running" — the
     // create event itself carries no status, so without this the dock
     // briefly shows every already-long-exited shell as live on load.
+    //
+    // `known: false` means the backend has no registry entry for this id at
+    // all — either a genuinely unknown id, or (the case that matters here)
+    // the shell's runner hasn't reached registration yet, still spawning
+    // the child process. Callers must NOT treat `known: false` as "exited" —
+    // that misreported a genuinely live, freshly-spawned shell as failed for
+    // its entire run (reagent P1 on PR #2770).
     ShellStatusCommand(
         client: RpcClient,
         data: { shell_id: string },
         opts?: RpcOpts,
-    ): Promise<{ running: boolean; exit_code?: number; line_count: number }> {
+    ): Promise<{ known: boolean; running: boolean; exit_code?: number; line_count: number }> {
         return client.rpcCall("shellstatus", data, opts);
     },
 

--- a/frontend/app/view/agent/hooks/useShellNodeStream.test.ts
+++ b/frontend/app/view/agent/hooks/useShellNodeStream.test.ts
@@ -14,15 +14,21 @@ import { shellStatusCorrection } from "./useShellNodeStream";
 
 describe("shellStatusCorrection", () => {
     it("returns null when the shell is still running", () => {
-        expect(shellStatusCorrection({ running: true }, 1000)).toBeNull();
+        expect(shellStatusCorrection({ known: true, running: true }, 1000)).toBeNull();
     });
 
-    it("returns null when the status check failed (best-effort fallback)", () => {
-        expect(shellStatusCorrection(null, 1000)).toBeNull();
+    // Reagent P1 round 2 on PR #2770: `known: false` means the backend has
+    // no registry entry yet — this is the routine race window for a
+    // genuinely live, freshly-spawned shell (shell_node_create publishes
+    // BEFORE the runner registers), not a confirmed exit. Must never be
+    // treated as "exited," or a real `task dev` gets misreported as failed
+    // for its whole run.
+    it("returns null when the backend doesn't know this shell yet (registration race)", () => {
+        expect(shellStatusCorrection({ known: false, running: false }, 1000)).toBeNull();
     });
 
     it("maps a clean exit (code 0) to exited-ok, using the fallback timestamp", () => {
-        expect(shellStatusCorrection({ running: false, exit_code: 0 }, 1000)).toEqual({
+        expect(shellStatusCorrection({ known: true, running: false, exit_code: 0 }, 1000)).toEqual({
             status: "exited-ok",
             exitCode: 0,
             exitedAt: 1000,
@@ -30,15 +36,15 @@ describe("shellStatusCorrection", () => {
     });
 
     it("maps a nonzero exit code to exited-err", () => {
-        expect(shellStatusCorrection({ running: false, exit_code: 1 }, 1000)).toEqual({
+        expect(shellStatusCorrection({ known: true, running: false, exit_code: 1 }, 1000)).toEqual({
             status: "exited-err",
             exitCode: 1,
             exitedAt: 1000,
         });
     });
 
-    it("maps a missing exit_code (unknown-id case) to exited-err with -1", () => {
-        expect(shellStatusCorrection({ running: false }, 1000)).toEqual({
+    it("maps a known-but-missing exit_code to exited-err with -1", () => {
+        expect(shellStatusCorrection({ known: true, running: false }, 1000)).toEqual({
             status: "exited-err",
             exitCode: -1,
             exitedAt: 1000,

--- a/frontend/app/view/agent/hooks/useShellNodeStream.test.ts
+++ b/frontend/app/view/agent/hooks/useShellNodeStream.test.ts
@@ -7,10 +7,37 @@
  * `ShellStatusCommand` check reveals it already exited (a replay of a
  * long-dead shell, not a live spawn). See
  * docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md.
+ *
+ * Also covers the hook-level ordering guard (reagent P1 round 3 / codex on
+ * PR #2770): the synthesized ShellStatusCommand correction and the shell's
+ * REAL exit/stop event (delivered via the independently-subscribed
+ * `shell:<id>` chunk ring) race with no ordering guarantee — once the real
+ * one lands, the synthesized one must never overwrite it.
  */
 
-import { describe, expect, it } from "vitest";
-import { shellStatusCorrection } from "./useShellNodeStream";
+import { createRoot } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+    shellStatus: vi.fn(),
+}));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; scope: string; handler: (e: unknown) => void }) => {
+        const key = `${sub.eventType}:${sub.scope}`;
+        hub.handlers.set(key, sub.handler);
+        return () => hub.handlers.delete(key);
+    }),
+}));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { ShellStatusCommand: (...args: unknown[]) => hub.shellStatus(...args) },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { WpsEvent } from "@/app/store/wps-events";
+import { shellStatusCorrection, useShellNodeStream } from "./useShellNodeStream";
+import type { StreamFlushQueue } from "../stream-flush-queue";
 
 describe("shellStatusCorrection", () => {
     it("returns null when the shell is still running", () => {
@@ -49,5 +76,77 @@ describe("shellStatusCorrection", () => {
             exitCode: -1,
             exitedAt: 1000,
         });
+    });
+});
+
+describe("useShellNodeStream — real exit vs. synthesized correction ordering", () => {
+    afterEach(() => {
+        hub.handlers.clear();
+        hub.shellStatus.mockReset();
+    });
+
+    function setup() {
+        const queue = {
+            pushShellCreate: vi.fn(),
+            pushShellChunk: vi.fn(),
+            pushShellExit: vi.fn(),
+            scheduleFlush: vi.fn(),
+        } as unknown as StreamFlushQueue;
+        let dispose: (() => void) | undefined;
+        createRoot((d) => {
+            dispose = d;
+            useShellNodeStream({ blockId: "b1", queue });
+        });
+        const createHandler = hub.handlers.get(`${WpsEvent.ShellNodeCreate}:block:b1`);
+        if (!createHandler) throw new Error("shell_node_create handler not registered");
+        return { queue, createHandler, dispose: dispose! };
+    }
+
+    // Reagent P1 round 3 / codex on PR #2770: the shell exits/stops for
+    // real BEFORE the ShellStatusCommand round trip resolves. The real
+    // event must win — the synthesized correction must be a no-op once it
+    // finally resolves, not overwrite the already-correct "stopped" row
+    // with a synthesized (and here, deliberately WRONG) "exited-err".
+    it("does not overwrite an already-landed real exit/stop event", async () => {
+        let resolveStatus!: (v: { known: boolean; running: boolean; exit_code?: number }) => void;
+        hub.shellStatus.mockReturnValue(new Promise((resolve) => { resolveStatus = resolve; }));
+        const { queue, createHandler } = setup();
+
+        createHandler({ data: { shell_id: "sh1", cmd: "task dev", timestamp: 1000 } });
+        expect(queue.pushShellCreate).toHaveBeenCalledTimes(1);
+
+        // The real exit/stop event lands first, via the per-shell scope.
+        const chunkHandler = hub.handlers.get(`${WpsEvent.ShellChunk}:shell:sh1`);
+        if (!chunkHandler) throw new Error("shell_chunk handler not registered");
+        chunkHandler({ data: { shell_id: "sh1", op: "exit", exit_code: 0, stopped: true, timestamp: 2000 } });
+        expect(queue.pushShellExit).toHaveBeenCalledTimes(1);
+        expect(queue.pushShellExit).toHaveBeenLastCalledWith("sh1", "stopped", 0, 2000);
+
+        // The status check finally resolves — with a DELIBERATELY wrong
+        // "already exited with a failure" reading, simulating a stale
+        // registry snapshot read before the real exit — to prove the guard
+        // actually suppresses it rather than happening to agree.
+        resolveStatus({ known: true, running: false, exit_code: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Still exactly one call — the real "stopped" one. Not stomped by
+        // a second, synthesized "exited-err" call.
+        expect(queue.pushShellExit).toHaveBeenCalledTimes(1);
+        expect(queue.pushShellExit).toHaveBeenLastCalledWith("sh1", "stopped", 0, 2000);
+    });
+
+    it("still applies the correction normally when it resolves before any real event", async () => {
+        let resolveStatus!: (v: { known: boolean; running: boolean; exit_code?: number }) => void;
+        hub.shellStatus.mockReturnValue(new Promise((resolve) => { resolveStatus = resolve; }));
+        const { queue, createHandler } = setup();
+
+        createHandler({ data: { shell_id: "sh2", cmd: "old command", timestamp: 500 } });
+        resolveStatus({ known: true, running: false, exit_code: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(queue.pushShellExit).toHaveBeenCalledTimes(1);
+        expect(queue.pushShellExit).toHaveBeenLastCalledWith("sh2", "exited-err", 1, 500);
     });
 });

--- a/frontend/app/view/agent/hooks/useShellNodeStream.test.ts
+++ b/frontend/app/view/agent/hooks/useShellNodeStream.test.ts
@@ -1,0 +1,47 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * shellStatusCorrection — the pure decision function useShellNodeStream
+ * uses to fast-correct a `shell_node_create`-spawned node whose
+ * `ShellStatusCommand` check reveals it already exited (a replay of a
+ * long-dead shell, not a live spawn). See
+ * docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shellStatusCorrection } from "./useShellNodeStream";
+
+describe("shellStatusCorrection", () => {
+    it("returns null when the shell is still running", () => {
+        expect(shellStatusCorrection({ running: true }, 1000)).toBeNull();
+    });
+
+    it("returns null when the status check failed (best-effort fallback)", () => {
+        expect(shellStatusCorrection(null, 1000)).toBeNull();
+    });
+
+    it("maps a clean exit (code 0) to exited-ok, using the fallback timestamp", () => {
+        expect(shellStatusCorrection({ running: false, exit_code: 0 }, 1000)).toEqual({
+            status: "exited-ok",
+            exitCode: 0,
+            exitedAt: 1000,
+        });
+    });
+
+    it("maps a nonzero exit code to exited-err", () => {
+        expect(shellStatusCorrection({ running: false, exit_code: 1 }, 1000)).toEqual({
+            status: "exited-err",
+            exitCode: 1,
+            exitedAt: 1000,
+        });
+    });
+
+    it("maps a missing exit_code (unknown-id case) to exited-err with -1", () => {
+        expect(shellStatusCorrection({ running: false }, 1000)).toEqual({
+            status: "exited-err",
+            exitCode: -1,
+            exitedAt: 1000,
+        });
+    });
+});

--- a/frontend/app/view/agent/hooks/useShellNodeStream.ts
+++ b/frontend/app/view/agent/hooks/useShellNodeStream.ts
@@ -18,12 +18,67 @@
 import { onCleanup } from "solid-js";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import type { ShellNode } from "../types";
 import type { StreamFlushQueue } from "../stream-flush-queue";
 
 export interface UseShellNodeStreamOptions {
     blockId: string;
     queue: StreamFlushQueue;
+}
+
+/** Payload carried by a `shell_node_create` WPS event. */
+interface ShellNodeCreateData {
+    shell_id?: unknown;
+    cmd?: unknown;
+    title?: unknown;
+    cwd?: unknown;
+    timestamp?: unknown;
+}
+
+/**
+ * Given a `ShellStatusCommand` response for a shell whose `shell_node_create`
+ * was just handled, decide whether a correction is needed — i.e. the shell
+ * had ALREADY exited by the time we checked, so the Activity Dock shouldn't
+ * keep showing it as "running" until the per-shell exit-chunk replay
+ * (subscribed in parallel, but a slower subscribe+ring-replay round trip)
+ * eventually corrects it on its own.
+ *
+ * `shell_node_create` fires identically for a genuinely-live spawn AND for a
+ * replay of the block's recent shell history (persist:64 ring, replayed on
+ * every pane mount/reconnect) — the event payload carries no status, so the
+ * node is always created as "running" first (see the handler below; this
+ * keeps the existing ordering guarantee that a shell's own chunk/exit
+ * events, which the reducer drops for an unknown id, always find a node
+ * already present). Without this correction, every already-long-exited
+ * shell rendered as "running" until that slower replay path caught up: a
+ * visible flash of stale rows on every load. See
+ * docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md.
+ *
+ * Returns `null` when no correction is needed: the shell is genuinely still
+ * running, or the status check itself failed (best-effort — the real exit
+ * event, if any, still corrects this later on its own, just not as fast).
+ *
+ * `fallbackTimestamp` (the shell's own creation timestamp from the
+ * `shell_node_create` payload) stands in for the real exit time, which
+ * `ShellStatusResponse` doesn't carry. That's fine for what this exists to
+ * fix: for an already-long-exited shell the proxy is already far outside
+ * the dock's retention window either way, so the row still renders as
+ * invisible the instant this correction lands. The real `exitedAt`/exit
+ * code get refined moments later regardless, once the shell's own
+ * `shell:<id>` chunk-ring replay delivers its actual exit event.
+ */
+export function shellStatusCorrection(
+    status: { running: boolean; exit_code?: number } | null,
+    fallbackTimestamp: number,
+): { status: "exited-ok" | "exited-err"; exitCode: number; exitedAt: number } | null {
+    if (status === null || status.running) return null;
+    return {
+        status: status.exit_code === 0 ? "exited-ok" : "exited-err",
+        exitCode: status.exit_code ?? -1,
+        exitedAt: fallbackTimestamp,
+    };
 }
 
 export function useShellNodeStream(opts: UseShellNodeStreamOptions): void {
@@ -88,31 +143,63 @@ export function useShellNodeStream(opts: UseShellNodeStreamOptions): void {
         perShellUnsubs.clear();
     });
 
-    // shell_node_create: backend published immediately when Shell tool is called.
-    // We build the full ShellNode and queue it for the next RAF flush. We also
+    // shell_node_create: backend published immediately when Shell tool is called
+    // — OR replayed (persist:64 ring) on every pane mount/reconnect for every
+    // shell in the block's recent history, indistinguishable from a live spawn
+    // in the event payload itself. We build the full ShellNode (always
+    // "running" at this point — unchanged from before, so a chunk/exit event
+    // for this shell can never race ahead of the node existing; see
+    // subscribeShellScope below) and queue it for the next RAF flush. We also
     // subscribe to this shell's per-shell `shell_chunk` ring so its chunks/exit
     // replay on remount even if a sibling shell evicted them from the block ring.
     const shellNodeCreateUnsub = waveEventSubscribe({
         eventType: WpsEvent.ShellNodeCreate,
         scope: `block:${opts.blockId}`,
         handler: (event: any) => {
-            const d = event?.data;
+            const d = event?.data as ShellNodeCreateData | undefined;
             if (!d || typeof d !== "object") return;
             const shellId = typeof d.shell_id === "string" ? d.shell_id : "";
             if (!shellId) return;
+            const spawnedAt = typeof d.timestamp === "number" ? d.timestamp : Date.now();
             const node: ShellNode = {
                 type: "shell",
                 id: shellId,
-                cmd: d.cmd ?? "",
-                title: d.title ?? d.cmd ?? "",
+                cmd: typeof d.cmd === "string" ? d.cmd : "",
+                title: typeof d.title === "string" ? d.title : (typeof d.cmd === "string" ? d.cmd : ""),
                 cwd: typeof d.cwd === "string" ? d.cwd : undefined,
                 status: "running",
-                spawnedAt: d.timestamp ?? Date.now(),
+                spawnedAt,
                 log: { chunks: [], open: true },
             };
             opts.queue.pushShellCreate(node);
             subscribeShellScope(shellId);
             opts.queue.scheduleFlush();
+
+            // Resolve the shell's TRUE current status and correct immediately
+            // if it already exited — see shellStatusCorrection's doc comment
+            // for the full "replay vs. live spawn" rationale. This
+            // authoritative registry lookup typically resolves much faster
+            // than the per-shell scope subscription's own subscribe+ring-
+            // replay round trip just kicked off above, so in practice the
+            // correction lands before the "running" row this pushShellCreate
+            // just queued ever actually paints.
+            RpcApi.ShellStatusCommand(TabRpcClient, { shell_id: shellId })
+                .then((status) => {
+                    const correction = shellStatusCorrection(status, spawnedAt);
+                    if (!correction) return;
+                    opts.queue.pushShellExit(
+                        shellId,
+                        correction.status,
+                        correction.exitCode,
+                        correction.exitedAt,
+                    );
+                    opts.queue.scheduleFlush();
+                })
+                .catch(() => {
+                    // Best-effort — if this shell really did already exit, its
+                    // own exit-chunk replay (already subscribed above) still
+                    // corrects the dock on its own, just not as fast.
+                });
         },
     });
     onCleanup(() => { try { shellNodeCreateUnsub(); } catch { /* ignore */ } });

--- a/frontend/app/view/agent/hooks/useShellNodeStream.ts
+++ b/frontend/app/view/agent/hooks/useShellNodeStream.ts
@@ -56,9 +56,16 @@ interface ShellNodeCreateData {
  * visible flash of stale rows on every load. See
  * docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md.
  *
- * Returns `null` when no correction is needed: the shell is genuinely still
- * running, or the status check itself failed (best-effort — the real exit
- * event, if any, still corrects this later on its own, just not as fast).
+ * Returns `null` when no correction is needed: `status.known` is `false`
+ * (no registry entry yet — do NOT treat this as "exited") or the shell is
+ * genuinely still running. `known: false` is not a rare edge case: since
+ * `shell_node_create` publishes BEFORE the runner even reaches
+ * registration (see server/mod.rs's `handle_shell_create`), a live,
+ * freshly-spawned shell routinely has no registry entry yet at the exact
+ * moment this check runs. Treating that the same as "confirmed exited"
+ * would misreport a genuinely-running shell (e.g. a real `task dev`) as
+ * failed for its entire run, since nothing ever restores a status once
+ * set — reagent P1 round 2 on PR #2770.
  *
  * `fallbackTimestamp` (the shell's own creation timestamp from the
  * `shell_node_create` payload) stands in for the real exit time, which
@@ -70,10 +77,10 @@ interface ShellNodeCreateData {
  * `shell:<id>` chunk-ring replay delivers its actual exit event.
  */
 export function shellStatusCorrection(
-    status: { running: boolean; exit_code?: number } | null,
+    status: { known: boolean; running: boolean; exit_code?: number },
     fallbackTimestamp: number,
 ): { status: "exited-ok" | "exited-err"; exitCode: number; exitedAt: number } | null {
-    if (status === null || status.running) return null;
+    if (!status.known || status.running) return null;
     return {
         status: status.exit_code === 0 ? "exited-ok" : "exited-err",
         exitCode: status.exit_code ?? -1,

--- a/frontend/app/view/agent/hooks/useShellNodeStream.ts
+++ b/frontend/app/view/agent/hooks/useShellNodeStream.ts
@@ -89,6 +89,22 @@ export function shellStatusCorrection(
 }
 
 export function useShellNodeStream(opts: UseShellNodeStreamOptions): void {
+    // Shell ids whose REAL terminal event (from the per-shell shell:<id>
+    // ring — handleShellChunk's exit branch below) has already landed. The
+    // ShellStatusCommand correction below and this real exit/stop event are
+    // two independent async round trips with no ordering guarantee either
+    // way; once the real one lands, it must never be overwritten by the
+    // synthesized correction arriving after it — the real event carries the
+    // true status (including "stopped", which ShellStatusResponse has no
+    // way to express at all) and exact exitedAt, while the synthesized one
+    // only distinguishes exited-ok/exited-err and stands in spawnedAt as a
+    // proxy timestamp. reagent P1 round 3 on PR #2770 / codex on the same
+    // line: without this guard, a shell that legitimately exits/stops for
+    // real BEFORE the status check resolves gets its correct row stomped by
+    // a stale, less-accurate one moments later (ShellStatusUpdate in the
+    // reducer overwrites unconditionally, regardless of current status).
+    const reallyResolved = new Set<string>();
+
     // shell_chunk handler — used by the per-shell subscriptions. The payload
     // always carries `shell_id`, so one handler routes correctly. Chunks are
     // delivered via a SINGLE scope (`shell:<id>`); there is no longer a separate
@@ -108,6 +124,7 @@ export function useShellNodeStream(opts: UseShellNodeStreamOptions): void {
             const status: ShellNode["status"] = d.stopped === true
                 ? "stopped"
                 : exitCode === 0 ? "exited-ok" : "exited-err";
+            reallyResolved.add(shellId);
             opts.queue.pushShellExit(shellId, status, exitCode, d.timestamp ?? Date.now());
             opts.queue.scheduleFlush();
             return;
@@ -192,6 +209,12 @@ export function useShellNodeStream(opts: UseShellNodeStreamOptions): void {
             // just queued ever actually paints.
             RpcApi.ShellStatusCommand(TabRpcClient, { shell_id: shellId })
                 .then((status) => {
+                    // The real exit/stop event (a separate, independently-
+                    // racing async round trip via the per-shell scope
+                    // subscribed above) already landed and is authoritative
+                    // — never overwrite it with this synthesized guess. See
+                    // `reallyResolved`'s doc comment.
+                    if (reallyResolved.has(shellId)) return;
                     const correction = shellStatusCorrection(status, spawnedAt);
                     if (!correction) return;
                     opts.queue.pushShellExit(


### PR DESCRIPTION
## Summary
- Reopening an agent pane briefly showed old, already-finished shell commands in the Activity Dock as running, then made them vanish — confirmed by direct user testing, not a hypothesis (asked timing + content clarifying questions first to rule out the dock's own intended retention-window fade behavior).
- Root cause: `shell_node_create` replays (persist:64 ring) on every pane mount/reconnect for every shell in the block's recent history, indistinguishable from a live spawn in the event payload — the frontend always built the node as `status: "running"` regardless, correcting only via a much slower, separate exit-event replay moments later.
- Fix: new `shellstatus` RPC command thinly wrapping the already-authoritative `ShellSessionRegistry::get_status`, fired immediately after every `shell_node_create`. If the shell already exited, pushes a fast correction via the same `pushShellExit`/`ShellStatusUpdate` path the real exit-event replay would eventually use anyway — a much cheaper single-registry-lookup round trip that in practice wins the race before the "running" row ever paints.
- Node creation itself is unchanged (still synchronous, always "running" at that point) — deliberately avoids introducing any risk of a chunk/exit event racing ahead of its own node's existence in the document (an earlier draft that deferred node creation itself was rejected for this reason; see the retro).

Full investigation + design rationale: `docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md`

## Test plan
- [x] `cargo test -p agentmux-srv` — 2750 passed, 0 failed (4 new tests for the `shellstatus` RPC handler: running / clean exit / nonzero exit / unknown id, exercised through the real `WshRpcEngine` dispatch path)
- [x] `npx vitest run` — 5 new tests for the pure `shellStatusCorrection` decision function; one unrelated pre-existing flaky timeout in `tool-renderers/registry.test.ts` confirmed to pass in isolation
- [x] `npx tsc --noEmit` — clean
- [x] Changeset added

<!-- agentmux:agent_id=camper -->