### PR TITLE
chore: release v0.55.22

### DIFF
--- a/.changesets/1787452355-fix-muxspect-wire-transcript-request-jekt-tier-enforcement-i-a01z.md
+++ b/.changesets/1787452355-fix-muxspect-wire-transcript-request-jekt-tier-enforcement-i-a01z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxspect): wire transcript_request jekt tier enforcement into the WAN delivery path (Phase C)

--- a/.changesets/1787453997-feat-layout-cross-fade-the-remaining-pane-mount-hard-cuts-ph-0ugb.md
+++ b/.changesets/1787453997-feat-layout-cross-fade-the-remaining-pane-mount-hard-cuts-ph-0ugb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(layout): cross-fade the remaining pane-mount hard cuts (Phase 3-4)

--- a/.changesets/1787460096-fix-editor-align-markdown-preview-scrollbar-to-the-pane-edge-1bjf.md
+++ b/.changesets/1787460096-fix-editor-align-markdown-preview-scrollbar-to-the-pane-edge-1bjf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): align markdown preview scrollbar to the pane edge, matching source mode

--- a/.changesets/1787461233-fix-agent-stop-activity-dock-flashing-stale-shell-rows-on-pa-a8zk.md
+++ b/.changesets/1787461233-fix-agent-stop-activity-dock-flashing-stale-shell-rows-on-pa-a8zk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): stop Activity Dock flashing stale shell rows on pane load

--- a/.changesets/1787462822-feat-ci-nightly-workflow-auto-tags-and-publishes-the-latest--5fhn.md
+++ b/.changesets/1787462822-feat-ci-nightly-workflow-auto-tags-and-publishes-the-latest--5fhn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ci): nightly workflow auto-tags and publishes the latest pending version bump

--- a/.changesets/1787463150-fix-agent-spawn-inject-per-agent-git-commit-identity-stop-mi-rys7.md
+++ b/.changesets/1787463150-fix-agent-spawn-inject-per-agent-git-commit-identity-stop-mi-rys7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-spawn): inject per-agent git commit identity, stop misattributing every agent's commits to whoever's real identity sits in the shared machine gitconfig

--- a/.changesets/1787508418-fix-activity-dock-coalesce-event-triggered-refreshes-to-stop-4njb.md
+++ b/.changesets/1787508418-fix-activity-dock-coalesce-event-triggered-refreshes-to-stop-4njb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(activity-dock): coalesce event-triggered refreshes to stop a pane-reopen request storm

--- a/.changesets/1787509055-fix-editor-use-a-real-native-scrollbar-for-markdown-preview--mhdn.md
+++ b/.changesets/1787509055-fix-editor-use-a-real-native-scrollbar-for-markdown-preview--mhdn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): use a real native scrollbar for markdown preview, matching source exactly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.21"
+version = "0.55.22"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.21"
+version = "0.55.22"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.21"
+version = "0.55.22"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.21"
+version = "0.55.22"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.21"
+version = "0.55.22"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.21"
+version = "0.55.22"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.21"
+version = "0.55.22"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,17 @@
 # AgentMux Version History
 
+## 0.55.22 — 2026-08-23
+
+- fix(muxspect): wire transcript_request jekt tier enforcement into the WAN delivery path (Phase C)
+- feat(layout): cross-fade the remaining pane-mount hard cuts (Phase 3-4)
+- fix(editor): align markdown preview scrollbar to the pane edge, matching source mode
+- fix(agent): stop Activity Dock flashing stale shell rows on pane load
+- feat(ci): nightly workflow auto-tags and publishes the latest pending version bump
+- fix(agent-spawn): inject per-agent git commit identity, stop misattributing every agent's commits to whoever's real identity sits in the shared machine gitconfig
+- fix(activity-dock): coalesce event-triggered refreshes to stop a pane-reopen request storm
+- fix(editor): use a real native scrollbar for markdown preview, matching source exactly
+
+
 ## 0.55.21 — 2026-08-22
 
 - feat(tabs): quick-fork keybinding, non-Claude fallback banner, and inherit-identity variant

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.21",
+  "version": "0.55.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.21",
+      "version": "0.55.22",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.21",
+  "version": "0.55.22",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming 8 pending changesets. Forced to a **patch** bump (`task release -- --as patch`) per explicit request, overriding the computed `minor` (two `feat` changesets are queued — see below) — those minor-level changes ship under this patch version, as intended.

0.55.21 → 0.55.22

## Changelog

- fix(muxspect): wire transcript_request jekt tier enforcement into the WAN delivery path (Phase C)
- feat(layout): cross-fade the remaining pane-mount hard cuts (Phase 3-4)
- fix(editor): align markdown preview scrollbar to the pane edge, matching source mode
- fix(agent): stop Activity Dock flashing stale shell rows on pane load
- feat(ci): nightly workflow auto-tags and publishes the latest pending version bump
- fix(agent-spawn): inject per-agent git commit identity, stop misattributing every agent's commits to whoever's real identity sits in the shared machine gitconfig
- fix(activity-dock): coalesce event-triggered refreshes to stop a pane-reopen request storm
- fix(editor): use a real native scrollbar for markdown preview, matching source exactly

## Verification

- Release consistency invariant confirmed by hand: `package.json`, `Cargo.toml`, `Cargo.lock` (workspace members), `package-lock.json`, and `VERSION_HISTORY.md`'s top section all agree at `0.55.22`.
- `scripts/release.sh`'s own post-bump check passed (`all 5 version locations agree`).
- No source code changes in this PR — version bump + changeset consumption only.

<!-- agentmux:agent_id=agentx -->