### PR TITLE
feat(agent-picker): sort control, reordered fields, distinct account-failure text

### DIFF
--- a/.changesets/1787599247-feat-agent-picker-sort-control-reordered-fields-distinct-acc-im7g.md
+++ b/.changesets/1787599247-feat-agent-picker-sort-control-reordered-fields-distinct-acc-im7g.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-picker): sort control, reordered fields, distinct account-failure text

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -334,6 +334,18 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     Vec::new()
                 });
 
+                // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+                // §4: when `agent_identity_list_all()` itself failed above,
+                // `links_by_agent` is empty for EVERY definition_id — not
+                // just the ones that genuinely have no bound identity —
+                // so every row would otherwise show the exact same
+                // "(ambient creds)" text a real unbound agent gets,
+                // making a source failure indistinguishable from a
+                // legitimate state. Computed once, outside the loop: this
+                // source only ever degrades before the loop starts, not
+                // per-row.
+                let identity_links_degraded = degraded.contains(&"identity_links");
+
                 // Build rows. Hits filestore once per instance; with
                 // raw_limit ≤ 500 and stat() being a single indexed
                 // SQLite query, the per-call cost is dominated by
@@ -356,6 +368,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             names.dedup();
                             names.join(", ")
                         }
+                        _ if identity_links_degraded => "(unknown account)".to_string(),
                         _ => "(ambient creds)".to_string(),
                     };
                     let memory_name = if inst.memory_id.is_empty() {
@@ -892,6 +905,46 @@ mod tests {
              (identity_list now tolerates it internally), got: {:?}",
             result.degraded
         );
+    }
+
+    /// docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+    /// §4: when `agent_identity_list_all()` itself fails, every row used to
+    /// fall back to the SAME "(ambient creds)" text a genuinely-unbound
+    /// agent gets — indistinguishable from a real backend failure. Forces
+    /// the failure by dropping `db_agent_identity_links` outright (a
+    /// deterministic way to make the query itself error, unlike the
+    /// per-row-tolerant `db_accounts` malformed-row case above) and asserts
+    /// every row instead shows the distinct "(unknown account)" text, with
+    /// `degraded` correctly reporting "identity_links".
+    #[tokio::test]
+    async fn identity_links_source_failure_uses_distinct_fallback_text_not_ambient_creds() {
+        let (state, engine, mut output_rx, _reg_dir, _def_dir) =
+            setup_with_n_cross_channel_agents(2);
+
+        {
+            let conn = state.wstore.conn().lock().unwrap();
+            conn.execute("DROP TABLE db_agent_identity_links", []).unwrap();
+        }
+
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+        assert_eq!(result.rows.len(), 2, "the identity_links failure must not zero out the whole list");
+        assert!(
+            result.degraded.contains(&"identity_links".to_string()),
+            "got: {:?}",
+            result.degraded
+        );
+        for row in &result.rows {
+            assert_eq!(
+                row.identity_name, "(unknown account)",
+                "a source FAILURE must read differently from a genuinely-unbound \
+                 agent's \"(ambient creds)\" — otherwise a backend outage looks \
+                 identical to a normal, healthy state"
+            );
+        }
     }
 
     /// Minimal local (not cross-channel registry) `AgentDefinition` —

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -296,8 +296,15 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let agent_identity_links = identity_store.agent_identity_list_all().unwrap_or_else(|e| {
                     tracing::warn!(
                         error = %e,
+                        // reagent P2, PR #2789: this fires alongside
+                        // degraded.push("identity_links") below, which the
+                        // row-building loop's own identity_links_degraded
+                        // check reads to show "(unknown account)" — NOT
+                        // "(ambient creds)" (that text is reserved for a
+                        // genuinely-unbound agent). Keep this message in
+                        // sync if that fallback text ever changes again.
                         "listrecentsessions: agent_identity_list_all failed — degrading to \
-                         empty (rows will show \"(ambient creds)\")"
+                         empty (rows will show \"(unknown account)\")"
                     );
                     degraded.push("identity_links");
                     Vec::new()

--- a/docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+++ b/docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
@@ -2,11 +2,17 @@
 
 **Date:** 2026-08-24
 **Author:** AgentY
-**Type:** Investigation + UX/architecture recommendations — no code changed yet
+**Type:** Investigation + UX/architecture recommendations, since implemented
+(§2, §3, §4 shipped; §5/§5a shipped separately — PR #2786)
 **Scope:** `frontend/app/view/agent/components/AgentPicker.tsx`,
 `AgentPickerFilterBar.tsx`, `MyAgentsList.tsx`,
 `frontend/app/view/agent/styles/_recent-sessions.scss`,
 `agentmux-srv/src/server/agent_handlers/session.rs`
+
+**Status update (2026-08-24, later same day):** §2 (field reorder), §3
+(sort control), and §4 (distinct account-failure text) implemented —
+see the PR that shipped this report's own recommendations. §5/§5a (the
+snapshot-preview fallback) shipped earlier, separately, as PR #2786.
 
 Prompted by direct user feedback: "a lot of the fields are out of order,"
 a request for name/launch-date/type sort controls at the right edge of the

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -48,9 +48,35 @@ import { realAccountIdOrEmpty } from "../identity-carry-over";
 import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
 import type { LaunchOverrides } from "./AgentLaunchModal";
-import { AgentPickerFilterBar } from "./AgentPickerFilterBar";
+import { AgentPickerFilterBar, DEFAULT_AGENT_SORT, type AgentSortOption } from "./AgentPickerFilterBar";
 import { HiddenTemplatesSection } from "./HiddenTemplatesSection";
 import { MyAgentsList } from "./MyAgentsList";
+
+/** This-machine-only preference — no cross-device sync, no existing
+ *  localStorage precedent in this component tree to extend (a new small
+ *  pattern, not a reuse). Wrapped defensively: localStorage can throw in
+ *  some embedding contexts (private browsing, storage quota), and a sort
+ *  preference is never worth a hard failure over. */
+const AGENT_SORT_STORAGE_KEY = "agentPicker:sortBy";
+
+function loadStoredSort(): AgentSortOption {
+    try {
+        const raw = localStorage.getItem(AGENT_SORT_STORAGE_KEY);
+        if (raw === "recent" || raw === "name" || raw === "type") return raw;
+    } catch {
+        // ignore — fall through to the default
+    }
+    return DEFAULT_AGENT_SORT;
+}
+
+function storeSort(sort: AgentSortOption): void {
+    try {
+        localStorage.setItem(AGENT_SORT_STORAGE_KEY, sort);
+    } catch {
+        // best-effort only — a failed write just means the preference
+        // doesn't survive to the next picker open, not a functional break
+    }
+}
 
 // ── useAgentDefinitions hook ───────────────────────────────────────────────────────
 
@@ -145,6 +171,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // an *existing agent*, and a shared query risks the template grid
     // silently shrinking for an unrelated reason right next to it.
     const [filterQuery, setFilterQuery] = createSignal("");
+    // Sort control, far right of the filter bar (SPEC follow-up — see
+    // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §3).
+    // Same narrowing-scope decision as filterQuery above: only MyAgentsList,
+    // not the template grid.
+    const [sortBy, setSortByState] = createSignal<AgentSortOption>(loadStoredSort());
+    const setSortBy = (sort: AgentSortOption) => {
+        setSortByState(sort);
+        storeSort(sort);
+    };
     const [agents, definitionsLoading] = useAgentDefinitions();
     const modalLayer = useModalLayer();
 
@@ -905,9 +940,12 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                             value={filterQuery}
                             onInput={setFilterQuery}
                             onClear={() => setFilterQuery("")}
+                            sortBy={sortBy}
+                            onSortChange={setSortBy}
                         />
                         <MyAgentsList
                             nameFilter={filterQuery}
+                            sortBy={sortBy}
                             onReattach={handleReattach}
                             openDefinitions={openDefinitions}
                             onFork={handleFork}

--- a/frontend/app/view/agent/components/AgentPickerFilterBar.tsx
+++ b/frontend/app/view/agent/components/AgentPickerFilterBar.tsx
@@ -3,7 +3,10 @@
 
 /**
  * AgentPickerFilterBar — a static, always-visible text filter atop the
- * AgentPicker, narrowing `MyAgentsList` by name as the user types.
+ * AgentPicker, narrowing `MyAgentsList` by name as the user types, plus a
+ * sort control (name / recently launched / type) at the far right —
+ * SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md follow-up, see
+ * docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §3.
  *
  * Distinct from `AgentSearchBar.tsx` in this same directory, which is an
  * unrelated feature: the in-session transcript search overlay (Ctrl+F),
@@ -11,17 +14,28 @@
  * one agent's pane. This component is always rendered (no show/hide
  * toggle) and searches agent names, not message content.
  *
- * Purely presentational — no data fetching of its own. `AgentPicker.tsx`
- * owns the query signal and threads it into `MyAgentsList` as `nameFilter`.
- * See docs/specs/SPEC_AGENT_PICKER_FILTER_SEARCH_2026_08_17.md.
+ * Purely presentational — no data fetching/sorting of its own.
+ * `AgentPicker.tsx` owns both signals and threads them into `MyAgentsList`
+ * as `nameFilter`/`sortBy`. See docs/specs/SPEC_AGENT_PICKER_FILTER_SEARCH_2026_08_17.md.
  */
 
 import { Show, type Accessor, type JSX } from "solid-js";
+
+/** "Recently launched" (most recent `started_at` first) is the default —
+ *  it matches the backend's own existing sort intent (see
+ *  `listrecentsessions`'s row ordering before the picker ever added a
+ *  user-facing sort control at all), so leaving the control untouched
+ *  reproduces today's behavior exactly. */
+export type AgentSortOption = "recent" | "name" | "type";
+
+export const DEFAULT_AGENT_SORT: AgentSortOption = "recent";
 
 export interface AgentPickerFilterBarProps {
     value: Accessor<string>;
     onInput: (query: string) => void;
     onClear: () => void;
+    sortBy: Accessor<AgentSortOption>;
+    onSortChange: (sort: AgentSortOption) => void;
 }
 
 export const AgentPickerFilterBar = (props: AgentPickerFilterBarProps): JSX.Element => {
@@ -58,6 +72,20 @@ export const AgentPickerFilterBar = (props: AgentPickerFilterBarProps): JSX.Elem
                     &times;
                 </button>
             </Show>
+            <label class="agent-picker-sort" data-testid="agent-picker-sort">
+                <span class="agent-picker-sort-label">Sort</span>
+                <select
+                    class="agent-picker-sort-select"
+                    aria-label="Sort My Agents by"
+                    data-testid="agent-picker-sort-select"
+                    value={props.sortBy()}
+                    onChange={(e) => props.onSortChange(e.currentTarget.value as AgentSortOption)}
+                >
+                    <option value="recent">Recently launched</option>
+                    <option value="name">Name (A–Z)</option>
+                    <option value="type">Type</option>
+                </select>
+            </label>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -373,6 +373,21 @@ describe("MyAgentsList — sortBy (docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_
         expect(await namesInOrder()).toEqual(["Alpha Host", "Bravo Host", "Zulu Sandbox", "Unknown Type"]);
     });
 
+    it('groups the legacy "standalone" agent_type with Host, not with unrecognized types (Codex P2 on PR #2789)', async () => {
+        // "standalone" is the pre-container-feature default agent_type
+        // (default_agent_type() in backend/storage/agents.rs) — every
+        // non-"container" value is treated as the host controller at
+        // launch, so a "standalone" agent IS effectively a host agent.
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ instance_id: "a", instance_name: "Sandbox Agent", agent_type: "container" }),
+            makeRow({ instance_id: "b", instance_name: "Legacy Standalone", agent_type: "standalone" }),
+            makeRow({ instance_id: "c", instance_name: "Explicit Host", agent_type: "host" }),
+        ]));
+        const [sortBy] = createSignal<AgentSortOption>("type");
+        render(() => <MyAgentsList sortBy={sortBy} onReattach={() => {}} />);
+        expect(await namesInOrder()).toEqual(["Explicit Host", "Legacy Standalone", "Sandbox Agent"]);
+    });
+
     it("re-sorts reactively when sortBy changes after mount", async () => {
         vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
             makeRow({ instance_id: "a", instance_name: "Zebra", started_at: 2000 }),

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -13,6 +13,7 @@ import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AgentSortOption } from "./AgentPickerFilterBar";
 import {
     EMPTY_FILTERED,
     EMPTY_GLOBAL,
@@ -320,6 +321,83 @@ describe("MyAgentsList — nameFilter (SPEC_AGENT_PICKER_FILTER_SEARCH_2026_08_1
         await Promise.resolve();
 
         expect(RpcApi.ListRecentSessionsCommand).not.toHaveBeenCalled();
+    });
+});
+
+describe("MyAgentsList — sortBy (docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §3)", () => {
+    const namesInOrder = async (): Promise<string[]> => {
+        const entries = await screen.findAllByTestId("agent-my-agents-entry");
+        return entries.map((e) => e.querySelector(".agent-recent-sessions-name")?.textContent ?? "");
+    };
+
+    it('defaults to "recent" (most-recently-launched first) when sortBy is omitted — existing callers get the same client-side sort as the explicit default, not raw backend order', async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ instance_id: "a", instance_name: "Zebra", started_at: 1000 }),
+            makeRow({ instance_id: "b", instance_name: "Alpha", started_at: 2000 }),
+        ]));
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        expect(await namesInOrder()).toEqual(["Alpha", "Zebra"]);
+    });
+
+    it('sorts by name (A→Z), case-insensitively, when sortBy is "name"', async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ instance_id: "a", instance_name: "zebra" }),
+            makeRow({ instance_id: "b", instance_name: "Alpha" }),
+            makeRow({ instance_id: "c", instance_name: "middle" }),
+        ]));
+        const [sortBy] = createSignal<AgentSortOption>("name");
+        render(() => <MyAgentsList sortBy={sortBy} onReattach={() => {}} />);
+        expect(await namesInOrder()).toEqual(["Alpha", "middle", "zebra"]);
+    });
+
+    it('sorts by most-recently-launched first when sortBy is "recent"', async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ instance_id: "a", instance_name: "Oldest", started_at: 1000 }),
+            makeRow({ instance_id: "b", instance_name: "Newest", started_at: 3000 }),
+            makeRow({ instance_id: "c", instance_name: "Middle", started_at: 2000 }),
+        ]));
+        const [sortBy] = createSignal<AgentSortOption>("recent");
+        render(() => <MyAgentsList sortBy={sortBy} onReattach={() => {}} />);
+        expect(await namesInOrder()).toEqual(["Newest", "Middle", "Oldest"]);
+    });
+
+    it('sorts Host before Sandbox (Container) before unknown when sortBy is "type", each group alphabetical', async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ instance_id: "a", instance_name: "Zulu Sandbox", agent_type: "container" }),
+            makeRow({ instance_id: "b", instance_name: "Bravo Host", agent_type: "host" }),
+            makeRow({ instance_id: "c", instance_name: "Alpha Host", agent_type: "host" }),
+            makeRow({ instance_id: "d", instance_name: "Unknown Type", agent_type: undefined }),
+        ]));
+        const [sortBy] = createSignal<AgentSortOption>("type");
+        render(() => <MyAgentsList sortBy={sortBy} onReattach={() => {}} />);
+        expect(await namesInOrder()).toEqual(["Alpha Host", "Bravo Host", "Zulu Sandbox", "Unknown Type"]);
+    });
+
+    it("re-sorts reactively when sortBy changes after mount", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ instance_id: "a", instance_name: "Zebra", started_at: 2000 }),
+            makeRow({ instance_id: "b", instance_name: "Alpha", started_at: 1000 }),
+        ]));
+        const [sortBy, setSortBy] = createSignal<AgentSortOption>("recent");
+        render(() => <MyAgentsList sortBy={sortBy} onReattach={() => {}} />);
+        expect(await namesInOrder()).toEqual(["Zebra", "Alpha"]);
+        setSortBy("name");
+        await waitFor(async () => expect(await namesInOrder()).toEqual(["Alpha", "Zebra"]));
+    });
+
+    it("does not mutate the underlying fetched row array when sorting (stale-while-revalidate safety)", async () => {
+        const rows = [
+            makeRow({ instance_id: "a", instance_name: "Zebra", started_at: 1000 }),
+            makeRow({ instance_id: "b", instance_name: "Alpha", started_at: 2000 }),
+        ];
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult(rows));
+        const [sortBy] = createSignal<AgentSortOption>("name");
+        render(() => <MyAgentsList sortBy={sortBy} onReattach={() => {}} />);
+        await namesInOrder();
+        // The array vitest handed to the mock's resolved value must still be
+        // in ITS OWN original order — if the sort memo sorted in place
+        // instead of copying first, this would now read ["Alpha", "Zebra"].
+        expect(rows.map((r) => r.instance_name)).toEqual(["Zebra", "Alpha"]);
     });
 });
 

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -62,8 +62,18 @@ import { RuntimeBadge } from "./RuntimeBadge";
 /** "type" sort groups Host before Sandbox (Container) before anything
  *  unrecognized, matching `RuntimeBadge`'s own known-runtime ordering —
  *  not alphabetical ("container" < "host" would put Sandbox first, which
- *  reads backwards next to the badge's own HOST/SANDBOX vocabulary). */
-const TYPE_SORT_RANK: Record<string, number> = { host: 0, container: 1 };
+ *  reads backwards next to the badge's own HOST/SANDBOX vocabulary).
+ *
+ *  Codex P2, PR #2789: `"standalone"` is the LEGACY default `agent_type`
+ *  (`default_agent_type()`, `backend/storage/agents.rs`) for definitions
+ *  predating the container feature, and every non-`"container"` value is
+ *  treated as the host controller at launch (`agent_open.rs`'s
+ *  `controller_type = if agent.agent_type == "container" {...} else {...}`)
+ *  — "standalone" IS a host agent, effectively, just under an older name.
+ *  Without this, legacy definitions would rank as "unknown" (last),
+ *  splitting them from genuinely host-labeled agents instead of grouping
+ *  correctly with them. */
+const TYPE_SORT_RANK: Record<string, number> = { host: 0, standalone: 0, container: 1 };
 const typeSortRank = (agentType: string): number => TYPE_SORT_RANK[agentType] ?? 2;
 
 function compareRows(sort: AgentSortOption, a: RecentSessionRow, b: RecentSessionRow): number {

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -56,7 +56,34 @@ import { DualProviderLogo } from "@/element/DualProviderLogo";
 import { formatTimeAgo } from "@/util/format-time";
 import { Logger } from "@/util/logger";
 import { resolveEffectiveVendor } from "../providers/catalog";
+import type { AgentSortOption } from "./AgentPickerFilterBar";
 import { RuntimeBadge } from "./RuntimeBadge";
+
+/** "type" sort groups Host before Sandbox (Container) before anything
+ *  unrecognized, matching `RuntimeBadge`'s own known-runtime ordering —
+ *  not alphabetical ("container" < "host" would put Sandbox first, which
+ *  reads backwards next to the badge's own HOST/SANDBOX vocabulary). */
+const TYPE_SORT_RANK: Record<string, number> = { host: 0, container: 1 };
+const typeSortRank = (agentType: string): number => TYPE_SORT_RANK[agentType] ?? 2;
+
+function compareRows(sort: AgentSortOption, a: RecentSessionRow, b: RecentSessionRow): number {
+    switch (sort) {
+        case "name":
+            return (a.instance_name || a.definition_name).localeCompare(b.instance_name || b.definition_name, undefined, {
+                sensitivity: "base",
+            });
+        case "type": {
+            const rankDiff = typeSortRank(a.agent_type) - typeSortRank(b.agent_type);
+            if (rankDiff !== 0) return rankDiff;
+            return (a.instance_name || a.definition_name).localeCompare(b.instance_name || b.definition_name, undefined, {
+                sensitivity: "base",
+            });
+        }
+        case "recent":
+        default:
+            return b.started_at - a.started_at;
+    }
+}
 
 /** Empty-state copy varies based on whether an identity filter was
  * applied — surfaced so the integration test can match it. */
@@ -93,6 +120,11 @@ export interface MyAgentsListProps {
      *  filter searches the full backend-capped set, not just the default
      *  page — see SPEC_AGENT_PICKER_FILTER_SEARCH_2026_08_17.md. */
     nameFilter?: Accessor<string | null | undefined>;
+    /** Optional reactive accessor for the sort order — client-side, over
+     *  the already-fetched/filtered row set (no backend RPC change).
+     *  Defaults to `"recent"` (today's implicit backend ordering) when
+     *  omitted. See docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §3. */
+    sortBy?: Accessor<AgentSortOption>;
     /** Called when the user clicks an entry that is NOT currently open
      *  in another pane. The parent (AgentPicker) hands this to
      *  `AgentViewModel.launchAgentDefinition` with the continuation
@@ -388,6 +420,18 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     // filter narrowed them all away — not "you have no agents."
     const isNoMatch = () => !isLoading() && !fetchError() && (rows() ?? []).length > 0 && filteredRows().length === 0;
 
+    // Sort applied AFTER filtering, over whatever's already in memory — no
+    // backend RPC change (§3 of the audit report above). `.slice()` before
+    // `.sort()` since Array.prototype.sort mutates in place and
+    // `filteredRows()` may be the SAME array reference `rows()` returned
+    // when there's no active name filter (see filteredRows's own `return
+    // all` fast path) — sorting that in place would mutate the resource's
+    // cached value out from under Solid's stale-while-revalidate.
+    const sortedRows = createMemo(() => {
+        const sort = props.sortBy?.() ?? "recent";
+        return filteredRows().slice().sort((a, b) => compareRows(sort, a, b));
+    });
+
     return (
         <div class="agent-recent-sessions" data-testid="agent-my-agents-list">
             <div class="agent-recent-sessions-header">
@@ -445,7 +489,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                 }
             >
                 <ul class="agent-recent-sessions-list">
-                    <For each={filteredRows()}>
+                    <For each={sortedRows()}>
                         {(row) => {
                             const isActive = () => (props.openDefinitions?.() ?? new Map()).has(row.definition_id);
                             const forkState = () => getForkState(row.definition_id);
@@ -487,9 +531,15 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                         "SANDBOX" in the pane the row launches into). */}
                                                     <RuntimeBadge runtime={row.agent_type} size="tag" />
                                                 </Show>
-                                                <span class="agent-recent-sessions-meta">
-                                                    {row.identity_name || "(ambient creds)"}
-                                                </span>
+                                            </span>
+                                            {/* Own line, not squeezed onto line1 via flex:1 next to
+                                                the name — the account is as important as the name
+                                                itself for a user managing multiple accounts, and
+                                                needs reliable space rather than competing ellipsis
+                                                with it. See
+                                                docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §2. */}
+                                            <span class="agent-recent-sessions-account">
+                                                {row.identity_name || "(ambient creds)"}
                                             </span>
                                             <Show
                                                 when={row.preview}
@@ -511,23 +561,14 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                     </span>
                                                 </span>
                                             </Show>
+                                            {/* Most-relevant-first, not chronological (Created →
+                                                Launch → Active): a picker exists to answer "what did
+                                                I last touch," which is Last Active (or Last Launch if
+                                                never active) — not when the agent was originally
+                                                created, which is the least actionable fact on the
+                                                row. See
+                                                docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §2. */}
                                             <span class="agent-recent-sessions-timestamps">
-                                                <Show when={row.agent_created_at > 0}>
-                                                    <span class="agent-recent-sessions-ts">
-                                                        <span class="agent-recent-sessions-ts-label">Created</span>
-                                                        <span class="agent-recent-sessions-ts-value">
-                                                            {formatTimeAgo(row.agent_created_at, now())}
-                                                        </span>
-                                                    </span>
-                                                </Show>
-                                                <Show when={row.started_at > 0}>
-                                                    <span class="agent-recent-sessions-ts">
-                                                        <span class="agent-recent-sessions-ts-label">Last Launch</span>
-                                                        <span class="agent-recent-sessions-ts-value">
-                                                            {formatTimeAgo(row.started_at, now())}
-                                                        </span>
-                                                    </span>
-                                                </Show>
                                                 <Show
                                                     when={
                                                         row.has_snapshot &&
@@ -539,6 +580,22 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                         <span class="agent-recent-sessions-ts-label">Last Active</span>
                                                         <span class="agent-recent-sessions-ts-value">
                                                             {formatTimeAgo(row.last_active_at, now())}
+                                                        </span>
+                                                    </span>
+                                                </Show>
+                                                <Show when={row.started_at > 0}>
+                                                    <span class="agent-recent-sessions-ts">
+                                                        <span class="agent-recent-sessions-ts-label">Last Launch</span>
+                                                        <span class="agent-recent-sessions-ts-value">
+                                                            {formatTimeAgo(row.started_at, now())}
+                                                        </span>
+                                                    </span>
+                                                </Show>
+                                                <Show when={row.agent_created_at > 0}>
+                                                    <span class="agent-recent-sessions-ts">
+                                                        <span class="agent-recent-sessions-ts-label">Created</span>
+                                                        <span class="agent-recent-sessions-ts-value">
+                                                            {formatTimeAgo(row.agent_created_at, now())}
                                                         </span>
                                                     </span>
                                                 </Show>

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -105,6 +105,47 @@
         }
     }
 
+    // Sort control — far right of the filter bar, after the input/clear
+    // button (`margin-left: auto` keeps it pinned right regardless of
+    // whether the clear button is currently rendered). See
+    // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §3.
+    .agent-picker-sort {
+        flex-shrink: 0;
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding-left: var(--space-2);
+        border-left: 1px solid var(--border-color);
+    }
+
+    .agent-picker-sort-label {
+        flex-shrink: 0;
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color);
+        opacity: 0.75;
+    }
+
+    .agent-picker-sort-select {
+        background: var(--main-bg-color);
+        color: var(--main-text-color);
+        border: 1px solid var(--border-color);
+        border-radius: 0;
+        padding: 2px var(--space-1);
+        font-size: 12px;
+        font-family: inherit;
+        outline: none;
+        cursor: default;
+        transition: border-color 0.15s;
+
+        &:focus {
+            border-color: var(--accent-color);
+        }
+    }
+
     // Two-tier picker (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md):
     // the "+ New from template" section header sits between the My
     // Agents list and the templates card grid. Tuned to match the

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -159,18 +159,25 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        flex-shrink: 0;
-        max-width: 60%;
+        // Was `flex-shrink: 0; max-width: 60%` when the account/identity
+        // name shared this row via `flex: 1` — now that it has its own
+        // line below (`.agent-recent-sessions-account`), line1 only holds
+        // the name + two small fixed-width badges, so the name can grow to
+        // fill the remaining space instead of being capped.
+        flex: 1;
+        min-width: 0;
     }
 
-    .agent-recent-sessions-meta {
+    // Account/identity name — own full-width line under line1, not
+    // squeezed into it via `flex: 1` next to the name anymore. See
+    // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §2.
+    .agent-recent-sessions-account {
         font-size: 11px;
         color: color-mix(in srgb, var(--secondary-text-color) 85%, transparent);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        flex: 1;
-        min-width: 0;
+        max-width: 100%;
     }
 
     .agent-recent-sessions-preview {


### PR DESCRIPTION
## Summary

Implements the remaining recommendations from `docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md` (§2, §3, §4), prompted by direct user feedback: "a lot of the fields are out of order," plus a request for name/launch-date/type sort controls at the right edge of the filter bar. (§5/§5a of that same report already shipped separately as #2786.)

- **§3 — sort control**: a right-aligned "Sort" select in `AgentPickerFilterBar` — **Recently launched** (default, matches today's implicit backend ordering exactly, so omitting the prop is a no-op behavior change) / **Name (A–Z)** / **Type** (Host before Sandbox, matching `RuntimeBadge`'s own HOST/SANDBOX vocabulary, not alphabetical). Applied client-side over `MyAgentsList`'s already-fetched row set — no backend RPC change. Persisted to `localStorage` (this-machine-only; no existing precedent in this component tree to extend, so this is a new small pattern).
- **§2 — field reorder**: the account/identity name was sharing line 1 with the name via `flex: 1`, squeezed after two badges — moved to its own full-width line below, since it's arguably as important as the name for a multi-account user and previously had the least reliable space on the card. Timestamps reordered to lead with the most relevant fact (Last Active, or Last Launch if never active) instead of the least-actionable one (Created), which was previously listed first.
- **§4 — backend fix**: when `agent_identity_list_all()` itself fails, every row used to fall back to the exact same `"(ambient creds)"` text a genuinely-unbound agent gets — a backend failure reading identically to a normal, healthy state. Now shows `"(unknown account)"` instead, gated on whether `identity_links` is present in the response's own `degraded` list (computed once, not per-row).

## Test plan

- [x] New tests: 6 sort-behavior tests (default/name/recent/type ordering, reactivity on `sortBy` change, in-place-mutation safety) in `MyAgentsList.test.tsx`; 1 backend test (`identity_links_source_failure_uses_distinct_fallback_text_not_ambient_creds`, forces the failure via `DROP TABLE db_agent_identity_links`) in `agent_handlers/session.rs`.
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 2777 passed.
- [x] `npx vitest run` — 3016 passed (1 unrelated pre-existing flaky test — `tool-renderers/registry.test.ts`, timeout under full-suite parallel load — confirmed passing in isolation).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx stylelint` on both touched SCSS files — clean (9 pre-existing raw-hex-color errors at untouched line numbers, confirmed present on `main` before this change too via `git stash`).
- [ ] Not manually verified in a running instance — flagging explicitly rather than claiming visual confirmation I don't have.

<!-- agentmux:agent_id=agenty -->