### PR TITLE
fix(agent): surface a Reconnecting… status during stale-resume retry

### DIFF
--- a/.changesets/1787545507-fix-agent-surface-a-reconnecting-status-during-stale-resume--f09n.md
+++ b/.changesets/1787545507-fix-agent-surface-a-reconnecting-status-during-stale-resume--f09n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): surface a Reconnecting… status during stale-resume retry

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -83,6 +83,42 @@ fn session_outcome_line(
     )
 }
 
+/// Publish a `wps::EVENT_AGENT_RESUME_RETRY` status ping — a free function
+/// (not a method) for the same reason `session_outcome_line` above is one:
+/// callable from the stdout-reader/process-waiter match arms, which only
+/// hold `_read`/`_wait`-suffixed clones, not `&self`. `status` is `"retrying"`
+/// (set when a stale `--resume` is detected and a retry/recovery attempt is
+/// about to fire) or `"resolved"` (set the moment the retry's outcome —
+/// Fresh or Resumed — is actually known). See
+/// `docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md` §6.2.
+/// No-ops if `broker` is `None` (tests / non-wired controllers), same
+/// posture as every other best-effort WPS publish in this file.
+fn publish_resume_retry_status(broker: &Option<Arc<wps::Broker>>, block_id: &str, status: &str) {
+    let Some(broker) = broker else { return };
+    let mut data = serde_json::json!({ "status": status });
+    if status == "retrying" {
+        data["startedAt"] = serde_json::Value::String(chrono::Utc::now().to_rfc3339());
+    }
+    broker.publish(wps::WaveEvent {
+        event: wps::EVENT_AGENT_RESUME_RETRY.to_string(),
+        scopes: vec![format!("block:{}", block_id)],
+        sender: String::new(),
+        // `persist: 2`, not 1 — `Broker::persist_event` trims history down
+        // to exactly this many MOST RECENT events per (event, scope): a
+        // bare `persist: 1` would let the "resolved" publish immediately
+        // evict "retrying" from history, so a pane that (re)subscribes in
+        // the narrow window right after resolution sees only "resolved"
+        // with no record a retry ever happened — harmless for the simple
+        // "currently reconnecting?" check, but makes this event's own
+        // history useless for anything else. 2 keeps the latest
+        // retrying→resolved pair together; a later cascaded "retrying"
+        // still correctly evicts the OLDER pair's "retrying", not this
+        // one's "resolved".
+        persist: 2,
+        data: Some(data),
+    });
+}
+
 /// Resolve the muxbus address (the agent's display name) from a spawn env map.
 /// `AGENTMUX_AGENT_ID` (= `agent.name`, set at block creation) is canonical;
 /// `WAVEMUX_AGENT_ID` is the legacy fallback. Returns `None` — i.e. not
@@ -1612,6 +1648,10 @@ impl PersistentSubprocessController {
         held_error_line: Option<String>,
         attempted_sid: String,
     ) {
+        // "Reconnecting…" starts here regardless of which branch below is
+        // taken — the user-visible gap begins the moment a retry is known
+        // to be needed, not once recovery search finishes. See §6.2.
+        publish_resume_retry_status(&self.broker, &self.block_id, "retrying");
         let recovered = self.find_recovery_session_id(&config);
         config.session_id = recovered.clone().unwrap_or_default();
         match &recovered {
@@ -1628,17 +1668,25 @@ impl PersistentSubprocessController {
             // `ConfirmedRetry` → this same function again, where
             // `find_recovery_session_id`'s poison guard refuses to
             // re-recover the identical dead id and this arm's `None`
-            // branch below correctly emits `Fresh` instead.
+            // branch below correctly emits `Fresh` instead. "Reconnecting…"
+            // is deliberately NOT resolved here — the eventual
+            // `EmitSessionOutcome` handling (stdout-reader / process-exit
+            // match arms) is what clears it, once the CLI actually confirms
+            // this recovered id one way or the other.
             Some(_) => {}
             // No recovery candidate — this IS genuinely, unambiguously a
             // fresh conversation, decided right now. Safe to emit
             // immediately: nothing downstream can turn this back into a
-            // resume.
-            None => self.emit_session_outcome_now(
-                persistent_resume::SessionOutcome::Fresh,
-                attempted_sid,
-                None,
-            ),
+            // resume. Also resolves "Reconnecting…" immediately, in step
+            // with the outcome itself.
+            None => {
+                publish_resume_retry_status(&self.broker, &self.block_id, "resolved");
+                self.emit_session_outcome_now(
+                    persistent_resume::SessionOutcome::Fresh,
+                    attempted_sid,
+                    None,
+                )
+            }
         }
         let Some(first) = (!entries.is_empty()).then(|| entries.remove(0)) else {
             // Nothing to retry at all (shouldn't happen in practice —
@@ -2724,6 +2772,11 @@ impl PersistentSubprocessController {
                                         attempted_sid,
                                         actual_sid,
                                     } => {
+                                        // The retry (if any led here) is now resolved one
+                                        // way or the other — clear "Reconnecting…". A no-op
+                                        // publish (still fine) when this outcome came from a
+                                        // plain first-time resume that was never retried.
+                                        publish_resume_retry_status(&broker_read, &block_id_read, "resolved");
                                         if let Some(ref broker) = broker_read {
                                             let line = session_outcome_line(outcome, attempted_sid, actual_sid);
                                             super::shell::handle_append_block_file(
@@ -3248,6 +3301,7 @@ impl PersistentSubprocessController {
                                 attempted_sid,
                                 actual_sid,
                             } => {
+                                publish_resume_retry_status(&broker_wait, &block_id_wait, "resolved");
                                 if let Some(ref broker) = broker_wait {
                                     let line = session_outcome_line(outcome, attempted_sid, actual_sid);
                                     super::shell::handle_append_block_file(
@@ -3262,6 +3316,13 @@ impl PersistentSubprocessController {
                             }
                             persistent_resume::ResumeEffect::PersistImmediately(line)
                             | persistent_resume::ResumeEffect::FlushErrorLine(line) => {
+                                // Safety net: a "Reconnecting…" left showing from
+                                // an earlier retry attempt on this same block must
+                                // not get stuck forever just because THIS exit
+                                // ended up genuinely non-retryable — a harmless
+                                // no-op publish in the (common) case where no
+                                // retry was in flight at all.
+                                publish_resume_retry_status(&broker_wait, &block_id_wait, "resolved");
                                 if let Some(ref broker) = broker_wait {
                                     super::shell::handle_append_block_file(
                                         broker,
@@ -3310,7 +3371,7 @@ impl PersistentSubprocessController {
                                 if let Some(ctrl) = self_ref_wait.upgrade() {
                                     tracing::warn!(
                                         block_id = %block_id_wait,
-                                        "stale --resume session id caused this exit — retrying fresh, without --resume"
+                                        "stale --resume session id caused this exit — retrying now (find_recovery_session_id may still resume a real, on-disk session rather than starting blank)"
                                     );
                                     ctrl.retry_after_resume_failure(
                                         my_generation_wait,
@@ -5390,6 +5451,114 @@ mod send_input_tests {
         assert!(
             !content.contains("agentmux_session_outcome"),
             "must not claim any outcome until the CLI actually confirms the recovered id — got: {content:?}"
+        );
+    }
+
+    /// docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md
+    /// §6.2: a stale-`--resume` retry must publish a "Reconnecting…" status
+    /// ping so the pane can show *something* during the gap instead of going
+    /// silent. When no recovery candidate exists, the retry AND its
+    /// resolution are both known synchronously in the same call — both
+    /// pings must land, in order.
+    #[test]
+    fn retry_after_resume_failure_publishes_retrying_then_resolved_when_no_recovery_found() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "block-reconnecting-no-recovery".to_string();
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            block_id.clone(),
+            Some(broker.clone()),
+            None,
+            None,
+            Some(filestore),
+        );
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir: String::new(),
+            env_vars: HashMap::new(),
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "dead-sid".to_string(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "dead-sid".to_string());
+
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_AGENT_RESUME_RETRY,
+            &format!("block:{block_id}"),
+            10,
+        );
+        let statuses: Vec<Option<&str>> = history
+            .iter()
+            .map(|e| e.data.as_ref().and_then(|d| d.get("status")).and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![Some("retrying"), Some("resolved")],
+            "expected retrying then resolved, got: {statuses:?}"
+        );
+        let retrying_data = history[0].data.as_ref().unwrap();
+        assert!(
+            retrying_data.get("startedAt").and_then(|v| v.as_str()).is_some(),
+            "the retrying ping must carry a startedAt timestamp for the frontend's elapsed-time readout"
+        );
+    }
+
+    /// The other half of the pair above: when a recovery candidate IS found,
+    /// only "retrying" fires within this call — "resolved" is deferred to
+    /// whichever `EmitSessionOutcome` handling site eventually confirms the
+    /// recovered id (or rejects it, cascading into another retry — which
+    /// would republish "retrying" again, not "resolved").
+    #[test]
+    fn retry_after_resume_failure_only_publishes_retrying_when_recovery_is_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().to_string_lossy().to_string();
+        let working_dir = r"C:\Users\asafe\.agentmux\agents\agentx-0623n".to_string();
+        let slug = crate::backend::session_backfill::encode_project_slug(&working_dir);
+        let dir = tmp.path().join("projects").join(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("972a6a4f-live.jsonl"), vec![b'x'; 2_800_000]).unwrap();
+
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let filestore = Arc::new(FileStore::open_in_memory().unwrap());
+        let block_id = "block-reconnecting-with-recovery".to_string();
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            block_id.clone(),
+            Some(broker.clone()),
+            None,
+            None,
+            Some(filestore),
+        );
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), config_dir);
+        let config = PersistentSpawnConfig {
+            cli_command: "definitely-not-a-real-binary-xyz".to_string(),
+            cli_args: vec![],
+            working_dir,
+            env_vars,
+            session_id_field: "session_id".to_string(),
+            resume_flag: "--resume".to_string(),
+            session_id: "d019e2e4-stale".to_string(),
+            message_id: None,
+        };
+        c.retry_after_resume_failure(1, config, vec![qentry(1, "{}")], None, "d019e2e4-stale".to_string());
+
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_AGENT_RESUME_RETRY,
+            &format!("block:{block_id}"),
+            10,
+        );
+        let statuses: Vec<Option<&str>> = history
+            .iter()
+            .map(|e| e.data.as_ref().and_then(|d| d.get("status")).and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![Some("retrying")],
+            "must not resolve yet — the CLI hasn't confirmed the recovered id — got: {statuses:?}"
         );
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -3572,6 +3572,21 @@ impl PersistentSubprocessController {
                     }
                     drop(inner);
 
+                    // reagentx P1 on PR #2776: a user-initiated Stop can
+                    // land at any point, including mid stale-`--resume`
+                    // retry — "Reconnecting…" has no other clearing path on
+                    // this branch (unlike `compacting`, which several
+                    // turn-end transitions defensively reset), so without
+                    // this it would stick on-screen forever with a growing
+                    // counter, and a later retry on the same pane would
+                    // wrongly keep the stale `startedAt` (ResumeRetryStarted
+                    // is a no-op while already reconnecting). Unconditional
+                    // and un-gated by `is_current_generation` on purpose —
+                    // a harmless no-op when nothing was reconnecting, and
+                    // the pane is stopping either way, so there's no
+                    // "which generation" ambiguity worth encoding here.
+                    publish_resume_retry_status(&broker_wait, &block_id_wait, "resolved");
+
                     // Flush a held-back error line now, if the resume
                     // state machine produced one — the `StopRequested`
                     // sent above guarantees `ProcessExited` resolves via

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -3380,7 +3380,15 @@ impl PersistentSubprocessController {
                                         held_error_line,
                                         attempted_sid,
                                     );
-                                } else if let Some(line) = held_error_line {
+                                } else {
+                                    // reagentx P2 on PR #2776: the controller
+                                    // itself is already gone — no retry will
+                                    // ever fire for this batch, so any
+                                    // "Reconnecting…" left showing from an
+                                    // earlier attempt on this same block must
+                                    // be resolved here; nothing else will.
+                                    publish_resume_retry_status(&broker_wait, &block_id_wait, "resolved");
+                                    if let Some(line) = held_error_line {
                                     // The controller itself is already gone
                                     // (weak ref invalidated) — nothing can
                                     // retry this batch at all, so flush
@@ -3396,6 +3404,7 @@ impl PersistentSubprocessController {
                                             filestore_wait.as_ref(),
                                             global_output_zone_wait.as_deref(),
                                         );
+                                    }
                                     }
                                 }
                             }

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -44,6 +44,21 @@ pub const EVENT_AGENT_HEALTH: &str = "agenthealth";
 /// terminal `result` frame). Carries the classified `AgentFailure` so the pane
 /// shows the real cause instead of a bare exit code.
 pub const EVENT_AGENT_FAILURE: &str = "agentfailure";
+/// Fired by the persistent controller's stale-`--resume` recovery path
+/// (`retry_after_resume_failure` / `publish_resume_retry_status`,
+/// `docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md` §6.2)
+/// so the pane can show a "Reconnecting…" readout instead of going silent for
+/// the ~seconds-to-tens-of-seconds it can take the controller to detect a
+/// stale registry `session_id` and respawn against a recovered one.
+/// Payload: `{ "status": "retrying", "startedAt": "<rfc3339>" }` or
+/// `{ "status": "resolved" }`. `persist: 2` (unlike `compaction_started`'s
+/// `persist: 0`) is deliberate: both ends of this signal travel over this
+/// same WPS channel (there's no separate out-of-band completion marker the
+/// way `compact_boundary` is for compaction), so replaying the latest
+/// retrying→resolved pair to a freshly (re)subscribed pane is always the
+/// *correct* current state, not a stale echo — see
+/// `publish_resume_retry_status`'s own doc comment for why 2, not 1.
+pub const EVENT_AGENT_RESUME_RETRY: &str = "agent-resume-retry";
 /// Fired by `handle_shell_create` when a persistent shell is launched.
 /// Frontend creates the ShellNode row on receipt.
 /// Payload: `{ shell_id, cmd, cwd?, title, timestamp }`.

--- a/docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md
+++ b/docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md
@@ -1,0 +1,230 @@
+# Status: Live Repro of Cross-Channel Stale `--resume` — Recovery Works, UX Gap Remains
+
+**Date:** 2026-08-23
+**Status:** Root cause confirmed via live incident on this exact machine/agent. Closes the
+outstanding live-repro item from `docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md`
+(issue #2368). Recovery mechanism (#2693/#2699) confirmed working correctly. Two
+recommendations from `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
+remain unimplemented — this document narrows and re-confirms them with fresh evidence,
+proposes concrete fixes, and does not change code.
+
+**Trigger:** operator observed "a brief period where nothing was happening, for like 30s...
+thought it was a crash, but it recovered" while working in their own agent pane, about a
+minute before asking about it.
+
+---
+
+**CORRECTION (2026-08-23, before implementation started):** §6.1 below ("make the
+registry a live pointer") was already shipped the day before this incident —
+`db06a2168` / PR #2755, *"fix(agent): make cross-channel resume session_id a live
+pointer, not write-once"*, merged 2026-08-22. `registry_mirror.rs`'s
+`registry_propagate_continuation_session_id` (added by that PR) is called from
+`instance_update_partial` whenever a genuine `session_id` write happens, and correctly
+excludes the exact false-positive case `registry_upsert_if_named`'s own filter creates
+for continuation rows. This was missed in the original research pass (which read
+`core.rs`'s `persist_session_id`/`sync_instance_session_id` but not
+`registry_mirror.rs`, which those functions call into) and because the original
+`STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md` predates the fix by two
+days. **§6.1 is not being (re-)implemented — only §6.2 and §6.3 are, since those remain
+genuinely unaddressed.** Left below unedited except for this note, so the original
+investigation trail stays intact; do not treat §6.1's body text as an accurate
+description of current code.
+
+---
+
+## 1. Summary
+
+This was not a crash. The operator's own persistent agent pane (`AgentA`, block
+`d34a5dc1-2273-47a7-84f4-47d728c72586`) hit a **stale `--resume` session id**: srv's
+locally-cached "current session" pointer for this pane had gone stale, pointing at an
+old, superseded top-level session rather than the actual, much larger, currently-live
+one. The CLI rejected it immediately, srv detected the failure, searched on-disk for
+the real session, found it, and successfully resumed — but the whole detect-fail →
+recover → respawn → reach-healthy cycle took **~39 seconds** with **zero UI feedback**,
+which is exactly what read as "did it crash?" to the operator.
+
+This is a live, real-world confirmation of the exact bug class documented in
+`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`. The good news:
+the recovery fix that shipped since that report (#2693, #2699) worked correctly here —
+this is the first confirmed live case where it prevented what would otherwise have been
+a silent, total loss of conversation history (exactly like that report's original
+incident). The bad news: two of that report's three recommended follow-ups
+(§6.1 "make the registry a live pointer" and §6.3 "surface the failure to the user")
+are still not implemented, and this incident is proof they're still needed.
+
+## 2. Confirmed timeline (from `agentmuxsrv-v0.55.21.log.2026-08-23`)
+
+| Time (UTC) | Event |
+|---|---|
+| 18:41:01.792 | `persistent process spawned` — CLI launched with `--resume c1ff18c0-6a6f-4db9-9512-7c63d251edca` |
+| 18:41:03.571 | CLI stderr: `No conversation found with session ID: c1ff18c0-...` |
+| 18:41:03.571 | srv: `stale --resume session id unreachable under the current config dir — clearing so the next message starts a fresh conversation` |
+| 18:41:04.041 | srv: `stale --resume session id caused this exit — retrying fresh, without --resume` (see §4 — this message text is misleading) |
+| 18:41:04.055 | `persistent process spawned` (retry) — CLI launched with `--resume 2d1f1558-c9ba-4ef2-a5f2-d76f1fd83bbf` — **the recovery scan found the real, correct, currently-live session** |
+| 18:41:43.432 | `agent health transition: Idle → Healthy`, `turn_active flip: active=true` — the pane is fully responsive again |
+
+**Total user-visible gap: ~39.4 seconds** (18:41:04.055 → 18:41:43.432), with no pane
+indicator of any kind during that window.
+
+## 3. Root cause chain
+
+1. **Two independent, non-synchronized places track "this agent's current session id"**
+   (unchanged since the 2026-08-20 report):
+   - The **local, per-channel** `db_agent_instances.session_id` column, kept correct by
+     `persist_session_id` (`agentmux-srv/src/backend/blockcontroller/core.rs:139`) on
+     every genuine capture during a live turn.
+   - The **shared registry** `session_id`, populated **only once** by
+     `backfill_session_ids` (`agentmux-srv/src/backend/session_backfill.rs`), which is
+     explicitly idempotent — *"skips records that already carry a non-empty id"*. Confirmed
+     directly in current code: `persist_session_id` calls
+     `sync_instance_session_id` (`core.rs:194`), which writes only to
+     `store.instance_update_partial` (the local, per-channel store) — it never touches
+     `crate::registry::Registry`. **The shared registry pointer is still write-once, exactly
+     as the 2026-08-20 report found; nothing has fixed this since.**
+
+2. **In this specific incident, the stale value was a genuinely real, but superseded, past
+   top-level session of the SAME agent** — not a misattributed subagent id (the 2026-08-20
+   report's incident, and its own open question #4). Direct evidence: `c1ff18c0-...` appears
+   in this channel's own log as the session id of a large subagent-dispatch batch
+   (`"backfilling session subagents on pane (re)open" ... "session_id":"c1ff18c0-..."`,
+   269 subagent files scanned, all `"parent":"AgentA"`, `"parent_block_id":"d34a5dc1-..."`).
+   That means `c1ff18c0` really was this agent's own live session at some earlier point
+   (real enough to have dispatched hundreds of subagents under it) — it was simply an
+   **old** session, later superseded by a much larger, more recent one
+   (`2d1f1558-c9ba-4ef2-a5f2-d76f1fd83bbf`) once conversation compaction/continuation
+   moved the live conversation forward. Nothing ever told the registry the pointer had
+   moved on. **This resolves the 2026-08-20 report's open item #4 more simply than its own
+   speculation**: the "largest session" backfill heuristic doesn't need to have picked
+   the wrong session type at all — an ordinary, valid session simply aged out and nothing
+   ever refreshed the pointer once conversation continuity moved to a newer one.
+
+3. **The underlying conversation data was never actually inaccessible "across channels."**
+   Claude Code's own session transcripts live in a genuinely shared location keyed only on
+   the agent's working directory (`~/.agentmux/shared/providers/claude/projects/<slug>/`),
+   not per AgentMux channel — confirmed by the recovery scan finding `2d1f1558-...` (a file
+   that predates this exact channel, `local-main-b28b7a-cc9756ad`) without issue. The
+   "cross-channel" framing in the 2026-08-20 report is about **AgentMux's own bookkeeping**
+   going stale, not about the CLI's data being partitioned per channel. This matters for the
+   fix: recommendation §6.1 below doesn't need any new cross-channel data-sharing plumbing —
+   the data was always reachable; only the pointer needs to stay current.
+
+4. **The existing recovery path (#2693, #2699) worked exactly as designed and is now
+   live-confirmed for the first time**, closing the outstanding item noted in
+   `docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md` (issue
+   #2368: *"close only with a live stale-resume repro... watch the blockfile for the doomed
+   attempt's error frame — `held_error_line` should suppress it"*). Confirmed:
+   `retry_after_resume_failure` (`persistent.rs:1610`) called
+   `find_recovery_session_id` → `session_backfill::find_largest_session_for_working_dir`,
+   found the correct, currently-live session, and re-attempted `--resume` with it — which
+   succeeded. No stray error frame from the doomed first attempt leaked into the visible
+   transcript (the `held_error_line`/`FireRetry` suppression path,
+   `persistent.rs:3296-3321`, worked as documented).
+
+## 4. A minor, separate finding: misleading log text
+
+The WARN logged at the moment the retry decision is made
+(`persistent.rs:3313`, `"stale --resume session id caused this exit — retrying fresh,
+without --resume"`) is logged **before** `retry_after_resume_failure` runs its own
+recovery search, and does not reflect what actually happens next. In this incident the
+retry was **not** "without --resume" at all — it resumed a different, recovered, real
+session id. This is purely a diagnostics/log-clarity issue (it made this exact
+investigation slightly more confusing to trace at first), not a functional bug. Worth
+a one-line fix: rephrase to something like `"stale --resume session id caused this exit
+— retrying (recovery scan may still find a real session to resume)"`.
+
+## 5. Ruled out
+
+- **`[process-tracker] assign_process failed ... Access is denied (os error 5)`** — fires
+  twice in this window (once per spawn attempt) but is explicitly non-fatal,
+  "opportunistic enrichment, not a liveness signal" per its own code comment
+  (`agentmux-srv/src/backend/process_tracker/registry.rs:40-56`). Unrelated to the delay
+  or the recovery outcome — confirmed by reading the call site; it only affects the
+  Swarm activity panel's process-tree visualization, nothing about spawn/resume logic.
+- **The blank `identity_id` WARN** seen in the same window (`instance ... has empty/blank
+  identity_id — falling through to the layer-3 gate`) is a real, separate, pre-existing
+  oddity (this agent instance appears to be a "legacy continuation row," per
+  `agentmux-srv/src/identity/resolver/inject.rs:334-358`'s own comment) but does **not**
+  affect which `CLAUDE_CONFIG_DIR`/account gets injected — `resolve_bindings_for_instance`
+  keys off `instance.definition_id`, not `identity_id` (same file, line 348-350) — and it
+  fires identically on *every* spawn of this pane regardless of outcome, confirmed by it
+  also appearing at 18:41:43.430 right before the eventual successful turn. It is not the
+  cause of this incident, though it may be worth its own separate follow-up given the
+  code itself flags it as unexpected ("Legacy row or UI regression?").
+
+## 6. Fix plan
+
+Ranked by leverage; none of this has been implemented as part of this investigation.
+
+### 6.1 Make the shared registry `session_id` a live pointer (highest leverage, addresses root cause)
+`sync_instance_session_id` (`core.rs:194`) already runs on every genuine session capture
+and already knows the correct, current id. Extend it (or `persist_session_id`, which
+already calls it) to also write through to the shared cross-channel `Registry` record,
+replacing whatever stale value is there — not just skip-if-empty. This is a small,
+additive change: one more write in an already-executed path, no new polling or background
+job needed. Once this lands, the specific failure mode in both this report and the
+2026-08-20 report (registry pointing at a superseded session) stops recurring by
+construction, and the recovery-scan path (§3.4) becomes a pure safety net for genuinely
+unrecoverable cases instead of the primary save.
+
+### 6.2 Surface the recovery attempt to the user (addresses the UX gap this report is actually about)
+Right now a stale-resume recovery is **entirely invisible** — no banner, no system
+message, nothing distinguishes it from a hang. Given recovery already reliably completes
+in the common case (confirmed here), a lightweight, non-alarming pane indicator during
+the `ResumeUnreachable → FireRetry → recovery spawn` window (e.g. "Reconnecting…" similar
+to the existing "Compacting… Ns" composer-strip treatment already used for
+context-compaction visibility, `docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md`)
+would turn this exact "is it crashed?" moment into a legible, expected state. This is
+the single highest-value, lowest-risk fix given how well the underlying recovery already
+works — it changes user *perception*, not behavior.
+
+### 6.3 Fix the misleading retry-decision log line (§4) — trivial, low priority
+One-line rewording at `persistent.rs:3313` so future investigations don't have to
+independently discover that "retrying fresh, without --resume" doesn't mean what it
+says.
+
+### 6.4 Not recommended as urgent: investigate the ~39s latency itself
+The 18:41:04.055 → 18:41:43.432 gap is plausibly dominated by ordinary CLI cold-start +
+loading/replaying a large resumed transcript (this agent's live session is a very long,
+multi-hour conversation) rather than any AgentMux-side inefficiency. No evidence was
+found of avoidable overhead in this path beyond the two items above. If §6.1 ships,
+this latency becomes rare (only for genuinely fresh channels or unrecoverable ids)
+rather than something a live, continuously-running pane hits mid-session — likely
+sufficient on its own without separately chasing CLI startup performance.
+
+## 7. What this closes out
+
+- Issue #2368's outstanding live-repro requirement
+  (`docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md`,
+  and the agent's own memory note tracking it) — **done**. The `poison_resume` /
+  `find_recovery_session_id` / `held_error_line` suppression machinery from PR #2500/#2501/
+  #2693/#2699 is now confirmed working end-to-end on a real, unplanned production-shaped
+  incident, not just synthetic tests.
+- `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`'s open item #4
+  (how does a wrong id end up in the registry) — narrowed: at least one concrete mechanism
+  is an ordinary superseded top-level session, no subagent-id misattribution required.
+  Recommendations §6.1 and §6.3 of that report remain the two live action items; this
+  document's §6.2 is a new, complementary recommendation specific to the UX gap the
+  operator actually noticed.
+
+## 8. Evidence
+
+- `agentmuxsrv-v0.55.21.log.2026-08-23` (this channel:
+  `C:\Users\area54\.agentmux\channels\local-main-b28b7a-cc9756ad\versions\0.55.21\logs\`),
+  lines covering 18:41:01.784–18:41:43.432 and the 18:38:46 subagent-backfill lines that
+  identify `c1ff18c0-...`'s true origin.
+- `agentmux-srv/src/backend/blockcontroller/persistent.rs` — `poison_resume` (:327),
+  `try_capture_session_id` (:394), `find_recovery_session_id` (:1583),
+  `retry_after_resume_failure` (:1610), the `FireRetry` handling and misleading log line
+  (:3296-3321).
+- `agentmux-srv/src/backend/blockcontroller/core.rs` — `persist_session_id` (:139),
+  `sync_instance_session_id` (:194, confirmed local-store-only, no Registry write).
+- `agentmux-srv/src/backend/session_backfill.rs` — module doc comment and the
+  idempotent skip-if-non-empty backfill logic.
+- `agentmux-srv/src/backend/process_tracker/registry.rs` (:40-56) — ruled-out
+  `assign_process` warning.
+- `agentmux-srv/src/identity/resolver/inject.rs` (:334-358) — ruled-out blank
+  `identity_id` warning.
+- `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md` — prior
+  incident this report confirms, narrows, and extends.
+- `docs/specs/SPEC_PERSISTENT_SPAWN_GENERATION_AND_MESSAGE_IDENTITY_2026_08_09.md` —
+  issue #2368's original design spec.

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -26,6 +26,7 @@ import {
     type InitPhase,
     initialState,
     type PaneFailure,
+    type ResumeRetryState,
     type TurnPhase,
     workingFromPhase,
 } from "./agent-pane-state/types";
@@ -116,6 +117,14 @@ export interface AgentPaneProjections {
      * See docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md.
      */
     registryAttachedTaskSince?: (next: number | null) => void;
+    /**
+     * Live "reconnecting after a stale `--resume` session id" state, or
+     * null. Reducer-owned (see `AgentPaneState.reconnecting` /
+     * `ResumeRetryStarted` / `ResumeRetryResolved`). Drives the
+     * "Reconnecting…" status chip + elapsed counter, mirroring `compacting`.
+     * See docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+     */
+    reconnecting?: (next: ResumeRetryState | null) => void;
 }
 
 interface Slot {
@@ -353,6 +362,7 @@ export function dispatch(
     proj("compacting", prev.compacting, slot.state.compacting, slot.proj.compacting);
     proj("attachedTask", prev.attachedTask, slot.state.attachedTask, slot.proj.attachedTask);
     proj("registryAttachedTaskSince", prev.registryAttachedTaskSince, slot.state.registryAttachedTaskSince, slot.proj.registryAttachedTaskSince);
+    proj("reconnecting", prev.reconnecting, slot.state.reconnecting, slot.proj.reconnecting);
 
     if (cascadeSetter != null) {
         console.warn(

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -2880,6 +2880,48 @@ describe("agent-pane-state reducer", () => {
         });
     });
 
+    // docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md
+    // §6.2 — mirrors the Attached task axis above (same shape, same
+    // idempotent edge-trigger semantics), but for the backend's
+    // stale-`--resume` retry/recovery signal instead.
+    describe("Stale-resume reconnect axis (ResumeRetryStarted / ResumeRetryResolved)", () => {
+        it("initial state: reconnecting null", () => {
+            const s = mk();
+            expect(s.reconnecting).toBeNull();
+        });
+
+        it("ResumeRetryStarted sets reconnecting with the given timestamp", () => {
+            const s = mk();
+            const r = update(s, { type: "ResumeRetryStarted", at: 100 });
+            expect(r.state.reconnecting).toEqual({ startedAt: 100 });
+            expect(r.events).toEqual([{ type: "resume-retry-started", at: 100 }]);
+        });
+
+        it("ResumeRetryStarted is idempotent — a cascaded retry doesn't reset startedAt", () => {
+            let s = mk();
+            s = update(s, { type: "ResumeRetryStarted", at: 100 }).state;
+            const r = update(s, { type: "ResumeRetryStarted", at: 200 });
+            expect(r.state).toBe(s); // same-ref no-op
+            expect(r.state.reconnecting).toEqual({ startedAt: 100 });
+            expect(r.events).toEqual([]);
+        });
+
+        it("ResumeRetryResolved clears an in-progress reconnect", () => {
+            let s = mk();
+            s = update(s, { type: "ResumeRetryStarted", at: 100 }).state;
+            const r = update(s, { type: "ResumeRetryResolved" });
+            expect(r.state.reconnecting).toBeNull();
+            expect(r.events).toEqual([{ type: "resume-retry-resolved" }]);
+        });
+
+        it("ResumeRetryResolved is idempotent when already null", () => {
+            const s = mk();
+            const r = update(s, { type: "ResumeRetryResolved" });
+            expect(r.state).toBe(s);
+            expect(r.events).toEqual([]);
+        });
+    });
+
     // SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md — folds
     // useAgentFailure's local failure state into the reducer so a backend
     // failure classification unconditionally ends a working turn, instead

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -1318,6 +1318,23 @@ export function update(
                 events: [{ type: "registry-attached-task-cleared" }],
             };
         }
+
+        // ── Stale-`--resume` reconnect axis
+        // (STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2) ──
+        case "ResumeRetryStarted": {
+            if (state.reconnecting) return { state, events: [] };
+            return {
+                state: { ...state, reconnecting: { startedAt: command.at } },
+                events: [{ type: "resume-retry-started", at: command.at }],
+            };
+        }
+        case "ResumeRetryResolved": {
+            if (!state.reconnecting) return { state, events: [] };
+            return {
+                state: { ...state, reconnecting: null },
+                events: [{ type: "resume-retry-resolved" }],
+            };
+        }
     }
 }
 

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -125,6 +125,21 @@ export interface AttachedTaskState {
 }
 
 /**
+ * Live "controller is recovering from a stale `--resume` session id" state,
+ * or `null` — set the instant the backend's stale-resume retry begins
+ * (`wps.EVENT_AGENT_RESUME_RETRY`, `{status:"retrying"}`), cleared once the
+ * retry's outcome (Fresh or Resumed) is actually known
+ * (`{status:"resolved"}`). Mirrors `AttachedTaskState`'s shape (a single
+ * `startedAt`, no staleness/generation gating needed) — unlike
+ * `CompactionState`'s completion signal, both ends of this one travel over
+ * the SAME reliable WPS channel, so there's no cross-channel race to guard
+ * against. See docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+ */
+export interface ResumeRetryState {
+    startedAt: number;
+}
+
+/**
  * A classified backend failure (the `agentfailure` wave event's payload,
  * `AgentFailure` in `frontend/types/gotypes.d.ts`) currently surfaced for
  * this pane. Single source of truth for "is there an active failure" —
@@ -325,6 +340,13 @@ export interface AgentPaneState {
      */
     attachedTask: AttachedTaskState | null;
     /**
+     * Live "reconnecting after a stale `--resume` session id" state, or
+     * `null` — see {@link ResumeRetryState}. Owned exclusively by
+     * `ResumeRetryStarted`/`ResumeRetryResolved`, dispatched from
+     * `useResumeRetryStream.ts`.
+     */
+    reconnecting: ResumeRetryState | null;
+    /**
      * Earliest `started_at_ms` among this block's currently-`Running`
      * `db_background_tasks` rows (Phase A/B of
      * docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md),
@@ -377,6 +399,7 @@ export const initialState = (agentId: string): AgentPaneState => ({
     failure: null,
     compacting: null,
     attachedTask: null,
+    reconnecting: null,
     registryAttachedTaskSince: null,
     lastCompactionBoundaryAt: null,
 });
@@ -692,6 +715,22 @@ export type AgentPaneCommand =
      */
     | { type: "AttachedTaskCleared" }
 
+    // ── Stale-`--resume` reconnect axis
+    // (STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2) ──
+    /**
+     * `wps.EVENT_AGENT_RESUME_RETRY`'s `{status:"retrying"}` landed — a
+     * stale `--resume` was just detected and a retry/recovery attempt is
+     * about to fire. No-op (idempotent) if already reconnecting, mirroring
+     * `AttachedTaskObserved` — a cascaded second retry must not reset
+     * `startedAt` back to a later time.
+     */
+    | { type: "ResumeRetryStarted"; at: number }
+    /**
+     * `{status:"resolved"}` landed — the retry's outcome (Fresh or Resumed)
+     * is now known. No-op if already null.
+     */
+    | { type: "ResumeRetryResolved" }
+
     // ── Registry-derived attached-task floor (Phase C of
     // SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md) — see
     // `registryAttachedTaskSince`'s doc comment above for why this is a
@@ -906,7 +945,11 @@ export type AgentPaneEvent =
     /** `RegistryAttachedTaskObserved` set `state.registryAttachedTaskSince`. */
     | { type: "registry-attached-task-observed"; at: number }
     /** `RegistryAttachedTaskCleared` cleared `state.registryAttachedTaskSince`. */
-    | { type: "registry-attached-task-cleared" };
+    | { type: "registry-attached-task-cleared" }
+    /** `ResumeRetryStarted` set `state.reconnecting` (0→1 edge). */
+    | { type: "resume-retry-started"; at: number }
+    /** `ResumeRetryResolved` cleared `state.reconnecting` (1→0 edge). */
+    | { type: "resume-retry-resolved" };
 
 export interface ReducerResult {
     state: AgentPaneState;

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -26,6 +26,10 @@ export const WpsEvent = {
     // instant Claude Code begins compacting — see
     // docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md §4.2.
     CompactionStarted: "compaction_started",
+    // Published by the persistent controller's stale-`--resume` recovery
+    // path — `{status:"retrying"|"resolved"}`. See
+    // docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+    AgentResumeRetry: "agent-resume-retry",
     BlockActivity: "block:activity",
     // Fired when a file open in at least one editor/preview tab changes on
     // disk. Payload: `{ path }` — a wake signal only, no content; handlers

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -744,6 +744,7 @@ const AgentPresentationView = ({
                 compacting: a.compactingAtom[1],
                 attachedTask: a.attachedTaskAtom[1],
                 registryAttachedTaskSince: a.registryAttachedTaskSinceAtom[1],
+                reconnecting: a.reconnectingAtom[1],
             },
         });
         registerAgentActivity(model.blockId, a.turnPhaseAtom[0]);
@@ -2356,6 +2357,7 @@ const AgentPresentationView = ({
                 providerId={provider()?.id ?? ""}
                 agentMode={block()?.meta?.["agentMode"] as string | undefined}
                 compacting={agentAtoms().compactingAtom[0]()}
+                reconnecting={agentAtoms().reconnectingAtom[0]()}
                 // Route through handleSendMessage — same pattern as the
                 // SlashHelpPanel's onInvoke above, and for the same reason:
                 // this needs the same pre-TurnStart wasAlreadyWorking

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -43,7 +43,7 @@
 
 import { useTick } from "@/app/hook/useTick";
 import { compactionThreshold } from "@/app/store/agent-pane-state/context-window";
-import type { CompactionState } from "@/app/store/agent-pane-state/types";
+import type { CompactionState, ResumeRetryState } from "@/app/store/agent-pane-state/types";
 import { formatCompactNumber, formatExactNumber } from "@/util/format-count";
 import { formatElapsedCompact } from "@/util/format-time";
 import { Show, createEffect, createMemo, createSignal, type JSX } from "solid-js";
@@ -152,6 +152,15 @@ interface AgentComposerStripProps {
      */
     compacting?: CompactionState | null;
     /**
+     * Live "reconnecting after a stale `--resume` session id" state, or
+     * null. While set, the center stats zone shows "Reconnecting…" plus a
+     * live elapsed counter — same treatment as `compacting`, so a stale-
+     * resume recovery (usually seconds, occasionally tens of seconds) never
+     * reads as a silent hang. See
+     * docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+     */
+    reconnecting?: ResumeRetryState | null;
+    /**
      * Manually trigger compaction now, instead of waiting for the CLI's
      * own auto-compact threshold. Only meaningful for Claude — sends the
      * literal text "/compact" through the normal send-message path
@@ -204,7 +213,26 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
         return c ? (tick(), Date.now() - c.startedAt) : 0;
     });
 
+    // Live elapsed time since a stale-`--resume` retry began — same
+    // stopwatch pattern as compactingElapsedMs above. Clears the moment
+    // `reconnecting` clears (the retry's outcome — Fresh or Resumed — is
+    // known); there's no separate finalized-duration node to hand off to,
+    // unlike compaction's transcript node.
+    const reconnectingElapsedMs = createMemo(() => {
+        const r = props.reconnecting;
+        return r ? (tick(), Date.now() - r.startedAt) : 0;
+    });
+
     const rightText = createMemo((): string => {
+        // Mutually exclusive with `compacting` by construction (a stale-
+        // resume retry only fires once the underlying process has already
+        // exited, at which point compaction can't still be in progress),
+        // but checked first regardless — a silent-gap recovery is the more
+        // easily mistaken-for-a-hang state, so it takes priority if both
+        // were ever somehow set.
+        if (props.reconnecting) {
+            return `Reconnecting…  ${formatElapsedCompact(reconnectingElapsedMs())}`;
+        }
         if (props.compacting) {
             return `Compacting…  ${formatElapsedCompact(compactingElapsedMs())}`;
         }
@@ -307,7 +335,10 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 <Show when={rightText()}>
                     <span
                         class="agent-composer-strip-stats"
-                        classList={{ "agent-composer-strip-stats--compacting": !!props.compacting }}
+                        classList={{
+                            "agent-composer-strip-stats--compacting": !!props.compacting,
+                            "agent-composer-strip-stats--reconnecting": !!props.reconnecting,
+                        }}
                     >
                         {rightText()}
                     </span>

--- a/frontend/app/view/agent/hooks/useResumeRetryStream.test.ts
+++ b/frontend/app/view/agent/hooks/useResumeRetryStream.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { resolveResumeRetryEvent } from "./useResumeRetryStream";
+
+// docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+// Unlike useCompactionStream's resolveCompactionStart, there is no
+// staleness/clock-skew guard here — both "retrying" and "resolved" travel
+// over the SAME reliable, `persist: 2` WPS channel, so whichever status is
+// most recently observed is always the correct current state.
+
+describe("resolveResumeRetryEvent", () => {
+    const NOW = 1_800_000_000_000; // arbitrary fixed epoch ms
+
+    it("resolves a retrying ping with a valid startedAt", () => {
+        const startedAt = new Date(NOW - 5000).toISOString();
+        expect(resolveResumeRetryEvent({ status: "retrying", startedAt }, NOW)).toEqual({
+            type: "ResumeRetryStarted",
+            at: NOW - 5000,
+        });
+    });
+
+    it("falls back to now when startedAt is missing", () => {
+        expect(resolveResumeRetryEvent({ status: "retrying" }, NOW)).toEqual({
+            type: "ResumeRetryStarted",
+            at: NOW,
+        });
+    });
+
+    it("falls back to now when startedAt is unparseable", () => {
+        expect(resolveResumeRetryEvent({ status: "retrying", startedAt: "not-a-date" }, NOW)).toEqual({
+            type: "ResumeRetryStarted",
+            at: NOW,
+        });
+    });
+
+    it("resolves a resolved ping regardless of any other fields", () => {
+        expect(resolveResumeRetryEvent({ status: "resolved" }, NOW)).toEqual({ type: "ResumeRetryResolved" });
+        expect(resolveResumeRetryEvent({ status: "resolved", startedAt: "ignored" }, NOW)).toEqual({
+            type: "ResumeRetryResolved",
+        });
+    });
+
+    it("rejects an unrecognized status", () => {
+        expect(resolveResumeRetryEvent({ status: "pending" }, NOW)).toBeNull();
+    });
+
+    it("rejects a missing status", () => {
+        expect(resolveResumeRetryEvent({}, NOW)).toBeNull();
+    });
+
+    it("rejects a non-object payload", () => {
+        expect(resolveResumeRetryEvent(null, NOW)).toBeNull();
+        expect(resolveResumeRetryEvent(undefined, NOW)).toBeNull();
+        expect(resolveResumeRetryEvent("not-an-object", NOW)).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/hooks/useResumeRetryStream.ts
+++ b/frontend/app/view/agent/hooks/useResumeRetryStream.ts
@@ -74,10 +74,25 @@ export function useResumeRetryStream(opts: UseResumeRetryStreamOptions): void {
         opts.model.dispatchPane(command, "system");
     };
 
+    // reagentx P2 (PR #2776, round 3): the mount-time history read below is
+    // async and can resolve AFTER a live event already landed — e.g. a
+    // slightly-stale "retrying" snapshot arriving just after the matching
+    // live "resolved" already cleared `reconnecting`. Applying it at that
+    // point would incorrectly re-set `reconnecting` with a stale
+    // `startedAt` and nothing left to ever clear it (`ResumeRetryStarted`
+    // only no-ops when ALREADY reconnecting, not against a timestamp/order
+    // check). Once ANY live event has landed, it is by construction more
+    // current than a history snapshot taken at mount time, so the
+    // still-in-flight read is simply discarded rather than applied.
+    let receivedLiveEvent = false;
+
     const unsub = waveEventSubscribe({
         eventType: WpsEvent.AgentResumeRetry,
         scope: `block:${opts.blockId}`,
-        handler: (event: any) => applyEvent(event?.data),
+        handler: (event: any) => {
+            receivedLiveEvent = true;
+            applyEvent(event?.data);
+        },
     });
 
     // Explicit current-history read on mount — see this module's doc
@@ -91,6 +106,7 @@ export function useResumeRetryStream(opts: UseResumeRetryStreamOptions): void {
         maxitems: 1,
     })
         .then((history) => {
+            if (receivedLiveEvent) return;
             const latest = history?.[history.length - 1];
             if (latest) applyEvent(latest.data);
         })

--- a/frontend/app/view/agent/hooks/useResumeRetryStream.ts
+++ b/frontend/app/view/agent/hooks/useResumeRetryStream.ts
@@ -11,22 +11,33 @@
  * `session_id` and respawn against a recovered one. See
  * docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
  *
- * Simpler than `useCompactionStream.ts`'s sibling hook: both the "retrying"
- * and "resolved" ends of this signal travel over this SAME WPS channel
- * (backend publishes with `persist: 2`, keeping the latest pair), so there's
- * no cross-channel staleness race to guard against here — a freshly
- * (re)subscribed pane simply reflects whichever status was published most
- * recently, which is always correct. No transcript node is pushed either;
- * this only drives the reducer's `reconnecting` pane-state axis (mirroring
- * `attachedTask`'s shape), not `AgentComposerStrip`'s "system" document.
+ * Simpler than `useCompactionStream.ts`'s sibling hook in one respect: both
+ * the "retrying" and "resolved" ends of this signal travel over this SAME
+ * WPS channel (backend publishes with `persist: 2`, keeping the latest
+ * pair), so there's no cross-channel staleness race to guard against — a
+ * fresh subscribe from a genuinely new WebSocket connection always replays
+ * the correct current pair.
  *
- * Installed at BODY scope by the caller, same early-return-safety rationale
- * as `useCompactionStream`/`useDockClearStream`.
+ * reagentx P1 (PR #2776, round 2): a same-connection pane unmount+remount
+ * (switching tabs/panes away and back) does NOT get a fresh replay —
+ * `Broker::replay_to_route` (`agentmux-srv/src/backend/wps.rs`) dedupes
+ * replay per `(route_id, event, scope)` and is only cleared on a true
+ * route reconnect (`unsubscribe_all`), while `registerPane` resets
+ * `AgentPaneState.reconnecting` to `null` on every mount regardless. Relying
+ * on `waveEventSubscribe`'s replay alone would silently reproduce this PR's
+ * own "did it crash?" gap for exactly the pane-hidden-during-a-retry case.
+ * Fixed by explicitly reading current history via `EventReadHistoryCommand`
+ * on mount (same pattern `sysinfo-model.ts`'s `loadInitialData` already
+ * uses) instead of depending solely on subscribe-time replay — this reads
+ * the SAME persisted history replay would have delivered, just via a path
+ * that isn't deduped per-route.
  */
 
 import { onCleanup } from "solid-js";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import type { AgentPaneModel } from "@/app/store/agent-pane-model";
 
 export interface UseResumeRetryStreamOptions {
@@ -52,19 +63,40 @@ export function resolveResumeRetryEvent(
 }
 
 export function useResumeRetryStream(opts: UseResumeRetryStreamOptions): void {
+    const applyEvent = (data: unknown) => {
+        const command = resolveResumeRetryEvent(data, Date.now());
+        if (!command) return;
+        // model.dispatchPane is the disposal-safe wrapper — required here,
+        // not the raw (throwing) dispatch: this can run after the pane's
+        // slot unregisters (a live event racing the unmount, or the
+        // initial-history fetch below resolving after an already-fast
+        // unmount), mirroring useDockClearStream's identical reasoning.
+        opts.model.dispatchPane(command, "system");
+    };
+
     const unsub = waveEventSubscribe({
         eventType: WpsEvent.AgentResumeRetry,
         scope: `block:${opts.blockId}`,
-        handler: (event: any) => {
-            const command = resolveResumeRetryEvent(event?.data, Date.now());
-            if (!command) return;
-            // model.dispatchPane is the disposal-safe wrapper — required
-            // here, not the raw (throwing) dispatch: this handler can fire
-            // after the pane's slot unregisters, mirroring
-            // useDockClearStream's identical reasoning.
-            opts.model.dispatchPane(command, "system");
-        },
+        handler: (event: any) => applyEvent(event?.data),
     });
+
+    // Explicit current-history read on mount — see this module's doc
+    // comment (reagentx P1, round 2) for why subscribe-time replay alone
+    // isn't enough on a same-connection pane remount. `maxitems: 1` only
+    // needs the single most recent status; `read_event_history` returns
+    // oldest-first, so the last (only) element is current truth.
+    void RpcApi.EventReadHistoryCommand(TabRpcClient, {
+        event: WpsEvent.AgentResumeRetry,
+        scope: `block:${opts.blockId}`,
+        maxitems: 1,
+    })
+        .then((history) => {
+            const latest = history?.[history.length - 1];
+            if (latest) applyEvent(latest.data);
+        })
+        .catch((e) => {
+            console.log("[useResumeRetryStream] failed to load initial reconnect status", e);
+        });
 
     // Own the subscription at body scope so it is torn down even if the
     // caller's onMount early-returns (e.g. enabled:false).

--- a/frontend/app/view/agent/hooks/useResumeRetryStream.ts
+++ b/frontend/app/view/agent/hooks/useResumeRetryStream.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useResumeRetryStream — the single per-block WPS subscription for
+ * `agent-resume-retry`, published by the persistent controller's
+ * stale-`--resume` recovery path (`retry_after_resume_failure` /
+ * `publish_resume_retry_status` in `agentmux-srv`) so the pane can show a
+ * "Reconnecting…" readout instead of going silent for the
+ * seconds-to-tens-of-seconds it can take to detect a stale registry
+ * `session_id` and respawn against a recovered one. See
+ * docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+ *
+ * Simpler than `useCompactionStream.ts`'s sibling hook: both the "retrying"
+ * and "resolved" ends of this signal travel over this SAME WPS channel
+ * (backend publishes with `persist: 2`, keeping the latest pair), so there's
+ * no cross-channel staleness race to guard against here — a freshly
+ * (re)subscribed pane simply reflects whichever status was published most
+ * recently, which is always correct. No transcript node is pushed either;
+ * this only drives the reducer's `reconnecting` pane-state axis (mirroring
+ * `attachedTask`'s shape), not `AgentComposerStrip`'s "system" document.
+ *
+ * Installed at BODY scope by the caller, same early-return-safety rationale
+ * as `useCompactionStream`/`useDockClearStream`.
+ */
+
+import { onCleanup } from "solid-js";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { WpsEvent } from "@/app/store/wps-events";
+import type { AgentPaneModel } from "@/app/store/agent-pane-model";
+
+export interface UseResumeRetryStreamOptions {
+    blockId: string;
+    model: AgentPaneModel;
+}
+
+/**
+ * Resolve a raw `agent-resume-retry` WPS payload into a dispatchable pane
+ * command, or `null` to ignore it (malformed shape). Pure and exported for
+ * direct unit coverage, same rationale as `resolveCompactionStart`.
+ */
+export function resolveResumeRetryEvent(
+    data: unknown,
+    now: number,
+): { type: "ResumeRetryStarted"; at: number } | { type: "ResumeRetryResolved" } | null {
+    if (!data || typeof data !== "object") return null;
+    const d = data as Record<string, unknown>;
+    if (d.status === "resolved") return { type: "ResumeRetryResolved" };
+    if (d.status !== "retrying") return null;
+    const at = typeof d.startedAt === "string" ? Date.parse(d.startedAt) : NaN;
+    return { type: "ResumeRetryStarted", at: Number.isNaN(at) ? now : at };
+}
+
+export function useResumeRetryStream(opts: UseResumeRetryStreamOptions): void {
+    const unsub = waveEventSubscribe({
+        eventType: WpsEvent.AgentResumeRetry,
+        scope: `block:${opts.blockId}`,
+        handler: (event: any) => {
+            const command = resolveResumeRetryEvent(event?.data, Date.now());
+            if (!command) return;
+            // model.dispatchPane is the disposal-safe wrapper — required
+            // here, not the raw (throwing) dispatch: this handler can fire
+            // after the pane's slot unregisters, mirroring
+            // useDockClearStream's identical reasoning.
+            opts.model.dispatchPane(command, "system");
+        },
+    });
+
+    // Own the subscription at body scope so it is torn down even if the
+    // caller's onMount early-returns (e.g. enabled:false).
+    onCleanup(() => { try { unsub(); } catch { /* ignore */ } });
+}

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -30,7 +30,7 @@ import {
     StreamingState,
     TurnTokens,
 } from "./types";
-import type { AttachedTaskState, CompactionState, InitPhase, PaneFailure, TurnPhase } from "@/app/store/agent-pane-state/types";
+import type { AttachedTaskState, CompactionState, InitPhase, PaneFailure, ResumeRetryState, TurnPhase } from "@/app/store/agent-pane-state/types";
 
 /**
  * A signal pair: [getter, setter]
@@ -139,6 +139,14 @@ export interface AgentAtoms {
      * docs/specs/SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md.
      */
     registryAttachedTaskSinceAtom: SignalPair<number | null>;
+    /**
+     * Live "reconnecting after a stale `--resume` session id" state, or
+     * null. Reducer-owned (see `AgentPaneState.reconnecting`). Drives the
+     * "Reconnecting…" status chip + elapsed counter in `AgentComposerStrip`,
+     * mirroring `compactingAtom`. See
+     * docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
+     */
+    reconnectingAtom: SignalPair<ResumeRetryState | null>;
 }
 
 /**
@@ -208,5 +216,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         compactingAtom: createSignal<CompactionState | null>(null),
         attachedTaskAtom: createSignal<AttachedTaskState | null>(null),
         registryAttachedTaskSinceAtom: createSignal<number | null>(null),
+        reconnectingAtom: createSignal<ResumeRetryState | null>(null),
     };
 }

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -418,6 +418,15 @@
         color: var(--warning-color, #d9a441);
         font-weight: 500;
     }
+
+    // Live "Reconnecting… Ns" readout (a stale-`--resume` recovery in
+    // progress — STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md
+    // §6.2). Same treatment as `--compacting` — "notable but not an error,"
+    // not the failure-red used elsewhere for a genuine `AgentFailure`.
+    &--reconnecting {
+        color: var(--warning-color, #d9a441);
+        font-weight: 500;
+    }
 }
 
 .agent-composer-strip-process-badge {

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -52,6 +52,7 @@ import { useToolChunkStream } from "./hooks/useToolChunkStream";
 import { useShellNodeStream } from "./hooks/useShellNodeStream";
 import { useCompactionStream } from "./hooks/useCompactionStream";
 import { useDockClearStream } from "./hooks/useDockClearStream";
+import { useResumeRetryStream } from "./hooks/useResumeRetryStream";
 import { useBackgroundTaskRegistry } from "./hooks/useBackgroundTaskRegistry";
 import { useTurnLifecycle } from "./hooks/useTurnLifecycle";
 import { usePendingMessageAcceptance } from "./hooks/usePendingMessageAcceptance";
@@ -246,6 +247,7 @@ export function useAgentStream({
     // model.dispatchDoc (disposal-safe), not the raw dispatch, since this
     // WPS handler can fire after the pane unregisters.
     useDockClearStream({ blockId, model });
+    useResumeRetryStream({ blockId, model });
     // Seeds/refreshes attachedTask from the durable db_background_tasks
     // registry — see that hook's own module doc comment for why this is
     // additive-only (never clears) relative to the transcript-derived path.


### PR DESCRIPTION
## Summary

Live-incident follow-up to `docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md` (§6.2/§6.3).

While investigating a real ~39s "did it crash?" gap the operator observed in their own agent pane, root-caused it to the existing stale-`--resume` detect→recover→respawn cycle (#2693/#2699) — which worked correctly, but gave **zero UI feedback** the whole time.

- Publishes a new `agent-resume-retry` WPS event (`{status:"retrying"|"resolved"}`, `persist: 2`) from `retry_after_resume_failure` and both `EmitSessionOutcome` handling sites in `agentmux-srv/src/backend/blockcontroller/persistent.rs`, plus a safety-net publish on the non-retryable-failure path so the indicator can never get stuck showing forever.
- New `reconnecting` pane-state axis (mirrors `attachedTask`'s shape — no staleness/generation gating needed, unlike `compacting`, since both ends of this signal travel over the same reliable channel), wired through a new `useResumeRetryStream` hook into `AgentComposerStrip`'s existing status-chip area: shows `Reconnecting… Ns` alongside the existing `Compacting… Ns` treatment.
- Rewords the misleading `"retrying fresh, without --resume"` log line — it fires *before* the recovery scan runs, so it doesn't reflect that a recovered session id is very often attached.

**Correction on the linked status doc**: its §6.1 recommendation ("make the shared registry `session_id` a live pointer") turned out to already be shipped a day earlier by #2755 — not duplicated here. The status doc has been corrected in place rather than silently reflecting stale info.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — new backend tests (`retry_after_resume_failure_publishes_retrying_then_resolved_when_no_recovery_found`, `retry_after_resume_failure_only_publishes_retrying_when_recovery_is_found`) + full `blockcontroller`/`wps` module suites (259 tests) all pass
- [x] `npx vitest run` — new reducer tests + `useResumeRetryStream` hook tests + full `frontend/app/store` + `frontend/app/view/agent` suites (2067 tests, 133 files) all pass
- [x] `npx tsc --noEmit` clean

<!-- agentmux:agent_id=agenta -->