### PR TITLE
feat(armory): AgentMux-controlled, highest-priority Global Memory system tier

### DIFF
--- a/.changesets/1787561798-feat-armory-add-agentmux-controlled-highest-priority-system--u77c.md
+++ b/.changesets/1787561798-feat-armory-add-agentmux-controlled-highest-priority-system--u77c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): add AgentMux-controlled, highest-priority system tier to Global Memory

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -280,6 +280,7 @@ fn seed_memories(wstore: &Arc<Store>, manifest: &SeedManifest) -> Result<usize, 
             sort_order: idx as i64,
             created_at: now,
             updated_at: now,
+            is_system: false,
         };
         // Use warn-and-skip rather than ? so a user bundle whose name
         // collides with the seeded name (UNIQUE constraint on name) does

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -671,6 +671,7 @@ fn template_promote_resolves_provider_through_the_templates_bundle_not_the_drift
         sort_order: 0,
         created_at: 0,
         updated_at: 0,
+        is_system: false,
     };
     wstore.bundle_memory_upsert(&bundle).unwrap();
 

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -725,6 +725,7 @@ mod tests {
             sort_order: 0,
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
+            is_system: false,
         }
     }
 

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -2113,6 +2113,7 @@ mod tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         let export = super::super::bundle_export::export_bundle(&bundle, &[]);
         let zip_bytes = super::super::bundle_export::zip_bundle_export(&export).unwrap();

--- a/agentmux-srv/src/backend/bundle_validate.rs
+++ b/agentmux-srv/src/backend/bundle_validate.rs
@@ -226,6 +226,7 @@ mod tests {
             sort_order: 0,
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
+            is_system: false,
         }
     }
 

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -221,6 +221,15 @@ pub const COMMAND_DELETE_MEMORY: &str = "deletememory";
 /// v9 — set the global-brain section order. `ids` is the full ordered list
 /// of global bundle ids; each row's `sort_order` becomes its index.
 pub const COMMAND_REORDER_GLOBAL_BRAIN: &str = "reorderglobalbrain";
+/// v27 — the ONLY commands that can write `db_bundles.is_system=1`. See
+/// docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md. Deliberately
+/// separate from `upsertmemory`/`deletememory` (never wired to any MCP
+/// tool) so the ordinary Global Memory editor, the per-agent Bundle
+/// editor, and ABF import/export can never touch a system entry even by
+/// accident — `Store::bundle_memory_upsert`/`_delete` refuse outright the
+/// moment they see an existing `is_system=1` row.
+pub const COMMAND_UPSERT_SYSTEM_MEMORY: &str = "upsertsystemmemory";
+pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1145,6 +1145,7 @@ impl Store {
             sort_order: 0,
             created_at: now,
             updated_at: now,
+            is_system: false,
         };
         self.bundle_memory_upsert(&bundle)?;
         Ok(bundle_id)
@@ -3045,6 +3046,7 @@ mod bundle_provisioning_store_separation_tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         store.bundle_memory_upsert(&taken).unwrap();
 
@@ -3137,6 +3139,7 @@ mod bundle_provisioning_store_separation_tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         store.bundle_memory_upsert(&bundle).unwrap();
         agent.memory_id = "bundle-empty-provider".to_string();

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -615,6 +615,7 @@ mod bundle_ref_tests {
                 sort_order: 0,
                 created_at: 1_700_000_000_000,
                 updated_at: 1_700_000_000_000,
+                is_system: false,
             })
             .unwrap();
     }

--- a/agentmux-srv/src/backend/storage/memory_bundles.rs
+++ b/agentmux-srv/src/backend/storage/memory_bundles.rs
@@ -11,7 +11,7 @@
 //! lives on `Store` via this `impl` block; callers stay on
 //! `storage::store::Memory` thanks to the re-export.
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use super::error::StoreError;
@@ -63,6 +63,15 @@ pub struct Memory {
     /// on conflict, so editing a bundle via the regular form keeps its place.
     #[serde(default)]
     pub sort_order: i64,
+    /// AgentMux-controlled, highest-priority Global Memory tier — always
+    /// also `is_global`, injected first in `format_global_brain_block`'s
+    /// output with explicit override wording. Writable ONLY through
+    /// `bundle_memory_upsert_system`/`bundle_memory_delete_system` — the
+    /// generic `bundle_memory_upsert`/`_delete`/`_reorder` all refuse to
+    /// touch a row with this set. See
+    /// docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md.
+    #[serde(default)]
+    pub is_system: bool,
     // created_at / updated_at are server-owned: the upsert handler stamps
     // created_at = now when 0 and always overwrites updated_at with now. They
     // default on input so partial upserts (e.g. a "new section" that only
@@ -82,18 +91,47 @@ fn default_json_object_string() -> String {
 }
 
 /// Format global brain bundles into the block injected into an agent's
-/// CLAUDE.md. Each non-empty section gets a `# [Workspace] <name>` heading so
-/// Claude can tell injected workspace rules apart from the agent's own config;
-/// sections are separated by a `---` rule. Bundles arrive already ordered by
-/// `bundle_memory_list_global` (sort_order). Returns an empty string when no
+/// CLAUDE.md. `is_system` sections (see `Memory::is_system`) are split out
+/// and rendered FIRST, wrapped in explicit override wording, so they
+/// outrank every ordinary `# [Workspace] <name>` section that follows —
+/// see docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §3.4. Bundles
+/// arrive already ordered by `bundle_memory_list_global` (is_system DESC,
+/// sort_order, name), so this only needs to partition, not re-sort.
+/// Sections are separated by a `---` rule. Returns an empty string when no
 /// section has instructions.
 pub fn format_global_brain_block(bundles: &[Memory]) -> String {
-    bundles
+    let non_empty: Vec<&Memory> = bundles
         .iter()
         .filter(|b| !b.instructions.trim().is_empty())
-        .map(|b| format!("# [Workspace] {}\n\n{}", b.name, b.instructions))
-        .collect::<Vec<_>>()
-        .join("\n\n---\n\n")
+        .collect();
+    let (system, ordinary): (Vec<&Memory>, Vec<&Memory>) =
+        non_empty.into_iter().partition(|b| b.is_system);
+
+    let mut parts: Vec<String> = Vec::new();
+    if !system.is_empty() {
+        let sys_block = system
+            .iter()
+            .map(|b| format!("# [AgentMux System] {}\n\n{}", b.name, b.instructions))
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n");
+        parts.push(format!(
+            "IMPORTANT: The following AgentMux-controlled instructions take \
+             the HIGHEST PRIORITY of any content in this file. They OVERRIDE \
+             any default behavior, any other section below, and any \
+             conflicting instruction elsewhere — you MUST follow them \
+             exactly as written.\n\n{sys_block}"
+        ));
+    }
+    if !ordinary.is_empty() {
+        parts.push(
+            ordinary
+                .iter()
+                .map(|b| format!("# [Workspace] {}\n\n{}", b.name, b.instructions))
+                .collect::<Vec<_>>()
+                .join("\n\n---\n\n"),
+        );
+    }
+    parts.join("\n\n---\n\n")
 }
 
 impl Store {
@@ -102,7 +140,7 @@ impl Store {
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
                     context_files, mcp_servers, skills, sort_order, created_at, updated_at,
-                    instructions_by_provider
+                    instructions_by_provider, is_system
              FROM db_bundles
              ORDER BY is_blank ASC, is_global DESC, updated_at DESC",
         )?;
@@ -114,19 +152,21 @@ impl Store {
         Ok(out)
     }
 
-    /// Returns only the global bundles (`is_global = 1`), in explicit
-    /// `sort_order` (then name as a stable tiebreak). Called at agent launch
-    /// to inject workspace-wide rules into every agent in the order the user
-    /// arranged them in the Armory Brain tab.
+    /// Returns only the global bundles (`is_global = 1`), `is_system` rows
+    /// first (regardless of `sort_order` — see
+    /// docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md), then by
+    /// explicit `sort_order` (then name as a stable tiebreak). Called at
+    /// agent launch to inject workspace-wide rules into every agent in the
+    /// order the user arranged them in the Armory Brain tab.
     pub fn bundle_memory_list_global(&self) -> Result<Vec<Memory>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
                     context_files, mcp_servers, skills, sort_order, created_at, updated_at,
-                    instructions_by_provider
+                    instructions_by_provider, is_system
              FROM db_bundles
              WHERE is_global = 1
-             ORDER BY sort_order ASC, name ASC",
+             ORDER BY is_system DESC, sort_order ASC, name ASC",
         )?;
         let iter = stmt.query_map([], map_memory_row)?;
         let mut out = Vec::new();
@@ -141,7 +181,7 @@ impl Store {
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, is_global, provider, model, instructions,
                     context_files, mcp_servers, skills, sort_order, created_at, updated_at,
-                    instructions_by_provider
+                    instructions_by_provider, is_system
              FROM db_bundles WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], map_memory_row);
@@ -152,18 +192,48 @@ impl Store {
         }
     }
 
+    /// Look up just the `is_system` flag for `id`, without decoding a full
+    /// `Memory` row. Shared by every guard in this file that needs to know
+    /// "is the EXISTING row (if any) a system entry" before deciding
+    /// whether to allow a write through the generic path.
+    fn bundle_is_system(&self, conn: &rusqlite::Connection, id: &str) -> Result<Option<bool>, StoreError> {
+        let existing: Option<i64> = conn
+            .query_row(
+                "SELECT is_system FROM db_bundles WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(existing.map(|v| v != 0))
+    }
+
+    /// Generic Global Memory upsert — used by the ordinary Armory editor,
+    /// the per-agent Bundle editor, ABF import, and internal seeding.
+    /// Refuses outright to touch an existing `is_system=1` row (content
+    /// included, not just the flag) — see
+    /// docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §3.2. Use
+    /// `bundle_memory_upsert_system` to create/edit a system entry.
     pub fn bundle_memory_upsert(&self, memory: &Memory) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        if self.bundle_is_system(&conn, &memory.id)? == Some(true) {
+            return Err(StoreError::Other(
+                "cannot modify a system Global Memory entry via the generic bundle upsert path"
+                    .to_string(),
+            ));
+        }
         conn.execute(
             // sort_order is deliberately NOT in the ON CONFLICT update set:
             // it is owned by `bundle_memory_reorder`, so editing a bundle
             // through the regular Memory form never disturbs its position in
-            // the global brain.
+            // the global brain. is_system is hardcoded to 0 on insert (this
+            // path can never CREATE a system row) and omitted from the
+            // update set entirely (an existing row's tier — always 0, given
+            // the guard above — is never touched here either).
             "INSERT INTO db_bundles
                 (id, name, description, is_blank, is_global, provider, model, instructions,
                  context_files, mcp_servers, skills, sort_order, created_at, updated_at,
-                 instructions_by_provider)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                 instructions_by_provider, is_system)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, 0)
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
@@ -197,7 +267,62 @@ impl Store {
         Ok(())
     }
 
-    /// Delete a Memory bundle. Refuses to delete the blank singleton.
+    /// The ONLY path that can write `is_system=1`. Refuses the mirror-image
+    /// case of `bundle_memory_upsert`'s guard: converting an EXISTING
+    /// non-system row into a system one by id collision is not allowed —
+    /// `id` must be either brand new or already a system entry.
+    /// `is_blank`/`is_global`/`is_system` are hardcoded (not read from
+    /// `memory`) so this method can never produce anything other than a
+    /// well-formed system row regardless of what the caller passed in.
+    pub fn bundle_memory_upsert_system(&self, memory: &Memory) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        if self.bundle_is_system(&conn, &memory.id)? == Some(false) {
+            return Err(StoreError::Other(
+                "cannot convert an existing non-system Global Memory entry into a system entry"
+                    .to_string(),
+            ));
+        }
+        conn.execute(
+            "INSERT INTO db_bundles
+                (id, name, description, is_blank, is_global, provider, model, instructions,
+                 context_files, mcp_servers, skills, sort_order, created_at, updated_at,
+                 instructions_by_provider, is_system)
+             VALUES (?1, ?2, ?3, 0, 1, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 1)
+             ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                is_global = 1,
+                is_system = 1,
+                provider = excluded.provider,
+                model = excluded.model,
+                instructions = excluded.instructions,
+                context_files = excluded.context_files,
+                mcp_servers = excluded.mcp_servers,
+                skills = excluded.skills,
+                updated_at = excluded.updated_at,
+                instructions_by_provider = excluded.instructions_by_provider",
+            params![
+                memory.id,
+                memory.name,
+                memory.description,
+                memory.provider,
+                memory.model,
+                memory.instructions,
+                memory.context_files,
+                memory.mcp_servers,
+                memory.skills,
+                memory.sort_order,
+                memory.created_at,
+                memory.updated_at,
+                memory.instructions_by_provider,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a Memory bundle. Refuses to delete the blank singleton, a
+    /// seeded bundle, or (new) a system entry — use
+    /// `bundle_memory_delete_system` for the last case.
     pub fn bundle_memory_delete(&self, id: &str) -> Result<bool, StoreError> {
         if id == "blank" {
             return Err(StoreError::Other(
@@ -213,23 +338,41 @@ impl Store {
             ));
         }
         let conn = self.conn.lock().unwrap();
+        if self.bundle_is_system(&conn, id)? == Some(true) {
+            return Err(StoreError::Other(
+                "cannot delete a system Global Memory entry via the generic delete path; use bundle_memory_delete_system".to_string(),
+            ));
+        }
         let rows = conn.execute("DELETE FROM db_bundles WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+
+    /// The ONLY path that can remove an `is_system=1` row — structurally
+    /// incapable of deleting anything else, even if misused.
+    pub fn bundle_memory_delete_system(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM db_bundles WHERE id = ?1 AND is_system = 1",
+            params![id],
+        )?;
         Ok(rows > 0)
     }
 
     /// Assign `sort_order` to the given bundle ids in the order supplied
     /// (position 0, 1, 2, …). Drives the Armory global brain ordering,
     /// which in turn controls CLAUDE.md injection order. Ids not present in
-    /// the table are skipped silently (a concurrently-deleted section is not
-    /// an error). Runs in a single transaction so a partial reorder never
-    /// lands. Returns the number of rows updated.
+    /// the table, OR present but `is_system=1`, are skipped silently — a
+    /// system row's position is fixed (always first, see
+    /// `bundle_memory_list_global`) and never disturbed by the generic
+    /// reorder command. Runs in a single transaction so a partial reorder
+    /// never lands. Returns the number of rows updated.
     pub fn bundle_memory_reorder(&self, ordered_ids: &[String]) -> Result<usize, StoreError> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let mut updated = 0usize;
         {
             let mut stmt =
-                tx.prepare("UPDATE db_bundles SET sort_order = ?1 WHERE id = ?2")?;
+                tx.prepare("UPDATE db_bundles SET sort_order = ?1 WHERE id = ?2 AND is_system = 0")?;
             for (idx, id) in ordered_ids.iter().enumerate() {
                 updated += stmt.execute(params![idx as i64, id])?;
             }
@@ -256,5 +399,6 @@ fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         created_at: row.get(12)?,
         updated_at: row.get(13)?,
         instructions_by_provider: row.get(14)?,
+        is_system: row.get::<_, i64>(15)? != 0,
     })
 }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -52,7 +52,11 @@ use super::error::StoreError;
 ///        the mirror in v6 only ever holds the current value, with no way
 ///        to see what a file contained before its last write. See
 ///        docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md.
-pub const SHARED_STORE_SCHEMA_VERSION: i64 = 8;
+///   v9 — db_bundles.is_system: AgentMux-controlled, highest-priority
+///        Global Memory tier — see OBJECT_SCHEMA_VERSION's v27 doc
+///        comment (objects.db, above run_object_schema) for the full
+///        design; this store just needs schema parity.
+pub const SHARED_STORE_SCHEMA_VERSION: i64 = 9;
 
 /// `user_version` value stamped into `objects.db` after `run_object_schema`.
 /// The flat schema reset the counter to 1 (the pre-flatten chain never set
@@ -232,7 +236,18 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 8;
 ///        default. `db_conversation_trust_grants` mirrors
 ///        `db_lan_peer_pubkey_pins`'s exact shape (own module,
 ///        get/set-style methods, case-insensitive agent_id lookups).
-pub const OBJECT_SCHEMA_VERSION: i64 = 26;
+///   v27 — db_bundles.is_system: an AgentMux-controlled, highest-priority
+///        Global Memory tier (INTEGER, default 0). A system row is always
+///        also is_global=1 (enforced in code, not a CHECK constraint —
+///        see `bundle_memory_upsert_system`). Writable only through the
+///        dedicated `upsertsystemmemory`/`deletesystemmemory` RPCs and
+///        `Store::bundle_memory_upsert_system`/`_delete_system` — the
+///        generic `bundle_memory_upsert`/`_delete`/`_reorder` all refuse
+///        to touch an is_system=1 row. Injected first in
+///        `format_global_brain_block`'s output, wrapped in explicit
+///        override wording, ahead of every ordinary Global Memory
+///        section. See docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md.
+pub const OBJECT_SCHEMA_VERSION: i64 = 27;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -449,7 +464,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             skills        TEXT NOT NULL DEFAULT '[]',
             sort_order    INTEGER NOT NULL DEFAULT 0,
             created_at    INTEGER NOT NULL DEFAULT 0,
-            updated_at    INTEGER NOT NULL DEFAULT 0
+            updated_at    INTEGER NOT NULL DEFAULT 0,
+            is_system     INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_bundles_is_blank
             ON db_bundles(is_blank);
@@ -932,6 +948,9 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         // named-on-db_agents case like memory_id/default_memory_id).
         "ALTER TABLE db_agent_definitions ADD COLUMN conversation_visibility TEXT NOT NULL DEFAULT 'private'",
         "ALTER TABLE db_agents ADD COLUMN conversation_visibility TEXT NOT NULL DEFAULT 'private'",
+        // v27: AgentMux-controlled, highest-priority Global Memory tier —
+        // see OBJECT_SCHEMA_VERSION's v27 doc comment above.
+        "ALTER TABLE db_bundles ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();
@@ -1087,7 +1106,8 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
             skills        TEXT NOT NULL DEFAULT '[]',
             sort_order    INTEGER NOT NULL DEFAULT 0,
             created_at    INTEGER NOT NULL DEFAULT 0,
-            updated_at    INTEGER NOT NULL DEFAULT 0
+            updated_at    INTEGER NOT NULL DEFAULT 0,
+            is_system     INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_ss_bundles_is_blank
             ON db_bundles(is_blank);
@@ -1221,6 +1241,9 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
         "ALTER TABLE db_cron_jobs ADD COLUMN max_age_secs INTEGER",
         // v7: provider-scoped bundle instructions (ABF v0.2 §2.2).
         "ALTER TABLE db_bundles ADD COLUMN instructions_by_provider TEXT NOT NULL DEFAULT '{}'",
+        // v9: AgentMux-controlled, highest-priority Global Memory tier —
+        // see OBJECT_SCHEMA_VERSION's v27 doc comment above.
+        "ALTER TABLE db_bundles ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();
@@ -1346,7 +1369,8 @@ pub fn run_identity_store_schema(conn: &Connection) -> Result<(), StoreError> {
             skills        TEXT NOT NULL DEFAULT '[]',
             sort_order    INTEGER NOT NULL DEFAULT 0,
             created_at    INTEGER NOT NULL DEFAULT 0,
-            updated_at    INTEGER NOT NULL DEFAULT 0
+            updated_at    INTEGER NOT NULL DEFAULT 0,
+            is_system     INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_ids_bundles_is_blank
             ON db_bundles(is_blank);
@@ -1447,6 +1471,18 @@ pub fn run_identity_store_schema(conn: &Connection) -> Result<(), StoreError> {
             (id, name, description, is_blank, created_at, updated_at)
          VALUES ('blank', '__blank__', 'Vanilla CLI — no instructions, no context', 1, 0, 0);",
     )?;
+
+    // Additive column added after this store's tables were first created —
+    // same idempotent pattern as run_shared_store_schema's own ALTER loop.
+    // db_bundles.is_system: see OBJECT_SCHEMA_VERSION's v27 doc comment.
+    if let Err(e) = conn.execute_batch(
+        "ALTER TABLE db_bundles ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0",
+    ) {
+        let msg = e.to_string();
+        if !msg.contains("duplicate column") {
+            return Err(e.into());
+        }
+    }
 
     Ok(())
 }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -1284,7 +1284,17 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
 ///        read path (mirroring what v2 did for db_accounts) is not blocked
 ///        on a missing table. See
 ///        docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md.
-pub const IDENTITY_STORE_SCHEMA_VERSION: i64 = 3;
+///   v4 — db_bundles.is_system, for schema parity with OBJECT_SCHEMA_VERSION
+///        v27 / SHARED_STORE_SCHEMA_VERSION v9 (same column, same reasoning
+///        as v3 above — this store's `db_bundles` copy is not an actively-
+///        written duplicate either). Real ALTER TABLE ADD COLUMN added to
+///        `run_identity_store_schema` in the same change, so this counter
+///        MUST bump alongside it — an unbumped counter would leave an
+///        existing identity-store.db stamped at the old user_version
+///        forever, silently defeating check_schema_compat/stamp_version's
+///        forward-compat lock for this one store (reagent P1, PR #2782).
+///        See docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md.
+pub const IDENTITY_STORE_SCHEMA_VERSION: i64 = 4;
 
 /// Initialize (or re-validate) the `~/.agentmux/shared/identity-store.db`
 /// schema — the permanently-global store introduced by

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -1016,6 +1016,7 @@ mod effective_skills_tests {
                 sort_order: 0,
                 created_at: 1_700_000_000_000,
                 updated_at: 1_700_000_000_000,
+                is_system: false,
             })
             .unwrap();
     }
@@ -1183,6 +1184,7 @@ mod bundle_ref_tests {
                 sort_order: 0,
                 created_at: 1_700_000_000_000,
                 updated_at: 1_700_000_000_000,
+                is_system: false,
             })
             .unwrap();
     }

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -844,6 +844,7 @@
             sort_order: 0,
             created_at: 100,
             updated_at: 100,
+            is_system: false,
         };
         store.bundle_memory_upsert(&coder).unwrap();
 
@@ -884,6 +885,7 @@
             sort_order: order,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         // Insert out of order: B at 0, A at 1.
         store.bundle_memory_upsert(&mk("g-a", "Alpha", 1)).unwrap();
@@ -920,6 +922,174 @@
         let block = super::super::format_global_brain_block(&g);
         let expected = "# [Workspace] Alpha\n\nedited\n\n---\n\n# [Workspace] Beta\n\nrules for Beta";
         assert_eq!(block, expected);
+    }
+
+    // ── v27 — system-tier Global Memory ──────────────────────────────────
+    // docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md
+
+    fn mk_ordinary(id: &str, name: &str, order: i64) -> Memory {
+        Memory {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            is_blank: false,
+            is_global: true,
+            provider: String::new(),
+            model: String::new(),
+            instructions: format!("rules for {name}"),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: order,
+            created_at: 0,
+            updated_at: 0,
+            is_system: false,
+        }
+    }
+
+    /// Deliberately "wrong" `is_blank`/`is_global`/`is_system` — used to
+    /// verify `bundle_memory_upsert_system` hardcodes all three regardless
+    /// of what the caller's `Memory` struct set them to. Callers that need
+    /// a struct which already correctly *represents* a system entry (e.g.
+    /// to feed `format_global_brain_block` directly, bypassing storage)
+    /// should override `is_system` via struct-update syntax.
+    fn mk_system(id: &str, name: &str) -> Memory {
+        Memory {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            is_blank: true,
+            is_global: false,
+            provider: String::new(),
+            model: String::new(),
+            instructions: format!("system rules for {name}"),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            sort_order: 0,
+            created_at: 0,
+            updated_at: 0,
+            is_system: false,
+        }
+    }
+
+    #[test]
+    fn bundle_memory_upsert_system_hardcodes_global_and_system_flags() {
+        let store = make_store();
+        store.bundle_memory_upsert_system(&mk_system("sys-1", "Policy")).unwrap();
+        let row = store.bundle_memory_get("sys-1").unwrap().unwrap();
+        assert!(row.is_global, "system rows are always global");
+        assert!(row.is_system);
+        assert!(!row.is_blank, "hardcoded false regardless of input");
+    }
+
+    #[test]
+    fn generic_upsert_refuses_to_touch_an_existing_system_row() {
+        let store = make_store();
+        store.bundle_memory_upsert_system(&mk_system("sys-1", "Policy")).unwrap();
+
+        // Content-only edit attempt via the generic path.
+        let mut tampered = mk_ordinary("sys-1", "Hijacked", 0);
+        tampered.is_system = false;
+        assert!(store.bundle_memory_upsert(&tampered).is_err());
+
+        // Row is untouched.
+        let row = store.bundle_memory_get("sys-1").unwrap().unwrap();
+        assert_eq!(row.name, "Policy");
+        assert!(row.is_system);
+    }
+
+    #[test]
+    fn system_upsert_refuses_to_convert_an_existing_non_system_row() {
+        let store = make_store();
+        store.bundle_memory_upsert(&mk_ordinary("g-a", "Alpha", 0)).unwrap();
+        let mut takeover = mk_system("g-a", "Stolen");
+        takeover.id = "g-a".to_string();
+        assert!(store.bundle_memory_upsert_system(&takeover).is_err());
+
+        let row = store.bundle_memory_get("g-a").unwrap().unwrap();
+        assert_eq!(row.name, "Alpha");
+        assert!(!row.is_system);
+    }
+
+    #[test]
+    fn generic_delete_refuses_a_system_row_dedicated_delete_only_removes_system_rows() {
+        let store = make_store();
+        store.bundle_memory_upsert_system(&mk_system("sys-1", "Policy")).unwrap();
+        store.bundle_memory_upsert(&mk_ordinary("g-a", "Alpha", 0)).unwrap();
+
+        assert!(store.bundle_memory_delete("sys-1").is_err());
+        assert!(store.bundle_memory_get("sys-1").unwrap().is_some());
+
+        // Dedicated delete is structurally incapable of removing a non-system row.
+        assert!(!store.bundle_memory_delete_system("g-a").unwrap());
+        assert!(store.bundle_memory_get("g-a").unwrap().is_some());
+
+        assert!(store.bundle_memory_delete_system("sys-1").unwrap());
+        assert!(store.bundle_memory_get("sys-1").unwrap().is_none());
+    }
+
+    #[test]
+    fn reorder_silently_skips_system_rows() {
+        let store = make_store();
+        store.bundle_memory_upsert_system(&mk_system("sys-1", "Policy")).unwrap();
+        store.bundle_memory_upsert(&mk_ordinary("g-a", "Alpha", 0)).unwrap();
+        store.bundle_memory_upsert(&mk_ordinary("g-b", "Beta", 1)).unwrap();
+
+        let updated = store
+            .bundle_memory_reorder(&["sys-1".to_string(), "g-b".to_string(), "g-a".to_string()])
+            .unwrap();
+        // Only the two ordinary ids actually update.
+        assert_eq!(updated, 2);
+        let sys = store.bundle_memory_get("sys-1").unwrap().unwrap();
+        assert_eq!(sys.sort_order, 0, "system row's sort_order is untouched");
+    }
+
+    #[test]
+    fn list_global_sorts_system_rows_first_regardless_of_sort_order_or_name() {
+        let store = make_store();
+        // Ordinary rows would otherwise sort before "Policy" alphabetically
+        // and by a lower sort_order — system-first must win regardless.
+        store.bundle_memory_upsert(&mk_ordinary("g-a", "Aaa", -1)).unwrap();
+        store.bundle_memory_upsert_system(&mk_system("sys-1", "Zzz")).unwrap();
+
+        let g = store.bundle_memory_list_global().unwrap();
+        assert_eq!(
+            g.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["sys-1", "g-a"]
+        );
+    }
+
+    #[test]
+    fn format_global_brain_block_puts_system_first_with_override_preamble() {
+        // format_global_brain_block reads each Memory's own is_system field
+        // directly (it doesn't go through storage) — unlike mk_system's
+        // deliberately-wrong default (see its own doc comment), this needs
+        // a struct that actually represents a system entry.
+        let sys = Memory { is_system: true, ..mk_system("sys-1", "Policy") };
+        let ord = mk_ordinary("g-a", "Alpha", 0);
+
+        let mixed = super::super::format_global_brain_block(&[sys.clone(), ord.clone()]);
+        assert!(mixed.starts_with("IMPORTANT: The following AgentMux-controlled instructions"));
+        assert!(mixed.contains("# [AgentMux System] Policy"));
+        assert!(mixed.contains("# [Workspace] Alpha"));
+        // System content appears before the ordinary section.
+        assert!(mixed.find("[AgentMux System]").unwrap() < mixed.find("[Workspace]").unwrap());
+        // Exactly one override preamble even with a single system entry.
+        assert_eq!(mixed.matches("HIGHEST PRIORITY").count(), 1);
+
+        let system_only = super::super::format_global_brain_block(&[sys.clone()]);
+        assert!(system_only.starts_with("IMPORTANT:"));
+        assert!(!system_only.contains("[Workspace]"));
+
+        let ordinary_only = super::super::format_global_brain_block(&[ord.clone()]);
+        assert!(!ordinary_only.contains("IMPORTANT:"));
+        assert!(ordinary_only.starts_with("# [Workspace] Alpha"));
+
+        let empty = super::super::format_global_brain_block(&[]);
+        assert_eq!(empty, "");
     }
 
     // ---- Registry parallel-write mirror (PR A) ----

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -2430,6 +2430,7 @@ mod tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         id_store.bundle_memory_upsert(&bundle).unwrap();
 

--- a/agentmux-srv/src/migrations/m0021_backfill_agent_bundles.rs
+++ b/agentmux-srv/src/migrations/m0021_backfill_agent_bundles.rs
@@ -183,6 +183,7 @@ impl Migration for M0021BackfillAgentBundles {
                 sort_order: 0,
                 created_at: now,
                 updated_at: now,
+                is_system: false,
             };
             bundle_store
                 .bundle_memory_upsert(&bundle)

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -779,6 +779,7 @@ mod tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         state.id_store.bundle_memory_upsert(&bundle).unwrap();
     }

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -187,7 +187,20 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     persist: 0,
                     data: None,
                 });
-                Ok(Some(serde_json::to_value(&memory).unwrap_or_default()))
+                // Return the row actually persisted, not the client-supplied
+                // struct — bundle_memory_upsert_system hardcodes
+                // is_blank/is_global/is_system server-side regardless of
+                // what `memory` carried (e.g. the frontend's saveSystemEdit
+                // sends only id/name/instructions, so `memory.is_global`/
+                // `is_system` deserialize to false via #[serde(default)]).
+                // Echoing `memory` back would misreport both to any caller
+                // that trusts the response instead of refetching. reagent
+                // P2, PR #2782.
+                let saved = wstore
+                    .bundle_memory_get(&memory.id)
+                    .map_err(|e| format!("upsertsystemmemory: {e}"))?
+                    .ok_or_else(|| format!("upsertsystemmemory: row {} vanished after upsert", memory.id))?;
+                Ok(Some(serde_json::to_value(&saved).unwrap_or_default()))
             })
         }),
     );

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -11,6 +11,7 @@ use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::{
     COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
     COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY, COMMAND_REORDER_GLOBAL_BRAIN,
+    COMMAND_UPSERT_SYSTEM_MEMORY, COMMAND_DELETE_SYSTEM_MEMORY,
     CommandGetMemoryData, CommandDeleteMemoryData, CommandReorderGlobalBrainData,
 };
 use crate::backend::storage::store::Memory;
@@ -149,4 +150,72 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
+    // ---- System-tier Global Memory — see
+    // docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md. Deliberately
+    // separate commands from the four above (never wired to any MCP tool)
+    // so the ordinary Global Memory editor and every other generic
+    // bundle-writing surface can never reach an is_system row.
+
+    let wstore = state.id_store.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UPSERT_SYSTEM_MEMORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let mut memory: Memory = serde_json::from_value(data)
+                    .map_err(|e| format!("upsertsystemmemory: {e}"))?;
+                if memory.id.is_empty() {
+                    memory.id = uuid::Uuid::new_v4().to_string();
+                }
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if memory.created_at == 0 {
+                    memory.created_at = now;
+                }
+                memory.updated_at = now;
+                wstore
+                    .bundle_memory_upsert_system(&memory)
+                    .map_err(|e| format!("upsertsystemmemory: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "memories:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&memory).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.id_store.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_DELETE_SYSTEM_MEMORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandDeleteMemoryData = serde_json::from_value(data)
+                    .map_err(|e| format!("deletesystemmemory: {e}"))?;
+                let deleted = wstore
+                    .bundle_memory_delete_system(&cmd.id)
+                    .map_err(|e| format!("deletesystemmemory: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "memories:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
 }

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -461,6 +461,7 @@ mod recent_sessions_tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         wstore.bundle_memory_upsert(&memory).unwrap();
 

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -630,6 +630,7 @@ mod tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         state.id_store.bundle_memory_upsert(&bundle).unwrap();
     }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -1081,6 +1081,7 @@ mod write_agent_config_files_tests {
                 sort_order: 0,
                 created_at: 1_700_000_000_000,
                 updated_at: 1_700_000_000_000,
+                is_system: false,
             })
             .unwrap();
         wstore

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -166,6 +166,7 @@ mod check_provider_model_immutable_tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         }
     }
 
@@ -1047,6 +1048,7 @@ async fn bundle_import_for_agent_impl(
         sort_order: 0,
         created_at: now,
         updated_at: now,
+        is_system: false,
     };
     if let Err(e) = id_store.bundle_memory_upsert(&memory) {
         let rollback_errors = rollback_skills(&imported_skill_ids);
@@ -1454,6 +1456,7 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     sort_order: 0,
                     created_at: now,
                     updated_at: now,
+                    is_system: false,
                 };
                 if let Err(e) = id_store.bundle_memory_upsert(&memory) {
                     // Codex P2, PR #2379: same rollback as above — the
@@ -2043,6 +2046,7 @@ async fn bundle_import_commit_impl(
                     sort_order: 0,
                     created_at: now,
                     updated_at: now,
+                    is_system: false,
                 };
                 if let Err(e) = id_store.bundle_memory_upsert(&memory) {
                     let rollback_errors = rollback_skills(&imported_skill_ids);
@@ -2720,6 +2724,7 @@ mod export_import_for_agent_tests {
             sort_order: 0,
             created_at: 0,
             updated_at: 0,
+            is_system: false,
         };
         state.id_store.bundle_memory_upsert(&bundle).unwrap();
         bundle

--- a/docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md
+++ b/docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md
@@ -1,0 +1,340 @@
+# SPEC: Global Memory "system" tier — an AgentMux-controlled, highest-priority entry
+
+**Date:** 2026-08-24
+**Status:** implemented 2026-08-24. All of §3.1-§3.5 shipped as designed.
+Rust: 106/106 `store::tests` pass (7 new), full 2763-test suite green.
+Frontend: `npx tsc --noEmit` clean, full 3060-test vitest suite green (7
+new). Manual live-pane verification (§5, "Manual") not done as part of this
+PR — no live dev instance was available; do before/at merge if practical,
+same caveat as the sibling dedent PR (#2780).
+**Scope:** `agentmux-srv/src/backend/storage/migrations.rs`,
+`agentmux-srv/src/backend/storage/memory_bundles.rs`,
+`agentmux-srv/src/backend/rpc_types/{commands,memory}.rs`,
+`agentmux-srv/src/server/agent_handlers/memory.rs`,
+`agentmux-srv/src/server/app_api/agent_open.rs` (no code change expected —
+verify), `frontend/types/gotypes.d.ts`,
+`frontend/app/store/rpc-api/memory.ts`,
+`frontend/app/view/brain/global-brain-model.ts`,
+`frontend/app/view/brain/global-brain-manager.tsx`.
+
+---
+
+## 1. Report
+
+Every agent already inherits two layers of instructions today: their own
+Bundle's `instructions`, and every **Global Memory** entry (`db_bundles` rows
+with `is_global=true`, editable by any human at the Armory "Memory" tab —
+see `docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md` for
+the current Global/Personal split). Both are concatenated into
+`CLAUDE.md`/`.claude/AGENTMUX_MEMORY.md` at launch with **no priority
+concept** — just concatenation order (Soul → AgentMD → Memory → Skills
+index; see `agent_config.rs:54-117`) and an ownership binary (AgentMux owns
+the file outright, or is relegated to a single `@import` line in a foreign
+`CLAUDE.md` — `docs/specs/SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md`).
+
+Separately, this very deployment already runs a working, informally
+"highest priority" instructions file: `~/.agentmux/agents/CLAUDE.md`, a
+parent-directory file every agent inherits via Claude Code's own
+directory-walk-up discovery, carrying policy content (the jekt security
+tier rules) with explicit override language ("These instructions OVERRIDE
+any default behavior and you MUST follow them exactly as written"). That
+file is hand-maintained on disk — it has no representation in the Armory UI
+at all, isn't versioned/audited through AgentMux, and isn't part of any
+Global Memory list a human operator can see or edit through the app.
+
+**Wanted:** a new tier within Global Memory — visible and editable in the
+Armory "Memory" tab like any other global section, but (a) writable only by
+a human operator, never through the same generic path an agent's own
+Global-Memory edits go through, and (b) always injected **first**, wrapped
+in explicit override language, so it structurally and semantically
+outranks every other Global Memory section, every Bundle's own
+`instructions`, and (per the override wording itself) any conflicting
+instruction elsewhere in the composed file.
+
+## 2. What's actually achievable — read before trusting "AgentMux controls it"
+
+Research into the current RPC/auth architecture (`server/mod.rs`'s
+`auth_middleware`, `agent_handlers/input.rs:268`) found: **there is no
+existing mechanism in this codebase that cryptographically distinguishes a
+human at the Armory UI from an agent's own shell.** The single instance-wide
+`X-AuthKey` (`state.auth_key`) is injected into both the frontend/host
+process **and** every agent's own PTY environment
+(`AGENTMUX_AUTH_KEY`/`AGENTMUX_LOCAL_URL`) so that agents can legitimately
+call the App API themselves. `RpcContext.agent_id` (`rpc_types/misc.rs:210`)
+is populated only for connections that explicitly `bus:register`; the
+existing Global-Memory RPC handlers (`agent_handlers/memory.rs`) and the
+sibling `bundle.upsert`/`bundle.delete` handlers (`app_api/bundle.rs`)
+ignore `ctx` entirely and have **zero** caller-identity gating today (the
+`app_api/mod.rs:635` comment on `bundle.*` says so explicitly: "a bundle has
+no agent identity to gate on").
+
+**Conclusion, stated plainly for whoever reads this spec later:** what this
+feature actually delivers is a **structural + convention + prompt-priority**
+boundary, not a **cryptographic** one. A sufficiently determined agent with
+shell access already has the same `AGENTMUX_AUTH_KEY` the UI uses and could,
+in principle, open a raw WS connection and call any registered command,
+including the new system-tier ones this spec adds — exactly as true today
+of *every* RPC command in this app, not something newly introduced here.
+This is consistent with this app's existing overall trust model (agents
+already merge PRs, push code, and run arbitrary shell commands under
+existing operator-granted autonomy). What this feature genuinely buys:
+
+1. **No accidental mutation.** The system tier is structurally isolated
+   from every generic bundle-editing surface (the ordinary Global Memory
+   editor, the per-agent Bundle editor, ABF import/export) — none of those
+   code paths can touch an `is_system` row's tier *or content*, even by
+   accident, because the generic `Store::bundle_memory_upsert`/`_delete`
+   refuse outright the moment they see `is_system=1` on the target row.
+2. **A real, working priority mechanism** at the one layer that actually
+   matters for an LLM agent: the composed `CLAUDE.md` content itself. The
+   override wording is a prompt-engineering guarantee (the model reads and
+   follows it), the same kind of guarantee the existing
+   `~/.agentmux/agents/CLAUDE.md` file already relies on today — not a new,
+   weaker promise than what's already shipped.
+3. **Visibility + audit.** Human operators get one authoritative place
+   (Armory → Memory) to see and edit AgentMux-level policy, instead of a
+   hand-maintained file on disk with no UI representation at all.
+
+If a hard cryptographic boundary is wanted later (e.g. a channel
+authenticated only by a secret the CEF host process holds, never handed to
+any agent's PTY), that is materially larger scope — a new IPC/auth
+primitive, not a `db_bundles` column — and is out of scope here, flagged as
+a explicit follow-up if ever needed.
+
+## 3. Design
+
+### 3.1 Schema — `db_bundles.is_system`
+
+New column, `OBJECT_SCHEMA_VERSION` v27 (objects.db) and the matching
+`SHARED_STORE_SCHEMA_VERSION` bump (shared store.db has its own parallel
+`db_bundles` DDL — both `CREATE TABLE IF NOT EXISTS` sites and both
+`ALTER TABLE ... ADD COLUMN` idempotent-migration lists need the column,
+exactly like `is_global`'s v8 entry and `instructions_by_provider`'s v16
+entry before it):
+
+```sql
+ALTER TABLE db_bundles ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0
+```
+
+A system row is always also `is_global=1` (it's always injected) — enforced
+in code (§3.2), not by a CHECK constraint, matching this table's existing
+style (no CHECK constraints used elsewhere in `db_bundles`).
+
+`Memory` struct (`memory_bundles.rs`) gains `pub is_system: bool` with
+`#[serde(default)]`, following `is_global`'s exact pattern. Every existing
+Rust struct-literal construction site (`agent_seed.rs`, `mcp_servers.rs`,
+`skills.rs`, `agent_open.rs`, `agents.rs`, test helpers — found via
+`grep bundle_memory_upsert`) needs the new field added explicitly; the
+compiler enforces this is not missed (no `Default` impl on `Memory` today —
+deliberately not adding one here either, so every constructor stays
+explicit about `is_system`, the same reasoning that already applies to
+every other field on this struct).
+
+### 3.2 Storage layer — two upsert methods, two delete methods, one shared read path
+
+**`Store::bundle_memory_upsert`** (existing, generic — used by every
+non-system caller: the ordinary Global Memory editor, per-agent Bundle
+editor, ABF import, agent seeding, migrations): gains a guard at the top —
+
+```rust
+let existing_is_system: Option<i64> = conn
+    .query_row("SELECT is_system FROM db_bundles WHERE id = ?1", params![memory.id], |r| r.get(0))
+    .optional()?;
+if existing_is_system == Some(1) {
+    return Err(StoreError::Other(
+        "cannot modify a system Global Memory entry via the generic bundle upsert path".to_string(),
+    ));
+}
+```
+
+The `INSERT`'s `is_system` column is hardcoded to `0` in the SQL text (not a
+bound parameter — the generic path can never *create* a system row), and
+`is_system` is omitted from the `ON CONFLICT ... DO UPDATE SET` list
+exactly like `sort_order` already is today ("owned by a different mutation
+path" — same precedent, same comment style).
+
+**`Store::bundle_memory_upsert_system`** (new — the only path that can ever
+write `is_system=1`): mirror-image guard —
+
+```rust
+if existing_is_system == Some(0) {
+    return Err(StoreError::Other(
+        "cannot convert an existing non-system Global Memory entry into a system entry".to_string(),
+    ));
+}
+```
+
+`is_blank=0`, `is_global=1`, `is_system=1` are all hardcoded literals in
+both the `INSERT` values and the `ON CONFLICT` update set — defense in
+depth, so even a caller that got `memory.is_global`/`is_system` wrong can't
+produce a system row that isn't also global, or a non-system row through
+this method.
+
+**`Store::bundle_memory_delete`**: gains the same `is_system=1` guard as
+`bundle_memory_upsert`, alongside the existing `"blank"`/`"seed-"` guards.
+**`Store::bundle_memory_delete_system`** (new): `DELETE ... WHERE id = ?1
+AND is_system = 1` — the only path that can remove a system row, and
+structurally incapable of deleting anything else even if misused.
+
+**`Store::bundle_memory_reorder`**: add `AND is_system = 0` to its `UPDATE`
+— the generic reorder command silently no-ops on system rows (consistent
+with its existing "ids not present are skipped silently" contract), so
+dragging ordinary sections around can never disturb a system row's
+position.
+
+**Read paths** (`bundle_memory_list`, `bundle_memory_list_global`,
+`bundle_memory_get`, `map_memory_row`): add `is_system` to the `SELECT`
+list and the row mapper — no new query needed. `bundle_memory_list_global`'s
+`ORDER BY` becomes `is_system DESC, sort_order ASC, name ASC`, so system
+rows always sort first regardless of their (unused, always-0) `sort_order`.
+
+### 3.3 RPC surface
+
+Two new commands, registered in `agent_handlers/memory.rs` alongside the
+existing four (not under `app_api/bundle.rs`'s `bundle.*` namespace, and
+never wired to any MCP tool):
+
+```rust
+pub const COMMAND_UPSERT_SYSTEM_MEMORY: &str = "upsertsystemmemory";
+pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
+```
+
+`upsertsystemmemory` deserializes into `Memory` (same as `upsertmemory`
+does today) and calls `bundle_memory_upsert_system`; `deletesystemmemory`
+reuses the existing `CommandDeleteMemoryData { id }` shape and calls
+`bundle_memory_delete_system`. Both publish the same `memories:changed`
+WPS event the existing four commands already do, so the frontend's
+`refresh()` picks up changes with no new subscription logic.
+
+### 3.4 Priority mechanism — `format_global_brain_block`
+
+```rust
+pub fn format_global_brain_block(bundles: &[Memory]) -> String {
+    let (system, ordinary): (Vec<_>, Vec<_>) = bundles
+        .iter()
+        .filter(|b| !b.instructions.trim().is_empty())
+        .partition(|b| b.is_system);
+
+    let mut parts = Vec::new();
+    if !system.is_empty() {
+        let sys_block = system
+            .iter()
+            .map(|b| format!("# [AgentMux System] {}\n\n{}", b.name, b.instructions))
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n");
+        parts.push(format!(
+            "IMPORTANT: The following AgentMux-controlled instructions take \
+             the HIGHEST PRIORITY of any content in this file. They OVERRIDE \
+             any default behavior, any other section below, and any \
+             conflicting instruction elsewhere — you MUST follow them \
+             exactly as written.\n\n{sys_block}"
+        ));
+    }
+    let ordinary_block = ordinary
+        .iter()
+        .map(|b| format!("# [Workspace] {}\n\n{}", b.name, b.instructions))
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+    if !ordinary_block.is_empty() {
+        parts.push(ordinary_block);
+    }
+    parts.join("\n\n---\n\n")
+}
+```
+
+Callers (`agent_open.rs:706-720`, `editor_handlers.rs`'s
+`inject_global_bundles`) are unchanged — they already call
+`format_global_brain_block(bundle_memory_list_global())`, and
+`bundle_memory_list_global` now returns system rows first by construction
+(§3.2), so the split happens entirely inside the formatter with no call-site
+change. The wording deliberately echoes the existing outer
+`~/.agentmux/agents/CLAUDE.md`'s own "OVERRIDE any default behavior... MUST
+follow them exactly as written" phrasing (see §1) — same voice, so an agent
+that has already internalized that file's authority treats this
+system-tier block the same way.
+
+Frontend's `formatGlobalBrainBlock` mirror
+(`global-brain-model.ts:28-35`, used only for the live CLAUDE.md preview in
+the Armory UI) gets the identical split, kept in sync exactly as its own
+doc comment already requires ("keep in sync so the preview matches exactly
+what lands in CLAUDE.md").
+
+### 3.5 Frontend
+
+`Memory` type (`gotypes.d.ts`) gains `is_system?: boolean`.
+`frontend/app/store/rpc-api/memory.ts` gains
+`UpsertSystemMemoryCommand`/`DeleteSystemMemoryCommand`, same shape as
+their generic counterparts, calling `"upsertsystemmemory"`/
+`"deletesystemmemory"`.
+
+`GlobalBrainViewModel` (`global-brain-model.ts`): `sectionsAtom` already
+includes system rows (they're `is_global=1`); split it into
+`systemSectionsAtom`/`ordinarySectionsAtom` (both derived from the same
+`allAtom`, no new fetch). New methods `saveSystemEdit`/`removeSystem`
+mirror `saveEdit`/`remove` but call the two new commands and skip the
+reorder step entirely (system rows never call `ReorderGlobalBrainCommand`).
+
+`GlobalBrainManager` (`global-brain-manager.tsx`): renders
+`systemSectionsAtom` in its own pinned group above the ordinary section
+list, with a distinct "AgentMux" badge/icon and its own (small, separate)
+edit affordance wired to `saveSystemEdit`/`removeSystem` — visually
+distinct enough that a human editing ordinary Global Memory never confuses
+the two, per the design goal in §1. No drag-to-reorder handle on system
+rows (nothing to reorder against — §3.2's guard already makes any such
+attempt a silent no-op server-side, but the UI shouldn't offer a control
+that does nothing).
+
+## 4. Out of scope
+
+- A cryptographic UI-vs-agent boundary (§2) — flagged as a real, larger
+  follow-up if ever needed, not attempted here.
+- Multiple system entries with independent, user-adjustable ordering among
+  themselves — `ORDER BY is_system DESC, sort_order ASC, name ASC` already
+  gives a stable (name-based) order if more than one ever exists; a
+  dedicated reorder-system command is not built until there's an actual
+  need for more than one system entry.
+- Retiring the hand-maintained `~/.agentmux/agents/CLAUDE.md` file or
+  migrating its content into a system-tier row — out of scope; that file
+  continues to work exactly as it does today via Claude Code's own
+  directory walk-up, independent of anything this spec changes.
+
+## 5. Test plan
+
+Rust (`memory_bundles.rs` / `store/tests.rs`):
+- [ ] `bundle_memory_upsert_system` creates a row with `is_global=1,
+      is_system=1` regardless of what the input `Memory` set those fields to.
+- [ ] `bundle_memory_upsert` refuses (returns `Err`) when targeting an
+      existing `is_system=1` row's id, for both a content-only edit attempt
+      and an attempt to flip `is_system` to `false`.
+- [ ] `bundle_memory_upsert_system` refuses when targeting an existing
+      `is_system=0` row's id (no silent "promotion").
+- [ ] `bundle_memory_delete` refuses on an `is_system=1` row;
+      `bundle_memory_delete_system` succeeds on it and refuses/no-ops on a
+      non-system id.
+- [ ] `bundle_memory_reorder` silently skips a system row's id (its
+      `sort_order` is unchanged).
+- [ ] `bundle_memory_list_global` returns system rows before ordinary rows
+      regardless of `sort_order`/`name`.
+- [ ] `format_global_brain_block`: system + ordinary mix produces the
+      override-wording preamble exactly once, system content first, then
+      ordinary `[Workspace]` sections; system-only and ordinary-only inputs
+      each produce the expected single block with no empty `---` separator;
+      empty input returns `""`.
+
+Frontend (vitest):
+- [ ] `formatGlobalBrainBlock` mirror matches the Rust version's output
+      shape for the same fixture set (system+ordinary, system-only,
+      ordinary-only, empty).
+- [ ] `GlobalBrainViewModel`'s section split puts `is_system` rows only in
+      `systemSectionsAtom`, never in `ordinarySectionsAtom`, and vice versa.
+
+Manual (`task dev`, since this touches the Armory UI + real `CLAUDE.md`
+injection):
+- [ ] Create a system entry via the new UI affordance; confirm it appears
+      pinned above ordinary Global Memory sections with the distinct badge.
+- [ ] Confirm the ordinary Global Memory editor has no way to select or
+      edit that row.
+- [ ] Launch an agent; inspect its generated `CLAUDE.md`/
+      `.claude/AGENTMUX_MEMORY.md` and confirm the system block appears
+      first with the override preamble, ahead of `[Workspace]` sections and
+      the agent's own bundle instructions.

--- a/frontend/app/store/launch-flow-state/types.ts
+++ b/frontend/app/store/launch-flow-state/types.ts
@@ -185,9 +185,17 @@ export function accountsForProvider(state: LaunchFlowState, providerId: string):
     return state.accounts.list.filter((a) => a.provider === providerId);
 }
 
-/** Real (non-blank) memory bundles. */
+/** Real (non-blank), non-system memory bundles — excludes is_system rows
+ *  the same way every sibling bundle-picker filter in the app does
+ *  (AgentLaunchModal's own dropdown, AgentStartupModal, drone-view,
+ *  MemoryViewModel.refresh). Without this, AgentLaunchModal's default-pick
+ *  effect (`firstReal = realMemories(flow.state)[0]`) could auto-select a
+ *  system Global Memory entry as memoryId — an id with no matching
+ *  <option> in that same dropdown, and one bundle_memory_upsert would
+ *  permanently refuse to let the launched agent's own bundle editor
+ *  modify. reagent P1, PR #2782. */
 export function realMemories(state: LaunchFlowState): Memory[] {
-    return state.memories.list.filter((m) => !m.is_blank);
+    return state.memories.list.filter((m) => !m.is_blank && !m.is_system);
 }
 
 /** True when the form is a continuation of a prior named agent

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -48,6 +48,26 @@ export const MemoryApi = {
         return client.rpcCall("reorderglobalbrain", data, opts);
     },
 
+    // System-tier Global Memory — see
+    // docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md. The ONLY
+    // commands that can write is_system=true; deliberately separate from
+    // UpsertMemoryCommand/DeleteMemoryCommand.
+    UpsertSystemMemoryCommand(
+        client: RpcClient,
+        data: Partial<Memory>,
+        opts?: RpcOpts,
+    ): Promise<Memory> {
+        return client.rpcCall("upsertsystemmemory", data, opts);
+    },
+
+    DeleteSystemMemoryCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("deletesystemmemory", data, opts);
+    },
+
     NativeMemoryListCommand(client: RpcClient, data: { agent_id: string }, opts?: RpcOpts): Promise<NativeMemoryListResult> {
         return client.rpcCall("agent:memory:list", data, opts);
     },

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -244,7 +244,9 @@ export const AgentCreateFromTemplateModalPanel = (
     // fallback provider and never reconsider once the real one lands.
     // `accountTouched` (mirroring runtimeTouched/modelTouched above)
     // stops the re-pick once the user has made an explicit choice.
-    const realMemories = createMemo(() => memories().filter((m) => !m.is_blank));
+    // is_system entries are AgentMux-controlled workspace policy, not a
+    // selectable per-agent bundle (reagent P1, PR #2782).
+    const realMemories = createMemo(() => memories().filter((m) => !m.is_blank && !m.is_system));
     let accountTouched = false;
     createEffect(() => {
         if (accountTouched) return;

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -781,7 +781,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     <Show when={!memoryId()}>
                                         <option value="" disabled>— Pick a bundle —</option>
                                     </Show>
-                                    <For each={(memories() ?? []).filter((m) => !m.is_blank)}>
+                                    {/* is_system entries are AgentMux-controlled workspace policy,
+                                        not a selectable per-agent bundle — bundle_memory_upsert
+                                        would refuse any later edit anyway. reagent P1, PR #2782. */}
+                                    <For each={(memories() ?? []).filter((m) => !m.is_blank && !m.is_system)}>
                                         {(memory) => (
                                             <option value={memory.id}>{memory.name}</option>
                                         )}

--- a/frontend/app/view/agent/components/AgentStartupModal.tsx
+++ b/frontend/app/view/agent/components/AgentStartupModal.tsx
@@ -46,10 +46,12 @@ export const AgentStartupModal = (props: AgentStartupModalProps): JSX.Element =>
         .catch(() => setSelectedId(null))
         .finally(() => setLoaded(true));
 
-    // Non-blank bundles only — "blank" is the vanilla-CLI sentinel with no
-    // instructions worth surfacing here (same filter convention used by the
-    // launch modal's own bundle picker).
-    const selectable = () => (bundles() ?? []).filter((m) => !m.is_blank);
+    // Non-blank, non-system bundles only — "blank" is the vanilla-CLI
+    // sentinel with no instructions worth surfacing here (same filter
+    // convention used by the launch modal's own bundle picker); is_system
+    // entries are AgentMux-controlled workspace policy, not a selectable
+    // per-agent bundle (reagent P1, PR #2782).
+    const selectable = () => (bundles() ?? []).filter((m) => !m.is_blank && !m.is_system);
     const selectedBundle = () => selectable().find((m) => m.id === selectedId());
 
     const handleChange = async (id: string): Promise<void> => {

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -64,6 +64,57 @@ function SectionEditor(props: { model: GlobalBrainViewModel; isNew: boolean }): 
     );
 }
 
+/** Inline editor card for the system tier — a separate component (not a
+ *  parameterized SectionEditor) so its state is never accidentally wired to
+ *  the ordinary draft signals. See
+ *  docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §3.5. */
+function SystemSectionEditor(props: { model: GlobalBrainViewModel; isNew: boolean }): JSX.Element {
+    const { model } = props;
+    return (
+        <div class="global-brain-editor global-brain-editor-system">
+            <label class="global-brain-field">
+                <span class="global-brain-field-label">Name</span>
+                <input
+                    class="global-brain-input"
+                    type="text"
+                    value={model.draftSystemNameAtom()}
+                    onInput={(e) => model.setDraftSystemName(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
+                    placeholder="e.g. AgentMux Policy"
+                />
+            </label>
+            <label class="global-brain-field">
+                <span class="global-brain-field-label">Content</span>
+                <textarea
+                    class="global-brain-textarea"
+                    rows={8}
+                    value={model.draftSystemInstructionsAtom()}
+                    onInput={(e) => model.setDraftSystemInstructions(e.currentTarget.value)}
+                    onContextMenu={showTextInputContextMenu}
+                    placeholder="Markdown injected FIRST into every agent's CLAUDE.md, wrapped in explicit override wording."
+                    spellcheck={false}
+                />
+            </label>
+            <div class="global-brain-editor-actions">
+                <button
+                    class="global-brain-btn"
+                    disabled={model.savingAtom()}
+                    onClick={() => model.cancelEditSystem()}
+                >
+                    Cancel
+                </button>
+                <button
+                    class="global-brain-btn global-brain-btn-primary"
+                    disabled={model.savingAtom() || !model.draftSystemNameAtom().trim()}
+                    onClick={() => void model.saveSystemEdit()}
+                >
+                    {model.savingAtom() ? "Saving…" : props.isNew ? "Add system entry" : "Save"}
+                </button>
+            </div>
+        </div>
+    );
+}
+
 export const GlobalBrainManager = (): JSX.Element => {
     const model = new GlobalBrainViewModel();
     onCleanup(() => model.dispose());
@@ -93,8 +144,71 @@ export const GlobalBrainManager = (): JSX.Element => {
                 <div class="global-brain-error">{model.errorAtom()}</div>
             </Show>
 
+            {/* System tier — pinned above ordinary sections, always injected
+                first with override wording. No move up/down: position is
+                fixed server-side regardless of what a reorder call sends.
+                See docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md. */}
+            <div class="global-brain-sections global-brain-sections-system">
+                <For each={model.systemSectionsAtom()}>
+                    {(section) => (
+                        <div
+                            class="global-brain-section global-brain-section-system"
+                            classList={{ "is-editing": model.editingSystemIdAtom() === section.id }}
+                        >
+                            <Show
+                                when={model.editingSystemIdAtom() === section.id}
+                                fallback={
+                                    <div class="global-brain-section-row">
+                                        <div class="global-brain-section-main">
+                                            <span class="global-brain-system-badge" title="AgentMux-controlled, highest priority">
+                                                AgentMux
+                                            </span>
+                                            <span class="global-brain-section-name">
+                                                {section.name}
+                                            </span>
+                                        </div>
+                                        <div class="global-brain-section-actions">
+                                            <button
+                                                class="global-brain-btn"
+                                                onClick={() => model.startEditSystem(section)}
+                                            >
+                                                Edit
+                                            </button>
+                                            <button
+                                                class="global-brain-btn global-brain-btn-danger"
+                                                title="Delete this system entry"
+                                                onClick={() => void model.removeSystem(section.id)}
+                                            >
+                                                Remove
+                                            </button>
+                                        </div>
+                                    </div>
+                                }
+                            >
+                                <SystemSectionEditor model={model} isNew={false} />
+                            </Show>
+                        </div>
+                    )}
+                </For>
+
+                <Show when={model.editingSystemIdAtom() === NEW_SECTION_ID}>
+                    <div class="global-brain-section global-brain-section-system is-editing">
+                        <SystemSectionEditor model={model} isNew={true} />
+                    </div>
+                </Show>
+
+                <Show when={model.systemSectionsAtom().length === 0 && model.editingSystemIdAtom() === null}>
+                    <button
+                        class="global-brain-btn global-brain-btn-system-add"
+                        onClick={() => model.startNewSystem()}
+                    >
+                        + Add AgentMux system entry
+                    </button>
+                </Show>
+            </div>
+
             <div class="global-brain-sections">
-                <For each={model.sectionsAtom()}>
+                <For each={model.ordinarySectionsAtom()}>
                     {(section, i) => (
                         <div
                             class="global-brain-section"
@@ -126,7 +240,7 @@ export const GlobalBrainManager = (): JSX.Element => {
                                             <button
                                                 class="global-brain-icon-btn"
                                                 title="Move down"
-                                                disabled={i() === model.sectionsAtom().length - 1}
+                                                disabled={i() === model.ordinarySectionsAtom().length - 1}
                                                 onClick={() => void model.move(section.id, 1)}
                                             >
                                                 ↓
@@ -162,7 +276,7 @@ export const GlobalBrainManager = (): JSX.Element => {
                     </div>
                 </Show>
 
-                <Show when={model.sectionsAtom().length === 0 && model.editingIdAtom() === null}>
+                <Show when={model.ordinarySectionsAtom().length === 0 && model.editingIdAtom() === null}>
                     <div class="global-brain-empty">
                         No global sections yet. Add one to give every agent shared context.
                     </div>

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -1,0 +1,109 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { formatGlobalBrainBlock } from "./global-brain-model";
+
+// docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §5 — must mirror
+// memory_bundles.rs's format_global_brain_block fixture-for-fixture.
+
+function ordinary(id: string, name: string, instructions = `rules for ${name}`): Memory {
+    return {
+        id,
+        name,
+        instructions,
+        is_global: true,
+        is_system: false,
+        created_at: 0,
+        updated_at: 0,
+    } as Memory;
+}
+
+function system(id: string, name: string, instructions = `system rules for ${name}`): Memory {
+    return {
+        id,
+        name,
+        instructions,
+        is_global: true,
+        is_system: true,
+        created_at: 0,
+        updated_at: 0,
+    } as Memory;
+}
+
+describe("formatGlobalBrainBlock", () => {
+    test("system entries render first with the override preamble, ordinary sections after", () => {
+        const out = formatGlobalBrainBlock([system("sys-1", "Policy"), ordinary("g-a", "Alpha")]);
+        expect(out.startsWith("IMPORTANT: The following AgentMux-controlled instructions")).toBe(true);
+        expect(out).toContain("# [AgentMux System] Policy");
+        expect(out).toContain("# [Workspace] Alpha");
+        expect(out.indexOf("[AgentMux System]")).toBeLessThan(out.indexOf("[Workspace]"));
+        expect(out.match(/HIGHEST PRIORITY/g)?.length).toBe(1);
+    });
+
+    test("system-only input has the preamble and no [Workspace] section", () => {
+        const out = formatGlobalBrainBlock([system("sys-1", "Policy")]);
+        expect(out.startsWith("IMPORTANT:")).toBe(true);
+        expect(out).not.toContain("[Workspace]");
+    });
+
+    test("ordinary-only input has no override preamble", () => {
+        const out = formatGlobalBrainBlock([ordinary("g-a", "Alpha")]);
+        expect(out).not.toContain("IMPORTANT:");
+        expect(out.startsWith("# [Workspace] Alpha")).toBe(true);
+    });
+
+    test("empty input returns an empty string", () => {
+        expect(formatGlobalBrainBlock([])).toBe("");
+    });
+
+    test("sections with blank instructions are excluded from both tiers", () => {
+        const out = formatGlobalBrainBlock([system("sys-1", "Policy", "   "), ordinary("g-a", "Alpha")]);
+        expect(out).not.toContain("IMPORTANT:");
+        expect(out).toBe("# [Workspace] Alpha\n\nrules for Alpha");
+    });
+});
+
+// GlobalBrainViewModel's section split — mocks RpcApi entirely since the
+// constructor fires an unawaited ListMemoriesCommand refresh(), same
+// pattern as frontend/app/view/memory/memory-model.test.ts.
+const listMemoriesMock = vi.fn().mockResolvedValue([]);
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
+    },
+}));
+
+describe("GlobalBrainViewModel system/ordinary split", () => {
+    beforeEach(() => {
+        listMemoriesMock.mockClear();
+        listMemoriesMock.mockResolvedValue([]);
+    });
+
+    test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const rows = [system("sys-1", "Policy"), ordinary("g-a", "Alpha"), ordinary("g-b", "Beta")];
+        listMemoriesMock.mockResolvedValue(rows);
+
+        const model = new GlobalBrainViewModel();
+        await model.refresh();
+
+        const systemIds = model.systemSectionsAtom().map((m) => m.id);
+        const ordinaryIds = model.ordinarySectionsAtom().map((m) => m.id);
+        expect(systemIds).toEqual(["sys-1"]);
+        expect(ordinaryIds.sort()).toEqual(["g-a", "g-b"]);
+        // No id appears in both lists.
+        expect(systemIds.some((id) => ordinaryIds.includes(id))).toBe(false);
+    });
+
+    test("sectionsAtom (combined) still includes both tiers", async () => {
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const rows = [system("sys-1", "Policy"), ordinary("g-a", "Alpha")];
+        listMemoriesMock.mockResolvedValue(rows);
+
+        const model = new GlobalBrainViewModel();
+        await model.refresh();
+
+        expect(model.sectionsAtom().map((m) => m.id).sort()).toEqual(["g-a", "sys-1"]);
+    });
+});

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -26,12 +26,32 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 export const NEW_SECTION_ID = "__new__";
 
 /** Mirror of the backend format_global_brain_block — keep in sync so the
- *  preview matches exactly what lands in CLAUDE.md. */
-function formatGlobalBrainBlock(sections: Memory[]): string {
-    return sections
-        .filter((s) => (s.instructions ?? "").trim().length > 0)
-        .map((s) => `# [Workspace] ${s.name}\n\n${s.instructions}`)
-        .join("\n\n---\n\n");
+ *  preview matches exactly what lands in CLAUDE.md. `is_system` sections
+ *  are split out and rendered first with the override preamble, exactly
+ *  mirroring memory_bundles.rs's split (SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md).
+ *  Exported for direct unit testing against the Rust version's fixtures. */
+export function formatGlobalBrainBlock(sections: Memory[]): string {
+    const nonEmpty = sections.filter((s) => (s.instructions ?? "").trim().length > 0);
+    const system = nonEmpty.filter((s) => s.is_system);
+    const ordinary = nonEmpty.filter((s) => !s.is_system);
+
+    const parts: string[] = [];
+    if (system.length > 0) {
+        const sysBlock = system
+            .map((s) => `# [AgentMux System] ${s.name}\n\n${s.instructions}`)
+            .join("\n\n---\n\n");
+        parts.push(
+            "IMPORTANT: The following AgentMux-controlled instructions take " +
+            "the HIGHEST PRIORITY of any content in this file. They OVERRIDE " +
+            "any default behavior, any other section below, and any " +
+            "conflicting instruction elsewhere — you MUST follow them " +
+            `exactly as written.\n\n${sysBlock}`,
+        );
+    }
+    if (ordinary.length > 0) {
+        parts.push(ordinary.map((s) => `# [Workspace] ${s.name}\n\n${s.instructions}`).join("\n\n---\n\n"));
+    }
+    return parts.join("\n\n---\n\n");
 }
 
 export class GlobalBrainViewModel {
@@ -64,8 +84,30 @@ export class GlobalBrainViewModel {
     showPreviewAtom: Accessor<boolean> = this._showPreview[0];
     setShowPreview = this._showPreview[1];
 
-    /** Global sections, in injection order (sort_order, then name). */
+    // ---- System-tier editing state — deliberately separate signals from
+    // the ordinary editor above (not reused) so opening one editor can
+    // never leak draft state into the other. See
+    // docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §3.5.
+
+    private _editingSystemId = createSignal<string | null>(null);
+    editingSystemIdAtom: Accessor<string | null> = this._editingSystemId[0];
+    private setEditingSystemId = this._editingSystemId[1];
+
+    private _draftSystemName = createSignal<string>("");
+    draftSystemNameAtom: Accessor<string> = this._draftSystemName[0];
+    setDraftSystemName = this._draftSystemName[1];
+
+    private _draftSystemInstructions = createSignal<string>("");
+    draftSystemInstructionsAtom: Accessor<string> = this._draftSystemInstructions[0];
+    setDraftSystemInstructions = this._draftSystemInstructions[1];
+
+    /** Global sections, in injection order (sort_order, then name) —
+     *  includes system rows (they're always is_global too). */
     sectionsAtom: Accessor<Memory[]>;
+    /** The AgentMux-controlled, highest-priority subset of sectionsAtom. */
+    systemSectionsAtom: Accessor<Memory[]>;
+    /** sectionsAtom minus systemSectionsAtom — what the ordinary editor list renders. */
+    ordinarySectionsAtom: Accessor<Memory[]>;
     /** Non-global, non-blank bundles eligible to promote into the brain. */
     candidatesAtom: Accessor<Memory[]>;
     /** Combined CLAUDE.md preview block. */
@@ -80,6 +122,12 @@ export class GlobalBrainViewModel {
                         (a.sort_order ?? 0) - (b.sort_order ?? 0) ||
                         a.name.localeCompare(b.name),
                 ),
+        );
+        this.systemSectionsAtom = createMemo(() =>
+            this.sectionsAtom().filter((m) => m.is_system),
+        );
+        this.ordinarySectionsAtom = createMemo(() =>
+            this.sectionsAtom().filter((m) => !m.is_system),
         );
         this.candidatesAtom = createMemo(() =>
             this.allAtom()
@@ -218,5 +266,80 @@ export class GlobalBrainViewModel {
 
     dispose(): void {
         // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+
+    // ---- System-tier — see
+    // docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §3.5. No
+    // promote/reorder/move here: a system entry has nowhere to be promoted
+    // FROM (it's created directly), and its position is always first,
+    // enforced server-side regardless of what a reorder call would send.
+
+    startEditSystem(section: Memory): void {
+        this.setError(null);
+        this.setEditingSystemId(section.id);
+        this.setDraftSystemName(section.name);
+        this.setDraftSystemInstructions(section.instructions ?? "");
+    }
+
+    startNewSystem(): void {
+        this.setError(null);
+        this.setEditingSystemId(NEW_SECTION_ID);
+        this.setDraftSystemName("");
+        this.setDraftSystemInstructions("");
+    }
+
+    cancelEditSystem(): void {
+        this.setEditingSystemId(null);
+        this.setDraftSystemName("");
+        this.setDraftSystemInstructions("");
+        this.setError(null);
+    }
+
+    /** Persist the current system-tier draft via the dedicated
+     *  upsertsystemmemory command — never UpsertMemoryCommand. */
+    async saveSystemEdit(): Promise<void> {
+        const name = this.draftSystemNameAtom().trim();
+        if (!name) {
+            this.setError("Section name is required.");
+            return;
+        }
+        const editingId = this.editingSystemIdAtom();
+        if (editingId === null) return;
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const instructions = this.draftSystemInstructionsAtom();
+            if (editingId === NEW_SECTION_ID) {
+                await RpcApi.UpsertSystemMemoryCommand(TabRpcClient, { id: "", name, instructions });
+            } else {
+                const existing = this.systemSectionsAtom().find((m) => m.id === editingId);
+                if (!existing) {
+                    this.setError("Section no longer exists.");
+                    return;
+                }
+                await RpcApi.UpsertSystemMemoryCommand(TabRpcClient, { ...existing, name, instructions });
+            }
+            await this.refresh();
+            this.cancelEditSystem();
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    /** Delete a system entry outright via the dedicated
+     *  deletesystemmemory command — never DeleteMemoryCommand. Unlike the
+     *  ordinary tier's `remove()`, there's no "demote and keep in
+     *  Memories" fallback: a system entry has no life outside this tier. */
+    async removeSystem(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.DeleteSystemMemoryCommand(TabRpcClient, { id });
+            if (this.editingSystemIdAtom() === id) this.cancelEditSystem();
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Remove failed: ${(e as Error).message ?? e}`);
+        }
     }
 }

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -194,7 +194,9 @@ export class GlobalBrainViewModel {
                     instructions,
                 });
                 // Append the new section to the end of the order.
-                const order = [...this.sectionsAtom().map((s) => s.id), saved.id];
+                // ordinarySectionsAtom, not sectionsAtom — see move()'s doc
+                // comment above (reagent P1, PR #2782).
+                const order = [...this.ordinarySectionsAtom().map((s) => s.id), saved.id];
                 await RpcApi.ReorderGlobalBrainCommand(TabRpcClient, { ids: order });
             } else {
                 const existing = this.allAtom().find((m) => m.id === editingId);
@@ -225,7 +227,11 @@ export class GlobalBrainViewModel {
         this.setError(null);
         try {
             await RpcApi.UpsertMemoryCommand(TabRpcClient, { ...bundle, is_global: true });
-            const order = [...this.sectionsAtom().map((s) => s.id), id];
+            // ordinarySectionsAtom, not sectionsAtom — the backend's reorder
+            // command silently skips is_system ids (reorderglobalbrain's own
+            // AND is_system = 0 guard), so including one here is pointless
+            // at best. reagent P1, PR #2782 (same root cause as move() below).
+            const order = [...this.ordinarySectionsAtom().map((s) => s.id), id];
             await RpcApi.ReorderGlobalBrainCommand(TabRpcClient, { ids: order });
             await this.refresh();
         } catch (e) {
@@ -250,7 +256,16 @@ export class GlobalBrainViewModel {
 
     /** Move a section one slot earlier/later and persist the new order. */
     async move(id: string, dir: -1 | 1): Promise<void> {
-        const ids = this.sectionsAtom().map((s) => s.id);
+        // ordinarySectionsAtom, not sectionsAtom — the manager's up/down
+        // buttons are indexed against ordinarySectionsAtom (its length
+        // bounds i()), and the backend's reorder command silently skips
+        // is_system ids. Building this list from the combined sectionsAtom
+        // (unsorted with system-first) could swap an ordinary row with an
+        // adjacent system id, sending a reorder payload where the backend
+        // drops the system id and the two ordinary rows' relative order
+        // never actually changes — a button the UI enabled doing nothing.
+        // reagent P1, PR #2782.
+        const ids = this.ordinarySectionsAtom().map((s) => s.id);
         const i = ids.indexOf(id);
         const j = i + dir;
         if (i === -1 || j < 0 || j >= ids.length) return;

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -110,6 +110,47 @@
     border: 1px dashed var(--border-color);
 }
 
+// ── System tier ──────────────────────────────────────────────────────────────
+// AgentMux-controlled, highest-priority Global Memory entries — visually
+// distinct from ordinary sections so a human editing regular Global Memory
+// never confuses the two. See
+// docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md §3.5.
+
+.global-brain-sections-system {
+    margin-bottom: var(--space-1);
+}
+
+.global-brain-section-system {
+    border-color: var(--accent-color);
+    background: color-mix(in srgb, var(--accent-color) 6%, transparent);
+
+    &.is-editing {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}
+
+.global-brain-system-badge {
+    flex-shrink: 0;
+    padding: 1px var(--space-1-5);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--button-text-color);
+    background: var(--accent-color);
+}
+
+.global-brain-editor-system {
+    border-left: 2px solid var(--accent-color);
+}
+
+.global-brain-btn-system-add {
+    align-self: flex-start;
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
 // ── Inline editor ────────────────────────────────────────────────────────────
 
 .global-brain-editor {

--- a/frontend/app/view/drone/drone-view.tsx
+++ b/frontend/app/view/drone/drone-view.tsx
@@ -851,7 +851,9 @@ const AgentRefEditor = (p: {
                     onChange={(e) => setRef({ memoryId: e.currentTarget.value })}
                 >
                     <option value="">— blank —</option>
-                    <For each={(memories() ?? []).filter((m) => !m.is_blank)}>
+                    {/* is_system entries are AgentMux-controlled workspace policy,
+                        not a selectable per-agent bundle (reagent P1, PR #2782). */}
+                    <For each={(memories() ?? []).filter((m) => !m.is_blank && !m.is_system)}>
                         {(memory) => <option value={memory.id}>{memory.name}</option>}
                     </For>
                 </select>

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -252,11 +252,17 @@ export class MemoryViewModel implements ViewModel {
         void this.refresh();
     }
 
-    /** Re-fetch the full list. Called on mount and after each mutation. */
+    /** Re-fetch the full list. Called on mount and after each mutation.
+     *  Excludes is_system rows — this is the generic Bundle Manager
+     *  (Armory "Memories" tab), not the dedicated Global Memory system-tier
+     *  editor; showing a system entry here would let a human open it and
+     *  have any edit silently rejected by bundle_memory_upsert's guard.
+     *  reagent P1, PR #2782 — see
+     *  docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md. */
     async refresh(): Promise<void> {
         try {
             const list = await RpcApi.ListMemoriesCommand(TabRpcClient, {});
-            this.setMemories(list);
+            this.setMemories(list.filter((m) => !m.is_system));
             this.setError(null);
         } catch (e) {
             this.setError(`Failed to load ABF bundles: ${(e as Error).message ?? e}`);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -497,6 +497,13 @@ declare global {
         sort_order?: number;
         created_at: number;
         updated_at: number;
+        /** AgentMux-controlled, highest-priority Global Memory tier — always
+         *  also is_global, injected first with explicit override wording.
+         *  Writable only through upsertsystemmemory/deletesystemmemory; the
+         *  ordinary upsertmemory/deletememory/reorderglobalbrain all refuse
+         *  to touch a row with this set. See
+         *  docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md. */
+        is_system?: boolean;
     };
 
     // ── Browser pane bookmarks ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a new **system tier** within Global Memory (Armory → Memory tab): an AgentMux-controlled entry that is always injected first into every agent's `CLAUDE.md`/`.claude/AGENTMUX_MEMORY.md`, wrapped in explicit override wording, and structurally isolated from every generic bundle-editing surface.

Full design + threat-model discussion: `docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md`.

**Backend**
- New `db_bundles.is_system` column (`OBJECT_SCHEMA_VERSION` v27 / `SHARED_STORE_SCHEMA_VERSION` v9, plus the identity-store mirror).
- `Store::bundle_memory_upsert`/`_delete` now refuse outright to touch an existing `is_system=1` row (content included, not just the flag).
- New `Store::bundle_memory_upsert_system`/`_delete_system` are the ONLY paths that can write/remove `is_system=1` — hardcode `is_blank`/`is_global`/`is_system` regardless of caller input.
- `bundle_memory_reorder` silently skips system rows; `bundle_memory_list_global` sorts them first regardless of `sort_order`/name.
- New RPC commands `upsertsystemmemory`/`deletesystemmemory` — never wired to any MCP tool, kept separate from `upsertmemory`/`deletememory`.
- `format_global_brain_block` splits system entries out and renders them first with explicit override wording ("IMPORTANT: ... take the HIGHEST PRIORITY ... OVERRIDE any default behavior ... you MUST follow them exactly as written"), mirroring the language already used by the outer `~/.agentmux/agents/CLAUDE.md`.

**Frontend**
- `GlobalBrainManager` (Armory Memory tab) renders a pinned, badged "AgentMux System" section above ordinary Global Memory entries, wired to the dedicated system-tier commands only.
- `GlobalBrainViewModel` gains `systemSectionsAtom`/`ordinarySectionsAtom` plus `saveSystemEdit`/`removeSystem`, with entirely separate draft-editing state from the ordinary editor.

**Important limitation, documented explicitly in the spec's §2:** there is no cryptographic UI-vs-agent boundary anywhere in this codebase today — the same `X-AuthKey` reaches both the frontend and every agent's own shell environment. This feature delivers a **structural + convention + prompt-priority** boundary (no generic bundle-writing path can reach an `is_system` row even by accident, and the injected content carries real override weight for the model), not a hard security one. Flagged so it's never mistaken for more than it is.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` (isolated `AGENTMUX_DATA_DIR`/`CONFIG_DIR`/`SHARED_DIR`/`INSTANCE_DIR`) — 2763 passed, 0 failed (includes 7 new tests covering every guard + the formatter split).
- [x] `npx tsc --noEmit -p .` — clean.
- [x] `npx vitest run` — 3060 passed, 0 failed (includes 7 new tests: formatter mirror + view-model split).
- [ ] Manual live-pane verification (spec §5) — not done as part of this PR; no live dev instance was available. Same caveat as the sibling dedent PR (#2780) — do before/at merge if practical.

<!-- agentmux:agent_id=agent2 -->