### PR TITLE
fix(activity-dock): coalesce event-triggered refreshes to stop a pane-reopen request storm

### DIFF
--- a/.changesets/1787508418-fix-activity-dock-coalesce-event-triggered-refreshes-to-stop-4njb.md
+++ b/.changesets/1787508418-fix-activity-dock-coalesce-event-triggered-refreshes-to-stop-4njb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(activity-dock): coalesce event-triggered refreshes to stop a pane-reopen request storm

--- a/docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md
+++ b/docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md
@@ -1,0 +1,272 @@
+# Analysis: reopening an existing "My Agents" pane triggers a multi-second frontend request storm
+
+**Date:** 2026-08-23
+**Trigger:** repo owner reopened a heavily-used agent ("AgentX," this session's
+own agent) from My Agents and asked why loading an existing agent takes a
+while, noting "docks and long-running tasks that show during load, then
+disappear."
+**Method:** this session's own agent pane reopening (block
+`537ce695-737f-4a88-b354-7fc67fc1119c`, channel `local-main-b28b7a-e5bfaf58`,
+build `0.55.21+gf59bb43b7`) was used as a live, real trace — not a synthetic
+repro. Evidence is direct log correlation (host `[fe]` console-bridge lines +
+`agentmux-srv` log), not inference from behavior alone.
+**Status:** root-caused with high confidence (precise counts + code paths
+confirmed on both frontend and backend); **no fix implemented** — this is an
+analysis writeup, not a PR. See §6 for concrete, unimplemented fix directions.
+
+---
+
+## TL;DR
+
+Reopening a pane with a large historical corpus of subagent (Task-tool /
+Workflow) activity replays that entire (capped) history as a burst of
+`subagent:spawned`/`subagent:completed` WebSocket events. Two independent
+frontend singletons (`dispatch-source.ts`, `subagent-source.ts` — the exact
+modules backing the Activity Dock's "long-running tasks" rows) each react to
+*every single event in the burst* by firing its own uncoalesced
+`ListDispatches`/`ListActive` RPC round trip, with zero debouncing. In this
+trace, a 155-event, ~2.2s backend burst produced roughly 300 overlapping
+frontend RPC calls that took **~7.6 seconds** to drain, during which:
+
+- round-trip latency for the SAME two endpoints grew monotonically from
+  ~84ms to over **7.2 seconds**, the classic signature of a request queue
+  whose depth is growing faster than it can drain;
+- the browser's own Long Task detector logged a 291ms main-thread block;
+- an ordinary `main_window_focus` IPC round trip — normally a few
+  milliseconds — took **2.08 seconds**, because the main thread was busy
+  processing the storm;
+- two unhandled promise rejections (`Cannot read properties of null
+  (reading 'getBoundingClientRect')`) and repeated `ResizeObserver loop
+  completed with undelivered notifications` errors fired, consistent with
+  layout thrashing from the same overload.
+
+The Activity Dock's "shows then disappears" rows the user is describing are
+exactly `dispatch-source.ts`/`subagent-source.ts`'s consumers repainting on
+every one of those ~300 refresh responses as they trickle back in — the dock
+isn't glitching on its own, it's faithfully rendering a genuinely churning
+data source.
+
+## 1. What was directly observed (this session's own reopen, as a live trace)
+
+Full annotated timeline, host log (`[fe]` = frontend console, bridged) and
+`agentmux-srv` log, both for the exact same reopen:
+
+| Time (UTC) | Source | Event |
+|---|---|---|
+| 12:06:04.859 | host `[fe]` | `[agent] Launching agent definition AgentX (claude)` — reopen begins |
+| 12:06:04.892 | host `[fe]` | `WaveObj updated block:537ce695-...` |
+| 12:06:04.899 | srv | `backfilling session subagents on pane (re)open` |
+| 12:06:04.934 – 12:06:07.171 | srv | **155× `subagent spawned`** log lines (2.24s span) — the capped cold-backfill replay |
+| 12:06:07.183 | host `[fe]` | `[reactive] registered agent AgentX -> 537ce695-...` |
+| 12:06:07.216 | host `[fe]` | first `subagent.ListDispatches` (19ms) / `ListActive` (21ms) — still healthy |
+| 12:06:07.327 → 12:06:14.862 | host `[fe]` | **the storm**: `subagent.ListDispatches`/`ListActive` fire essentially back-to-back, hundreds of times; each call's own reported round-trip grows over the window: 84ms → ~500ms (12:06:07.6) → ~2000ms (12:06:09.4) → ~5000ms (12:06:12.6) → **7201ms** (12:06:14.7, the last one) |
+| 12:06:08.479 | host `[fe]` | `[perf] long-task 291.0ms name=self` — a single main-thread task blocked the browser for 291ms |
+| 12:06:14.859 | host `[fe]` | `block.GetControllerStatus` itself reports **7180ms** — an unrelated call caught behind the same queue |
+| 12:06:14.942–14.944 | host `[fe]` | 2× `[unhandled-rejection] TypeError: Cannot read properties of null (reading 'getBoundingClientRect')` |
+| 12:06:15.056 | host `[fe]` | `[perf] ipc main_window_focus 2076.8ms` — a normally-instant native IPC call, starved by the same overload |
+| 12:06:15.827, 16.521, 18.581, 18.695 | host `[fe]` | 4× `[uncaught-error] Error: ResizeObserver loop completed with undelivered notifications` |
+| ~12:06:18.7 | host `[fe]` | settles into ordinary turn-based (`wave-turn`) activity — the storm is over |
+
+**Total elapsed from "Launching agent definition" to genuinely settled:
+~14 seconds.** The backend's own replay burst took only ~2.2s of that; the
+remaining ~12s is the frontend queue draining and recovering.
+
+## 2. Root cause
+
+### 2.1 The backend replays capped, but real, history on every reopen
+
+`agentmux-srv/src/backend/subagent_watcher/scan.rs`'s `scan_subagents_dir`
+runs on every pane (re)open with a pre-existing session id
+(`server/reactive.rs`), walking every `agent-*.jsonl` under the session's
+`subagents/` directory (plus every workflow run's member files) and calling
+`process_jsonl_change(..., live: false)` for each. This is the exact
+mechanism a prior incident
+([retro-subagent-backfill-storm-oom-2026-07-17.md](../retro/retro-subagent-backfill-storm-oom-2026-07-17.md))
+already found and partially fixed: that incident hit **1,000+** replayed
+files across repeated srv crashes and OOM'd the whole app. **Fix A** from
+that retro caps the replay to `BACKFILL_MAX_FILES` (200) most-recently-
+modified files — which is why this trace shows 155 events, not 1,000+, and
+why the process didn't crash. That fix's own doc comment is explicit about
+its scope: *"this only bounds the push (broadcast) side of a cold
+backfill"* — it bounds the SIZE of the burst, not what happens to it once it
+reaches the frontend.
+
+### 2.2 `process_jsonl_change`'s `live` flag exists but never reaches the wire
+
+`process_jsonl_change` (`agentmux-srv/src/backend/subagent_watcher/jsonl.rs`)
+already distinguishes backfill replay from a genuine live spawn via its own
+`live: bool` parameter — but that flag is currently used **only** to gate
+the eager-Haiku-naming side effect (`if live && self.naming_triggered...`).
+The actual WebSocket broadcast a few lines later —
+`self.event_bus.broadcast_event(&spawned_event)` — fires unconditionally,
+and the event payload sent to the frontend (`agentId`, `slug`, `parentAgent`,
+`parentBlockId`, `sessionId`, `model`, `dispatchId`) carries no `live`/
+`replay` field at all. The frontend has no way to tell "this is 1 of 155
+historical events replaying in a 2-second burst" from "this is a single,
+genuinely new spawn" — every one of the 155 looks identical to a live event.
+
+### 2.3 Two independent frontend singletons each refresh, uncoalesced, per event
+
+`frontend/app/view/agent/activity/dispatch-source.ts` and
+`frontend/app/view/agent/activity/subagent-source.ts` are the app-lifetime,
+singleton data sources behind the Activity Dock's dispatch cards and
+subagent rows respectively (one shared instance across every open pane, by
+design — see each file's own header comment). Both independently subscribe
+to the same `subagent:spawned`/`subagent:completed`/`subagent:abandoned`
+event types, and **both call their own unconditional, undebounced
+`refresh()` on every single event**:
+
+```ts
+// subagent-source.ts
+waveEventSubscribe({ eventType: "subagent:spawned", handler: () => void refresh() });
+waveEventSubscribe({ eventType: "subagent:completed", handler: () => void refresh() });
+waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => void refresh() });
+
+// dispatch-source.ts — same three, plus subagent:named and dispatch:updated
+```
+
+`refresh()` in both files is a bare `await callBackendService(...)` with no
+in-flight guard, no debounce, and no coalescing — confirmed by reading
+`callBackendService` itself (`frontend/app/store/wos.ts`): it is a plain
+`fetch()` wrapper with no request de-duplication of any kind. A burst of N
+backfill events therefore fires up to **2N** independent, fully-overlapping
+HTTP round trips (N `ListActive` calls from `subagent-source.ts`, N
+`ListDispatches` calls from `dispatch-source.ts`) into the same two backend
+endpoints, all in flight simultaneously, none aware of the others. This is
+the direct mechanical cause of the growing-latency queue observed in §1 —
+each new request queues behind however many are already in flight, so
+round-trip time grows roughly with elapsed time, exactly as measured (84ms
+→ 7201ms across the ~7.5s window).
+
+`dispatch-source.ts` does have a debounce/coalescing mechanism —
+`scheduleQuietWindowRefresh` — but it solves a different, unrelated problem
+(scheduling exactly one *delayed* follow-up refresh for a dispatch's lazy
+running→completed transition). It only ever schedules a refresh that isn't
+already pending; it does nothing to coalesce the *immediate* refreshes each
+event handler fires on arrival.
+
+## 3. What this is NOT
+
+- **Not the Activity Dock shell-row flash bug**
+  ([PR #2770](https://github.com/agentmuxai/agentmux/pull/2770),
+  [retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md](../retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md)),
+  even though the user's own description ("docks... show and then
+  disappear") echoes that bug's report almost verbatim. That bug is about
+  **shell** nodes specifically (`useShellNodeStream.ts`) momentarily
+  rendering `status: "running"` for an already-long-dead shell before a
+  correction lands — a display-correctness bug with a near-instant fix
+  window, already root-caused and merged. This report is about **subagent**
+  dispatch/active rows (`dispatch-source.ts`/`subagent-source.ts`) and is a
+  **performance/request-volume** problem, not a display-correctness one —
+  a different symptom (rows appearing and settling as data churns) with a
+  superficially similar user description, but an unrelated mechanism and
+  an unrelated fix. Note: the build this trace was captured on (`0.55.21+gf59bb43b7`,
+  built before PR #2770 merged) does NOT yet include that fix either, so
+  the shell-flash bug is *also* still live in this exact instance — but it
+  is not what produced the ~14-second stall analyzed here.
+- **Not a new OOM/crash risk.** The July 17 incident this traces back to was
+  a crash; this is a multi-second UI stall. Fix A from that retro is working
+  as designed (155 ≤ 200 cap; no crash, no restart-loop).
+- **Not caused by any of this session's own recent frontend PRs** (#2761,
+  #2768 — the pane-mount reveal-gate/cross-fade work). Those touch
+  `agent-view.tsx`, `block.tsx`, `PaneTabStrip.tsx`, and related `.scss` —
+  none of which are in the call path identified here. `dispatch-source.ts`/
+  `subagent-source.ts` are untouched by either PR.
+- **Not specific to this one agent's pane in principle** — the mechanism
+  (backfill-on-reopen → uncoalesced per-event refresh) applies to any pane
+  reopened with a nontrivial subagent/dispatch history. It's simply most
+  visible on a heavily-used, long-running agent (this session's own AgentX
+  pane has accumulated a large history from extensive Task-tool/Workflow
+  usage across a long session) — which is exactly the "My Agents" reopen
+  case the user was exercising.
+
+## 4. Why "docks and long-running tasks... show then disappear"
+
+The Activity Dock's subagent/dispatch rows are rendered directly from
+`allSubagentsAtom`/`allDispatchesAtom` — the two signals `subagent-source.ts`/
+`dispatch-source.ts` update on every `refresh()` resolution. During the
+~7.6s storm, those signals update roughly 300 times as each queued response
+trickles back (not simultaneously — they resolve in whatever order the
+queue drains them, which is not necessarily arrival order), so the dock
+genuinely re-renders with a rapidly, non-monotonically changing snapshot of
+"currently active/dispatched" subagents until the last response lands and
+the true final state settles. Rows that appear mid-storm and vanish once a
+later, more-complete response supersedes them are not an animation glitch —
+they are literally different intermediate answers to "what's active right
+now," arriving out of order.
+
+## 5. Quantifying the amplification
+
+| Stage | Duration | Notes |
+|---|---|---|
+| Backend backfill replay | ~2.24s | 155 `subagent spawned` broadcasts, bounded by the existing 200-file cap |
+| Frontend storm (drain) | ~7.6s | Up to ~310 overlapping RPC calls (155 × 2 sources), growing queue depth |
+| Recovery tail (jank/errors) | ~4s | Long Task, starved `main_window_focus`, ResizeObserver loop errors, null-ref rejections |
+| **Total, launch to settled** | **~14s** | vs. ~2.2s of actual new information from the backend |
+
+The frontend spends roughly **6x longer processing the storm than the
+backend spent producing it** — the amplification is entirely on the
+consumption side, not the backfill-generation side.
+
+## 6. Fix directions (not implemented — for discussion)
+
+None of these have been built or verified; they're starting points.
+
+1. **Coalesce bursts on the frontend (smallest, most targeted change).**
+   Both `dispatch-source.ts` and `subagent-source.ts` could debounce their
+   event-triggered `refresh()` calls — e.g. a short (50-100ms) trailing-edge
+   debounce shared per module, so N events arriving within one burst collapse
+   into a single `refresh()` call once the burst goes quiet, instead of N
+   independent ones. This alone would cut the ~300 calls in this trace down
+   to 2 (one per module). Doesn't require any backend change.
+2. **Thread the existing `live` flag through to the wire.** Since
+   `process_jsonl_change` already knows `live: false` for every backfill-
+   replay event, adding a `"live": bool` field to the broadcast payload
+   would let the frontend distinguish "historical replay" from "genuinely
+   new" without any heuristic — a backfill-tagged event could always debounce
+   hard (or even skip triggering `refresh()` per-event entirely, doing a
+   single fetch once the pane is done backfilling), while a live event keeps
+   today's immediate-refresh behavior for real-time responsiveness.
+3. **In-flight de-duplication in `callBackendService` (broadest, most
+   invasive).** A generic "if an identical in-flight call to this
+   service+method exists, return that promise instead of issuing a new
+   request" layer would help this specific storm and any future one shaped
+   like it, but changes shared infrastructure every RPC call goes through —
+   higher review/regression surface than options 1-2 for what is currently
+   a single, localized hot spot.
+4. **Cap harder or paginate the backfill itself** (revisit
+   `BACKFILL_MAX_FILES`) — lower-leverage than 1-2, since even a smaller cap
+   still produces an uncoalesced 1:1 refresh-per-event storm at a smaller
+   scale; doesn't fix the mechanism, just shrinks the symptom.
+
+**Recommendation for a first pass, if picked up:** option 1 is the smallest,
+lowest-risk change that directly addresses the measured amplification
+(§5's 6x factor), independently shippable without any backend change, and
+directly testable (mock `waveEventSubscribe` firing N events synchronously,
+assert `refresh`'s underlying RPC call fires once, not N times — the same
+testing pattern already established in this codebase for
+`useShellNodeStream.test.ts` and `tab-reveal.test.ts`). Option 2 is a good
+complementary follow-up since it fixes the same problem more precisely (no
+timing-based heuristic), but touches both backend and frontend and a wire
+payload shape, so it's a larger, separate piece of work.
+
+## 7. Open questions / not investigated here
+
+- Whether `block.GetControllerStatus`, `object.UpdateObjectMeta`, and other
+  `[fe] [service]` calls seen elsewhere in this same window are independently
+  contributing any load, or are purely victims of the same queue (this
+  report assumes the latter, based on `block.GetControllerStatus`'s own
+  7180ms figure appearing at the same moment the ListDispatches/ListActive
+  queue was at its deepest — but this wasn't isolated by, e.g., temporarily
+  stubbing one call path and re-measuring).
+- The two `getBoundingClientRect`-on-null unhandled rejections and the
+  `ResizeObserver loop completed` errors are noted as corroborating evidence
+  of main-thread overload, not separately root-caused — they may be a
+  distinct, pre-existing bug (an unguarded ref read somewhere in the
+  document/dock rendering path) that only *manifests* under this storm's
+  timing pressure. Worth a dedicated look if they recur outside this
+  scenario.
+- Whether `BACKFILL_MAX_FILES` (200) is still an appropriate cap now that
+  the *consumption*-side cost (this report's finding) is understood — the
+  July 17 fix was tuned against the OOM-crash risk alone, not against
+  frontend-storm duration.

--- a/docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md
+++ b/docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md
@@ -1,0 +1,159 @@
+# Activity Dock: coalesce event-triggered refreshes on pane reopen
+
+**Status:** implemented (this PR)
+**Owner:** AgentX
+**Date:** 2026-08-23
+**Scope:** `frontend/app/view/agent/activity/dispatch-source.ts`,
+`frontend/app/view/agent/activity/subagent-source.ts`, a new shared
+`frontend/app/view/agent/activity/debounced-refresh.ts`.
+**Related:** `docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md`
+(the analysis this spec implements — read that first for the full
+measurement/evidence; this doc covers only the fix design),
+`docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md` (the prior,
+backend-side fix this one complements — bounds the burst *size*, not what
+the frontend does with it), `docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md`
+(a different, already-fixed Activity Dock bug — display-correctness, not
+performance; unrelated mechanism).
+
+---
+
+## 1. Problem (see the REPORT for full measurement)
+
+Reopening a pane with a nontrivial subagent/dispatch history replays that
+history as a burst of `subagent:spawned`/`subagent:completed`/
+`subagent:abandoned`/`dispatch:updated` WebSocket events (backend-side
+bounded to `BACKFILL_MAX_FILES` = 200 events per the July 17 fix). Two
+independent, app-lifetime singleton modules behind the Activity Dock —
+`dispatch-source.ts` (dispatch cards) and `subagent-source.ts` (subagent
+rows) — each fire their own **uncoalesced** `ListDispatches`/`ListActive`
+RPC call on every single event in that burst, with no debounce and no
+in-flight de-duplication anywhere in the call stack (`callBackendService`
+is a bare `fetch()` wrapper). A measured live trace: 155 backfill events →
+~300 overlapping RPC calls → round-trip latency for the same two endpoints
+grew from 84ms to 7.2s as the queue backed up, ~14 seconds total from pane
+reopen to settled, with knock-on main-thread jank (a Long Task, a starved
+`main_window_focus` IPC call, ResizeObserver loop errors).
+
+## 2. Design
+
+### 2.1 Decision: trailing-edge debounce with a max-wait ceiling, frontend-only
+
+Of the four directions the REPORT sketched, this implements **option 1**
+(smallest, most targeted, no backend change): debounce each module's
+event-triggered `refresh()` so a dense burst of events collapses into one
+actual RPC call once the burst goes quiet, instead of one per event.
+
+- **Trailing-edge, not leading-edge or throttle**: the goal is "wait until
+  the burst is over, then fetch the final state once" — a leading-edge call
+  would fire on the FIRST event and then need updating again once later
+  events land anyway (no better than today); a fixed-interval throttle
+  would still fire many times across a 2+ second burst.
+- **Max-wait ceiling**: without one, a continuous stream of events spaced
+  closer together than the debounce window would defer the underlying call
+  indefinitely (each new event resets the trailing timer before it fires).
+  A ceiling forces a refresh periodically even under sustained load, at the
+  cost of occasionally firing more than the theoretical minimum — a safe
+  trade.
+- **Chosen values: 100ms trailing wait, 1000ms max wait.** 100ms is well
+  under the threshold of a perceptible delay for a *live* spawn/completion
+  event (the debounce applies uniformly to both backfill-replay and live
+  events in this pass — see §2.2 for why), while being long enough that the
+  measured backfill burst's typical inter-event spacing (155 events over
+  2.24s, ~14ms average) collapses into one call. 1000ms as a ceiling means
+  even a pathologically dense, sustained stream refreshes at least once per
+  second — frequent enough to still feel responsive, far short of today's
+  effectively-uncapped-until-the-queue-drains behavior.
+- **Frontend-only, no backend change**: `process_jsonl_change`'s existing
+  `live: bool` parameter (already computed server-side, currently used only
+  to gate the eager-naming side effect) is a good foundation for a more
+  precise future fix — threading it through to the wire and using it to
+  batch backfill-tagged events differently from live ones (the REPORT's
+  option 2) — but that's a larger, separate change touching a wire payload
+  shape on both sides. Deferred; not needed to fix the measured storm, since
+  a uniform debounce already collapses both cases correctly.
+
+### 2.2 Why apply the debounce uniformly to backfill AND live events
+
+The frontend currently has no signal distinguishing a backfill-replay event
+from a live one (§2.1's deferred option 2 would add one). Given that, the
+only implementable-today choice is a single debounce policy applied to
+every event regardless of origin. This is a deliberate, low-cost trade: a
+genuinely live subagent spawn during active use is delayed by at most
+~100ms before the dock reflects it (imperceptible), in exchange for
+collapsing a 200-event backfill burst into a single call. If option 2 is
+built later, live events could bypass the debounce entirely for maximal
+real-time responsiveness while backfill events keep collapsing — not
+needed for this pass.
+
+### 2.3 Shared helper, not two copies
+
+`dispatch-source.ts` and `subagent-source.ts` need byte-for-byte identical
+debounce behavior (same constants, same trailing+ceiling semantics) — a
+genuine, not premature, case for extracting `debounced-refresh.ts`: two
+real call sites needing the same tuned behavior, where drift between them
+(one file's debounce window silently diverging from the other's during a
+future edit) would be a real, easy-to-introduce bug. The extracted function
+takes the underlying callback and both timings as parameters — no other
+app-specific coupling — so it's independently unit-testable without
+mocking either source module.
+
+### 2.4 What does NOT change
+
+- The module-load-time initial `void refresh()` call in both files stays
+  immediate, undebounced — the first paint of the dock should reflect
+  real data as soon as possible, not wait out a debounce window with
+  nothing to coalesce against yet.
+- `dispatch-source.ts`'s existing `scheduleQuietWindowRefresh` (the
+  lazy running→completed quiet-window follow-up) is unrelated and
+  untouched — it already only ever schedules one pending timer, solving a
+  different problem (a single deferred refresh at a known future deadline,
+  not coalescing a burst of already-arrived events).
+- `subagent:named`'s handler in `subagent-source.ts` is untouched — it
+  patches `allSubagents` locally from the event payload directly and never
+  calls `refresh()`, so it was never part of the storm.
+
+## 3. Implementation
+
+`debounced-refresh.ts` exports `createDebouncedRefresh(fn, waitMs,
+maxWaitMs)`, returning a `trigger()` function. Each `trigger()` call:
+resets the trailing timer to fire `fn` after `waitMs` of quiet; arms a
+separate max-wait timer (only if one isn't already pending) that
+force-fires `fn` after `maxWaitMs` regardless of continued triggers. Either
+timer firing clears both (so a max-wait fire doesn't leave a stale trailing
+timer that fires `fn` a second time shortly after).
+
+Both `dispatch-source.ts` and `subagent-source.ts` replace their event
+handlers' direct `() => void refresh()` with `() => scheduleRefresh()`,
+where `scheduleRefresh = createDebouncedRefresh(() => void refresh(), 100, 1000)`
+is constructed once at module scope (same singleton-per-module lifetime as
+everything else in these files).
+
+## 4. Testing
+
+- New `debounced-refresh.test.ts`: fake timers: N rapid `trigger()` calls
+  collapse to exactly 1 `fn` call after `waitMs`; a trailing call within the
+  window resets the timer (still only 1 call, later); a call spaced past
+  `maxWaitMs` since the first trigger fires early via the ceiling even
+  under continuous triggering; independent instances don't interfere.
+- `subagent-source.test.ts`: existing "also still refreshes on
+  subagent:spawned and subagent:completed" test updated — two events fired
+  back-to-back (microtask-only spacing) now correctly assert exactly ONE
+  underlying `ListActive` call once fake timers advance past the debounce
+  window, not two immediate ones (the old assertion encoded the pre-fix,
+  uncoalesced behavior). A new test confirms the coalescing directly: many
+  rapid `subagent:spawned` events collapse into one `ListActive` call.
+- `dispatch-source.ts` gets an equivalent new describe block (previously had
+  zero event-wiring test coverage at all — see `dispatch-source.test.ts`'s
+  pre-existing scope, limited to the pure `msUntilNextQuietWindowRefresh`
+  predicate).
+
+## 5. Non-goals (this pass)
+
+- Threading the backend's `live` flag through to the wire (REPORT §6
+  option 2) — a larger, separate change.
+- In-flight de-duplication inside `callBackendService` itself (REPORT §6
+  option 3) — broader shared-infrastructure change, higher review surface,
+  not needed once the two known call sites debounce.
+- Revisiting `BACKFILL_MAX_FILES` (REPORT §6 option 4 / §7) — this fix
+  makes the cap's frontend cost roughly constant regardless of its value,
+  so there's less pressure to tune it further as a result of this work.

--- a/frontend/app/view/agent/activity/debounced-refresh.test.ts
+++ b/frontend/app/view/agent/activity/debounced-refresh.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * createDebouncedRefresh — see docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md.
+ *
+ * All timer advances below deliberately land a comfortable margin before/
+ * after each deadline (never exactly on one) to avoid relying on fake-timer
+ * inclusive/exclusive boundary semantics.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDebouncedRefresh } from "./debounced-refresh";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("createDebouncedRefresh", () => {
+    it("collapses a rapid burst of triggers into exactly one call, after the wait window", () => {
+        const fn = vi.fn();
+        const trigger = createDebouncedRefresh(fn, 100, 1000);
+
+        for (let i = 0; i < 50; i++) trigger();
+        expect(fn).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(90);
+        expect(fn).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(20); // total 110 — past the 100ms trailing deadline
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("a trigger within the wait window resets the timer instead of adding a second call", () => {
+        const fn = vi.fn();
+        const trigger = createDebouncedRefresh(fn, 100, 1000);
+
+        trigger(); // trailing deadline: 100
+        vi.advanceTimersByTime(80); // before the original deadline
+        trigger(); // resets — new trailing deadline: 80 + 100 = 180
+        vi.advanceTimersByTime(80); // total 160 — before the new deadline
+        expect(fn).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(30); // total 190 — past 180
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("the max-wait ceiling forces a call even under continuous triggering faster than the wait window", () => {
+        const fn = vi.fn();
+        const trigger = createDebouncedRefresh(fn, 100, 1000);
+
+        trigger(); // max deadline fixed at 1000
+        // Re-trigger every 60ms (< the 100ms wait) so the trailing timer
+        // never gets a chance to fire on its own, for ~960ms total —
+        // comfortably short of the 1000ms ceiling.
+        for (let i = 0; i < 16; i++) {
+            vi.advanceTimersByTime(60);
+            trigger();
+        }
+        expect(fn).not.toHaveBeenCalled(); // t=960, ceiling is at 1000
+
+        vi.advanceTimersByTime(60); // total 1020 — past the ceiling
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("firing via the ceiling does not ALSO fire the trailing timer shortly after", () => {
+        const fn = vi.fn();
+        const trigger = createDebouncedRefresh(fn, 100, 1000);
+
+        trigger();
+        for (let i = 0; i < 16; i++) {
+            vi.advanceTimersByTime(60);
+            trigger();
+        }
+        vi.advanceTimersByTime(60); // crosses the ceiling — fires once
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        // No further triggers — nothing else should fire later, even
+        // though the last trigger's own trailing deadline would otherwise
+        // still be pending in this range had `fire()` not cleared it.
+        vi.advanceTimersByTime(2000);
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("independent instances never interfere with each other", () => {
+        const fnA = vi.fn();
+        const fnB = vi.fn();
+        const triggerA = createDebouncedRefresh(fnA, 100, 1000);
+        const triggerB = createDebouncedRefresh(fnB, 100, 1000);
+
+        triggerA(); // A's trailing deadline: 100
+        vi.advanceTimersByTime(50);
+        triggerB(); // B's trailing deadline: 50 + 100 = 150
+        vi.advanceTimersByTime(70); // total 120 — past A's deadline, before B's
+        expect(fnA).toHaveBeenCalledTimes(1);
+        expect(fnB).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(50); // total 170 — past B's deadline
+        expect(fnB).toHaveBeenCalledTimes(1);
+    });
+
+    it("a new burst after a prior one settled starts a fresh cycle", () => {
+        const fn = vi.fn();
+        const trigger = createDebouncedRefresh(fn, 100, 1000);
+
+        trigger();
+        vi.advanceTimersByTime(110);
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        trigger();
+        vi.advanceTimersByTime(110);
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+});

--- a/frontend/app/view/agent/activity/debounced-refresh.ts
+++ b/frontend/app/view/agent/activity/debounced-refresh.ts
@@ -1,0 +1,42 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Trailing-edge debounce with a hard max-wait ceiling, for coalescing a
+ * burst of event-triggered refreshes into a small, bounded number of actual
+ * calls. Shared between `dispatch-source.ts` and `subagent-source.ts`,
+ * which each need byte-for-byte identical debounce behavior — see
+ * docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md §2.3.
+ *
+ * Trailing-edge: each `trigger()` call resets the wait window, so a dense
+ * burst (e.g. the up-to-200-event subagent backfill replay on pane reopen,
+ * docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md)
+ * collapses into ONE call once the burst goes quiet, instead of one call
+ * per event queuing behind the last.
+ *
+ * `maxWaitMs`: without a ceiling, a continuous stream of triggers spaced
+ * closer together than `waitMs` would defer `fn` indefinitely — every new
+ * trigger resets the trailing timer before it ever fires. The ceiling
+ * forces a call at least once every `maxWaitMs` regardless of continued
+ * triggering.
+ */
+export function createDebouncedRefresh(fn: () => void, waitMs: number, maxWaitMs: number): () => void {
+    let trailingTimer: ReturnType<typeof setTimeout> | undefined;
+    let maxTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const fire = (): void => {
+        clearTimeout(trailingTimer);
+        clearTimeout(maxTimer);
+        trailingTimer = undefined;
+        maxTimer = undefined;
+        fn();
+    };
+
+    return function trigger(): void {
+        clearTimeout(trailingTimer);
+        trailingTimer = setTimeout(fire, waitMs);
+        if (maxTimer === undefined) {
+            maxTimer = setTimeout(fire, maxWaitMs);
+        }
+    };
+}

--- a/frontend/app/view/agent/activity/dispatch-source.test.ts
+++ b/frontend/app/view/agent/activity/dispatch-source.test.ts
@@ -1,8 +1,26 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentDispatch } from "../../swarm/swarm-model";
+import * as wos from "@/app/store/wos";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+}));
+
+// Mirrors subagent-source.test.ts's mocking pattern exactly — see that
+// file's own comment for why only `wps` is mocked, not the whole `wos`
+// module.
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        hub.handlers.set(sub.eventType, sub.handler);
+        return () => hub.handlers.delete(sub.eventType);
+    }),
+}));
+
+const callBackendServiceSpy = vi.spyOn(wos, "callBackendService").mockResolvedValue([]);
+
 import { msUntilNextQuietWindowRefresh } from "./dispatch-source";
 
 function mkDispatch(overrides: Partial<AgentDispatch> & Pick<AgentDispatch, "dispatch_id">): AgentDispatch {
@@ -55,5 +73,59 @@ describe("msUntilNextQuietWindowRefresh", () => {
     it("ignores a dispatch with member_count 0 (nothing to be complete about)", () => {
         const d = mkDispatch({ dispatch_id: "d1", member_count: 0, members_done: 0, status: "running" });
         expect(msUntilNextQuietWindowRefresh([d], 0)).toBeNull();
+    });
+});
+
+// SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md /
+// docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md: a
+// backfill-replay burst on pane reopen used to fire one uncoalesced
+// ListDispatches call per subagent:spawned/completed/named/abandoned or
+// dispatch:updated event (up to ~200 in a real trace). These events must
+// now collapse into a single call once the burst goes quiet. Mirrors
+// subagent-source.test.ts's own coalescing tests for its sibling singleton.
+describe("dispatch-source — refresh coalescing", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    async function flushMicrotasks(): Promise<void> {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    it("registered handlers for every event this module is documented to refresh on", () => {
+        for (const type of ["subagent:spawned", "subagent:completed", "subagent:named", "subagent:abandoned", "dispatch:updated"]) {
+            expect(hub.handlers.has(type)).toBe(true);
+        }
+    });
+
+    it("collapses a rapid burst of subagent:spawned events into a single ListDispatches call", async () => {
+        await flushMicrotasks(); // let the module-load-time refresh() settle
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+
+        const spawned = hub.handlers.get("subagent:spawned")!;
+        for (let i = 0; i < 50; i++) spawned({ data: {} });
+        await flushMicrotasks();
+        expect(callBackendServiceSpy).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(150); // past the debounce window
+        expect(callBackendServiceSpy).toHaveBeenCalledWith("subagent", "ListDispatches", []);
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("collapses a MIXED burst across different event types into a single call", async () => {
+        await flushMicrotasks();
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+
+        hub.handlers.get("subagent:spawned")!({ data: {} });
+        hub.handlers.get("subagent:completed")!({ data: {} });
+        hub.handlers.get("dispatch:updated")!({ data: {} });
+        hub.handlers.get("subagent:abandoned")!({ data: {} });
+        await flushMicrotasks();
+        expect(callBackendServiceSpy).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(150);
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/app/view/agent/activity/dispatch-source.ts
+++ b/frontend/app/view/agent/activity/dispatch-source.ts
@@ -21,6 +21,7 @@ import { callBackendService } from "@/app/store/wos";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { createSignal, type Accessor } from "solid-js";
 import type { AgentDispatch } from "../../swarm/swarm-model";
+import { createDebouncedRefresh } from "./debounced-refresh";
 
 /** The backend's own quiet window (`refresh_dispatch_status`,
  *  `subagent_watcher/jsonl.rs`) — how long a dispatch must go without a new
@@ -82,15 +83,24 @@ async function refresh(): Promise<void> {
     }
 }
 
+// Coalesces a burst of event-triggered refreshes into a single call — see
+// docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md. Without
+// this, the up-to-200-event subagent backfill replay on pane reopen fired
+// one uncoalesced ListDispatches call per event
+// (docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md).
+const scheduleRefresh = createDebouncedRefresh(() => void refresh(), 100, 1000);
+
 // Started once at module load (ES modules are singletons — every importer
 // shares this one subscription set), never torn down — mirrors
-// `subagent-source.ts`'s own lifecycle rationale.
+// `subagent-source.ts`'s own lifecycle rationale. The module-load-time
+// refresh itself stays immediate (undebounced) — see that module's
+// identical comment for why.
 void refresh();
-waveEventSubscribe({ eventType: "subagent:spawned", handler: () => void refresh() });
-waveEventSubscribe({ eventType: "subagent:completed", handler: () => void refresh() });
-waveEventSubscribe({ eventType: "subagent:named", handler: () => void refresh() });
-waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => void refresh() });
-waveEventSubscribe({ eventType: "dispatch:updated", handler: () => void refresh() });
+waveEventSubscribe({ eventType: "subagent:spawned", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:completed", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:named", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "dispatch:updated", handler: () => scheduleRefresh() });
 
 /** Every tracked dispatch (Solo or Workflow) currently known, across the
  *  whole app. Callers filter by `parent_block_id` for their own pane. */

--- a/frontend/app/view/agent/activity/subagent-source.test.ts
+++ b/frontend/app/view/agent/activity/subagent-source.test.ts
@@ -14,7 +14,7 @@
  * ("running", frozen timestamp/event count) indefinitely.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActiveSubagent } from "../../swarm/swarm-model";
 import * as wos from "@/app/store/wos";
 
@@ -66,6 +66,14 @@ async function flushMicrotasks(): Promise<void> {
     await Promise.resolve();
 }
 
+// Fake timers for the whole file: every event-triggered refresh now goes
+// through createDebouncedRefresh (SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md),
+// so tests need to advance past its wait window. Fake timers don't affect
+// Promise microtask resolution, so flushMicrotasks() above still works
+// unchanged alongside them.
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
 describe("subagent-source — subagent:abandoned wiring", () => {
     it("registered a handler for subagent:abandoned (the fix's own precondition)", () => {
         expect(hub.handlers.has("subagent:abandoned")).toBe(true);
@@ -81,6 +89,7 @@ describe("subagent-source — subagent:abandoned wiring", () => {
         const handler = hub.handlers.get("subagent:abandoned");
         expect(handler).toBeDefined();
         handler!({ data: {} });
+        await vi.advanceTimersByTimeAsync(150); // past the debounce window
         await flushMicrotasks();
 
         expect(callBackendServiceSpy).toHaveBeenCalledWith("subagent", "ListActive", []);
@@ -93,11 +102,51 @@ describe("subagent-source — subagent:abandoned wiring", () => {
         callBackendServiceSpy.mockResolvedValue([]);
 
         hub.handlers.get("subagent:spawned")!({ data: {} });
+        await vi.advanceTimersByTimeAsync(150);
         await flushMicrotasks();
         expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
 
         hub.handlers.get("subagent:completed")!({ data: {} });
+        await vi.advanceTimersByTimeAsync(150);
         await flushMicrotasks();
         expect(callBackendServiceSpy).toHaveBeenCalledTimes(2);
+    });
+});
+
+// SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md /
+// docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md: a
+// backfill-replay burst on pane reopen used to fire one uncoalesced
+// ListActive call per event (up to ~200 in a real trace). These events must
+// now collapse into a single call once the burst goes quiet.
+describe("subagent-source — refresh coalescing", () => {
+    it("collapses a rapid burst of subagent:spawned events into a single ListActive call", async () => {
+        await flushMicrotasks(); // let the module-load-time refresh() settle
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+
+        const spawned = hub.handlers.get("subagent:spawned")!;
+        for (let i = 0; i < 50; i++) spawned({ data: {} });
+        await flushMicrotasks();
+        expect(callBackendServiceSpy).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(150); // past the debounce window
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("still refreshes under a SUSTAINED burst, via the max-wait ceiling, without waiting for it to fully quiet", async () => {
+        await flushMicrotasks();
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+
+        const spawned = hub.handlers.get("subagent:spawned")!;
+        // Re-fire every 60ms (under the 100ms debounce window) for longer
+        // than the 1000ms ceiling — mirrors the real trace's ~14ms average
+        // spacing across a multi-second backfill burst.
+        for (let i = 0; i < 20; i++) {
+            spawned({ data: {} });
+            await vi.advanceTimersByTimeAsync(60);
+        }
+        await flushMicrotasks();
+        expect(callBackendServiceSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
     });
 });

--- a/frontend/app/view/agent/activity/subagent-source.ts
+++ b/frontend/app/view/agent/activity/subagent-source.ts
@@ -19,6 +19,7 @@ import { callBackendService } from "@/app/store/wos";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { createSignal, type Accessor } from "solid-js";
 import { mergeSubagentsPreservingIdentity, type ActiveSubagent } from "../../swarm/swarm-model";
+import { createDebouncedRefresh } from "./debounced-refresh";
 
 const [allSubagents, setAllSubagents] = createSignal<ActiveSubagent[]>([]);
 
@@ -32,13 +33,23 @@ async function refresh(): Promise<void> {
     }
 }
 
+// Coalesces a burst of event-triggered refreshes into a single call — see
+// docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md. Without
+// this, the up-to-200-event subagent backfill replay on pane reopen fired
+// one uncoalesced ListActive call per event
+// (docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md).
+const scheduleRefresh = createDebouncedRefresh(() => void refresh(), 100, 1000);
+
 // Started once at module load (ES modules are singletons — every importer
 // shares this one subscription set), never torn down: the dock's subagent
 // rows should reflect swarm-wide activity for the lifetime of the app, same
-// as `providers/index.ts`'s `modelOverlay` singleton.
+// as `providers/index.ts`'s `modelOverlay` singleton. The module-load-time
+// refresh itself stays immediate (undebounced) — the dock's first paint
+// should reflect real data as soon as possible, not wait out a debounce
+// window with nothing yet to coalesce against.
 void refresh();
-waveEventSubscribe({ eventType: "subagent:spawned", handler: () => void refresh() });
-waveEventSubscribe({ eventType: "subagent:completed", handler: () => void refresh() });
+waveEventSubscribe({ eventType: "subagent:spawned", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:completed", handler: () => scheduleRefresh() });
 // Without this, a subagent the backend reconciles from active to abandoned
 // (parent turn already ended — see `reconcile_stale_subagents`, which runs
 // on every pane reopen with a persisted session id, i.e. exactly the app-
@@ -48,7 +59,7 @@ waveEventSubscribe({ eventType: "subagent:completed", handler: () => void refres
 // refresh — which, for an otherwise-idle pane, may never happen. Mirrors
 // `dispatch-source.ts`'s identical fix (reagent/codex, PR #2676) for the
 // sibling dispatch-card singleton, which this module predates.
-waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => void refresh() });
+waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => scheduleRefresh() });
 waveEventSubscribe({
     eventType: "subagent:named",
     handler: (event: WaveEvent) => {


### PR DESCRIPTION
## Summary

Reopening a pane with a nontrivial subagent/dispatch history (e.g. a heavily-used "My Agents" entry) currently triggers a multi-second request storm. Root-caused via a live trace of this session's own agent pane reopening — see `docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md` for full measurement.

**Root cause:** pane reopen replays the session's (capped, ≤200-event) subagent/dispatch history as a burst of `subagent:spawned`/`completed`/`abandoned`/`dispatch:updated` WebSocket events — an existing, already-fixed OOM-crash guard from `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`. But `dispatch-source.ts` and `subagent-source.ts` (the Activity Dock's two data singletons) each fire their own **uncoalesced** `ListDispatches`/`ListActive` RPC call on *every single event* — no debounce anywhere in the stack (`callBackendService` is a bare `fetch()`). Measured: 155 backfill events → ~300 overlapping RPC calls → round-trip latency for the same two endpoints grew from 84ms to **7.2 seconds** as the queue backed up, ~14 seconds total from pane reopen to settled, with a 291ms main-thread Long Task and a normally-instant `main_window_focus` IPC call taking 2.08s as knock-on effects.

**Fix** (design doc: `docs/specs/SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md`): a new shared `createDebouncedRefresh` (trailing-edge debounce + a max-wait ceiling, so a burst collapses into one call once it goes quiet, while a sustained/continuous stream still refreshes at least once per second). Both singletons' event handlers now go through it instead of calling `refresh()` directly. The module-load-time initial refresh stays immediate/undebounced — only event-triggered refreshes are coalesced.

This is a frontend-only, no-backend-change fix (option 1 of 4 sketched in the REPORT) — deliberately the smallest, most targeted change; larger follow-ups (threading the backend's existing `live` flag through to the wire, generic in-flight RPC de-duplication) are documented as explicit non-goals for this pass.

## Test plan

- [x] `debounced-refresh.test.ts` (new, 6 tests): burst collapsing, trailing reset, max-wait ceiling under continuous triggering, no double-fire, instance independence, fresh cycle after settling.
- [x] `subagent-source.test.ts`: existing event-wiring tests updated for the new debounce timing; 2 new tests confirm a 50-event burst and a sustained continuous burst both coalesce correctly.
- [x] `dispatch-source.test.ts`: 3 new tests (previously zero event-wiring coverage in this file) — handler registration, single-event-type burst coalescing, and a mixed-event-type burst coalescing.
- [x] `tsc --noEmit`: clean.
- [x] `vitest run`: full suite green (3013 passed, 3 skipped; one pre-existing, unrelated flaky test — `tool-renderer registry` — confirmed to only time out under full-suite parallel load, not in isolation).

<!-- agentmux:agent_id=agentx -->