### PR TITLE
Manoz@Area54: Pause AskUserQuestion auto-timeout on keyboard activity, not just mouse hover

### DIFF
--- a/.changesets/1787584354-feat-agent-view-pause-askuserquestion-auto-timeout-on-keyboa-iwv0.md
+++ b/.changesets/1787584354-feat-agent-view-pause-askuserquestion-auto-timeout-on-keyboa-iwv0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-view): pause AskUserQuestion auto-timeout on keyboard activity, not just mouse hover

--- a/docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md
@@ -309,3 +309,48 @@ generic helper, e.g. `keydownOn(el, key)`):
   proceeds to auto-submit at 0 if still untouched — the keyboard analog of
   the hover-pause spec's own "cursor parked, no further activity" manual
   check.
+
+---
+
+## 8. Post-review revisions (2026-08-24, PR #2787)
+
+Three gaps found during review, all fixed before merge:
+
+1. **reagentx P1 — unbounded pause via key-repeat/continuous typing.** §2.1's
+   "any qualifying keydown calls `onPanelPointerEnter()` directly" turned out
+   not to be a safe direct reuse: `mouseenter` only fires once per actual
+   boundary-crossing (a real browser can't spam it under normal use), but
+   `keydown` fires on every keystroke, including OS key-repeat and every
+   character typed. Re-arming unconditionally on each one meant typing
+   faster than 15s apart — or simply holding a key — suppressed the
+   auto-timeout indefinitely, breaking the "at most one `HOVER_HIDE_GRACE_MS`
+   window" invariant this spec's own §3 edge-case table claimed ("typing
+   alone does not extend the hide window"). **Fix:** gate the trigger on
+   `!hidden()` — only the transition *into* the paused state (re)arms the
+   window; further qualifying events while already hidden are no-ops. This
+   also revises §7's "second qualifying keydown mid-window restarts the
+   window" test expectation, which described the exact behavior being fixed
+   here — the corrected expectation is the opposite: a second keydown
+   *mid-window* does **not** restart it; only a keydown *after* the window
+   has actually resumed does.
+2. **Codex P2 — minimized chip not excluded.** §2.2 says the minimized chip
+   is excluded "for the identical reason" as the mouse trigger, but that
+   exclusion isn't automatic for keyboard: while minimized, `rootRef` is
+   reassigned to the minimized `<button>`, so a keydown/focus landing
+   directly on that focusable button read as `inPanel = true`. **Fix:**
+   also gate the trigger on `!minimized()`.
+3. **Codex P2 — Tab-into-panel from outside doesn't pause.** A real browser
+   moves focus only *after* a `Tab` keydown's default action runs, so the
+   keydown that causes a keyboard-only user's first entry into the panel has
+   `e.target` still pointed at whatever was focused before — outside the
+   panel. `handleKey`'s target-at-dispatch-time `inPanel` check necessarily
+   misses that one event. **Fix:** a second, separate `focusin` listener
+   (which bubbles and fires once focus has actually landed) reusing the same
+   gated check, registered in the same effect as the `keydown` listener.
+
+All three fixes share one helper, `maybePauseFor(target)` — computes
+`inPanel` and gates on `!minimized() && !hidden()` — called from both
+`handleKey` and the new `handleFocusIn`. §2.3's "extend `handleKey`, don't
+add a second listener" decision is narrowed by fix 3: it still holds for a
+second *keydown* listener, but a `focusin` listener addresses a distinct
+browser-timing gap `keydown` structurally cannot catch.

--- a/docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md
@@ -1,0 +1,311 @@
+# SPEC: Keyboard-driven pause for the AskUserQuestion auto-timeout countdown
+
+**Date:** 2026-08-20
+**Status:** proposed
+**Builds on:** `docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md`
+(implemented). This spec adds a *second trigger* for that spec's existing
+`hidden`/hide-timer mechanism — it does not change what "paused" means, how
+long a pause lasts, how it resumes, or anything about §2's "live but
+strictly bounded" safety argument. It also does not reopen
+`docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md`'s original
+"merge, no disarm" decision, for the same reason the hover-pause spec's own
+§2 already established: a bounded, self-resuming pause is a different kind
+of mechanism than a permanent one-shot disarm, and this spec doesn't touch
+that distinction at all — it only adds a second *way to enter* an existing,
+already-bounded pause state.
+
+---
+
+## 0. Ask
+
+> for the askquestion, we need to extend the timer to listen to keyboard
+> events too .. urrently it only listens to mouse. take a look, write spec
+> to file
+
+---
+
+## 1. Current behavior (audited against source, 2026-08-20)
+
+`frontend/app/view/agent/components/AgentQuestionPanel.tsx`, confirmed
+against the live file directly (not from the hover-pause spec's own prose,
+which predates one change noted below):
+
+- The hover-pause mechanism from the prior spec is implemented exactly as
+  that spec describes: `hidden` signal (line 150), `hideTimeoutId` +
+  `clearHideTimer` (lines 151–158), `onPanelPointerEnter` (lines 204–211)
+  which hides the countdown and starts a flat, unconditional
+  `HOVER_HIDE_GRACE_MS` (15s, line 47) window, and the timer-arm effect
+  (lines 350–367) gated on `hidden()`.
+- **The only thing that currently calls `onPanelPointerEnter` is
+  `onMouseEnter` on the panel's root `<div class="agent-question-panel">`**
+  (line 479) — confirmed via grep, this is the sole call site. There is no
+  `mousemove`/`mousedown`/`click`/`focus`/`keydown` listener wired to it
+  anywhere in the file.
+- **One relevant drift from the hover-pause spec's own text:**
+  `AUTO_TIMEOUT_MS` is no longer a hardcoded constant — it's now
+  `autoTimeoutMs()` (lines 118–138), reading `agent:askquestiontimeoutms`
+  from settings with `DEFAULT_AUTO_TIMEOUT_MS` (30s, line 39) as the
+  fallback. Not relevant to this spec's design (the timer-arm effect
+  already calls `autoTimeoutMs()` fresh at line 355), but worth naming so a
+  reader comparing this file against the hover-pause spec's own quoted code
+  isn't confused by the rename.
+- **A keyboard listener already exists in this file, for a different
+  purpose.** `handleKey` (lines 395–421), wired via a global
+  `window.addEventListener("keydown", ..., true)` inside its own
+  `createEffect` (lines 427–432, gated on `request()`). It handles exactly
+  two keys: `Enter` (submit, unless the target is an editable control
+  outside this panel) and `Escape` (defer/minimize). Every other key is a
+  no-op today — typing a letter into the "Other" field, or Tab-navigating
+  between radio options, does nothing to the countdown at all.
+  - This listener is global-on-`window` with capture, specifically because
+    the panel root has `tabindex={-1}` and never auto-focuses (see the
+    comment at lines 423–426) — a plain `onKeyDown` on the root div would
+    only fire after the user had already clicked something inside it. This
+    same reasoning is why the new keyboard-pause trigger below must reuse
+    this listener rather than attach a local one — see §3.3.
+  - It already has the exact scoping primitives this spec needs:
+    `paneRoot`/`paneRoot.contains(target)` (lines 400–401, scopes to "this
+    question's own pane, not some other pane on screen") and `inPanel`
+    (lines 403–406, scopes to "the keystroke actually landed inside this
+    panel's own DOM, not just its pane") and `isEditableTarget` (lines
+    388–393).
+
+**Gap:** a user who answers (or is about to answer) purely by keyboard —
+Tab-ing between options and pressing Space, or typing into the "Other"
+field without ever moving the mouse over the panel — gets none of the
+breathing room the hover-pause spec added for mouse users. The countdown
+keeps ticking and can auto-submit out from under them mid-keystroke, which
+is exactly the scenario the hover-pause spec exists to prevent for mouse
+users (§0 of that spec: "if there is any mouse hover for typing into that
+pane, the timer disappears").
+
+---
+
+## 2. Design
+
+### 2.1 Trigger: reuse `onPanelPointerEnter`, don't parallel it
+
+**Decision: any qualifying keydown calls the existing
+`onPanelPointerEnter()` directly.** Not a new signal, not a new timeout, not
+a new grace-period constant — the exact same function the mouse path
+already calls, so "paused" has one single meaning and one single
+implementation regardless of what triggered it. This is the direct
+extension of the DRY principle the hover-pause spec itself was built under
+(see that spec's own "Reuses" line).
+
+Practically: `onPanelPointerEnter` hides the countdown and starts a flat,
+unconditional `HOVER_HIDE_GRACE_MS` window from *this* trigger — identical
+behavior, identical bound, whether the trigger was a `mouseenter` or a
+qualifying `keydown`. Everything in the prior spec's §2 ("live but strictly
+bounded," worst case one `HOVER_HIDE_GRACE_MS` window per fresh trigger)
+carries over unchanged, because it's the same mechanism, not a new one.
+
+### 2.2 Scope: which keydowns count
+
+**Decision: reuse `handleKey`'s existing `inPanel` check** (lines 403–406)
+— a keydown counts as engagement only if it targets something inside the
+panel's own DOM (an option, the "Other" input, the panel root, or any focus
+inside it), the same scope the hover-pause spec chose for mouse entry
+(§3.1 of that spec: "the entire expanded panel," not narrowly the "Other"
+input, and not the wider pane).
+
+Considered and rejected: firing on any keydown within the whole pane
+(`paneRoot.contains(target)`, the *broader* scope `handleKey` already uses
+for Escape). Rejected because a user typing in the main chat composer, or
+searching with Ctrl+F, elsewhere in the same pane, is not "engaged with
+this question" — pausing its timer on unrelated keystrokes would silently
+extend the safety-net window for a question nobody is actually looking at,
+which is the opposite of what the hover-pause spec's own bound was
+designed to guarantee stays tight. `inPanel` — mirroring the mouse trigger's
+own "must actually enter the panel" scope exactly — is the correct
+analog.
+
+**Excluded: the minimized chip**, for the identical reason the hover-pause
+spec excludes it from mouse-hover (§3.1 of that spec): no typing surface,
+no keyboard focus target, and the "keeps running while minimized" guarantee
+is untouched by this spec.
+
+### 2.3 Where the listener lives: extend `handleKey`, don't add a second one
+
+**Decision: add the pause trigger inside the existing `handleKey` function**
+(lines 395–421), not a second `window.addEventListener`. Two independent
+global capture-phase keydown listeners on the same window, both scoped by
+overlapping-but-not-identical logic, is a maintenance hazard for no
+benefit — `handleKey` already runs on every keydown this panel cares about
+and already has the exact scoping primitives (§2.2) this needs. The
+existing listener-registration effect (lines 427–432) is unchanged; only
+`handleKey`'s body gains one new line.
+
+Sketch (illustrative, not final code — implementation is a separate PR):
+
+```ts
+const handleKey = (e: KeyboardEvent) => {
+    const target = e.target as HTMLElement | null;
+    const paneRoot = rootRef?.closest(".agent-view") as HTMLElement | null;
+    if (paneRoot && target && !paneRoot.contains(target)) return;
+
+    const inPanel = !!rootRef && !!target && rootRef.contains(target);
+
+    // New: any keydown that actually lands inside this panel counts as
+    // engagement, the same as a mouseenter — see
+    // SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md §2.
+    // Deliberately unconditional on which key (§2.4) and fires before the
+    // Enter/Escape branches below, which is a no-op change for those two
+    // keys specifically since they tear the panel state down/reset it
+    // anyway (§2.4).
+    if (inPanel) onPanelPointerEnter();
+
+    if (e.key === "Enter" && !e.shiftKey) {
+        if (!inPanel && isEditableTarget(target)) return;
+        e.preventDefault();
+        submit();
+    } else if (e.key === "Escape") {
+        e.preventDefault();
+        defer();
+    }
+};
+```
+
+### 2.4 Does it matter that this also fires for Enter/Escape?
+
+**Decision: no special-casing — let it fire for every in-panel key,
+including Enter and Escape.** Considered excluding those two (since Enter
+submits and Escape defers, both of which make the just-started hide-timer
+moot within the same tick) and rejected it as unnecessary complexity for a
+harmless case:
+
+- **Enter (submit):** `submit()` doesn't touch `hidden`/`hideTimeoutId` at
+  all, so the freshly-started hide-timer is simply abandoned. If
+  `props.onAnswer` advances the queue to a new `tool_use_id`, the reset
+  effect (lines 170–178) unconditionally clears it (`clearHideTimer();
+  setHidden(false);`) same as it always does. If the component unmounts
+  instead, `onCleanup(clearHideTimer)` (line 163) tears it down. No leak
+  either way — see §4 for the explicit case.
+- **Escape (defer):** `defer()` (lines 369–379) already calls
+  `clearHideTimer(); setHidden(false);` itself, *before* `setMinimized(true)`
+  — so a hide-timer started one line earlier by the same keydown is
+  immediately cleared again by `defer()`'s own existing cleanup. Net
+  effect: none.
+
+Special-casing these two keys out would only save starting-then-instantly-
+discarding one `setTimeout`, at the cost of a second conditional a reader
+has to reconcile against `handleKey`'s existing branches. Not worth it.
+
+---
+
+## 3. Edge cases
+
+| Case | Behavior |
+|---|---|
+| User Tabs into the panel (no typing yet) | Tab is a keydown targeting an element now inside the panel → counts as engagement, same as a mouseenter. Countdown hides, resumes in 15s at a fresh timeout, same as the mouse path. |
+| User types into "Other" continuously for 20s straight | Same as continuous mouse hover today (§4 "Mouse enters and never leaves" case in the hover-pause spec): the countdown still resumes visibly 15s after the *first* keystroke and runs its normal course from there — typing alone does not extend the hide window past `HOVER_HIDE_GRACE_MS`. A second keystroke *after* that resumption starts a fresh window, same recursive behavior as repeated mouse re-entry. |
+| User presses Space to toggle a checkbox option | Space while focus is on a checkbox `<input>` inside the panel → `inPanel` is true → counts as engagement. No special handling needed; falls out of the existing scoping. |
+| User is mid-hover (mouse-triggered hide already active) and also presses a key | `onPanelPointerEnter()` re-arms the same hide-timer from this new trigger (`clearHideTimer()` at its top, same as any repeated call) — equivalent to the existing "fresh mouseenter mid-window restarts the window" case, just via a different trigger. One shared mechanism, no cross-trigger special case needed. |
+| User presses Enter while a question is fully answered | `onPanelPointerEnter()` fires first (harmless, see §2.4), then `submit()` — unchanged behavior, no visible effect from the new code. |
+| User presses Escape | `onPanelPointerEnter()` fires first, immediately undone by `defer()`'s own `clearHideTimer()`/`setHidden(false)` — net no-op, see §2.4. |
+| Keydown targets the main chat composer or Ctrl+F search, elsewhere in the same pane | `inPanel` is false (target isn't inside `rootRef`) → does not trigger the pause, even though `paneRoot.contains(target)` is true and `handleKey` still runs. Matches §2.2's decision not to use the broader pane-level scope. |
+| Keydown happens while the panel is minimized | The minimized chip isn't inside `.agent-question-panel` (it's a separate `<button class="agent-question-panel-minimized">`, lines 450–468) — `rootRef` points at whichever root is currently mounted, so `inPanel` is false while minimized. No pause triggered; matches the mouse path's existing exclusion of the minimized chip (§2.2). |
+
+---
+
+## 4. Resolved design decisions
+
+1. **New mechanism vs. reuse — resolved: reuse `onPanelPointerEnter`
+   directly.** §2.1. One pause mechanism, two triggers, not two parallel
+   pause mechanisms that could drift apart.
+2. **Scope of "keyboard activity" — resolved: `inPanel`, mirroring the
+   mouse trigger's whole-panel (not whole-pane) scope.** §2.2. Rejected the
+   broader pane-wide scope `handleKey` uses for Escape, because unrelated
+   keystrokes elsewhere in the pane aren't engagement with *this* question.
+3. **New listener vs. extend the existing one — resolved: extend
+   `handleKey`.** §2.3. Avoids a second global capture-phase listener with
+   overlapping scoping logic to keep in sync with the first.
+4. **Special-case Enter/Escape — resolved: no, let them fire through
+   uniformly.** §2.4. Both are provably harmless no-ops given the existing
+   cleanup paths; special-casing would add complexity for zero behavioral
+   difference.
+
+---
+
+## 5. Non-goals
+
+- No new grace-period constant — reuses `HOVER_HIDE_GRACE_MS` (15s)
+  unchanged. A keyboard-specific duration was not requested and there's no
+  stated reason keyboard engagement should be trusted for a different
+  length of time than mouse engagement.
+- No change to what happens at zero (`applyRecommendedDefaults`,
+  `submit()`, `autoFilledCount`) — entirely orthogonal to this spec, same
+  as the hover-pause spec's own §2 non-goal list.
+- No change to the minimized-chip countdown, or to `defer()`'s existing
+  "always force an immediate resume" behavior — §2.2, §2.4.
+- No configurability of scope or duration — matches both prior specs'
+  "hardcoded, no settings toggle" stance for the grace window; only
+  `autoTimeoutMs()` itself is user-configurable, and that's unrelated to
+  this spec.
+- `AgentDecisionPanel` remains out of scope, same as both prior specs.
+
+---
+
+## 6. Files touched (implementation, not this spec)
+
+- `frontend/app/view/agent/components/AgentQuestionPanel.tsx` — one new
+  call (`onPanelPointerEnter()`) inside the existing `handleKey` function,
+  gated on the existing `inPanel` check. No new signals, no new timers, no
+  new listener registration.
+- `frontend/app/view/agent/components/AgentQuestionPanel.test.tsx` — new
+  test cases per §7. No changes to existing mouse-hover tests expected;
+  this is purely additive.
+- No `.scss` changes — the countdown's hidden state already renders via the
+  existing `<Show when={!hidden()}>` (line 489), unaffected by which
+  trigger set `hidden` to `true`.
+- No `agentmux-srv` (Rust) changes, no wire-format changes — entirely
+  frontend-local, same as both prior specs in this chain.
+
+---
+
+## 7. Test plan
+
+**Unit** (`AgentQuestionPanel.test.tsx`, extending the existing
+`vi.useFakeTimers()` conventions and the file's existing raw
+`KeyboardEvent` dispatch helpers — `enterOn`/`escapeOn` — with a new
+generic helper, e.g. `keydownOn(el, key)`):
+
+- A qualifying keydown inside the panel (e.g. `Tab`, or a printable
+  character while focus is on the "Other" input) hides the countdown
+  immediately, mirroring the existing "mouse enters at t=5s" test.
+- Countdown resumes exactly 15s after that keydown, at a fresh
+  `autoTimeoutMs()` — mirroring the existing hover-resume test.
+- A second qualifying keydown mid-window restarts the 15s window from that
+  second keydown — mirroring the existing "recursive" mouse test.
+- **Regression guard, mirroring the hover-pause spec's own §9 guard:** a
+  keydown followed by *no further activity at all* for the rest of the
+  test still resumes and auto-submits on schedule — confirms this doesn't
+  reintroduce an indefinite-pause failure mode via a different trigger.
+- Keydown targeting an element *outside* the panel but inside the pane
+  (e.g. a mock composer textarea in the same `.agent-view`) does **not**
+  hide the countdown — confirms the `inPanel` scoping decision (§2.2), not
+  the broader pane scope.
+- Keydown while minimized does not hide/pause anything (there's nothing to
+  hide — the countdown chip in the minimized state is unaffected, matching
+  existing behavior).
+- Enter and Escape, fired inside the panel, still submit/defer exactly as
+  today — confirms §2.4's "no special-casing needed" claim isn't a
+  regression on the pre-existing key-handling tests.
+- A keydown-triggered pause and a mouse-triggered pause compose correctly:
+  hover in, then press a key mid-window — window restarts from the
+  keydown, single shared `hidden` state, no double-hide/double-timer
+  artifacts.
+
+**Manual / integration:**
+
+- `task dev`, trigger a live `AskUserQuestion`, answer entirely via
+  keyboard (Tab between options, Space to select, type into "Other")
+  without ever moving the mouse over the panel. Confirm the countdown
+  disappears on first keystroke and behaves identically to the
+  mouse-hover flow described in the hover-pause spec's own manual test
+  plan.
+- Tab into the panel, then stop touching the keyboard or mouse entirely.
+  Confirm the countdown reappears at 15s showing a fresh full timeout, and
+  proceeds to auto-submit at 0 if still untouched — the keyboard analog of
+  the hover-pause spec's own "cursor parked, no further activity" manual
+  check.

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -90,6 +90,10 @@ function escapeOn(el: Element): void {
     el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
 }
 
+function keydownOn(el: Element, key = "Tab"): void {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
 describe("AgentQuestionPanel keyboard handling", () => {
     it("does not submit on Enter before any option is selected", () => {
         const onAnswer = vi.fn();
@@ -441,5 +445,153 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
 
         vi.advanceTimersByTime(30_000);
         expect(onAnswer).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md)", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const panel = () => screen.getByRole("group", { name: /Agent question/ });
+
+    it("hides the countdown immediately on a qualifying keydown inside the panel", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        vi.advanceTimersByTime(5_000); // 25s remaining
+        expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
+
+        keydownOn(panel(), "Tab");
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+    });
+
+    // Also serves as the regression guard mirroring the hover-pause spec's
+    // own §9 guard: no activity at all after this single keydown, and it
+    // still resumes and auto-submits on schedule rather than pausing
+    // indefinitely.
+    it("resumes at a fresh 30s exactly 15s after that keydown, then auto-submits on schedule with no further activity", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        vi.advanceTimersByTime(18_000); // 12s remaining
+        keydownOn(panel(), "Tab");
+
+        vi.advanceTimersByTime(10_000);
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+        expect(onAnswer).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(5_000);
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(30_000);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    it("a second qualifying keydown mid-window restarts a fresh 15s window from that point", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        keydownOn(panel(), "Tab");
+        vi.advanceTimersByTime(10_000); // 10s into the first 15s window
+        keydownOn(panel(), "a"); // a fresh keydown restarts the window
+
+        // Would have resumed at t=15s under the original window — confirm
+        // it didn't, because the second keydown reset the clock to t=10+15=25s.
+        vi.advanceTimersByTime(5_000); // t=15s
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+
+        vi.advanceTimersByTime(9_000); // t=24s — still inside the restarted window
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+        expect(onAnswer).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1_000); // t=25s — restarted window elapses
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
+    });
+
+    it("a keydown targeting an element outside the panel but inside the pane does not hide the countdown", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => (
+            <div class="agent-view">
+                <textarea data-testid="composer" />
+                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />
+            </div>
+        ));
+
+        vi.advanceTimersByTime(5_000); // 25s remaining
+        keydownOn(screen.getByTestId("composer"), "a");
+
+        expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
+    });
+
+    it("keydown while minimized does not hide/pause anything", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        await user.click(screen.getByRole("button", { name: /Answer later/ }));
+        keydownOn(document.body, "a");
+
+        // Minimized chip shows the countdown ticking normally, unaffected —
+        // hover-pause never applies to it and neither does this new trigger.
+        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(30_000);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    it("Enter fired inside the panel still submits, unaffected by the new pause trigger", async () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        const user = userEvent.setup({ delay: null });
+        await user.click(screen.getByRole("radio", { name: /Red/ }));
+
+        enterOn(panel());
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        expect(onAnswer.mock.calls[0][0].answers_map["Pick a color"]).toBe("Red");
+    });
+
+    it("Escape fired inside the panel still defers, unaffected by the new pause trigger", () => {
+        const onAnswer = vi.fn();
+        const onDefer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onDefer={onDefer} />);
+
+        escapeOn(panel());
+        expect(onDefer).toHaveBeenCalledTimes(1);
+        expect(onAnswer).not.toHaveBeenCalled();
+    });
+
+    it("composes with a mouse-triggered pause: a keydown mid-hover-window restarts the same shared window", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        fireEvent.mouseEnter(panel());
+        vi.advanceTimersByTime(10_000); // 10s into the mouse-triggered 15s window
+        keydownOn(panel(), "Tab"); // restarts the same shared window from the keydown
+
+        // Would have resumed at t=15s under the original mouse-only window —
+        // confirm it didn't, because the keydown reset the clock to t=10+15=25s.
+        vi.advanceTimersByTime(5_000); // t=15s
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+
+        vi.advanceTimersByTime(9_000); // t=24s — still inside the restarted window
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+        expect(onAnswer).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1_000); // t=25s — restarted window elapses
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
     });
 });

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -494,25 +494,55 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         expect(onAnswer).toHaveBeenCalledTimes(1);
     });
 
-    it("a second qualifying keydown mid-window restarts a fresh 15s window from that point", () => {
+    // reagentx P1, PR #2787: an earlier version of this feature called
+    // onPanelPointerEnter() unconditionally on every qualifying keydown,
+    // including OS key-repeat while a key is held and every character of
+    // continuous typing. Unlike `mouseenter` — which a real browser only
+    // fires on an actual boundary-crossing, so it can't be spammed by normal
+    // use — `keydown` fires on every keystroke, so re-arming on each one let
+    // typing faster than 15s apart (or simply holding a key) suppress the
+    // auto-timeout indefinitely, breaking the "paused for at most one
+    // HOVER_HIDE_GRACE_MS window" safety invariant. Pin the fix: only the
+    // FIRST keydown of a burst (the transition into the paused state)
+    // (re)arms the window — later keydowns while still hidden are no-ops.
+    it("repeated keydowns while still hidden do not extend the window past one HOVER_HIDE_GRACE_MS (key-repeat/continuous-typing safety bound)", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        keydownOn(panel(), "Tab"); // first keydown — hides, starts the 15s window
+        vi.advanceTimersByTime(10_000); // 10s into the window, still hidden
+
+        // Simulates continuous typing / OS key-repeat: several more
+        // qualifying keydowns while already hidden. None of these should
+        // push the window out any further.
+        keydownOn(panel(), "a");
+        keydownOn(panel(), "b");
+        keydownOn(panel(), "c");
+
+        // Elapses exactly 15s after the FIRST keydown, unaffected by the
+        // later ones — the pause never got extended.
+        vi.advanceTimersByTime(5_000);
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
+    });
+
+    it("a keydown after the window resumes starts a fresh window (recursive re-engagement, mirrors the mouse 'recursive' case)", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
         render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
 
         keydownOn(panel(), "Tab");
-        vi.advanceTimersByTime(10_000); // 10s into the first 15s window
-        keydownOn(panel(), "a"); // a fresh keydown restarts the window
+        vi.advanceTimersByTime(15_000); // window elapses, resumes at a fresh 30s
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
 
-        // Would have resumed at t=15s under the original window — confirm
-        // it didn't, because the second keydown reset the clock to t=10+15=25s.
-        vi.advanceTimersByTime(5_000); // t=15s
+        keydownOn(panel(), "Tab"); // a fresh, post-resumption keydown re-arms the window
         expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
 
-        vi.advanceTimersByTime(9_000); // t=24s — still inside the restarted window
+        vi.advanceTimersByTime(14_000);
         expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
         expect(onAnswer).not.toHaveBeenCalled();
 
-        vi.advanceTimersByTime(1_000); // t=25s — restarted window elapses
+        vi.advanceTimersByTime(1_000); // t=15s from the second keydown — resumes again
         expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
     });
 
@@ -549,6 +579,60 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         expect(onAnswer).toHaveBeenCalledTimes(1);
     });
 
+    // codex P2, PR #2787: while minimized, `rootRef` is reassigned to the
+    // separate minimized `<button>`, so a keydown/focus landing directly on
+    // THAT button (not just elsewhere, like the document.body case above)
+    // used to read as "inside the panel" and incorrectly pause a countdown
+    // that's supposed to keep running unaffected while minimized.
+    it("keydown targeting the minimized button itself does not hide/pause anything", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        await user.click(screen.getByRole("button", { name: /Answer later/ }));
+        keydownOn(screen.getByRole("button", { name: /Question waiting/ }), "Tab");
+
+        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(30_000);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    it("focus landing on the minimized button does not hide/pause anything", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        await user.click(screen.getByRole("button", { name: /Answer later/ }));
+        fireEvent.focusIn(screen.getByRole("button", { name: /Question waiting/ }));
+
+        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
+
+        vi.advanceTimersByTime(30_000);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    // codex P2, PR #2787: a real browser moves focus only AFTER a Tab
+    // keydown's default action runs, so the keydown that causes a
+    // keyboard-only user's first entry into the panel has `e.target` still
+    // pointed at whatever they were focused on *before* — outside the
+    // panel. `handleKey`'s own `inPanel` check necessarily misses that one
+    // event; the separate `focusin` listener (which fires once focus has
+    // actually landed) is what catches it.
+    it("focus landing inside the panel (e.g. via Tab) pauses the countdown even though the causing keydown's own target was outside", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        vi.advanceTimersByTime(5_000); // 25s remaining
+        expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
+
+        fireEvent.focusIn(screen.getByRole("radio", { name: /Red/ }));
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+    });
+
     it("Enter fired inside the panel still submits, unaffected by the new pause trigger", async () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
@@ -573,25 +657,25 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         expect(onAnswer).not.toHaveBeenCalled();
     });
 
-    it("composes with a mouse-triggered pause: a keydown mid-hover-window restarts the same shared window", () => {
+    it("composes with a mouse-triggered pause: a keydown while already hidden does not extend the mouse-triggered window (single shared bound)", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
         render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
 
         fireEvent.mouseEnter(panel());
-        vi.advanceTimersByTime(10_000); // 10s into the mouse-triggered 15s window
-        keydownOn(panel(), "Tab"); // restarts the same shared window from the keydown
+        vi.advanceTimersByTime(10_000); // 10s into the mouse-triggered 15s window, still hidden
+        keydownOn(panel(), "Tab"); // continued engagement via keyboard while already paused
 
-        // Would have resumed at t=15s under the original mouse-only window —
-        // confirm it didn't, because the keydown reset the clock to t=10+15=25s.
-        vi.advanceTimersByTime(5_000); // t=15s
-        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
-
-        vi.advanceTimersByTime(9_000); // t=24s — still inside the restarted window
-        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
+        // Elapses exactly 15s after the mouse entry, unaffected by the
+        // keydown — one shared `hidden` state, bounded to a single window
+        // regardless of which trigger(s) fired during it.
+        vi.advanceTimersByTime(5_000);
+        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
         expect(onAnswer).not.toHaveBeenCalled();
 
-        vi.advanceTimersByTime(1_000); // t=25s — restarted window elapses
-        expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
+        // And a keydown AFTER that resumption still re-arms it normally,
+        // same as the standalone "recursive re-engagement" test above.
+        keydownOn(panel(), "Tab");
+        expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
     });
 });

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -396,6 +396,36 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         return el.isContentEditable;
     };
 
+    // Shared gate for both keyboard-pause trigger paths below (`handleKey`'s
+    // keydown and `handleFocusIn`'s focusin). A target counts as
+    // pause-worthy engagement only if it's actually inside this panel's own
+    // DOM AND the panel is in its expanded (non-minimized) state AND we're
+    // not already paused:
+    //  - `!minimized()`: while minimized, `rootRef` is reassigned to the
+    //    separate `<button class="agent-question-panel-minimized">` (below),
+    //    so a keydown/Tab landing on that focusable button would otherwise
+    //    read as "inside the panel" and incorrectly pause a countdown that's
+    //    supposed to keep running unaffected while minimized — codex P2,
+    //    PR #2787.
+    //  - `!hidden()`: only the *transition into* the paused state re-arms
+    //    the flat HOVER_HIDE_GRACE_MS window. Unlike `mouseenter` — which a
+    //    real browser only fires on an actual boundary-crossing, so it can't
+    //    be spammed by normal use — `keydown` fires on every keystroke,
+    //    including OS key-repeat while a key is held and every character of
+    //    continuous typing. Re-arming unconditionally on every one of those
+    //    (the original implementation) meant typing faster than 15s apart,
+    //    or simply holding a key, suppressed the auto-timeout indefinitely —
+    //    reagentx P1, PR #2787, breaking the "paused for at most one
+    //    HOVER_HIDE_GRACE_MS window" invariant documented on the timer
+    //    effect above. Gating here bounds every pause to exactly one window
+    //    regardless of how many qualifying events fire inside it; a fresh
+    //    trigger only re-arms once that window has actually elapsed and
+    //    `hidden()` has flipped back to false.
+    const maybePauseFor = (target: EventTarget | null) => {
+        const inPanel = !!rootRef && !!target && rootRef.contains(target as Node);
+        if (inPanel && !minimized() && !hidden()) onPanelPointerEnter();
+    };
+
     const handleKey = (e: KeyboardEvent) => {
         const target = e.target as HTMLElement | null;
         // Scope to this panel's own pane so a question in pane A doesn't
@@ -423,8 +453,9 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         // own existing paths immediately below/in `defer()`, so firing this
         // first for them is a harmless, immediately-superseded no-op, not
         // worth special-casing out. See
-        // SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md §2.
-        if (inPanel) onPanelPointerEnter();
+        // SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md §2,
+        // and §8 for the `maybePauseFor` gating added after review.
+        maybePauseFor(target);
 
         if (e.key === "Enter" && !e.shiftKey) {
             // Outside the panel, don't hijack Enter from a real editable
@@ -441,6 +472,17 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         }
     };
 
+    // Tab moving focus INTO the panel from outside it fires its `keydown`
+    // with `e.target` still the element that's *about to lose* focus —
+    // browsers move focus only after the keydown's default action runs — so
+    // `handleKey`'s `inPanel` check above misses exactly the keystroke that
+    // causes a keyboard-only user's first entry into the panel via Tab.
+    // `focusin` bubbles and fires once focus has actually landed inside the
+    // panel, so listening for it separately (reusing the same
+    // `maybePauseFor` gate) catches that case without complicating
+    // `handleKey`'s own target-at-dispatch-time logic — codex P2, PR #2787.
+    const handleFocusIn = (e: FocusEvent) => maybePauseFor(e.target);
+
     // Global capture-phase listener, mirroring AgentDecisionPanel: the panel
     // has tabindex=-1 and never auto-focuses, so a plain onKeyDown on the
     // root div only fired once the user had already clicked something
@@ -449,7 +491,12 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         if (!request()) return;
         const onWindowKey = (e: KeyboardEvent) => handleKey(e);
         window.addEventListener("keydown", onWindowKey, true);
-        onCleanup(() => window.removeEventListener("keydown", onWindowKey, true));
+        // `focusin` already bubbles to `window`, so no capture flag needed.
+        window.addEventListener("focusin", handleFocusIn);
+        onCleanup(() => {
+            window.removeEventListener("keydown", onWindowKey, true);
+            window.removeEventListener("focusin", handleFocusIn);
+        });
     });
 
     const countdownSeconds = () => Math.ceil(remainingMs() / 1000);

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -13,15 +13,19 @@
  * the agent's turn forever: any question the user hasn't touched by zero is
  * filled in with its recommended option and the (possibly-merged) answer is
  * submitted automatically. See §2.3 for why this merges rather than
- * disarming on first interaction. Hovering the panel hides the countdown and
- * pauses the underlying deadline for a flat 15s from that hover, then
+ * disarming on first interaction. Hovering the panel — or, as of the
+ * keyboard-pause spec below, pressing any key while focus is inside the
+ * panel (Tab-navigating options, typing into "Other") — hides the countdown
+ * and pauses the underlying deadline for a flat 15s from that trigger, then
  * unconditionally resumes at a fresh timeout regardless of whether the mouse
- * is still there — a bounded, self-resuming pause, not the permanent disarm
- * §2.3/§5.1 rejected. See the hover-pause spec above.
+ * or keyboard is still active — a bounded, self-resuming pause, not the
+ * permanent disarm §2.3/§5.1 rejected. Both triggers share one mechanism —
+ * see the keyboard-pause spec below.
  *
  * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md,
  * docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md,
- * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md.
+ * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md,
+ * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md.
  */
 
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, untrack, type Accessor, type JSX } from "solid-js";
@@ -404,6 +408,23 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         // DOM (an option, the "Other" input, or the panel root itself) —
         // mirrors AgentDecisionPanel's `inPanel` (AgentDecisionPanel.tsx:208).
         const inPanel = !!rootRef && !!target && rootRef.contains(target);
+
+        // Any keydown that lands inside this panel counts as engagement,
+        // the same as a mouseenter — reuses the exact same pause mechanism
+        // (hide the countdown, resume unconditionally after a flat
+        // HOVER_HIDE_GRACE_MS) rather than a parallel one, so a user
+        // answering entirely by keyboard (Tab between options, typing into
+        // "Other") gets the same breathing room a mouse-hovering user
+        // already does. Scoped to `inPanel`, NOT the broader `paneRoot`
+        // scope Escape uses below — a keystroke elsewhere in this pane
+        // (the chat composer, Ctrl+F) isn't engagement with this question.
+        // Deliberately unconditional on which key, including Enter/Escape:
+        // both already tear down or reset this same pause state via their
+        // own existing paths immediately below/in `defer()`, so firing this
+        // first for them is a harmless, immediately-superseded no-op, not
+        // worth special-casing out. See
+        // SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md §2.
+        if (inPanel) onPanelPointerEnter();
 
         if (e.key === "Enter" && !e.shiftKey) {
             // Outside the panel, don't hijack Enter from a real editable


### PR DESCRIPTION
## Summary
- Extends the AskUserQuestion 30s auto-timeout's hover-pause mechanism to also fire on keyboard activity, not just mouse hover.
- Reuses the existing `onPanelPointerEnter` pause function directly (same `hidden` signal, same flat `HOVER_HIDE_GRACE_MS` window, same resume behavior) — no new timer/signal/mechanism.
- Scoped to `inPanel` (keydown must land inside the panel's own DOM), mirroring the mouse trigger's scope exactly. Keystrokes elsewhere in the pane (chat composer, Ctrl+F) don't count as engagement with this question.
- No behavior change for Enter/Escape — both already tear down or reset this same pause state via their own existing paths, so firing the new trigger first for them is a harmless no-op.

See `docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md` for full design rationale.

## Test plan
- [x] New unit tests in `AgentQuestionPanel.test.tsx` covering: hides on qualifying keydown, resumes at fresh 30s after 15s, second keydown restarts the window, keydown outside panel but inside pane doesn't trigger, keydown while minimized is a no-op, Enter/Escape still work, composes correctly with mouse-triggered pause.
- [x] Full existing suite still passes (29/29, no regressions to hover-pause or Enter/Escape tests).

<!-- agentmux:agent_id=manoz -->