### PR TITLE
fix(agent-pane): render tool-preview tabs at 2 spaces

### DIFF
--- a/.changesets/1787583377-fix-agent-pane-render-tool-preview-tabs-at-2-spaces-instead--i3yd.md
+++ b/.changesets/1787583377-fix-agent-pane-render-tool-preview-tabs-at-2-spaces-instead--i3yd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): render tool-preview tabs at 2 spaces instead of the inherited 4

--- a/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
@@ -24,6 +24,18 @@ marker as ignorable exactly like a blank line.
 **Related:** `SPEC_TOOL_PREVIEW_SCROLLBAR_EDGE_PADDING_2026_08_08.md`
 (refinement #1 of this series — this is refinement #2)
 
+**Follow-up (2026-08-24):** tab-indented previews rendered noticeably wider
+than space-indented ones — `dedent.ts` only strips the COMMON leading
+prefix (deliberately never conflating tabs with spaces, §3.3), so a literal
+tab in the RELATIVE indentation that's left over was rendering at the
+global `tab-size: 4` (`reset.scss`, inherited app-wide, including the
+Editor pane's CodeMirror instance). Fixed as a CSS-only change, not a
+`dedent.ts` change: `tab-size: 2` scoped to `.agent-tool-panel`
+(`frontend/app/view/agent/styles/_document-nodes.scss`) — the shared
+ancestor of every Read/Write/Edit/Diff preview path (Shiki and plain-
+fallback alike) — rather than the global `reset.scss` rule, so the Editor
+pane keeps its own 4-wide default unaffected.
+
 ---
 
 ## 1. Report

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -376,6 +376,21 @@
             overflow: hidden;
             font-family: var(--fixed-font, monospace);
             font-size: 12px;
+            // Overrides the global `tab-size: 4` from reset.scss (inherited
+            // by every preview here — Read/Write/Edit/Diff, Shiki and plain-
+            // fallback paths alike — since nothing in between re-declares
+            // it). A literal tab left over after dedent.ts strips the
+            // COMMON leading-indent prefix (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md)
+            // is RELATIVE indentation the source file actually uses — at
+            // the global 4-wide (or the browser's 8-wide UA default,
+            // wherever nothing overrides it) a tab-indented preview reads
+            // noticeably wider than the same file's space-indented sibling.
+            // 2 matches this app's own soft-tab width elsewhere. Scoped to
+            // this shared tool-preview ancestor only, not reset.scss itself
+            // — the Editor pane's CodeMirror instance intentionally keeps
+            // the global default (its own tabSize facet already agrees
+            // with reset.scss's 4; changing that is a separate concern).
+            tab-size: 2;
             // Quick smooth transition on all collapse-related properties.
             // Per 2026-05-26 user request — the prior instant-snap (no
             // max-height transition) felt jittery during auto-collapse


### PR DESCRIPTION
## Summary

Small follow-up to the tool-preview dedent work (`dedent.ts`, PR #2780, `docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md`). That utility strips only the leading indentation *common* to every displayed line and deliberately never conflates tabs with spaces (there's no reliable way to know how wide a tab renders). The *relative* indentation left over in a tab-indented preview was rendering at the app's global `tab-size: 4` (`reset.scss`, inherited everywhere including the Editor pane), making a tab-indented Read/Write/Edit preview read noticeably wider than the same file's space-indented sibling.

This is a CSS-only fix, not a `dedent.ts` change — `tab-size: 2` scoped to `.agent-tool-panel` (`frontend/app/view/agent/styles/_document-nodes.scss`), the shared ancestor of every Read/Write/Edit/Diff preview path (Shiki-highlighted and plain-fallback alike). The Editor pane's CodeMirror instance is untouched — it keeps the global 4-wide default, which is a separate concern from tool-preview rendering.

## Test plan
- [x] `npx sass` compile of the agent-view SCSS entrypoint — confirms the rule lands in the output CSS with no syntax errors.
- [x] `npx tsc --noEmit -p .` — clean (CSS-only change, no TS touched).
- [ ] Manual visual check in a live pane — not done as part of this PR; no live dev instance was available.

<!-- agentmux:agent_id=agent2 -->