### PR TITLE
fix(agent-pane): stop the block-mount BrainSpinner overlay getting stuck visible forever

### DIFF
--- a/.changesets/1787550573-fix-agent-pane-stop-the-block-mount-brainspinner-overlay-get-tod8.md
+++ b/.changesets/1787550573-fix-agent-pane-stop-the-block-mount-brainspinner-overlay-get-tod8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): stop the block-mount BrainSpinner overlay getting stuck visible forever

--- a/docs/retro/retro-block-ready-gate-spinner-stuck-visible-race-2026-08-23.md
+++ b/docs/retro/retro-block-ready-gate-spinner-stuck-visible-race-2026-08-23.md
@@ -1,0 +1,123 @@
+# Retro: block-mount BrainSpinner overlay can get stuck visible forever
+
+**Date:** 2026-08-23
+**Owner:** AgentY
+**Area:** `frontend/app/block/block.tsx` (`Block`'s `ready()` gate), `frontend/app/view/agent/agent-view.tsx` (`AgentPicker` -> `AgentPresentationView` cross-fade)
+**Introduced by:** PR #2768 (`f59bb43b7`, 2026-08-22), "feat(layout): cross-fade the remaining pane-mount hard cuts (Phase 3-4)"
+
+---
+
+## Symptom
+
+Reported by the user directly: a "pulsating brain logo" (`BrainSpinner`)
+visible in agent panes, seemingly permanently, on top of already-loaded,
+actively-rendering content. Confirmed live in the reporting session's own
+hosting window via `UIScreenshot` + `UIQuery`: multiple
+`.block-ready-gate-host.is-overlay` elements were mounted at full opacity,
+carrying no `is-fading` class, in panes that had been actively rendering
+new content for the entire (long-running) session. Not a cosmetic flicker —
+a real, indefinite stuck state.
+
+## Root cause
+
+`block.tsx`'s `ready()`-gate spinner (added same as the bug in PR #1992,
+restructured into a cross-fade by PR #2768) used this shape:
+
+```ts
+const [spinnerVisible, setSpinnerVisible] = createSignal(!ready());   // (A)
+...
+createEffect(on(ready, (isReady) => {
+    if (isReady) {
+        ...
+        setTimeout(() => setSpinnerVisible(false), READY_GATE_FADE_MS);  // (B) — the ONLY place that hides it
+    }
+    ...
+}, { defer: true }));
+```
+
+`on(..., { defer: true })` intentionally skips calling the callback on the
+effect's first run — the assumption being that if `ready()` is already
+`true` by then, (A) already seeded `spinnerVisible` correctly to `false`
+and there's nothing to do.
+
+The bug: (A) and the effect's first run are **not the same read, taken at
+the same time.** (A) runs synchronously during component construction,
+before any child renders. `createEffect` doesn't get its first flush until
+after the render commits — a later pass of Solid's scheduler. If `ready()`
+flips from `false` (at the moment (A) ran) to `true` in that gap — which is
+the *common* case, not a rare edge case, for any block whose `blockData`/
+`viewModel` resolve from an already-warm cache within a microtask of mount
+— then:
+
+- (A) seeded `spinnerVisible = true` (ready was false at that instant).
+- The effect's first run sees `ready() === true`, and `defer` swallows the
+  callback — (B) never runs.
+- `ready()` doesn't change again (it's already settled `true` and stays
+  that way for the rest of the block's life), so the effect never fires a
+  second time either.
+- `spinnerVisible` is stuck at `true` forever. The `BrainSpinner` stays
+  mounted, at full opacity, animating its normal 1.8s CSS pulse
+  indefinitely — reading exactly as "a pulsating brain logo that never goes
+  away."
+
+The identical shape existed in `agent-view.tsx`'s `AgentPicker` ->
+`AgentPresentationView` cross-fade, added in the same PR, seeded from
+`agentId()` instead of `ready()`. Same race, same fix needed, not
+separately live-reproduced but structurally identical — fixed alongside the
+confirmed one rather than left as a known-latent duplicate.
+
+This is a brand-new regression, not a long-standing bug: before PR #2768,
+`block.tsx`'s gate was a plain `<Show when={ready()}>` hard cut with no
+persisted "shown" signal at all, so this construction-vs-effect timing gap
+had nothing to get stuck on. The PR's own description flagged "Not manually
+verified in a running browser" for exactly this code.
+
+## Fix
+
+Collapse the two separate reads into one. Instead of seeding a signal at
+construction and separately gating a deferred effect, read `ready()` (or
+`agentId()`) once per effect run and special-case the *first* run inline,
+using a local (non-reactive) `initialized` flag:
+
+```ts
+const [spinnerVisible, setSpinnerVisible] = createSignal(true);
+let spinnerGateInitialized = false;
+createEffect(() => {
+    const isReady = ready();
+    if (!spinnerGateInitialized) {
+        spinnerGateInitialized = true;
+        setSpinnerVisible(!isReady);
+        setSpinnerFading(false);
+        return;
+    }
+    // ...unchanged fade-out / re-show logic
+});
+```
+
+Now there is exactly one read of `ready()` that decides the initial state,
+and it happens inside the same effect that will later react to changes —
+no gap for the two to disagree in.
+
+## Verification
+
+- `npx tsc --noEmit` — clean.
+- `npx vitest run` — full suite green, no regressions.
+- No dedicated component-render test exists for either `block.tsx` or
+  `agent-view.tsx` (`Block`/`AgentViewWrapper` are heavy RPC/store
+  orchestration components with no existing render harness — the same gap
+  PR #2622 and PR #2768 both explicitly flagged and deferred). Following
+  the same precedent rather than introducing a new, riskier test harness
+  under this fix; not manually re-verified in a running browser this pass
+  either — flagging plainly rather than claiming visual confirmation that
+  wasn't done.
+
+## Prevention / follow-ups
+
+- Not done here, deliberately: extracting a shared `createRevealGate`
+  primitive for the two now-identical fixed patterns. Would reduce future
+  duplication risk but widens this fix's diff and touches both call sites'
+  signal names — left as a follow-up rather than bundled into a bug fix.
+- Worth a broader sweep for any OTHER `on(signal, ..., { defer: true })`
+  use paired with a construction-time seed derived from that same signal —
+  this exact shape is the actual bug pattern, not something specific to
+  spinners. Not performed in this pass.

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -25,7 +25,7 @@ import { focusedBlockId } from "@/util/focusutil";
 import { isBlank, useAtomValueSafe } from "@/util/util";
 import clsx from "clsx";
 import type { JSX } from "solid-js";
-import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, Suspense } from "solid-js";
+import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, Suspense } from "solid-js";
 import "./block.scss";
 import "./pane-size-badge.scss";
 import { BlockErrorBoundary } from "./BlockErrorBoundary";
@@ -304,47 +304,63 @@ function Block(props: BlockProps): JSX.Element {
     // content instead of an instant hard cut (SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md
     // §2.3/§4 Option B) — this is generic over every block type (agent,
     // terminal, browser, ...), unlike agent-view.tsx's picker-fade which is
-    // agent-specific. `spinnerVisible`'s initial value is read once, at
-    // this component's own construction: if `ready()` is already true at
-    // mount (data arrived before the first paint), there's no spinner-to-
-    // content transition to smooth, so it should start false.
-    const [spinnerVisible, setSpinnerVisible] = createSignal(!ready());
+    // agent-specific.
+    //
+    // An earlier version seeded `spinnerVisible` from `!ready()` read once
+    // at construction (synchronous), then relied on `on(ready, ...,
+    // {defer: true})`'s first (swallowed) run to treat "already ready" as
+    // "nothing to do." Those are two DIFFERENT reads of `ready()` taken at
+    // two different times — construction vs. the effect's first flush a
+    // render pass later — so a block whose data resolves in that gap (the
+    // common case for an already-warm cache) got seeded `true` and then
+    // never corrected: `defer` skips the one call that would have set it
+    // to `false`, and since `ready()` never changes again, nothing else
+    // ever runs it either. The spinner stayed mounted at full opacity
+    // indefinitely (see docs/retro/retro-block-ready-gate-spinner-stuck-visible-race-2026-08-23.md).
+    // Fixed by making the first observation of `ready()` and the seed the
+    // same read, inside the same effect — no gap for them to disagree in.
+    const [spinnerVisible, setSpinnerVisible] = createSignal(true);
     const [spinnerFading, setSpinnerFading] = createSignal(false);
     let spinnerFadeRaf: number | undefined;
     let spinnerFadeTimeout: ReturnType<typeof setTimeout> | undefined;
+    let spinnerGateInitialized = false;
     onCleanup(() => {
         if (spinnerFadeRaf !== undefined) cancelAnimationFrame(spinnerFadeRaf);
         clearTimeout(spinnerFadeTimeout);
     });
-    createEffect(
-        on(
-            ready,
-            (isReady) => {
-                if (spinnerFadeRaf !== undefined) cancelAnimationFrame(spinnerFadeRaf);
-                clearTimeout(spinnerFadeTimeout);
-                if (isReady) {
-                    if (!spinnerVisible()) return; // already past the transition
-                    // One rAF so the spinner paints at full opacity at
-                    // least once before the fade starts — flipping
-                    // straight to the "is-fading" class in this same tick
-                    // would apply opacity:0 on the very first paint, with
-                    // nothing to visibly transition from.
-                    spinnerFadeRaf = requestAnimationFrame(() => setSpinnerFading(true));
-                    spinnerFadeTimeout = setTimeout(() => {
-                        setSpinnerVisible(false);
-                        setSpinnerFading(false);
-                    }, READY_GATE_FADE_MS);
-                } else {
-                    // Not ready anymore (e.g. the view type changed out
-                    // from under this block) — show the spinner again
-                    // immediately, no fade needed going this direction.
-                    setSpinnerFading(false);
-                    setSpinnerVisible(true);
-                }
-            },
-            { defer: true }
-        )
-    );
+    createEffect(() => {
+        const isReady = ready();
+        if (spinnerFadeRaf !== undefined) cancelAnimationFrame(spinnerFadeRaf);
+        clearTimeout(spinnerFadeTimeout);
+        if (!spinnerGateInitialized) {
+            // First observation of `ready()` for this mount: reflect it
+            // directly, no fade — there's nothing painted yet to fade
+            // from either way.
+            spinnerGateInitialized = true;
+            setSpinnerVisible(!isReady);
+            setSpinnerFading(false);
+            return;
+        }
+        if (isReady) {
+            if (!spinnerVisible()) return; // already past the transition
+            // One rAF so the spinner paints at full opacity at least once
+            // before the fade starts — flipping straight to the
+            // "is-fading" class in this same tick would apply opacity:0
+            // on the very first paint, with nothing to visibly transition
+            // from.
+            spinnerFadeRaf = requestAnimationFrame(() => setSpinnerFading(true));
+            spinnerFadeTimeout = setTimeout(() => {
+                setSpinnerVisible(false);
+                setSpinnerFading(false);
+            }, READY_GATE_FADE_MS);
+        } else {
+            // Not ready anymore (e.g. the view type changed out from
+            // under this block) — show the spinner again immediately, no
+            // fade needed going this direction.
+            setSpinnerFading(false);
+            setSpinnerVisible(true);
+        }
+    });
 
     // Per-block ErrorBoundary: a renderer fault in this pane only blanks
     // THIS pane, not the whole tab. See retro

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -178,48 +178,59 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     // agent from a blank "+" tab's picker — no block-stack mutation, no
     // node remount, so PR #2761's leaf reveal gate never covers this
     // transition at all). SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md
-    // §2.3/§4 Option B. `pickerVisible`'s initial value is read once, at
-    // this component's own construction — correct either way: if agentId()
-    // is already set at mount (a fresh remount straight into a launched
-    // agent), there's no picker-to-content transition to smooth, so it
-    // should start false; if empty, the fallback below needs to render.
-    const [pickerVisible, setPickerVisible] = createSignal(!agentId());
+    // §2.3/§4 Option B.
+    //
+    // Same stuck-visible race as block.tsx's ready()-gate (see
+    // docs/retro/retro-block-ready-gate-spinner-stuck-visible-race-2026-08-23.md):
+    // seeding `pickerVisible` from `!agentId()` read once at construction,
+    // then relying on `on(agentId, ..., {defer: true})`'s first (swallowed)
+    // run to treat "agentId already set" as "nothing to do," is two
+    // different reads of `agentId()` taken at two different times. If
+    // `agentId()` resolves in the gap between them, the seed is never
+    // corrected. Fixed the same way: the first observation and the seed
+    // are now the same read, inside the same effect.
+    const [pickerVisible, setPickerVisible] = createSignal(true);
     const [pickerFadingOut, setPickerFadingOut] = createSignal(false);
     let pickerFadeRaf: number | undefined;
     let pickerFadeTimeout: ReturnType<typeof setTimeout> | undefined;
+    let pickerGateInitialized = false;
     onCleanup(() => {
         if (pickerFadeRaf !== undefined) cancelAnimationFrame(pickerFadeRaf);
         clearTimeout(pickerFadeTimeout);
     });
-    createEffect(
-        on(
-            agentId,
-            (id) => {
-                if (pickerFadeRaf !== undefined) cancelAnimationFrame(pickerFadeRaf);
-                clearTimeout(pickerFadeTimeout);
-                if (id) {
-                    if (!pickerVisible()) return; // already past the transition
-                    // One rAF so the picker paints at full opacity at least
-                    // once before the fade starts — flipping straight to
-                    // the "is-fading" class in this same tick would apply
-                    // opacity:0 on the very first paint, with nothing to
-                    // visibly transition from.
-                    pickerFadeRaf = requestAnimationFrame(() => setPickerFadingOut(true));
-                    pickerFadeTimeout = setTimeout(() => {
-                        setPickerVisible(false);
-                        setPickerFadingOut(false);
-                    }, PICKER_FADE_OUT_MS);
-                } else {
-                    // Lost the agentId (not a normal path, but stay
-                    // correct) — show the picker again immediately, no
-                    // fade needed going this direction.
-                    setPickerFadingOut(false);
-                    setPickerVisible(true);
-                }
-            },
-            { defer: true }
-        )
-    );
+    createEffect(() => {
+        const id = agentId();
+        if (pickerFadeRaf !== undefined) cancelAnimationFrame(pickerFadeRaf);
+        clearTimeout(pickerFadeTimeout);
+        if (!pickerGateInitialized) {
+            // First observation of `agentId()` for this mount: reflect it
+            // directly, no fade — there's nothing painted yet to fade from
+            // either way.
+            pickerGateInitialized = true;
+            setPickerVisible(!id);
+            setPickerFadingOut(false);
+            return;
+        }
+        if (id) {
+            if (!pickerVisible()) return; // already past the transition
+            // One rAF so the picker paints at full opacity at least once
+            // before the fade starts — flipping straight to the
+            // "is-fading" class in this same tick would apply opacity:0
+            // on the very first paint, with nothing to visibly transition
+            // from.
+            pickerFadeRaf = requestAnimationFrame(() => setPickerFadingOut(true));
+            pickerFadeTimeout = setTimeout(() => {
+                setPickerVisible(false);
+                setPickerFadingOut(false);
+            }, PICKER_FADE_OUT_MS);
+        } else {
+            // Lost the agentId (not a normal path, but stay correct) —
+            // show the picker again immediately, no fade needed going
+            // this direction.
+            setPickerFadingOut(false);
+            setPickerVisible(true);
+        }
+    });
 
     // Portal target for the marching-ants progress bar (below) — the bar's
     // own working-state/turn-phase reads live inside AgentPresentationView


### PR DESCRIPTION
## Summary

Live-reported: a "pulsating brain logo" (`BrainSpinner`) stuck permanently
visible in agent panes, on top of already-loaded, actively-rendering
content — not a cosmetic flicker, an indefinite stuck state. Confirmed
live in the reporting session's own hosting window via `UIScreenshot` +
`UIQuery`: `.block-ready-gate-host.is-overlay` elements mounted at full
opacity, no `is-fading`, in panes that had been actively rendering new
content for the entire (long, ~180k-token) session.

**Root cause** (full writeup: `docs/retro/retro-block-ready-gate-spinner-stuck-visible-race-2026-08-23.md`):
introduced by #2768's `ready()`-gate cross-fade in `block.tsx`. It seeded
`spinnerVisible` from `!ready()` read once at component *construction*
(synchronous), then relied on `on(ready, ..., { defer: true })`'s first
(swallowed) run to treat "already ready" as "nothing to do" — assuming
that first run would see the same `ready()` value the seed did. It won't,
reliably: `createEffect`'s first flush happens a render pass *after*
construction. If `ready()` flips `false → true` in that gap — the common
case for a block whose `blockData`/`viewModel` resolve from an
already-warm cache within a microtask of mount, not a rare edge case —
the seed (`true`) is never corrected: `defer` skips the one callback
invocation that would set it back to `false`, and since `ready()` never
changes again, nothing else ever does either. Spinner stays mounted,
full opacity, pulsing its normal 1.8s CSS animation, forever.

The identical shape existed in `agent-view.tsx`'s `AgentPicker` ->
`AgentPresentationView` cross-fade, added in the same PR, seeded from
`agentId()` instead of `ready()`. Not separately live-reproduced, but
structurally identical — fixed alongside the confirmed one.

Swept the rest of the frontend for the same pattern (construction-time
seed from a signal + `on(that signal, ..., { defer: true })`) — the only
other `{ defer: true }` sites (`agent-view.tsx`'s turn-end re-poll,
`PaneTabStrip.tsx`'s width transition, two unrelated hooks) don't pair a
construction-time seed with the deferred signal, so they don't have this
bug shape.

## Fix

Collapse the two separate reads into one: read the signal once per effect
run and special-case the first run inline via a local (non-reactive)
`initialized` flag, instead of splitting "seed at construction" and
"react to changes" across two different reactive primitives that have to
agree by coincidence.

```ts
const [spinnerVisible, setSpinnerVisible] = createSignal(true);
let spinnerGateInitialized = false;
createEffect(() => {
    const isReady = ready();
    if (!spinnerGateInitialized) {
        spinnerGateInitialized = true;
        setSpinnerVisible(!isReady);
        setSpinnerFading(false);
        return;
    }
    // ...unchanged fade-out / re-show logic
});
```

Now there is exactly one read of `ready()` deciding the initial state,
inside the same effect that reacts to later changes — no gap for the two
to disagree in. Same treatment applied to `agent-view.tsx`'s
`pickerVisible`/`agentId()` pair.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run app/block app/view/agent` — 1375/1376 passing. The
      one failure (`tool-renderers/registry.test.ts` timeout) is a
      pre-existing flake under full-suite parallel load, already
      documented in `docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md`
      — unrelated to this change, passes in isolation.
- [x] Confirmed the BUG live before this fix: `UIScreenshot` + `UIQuery`
      against a running 0.55.21 portable build showed the exact stuck
      `.block-ready-gate-host.is-overlay` elements described above.
- [ ] Not yet re-verified live with this fix applied (would require a
      fresh build/relaunch) — flagging explicitly rather than claiming
      visual confirmation I don't have.
- No dedicated component-render test exists for `block.tsx` or
  `agent-view.tsx` (`Block`/`AgentViewWrapper` are heavy RPC/store
  orchestration components with no render harness — the same gap #2622
  and #2768 both explicitly flagged and deferred). Followed the same
  precedent rather than introducing a new test harness under a bug fix.

<!-- agentmux:agent_id=agenty -->