### PR TITLE
feat(agent-picker): on-demand Haiku activity summary fallback when no conversation snapshot exists

### DIFF
--- a/.changesets/1787584272-feat-agent-picker-on-demand-haiku-activity-summary-fallback--t0va.md
+++ b/.changesets/1787584272-feat-agent-picker-on-demand-haiku-activity-summary-fallback--t0va.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-picker): on-demand Haiku activity summary fallback when no conversation snapshot exists

--- a/agentmux-srv/src/backend/storage/agent_activity_summaries.rs
+++ b/agentmux-srv/src/backend/storage/agent_activity_summaries.rs
@@ -1,0 +1,116 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-demand, once-per-definition activity summary — see
+//! `db_agent_activity_summaries` in migrations.rs (`OBJECT_SCHEMA_VERSION`
+//! v27) and
+//! docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §5a.
+//!
+//! Fallback preview text for the AgentPicker's "My Agents" rows whose
+//! instance has no structured `output.state.json` conversation snapshot —
+//! generated once, lazily, via `app_api::session::generate_definition_activity_summary`,
+//! and cached here forever (never regenerated once non-empty). An absent
+//! row IS the "not generated yet" state; there is no separate pending flag.
+
+use rusqlite::params;
+
+use super::error::StoreError;
+use super::store::Store;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentActivitySummary {
+    pub definition_id: String,
+    pub summary: String,
+    pub updated_at: i64,
+}
+
+impl Store {
+    pub fn agent_activity_summary_get(
+        &self,
+        definition_id: &str,
+    ) -> Result<Option<AgentActivitySummary>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT definition_id, summary, updated_at FROM db_agent_activity_summaries WHERE definition_id = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![definition_id], map_row)?;
+        match rows.next() {
+            Some(r) => Ok(Some(r?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Upsert — a definition's summary is generated at most once in the
+    /// common case, but an upsert (rather than plain INSERT) keeps this
+    /// safe against the rare double-generation race the Ambient Model Call
+    /// gateway doesn't fully close (two independent process starts, or a
+    /// restart mid-generation).
+    pub fn agent_activity_summary_set(
+        &self,
+        definition_id: &str,
+        summary: &str,
+        updated_at: i64,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_agent_activity_summaries (definition_id, summary, updated_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(definition_id) DO UPDATE SET summary = ?2, updated_at = ?3",
+            params![definition_id, summary, updated_at],
+        )?;
+        Ok(())
+    }
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentActivitySummary> {
+    Ok(AgentActivitySummary {
+        definition_id: row.get(0)?,
+        summary: row.get(1)?,
+        updated_at: row.get(2)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object_store() -> Store {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Store::open(tmp.path()).unwrap()
+    }
+
+    #[test]
+    fn get_returns_none_when_never_generated() {
+        let store = object_store();
+        assert!(store.agent_activity_summary_get("def-1").unwrap().is_none());
+    }
+
+    #[test]
+    fn set_then_get_roundtrips() {
+        let store = object_store();
+        store.agent_activity_summary_set("def-1", "Debugging a flaky test", 1000).unwrap();
+        let got = store.agent_activity_summary_get("def-1").unwrap().unwrap();
+        assert_eq!(got.definition_id, "def-1");
+        assert_eq!(got.summary, "Debugging a flaky test");
+        assert_eq!(got.updated_at, 1000);
+    }
+
+    #[test]
+    fn set_twice_upserts_instead_of_erroring() {
+        let store = object_store();
+        store.agent_activity_summary_set("def-1", "first summary", 1000).unwrap();
+        store.agent_activity_summary_set("def-1", "second summary", 2000).unwrap();
+        let got = store.agent_activity_summary_get("def-1").unwrap().unwrap();
+        assert_eq!(got.summary, "second summary");
+        assert_eq!(got.updated_at, 2000);
+    }
+
+    #[test]
+    fn distinct_definitions_do_not_collide() {
+        let store = object_store();
+        store.agent_activity_summary_set("def-1", "summary one", 1000).unwrap();
+        store.agent_activity_summary_set("def-2", "summary two", 2000).unwrap();
+        assert_eq!(store.agent_activity_summary_get("def-1").unwrap().unwrap().summary, "summary one");
+        assert_eq!(store.agent_activity_summary_get("def-2").unwrap().unwrap().summary, "summary two");
+    }
+}

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -247,7 +247,27 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 9;
 ///        `format_global_brain_block`'s output, wrapped in explicit
 ///        override wording, ahead of every ordinary Global Memory
 ///        section. See docs/specs/SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md.
-pub const OBJECT_SCHEMA_VERSION: i64 = 27;
+///   v28 — db_agent_activity_summaries: one-shot, on-demand Haiku-generated
+///        activity summary per `definition_id`, used as the AgentPicker's
+///        "My Agents" conversation-preview fallback when a row has no
+///        structured `output.state.json` snapshot to preview (legacy rows
+///        predating snapshot persistence — see `has_snapshot` in
+///        `listrecentsessions`, `agent_handlers/session.rs`). Generated
+///        from the instance's raw `"output"` filestore file (present even
+///        when the newer structured snapshot isn't) via the same shared
+///        Ambient Model Call gateway `dispatch_name`/`term:ambient_summary`
+///        already use (`invoke_ambient_haiku_call`,
+///        `docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md`).
+///        Generated lazily (first picker load that needs it, not on every
+///        turn) and cached forever once non-empty — mirrors
+///        `SubAgent.display_name`'s cache-once posture, not
+///        `term:ambient_summary`'s per-turn refresh. Renumbered from an
+///        earlier v27 — merged alongside the Global Memory system-tier PR
+///        (#2782), which independently claimed v27 for an unrelated
+///        column (same collision class as this file's own v20→v22 and
+///        v24→v25 history, see those entries above). See
+///        docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §5a.
+pub const OBJECT_SCHEMA_VERSION: i64 = 28;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -860,6 +880,17 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             tier                 TEXT NOT NULL,
             granted_at           INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (agent_id, granted_peer_agent_id, tier)
+        );
+
+        -- v27: one-shot, on-demand activity summary per definition — see
+        -- OBJECT_SCHEMA_VERSION's v27 doc comment above. `summary` is empty
+        -- only transiently (a row is only ever inserted once generation
+        -- succeeds); there is no 'pending' state stored here — an absent
+        -- row IS the pending state.
+        CREATE TABLE IF NOT EXISTS db_agent_activity_summaries (
+            definition_id TEXT PRIMARY KEY,
+            summary       TEXT NOT NULL DEFAULT '',
+            updated_at    INTEGER NOT NULL DEFAULT 0
         );",
     )?;
 

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -882,8 +882,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             PRIMARY KEY (agent_id, granted_peer_agent_id, tier)
         );
 
-        -- v27: one-shot, on-demand activity summary per definition — see
-        -- OBJECT_SCHEMA_VERSION's v27 doc comment above. `summary` is empty
+        -- v28: one-shot, on-demand activity summary per definition — see
+        -- OBJECT_SCHEMA_VERSION's v28 doc comment above. `summary` is empty
         -- only transiently (a row is only ever inserted once generation
         -- succeeds); there is no 'pending' state stored here — an absent
         -- row IS the pending state.

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -4,6 +4,7 @@
 //! Storage layer: SQLite-backed object store and file store.
 //! Port of Go's pkg/wstore and pkg/filestore.
 
+pub mod agent_activity_summaries;
 pub mod agent_credentials;
 pub mod agent_groups;
 pub mod agent_jekt_keys;

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -441,15 +441,42 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 let broker_bg = broker.clone();
                                 let definition_id_bg = inst.definition_id.clone();
                                 let block_id_bg = inst.block_id.clone();
+                                let provider_id_bg = def.map(|d| d.provider.clone()).unwrap_or_default();
                                 tokio::spawn(async move {
-                                    crate::server::app_api::session::generate_definition_activity_summary(
+                                    let result = crate::server::app_api::session::generate_definition_activity_summary(
                                         &wstore_bg,
                                         &filestore_bg,
                                         &broker_bg,
                                         &definition_id_bg,
                                         &block_id_bg,
+                                        &provider_id_bg,
                                     )
                                     .await;
+                                    // reagent P2, PR #2786: at minimum, log the
+                                    // spend so it's observable — no UI-facing
+                                    // total exists for ANY background-triggered
+                                    // ambient call today (dispatch_name/
+                                    // subagent_name via trigger_eager_naming,
+                                    // generate_pushed_activity_summary all
+                                    // discard their own returned tokens the
+                                    // same way; only the live, RPC-response
+                                    // pull paths — session:activity_summary,
+                                    // session:next_prompt_suggestion — thread
+                                    // usage to the frontend, since only they
+                                    // have a response channel to thread it
+                                    // through). A real aggregate sink for
+                                    // background ambient spend is a separate,
+                                    // cross-cutting follow-up, not scoped to
+                                    // this one call site.
+                                    if let Some((_, tokens)) = result {
+                                        if let Some(tokens) = tokens {
+                                            tracing::debug!(
+                                                definition_id = %definition_id_bg,
+                                                ?tokens,
+                                                "listrecentsessions: definition activity summary generated"
+                                            );
+                                        }
+                                    }
                                 });
                             }
                             Ok(None) | Ok(Some(_)) => {

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -24,6 +24,18 @@ use crate::backend::storage::store::{AgentDefinition, AgentIdentityLink, AgentIn
 use super::super::AppState;
 use super::read_session_preview;
 
+/// At-most-once-per-process-lifetime claim set for definition-summary
+/// generation attempts triggered from `listrecentsessions` — see the call
+/// site below and `db_agent_activity_summaries` (OBJECT_SCHEMA_VERSION
+/// v28). `HashSet::insert` returns `true` only the first time a given
+/// `definition_id` is claimed; every later call for the same id (a repeat
+/// poll of "My Agents") sees `false` and does not re-spawn.
+fn definition_summary_attempted() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    static SET: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        std::sync::OnceLock::new();
+    SET.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // ---- Recent sessions (cascade follow-up 2026-05-23) ----
     //
@@ -395,16 +407,35 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             Ok(Some(existing)) if !existing.summary.is_empty() => {
                                 preview = existing.summary;
                             }
-                            Ok(None) => {
+                            // `insert` returns `true` only the FIRST time this
+                            // definition_id is claimed for this process's
+                            // lifetime — mirrors `SubagentWatcher.naming_triggered`'s
+                            // "claim once regardless of success/failure"
+                            // pattern (reagent P1, PR #2786). Without this,
+                            // `ambient::gateway().admit()` alone only
+                            // coalesces CONCURRENT triggers, not sequential
+                            // ones — a definition that can never be
+                            // summarized (no cmd meta, no raw output, CLI
+                            // failure) would otherwise be re-spawned on
+                            // EVERY subsequent listrecentsessions call (tab
+                            // visibility regain, agents:changed refetch, …)
+                            // forever. A successful generation is unaffected
+                            // by this gate: it persists to
+                            // db_agent_activity_summaries, which the branch
+                            // above already checks first.
+                            // `Ok(Some(existing))` with an empty `summary`
+                            // shouldn't occur in normal operation (a row is
+                            // only ever inserted once generation succeeds —
+                            // see the table's own doc comment) but is
+                            // handled the same as `Ok(None)` regardless,
+                            // rather than relying on that invariant to make
+                            // the match exhaustive.
+                            Ok(None) | Ok(Some(_))
+                                if definition_summary_attempted().lock().unwrap().insert(inst.definition_id.clone()) =>
+                            {
                                 // Fire-and-forget: generation (a real Haiku
                                 // CLI round-trip) must not block this
-                                // response. The gateway's admit() coalesces
-                                // concurrent triggers for the same
-                                // definition_id, so spawning here on every
-                                // request that finds nothing persisted yet
-                                // is safe — only the first spawn actually
-                                // runs the CLI; later ones are turned away
-                                // as StaleOnArrival.
+                                // response.
                                 let wstore_bg = wstore.clone();
                                 let filestore_bg = filestore.clone();
                                 let broker_bg = broker.clone();
@@ -421,7 +452,22 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                     .await;
                                 });
                             }
-                            _ => {}
+                            Ok(None) | Ok(Some(_)) => {
+                                // Already attempted this process lifetime —
+                                // no-op, same as any other row without a
+                                // persisted summary.
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    definition_id = %inst.definition_id,
+                                    "listrecentsessions: agent_activity_summary_get failed — \
+                                     row keeps its plain fallback preview text"
+                                );
+                                if !degraded.contains(&"activity_summary") {
+                                    degraded.push("activity_summary");
+                                }
+                            }
                         }
                     }
 
@@ -944,5 +990,29 @@ mod tests {
         let row = &result.rows[0];
         assert!(!row.has_snapshot);
         assert_eq!(row.preview, "", "no summary persisted yet — preview must stay empty, not fabricated");
+    }
+
+    /// reagent P1, PR #2786: without a dedup gate, a definition that can
+    /// never be summarized (no cmd meta, no raw output, CLI failure) gets
+    /// re-spawned on every `listrecentsessions` poll forever —
+    /// `ambient::gateway().admit()` alone only coalesces CONCURRENT
+    /// triggers, not sequential ones, since its guard drops (freeing the
+    /// slot) the moment one call finishes. This tests
+    /// `definition_summary_attempted()`'s claim set directly rather than
+    /// the RPC dispatch (which can't observe whether a background
+    /// `tokio::spawn` happened without mocking the Haiku CLI) — a unique
+    /// id avoids cross-test interference with the process-wide static set.
+    #[test]
+    fn definition_summary_attempted_claims_a_definition_id_at_most_once() {
+        let id = "def-dedup-test-unique-9f3a1b".to_string();
+        assert!(
+            definition_summary_attempted().lock().unwrap().insert(id.clone()),
+            "first claim for a fresh id must succeed"
+        );
+        assert!(
+            !definition_summary_attempted().lock().unwrap().insert(id.clone()),
+            "second claim for the same id must be rejected — this is the fix for \
+             reagent's unbounded-retry finding on PR #2786"
+        );
     }
 }

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -19,7 +19,7 @@ use crate::backend::rpc_types::{
     CommandAgentSessionArchiveData, AgentSessionArchiveResult,
     CommandAgentSessionListArchivesData, AgentArchiveRow,
 };
-use crate::backend::storage::store::{AgentIdentityLink, AgentInstance, IdentityAccount};
+use crate::backend::storage::store::{AgentDefinition, AgentIdentityLink, AgentInstance, IdentityAccount};
 
 use super::super::AppState;
 use super::read_session_preview;
@@ -43,6 +43,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store_lrs = state.id_store.clone();
     let identity_store_lrs = state.identity_store.clone();
     let filestore = state.filestore.clone();
+    let broker_lrs = state.broker.clone();
     engine.register_handler(
         COMMAND_LIST_RECENT_SESSIONS,
         Box::new(move |data, _ctx| {
@@ -50,6 +51,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let id_store = id_store_lrs.clone();
             let identity_store = identity_store_lrs.clone();
             let filestore = filestore.clone();
+            let broker = broker_lrs.clone();
             Box::pin(async move {
                 let t0 = std::time::Instant::now();
                 let cmd: CommandListRecentSessionsData =
@@ -357,7 +359,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Stat first (cheap) — gives us the modts for
                     // sorting. Only fetch the full content if the
                     // snapshot exists.
-                    let (has_snapshot, last_active_at, preview, node_count) =
+                    let (has_snapshot, last_active_at, mut preview, node_count) =
                         if inst.block_id.is_empty() {
                             (false, inst.started_at, String::new(), 0usize)
                         } else {
@@ -377,6 +379,51 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 _ => (false, inst.started_at, String::new(), 0usize),
                             }
                         };
+
+                    // No structured snapshot to preview — fall back to a
+                    // once-per-definition, on-demand Haiku summary of the
+                    // instance's raw terminal output (see
+                    // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+                    // §5a). Only meaningful for a LOCAL row with a real
+                    // block_id — a cross-channel row's synthetic empty
+                    // block_id has no local raw output to summarize either,
+                    // so it's left alone (still shows the plain fallback
+                    // text, which is accurate for that case: this channel
+                    // genuinely has nothing).
+                    if !has_snapshot && !inst.block_id.is_empty() {
+                        match wstore.agent_activity_summary_get(&inst.definition_id) {
+                            Ok(Some(existing)) if !existing.summary.is_empty() => {
+                                preview = existing.summary;
+                            }
+                            Ok(None) => {
+                                // Fire-and-forget: generation (a real Haiku
+                                // CLI round-trip) must not block this
+                                // response. The gateway's admit() coalesces
+                                // concurrent triggers for the same
+                                // definition_id, so spawning here on every
+                                // request that finds nothing persisted yet
+                                // is safe — only the first spawn actually
+                                // runs the CLI; later ones are turned away
+                                // as StaleOnArrival.
+                                let wstore_bg = wstore.clone();
+                                let filestore_bg = filestore.clone();
+                                let broker_bg = broker.clone();
+                                let definition_id_bg = inst.definition_id.clone();
+                                let block_id_bg = inst.block_id.clone();
+                                tokio::spawn(async move {
+                                    crate::server::app_api::session::generate_definition_activity_summary(
+                                        &wstore_bg,
+                                        &filestore_bg,
+                                        &broker_bg,
+                                        &definition_id_bg,
+                                        &block_id_bg,
+                                    )
+                                    .await;
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
 
                     rows.push(RecentSessionRow {
                         instance_id: inst.id,
@@ -772,5 +819,130 @@ mod tests {
              (identity_list now tolerates it internally), got: {:?}",
             result.degraded
         );
+    }
+
+    /// Minimal local (not cross-channel registry) `AgentDefinition` —
+    /// mirrors `agents.rs`'s own private `test_agent_def` test fixture
+    /// shape, duplicated here rather than widening that helper's
+    /// visibility for one caller.
+    fn local_agent_def(id: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: format!("Agent {id}"),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1,
+            agent_type: "standalone".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            model_vendor_base_url: String::new(),
+            auto_continue_enabled: 0,
+            memory_id: String::new(),
+            conversation_visibility: "private".to_string(),
+        }
+    }
+
+    fn local_agent_instance(id: &str, definition_id: &str, block_id: &str) -> AgentInstance {
+        AgentInstance {
+            id: id.to_string(),
+            definition_id: definition_id.to_string(),
+            parent_instance_id: String::new(),
+            block_id: block_id.to_string(),
+            session_id: String::new(),
+            status: "available".to_string(),
+            github_context: String::new(),
+            started_at: 1,
+            ended_at: 0,
+            created_at: 1,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: id.to_string(),
+            working_directory: String::new(),
+            display_hidden: false,
+        }
+    }
+
+    /// docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+    /// §5a: a row with no structured `output.state.json` snapshot but a
+    /// PERSISTED `db_agent_activity_summaries` row for its definition must
+    /// surface that summary as `preview`, still reporting `has_snapshot:
+    /// false` (accurate — there genuinely is no structured snapshot; the
+    /// summary is a substitute, not a claim that one exists).
+    #[tokio::test]
+    async fn snapshot_less_row_uses_a_persisted_definition_summary_as_preview() {
+        let state = test_state();
+        let mut def = local_agent_def("def-local-1");
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state
+            .wstore
+            .instance_create(&local_agent_instance("inst-local-1", "def-local-1", "block-local-1"))
+            .unwrap();
+        state
+            .wstore
+            .agent_activity_summary_set("def-local-1", "Fixed the login race condition", 1000)
+            .unwrap();
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+        assert_eq!(result.rows.len(), 1);
+        let row = &result.rows[0];
+        assert!(!row.has_snapshot, "no output.state.json was ever written for this instance");
+        assert_eq!(
+            row.preview, "Fixed the login race condition",
+            "persisted definition summary must surface as the row's preview \
+             when there's no real snapshot to preview instead"
+        );
+    }
+
+    /// Counterpart to the above: when NOTHING is persisted yet for the
+    /// definition, the row's `preview` stays empty — the frontend's own
+    /// existing "(no conversation snapshot)" fallback text is unaffected.
+    /// Generation itself (a real Haiku CLI round-trip) is fire-and-forget
+    /// and not asserted here — this only locks in that a missing summary
+    /// never surfaces as a fabricated non-empty preview.
+    #[tokio::test]
+    async fn snapshot_less_row_with_no_persisted_summary_leaves_preview_empty() {
+        let state = test_state();
+        let mut def = local_agent_def("def-local-2");
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state
+            .wstore
+            .instance_create(&local_agent_instance("inst-local-2", "def-local-2", "block-local-2"))
+            .unwrap();
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+        assert_eq!(result.rows.len(), 1);
+        let row = &result.rows[0];
+        assert!(!row.has_snapshot);
+        assert_eq!(row.preview, "", "no summary persisted yet — preview must stay empty, not fabricated");
     }
 }

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -211,6 +211,36 @@ fn definition_summary_semaphore() -> &'static tokio::sync::Semaphore {
     SEM.get_or_init(|| tokio::sync::Semaphore::new(MAX_CONCURRENT_DEFINITION_SUMMARIES))
 }
 
+/// Read-only CLI path lookup for `provider_id` — checks the versioned
+/// local-install dir, then falls back to system PATH. Deliberately never
+/// installs anything (unlike the `resolvecli` RPC handler / `agent_open.rs`'s
+/// launch-time resolution, which both trigger an npm install as a fallback):
+/// this is a best-effort BACKGROUND call, not a user-initiated launch —
+/// silently installing a CLI as a side effect of a picker preview summary
+/// would be a surprising, unwanted cost. Returns `None` (not an error) for
+/// an unknown provider or a CLI that isn't already available either way;
+/// the caller treats that the same as any other unresolvable case.
+async fn resolve_provider_cli_path_readonly(provider_id: &str) -> Option<String> {
+    const AGENTMUX_VERSION: &str = env!("CARGO_PKG_VERSION");
+    let provider = crate::backend::providers::get_provider(provider_id)?;
+    let paths = agentmux_common::DataPaths::from_env()?;
+    let provider_dir = paths
+        .home_dir
+        .join("instances")
+        .join(format!("v{AGENTMUX_VERSION}"))
+        .join("cli")
+        .join(provider.id);
+    let npm_bin = if cfg!(windows) {
+        provider_dir.join("node_modules").join(".bin").join(format!("{}.cmd", provider.cli_command))
+    } else {
+        provider_dir.join("node_modules").join(".bin").join(provider.cli_command)
+    };
+    if npm_bin.exists() {
+        return Some(npm_bin.to_string_lossy().to_string());
+    }
+    crate::server::cli_handlers::resolve_cli_on_path(provider.cli_command).await
+}
+
 /// Generate (and persist) a short activity summary for a definition whose
 /// AgentPicker row has no structured `output.state.json` conversation
 /// snapshot to preview — legacy rows predating snapshot persistence, per
@@ -227,21 +257,34 @@ fn definition_summary_semaphore() -> &'static tokio::sync::Semaphore {
 /// in-flight call here (unlike the pull/pushed activity-summary RPCs,
 /// which regenerate every turn for a LIVE conversation).
 ///
+/// CLI path resolution (reagent P1, PR #2786): the row shape this feature
+/// actually targets is a CLOSED pane — `DeleteBlock`
+/// (`sagas::delete_block::run`) removes the `Block` row entirely on pane
+/// close while the instance row and raw filestore output survive. For such
+/// rows there is no live block to read `cmd`/`cmd:env` meta from at all, so
+/// this prefers the block record when it still exists (richer: carries the
+/// per-block auth env the CLI needs) and falls back to
+/// `resolve_provider_cli_path_readonly` + an EMPTY auth env otherwise —
+/// best-effort: a provider that needs per-block injected credentials (no
+/// ambient/global login available) fails the Haiku call cleanly (`None`,
+/// same as any other unresolvable case here), not a wrong result.
+///
 /// Fire-and-forget by design: the caller (`listrecentsessions`) spawns this
 /// in the background and does not await it inline. The row that triggered
 /// generation still shows its existing fallback text on THIS response; on
 /// success this broadcasts `agents:changed`, which `MyAgentsList.tsx`
 /// already refetches on, picking up the now-persisted summary on the next
 /// load. Returns `None` (nothing persisted, nothing broadcast) when there's
-/// no raw output to summarize, the block/CLI path isn't resolvable, this
-/// call was superseded/capped, or the CLI failed — the caller treats all of
-/// these as "still nothing to show," not an error.
+/// no raw output to summarize, the CLI path isn't resolvable, this call was
+/// superseded/capped, or the CLI failed — the caller treats all of these as
+/// "still nothing to show," not an error.
 pub(crate) async fn generate_definition_activity_summary(
     wstore: &Store,
     filestore: &crate::backend::storage::filestore::FileStore,
     broker: &Arc<crate::backend::wps::Broker>,
     definition_id: &str,
     block_id: &str,
+    provider_id: &str,
 ) -> Option<(String, Option<crate::agents::TokenCounts>)> {
     let key = crate::ambient::AmbientCallKey::new(definition_id.to_string(), AMBIENT_PURPOSE_DEFINITION_SUMMARY);
     let guard = match crate::ambient::gateway().admit(key, 1) {
@@ -267,18 +310,27 @@ pub(crate) async fn generate_definition_activity_summary(
         return None;
     };
 
-    let block: Block = match wstore.get(block_id) {
-        Ok(Some(b)) => b,
+    let (cli_path, meta): (String, MetaMapType) = match wstore.get::<Block>(block_id) {
+        Ok(Some(block)) => {
+            let p = obj::meta_get_string(&block.meta, "cmd", "");
+            if p.is_empty() {
+                let Some(p) = resolve_provider_cli_path_readonly(provider_id).await else {
+                    drop(guard);
+                    return None;
+                };
+                (p, MetaMapType::new())
+            } else {
+                (p, block.meta.clone())
+            }
+        }
         _ => {
-            drop(guard);
-            return None;
+            let Some(p) = resolve_provider_cli_path_readonly(provider_id).await else {
+                drop(guard);
+                return None;
+            };
+            (p, MetaMapType::new())
         }
     };
-    let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
-    if cli_path.is_empty() {
-        drop(guard);
-        return None;
-    }
 
     let prompt = format!(
         "Summarize in 12 words or fewer what this conversation/session was \
@@ -288,7 +340,7 @@ pub(crate) async fn generate_definition_activity_summary(
          Recent activity:\n\n{digest}"
     );
 
-    let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
+    let result = invoke_ambient_haiku_call(&cli_path, &prompt, &meta, cancel).await.ok();
     drop(guard);
 
     let (summary, tokens) = result?;
@@ -1156,6 +1208,22 @@ mod build_session_title_prompt_tests {
         assert!(prompt.contains("repeat it back EXACTLY, unchanged"));
         assert!(prompt.contains("OVERALL GOAL"));
         assert!(!prompt.contains("what is currently being worked on"));
+    }
+}
+
+/// reagent P1, PR #2786: `generate_definition_activity_summary` falls back
+/// to this resolver when the instance's `Block` row is gone (the closed-
+/// pane case this feature actually targets). Only the cheap, deterministic
+/// "unknown provider" early return is exercised here — the filesystem/PATH
+/// probing branches depend on this machine's actual CLI install state and
+/// aren't meaningfully unit-testable without mocking the filesystem.
+#[cfg(test)]
+mod resolve_provider_cli_path_readonly_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unknown_provider_returns_none_without_touching_the_filesystem() {
+        assert!(resolve_provider_cli_path_readonly("not-a-real-provider-xyz").await.is_none());
     }
 }
 

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -353,14 +353,30 @@ pub(crate) async fn generate_definition_activity_summary(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
-    if wstore.agent_activity_summary_set(definition_id, &summary, now).is_ok() {
-        broker.publish(crate::backend::wps::WaveEvent {
-            event: "agents:changed".to_string(),
-            scopes: vec![],
-            sender: String::new(),
-            persist: 0,
-            data: None,
-        });
+    match wstore.agent_activity_summary_set(definition_id, &summary, now) {
+        Ok(()) => {
+            broker.publish(crate::backend::wps::WaveEvent {
+                event: "agents:changed".to_string(),
+                scopes: vec![],
+                sender: String::new(),
+                persist: 0,
+                data: None,
+            });
+        }
+        Err(e) => {
+            // reagent P2, PR #2786: the caller's definition_summary_attempted()
+            // gate already permanently claims definition_id before spawning —
+            // a persistence failure here silently and permanently discards a
+            // successfully generated (and billed) summary with no diagnostic
+            // trail otherwise, unlike every other fallible store call this PR
+            // touches (agent_activity_summary_get's error path logs).
+            tracing::warn!(
+                error = %e,
+                definition_id = %definition_id,
+                "generate_definition_activity_summary: agent_activity_summary_set \
+                 failed — a successfully generated summary was discarded"
+            );
+        }
     }
 
     Some((summary, tokens))

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -189,6 +189,116 @@ pub(crate) async fn generate_pushed_activity_summary(
     result.filter(|(summary, _)| !summary.is_empty())
 }
 
+/// Ambient-call purpose tag for the on-demand, once-per-definition activity
+/// summary used as the AgentPicker's "My Agents" conversation-preview
+/// fallback — see `generate_definition_activity_summary` below and
+/// `db_agent_activity_summaries` (OBJECT_SCHEMA_VERSION v27).
+const AMBIENT_PURPOSE_DEFINITION_SUMMARY: &str = "definition_summary";
+
+/// Generate (and persist) a short activity summary for a definition whose
+/// AgentPicker row has no structured `output.state.json` conversation
+/// snapshot to preview — legacy rows predating snapshot persistence, per
+/// `has_snapshot` in `agent_handlers::session::listrecentsessions`. Built
+/// from the instance's raw terminal capture (the `"output"` filestore file,
+/// written unconditionally by the CLI pipeline, independent of the newer
+/// structured snapshot), reusing `read_recent_activity_digest` — the same
+/// extraction `generate_pushed_activity_summary` above uses.
+///
+/// One-shot per definition, not per-turn: `generation` is always the
+/// constant `1`, mirroring `generate_subagent_name`'s cache-once posture —
+/// the caller only invokes this when `agent_activity_summary_get` found
+/// nothing persisted yet, so there is no "newer turn" to supersede an
+/// in-flight call here (unlike the pull/pushed activity-summary RPCs,
+/// which regenerate every turn for a LIVE conversation).
+///
+/// Fire-and-forget by design: the caller (`listrecentsessions`) spawns this
+/// in the background and does not await it inline. The row that triggered
+/// generation still shows its existing fallback text on THIS response; on
+/// success this broadcasts `agents:changed`, which `MyAgentsList.tsx`
+/// already refetches on, picking up the now-persisted summary on the next
+/// load. Returns `None` (nothing persisted, nothing broadcast) when there's
+/// no raw output to summarize, the block/CLI path isn't resolvable, this
+/// call was superseded/capped, or the CLI failed — the caller treats all of
+/// these as "still nothing to show," not an error.
+pub(crate) async fn generate_definition_activity_summary(
+    wstore: &Store,
+    filestore: &crate::backend::storage::filestore::FileStore,
+    broker: &Arc<crate::backend::wps::Broker>,
+    definition_id: &str,
+    block_id: &str,
+) -> Option<(String, Option<crate::agents::TokenCounts>)> {
+    let key = crate::ambient::AmbientCallKey::new(definition_id.to_string(), AMBIENT_PURPOSE_DEFINITION_SUMMARY);
+    let guard = match crate::ambient::gateway().admit(key, 1) {
+        crate::ambient::Admission::Proceed(guard) => guard,
+        crate::ambient::Admission::StaleOnArrival => return None,
+    };
+    let cancel = guard.cancellation();
+
+    // Same cross-block concurrency cap as every other on-demand ambient
+    // caller (subagent/dispatch naming) — a picker load with many
+    // snapshot-less rows shouldn't spawn unbounded concurrent Haiku CLIs.
+    let permit = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        permit = pull_call_semaphore().acquire() => permit.ok(),
+    };
+    let Some(_permit) = permit else {
+        drop(guard);
+        return None;
+    };
+
+    let Some(digest) = read_recent_activity_digest(filestore, block_id) else {
+        drop(guard);
+        return None;
+    };
+
+    let block: Block = match wstore.get(block_id) {
+        Ok(Some(b)) => b,
+        _ => {
+            drop(guard);
+            return None;
+        }
+    };
+    let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
+    if cli_path.is_empty() {
+        drop(guard);
+        return None;
+    }
+
+    let prompt = format!(
+        "Summarize in 12 words or fewer what this conversation/session was \
+         about, based on the raw terminal output below. Plain text only — \
+         no markdown, no code fences, no backticks, no quotes, no \
+         punctuation at the end, no preamble.\n\n\
+         Recent activity:\n\n{digest}"
+    );
+
+    let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
+    drop(guard);
+
+    let (summary, tokens) = result?;
+    let summary = summary.trim().to_string();
+    if summary.is_empty() {
+        return None;
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    if wstore.agent_activity_summary_set(definition_id, &summary, now).is_ok() {
+        broker.publish(crate::backend::wps::WaveEvent {
+            event: "agents:changed".to_string(),
+            scopes: vec![],
+            sender: String::new(),
+            persist: 0,
+            data: None,
+        });
+    }
+
+    Some((summary, tokens))
+}
+
 /// Ambient-call purpose tag for the on-demand subagent display name (see
 /// `generate_subagent_name`). One-shot per subagent — `generation` is always
 /// the constant `1` since a name, once generated, is cached on

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -192,8 +192,24 @@ pub(crate) async fn generate_pushed_activity_summary(
 /// Ambient-call purpose tag for the on-demand, once-per-definition activity
 /// summary used as the AgentPicker's "My Agents" conversation-preview
 /// fallback — see `generate_definition_activity_summary` below and
-/// `db_agent_activity_summaries` (OBJECT_SCHEMA_VERSION v27).
+/// `db_agent_activity_summaries` (OBJECT_SCHEMA_VERSION v28).
 const AMBIENT_PURPOSE_DEFINITION_SUMMARY: &str = "definition_summary";
+
+/// Max simultaneous Haiku CLI spawns for definition-summary generation.
+/// Deliberately its OWN semaphore, not `pull_call_semaphore()` (reagent P1,
+/// PR #2786): that one is reserved for live, user-turn-triggered pull RPCs
+/// specifically so background bursts don't queue behind or block them (see
+/// its own doc comment above) — this call is background-triggered (a
+/// `listrecentsessions` poll, not a direct user action), the same class as
+/// `activity_watcher.rs`'s pushed-summary sweep, which likewise gets its
+/// own dedicated semaphore rather than sharing this one. Capped at 1: this
+/// is best-effort background fill-in, not latency-sensitive.
+const MAX_CONCURRENT_DEFINITION_SUMMARIES: usize = 1;
+
+fn definition_summary_semaphore() -> &'static tokio::sync::Semaphore {
+    static SEM: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
+    SEM.get_or_init(|| tokio::sync::Semaphore::new(MAX_CONCURRENT_DEFINITION_SUMMARIES))
+}
 
 /// Generate (and persist) a short activity summary for a definition whose
 /// AgentPicker row has no structured `output.state.json` conversation
@@ -234,13 +250,12 @@ pub(crate) async fn generate_definition_activity_summary(
     };
     let cancel = guard.cancellation();
 
-    // Same cross-block concurrency cap as every other on-demand ambient
-    // caller (subagent/dispatch naming) — a picker load with many
-    // snapshot-less rows shouldn't spawn unbounded concurrent Haiku CLIs.
+    // Background-call semaphore, not `pull_call_semaphore()` — see
+    // `definition_summary_semaphore`'s own doc comment above.
     let permit = tokio::select! {
         biased;
         _ = cancel.cancelled() => None,
-        permit = pull_call_semaphore().acquire() => permit.ok(),
+        permit = definition_summary_semaphore().acquire() => permit.ok(),
     };
     let Some(_permit) = permit else {
         drop(guard);

--- a/docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+++ b/docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
@@ -1,0 +1,237 @@
+# Report — AgentPicker "My Agents" audit: field order, missing sort, and two data-fallback gaps
+
+**Date:** 2026-08-24
+**Author:** AgentY
+**Type:** Investigation + UX/architecture recommendations — no code changed yet
+**Scope:** `frontend/app/view/agent/components/AgentPicker.tsx`,
+`AgentPickerFilterBar.tsx`, `MyAgentsList.tsx`,
+`frontend/app/view/agent/styles/_recent-sessions.scss`,
+`agentmux-srv/src/server/agent_handlers/session.rs`
+
+Prompted by direct user feedback: "a lot of the fields are out of order,"
+a request for name/launch-date/type sort controls at the right edge of the
+filter bar, and two specific data gaps — "(ambient creds)" and "(no
+conversation snapshot)" appearing where they shouldn't.
+
+---
+
+## 1. Current state — row layout
+
+Each row in the "My Agents" list (`MyAgentsList.tsx:453-547`) renders, top
+to bottom:
+
+1. **Line 1** (`agent-recent-sessions-line1`, one flex row, baseline-aligned):
+   provider icon → **name** (`max-width: 60%`, ellipsis) → active-badge (dot,
+   if open elsewhere) → runtime badge ("HOST"/"SANDBOX" tag, if known) →
+   **account/identity name** (`agent-recent-sessions-meta`, `flex: 1`, own
+   ellipsis, fallback `"(ambient creds)"`).
+2. **Preview line**: first user message, or `"(no user message yet)"` /
+   `"(no conversation snapshot)"`.
+3. **Line 3** (conditional): `"N messages"`.
+4. **Timestamps row**: `Created` → `Last Launch` → `Last Active` (each
+   conditionally shown; `Last Active` only when it's later than `Last
+   Launch`).
+
+No sort control exists anywhere in the picker today — `AgentPickerFilterBar.tsx`
+is a single text input + clear button (lines 38-63), nothing else. Rows come
+back from `ListRecentSessionsCommand` in whatever order the backend returns
+them (not verified server-side ordering in this pass — worth confirming
+before shipping a sort UI, since "sort" needs a defined base case to toggle
+away from).
+
+## 2. Field-order findings
+
+**The account/identity field is the most likely source of "out of order."**
+It shares one flex row with the name via `flex: 1` (`_recent-sessions.scss:166-174`),
+so it's squeezed into whatever space the name, active-badge, and runtime
+badge don't take — on a narrow tile (`minmax(240px, 1fr)` grid,
+`_recent-sessions.scss:98`) this reads as an afterthought crammed at the
+end of a crowded line, competing for space with the name's own ellipsis
+rather than being reliably visible. It's also the ONE piece of
+account-identifying info on the card, arguably as important as the name
+itself for a user managing multiple accounts — currently it has the least
+reliable visual space of anything on the row.
+
+**Timestamp order is chronological (Created → Launch → Active), not
+recency-first.** That's an internally consistent choice, but it means the
+*most actionable* fact — when was this last active — is buried last,
+after two less-actionable facts. Most comparable "recent items" UIs (VS
+Code's Recent, GitHub's repo list, browser history) lead with the most
+recent/relevant timestamp, not the oldest.
+
+**Recommendation (design judgment, not a bug fix):**
+- Move the account/identity name off the crowded name row entirely — pair
+  it with the runtime badge on its own metadata line (or immediately
+  under the name), consistently visible instead of flex-squeezed.
+- Reorder timestamps to lead with whichever is most relevant right now:
+  `Last Active` (or `Last Launch` if never active) first, `Created` last —
+  the "when did I last touch this" question a picker exists to answer,
+  answered first.
+- Keep the runtime badge directly adjacent to the name (current position)
+  — that pairing already reads well and matches the composer-strip's own
+  badge placement convention.
+
+This is a call worth confirming with the user before implementing — listed
+as a recommendation, not committed to code in this pass.
+
+## 3. Sort control — recommendation
+
+No sort UI exists to extend, so this is new surface, not a fix. Best-practice
+shape for "far right of the filter bar," matching this component's own
+minimal, flat, bordered styling (`AgentPickerFilterBar.tsx`/`_picker.scss`):
+
+- A single **"Sort ▾"** control (button + small dropdown, or a 3-way segmented
+  toggle if space allows) right-aligned in `.agent-picker-filter-bar`, after
+  the text input.
+- Options: **Name (A→Z)**, **Recently launched** (default — matches today's
+  implicit "most relevant first" intent, needs confirming what the backend's
+  current unsorted order actually is), **Type** (groups Host vs. Sandbox —
+  matches `RuntimeBadge`'s existing "host"/"container" vocabulary exactly,
+  so the sort labels should read "Host" / "Sandbox" to match the tag wording
+  the user already sees on each row, per `RuntimeBadge.tsx:28`).
+- Persist the choice (this machine only, e.g. `localStorage`) — no existing
+  precedent for a control exactly like this in the codebase to match against,
+  so this would be a new small pattern, not an extension of one.
+- Sorting should apply to the **already-fetched, filtered row set**
+  (`filteredRows()` in `MyAgentsList.tsx:381-386`) client-side — no backend
+  RPC change needed, since the full candidate set (up to `SEARCH_LIMIT` while
+  filtering, `limit ?? 20` otherwise) is already in memory.
+
+Not designed further than this (control placement + options) — full visual
+spec/implementation is follow-up work, not part of this audit.
+
+## 4. Bug: "(ambient creds)" can appear on agents that DO have a bound account
+
+**Real, confirmed regression class — not by-design for the failure case.**
+
+`identity_name` is populated in `session.rs:330-346` by looking up
+`links_by_agent[definition_id]`, built from `identity_store.agent_identity_list_all()`.
+When no link rows exist for a definition, the code hard-codes `"(ambient
+creds)"` — correct when the agent genuinely has no bound identity.
+
+**The bug:** if `agent_identity_list_all()` itself errors (`session.rs:282-290`
+— the doc comment cites the exact `secret_ref` serde-tag mismatch behind
+PR #2296), `links_by_agent` comes back empty for the WHOLE response, so
+**every** row shows `"(ambient creds)"`, including agents with a real,
+correctly-bound account. This exact failure mode is already documented in
+`docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md` §9 rec 1
+— previously caused the whole list to look empty; the current code degrades
+that source in isolation instead of aborting the request (an improvement),
+but the wrong-text symptom on every row was never itself eliminated.
+
+Secondary, narrower gap: the identity lookup joins by `agent_id` only, not
+`provider` (`session.rs:330-344`), so a multi-provider agent could show a
+stitched `"nameA, nameB"` instead of the identity actually used by that
+specific instance — a display-accuracy issue, not the empty-string bug.
+
+**Recommendation:** give the `identity_links`-source-failure case its own
+distinct fallback text (e.g. `"(unknown account)"` or similar), instead of
+reusing the same string genuinely-no-identity uses — mirroring the exact
+pattern this codebase already applies one layer up (`FETCH_ERROR` vs.
+`EMPTY_GLOBAL`/`EMPTY_FILTERED` in `MyAgentsList.tsx:63-71`, built
+specifically so a backend failure never looks identical to a legitimate
+empty state). Also worth a loud log line at the failure site if one isn't
+already there (not confirmed in this pass).
+
+## 5. Bug: "(no conversation snapshot)" can appear on agents that DO have history
+
+Two distinct causes, one a real bug, one by-design-but-confusing:
+
+**Real bug:** `has_snapshot` is computed from `filestore.stat(&inst.block_id,
+"output.state.json")` (`session.rs:360-379`), which returns
+`Result<Option<WaveFile>, StoreError>`. The match arm collapses `Err(...)`
+(I/O error, lock contention, DB read failure) into the SAME branch as
+`Ok(None)` (genuinely no snapshot) — a transient storage error on a row that
+DOES have a real snapshot renders identically to "never had one," with no
+log line. This is unconditional error-swallowing, and it isn't covered by
+the `degraded` mechanism at all (filestore isn't one of the six tracked
+sources).
+
+**By-design, but the copy doesn't say so:** rows sourced from the
+cross-channel registry (no matching local SQLite instance) get a synthetic
+`AgentInstance` with `block_id: String::new()` (`session.rs:219-235`,
+explicit comment: "Cross-channel rows arrive as synthetic instances"). An
+empty `block_id` short-circuits to `has_snapshot: false` before `stat()` is
+ever called — correct given this instance's own filestore genuinely has
+nothing, but the row's real conversation may well exist in a *different*
+channel's filestore. `"(no conversation snapshot)"` reads as "there is no
+history," when the more accurate statement is "no history in THIS channel."
+
+**Recommendation:**
+- Fix the error-swallowing: distinguish `Err` from `Ok(None)` in the match
+  arm, log the error case, and consider a third UI state (or at least a
+  console/log signal) instead of silently reporting "no snapshot."
+- For the cross-channel case, adjust the copy to hint at the real situation
+  — e.g. "(history may exist in another version)" — rather than the flatly
+  incorrect-sounding "no conversation snapshot."
+
+### 5a. Addendum — a real fallback source exists (correction to an earlier draft of this report)
+
+An earlier pass of this investigation checked the **swarm** dispatch system
+(`AgentDispatch`/`dispatch_name`) as a possible fallback preview source and
+correctly ruled it out — it's live/in-memory only, keyed by `parent_block_id`/
+a live request's `agent_id`, not `definition_id`, and dies with the block.
+
+The user then pointed at the right thing: dispatch naming and terminal
+`term:ambient_summary` generation aren't two independent Haiku features —
+**they share one call site.** Confirmed: `generate_dispatch_name`,
+`generate_subagent_name`, `register_session_activity_summary`, and
+`generate_pushed_activity_summary` (`session.rs:156,215,308,374`) all funnel
+through `invoke_ambient_haiku_call()` (`session.rs:670`) via the same
+coalescing gateway, `crate::ambient::gateway()` (`agentmux-srv/src/ambient/mod.rs:61`),
+keyed by `AmbientCallKey{entity_id, purpose}` — a deliberately reusable
+choke point per `docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md`
+and `docs/specs/SPEC_AMBIENT_SUMMARY_SANITIZATION_AND_TERSENESS_2026_07_08.md:89-91`
+("any future ambient-call purpose gets the same protection for free").
+
+`invoke_ambient_haiku_call(cli_path, prompt, meta, cancel)` takes an
+arbitrary caller-built prompt (not a fixed template) and returns raw Haiku
+text — nothing about it is scoped to dispatches or terminals specifically.
+**This makes a definition-keyed "last activity" summary genuinely buildable**,
+closing the gap this report originally flagged as unbridgeable — with two
+things still needed, neither of which exists today:
+
+1. **A new call site** in `session.rs`, shaped like `generate_dispatch_name`
+   (`session.rs:308-372`): build a prompt from the instance's latest
+   `output.state.json`/recent output (reusing the same extraction helpers
+   `read_task_prompt()`/`read_recent_activity_digest()` already use), call
+   `invoke_ambient_haiku_call` through `ambient::gateway().admit(AmbientCallKey::new(definition_id, "definition_summary"), ...)`.
+2. **New persistence** — the actual gap, not the Haiku call itself. Nothing
+   today stores anything keyed by `definition_id` for this purpose (dispatch
+   names live in in-process memory; `term:ambient_summary` lives in ephemeral
+   block meta keyed by `block_id`). This needs a durable, `definition_id`-keyed
+   store (a new SQLite table, or a field alongside `registry/def_store.rs`)
+   holding `(definition_id, summary, updated_at)`, written by the new call
+   site and read back in `session.rs:381-409` as the `preview` fallback
+   whenever `has_snapshot` is false.
+
+**Open design question, not yet resolved:** what triggers generation/refresh
+— every turn-end (mirrors the existing `activity_summary` pushed-sweep
+trigger, but multiplies Haiku spend across every agent definition, not just
+open panes), only when a pane closes (cheaper, but stale until the agent is
+reopened elsewhere), or on-demand the first time the picker actually needs
+one for a snapshot-less row (cheapest, but adds latency to that row's first
+render)? This is a cost/freshness tradeoff, not a technical constraint —
+worth deciding before implementing.
+
+## 6. Non-goals / not investigated this pass
+
+- Server-side default row ordering (needed to pick a sensible sort default)
+  — not confirmed.
+- Whether `filestore.stat()`'s error rate in production is actually
+  meaningful (no telemetry reviewed) — the fix is justified by the
+  swallowing pattern itself (same class of bug the `identity_links`
+  precedent already proved worth fixing), not by observed frequency.
+- Visual mockup / exact CSS for the reordered row or the new sort control.
+- Any change to `ListRecentSessionsCommand`'s RPC contract.
+
+## 7. Suggested next steps, in order
+
+1. Confirm the proposed field-order change and sort-control placement with
+   the user before implementing (design judgment call, not a pure bug fix).
+2. Fix `has_snapshot`'s `Err`/`Ok(None)` conflation (`session.rs:360-379`) —
+   smallest, most clearly a bug of the four findings here.
+3. Give the `identity_links`-failure case distinct fallback text from the
+   genuinely-empty case, matching the existing `FETCH_ERROR` pattern.
+4. Implement the sort control (client-side, over `filteredRows()`).
+5. Reorder row fields per §2, if confirmed.


### PR DESCRIPTION
## Summary

Follow-up to the audit in `docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md` §5 — the AgentPicker's "My Agents" rows show `"(no conversation snapshot)"` for legacy rows that predate structured `output.state.json` snapshot persistence, even when the instance genuinely has real conversation history in its raw terminal capture.

- **New table** `db_agent_activity_summaries` (`OBJECT_SCHEMA_VERSION` v27): one row per `definition_id`, generated at most once, cached forever.
- **No new Haiku-calling machinery.** `generate_definition_activity_summary` (`agentmux-srv/src/server/app_api/session.rs`) reuses the exact same shared Ambient Model Call gateway (`invoke_ambient_haiku_call`, `crate::ambient::gateway()`) that `dispatch_name`/`subagent_name`/`term:ambient_summary` already share — just a new purpose tag (`"definition_summary"`) and a new persistence layer.
- **Source data**: the instance's raw `"output"` filestore file (written unconditionally by the CLI capture pipeline) via `read_recent_activity_digest` — the same extraction `generate_pushed_activity_summary` already uses. This is why it works even when the structured snapshot doesn't exist.
- **On-demand, fire-and-forget**: `listrecentsessions` (`agentmux-srv/src/server/agent_handlers/session.rs`) checks the persisted table synchronously (cheap indexed read); if nothing's there yet, it spawns generation in the background and returns immediately — the row keeps showing today's fallback text on that first load. On success, generation broadcasts `agents:changed`, which `MyAgentsList.tsx` already refetches on.
- **Zero frontend changes.** `<Show when={row.preview} fallback={...}>` already prefers a non-empty `preview` over the fallback text — populating `preview` from the persisted summary is enough.
- **Scoped to local rows only** — a cross-channel row's synthetic empty `block_id` has no local raw output to summarize either, so it's left alone (the existing fallback text is accurate for that case: this channel genuinely has nothing).

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2767 passed (one `sysinfo` handle-leak test flaked under full-suite parallel load, confirmed passing in isolation, unrelated Windows process-handle counting code untouched by this PR).
- [x] New tests: `agent_activity_summaries::tests` (4, storage get/set/upsert roundtrip), `agent_handlers::session::tests::snapshot_less_row_uses_a_persisted_definition_summary_as_preview` + `..._with_no_persisted_summary_leaves_preview_empty` (end-to-end through the real RPC dispatch).
- [x] `npx tsc --noEmit` — clean (no frontend changes).
- [ ] Not manually verified in a running instance — the Haiku CLI round-trip itself isn't exercised by these tests (would require a real CLI binary + subprocess spawn). The persistence/wiring logic is fully covered; the actual generation path is the same, already-production, `invoke_ambient_haiku_call` code every other ambient-call feature already relies on.

<!-- agentmux:agent_id=agenty -->