### PR TITLE
fix(agent-pane): strip common indentation from mid-file tool previews

### DIFF
--- a/.changesets/1787554977-fix-agent-pane-strip-common-indentation-from-mid-file-tool-p-9uya.md
+++ b/.changesets/1787554977-fix-agent-pane-strip-common-indentation-from-mid-file-tool-p-9uya.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): strip common indentation from mid-file tool previews

--- a/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
@@ -1,7 +1,12 @@
 # SPEC: Tool preview common-indentation stripping (dedent)
 
 **Date:** 2026-08-08
-**Status:** proposed — verified unimplemented as of 2026-08-10 (sibling refinement #2467 shipped; this one did not).
+**Status:** implemented 2026-08-24. `stripCommonIndentSharedPrefix` was added
+as a third exported helper (not spelled out in §3.1's two-function sketch) to
+keep the Edit call site's "one shared prefix across two related strings"
+concern inside this module rather than duplicated at the DiffViewer call
+site. Live-pane visual verification (§5) not yet done as of this PR — see
+the PR body for why, and do it before/at merge if practical.
 **Scope:** `frontend/app/view/agent/components/ToolOverlayLog.tsx`,
 `frontend/app/view/agent/components/DiffViewer.tsx`, one new shared util
 (+ tests)

--- a/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
@@ -7,6 +7,17 @@ keep the Edit call site's "one shared prefix across two related strings"
 concern inside this module rather than duplicated at the DiffViewer call
 site. Live-pane visual verification (§5) not yet done as of this PR — see
 the PR body for why, and do it before/at merge if practical.
+
+Two issues found by reagent review on PR #2780, both fixed same-day: (1)
+`renderWrite` was calling the Read-specific numbered-line dedent variant on
+raw Write content, misreading a genuine tab-delimited data file's leading
+numeric column as a line-number gutter — switched to the plain
+`stripCommonIndent`. (2) `capText`'s char-budget truncation marker is a
+column-0 line that can land inside capped preview text and was not excluded
+from the common-prefix computation, silently defeating dedent (or, on the
+numbered Read path, the "every line numbered" check) for any node whose
+content exceeded `MAX_TOOL_OUTPUT_CHARS` — `dedent.ts` now treats the
+marker as ignorable exactly like a blank line.
 **Scope:** `frontend/app/view/agent/components/ToolOverlayLog.tsx`,
 `frontend/app/view/agent/components/DiffViewer.tsx`, one new shared util
 (+ tests)

--- a/frontend/app/view/agent/components/DiffViewer.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.tsx
@@ -25,6 +25,7 @@ import type { EditParams, EditResult } from "../types";
 import { detectLanguage } from "./detectLanguage";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { stripCommonIndentSharedPrefix } from "./dedent";
 
 const ShikiTheme = "github-dark-high-contrast";
 
@@ -133,7 +134,14 @@ export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
         if (succeeded) {
             const p = props.params;
             if (p && (p.old_string != null || p.new_string != null)) {
-                return buildDiffFromParams(p.old_string ?? "", p.new_string ?? "");
+                // Dedent BEFORE building the diff, with one prefix shared
+                // across both sides (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
+                // §3.2.2) — an independent per-side dedent could shift one
+                // side by a different amount than the other (e.g. new_string
+                // adding a shallower wrapper line) and manufacture a phantom
+                // indentation diff that was never actually part of the edit.
+                const { oldStr, newStr } = stripCommonIndentSharedPrefix(p.old_string ?? "", p.new_string ?? "");
+                return buildDiffFromParams(oldStr, newStr);
             }
         }
         return undefined;

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -27,7 +27,7 @@ import { DiffViewer } from "./DiffViewer";
 import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capChars, createChunkCapper, createSpinnerCollapser, capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
-import { stripCommonIndentNumbered } from "./dedent";
+import { stripCommonIndent, stripCommonIndentNumbered } from "./dedent";
 import { detectLanguage } from "./detectLanguage";
 import {
     registerToolRenderer,
@@ -519,12 +519,14 @@ function renderWrite(node: ToolNode): JSX.Element {
     const content: string | undefined = (node.params as any).content;
     const bytes: number | undefined = (node.result as any)?.bytesWritten;
     const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
-    // Same helper as Read (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.3) —
-    // a whole written file almost always starts at column 0 already (the
-    // numbered variant falls through to a no-op plain dedent when no line
-    // matches the "<N>\t" shape, which every Write body hits), so this is
-    // included for uniformity rather than because Write is commonly indented.
-    const dedentedText = capped ? stripCommonIndentNumbered(capped.text) : "";
+    // Plain dedent, NOT the Read-specific numbered variant
+    // (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.3) — Write content has no
+    // CLI-added "<N>\t" line-number prefix, so stripCommonIndentNumbered's
+    // heuristic would misfire on a genuine tab-delimited file (TSV/BED/GTF)
+    // whose every non-blank line happens to start with digits+tab, silently
+    // dropping that real leading column. stripCommonIndent has no such
+    // ambiguity and is a no-op for the common already-flush case anyway.
+    const dedentedText = capped ? stripCommonIndent(capped.text) : "";
     const isMarkdown = filePath.endsWith(".md") || filePath.endsWith(".mdx");
     return (
         <div class="agent-tool-write">

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -27,6 +27,7 @@ import { DiffViewer } from "./DiffViewer";
 import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capChars, createChunkCapper, createSpinnerCollapser, capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { stripCommonIndentNumbered } from "./dedent";
 import { detectLanguage } from "./detectLanguage";
 import {
     registerToolRenderer,
@@ -461,6 +462,13 @@ function renderRead(node: ToolNode): JSX.Element {
     // the conversation DOM; HighlightedCode stays simple (it injects
     // innerHTML, so capping here is cleaner than inside it).
     const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
+    // Strip indentation common to every VISIBLE line — computed after
+    // capping so a deeper hidden tail can't reduce the dedent of what's
+    // actually shown (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.1). Claude
+    // Code's Read result lines are "<N>\t<code>"; the numbered variant
+    // splits off that prefix before dedenting so the line-number gutter
+    // itself is untouched.
+    const dedentedText = capped ? stripCommonIndentNumbered(capped.text) : "";
     // Render markdown files as formatted markdown, matching renderWrite. Without
     // this a .md Read shows raw source instead of a rendered preview.
     const isMarkdown = filePath.endsWith(".md") || filePath.endsWith(".mdx");
@@ -479,14 +487,17 @@ function renderRead(node: ToolNode): JSX.Element {
                     when={isMarkdown}
                     fallback={
                         <HighlightedCode
-                            code={capped!.text}
+                            code={dedentedText}
+                            // Language detection reads the RAW (non-dedented) first
+                            // line — shebang/content sniffing should see the file
+                            // as-is; only the displayed text is dedented.
                             lang={detectLanguage(filePath, capped!.text.split("\n")[0])}
                             class="agent-tool-read-content"
                         />
                     }
                 >
                     <div class="agent-tool-read-content agent-tool-read-md">
-                        <Markdown text={capped!.text} />
+                        <Markdown text={dedentedText} />
                     </div>
                 </Show>
                 <Show when={capped!.hiddenLines > 0}>
@@ -508,6 +519,12 @@ function renderWrite(node: ToolNode): JSX.Element {
     const content: string | undefined = (node.params as any).content;
     const bytes: number | undefined = (node.result as any)?.bytesWritten;
     const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
+    // Same helper as Read (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.3) —
+    // a whole written file almost always starts at column 0 already (the
+    // numbered variant falls through to a no-op plain dedent when no line
+    // matches the "<N>\t" shape, which every Write body hits), so this is
+    // included for uniformity rather than because Write is commonly indented.
+    const dedentedText = capped ? stripCommonIndentNumbered(capped.text) : "";
     const isMarkdown = filePath.endsWith(".md") || filePath.endsWith(".mdx");
     return (
         <div class="agent-tool-write">
@@ -522,14 +539,14 @@ function renderWrite(node: ToolNode): JSX.Element {
                     when={isMarkdown}
                     fallback={
                         <HighlightedCode
-                            code={capped!.text}
+                            code={dedentedText}
                             lang={detectLanguage(filePath, capped!.text.split("\n")[0])}
                             class="agent-tool-write-content"
                         />
                     }
                 >
                     <div class="agent-tool-write-content agent-tool-write-md">
-                        <Markdown text={capped!.text} />
+                        <Markdown text={dedentedText} />
                     </div>
                 </Show>
                 <Show when={capped!.hiddenLines > 0}>

--- a/frontend/app/view/agent/components/dedent.test.ts
+++ b/frontend/app/view/agent/components/dedent.test.ts
@@ -1,0 +1,157 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { stripCommonIndent, stripCommonIndentNumbered, stripCommonIndentSharedPrefix } from "./dedent";
+
+describe("stripCommonIndent", () => {
+    it("strips a uniform space indent to flush, preserving relative levels", () => {
+        const input = "    if (x) {\n        doThing();\n    }";
+        const out = stripCommonIndent(input);
+        expect(out).toBe("if (x) {\n    doThing();\n}");
+    });
+
+    it("strips a uniform tab indent by literal tab prefix", () => {
+        const input = "\tif (x) {\n\t\tdoThing();\n\t}";
+        const out = stripCommonIndent(input);
+        expect(out).toBe("if (x) {\n\tdoThing();\n}");
+    });
+
+    it("is a no-op when tabs and spaces disagree at the same depth (no true common prefix)", () => {
+        const input = "\tfoo();\n    bar();";
+        expect(stripCommonIndent(input)).toBe(input);
+    });
+
+    it("ignores blank lines when computing the common prefix, and leaves them empty in output", () => {
+        const input = "    a();\n\n    b();";
+        expect(stripCommonIndent(input)).toBe("a();\n\nb();");
+    });
+
+    it("ignores whitespace-only blank lines the same as fully-empty ones", () => {
+        const input = "    a();\n   \n    b();";
+        const out = stripCommonIndent(input);
+        expect(out).toBe("a();\n   \nb();");
+    });
+
+    it("is a no-op for already-flush content (column-0 lines)", () => {
+        const input = "a();\nb();\nif (x) {\n    c();\n}";
+        expect(stripCommonIndent(input)).toBe(input);
+    });
+
+    it("handles a single-line input", () => {
+        expect(stripCommonIndent("    solo();")).toBe("solo();");
+    });
+
+    it("handles all-blank content as a no-op", () => {
+        expect(stripCommonIndent("   \n\t\n   ")).toBe("   \n\t\n   ");
+    });
+
+    it("handles an empty string", () => {
+        expect(stripCommonIndent("")).toBe("");
+    });
+
+    it("does not treat a CRLF line's trailing \\r as part of the indent", () => {
+        const input = "    a();\r\n    b();\r";
+        const out = stripCommonIndent(input);
+        expect(out).toBe("a();\r\nb();\r");
+    });
+
+    it("dedents by the SHALLOWEST line's indent, not the deepest", () => {
+        const input = "  outer();\n    inner();\n  outer2();";
+        const out = stripCommonIndent(input);
+        expect(out).toBe("outer();\n  inner();\nouter2();");
+    });
+});
+
+describe("stripCommonIndentNumbered", () => {
+    it("preserves the N\\t prefix and dedents only the code portion", () => {
+        const input = "80\t        unsetEnv: [\"CLAUDECODE\"],\n81\t            authConfigDirEnvVar: \"X\",";
+        const out = stripCommonIndentNumbered(input);
+        expect(out).toBe('80\tunsetEnv: ["CLAUDECODE"],\n81\t    authConfigDirEnvVar: "X",');
+    });
+
+    it("falls through to plain dedent for non-uniformly-numbered input", () => {
+        const input = "1\tfoo();\nnot numbered\n3\tbar();";
+        // Not every non-blank line matches the numbered shape, so this
+        // falls through to stripCommonIndent on the raw text — which finds
+        // no common leading whitespace here (lines start with digits/text),
+        // so it's a no-op.
+        expect(stripCommonIndentNumbered(input)).toBe(input);
+    });
+
+    it("falls through to plain dedent for completely unnumbered input", () => {
+        const input = "    a();\n    b();";
+        expect(stripCommonIndentNumbered(input)).toBe("a();\nb();");
+    });
+
+    it("is a no-op when the numbered code portions have no common indent", () => {
+        const input = "1\ta();\n2\t    b();";
+        expect(stripCommonIndentNumbered(input)).toBe(input);
+    });
+
+    it("handles blank lines within numbered content", () => {
+        const input = "1\t    a();\n2\t\n3\t    b();";
+        const out = stripCommonIndentNumbered(input);
+        expect(out).toBe("1\ta();\n2\t\n3\tb();");
+    });
+
+    it("handles an empty string", () => {
+        expect(stripCommonIndentNumbered("")).toBe("");
+    });
+
+    it("handles a single numbered line", () => {
+        expect(stripCommonIndentNumbered("1\t    solo();")).toBe("1\tsolo();");
+    });
+
+    it("tolerates multi-digit line numbers and varying digit widths", () => {
+        const input = "9\t    a();\n10\t    b();\n100\t    c();";
+        const out = stripCommonIndentNumbered(input);
+        expect(out).toBe("9\ta();\n10\tb();\n100\tc();");
+    });
+});
+
+describe("stripCommonIndentSharedPrefix", () => {
+    it("dedents both sides by ONE shared prefix, preserving add/del alignment", () => {
+        const oldStr = "        const x = 1;\n        return x;";
+        const newStr = "        const x = 2;\n        return x;";
+        const { oldStr: o, newStr: n } = stripCommonIndentSharedPrefix(oldStr, newStr);
+        expect(o).toBe("const x = 1;\nreturn x;");
+        expect(n).toBe("const x = 2;\nreturn x;");
+    });
+
+    it("uses the MINIMUM shared indent across both sides when they differ", () => {
+        // new_string adds a shallower wrapper line — the shared prefix must
+        // be the min of the two sides' own minimums, not either side alone,
+        // so relative indentation between old and new lines up correctly.
+        const oldStr = "        inner();";
+        const newStr = "      if (cond) {\n        inner();\n      }";
+        const { oldStr: o, newStr: n } = stripCommonIndentSharedPrefix(oldStr, newStr);
+        expect(o).toBe("  inner();");
+        expect(n).toBe("if (cond) {\n  inner();\n}");
+    });
+
+    it("is a no-op when there is no shared prefix across both sides", () => {
+        const oldStr = "\tfoo();";
+        const newStr = "    bar();";
+        const result = stripCommonIndentSharedPrefix(oldStr, newStr);
+        expect(result.oldStr).toBe(oldStr);
+        expect(result.newStr).toBe(newStr);
+    });
+
+    it("handles empty old_string (pure insertion)", () => {
+        const { oldStr, newStr } = stripCommonIndentSharedPrefix("", "    added();");
+        expect(oldStr).toBe("");
+        expect(newStr).toBe("added();");
+    });
+
+    it("handles empty new_string (pure deletion)", () => {
+        const { oldStr, newStr } = stripCommonIndentSharedPrefix("    removed();", "");
+        expect(oldStr).toBe("removed();");
+        expect(newStr).toBe("");
+    });
+
+    it("handles both sides empty", () => {
+        const result = stripCommonIndentSharedPrefix("", "");
+        expect(result).toEqual({ oldStr: "", newStr: "" });
+    });
+});

--- a/frontend/app/view/agent/components/dedent.test.ts
+++ b/frontend/app/view/agent/components/dedent.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import { stripCommonIndent, stripCommonIndentNumbered, stripCommonIndentSharedPrefix } from "./dedent";
+import { TRUNCATED_MARKER } from "./output-cap";
 
 describe("stripCommonIndent", () => {
     it("strips a uniform space indent to flush, preserving relative levels", () => {
@@ -61,6 +62,12 @@ describe("stripCommonIndent", () => {
         const out = stripCommonIndent(input);
         expect(out).toBe("outer();\n  inner();\nouter2();");
     });
+
+    it("ignores capText's truncation marker line when computing the common prefix, and leaves it unstripped", () => {
+        const input = `    a();\n    b();\n${TRUNCATED_MARKER}`;
+        const out = stripCommonIndent(input);
+        expect(out).toBe(`a();\nb();\n${TRUNCATED_MARKER}`);
+    });
 });
 
 describe("stripCommonIndentNumbered", () => {
@@ -107,6 +114,12 @@ describe("stripCommonIndentNumbered", () => {
         const input = "9\t    a();\n10\t    b();\n100\t    c();";
         const out = stripCommonIndentNumbered(input);
         expect(out).toBe("9\ta();\n10\tb();\n100\tc();");
+    });
+
+    it("ignores a trailing truncation marker so the numbered-shape check still passes and the code still dedents", () => {
+        const input = `80\t    a();\n81\t    b();\n${TRUNCATED_MARKER}`;
+        const out = stripCommonIndentNumbered(input);
+        expect(out).toBe(`80\ta();\n81\tb();\n${TRUNCATED_MARKER}`);
     });
 });
 

--- a/frontend/app/view/agent/components/dedent.ts
+++ b/frontend/app/view/agent/components/dedent.ts
@@ -14,6 +14,8 @@
  * SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md.
  */
 
+import { TRUNCATED_MARKER } from "./output-cap";
+
 /** Leading run of spaces/tabs. `\r` is deliberately excluded so a CRLF
  *  line's trailing `\r` (see `splitLines`) never gets treated as part of
  *  the indent. */
@@ -24,6 +26,20 @@ const LEADING_WHITESPACE_RE = /^[ \t]*/;
  *  occur in practice, but isn't assumed away — degrades to the plain
  *  dedent path rather than corrupting a subset of lines. */
 const NUMBERED_LINE_RE = /^\s*\d+\t/;
+
+/** Is `line` ignorable for common-indent purposes — a blank line, or
+ *  `capText`'s char-budget truncation marker (`output-cap.ts`)? Both can
+ *  land inside otherwise-uniformly-indented preview text: a blank line
+ *  carries no indentation signal, and the marker is a column-0 line
+ *  injected by capping, not real file content. Either would otherwise force
+ *  the common prefix to empty (or, for the numbered Read variant, break the
+ *  "every non-blank line is numbered" check and fall through to a
+ *  whole-text dedent that finds no common prefix at all) — so both are
+ *  excluded from the computation and left unstripped in the output, exactly
+ *  like a blank line already was. */
+function isIgnorableForIndent(line: string): boolean {
+    return line.trim() === "" || line === TRUNCATED_MARKER;
+}
 
 /** Split on `\n`, tolerating a CRLF source (`\r` stays attached to each
  *  line here; callers that need to inspect content should trim it, but
@@ -36,18 +52,19 @@ function splitLines(text: string): string[] {
 }
 
 /** Literal longest-common-leading-whitespace prefix across `lines`,
- *  ignoring blank (whitespace-only) lines for the computation — a blank
- *  line carries no indentation signal and would otherwise force the
- *  common prefix to empty for an all-but-one-blank-line snippet. Compared
- *  as a literal string prefix (not by counting tab-equivalent columns), so
- *  tabs and spaces are never conflated: `"\t\tfoo"` and `"    foo"` share
- *  no common prefix and dedent is correctly a no-op — there is no reliable
- *  way to know how wide a tab renders, so guessing would sometimes be
- *  wrong; declining to dedent is always safe. */
+ *  ignoring lines {@link isIgnorableForIndent} flags (blank lines, and
+ *  `capText`'s truncation marker) for the computation — neither carries an
+ *  indentation signal and either would otherwise force the common prefix to
+ *  empty for an otherwise-uniformly-indented snippet. Compared as a literal
+ *  string prefix (not by counting tab-equivalent columns), so tabs and
+ *  spaces are never conflated: `"\t\tfoo"` and `"    foo"` share no common
+ *  prefix and dedent is correctly a no-op — there is no reliable way to know
+ *  how wide a tab renders, so guessing would sometimes be wrong; declining
+ *  to dedent is always safe. */
 function commonLeadingWhitespace(lines: readonly string[]): string {
     let common: string | null = null;
     for (const line of lines) {
-        if (line.trim() === "") continue; // blank line — no signal
+        if (isIgnorableForIndent(line)) continue;
         const indent = LEADING_WHITESPACE_RE.exec(line)![0];
         if (common === null) {
             common = indent;
@@ -63,13 +80,13 @@ function commonLeadingWhitespace(lines: readonly string[]): string {
     return common ?? "";
 }
 
-/** Strip `prefix` (a literal leading-whitespace run) from every non-blank
- *  line of `lines`; blank lines pass through unchanged (there is nothing
- *  to strip, and forcing them to `""` would be indistinguishable from
- *  already-empty input — they already read as empty either way). */
+/** Strip `prefix` (a literal leading-whitespace run) from every line of
+ *  `lines` that isn't {@link isIgnorableForIndent}; blank lines and the
+ *  truncation marker pass through unchanged — there is nothing meaningful
+ *  to strip from either. */
 function stripPrefixFromLines(lines: readonly string[], prefix: string): string[] {
     if (prefix === "") return lines.slice();
-    return lines.map((line) => (line.trim() === "" ? line : line.slice(prefix.length)));
+    return lines.map((line) => (isIgnorableForIndent(line) ? line : line.slice(prefix.length)));
 }
 
 /**
@@ -104,14 +121,20 @@ export function stripCommonIndent(text: string): string {
 export function stripCommonIndentNumbered(text: string): string {
     if (!text) return text;
     const lines = splitLines(text);
-    const nonBlank = lines.filter((l) => l.trim() !== "");
-    const allNumbered = nonBlank.length > 0 && nonBlank.every((l) => NUMBERED_LINE_RE.test(l));
+    // Blank lines AND the truncation marker are excluded from the
+    // "every line is numbered" check, same rationale as everywhere else in
+    // this file: neither is real Read content, so requiring either to match
+    // the `<N>\t` shape would wrongly reject an otherwise-fully-numbered,
+    // truncated body and fall through to a whole-text dedent that finds no
+    // common prefix at all (every real line still starts with a digit).
+    const relevant = lines.filter((l) => !isIgnorableForIndent(l));
+    const allNumbered = relevant.length > 0 && relevant.every((l) => NUMBERED_LINE_RE.test(l));
     if (!allNumbered) return stripCommonIndent(text);
 
     const numberPrefixes: string[] = [];
     const codes: string[] = [];
     for (const line of lines) {
-        if (line.trim() === "") {
+        if (isIgnorableForIndent(line)) {
             numberPrefixes.push("");
             codes.push(line);
             continue;

--- a/frontend/app/view/agent/components/dedent.ts
+++ b/frontend/app/view/agent/components/dedent.ts
@@ -1,0 +1,148 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Common-indentation stripping for tool previews (Read/Write/Edit). A
+ * mid-file snippet — a Read at an offset, or an Edit hunk deep inside a
+ * nested scope — carries the source file's original leading indentation on
+ * every line even though the preview can't show the enclosing scopes that
+ * indentation refers to. Stripping the indentation common to every
+ * displayed line makes the shallowest line render flush-left while keeping
+ * the *relative* indentation between lines — the part that actually
+ * encodes structure.
+ *
+ * SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md.
+ */
+
+/** Leading run of spaces/tabs. `\r` is deliberately excluded so a CRLF
+ *  line's trailing `\r` (see `splitLines`) never gets treated as part of
+ *  the indent. */
+const LEADING_WHITESPACE_RE = /^[ \t]*/;
+
+/** A Claude Code `Read` result line: `<line number><tab><code>`. Matched
+ *  per-line (not per-text) so a partially-numbered body — which shouldn't
+ *  occur in practice, but isn't assumed away — degrades to the plain
+ *  dedent path rather than corrupting a subset of lines. */
+const NUMBERED_LINE_RE = /^\s*\d+\t/;
+
+/** Split on `\n`, tolerating a CRLF source (`\r` stays attached to each
+ *  line here; callers that need to inspect content should trim it, but
+ *  dedent itself only ever reads/removes the LEADING whitespace run, which
+ *  `LEADING_WHITESPACE_RE` never includes `\r` in — so a trailing `\r` is
+ *  simply carried through untouched in both the prefix computation and the
+ *  stripped output). */
+function splitLines(text: string): string[] {
+    return text.split("\n");
+}
+
+/** Literal longest-common-leading-whitespace prefix across `lines`,
+ *  ignoring blank (whitespace-only) lines for the computation — a blank
+ *  line carries no indentation signal and would otherwise force the
+ *  common prefix to empty for an all-but-one-blank-line snippet. Compared
+ *  as a literal string prefix (not by counting tab-equivalent columns), so
+ *  tabs and spaces are never conflated: `"\t\tfoo"` and `"    foo"` share
+ *  no common prefix and dedent is correctly a no-op — there is no reliable
+ *  way to know how wide a tab renders, so guessing would sometimes be
+ *  wrong; declining to dedent is always safe. */
+function commonLeadingWhitespace(lines: readonly string[]): string {
+    let common: string | null = null;
+    for (const line of lines) {
+        if (line.trim() === "") continue; // blank line — no signal
+        const indent = LEADING_WHITESPACE_RE.exec(line)![0];
+        if (common === null) {
+            common = indent;
+            continue;
+        }
+        // Shrink `common` to the literal shared prefix of itself and `indent`.
+        let i = 0;
+        const max = Math.min(common.length, indent.length);
+        while (i < max && common[i] === indent[i]) i++;
+        common = common.slice(0, i);
+        if (common === "") break; // already empty — no further line can add one
+    }
+    return common ?? "";
+}
+
+/** Strip `prefix` (a literal leading-whitespace run) from every non-blank
+ *  line of `lines`; blank lines pass through unchanged (there is nothing
+ *  to strip, and forcing them to `""` would be indistinguishable from
+ *  already-empty input — they already read as empty either way). */
+function stripPrefixFromLines(lines: readonly string[], prefix: string): string[] {
+    if (prefix === "") return lines.slice();
+    return lines.map((line) => (line.trim() === "" ? line : line.slice(prefix.length)));
+}
+
+/**
+ * Strip the whitespace indentation common to every non-blank line of
+ * `text`, so the shallowest line renders flush-left. Relative indentation
+ * between lines is always preserved — only the shared prefix is removed.
+ * A no-op (returns `text` unchanged, no allocation) when there is no
+ * common indentation to strip, which covers the common case of an
+ * already-flush Write body.
+ */
+export function stripCommonIndent(text: string): string {
+    if (!text) return text;
+    const lines = splitLines(text);
+    const prefix = commonLeadingWhitespace(lines);
+    if (prefix === "") return text;
+    return stripPrefixFromLines(lines, prefix).join("\n");
+}
+
+/**
+ * Read-tool variant of {@link stripCommonIndent}: Claude Code's `Read`
+ * result lines are `<N>\t<code>` (verified against real session
+ * transcripts) — a plain whole-line dedent would see every line start with
+ * a different digit and find no common prefix at all. When every non-blank
+ * line matches that shape, this splits off the `<N>\t` prefix, dedents only
+ * the code portions together (so relative indentation across lines is
+ * still computed correctly), and rejoins. Any line that doesn't match the
+ * numbered shape — including a completely unnumbered body, e.g. if this
+ * ever runs on non-Read content — falls through to the plain
+ * {@link stripCommonIndent} over the whole text, which is always safe (at
+ * worst a no-op).
+ */
+export function stripCommonIndentNumbered(text: string): string {
+    if (!text) return text;
+    const lines = splitLines(text);
+    const nonBlank = lines.filter((l) => l.trim() !== "");
+    const allNumbered = nonBlank.length > 0 && nonBlank.every((l) => NUMBERED_LINE_RE.test(l));
+    if (!allNumbered) return stripCommonIndent(text);
+
+    const numberPrefixes: string[] = [];
+    const codes: string[] = [];
+    for (const line of lines) {
+        if (line.trim() === "") {
+            numberPrefixes.push("");
+            codes.push(line);
+            continue;
+        }
+        const m = NUMBERED_LINE_RE.exec(line)!;
+        numberPrefixes.push(m[0]);
+        codes.push(line.slice(m[0].length));
+    }
+    const commonCodeIndent = commonLeadingWhitespace(codes);
+    if (commonCodeIndent === "") return text;
+    const dedentedCodes = stripPrefixFromLines(codes, commonCodeIndent);
+    return lines.map((_, i) => numberPrefixes[i] + dedentedCodes[i]).join("\n");
+}
+
+/**
+ * Dedent an Edit hunk's `old_string`/`new_string` pair with ONE shared
+ * prefix computed across both sides together, then applied to each
+ * independently — not two independent dedents. A shared prefix preserves
+ * add/del line alignment; if one side happened to have a shallower minimum
+ * indent than the other (e.g. `new_string` adds a less-nested wrapper
+ * line), an independent per-side dedent would shift that side by a
+ * different amount than the other, manufacturing a phantom indentation
+ * diff that was never actually part of the edit.
+ */
+export function stripCommonIndentSharedPrefix(oldStr: string, newStr: string): { oldStr: string; newStr: string } {
+    const oldLines = splitLines(oldStr ?? "");
+    const newLines = splitLines(newStr ?? "");
+    const prefix = commonLeadingWhitespace([...oldLines, ...newLines]);
+    if (prefix === "") return { oldStr, newStr };
+    return {
+        oldStr: stripPrefixFromLines(oldLines, prefix).join("\n"),
+        newStr: stripPrefixFromLines(newLines, prefix).join("\n"),
+    };
+}

--- a/frontend/app/view/agent/components/output-cap.ts
+++ b/frontend/app/view/agent/components/output-cap.ts
@@ -27,6 +27,13 @@ export interface CappedText {
     hiddenLines: number;
 }
 
+/** The literal marker line `capText` inserts when the char budget (not just
+ *  the line budget) trims a body — exported so callers that post-process
+ *  capped text (e.g. `dedent.ts`'s common-indent stripping) can recognize
+ *  and skip over it rather than treating it as a real, column-0 content
+ *  line. */
+export const TRUNCATED_MARKER = "…(truncated)";
+
 /**
  * Cap a text body to `max` lines, keeping the head or the tail. Logs and
  * command output use "tail" (the latest matters); file/diff content uses
@@ -56,8 +63,8 @@ export function capText(
     // marker so the rendered <pre> stays bounded regardless of line count.
     if (out.length > MAX_TOOL_OUTPUT_CHARS) {
         out = from === "tail"
-            ? "…(truncated)\n" + out.slice(out.length - MAX_TOOL_OUTPUT_CHARS)
-            : out.slice(0, MAX_TOOL_OUTPUT_CHARS) + "\n…(truncated)";
+            ? TRUNCATED_MARKER + "\n" + out.slice(out.length - MAX_TOOL_OUTPUT_CHARS)
+            : out.slice(0, MAX_TOOL_OUTPUT_CHARS) + "\n" + TRUNCATED_MARKER;
     }
     return { text: out, hiddenLines };
 }
@@ -70,7 +77,7 @@ export function capText(
  */
 export function capChars(text: string, max: number = MAX_TOOL_OUTPUT_CHARS): string {
     if (text.length <= max) return text;
-    return "…(truncated)\n" + text.slice(text.length - max);
+    return TRUNCATED_MARKER + "\n" + text.slice(text.length - max);
 }
 
 export interface CappedChunks<T> {


### PR DESCRIPTION
## Summary
- Implements `docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md` — refinement #2 of the tool-preview series (refinement #1, scrollbar-edge padding, shipped in #2467).
- Root problem: a mid-file `Read` (with `offset`) or an `Edit` hunk deep inside a nested scope renders every line with the source file's full original indentation, even though the preview can't show the enclosing scopes that indentation refers to — wasted columns in an already-tight preview.
- New `frontend/app/view/agent/components/dedent.ts`: literal longest-common-whitespace-prefix stripping (no tab-width guessing — a file mixing tabs/spaces at the same depth correctly no-ops rather than guessing), always preserving *relative* indentation between lines.
  - `stripCommonIndent` — the base algorithm.
  - `stripCommonIndentNumbered` — Read-specific: Claude Code's Read results are `<N>\t<code>` lines (verified against a real session transcript in the spec's research); this splits off that prefix before dedenting so the line-number gutter is untouched, and falls through safely to the plain algorithm if the numbered shape doesn't match.
  - `stripCommonIndentSharedPrefix` — a third helper (not spelled out in the spec's original two-function sketch, added to keep the "one shared prefix across two related strings" concern in this module rather than duplicated at the call site) for Edit's `old_string`/`new_string` pair: computes ONE prefix across both sides together so an independent per-side dedent can't skew add/del alignment and manufacture a phantom indentation diff.
- Wired into the three call sites the spec identified: `renderRead`/`renderWrite` in `ToolOverlayLog.tsx` dedent their visible (post-`capText`) text; `DiffViewer` dedents `old_string`/`new_string` before building its LCS diff. Bash, Grep/Glob, and streaming chunks are explicitly out of scope (spec §2's own reasoning — independent match lines / no stable "file indentation" concept / can't compute a common prefix mid-stream).
- Language detection (`detectLanguage`) still reads the RAW (non-dedented) first line for Read/Write — shebang/content sniffing should see the file as-is; only the *displayed* text is dedented.

## Test plan
- [x] 25 new unit tests (`dedent.test.ts`) covering: uniform space/tab indent, mixed-indent no-op, blank-line handling, CRLF, shallowest-line-wins, the numbered-Read variant (incl. non-uniform/unnumbered fallback, multi-digit line numbers), and the shared-prefix diff variant (incl. asymmetric old/new depths, pure insertion/deletion)
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx vitest run` — 3051 passed, 0 failed
- [ ] Live-pane visual check (spec §5's matrix: mid-file Read, deeply-nested Edit diff, normal Write no-op, `.md` Read) — no dev instance was live to check against at PR time; please do this before/at merge if practical, or I'll follow up with a dev-build check

<!-- agentmux:agent_id=agent2 -->