### PR TITLE
chore: release v0.55.23

### DIFF
--- a/.changesets/1787545507-fix-agent-surface-a-reconnecting-status-during-stale-resume--f09n.md
+++ b/.changesets/1787545507-fix-agent-surface-a-reconnecting-status-during-stale-resume--f09n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): surface a Reconnecting… status during stale-resume retry

--- a/.changesets/1787550573-fix-agent-pane-stop-the-block-mount-brainspinner-overlay-get-tod8.md
+++ b/.changesets/1787550573-fix-agent-pane-stop-the-block-mount-brainspinner-overlay-get-tod8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): stop the block-mount BrainSpinner overlay getting stuck visible forever

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.22"
+version = "0.55.23"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.22"
+version = "0.55.23"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.22"
+version = "0.55.23"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.22"
+version = "0.55.23"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.22"
+version = "0.55.23"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.22"
+version = "0.55.23"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.22"
+version = "0.55.23"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,11 @@
 # AgentMux Version History
 
+## 0.55.23 — 2026-08-23
+
+- fix(agent): surface a Reconnecting… status during stale-resume retry
+- fix(agent-pane): stop the block-mount BrainSpinner overlay getting stuck visible forever
+
+
 ## 0.55.22 — 2026-08-23
 
 - fix(muxspect): wire transcript_request jekt tier enforcement into the WAN delivery path (Phase C)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.22",
+  "version": "0.55.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.22",
+      "version": "0.55.23",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.22",
+  "version": "0.55.23",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release consuming 2 pending changesets:

- fix(agent): surface a Reconnecting… status during stale-resume retry
- fix(agent-pane): stop the block-mount BrainSpinner overlay getting stuck visible forever (#2777)

`0.55.22 -> 0.55.23`, all 5 version locations (Cargo.toml, Cargo.lock, package.json, package-lock.json, VERSION_HISTORY.md) verified in agreement by `task release:patch`.

## Test plan

- [x] `task release:patch` reported all 5 version locations agree at 0.55.23.
- [x] Diff reviewed before commit — only version files + VERSION_HISTORY.md + changeset deletions, no source changes.

<!-- agentmux:agent_id=agenty -->