### PR TITLE
Korp@claudius: fix(editor): use a real native scrollbar for markdown preview, matching source exactly

### DIFF
--- a/.changesets/1787509055-fix-editor-use-a-real-native-scrollbar-for-markdown-preview--mhdn.md
+++ b/.changesets/1787509055-fix-editor-use-a-real-native-scrollbar-for-markdown-preview--mhdn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): use a real native scrollbar for markdown preview, matching source exactly

--- a/docs/specs/SPEC_EDITOR_MARKDOWN_PREVIEW_SCROLLBAR_ALIGNMENT_2026_08_22.md
+++ b/docs/specs/SPEC_EDITOR_MARKDOWN_PREVIEW_SCROLLBAR_ALIGNMENT_2026_08_22.md
@@ -115,3 +115,36 @@ already wired through to `.content` for this exact purpose.
 - Manual: spot-check another `<Markdown>` consumer (e.g. an agent chat
   message) to confirm its scrollbar/padding is unaffected, since
   `.editor-preview-markdown-content` is scoped to the editor's call site only.
+
+## 6. Follow-up: native scrollbar, not just repositioned (same day)
+
+Repositioning (§3) put the OverlayScrollbars track at the right spot, but it's
+still visually a different scrollbar technology than Source mode's plain
+native CodeMirror scrollbar — a JS-rendered overlay track with `autoHide:
+"leave"` fade behavior, thinner-looking than a real webkit scrollbar even at
+the same declared `--os-size`/`width` (7px both). Requested follow-up: make
+Preview use the exact same scrollbar as Source, not just a same-sized one in
+the same place.
+
+**Fix:** `<Markdown>` gains a new `nativeScrollbar` prop
+(`frontend/app/element/markdown.tsx`). When set, `onMount` skips calling
+`OverlayScrollbars(contentsEl, ...)` entirely, leaving `.content`'s plain CSS
+`overflow` to render a real native/webkit scrollbar — styled by the exact
+same universal `*::-webkit-scrollbar` rule (`app.scss:87-90`) CodeMirror's
+`.cm-scroller` already uses. The heading-anchor-scroll effect (`focusedHeading`)
+was updated to fall back to `contentsEl` directly as the scroll viewport when
+`contentsOs` is null, so in-page anchor links (`[text](#heading)`) still work
+in native mode.
+
+Editor preview passes `nativeScrollbar` at its one call site
+(`editor-view.tsx`). `editor-view.scss`'s `.content.editor-preview-markdown-content`
+override switches `overflow-y` from the base `.content { overflow: scroll }`
+to `auto` (matching CodeMirror's `.cm-scroller` default — no reserved
+scrollbar gutter when content already fits).
+
+No other `<Markdown>` consumer passes `nativeScrollbar` — everyone else keeps
+OverlayScrollbars unchanged (default `false`).
+
+Verified live via `task dev`: Source and Preview scrollbars are now visually
+identical (same width, same native browser rendering, no auto-hide fade
+behavior difference).

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -73,6 +73,13 @@ type MarkdownProps = {
     onClickExecute?: (cmd: string) => void;
     resolveOpts?: MarkdownResolveOpts;
     scrollable?: boolean;
+    /** When true, skip OverlayScrollbars entirely and let `.content` use its
+     *  plain CSS `overflow` — a real native/webkit scrollbar, styled by the
+     *  same universal `*::-webkit-scrollbar` rule (app.scss) every other
+     *  native scroll surface (CodeMirror, etc.) already uses, instead of
+     *  OverlayScrollbars' JS-rendered auto-hide overlay track. No effect
+     *  when `scrollable` is false. */
+    nativeScrollbar?: boolean;
     rehype?: boolean;
     /** When false, skip the (expensive) syntax-highlighting rehype plugin
      *  while keeping every other plugin (sanitize, etc.). Read reactively so
@@ -101,6 +108,7 @@ const Markdown = (props: MarkdownProps) => {
         fontSizeOverride,
         fixedFontSizeOverride,
         scrollable = true,
+        nativeScrollbar = false,
         rehype = true,
         onClickExecute,
     } = props;
@@ -133,14 +141,18 @@ const Markdown = (props: MarkdownProps) => {
 
     createEffect(() => {
         const heading = focusedHeading();
-        if (heading && contentsOs) {
-            const { viewport } = contentsOs.elements();
-            const el = document.getElementById(idPrefix() + heading.slice(1));
-            if (el) {
-                const headingRect = el.getBoundingClientRect();
-                const viewportRect = viewport.getBoundingClientRect();
-                viewport.scrollBy({ top: headingRect.top - viewportRect.top });
-            }
+        if (!heading) return;
+        // In OverlayScrollbars mode the real scrolling element is its
+        // generated viewport, not contentsEl itself; in nativeScrollbar mode
+        // contentsEl IS the scrolling element (plain CSS overflow, no
+        // OverlayScrollbars restructuring ever happened).
+        const viewport = contentsOs ? contentsOs.elements().viewport : contentsEl;
+        if (!viewport) return;
+        const el = document.getElementById(idPrefix() + heading.slice(1));
+        if (el) {
+            const headingRect = el.getBoundingClientRect();
+            const viewportRect = viewport.getBoundingClientRect();
+            viewport.scrollBy({ top: headingRect.top - viewportRect.top });
         }
     });
 
@@ -297,7 +309,7 @@ const Markdown = (props: MarkdownProps) => {
     const tocItems = createMemo<TocItem[]>(() => renderedMarkdown().toc);
 
     onMount(() => {
-        if (scrollable && contentsEl) {
+        if (scrollable && !nativeScrollbar && contentsEl) {
             contentsOs = OverlayScrollbars(contentsEl, { scrollbars: { autoHide: "leave" } });
             onCleanup(() => contentsOs?.destroy());
         }

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -587,13 +587,24 @@
     // CodeMirror scrollbar. Same failure mode + fix as
     // SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md — the inset is
     // re-homed onto `.editor-preview-markdown-content` below, which targets
-    // `.content` (the OverlayScrollbars-managed scroll owner) directly.
+    // `.content` (the scroll owner) directly.
     flex: 1 1 auto;
     min-height: 0;
 
     .markdown {
         font-size: var(--markdown-font-size, 14px);
     }
+}
+
+// Compound selector (needs the extra specificity to beat the base `.content
+// { overflow: scroll }` rule in markdown.scss). `<Markdown nativeScrollbar>`
+// at this one call site skips OverlayScrollbars entirely, so `.content`'s
+// own CSS `overflow` is what actually renders the scrollbar — `auto` (not
+// `scroll`) matches CodeMirror's `.cm-scroller` default: no reserved
+// scrollbar gutter when content already fits.
+.content.editor-preview-markdown-content {
+    padding: 16px 24px;
+    overflow-y: auto;
 }
 
 .editor-preview-markdown-content {

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -604,7 +604,11 @@
 // scrollbar gutter when content already fits.
 .content.editor-preview-markdown-content {
     padding: 16px 24px;
-    overflow-y: auto;
+    // Shorthand, not just overflow-y: the base `.content { overflow: scroll }`
+    // rule (markdown.scss) sets BOTH axes — overriding only overflow-y left
+    // overflow-x: scroll in effect, permanently reserving a horizontal
+    // scrollbar even when content fits (codex P2 on PR #2774).
+    overflow: auto;
 }
 
 .editor-preview-markdown-content {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -914,6 +914,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                                     <Markdown
                                         textAtom={() => liveDoc()}
                                         contentClass="editor-preview-markdown-content"
+                                        nativeScrollbar
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary

Follow-up to #2769 (already merged), which repositioned the markdown
preview's scrollbar to sit flush at the pane edge. That fixed *position*
but not *appearance*: Preview still used OverlayScrollbars (a JS-rendered
overlay track with `autoHide: "leave"` fade behavior), which looks visually
thinner/different than Source mode's plain native CodeMirror scrollbar even
at the same declared 7px width. Requested follow-up: make Preview use the
exact same scrollbar as Source, not just a same-sized one in the same spot.

## Changes

- `frontend/app/element/markdown.tsx` — new `nativeScrollbar` prop on
  `<Markdown>`. When set, `onMount` skips calling `OverlayScrollbars(...)`
  entirely, so `.content`'s plain CSS `overflow` renders a real native
  scrollbar styled by the same universal `*::-webkit-scrollbar` rule
  CodeMirror's `.cm-scroller` already uses. The heading-anchor-scroll effect
  (`focusedHeading`) now falls back to `contentsEl` directly as the scroll
  viewport when `contentsOs` is `null`, so in-page anchor links
  (`[text](#heading)`) still work in native mode.
- `frontend/app/view/editor/editor-view.tsx` — passes `nativeScrollbar` to
  `<Markdown>` at the editor preview's one call site.
- `frontend/app/view/editor/editor-view.scss` —
  `.content.editor-preview-markdown-content` switches `overflow-y` from the
  base `.content { overflow: scroll }` to `auto`, matching CodeMirror's
  `.cm-scroller` default (no reserved scrollbar gutter when content already
  fits).
- Spec updated: `docs/specs/SPEC_EDITOR_MARKDOWN_PREVIEW_SCROLLBAR_ALIGNMENT_2026_08_22.md` §6.

No other `<Markdown>` consumer is affected — `nativeScrollbar` defaults to
`false`, so every other call site (agent chat, tool output, etc.) keeps its
existing OverlayScrollbars behavior unchanged.

## Verification

- `npx tsc --noEmit` — clean.
- `npx stylelint` on both touched SCSS files — no new findings (13
  pre-existing issues elsewhere in `editor-view.scss`, none on touched
  lines).
- **Verified live via `task dev`**: opened a markdown file, compared Source
  and Preview scrollbars side by side — now visually identical (same width,
  same native rendering, no auto-hide fade difference).

<!-- agentmux:agent_id=korp -->