### PR TITLE
feat(toolchain): one-click install of git/Node/npm/Python across Windows/macOS/Linux

### DIFF
--- a/.changesets/1787599434-feat-toolchain-one-click-install-of-git-node-npm-python-via--42on.md
+++ b/.changesets/1787599434-feat-toolchain-one-click-install-of-git-node-npm-python-via--42on.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(toolchain): one-click install of git/Node/npm/Python via winget/brew/system package manager

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -70,6 +70,12 @@ struct InstallCheckReq {
 pub struct InstallSessionRegistry {
     sessions: Mutex<std::collections::HashMap<String, tokio::sync::oneshot::Sender<()>>>,
     active_providers: Mutex<std::collections::HashSet<String>>,
+    /// Same idea as `active_providers`, but a separate set keyed by
+    /// system-tool id (`"git"`, `"node"`, …) rather than provider id — a
+    /// distinct namespace so a future provider literally named e.g. "git"
+    /// can never collide with a system-tool claim. See
+    /// `system_install_handlers.rs` / `SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md`.
+    active_system_tools: Mutex<std::collections::HashSet<String>>,
 }
 
 impl InstallSessionRegistry {
@@ -77,7 +83,7 @@ impl InstallSessionRegistry {
         Arc::new(Self::default())
     }
 
-    fn insert(&self, session_id: String, tx: tokio::sync::oneshot::Sender<()>) {
+    pub(crate) fn insert(&self, session_id: String, tx: tokio::sync::oneshot::Sender<()>) {
         self.sessions.lock().insert(session_id, tx);
     }
 
@@ -91,6 +97,16 @@ impl InstallSessionRegistry {
         self.active_providers.lock().remove(provider_id);
     }
 
+    /// Try to claim a system tool (git/node/npm/python); returns false if
+    /// another session is already installing this tool.
+    pub(crate) fn try_claim_system_tool(&self, tool_id: &str) -> bool {
+        self.active_system_tools.lock().insert(tool_id.to_string())
+    }
+
+    pub(crate) fn release_system_tool(&self, tool_id: &str) {
+        self.active_system_tools.lock().remove(tool_id);
+    }
+
     fn cancel(&self, session_id: &str) -> bool {
         if let Some(tx) = self.sessions.lock().remove(session_id) {
             let _ = tx.send(());
@@ -100,7 +116,7 @@ impl InstallSessionRegistry {
         }
     }
 
-    fn drop_session(&self, session_id: &str) {
+    pub(crate) fn drop_session(&self, session_id: &str) {
         self.sessions.lock().remove(session_id);
     }
 }
@@ -153,7 +169,7 @@ fn provider_install_dir(provider_id: &str) -> Option<std::path::PathBuf> {
 /// system dependencies are installed. The probe is path-only — never
 /// executes the tool — so it's safe to call without side effects.
 /// See SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
-async fn resolve_tool_path(tool: &str) -> Option<String> {
+pub(crate) async fn resolve_tool_path(tool: &str) -> Option<String> {
     let cmd = if cfg!(windows) { "where" } else { "which" };
     let mut c = tokio::process::Command::new(cmd);
     c.arg(tool);

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -12,6 +12,7 @@ mod identity_auth_spawn;
 mod identity_handlers;
 pub mod install_handlers;
 mod lsp_handlers;
+mod system_install_handlers;
 mod messagebus;
 // pub(crate): muxbus::cloud_subscriber (the WAN delivery path) calls
 // resolve_transcript_request_tier_fields directly — see that function's

--- a/agentmux-srv/src/server/system_install_handlers.rs
+++ b/agentmux-srv/src/server/system_install_handlers.rs
@@ -277,6 +277,15 @@ async fn resolve_install_step(tool_id: &str) -> Option<SystemInstallStep> {
         resolve_brew_step(tool_id)
     } else {
         let pm = detect_linux_package_manager().await?;
+        // Same class of check as the Windows/winget and macOS/brew
+        // branches above: a package manager being present doesn't mean
+        // `pkexec` (this module's one elevation mechanism on Linux, §3.1)
+        // is too — minimal containers, some WSL distros, and server
+        // images without a desktop/polkit stack routinely have apt/dnf
+        // but no pkexec. Without this check, `available: true` would be
+        // reported with a command that fails to spawn instead of falling
+        // back to the link+copy-command UI. reagent P2, PR #2790.
+        resolve_tool_path("pkexec").await?;
         resolve_linux_step(tool_id, pm)
     }
 }

--- a/agentmux-srv/src/server/system_install_handlers.rs
+++ b/agentmux-srv/src/server/system_install_handlers.rs
@@ -59,6 +59,19 @@ struct SystemInstallStep {
     /// this ("This will show a Windows permission prompt" / "This will
     /// ask for your password") — never used to skip or alter execution.
     needs_elevation: bool,
+    /// Binary name to re-probe after a successful package-manager exit
+    /// (git/node/python's real executable — "npm" verifies via "node",
+    /// same bundled-together reasoning as `claim_key_for_tool`). A
+    /// package manager reporting success does NOT mean this process's
+    /// own PATH can see the new binary yet: on Windows especially,
+    /// winget/MSI installers update the registry-backed PATH, but a
+    /// long-running process (this srv) only re-reads its environment at
+    /// startup, not via the registry-change broadcast a newly-spawned
+    /// process would pick up. Verifying here lets the success message
+    /// tell the truth instead of silently declaring "installed" right
+    /// before the caller's own immediate re-probe shows "still not
+    /// found" — Codex P1, PR #2790.
+    verify_bin: String,
 }
 
 /// Linux package managers this module knows how to drive, in detection
@@ -126,6 +139,19 @@ async fn detect_linux_package_manager() -> Option<LinuxPackageManager> {
     None
 }
 
+/// Binary name to re-probe after a successful install (see
+/// `SystemInstallStep::verify_bin`'s doc comment). `"npm"` verifies via
+/// `"node"` (bundled together, same reasoning as `claim_key_for_tool`);
+/// `"python"`'s real executable name differs by platform.
+fn verify_bin_for_tool(tool_id: &str, windows: bool) -> Option<&'static str> {
+    match tool_id {
+        "git" => Some("git"),
+        "node" | "npm" => Some("node"),
+        "python" => Some(if windows { "python" } else { "python3" }),
+        _ => None,
+    }
+}
+
 fn resolve_windows_step(tool_id: &str) -> Option<SystemInstallStep> {
     // winget package identifiers — see https://github.com/microsoft/winget-pkgs.
     // `node`/`npm` share one identifier: npm ships bundled with Node, so
@@ -156,6 +182,7 @@ fn resolve_windows_step(tool_id: &str) -> Option<SystemInstallStep> {
         // from a non-console GUI-launched process is an open, real-
         // hardware verification item, not yet confirmed.
         needs_elevation: true,
+        verify_bin: verify_bin_for_tool(tool_id, true)?.to_string(),
     })
 }
 
@@ -174,6 +201,7 @@ fn resolve_brew_step(tool_id: &str) -> Option<SystemInstallStep> {
         // Homebrew must not be run as root — this is the one platform
         // with no elevation step to build at all.
         needs_elevation: false,
+        verify_bin: verify_bin_for_tool(tool_id, false)?.to_string(),
     })
 }
 
@@ -211,6 +239,7 @@ fn resolve_linux_step(tool_id: &str, pm: LinuxPackageManager) -> Option<SystemIn
         program: "pkexec".to_string(),
         args,
         needs_elevation: true,
+        verify_bin: verify_bin_for_tool(tool_id, false)?.to_string(),
     })
 }
 
@@ -220,8 +249,28 @@ fn resolve_linux_step(tool_id: &str, pm: LinuxPackageManager) -> Option<SystemIn
 /// tool id, or — macOS/Linux only — no usable package manager found);
 /// callers must treat `None` as "fall back to the existing link+copy-
 /// command UI," never as an error.
+/// Normalizes which claim slot a tool_id occupies in
+/// `InstallSessionRegistry.active_system_tools`. `"npm"` shares Node's
+/// slot on every platform (§3.5: they resolve to the exact same
+/// winget/brew/apt-family package transaction — installing Node already
+/// gets npm), so starting installs from both rows concurrently must not
+/// be allowed to both pass the claim check and race two installs of the
+/// same package (winget/msi lock errors, duplicate install prompts).
+/// Codex P2, PR #2790.
+fn claim_key_for_tool(tool_id: &str) -> &str {
+    if tool_id == "npm" { "node" } else { tool_id }
+}
+
 async fn resolve_install_step(tool_id: &str) -> Option<SystemInstallStep> {
     if cfg!(windows) {
+        // Symmetric with the macOS/Linux branches below: confirm the
+        // package manager itself is actually present before resolving a
+        // command for it. Without this, a Windows machine lacking winget
+        // (rare, but real — pre-App-Installer Windows 10) would get
+        // `available: true` with a command that fails to spawn instead of
+        // gracefully falling back to the existing link+copy-command UI.
+        // reagent P1, PR #2790.
+        resolve_tool_path("winget").await?;
         resolve_windows_step(tool_id)
     } else if cfg!(target_os = "macos") {
         resolve_tool_path("brew").await?;
@@ -287,7 +336,8 @@ pub fn register_system_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppS
                         req.tool_id
                     )
                 })?;
-                if !registry.try_claim_system_tool(&req.tool_id) {
+                let claim_key = claim_key_for_tool(&req.tool_id).to_string();
+                if !registry.try_claim_system_tool(&claim_key) {
                     return Err(format!(
                         "toolchain.install_system_tool: {} is already being installed in another session",
                         req.tool_id
@@ -309,7 +359,7 @@ pub fn register_system_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppS
                     broker,
                     registry,
                     session_id.clone(),
-                    req.tool_id,
+                    claim_key,
                     step,
                     cancel_rx,
                 );
@@ -324,7 +374,10 @@ fn spawn_system_install_task(
     broker: Arc<Broker>,
     registry: Arc<crate::server::install_handlers::InstallSessionRegistry>,
     session_id: String,
-    tool_id: String,
+    // Already normalized via `claim_key_for_tool` by the caller — "npm"
+    // and "node" share this same key so a release here always matches
+    // whichever key was actually claimed.
+    claim_key: String,
     step: SystemInstallStep,
     mut cancel_rx: tokio::sync::oneshot::Receiver<()>,
 ) {
@@ -381,7 +434,7 @@ fn spawn_system_install_task(
             Err(e) => {
                 emit_done(&broker, false, Some(format!("spawn {}: {e}", step.program)));
                 registry.drop_session(&session_id);
-                registry.release_system_tool(&tool_id);
+                registry.release_system_tool(&claim_key);
                 return;
             }
         };
@@ -426,7 +479,30 @@ fn spawn_system_install_task(
                 let _ = stdout_task.await;
                 let _ = stderr_task.await;
                 match wait {
-                    Ok(s) if s.success() => emit_done(&broker, true, None),
+                    Ok(s) if s.success() => {
+                        // The package manager succeeding does NOT mean
+                        // THIS already-running process can see the new
+                        // binary yet — its own PATH was captured at
+                        // startup and isn't refreshed by a Windows
+                        // registry-change broadcast or a new login-shell
+                        // read. Re-probe with the same mechanism the
+                        // caller's post-install refresh will use, so a
+                        // stale-PATH case is explained here instead of
+                        // silently contradicting itself a moment later
+                        // when that refresh still reports "not found".
+                        // Codex P1, PR #2790.
+                        if resolve_tool_path(&step.verify_bin).await.is_none() {
+                            emit_line(
+                                &broker,
+                                format!(
+                                    "Note: {} finished successfully, but AgentMux's current session doesn't see \"{}\" yet — restart AgentMux to pick up the updated PATH.",
+                                    step.program, step.verify_bin
+                                ),
+                                "stdout",
+                            );
+                        }
+                        emit_done(&broker, true, None);
+                    }
                     Ok(s) => emit_done(&broker, false, Some(format!("{} exited {:?}", step.program, s.code()))),
                     Err(e) => emit_done(&broker, false, Some(format!("wait: {e}"))),
                 }
@@ -449,7 +525,7 @@ fn spawn_system_install_task(
         }
 
         registry.drop_session(&session_id);
-        registry.release_system_tool(&tool_id);
+        registry.release_system_tool(&claim_key);
     });
 }
 

--- a/agentmux-srv/src/server/system_install_handlers.rs
+++ b/agentmux-srv/src/server/system_install_handlers.rs
@@ -1,0 +1,550 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `toolchain.resolve_install_command` / `toolchain.install_system_tool` —
+//! one-click install of git/Node/npm/Python through the platform's own
+//! package manager, streamed via the exact same `install_chunk` wire
+//! shape `install.start` already uses.
+//!
+//! SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md. This is that spec's
+//! Phase 1+2 (Linux + macOS + Windows) — NOT its deferred Phase 3
+//! (bootstrapping a MISSING package manager itself: installing Homebrew
+//! from scratch, or guiding a pre-App-Installer Windows through updating
+//! it). If `brew`/`winget` aren't present, `resolve_install_step` simply
+//! returns `None` and the caller falls back to the existing link+copy-
+//! command UI — this module never tries to install the package manager.
+//!
+//! **The security-critical invariant of this whole module:** every
+//! command this module can ever run comes from the fixed, hardcoded
+//! catalog in `resolve_install_step` below, addressed only by a `tool_id`
+//! validated against `is_safe_tool_id`. The RPC boundary never accepts a
+//! package name, a raw command, or anything else that could reach a
+//! `Command`'s argv from client input. Every entry is a `Vec<String>`
+//! passed straight to `Command::new(program).args(args)` — never a shell
+//! string through `sh -c`/`cmd /c` — so there is no interpolation surface
+//! even though nothing in this table is user-suppliable today.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::backend::rpc::engine::WshRpcEngine;
+use crate::backend::wps::{Broker, WaveEvent};
+use crate::server::install_handlers::resolve_tool_path;
+use crate::server::AppState;
+
+pub const COMMAND_TOOLCHAIN_RESOLVE_INSTALL_COMMAND: &str = "toolchain.resolve_install_command";
+pub const COMMAND_TOOLCHAIN_INSTALL_SYSTEM_TOOL: &str = "toolchain.install_system_tool";
+
+/// Tool ids feed straight into the catalog match in `resolve_install_step`
+/// — same shape constraint as `install_handlers::is_safe_provider_id`
+/// (short, alnum + `_`/`-`), kept as its own function rather than reused
+/// so this module's validation doesn't silently drift if that one's
+/// constraints ever change for provider-id-specific reasons.
+fn is_safe_tool_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 32
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+/// One resolved, ready-to-spawn install command. Never constructed from
+/// client input — always the output of `resolve_install_step`'s fixed
+/// catalog lookup.
+#[derive(Debug, Clone)]
+struct SystemInstallStep {
+    program: String,
+    args: Vec<String>,
+    /// Informs the consent-step copy the frontend shows before running
+    /// this ("This will show a Windows permission prompt" / "This will
+    /// ask for your password") — never used to skip or alter execution.
+    needs_elevation: bool,
+}
+
+/// Linux package managers this module knows how to drive, in detection
+/// priority order (first found on PATH wins — see `detect_linux_package_manager`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinuxPackageManager {
+    AptGet,
+    Dnf,
+    Yum,
+    Pacman,
+    Zypper,
+    Apk,
+}
+
+impl LinuxPackageManager {
+    const ALL_IN_PRIORITY_ORDER: [LinuxPackageManager; 6] = [
+        LinuxPackageManager::AptGet,
+        LinuxPackageManager::Dnf,
+        LinuxPackageManager::Yum,
+        LinuxPackageManager::Pacman,
+        LinuxPackageManager::Zypper,
+        LinuxPackageManager::Apk,
+    ];
+
+    fn binary_name(&self) -> &'static str {
+        match self {
+            Self::AptGet => "apt-get",
+            Self::Dnf => "dnf",
+            Self::Yum => "yum",
+            Self::Pacman => "pacman",
+            Self::Zypper => "zypper",
+            Self::Apk => "apk",
+        }
+    }
+
+    /// Per-manager non-interactive install flags + the package list.
+    /// Each manager has genuinely different flag syntax — there is no
+    /// single "install -y <pkgs>" that works across all of them (pacman
+    /// uses `-S --noconfirm`, apk uses a bare `add`).
+    fn install_args(&self, packages: &[&str]) -> Vec<String> {
+        let mut args: Vec<String> = match self {
+            Self::AptGet | Self::Dnf | Self::Yum | Self::Zypper => {
+                vec!["install".to_string(), "-y".to_string()]
+            }
+            Self::Pacman => vec!["-S".to_string(), "--noconfirm".to_string()],
+            Self::Apk => vec!["add".to_string()],
+        };
+        args.extend(packages.iter().map(|s| s.to_string()));
+        args
+    }
+}
+
+/// Probe for a Linux system package manager on PATH, in priority order —
+/// first match wins (a system with both `apt-get` and an unrelated
+/// manually-installed tool named e.g. `dnf` should still prefer the
+/// native one). Every mainstream Linux distro ships with exactly one of
+/// these as part of the base OS — unlike Homebrew/winget, there is no
+/// "package manager itself might be missing" case to handle here.
+async fn detect_linux_package_manager() -> Option<LinuxPackageManager> {
+    for pm in LinuxPackageManager::ALL_IN_PRIORITY_ORDER {
+        if resolve_tool_path(pm.binary_name()).await.is_some() {
+            return Some(pm);
+        }
+    }
+    None
+}
+
+fn resolve_windows_step(tool_id: &str) -> Option<SystemInstallStep> {
+    // winget package identifiers — see https://github.com/microsoft/winget-pkgs.
+    // `node`/`npm` share one identifier: npm ships bundled with Node, so
+    // there is no separate winget package for it (mirrors the frontend
+    // catalog's existing node/npm-both-resolve-to-node modeling).
+    let winget_id = match tool_id {
+        "git" => "Git.Git",
+        "node" | "npm" => "OpenJS.NodeJS.LTS",
+        "python" => "Python.Python.3.12",
+        _ => return None,
+    };
+    Some(SystemInstallStep {
+        program: "winget".to_string(),
+        args: vec![
+            "install".to_string(),
+            "--id".to_string(),
+            winget_id.to_string(),
+            "-e".to_string(),
+            "--silent".to_string(),
+            "--accept-package-agreements".to_string(),
+            "--accept-source-agreements".to_string(),
+        ],
+        // winget raises its own UAC prompt when a package's installer
+        // requires elevation (Git-for-Windows's and Node's MSI both do)
+        // — this process is never pre-elevated by AgentMux itself.
+        // SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md §3.1 flags that
+        // whether that prompt reliably attaches when winget is spawned
+        // from a non-console GUI-launched process is an open, real-
+        // hardware verification item, not yet confirmed.
+        needs_elevation: true,
+    })
+}
+
+/// Only reachable when `brew` is already on PATH (checked by the caller,
+/// `resolve_install_step`) — this module never bootstraps Homebrew itself.
+fn resolve_brew_step(tool_id: &str) -> Option<SystemInstallStep> {
+    let formula = match tool_id {
+        "git" => "git",
+        "node" | "npm" => "node",
+        "python" => "python@3.12",
+        _ => return None,
+    };
+    Some(SystemInstallStep {
+        program: "brew".to_string(),
+        args: vec!["install".to_string(), formula.to_string()],
+        // Homebrew must not be run as root — this is the one platform
+        // with no elevation step to build at all.
+        needs_elevation: false,
+    })
+}
+
+/// Elevated via `pkexec`, which raises the desktop's own native polkit
+/// authentication dialog — AgentMux never renders a password field or
+/// handles a credential itself. If no polkit agent is running (minimal
+/// window managers, some server-oriented desktops), `pkexec` fails fast
+/// with a clear, distinct error; the caller's existing link+copy-command
+/// fallback remains available regardless.
+///
+/// Package-name note (flagged, not "fixed" — SPEC §3.1): the Debian/
+/// Ubuntu (`apt-get`) `nodejs`/`npm` packages in the default repos are
+/// frequently well behind current Node LTS. A more correct install on
+/// `apt` systems specifically would go through the NodeSource setup
+/// script rather than the bare distro package; that's a real, open data
+/// decision for this catalog (bigger scope — a two-step fetch-then-run,
+/// not a plain package install) and is deliberately NOT implemented
+/// here. `dnf`/`pacman`/`zypper`/`apk`'s Node packages don't have the
+/// same well-known staleness reputation.
+fn resolve_linux_step(tool_id: &str, pm: LinuxPackageManager) -> Option<SystemInstallStep> {
+    let packages: &[&str] = match tool_id {
+        "git" => &["git"],
+        "node" | "npm" => &["nodejs", "npm"],
+        "python" => match pm {
+            LinuxPackageManager::AptGet => &["python3", "python3-pip", "python3-venv"],
+            LinuxPackageManager::Pacman => &["python", "python-pip"],
+            LinuxPackageManager::Apk => &["python3", "py3-pip"],
+            _ => &["python3", "python3-pip"],
+        },
+        _ => return None,
+    };
+    let mut args = vec![pm.binary_name().to_string()];
+    args.extend(pm.install_args(packages));
+    Some(SystemInstallStep {
+        program: "pkexec".to_string(),
+        args,
+        needs_elevation: true,
+    })
+}
+
+/// The one entry point into the catalog — dispatches by compile-time
+/// platform, then (macOS/Linux) by what's actually detected on this
+/// machine. Returns `None` whenever nothing can be resolved (unknown
+/// tool id, or — macOS/Linux only — no usable package manager found);
+/// callers must treat `None` as "fall back to the existing link+copy-
+/// command UI," never as an error.
+async fn resolve_install_step(tool_id: &str) -> Option<SystemInstallStep> {
+    if cfg!(windows) {
+        resolve_windows_step(tool_id)
+    } else if cfg!(target_os = "macos") {
+        resolve_tool_path("brew").await?;
+        resolve_brew_step(tool_id)
+    } else {
+        let pm = detect_linux_package_manager().await?;
+        resolve_linux_step(tool_id, pm)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ToolIdReq {
+    tool_id: String,
+}
+
+pub fn register_system_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    engine.register_handler(
+        COMMAND_TOOLCHAIN_RESOLVE_INSTALL_COMMAND,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let req: ToolIdReq = serde_json::from_value(data)
+                    .map_err(|e| format!("toolchain.resolve_install_command: {e}"))?;
+                if !is_safe_tool_id(&req.tool_id) {
+                    return Err(format!(
+                        "toolchain.resolve_install_command: invalid tool id {:?}",
+                        req.tool_id
+                    ));
+                }
+                match resolve_install_step(&req.tool_id).await {
+                    Some(step) => Ok(Some(json!({
+                        "available": true,
+                        "program": step.program,
+                        "args": step.args,
+                        "needsElevation": step.needs_elevation,
+                        "commandPreview": format!("{} {}", step.program, step.args.join(" ")),
+                    }))),
+                    None => Ok(Some(json!({ "available": false }))),
+                }
+            })
+        }),
+    );
+
+    let registry = state.install_sessions.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_TOOLCHAIN_INSTALL_SYSTEM_TOOL,
+        Box::new(move |data, _ctx| {
+            let registry = registry.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let req: ToolIdReq = serde_json::from_value(data)
+                    .map_err(|e| format!("toolchain.install_system_tool: {e}"))?;
+                if !is_safe_tool_id(&req.tool_id) {
+                    return Err(format!(
+                        "toolchain.install_system_tool: invalid tool id {:?}",
+                        req.tool_id
+                    ));
+                }
+                let step = resolve_install_step(&req.tool_id).await.ok_or_else(|| {
+                    format!(
+                        "toolchain.install_system_tool: no installable command resolved for {:?} on this platform",
+                        req.tool_id
+                    )
+                })?;
+                if !registry.try_claim_system_tool(&req.tool_id) {
+                    return Err(format!(
+                        "toolchain.install_system_tool: {} is already being installed in another session",
+                        req.tool_id
+                    ));
+                }
+                let session_id = format!("sysinstall-{}", uuid::Uuid::new_v4());
+                tracing::info!(
+                    session_id = %session_id,
+                    tool_id = %req.tool_id,
+                    program = %step.program,
+                    args = ?step.args,
+                    "toolchain.install_system_tool"
+                );
+
+                let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+                registry.insert(session_id.clone(), cancel_tx);
+
+                spawn_system_install_task(
+                    broker,
+                    registry,
+                    session_id.clone(),
+                    req.tool_id,
+                    step,
+                    cancel_rx,
+                );
+
+                Ok(Some(json!({ "sessionId": session_id })))
+            })
+        }),
+    );
+}
+
+fn spawn_system_install_task(
+    broker: Arc<Broker>,
+    registry: Arc<crate::server::install_handlers::InstallSessionRegistry>,
+    session_id: String,
+    tool_id: String,
+    step: SystemInstallStep,
+    mut cancel_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        use std::process::Stdio;
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        use tokio::process::Command;
+
+        // Reuses the EXACT `install_chunk` wire shape `install.start`
+        // already emits (`sessionId`/`line`/`stream`, and a terminal
+        // `{op:"done", ok, error?}`) scoped `install:<sessionId>` — so
+        // the frontend's existing streaming-log subscription code needs
+        // no new event type to render this.
+        let scope = format!("install:{}", session_id);
+        let emit_line = |broker: &Broker, line: String, stream: &'static str| {
+            broker.publish(WaveEvent {
+                event: "install_chunk".to_string(),
+                scopes: vec![scope.clone()],
+                sender: String::new(),
+                persist: 1024,
+                data: Some(json!({ "sessionId": session_id, "line": line, "stream": stream })),
+            });
+        };
+        let emit_done = |broker: &Broker, ok: bool, error: Option<String>| {
+            broker.publish(WaveEvent {
+                event: "install_chunk".to_string(),
+                scopes: vec![scope.clone()],
+                sender: String::new(),
+                persist: 1024,
+                data: Some(json!({ "sessionId": session_id, "op": "done", "ok": ok, "error": error })),
+            });
+        };
+
+        emit_line(
+            &broker,
+            format!("$ {} {}", step.program, step.args.join(" ")),
+            "stdout",
+        );
+
+        let mut cmd = Command::new(&step.program);
+        cmd.args(&step.args);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        }
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                emit_done(&broker, false, Some(format!("spawn {}: {e}", step.program)));
+                registry.drop_session(&session_id);
+                registry.release_system_tool(&tool_id);
+                return;
+            }
+        };
+
+        let stdout = child.stdout.take().expect("piped");
+        let stderr = child.stderr.take().expect("piped");
+
+        let broker_out = broker.clone();
+        let scope_out = scope.clone();
+        let session_out = session_id.clone();
+        let stdout_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                broker_out.publish(WaveEvent {
+                    event: "install_chunk".to_string(),
+                    scopes: vec![scope_out.clone()],
+                    sender: String::new(),
+                    persist: 1024,
+                    data: Some(json!({ "sessionId": session_out, "line": line, "stream": "stdout" })),
+                });
+            }
+        });
+
+        let broker_err = broker.clone();
+        let scope_err = scope.clone();
+        let session_err = session_id.clone();
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                broker_err.publish(WaveEvent {
+                    event: "install_chunk".to_string(),
+                    scopes: vec![scope_err.clone()],
+                    sender: String::new(),
+                    persist: 1024,
+                    data: Some(json!({ "sessionId": session_err, "line": line, "stream": "stderr" })),
+                });
+            }
+        });
+
+        tokio::select! {
+            wait = child.wait() => {
+                let _ = stdout_task.await;
+                let _ = stderr_task.await;
+                match wait {
+                    Ok(s) if s.success() => emit_done(&broker, true, None),
+                    Ok(s) => emit_done(&broker, false, Some(format!("{} exited {:?}", step.program, s.code()))),
+                    Err(e) => emit_done(&broker, false, Some(format!("wait: {e}"))),
+                }
+            }
+            // Reachable only if a session dies via connection drop before
+            // the process starts producing output — the frontend never
+            // offers a Cancel button once this task has actually spawned
+            // the privileged command (SPEC §3.4: interrupting a package
+            // manager mid-transaction, e.g. mid-dpkg-unpack, can leave
+            // broken system state; that's a pre-existing risk of package
+            // managers in general, not one this UI should make easier to
+            // hit by offering a cancel button that implies it's safe).
+            _ = &mut cancel_rx => {
+                tracing::info!(session_id = %session_id, "toolchain.install_system_tool: cancel — killing child");
+                let _ = child.kill().await;
+                let _ = stdout_task.await;
+                let _ = stderr_task.await;
+                emit_done(&broker, false, Some("cancelled".into()));
+            }
+        }
+
+        registry.drop_session(&session_id);
+        registry.release_system_tool(&tool_id);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_safe_tool_id_accepts_the_real_catalog_ids() {
+        for id in ["git", "node", "npm", "python"] {
+            assert!(is_safe_tool_id(id), "{id} should be accepted");
+        }
+    }
+
+    #[test]
+    fn is_safe_tool_id_rejects_shell_metacharacters_and_oversized_input() {
+        for id in ["git; rm -rf /", "node && curl evil.sh | sh", "", &"a".repeat(33), "../etc"] {
+            assert!(!is_safe_tool_id(id), "{id:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn resolve_windows_step_covers_the_catalog_and_rejects_unknown_ids() {
+        let git = resolve_windows_step("git").unwrap();
+        assert_eq!(git.program, "winget");
+        assert!(git.args.contains(&"Git.Git".to_string()));
+        assert!(git.needs_elevation);
+
+        // node and npm resolve to the SAME winget package — npm ships
+        // bundled with Node, there is no separate winget entry for it.
+        let node = resolve_windows_step("node").unwrap();
+        let npm = resolve_windows_step("npm").unwrap();
+        assert_eq!(node.args, npm.args);
+        assert!(node.args.contains(&"OpenJS.NodeJS.LTS".to_string()));
+
+        assert!(resolve_windows_step("python").is_some());
+        assert!(resolve_windows_step("docker").is_none());
+        assert!(resolve_windows_step("").is_none());
+    }
+
+    #[test]
+    fn resolve_brew_step_covers_the_catalog_and_never_needs_elevation() {
+        for id in ["git", "node", "npm", "python"] {
+            let step = resolve_brew_step(id).unwrap();
+            assert_eq!(step.program, "brew");
+            assert!(!step.needs_elevation, "brew must never be modeled as needing elevation");
+        }
+        assert!(resolve_brew_step("docker").is_none());
+    }
+
+    #[test]
+    fn resolve_linux_step_uses_the_correct_flag_syntax_per_manager() {
+        let apt = resolve_linux_step("git", LinuxPackageManager::AptGet).unwrap();
+        assert_eq!(apt.program, "pkexec");
+        assert_eq!(apt.args, vec!["apt-get", "install", "-y", "git"]);
+
+        let pacman = resolve_linux_step("git", LinuxPackageManager::Pacman).unwrap();
+        assert_eq!(pacman.args, vec!["pacman", "-S", "--noconfirm", "git"]);
+
+        let apk = resolve_linux_step("node", LinuxPackageManager::Apk).unwrap();
+        assert_eq!(apk.args, vec!["apk", "add", "nodejs", "npm"]);
+
+        // python's package list is genuinely different per manager —
+        // not just a flag-syntax difference.
+        let python_pacman = resolve_linux_step("python", LinuxPackageManager::Pacman).unwrap();
+        assert_eq!(python_pacman.args, vec!["pacman", "-S", "--noconfirm", "python", "python-pip"]);
+        let python_apt = resolve_linux_step("python", LinuxPackageManager::AptGet).unwrap();
+        assert_eq!(
+            python_apt.args,
+            vec!["apt-get", "install", "-y", "python3", "python3-pip", "python3-venv"]
+        );
+
+        assert!(resolve_linux_step("docker", LinuxPackageManager::AptGet).is_none());
+    }
+
+    #[test]
+    fn every_populated_catalog_entry_uses_a_plain_argv_never_a_shell_string() {
+        // Defense-in-depth check for the module's own stated invariant:
+        // no entry anywhere in the catalog should ever route through a
+        // shell interpreter — every program is the real binary, never
+        // "sh"/"bash"/"cmd"/"powershell" wrapping a formatted string.
+        let shells = ["sh", "bash", "cmd", "cmd.exe", "powershell", "powershell.exe"];
+        for id in ["git", "node", "npm", "python"] {
+            if let Some(s) = resolve_windows_step(id) {
+                assert!(!shells.contains(&s.program.as_str()));
+            }
+            if let Some(s) = resolve_brew_step(id) {
+                assert!(!shells.contains(&s.program.as_str()));
+            }
+            for pm in LinuxPackageManager::ALL_IN_PRIORITY_ORDER {
+                if let Some(s) = resolve_linux_step(id, pm) {
+                    assert!(!shells.contains(&s.program.as_str()));
+                    assert_eq!(s.program, "pkexec");
+                }
+            }
+        }
+    }
+}

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1430,6 +1430,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     // docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md)
     super::install_handlers::register_install_handlers(engine, &state);
 
+    // System-toolchain install handlers (toolchain.resolve_install_command /
+    // toolchain.install_system_tool — see
+    // docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md). Shares
+    // state.install_sessions with the handlers just above (same
+    // InstallSessionRegistry — install.cancel already works unchanged for
+    // these sessions too, no new cancel command needed).
+    super::system_install_handlers::register_system_install_handlers(engine, &state);
+
     // App API handlers (agent.open, agent.send, agent.stop, agent.status, agent.list, agent.output)
     super::app_api::register_app_api_handlers(engine, &state);
 

--- a/docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md
+++ b/docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md
@@ -1,0 +1,398 @@
+# SPEC: One-click system-toolchain installer (git, Node/npm, and friends) across Windows/macOS/Linux
+
+**Date:** 2026-08-24
+**Status:** implemented 2026-08-24 — §3.1-§3.5 for git/Node/npm/Python
+across Windows/macOS/Linux (Phases 1+2 of §6). Backend: 6 new Rust unit
+tests, full 2774-test suite green. Frontend: `npx tsc --noEmit` clean,
+full 3092-test vitest suite green (5 new). §6.3's Phase 3 (bootstrapping a
+MISSING package manager itself) and §6.4's NodeSource-vs-bare-package
+decision remain explicitly **not implemented** — flagged, not defaulted.
+The §3.1 Windows UAC-prompt-origin question is **not yet verified on real
+hardware** — the winget command construction is implemented and unit-
+tested, but whether the OS's own elevation prompt reliably attaches when
+spawned from this app's non-console process is an open manual-verification
+item (see §5's manual test plan), same honesty posture as this repo's
+other "implemented, live-environment check still pending" PRs. `uv` and
+Docker are intentionally excluded from the executable-install catalog
+(script-based install / interactive GUI installer — different risk
+profile, not requested); their existing link+copy-command rows are
+unchanged.
+**Related:** `docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` (shipped
+P0-P1: PATH enrichment + read-only Toolchain modal; **this spec implements
+its deferred P3** — "one-click brew install… P3 add-on, not yet shipped" —
+generalized to Windows/Linux, not brew-only), `docs/specs/SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md`
+(the reactive `AgentPrereqModal` blocker this spec also wires into),
+`docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md` (the `install.start`
+streamed-install machinery this spec reuses),
+`docs/specs/SPEC_TOOLCHAIN_MANAGER_EXTERNAL_WIDGETS_2026_06_22.md`
+(extends the same catalog to Python/uv + widget tools — same pattern,
+this spec's design should stay compatible with it).
+
+---
+
+## 1. Report
+
+Users hit a hard wall the moment an agent's shell needs `git` or `npm` and
+either isn't installed or isn't on PATH — this is a real, repeated
+onboarding blocker, not a hypothetical. AgentMux already has **two**
+places that know about this class of problem, and both stop at
+"tell the user, give them a link":
+
+1. **Reactive (`AgentPrereqModal.tsx`)** — fires at agent-launch time when
+   a provider's declared `systemPrereqs` (today: just `git`, on
+   claude/openclaw — `frontend/app/view/agent/providers/catalog.ts:106,325`)
+   aren't on PATH. Shows an install-URL link per missing tool and a
+   "Launch anyway" override. **Never installs anything.**
+2. **Proactive (`toolchain-view.tsx` / `toolchain-catalog.ts`)** — the
+   hamburger-menu "Toolchain" modal lists `node`/`npm`/`git`/`docker`/
+   `python`/`uv` with detected version/path and, per
+   `toolchain-view.tsx:286-299`, a copyable `installCommand` string
+   (`code>{row.installCommand}</code>` + a copy button) and an "Install ↗"
+   button that **only opens the tool's official download page**
+   (`open(row.installUrl)` — no command execution anywhere in this file
+   or `install_handlers.rs`). `CoreTool.brewFormula` exists on the catalog
+   type (`toolchain-catalog.ts:58`) but is **never read** by any spawn
+   code — it's inert data, a placeholder for the feature this spec
+   builds. `SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` §4.2/§6 designed this
+   exact gap as "P3 — one-click `brew install`… not yet shipped" and
+   scoped it to macOS/brew only; this spec is that P3, generalized to all
+   three platforms.
+
+**What's missing, concretely (verified against the catalog, not
+assumed):** `installCommand` has **no Windows entry at all** for
+`node`/`npm`/`git`/`docker` (`toolchain-catalog.ts:93,104,120` — only
+`macos`/`linux` keys) — a Windows user gets a bare download link and
+nothing copyable, worse coverage than macOS/Linux today. There is **no**
+Linux distro-family detection anywhere in the Rust backend (`grep` for
+`/etc/os-release`, `dnf`, `pacman`, `zypper` across `agentmux-srv/src` and
+`agentmux-common/src` returns nothing) — the one Linux command shown
+(`sudo apt install -y ...`) is silently wrong on Fedora/Arch/openSUSE.
+There is **no** privilege-elevation handling anywhere in the codebase
+(no `sudo`, `pkexec`, or UAC-elevation code) — every install action this
+app has ever executed (`install.start`'s `npm install`) runs unprivileged,
+into an AgentMux-owned directory; a system package-manager install is a
+fundamentally different, higher-trust class of action this codebase has
+never done before.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A real "Install" action (not just a link) for `git`/`node`/`npm` (and,
+  opportunistically, the rest of `CORE_TOOLS` — `docker`, `python`, `uv`)
+  on Windows, macOS, and Linux, reusing the existing streamed-install UI
+  pattern (`install_chunk` WPS events, live output, same visual language
+  as `AgentInstallModal`).
+- Wired into **both** existing surfaces: the reactive `AgentPrereqModal`
+  (the actual blocker moment) and the proactive Toolchain modal (today's
+  copy-command fallback becomes a real button when a package manager is
+  available; the fallback stays as-is when one isn't).
+- Correct, distro-aware command construction on Linux (no more blanket
+  `apt install` shown on non-Debian systems).
+- Every executed command comes from a **fixed, backend-owned catalog** —
+  the frontend can request "install git," never an arbitrary command
+  string. Same allowlist discipline as `is_safe_cli_command`/
+  `is_safe_provider_id` today, extended to a strictly bigger blast radius
+  (elevated system commands, not an unprivileged install into
+  `~/.agentmux/...`).
+- Full transparency before anything elevated runs: show the exact command,
+  require an explicit click, never silent/background.
+
+**Non-goals (this iteration — see §6 for what's phased vs. flagged
+[DECISION NEEDED])**
+- Auto-bootstrapping a *missing package manager itself* (Homebrew on a
+  mac that's never had it; a pre-App-Installer Windows without `winget`).
+  Both are materially bigger trust actions than "run a formula install
+  through a package manager the user already opted into" — flagged, not
+  defaulted to yes (§6.3).
+- A general-purpose "run any elevated command" primitive. This feature is
+  a small, fixed, versioned catalog of (toolId → per-platform install
+  command), not a shell.
+- Version pinning / "install exactly Node 20.11" — package managers
+  install whatever their repo currently has; that's an accepted, existing
+  limitation of every `installCommand` shown today too.
+- Docker Desktop installation (still `optional: true`, still link-only —
+  Docker Desktop's own installer is a large, interactive GUI flow that
+  doesn't fit a headless streamed-install session; unchanged from today).
+
+## 3. Design
+
+### 3.1 Per-platform package-manager strategy
+
+**Windows — `winget`.** Bundled with Windows 11 and modern Windows 10
+(App Installer, auto-updated via the Store) — no bootstrap needed for the
+overwhelming majority of target machines. Command shape:
+`winget install --id <PackageIdentifier> --silent --accept-package-agreements --accept-source-agreements`.
+Elevation: winget handles its own UAC prompt per-package when a package's
+installer requires it (Git-for-Windows's installer does; Node's MSI
+does); AgentMux does **not** need to pre-elevate the `winget` process
+itself for a per-user-scope install. **[DECISION NEEDED — research
+spike, not assumed]:** does a UAC prompt raised by a child process spawned
+from a non-console GUI app (`agentmux-srv`, itself spawned by
+`agentmux-cef`/the launcher) reliably surface and attach to the correct
+desktop session? This needs to be verified on a real Windows box before
+Phase 2 (§6) ships — if it doesn't reliably attach, the fallback is
+spawning through `ShellExecuteW` with `runas`, which is a different code
+path than the plain `tokio::process::Command` this codebase uses
+everywhere else. If `winget` itself is missing (rare, old Windows), no
+auto-bootstrap — same non-goal posture as today; keep the existing
+download-link fallback.
+
+**macOS — `brew`.** Exactly the already-designed P3
+(`SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` §4.2): `brew install <formula>`,
+never run as root (Homebrew refuses most operations under `sudo` by
+design, so there is no elevation step to build — the *simplest*
+platform here). Only reachable when `brew` is already detected on PATH.
+If it's missing, fall through to the existing link+copy-command UI
+unchanged (auto-bootstrapping Homebrew itself is §6.3, not this).
+
+**Linux — detect the system package manager, no bootstrap ever needed.**
+Every mainstream Linux distro ships with its own package manager
+pre-installed as part of the base OS — unlike brew/winget, there is no
+"package manager itself might be missing" case to design around. Detect
+by checking for each manager's binary on PATH in priority order (first
+match wins, since a system with e.g. both `apt` and a manually-installed
+`brew` should prefer the native one): `apt-get` → `dnf` → `yum` → `pacman`
+→ `zypper` → `apk`. Cross-check against `/etc/os-release`'s `ID`/
+`ID_LIKE` fields where the mapping is ambiguous (e.g. distinguishing a
+`dnf`-based immutable/Silverblue variant that may need `rpm-ostree`
+instead — out of scope for v1, falls through to link+copy-command).
+Elevation: **`pkexec <package-manager> install -y <package>`** —
+`pkexec` triggers the desktop's own native polkit authentication dialog
+(password or fingerprint, whatever the session's polkit agent provides)
+without AgentMux ever rendering a password field itself. If no polkit
+agent is running (minimal window managers, some server-oriented desktop
+setups) `pkexec` fails fast with a clear error — falls through to the
+existing copy-command-into-your-own-terminal UX, never a dead end.
+
+**Package-name mapping caveat (real, not hypothetical) — Node on Debian/
+Ubuntu.** The `apt` repositories' default `nodejs`/`npm` packages are
+frequently far behind current LTS (a long-standing, well-known Debian/
+Ubuntu packaging gap). A naive `sudo apt install -y nodejs npm` (today's
+`toolchain-catalog.ts:93` literal string) reproduces that gap. The
+per-platform catalog entry for `node` on `apt`-family systems should point
+at the NodeSource setup script path instead (documented, official,
+distro-recommended) rather than the bare distro package — this is a
+**content decision for the catalog data**, not a code-architecture one;
+flagged here so it isn't silently carried forward unfixed. `git` has no
+equivalent gap (distro `git` packages are reasonably current everywhere
+that matters).
+
+### 3.2 Command catalog — the actual security boundary
+
+New Rust-side data structure, `SystemInstallCatalog` (analogous to, and
+living alongside, the existing frontend `CORE_TOOLS` catalog — but this
+one is the **execution-authoritative** copy; the frontend catalog stays
+display-only, exactly as today):
+
+```rust
+struct SystemInstallStep {
+    program: String,        // e.g. "winget", "brew", "pkexec"
+    args: Vec<String>,      // e.g. ["install", "--id", "Git.Git", "-e", "--silent"]
+    needs_elevation: bool,  // informs the confirm-step copy shown to the user
+}
+
+// Keyed by (tool_id, platform, package_manager). Every command is a fixed
+// argv Vec<String> — NEVER a shell string passed through `sh -c`/`cmd /c`,
+// so there is no interpolation surface even though every entry in this
+// table is itself hardcoded (defense in depth: a future catalog edit that
+// accidentally introduces a format!()-built arg still can't smuggle shell
+// metacharacters through a Vec<String> argv the way it could through a
+// single command string).
+```
+
+The RPC surface takes **only** a `tool_id` (validated against a fixed
+allowlist, same style as `is_safe_provider_id`) — never a package-manager
+package name, never a raw command, from the frontend. The frontend's job
+is to display the resolved command (fetched from the backend, which is
+the one source of truth for what will actually run) for the consent step
+in §3.3 — it never constructs or edits it.
+
+New RPC: `toolchain.install_system_tool` (parallel to `install.start`,
+same session/streaming/cancel shape from `InstallSessionRegistry`):
+```ts
+ToolchainInstallSystemToolCommand(client, { toolId: string }): Promise<{ sessionId: string }>
+```
+Backend resolves `(toolId, detected_platform, detected_package_manager)` →
+the catalog's `SystemInstallStep`, spawns `Command::new(step.program).args(step.args)`
+(plain piped stdio, matching `install.start`'s existing pattern — no PTY
+needed for `winget`/`brew`/`pkexec`'s own non-interactive `-y`/`--silent`
+flags), streams stdout+stderr line-by-line to `install_chunk` events
+scoped `install:<sessionId>` — **identical wire format** to the existing
+npm-install flow, so `AgentInstallModal`'s streaming-log rendering code
+is reusable as-is for this new session kind, not a fork.
+
+### 3.3 Consent — the non-negotiable step before anything elevated runs
+
+Before `toolchain.install_system_tool` is ever called, the frontend shows
+a confirm step (a small panel, not a native `confirm()`) displaying:
+- The exact resolved command (fetched via a read-only
+  `toolchain.resolve_install_command({ toolId })` preview call — same
+  catalog lookup as the execute path, but zero side effects, so the user
+  sees precisely what they're about to approve).
+- Whether it needs elevation (`needs_elevation`), phrased plainly ("This
+  will ask for your password" / "This will show a Windows permission
+  prompt").
+- An explicit **Install** button — no default-focus auto-trigger, no
+  countdown, no "don't ask again" checkbox that could silently promote
+  this to unattended in a future session.
+
+This directly fulfills, rather than relaxes, the existing spec's stated
+non-goal ("we do not background-install heavyweight runtimes without
+consent," `SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` §2) — it's the consent
+mechanism made real, not a loosening of that posture.
+
+### 3.4 Cancellation — narrower than the npm flow, on purpose
+
+`install.start`'s existing cancel semantics (kill child, `rm_rf` the
+partial install dir) are safe because an npm install only ever touches an
+AgentMux-owned directory. A system package-manager transaction (`apt`/
+`dpkg`, `winget`'s MSI/EXE installers, `brew`'s own transactional model)
+can leave broken system state if killed mid-write. **Cancel is only
+offered before the privileged command actually starts** (i.e., during the
+consent step, or while `pkexec`/UAC's own auth prompt is still pending) —
+once the underlying package manager has begun, the UI shows progress only,
+no cancel button, mirroring how a real terminal `apt install` behaves
+today (Ctrl-C mid-`dpkg`-unpack is already inadvisable outside this app
+too — this isn't a new restriction, just not pretending otherwise).
+
+### 3.5 Wiring into the two existing surfaces
+
+- **`AgentPrereqModal.tsx`** — each `MissingPrereq` row gains an "Install"
+  button (rendered only when `toolId` is in the backend's install catalog
+  for the detected platform+package-manager; otherwise the existing
+  link-only row is unchanged). On success, calls the same `onRefresh()`
+  the modal already exposes — no new refresh mechanism.
+- **`toolchain-view.tsx`** — the existing "Install ↗" button
+  (`toolchain-view.tsx:297`, currently `open(row.installUrl)` only)
+  becomes conditional: when the catalog resolves an installable command
+  for this row+platform, it opens the §3.3 consent panel instead of the
+  external URL; when it doesn't (no package manager detected, or the
+  tool has no catalog entry — e.g. Docker, which stays link-only per §2's
+  non-goals), it falls back to today's exact behavior. The copyable
+  `installCommand` text stays visible either way — it's the correct
+  fallback for a user who prefers running it themselves in their own
+  terminal, or whose desktop has no polkit agent for `pkexec` to hand off
+  to.
+- **Redundant-entry note:** `node` and `npm` are two separate `CoreTool`
+  rows that already both resolve to the same install target (npm ships
+  bundled with Node — `toolchain-catalog.ts:93-105` show both entries
+  pointing at `brewFormula: "node"` / `brew install node`). Wiring real
+  execution behind two independent buttons risks a confusing double
+  install-and-consent-prompt if a user clicks both in sequence. Recommend
+  the `npm` row's "Install" action simply re-triggers the same session as
+  `node`'s (or is visually merged into one action) — a UI-only decision,
+  not a backend catalog change.
+
+## 4. Security
+
+- **Fixed catalog, not free-form execution.** Reiterating §3.2's core
+  invariant since it's the entire security argument for this feature:
+  the RPC boundary accepts a `tool_id` from a small, backend-owned
+  enum-like allowlist — structurally identical to how `is_safe_cli_command`
+  already gates `install.start`, just applied to a category of action
+  (elevated system commands) that has a much higher cost if that
+  discipline is ever skipped at a new call site.
+- **No shell string interpolation, ever.** Every catalog entry is a
+  `Vec<String>` argv passed straight to `Command::new(program).args(args)`
+  — never `sh -c`/`cmd /c` with a formatted string. This is true even
+  though every entry is hardcoded today (no user input reaches the argv
+  at all in v1) — it's the same "don't build the injection surface even
+  when nothing currently exploits it" posture as the rest of this
+  codebase's command-spawning code.
+- **Elevation is delegated to the OS's own consent UI** (`pkexec`'s
+  polkit dialog, Windows' native UAC prompt, brew's no-root-needed model)
+  — AgentMux never asks for or handles a sudo password itself, never
+  stores one, never runs as an elevated process for longer than the one
+  package-manager invocation.
+- **Residual risk, stated plainly:** a `winget`/`brew`/`pkexec` package
+  install can still run arbitrary code as an implicit consequence of what
+  "installing a package" fundamentally means (pre/post-install scripts
+  are a normal, expected part of every package manager on earth) — this
+  is the same trust boundary a user already crosses running `brew install
+  git` in their own terminal; this feature doesn't create a new kind of
+  risk, it automates a command the user could already type themselves,
+  with the exact command shown before it runs. Flagged for completeness,
+  not as something this design can or should try to eliminate.
+
+## 5. Test plan
+
+- Rust: catalog resolution — `(tool_id, platform, package_manager)` →
+  expected `SystemInstallStep` for every populated combination; unknown
+  `tool_id` → `None`/error, never a fallback that guesses a command;
+  Linux package-manager detection priority order given a fake PATH with
+  0/1/2+ managers present; `/etc/os-release` parsing for the Node/apt
+  NodeSource-vs-bare-package distinction (§3.1).
+- Rust: `toolchain.install_system_tool` handler — spawns the resolved
+  argv (assert on the `Command` built, not an actual execution, in unit
+  tests — mirrors how `install.start`'s tests likely already avoid a real
+  `npm` invocation); streams `install_chunk` events in the same shape as
+  the existing npm flow; cancel is rejected once the child has started
+  (§3.4), accepted before.
+- Frontend: `AgentPrereqModal` renders an Install button only when the
+  backend catalog resolves a command for the current platform; the
+  consent panel shows the exact resolved command text (mocked RPC);
+  `toolchain-view.tsx`'s row falls back to the existing link+copy-command
+  behavior when no command resolves.
+- **Manual, per-OS (this feature is fundamentally environment-dependent —
+  unit tests can't cover "does `pkexec` actually work on a real desktop
+  session," "does `winget` actually resolve `Git.Git`," etc.):**
+  - [ ] Windows: install git via winget from a clean VM without git;
+    confirm the UAC/consent flow's origin question from §3.1.
+  - [ ] macOS with brew already present: install node via the Toolchain
+    modal; confirm no sudo prompt (brew must not run as root).
+  - [ ] Ubuntu/Debian, Fedora, Arch (three real or containerized distros
+    minimum): confirm the correct package manager is detected on each and
+    the resulting command is distro-correct, not a blanket `apt`.
+  - [ ] A machine with no polkit agent running (or `winget`/`brew`
+    genuinely absent): confirm graceful fallback to the existing
+    link+copy-command UI, not an unhandled error.
+
+## 6. Rollout & open decisions
+
+1. **Phase 1 — Linux + macOS.** Both platforms have a package manager
+   that's essentially guaranteed already present (Linux: always, it's
+   part of the base OS; macOS: only reachable when `brew` is already
+   detected, same gate as today's inert `brewFormula` field) and a
+   consent-friendly elevation story (native polkit dialog / no elevation
+   needed at all). Lowest-risk, ships first.
+2. **Phase 2 — Windows via `winget`.** Gated on resolving the
+   UAC-prompt-origin question in §3.1 first (a short research spike, not
+   a large build) — the one platform where "will the OS's own consent
+   dialog actually show up correctly" isn't already known from existing
+   precedent elsewhere in this codebase.
+3. **[DECISION NEEDED] Phase 3 — bootstrapping a MISSING package
+   manager itself** (installing Homebrew when a mac has never had it;
+   guiding a pre-App-Installer Windows through updating it). This is
+   explicitly **not** included in Phases 1-2 above and is flagged, not
+   assumed — running Homebrew's official install script is itself a
+   "fetch and run a script from the internet" action, a categorically
+   bigger trust step than "run a formula install through a package
+   manager the user already has and has already used." Recommend
+   deciding this separately, after Phase 1-2 ship and the consent-UX
+   pattern has real usage to point to, rather than bundling it into v1.
+4. **[DECISION NEEDED] Node's Debian/Ubuntu package-name mapping**
+   (§3.1's NodeSource-vs-bare-package caveat) — a content/data decision
+   for the catalog, flagged so it isn't silently shipped wrong; doesn't
+   block the architecture in §3.2-§3.5.
+
+## 7. Touch points (files)
+
+- `agentmux-srv/src/server/install_handlers.rs` (or a new sibling module,
+  e.g. `system_install_handlers.rs`) — `SystemInstallCatalog`,
+  `toolchain.install_system_tool` / `toolchain.resolve_install_command`
+  handlers, reusing `InstallSessionRegistry`'s streaming/cancel plumbing.
+- `agentmux-common/src/` — Linux package-manager + distro detection
+  (a natural sibling to the existing `toolchain_path.rs`'s "what's on
+  this machine" logic).
+- `frontend/app/store/rpc-api.ts` (or a dedicated `toolchain-rpc.ts`) —
+  `ToolchainInstallSystemToolCommand` / `ToolchainResolveInstallCommandCommand`.
+- `frontend/app/view/agent/components/AgentPrereqModal.tsx` — per-row
+  Install button + consent panel.
+- `frontend/app/view/toolchain/toolchain-view.tsx:286-299` — the existing
+  "Install ↗" button gains the conditional real-execution path described
+  in §3.5; the copy-command fallback is untouched.
+- `frontend/app/view/agent/providers/toolchain-catalog.ts` — add missing
+  Windows `installCommand` entries for node/npm/git/docker (currently
+  absent, §1); no structural change to `CoreTool` needed beyond what
+  `brewFormula` already implies (a parallel `wingetId` field is the
+  natural Windows counterpart, mirroring `brewFormula`'s existing shape).

--- a/frontend/app/store/rpc-api/identity.ts
+++ b/frontend/app/store/rpc-api/identity.ts
@@ -260,6 +260,40 @@ export const IdentityApi = {
         return client.rpcCall("resolve.prereqs", data, opts);
     },
 
+    // ── System-toolchain install (SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md) ──
+
+    // command "toolchain.resolve_install_command" — read-only preview:
+    // resolves what command WOULD run to install `toolId` (git/node/npm/
+    // python) via the platform's own package manager (winget/brew/a
+    // detected Linux package manager), without side effects. `available:
+    // false` means no installable command exists on this platform/machine
+    // (e.g. brew not installed on macOS, no known package manager found
+    // on Linux) — callers must fall back to the existing link+copy-command
+    // UI, never treat this as an error.
+    ToolchainResolveInstallCommandCommand(
+        client: RpcClient,
+        data: { toolId: string },
+        opts?: RpcOpts,
+    ): Promise<
+        | { available: false }
+        | { available: true; program: string; args: string[]; needsElevation: boolean; commandPreview: string }
+    > {
+        return client.rpcCall("toolchain.resolve_install_command", data, opts);
+    },
+
+    // command "toolchain.install_system_tool" — spawns the resolved
+    // install command and streams output via the SAME `install_chunk` WPS
+    // event shape `install.start` uses, scoped `install:<sessionId>`.
+    // `InstallCancelCommand` above already works unchanged for these
+    // sessions (shared session registry) — no separate cancel command.
+    ToolchainInstallSystemToolCommand(
+        client: RpcClient,
+        data: { toolId: string },
+        opts?: RpcOpts,
+    ): Promise<{ sessionId: string }> {
+        return client.rpcCall("toolchain.install_system_tool", data, opts);
+    },
+
     // command "identity.ensureaccountdir" — mints (or resolves, when
     // existingAccountId is set) a per-account isolated config dir without
     // spawning a CLI or an OAuth handshake. Used by the seed-from-global

--- a/frontend/app/view/agent/components/AgentPrereqModal.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.tsx
@@ -9,10 +9,11 @@
  * SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
  */
 
-import { For, type JSX } from "solid-js";
+import { createSignal, For, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
 import { getApi } from "@/app/store/global";
+import { SystemToolInstallInline } from "@/app/view/toolchain/SystemToolInstallInline";
 
 interface MissingPrereq {
     tool: string;
@@ -20,6 +21,12 @@ interface MissingPrereq {
     installUrl: string;
     installLinkText: string;
 }
+
+// Tool ids the backend's system-install catalog covers
+// (system_install_handlers.rs) — anything else keeps the existing
+// link-only row unchanged. See
+// docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md.
+const SYSTEM_INSTALLABLE_IDS = new Set(["git", "node", "npm", "python"]);
 
 interface AgentPrereqModalPanelProps {
     agent: AgentDefinition;
@@ -37,6 +44,15 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
             // Fall through — if external-open fails, the link is at
             // least visible in the modal as text the user can copy.
         }
+    };
+
+    const [expandedInstalls, setExpandedInstalls] = createSignal<ReadonlySet<string>>(new Set());
+    const toggleInstallPanel = (tool: string) => {
+        setExpandedInstalls((prev) => {
+            const next = new Set(prev);
+            if (next.has(tool)) next.delete(tool); else next.add(tool);
+            return next;
+        });
     };
 
     return (
@@ -72,6 +88,24 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
                                         {req.installLinkText}
                                         <span class="agent-prereq-modal-link-arrow" aria-hidden="true"> ↗</span>
                                     </a>
+                                    <Show when={SYSTEM_INSTALLABLE_IDS.has(req.tool)}>
+                                        <button
+                                            type="button"
+                                            class="agent-prereq-modal-link"
+                                            onClick={() => toggleInstallPanel(req.tool)}
+                                        >
+                                            or install it now ↓
+                                        </button>
+                                        <Show when={expandedInstalls().has(req.tool)}>
+                                            <SystemToolInstallInline
+                                                toolId={req.tool}
+                                                onInstalled={() => {
+                                                    toggleInstallPanel(req.tool);
+                                                    props.onRefresh();
+                                                }}
+                                            />
+                                        </Show>
+                                    </Show>
                                 </div>
                             </li>
                         )}

--- a/frontend/app/view/agent/components/AgentPrereqModal.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.tsx
@@ -54,6 +54,21 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
             return next;
         });
     };
+    // Hides the "or install it now" toggle once resolution confirms
+    // there's nothing to offer (no package manager detected/usable) —
+    // the primary install-URL link above stays visible regardless
+    // either way; this only prevents the SECONDARY toggle from lingering
+    // as a button that expands to a permanently blank panel. reagent P2,
+    // PR #2790.
+    const [unavailableInstalls, setUnavailableInstalls] = createSignal<ReadonlySet<string>>(new Set());
+    const markUnavailable = (tool: string) => {
+        setExpandedInstalls((prev) => {
+            const next = new Set(prev);
+            next.delete(tool);
+            return next;
+        });
+        setUnavailableInstalls((prev) => new Set(prev).add(tool));
+    };
 
     return (
         <>
@@ -88,7 +103,7 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
                                         {req.installLinkText}
                                         <span class="agent-prereq-modal-link-arrow" aria-hidden="true"> ↗</span>
                                     </a>
-                                    <Show when={SYSTEM_INSTALLABLE_IDS.has(req.tool)}>
+                                    <Show when={SYSTEM_INSTALLABLE_IDS.has(req.tool) && !unavailableInstalls().has(req.tool)}>
                                         <button
                                             type="button"
                                             class="agent-prereq-modal-link"
@@ -103,6 +118,7 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
                                                     toggleInstallPanel(req.tool);
                                                     props.onRefresh();
                                                 }}
+                                                onUnavailable={() => markUnavailable(req.tool)}
                                             />
                                         </Show>
                                     </Show>

--- a/frontend/app/view/agent/providers/toolchain-catalog.ts
+++ b/frontend/app/view/agent/providers/toolchain-catalog.ts
@@ -57,6 +57,13 @@ export interface CoreTool {
     installCommand?: Partial<Record<Platform, string>>;
     /** Homebrew formula — enables the P3 one-click install when brew exists. */
     brewFormula?: string;
+    /** winget package identifier (e.g. "Git.Git") — mirrors `brewFormula`'s
+     *  role on Windows. Display-only, like `brewFormula`: the backend's own
+     *  fixed catalog (`system_install_handlers.rs`) is the execution-
+     *  authoritative copy — this field is never sent to the backend, only
+     *  used to decide whether to show the one-click Install action. See
+     *  docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md. */
+    wingetId?: string;
     /** What "available" means for this tool. Defaults to `"path"` when omitted. */
     checkKind?: CheckKind;
 }
@@ -90,8 +97,13 @@ export const CORE_TOOLS: CoreTool[] = [
         description: "JavaScript runtime — required to install & run the npm-based agent CLIs.",
         docsUrl: "https://nodejs.org/",
         installUrls: { windows: NODE_DOWNLOAD, macos: NODE_DOWNLOAD, linux: NODE_DOWNLOAD },
-        installCommand: { macos: "brew install node", linux: "sudo apt install -y nodejs npm" },
+        installCommand: {
+            windows: "winget install --id OpenJS.NodeJS.LTS -e",
+            macos: "brew install node",
+            linux: "sudo apt install -y nodejs npm",
+        },
         brewFormula: "node",
+        wingetId: "OpenJS.NodeJS.LTS",
     },
     {
         id: "npm",
@@ -101,8 +113,20 @@ export const CORE_TOOLS: CoreTool[] = [
         description: "Node package manager — ships with Node.js; installs the agent CLIs.",
         docsUrl: "https://docs.npmjs.com/",
         installUrls: { windows: NODE_DOWNLOAD, macos: NODE_DOWNLOAD, linux: NODE_DOWNLOAD },
-        installCommand: { macos: "brew install node", linux: "sudo apt install -y nodejs npm" },
+        // Same target as "node" above — npm ships bundled with Node, there
+        // is no separate winget/brew/apt package for it. The one-click
+        // Install action for this row re-triggers the same backend
+        // resolution as node's (both resolve to the same tool_id-keyed
+        // catalog entry server-side); modeled as two rows here only
+        // because the Toolchain modal displays them as two detectable
+        // binaries, not because they install separately.
+        installCommand: {
+            windows: "winget install --id OpenJS.NodeJS.LTS -e",
+            macos: "brew install node",
+            linux: "sudo apt install -y nodejs npm",
+        },
         brewFormula: "node",
+        wingetId: "OpenJS.NodeJS.LTS",
     },
     {
         id: "git",
@@ -117,8 +141,13 @@ export const CORE_TOOLS: CoreTool[] = [
             macos: "https://git-scm.com/download/mac",
             linux: "https://git-scm.com/download/linux",
         },
-        installCommand: { macos: "brew install git", linux: "sudo apt install -y git" },
+        installCommand: {
+            windows: "winget install --id Git.Git -e",
+            macos: "brew install git",
+            linux: "sudo apt install -y git",
+        },
         brewFormula: "git",
+        wingetId: "Git.Git",
     },
     {
         id: "docker",
@@ -155,11 +184,12 @@ export const CORE_TOOLS: CoreTool[] = [
             linux: "https://www.python.org/downloads/source/",
         },
         installCommand: {
-            windows: "winget install Python.Python.3.12",
+            windows: "winget install --id Python.Python.3.12 -e",
             macos: "brew install python@3.12",
             linux: "sudo apt install -y python3 python3-pip python3-venv",
         },
         brewFormula: "python@3.12",
+        wingetId: "Python.Python.3.12",
     },
     {
         id: "uv",

--- a/frontend/app/view/toolchain/SystemToolInstallInline.scss
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.scss
@@ -1,0 +1,92 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.system-tool-install-inline {
+    margin-top: var(--space-1, 6px);
+    padding: var(--space-2, 8px);
+    border: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5, 10px);
+}
+
+.system-tool-install-consent {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1, 6px);
+}
+
+.system-tool-install-consent-text {
+    margin: 0;
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+}
+
+.system-tool-install-command {
+    display: block;
+    padding: var(--space-1, 6px) var(--space-1-5, 10px);
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-xs, 11px);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.system-tool-install-elevation-note {
+    margin: 0;
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+
+    i {
+        color: var(--accent-color);
+    }
+}
+
+.system-tool-install-log {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1, 6px);
+}
+
+.system-tool-install-log-header {
+    font-size: var(--text-xs, 11px);
+    color: var(--secondary-text-color);
+}
+
+.system-tool-install-ok {
+    color: var(--success-color, #3ba55d);
+}
+
+.system-tool-install-fail {
+    color: var(--error-color);
+}
+
+.system-tool-install-spinner {
+    display: inline-block;
+}
+
+.system-tool-install-log-body {
+    margin: 0;
+    padding: var(--space-1-5, 10px);
+    max-height: 200px;
+    overflow-y: auto;
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-xs, 11px);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+.system-tool-install-error {
+    padding: var(--space-1, 6px) var(--space-1-5, 10px);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 30%, transparent);
+    color: var(--error-color);
+    font-size: var(--text-xs, 11px);
+}

--- a/frontend/app/view/toolchain/SystemToolInstallInline.test.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.test.tsx
@@ -48,6 +48,26 @@ describe("SystemToolInstallInline", () => {
         expect(container.textContent).toBe("");
     });
 
+    it("calls onUnavailable when resolution reports no installable command, so callers can hide their toggle", async () => {
+        resolveMock.mockResolvedValue({ available: false });
+        const onUnavailable = vi.fn();
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => (
+            <SystemToolInstallInline toolId="git" onInstalled={() => {}} onUnavailable={onUnavailable} />
+        ));
+        await waitFor(() => expect(onUnavailable).toHaveBeenCalledTimes(1));
+    });
+
+    it("calls onUnavailable when the resolve RPC itself throws", async () => {
+        resolveMock.mockRejectedValue(new Error("boom"));
+        const onUnavailable = vi.fn();
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => (
+            <SystemToolInstallInline toolId="git" onInstalled={() => {}} onUnavailable={onUnavailable} />
+        ));
+        await waitFor(() => expect(onUnavailable).toHaveBeenCalledTimes(1));
+    });
+
     it("renders the resolved command as a consent step before installing anything", async () => {
         resolveMock.mockResolvedValue({
             available: true,

--- a/frontend/app/view/toolchain/SystemToolInstallInline.test.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.test.tsx
@@ -1,0 +1,128 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SystemToolInstallInline — the state machine for one-click system-tool
+ * installs (SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md §3.3-§3.4):
+ * renders nothing when unavailable (caller keeps its own link+copy-
+ * command fallback), shows the exact resolved command before running
+ * anything, and streams install_chunk output through to done/failed.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveMock = vi.fn();
+const installMock = vi.fn();
+let chunkHandler: ((event: unknown) => void) | null = null;
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ToolchainResolveInstallCommandCommand: (...args: unknown[]) => resolveMock(...args),
+        ToolchainInstallSystemToolCommand: (...args: unknown[]) => installMock(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: (sub: { handler: (event: unknown) => void }) => {
+        chunkHandler = sub.handler;
+        return () => { chunkHandler = null; };
+    },
+}));
+
+afterEach(() => {
+    cleanup();
+    resolveMock.mockReset();
+    installMock.mockReset();
+    chunkHandler = null;
+});
+
+describe("SystemToolInstallInline", () => {
+    it("renders nothing when the backend reports no installable command", async () => {
+        resolveMock.mockResolvedValue({ available: false });
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        const { container } = render(() => (
+            <SystemToolInstallInline toolId="git" onInstalled={() => {}} />
+        ));
+        await waitFor(() => expect(resolveMock).toHaveBeenCalledWith({}, { toolId: "git" }));
+        expect(container.textContent).toBe("");
+    });
+
+    it("renders the resolved command as a consent step before installing anything", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "brew",
+            args: ["install", "git"],
+            needsElevation: false,
+            commandPreview: "brew install git",
+        });
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => <SystemToolInstallInline toolId="git" onInstalled={() => {}} />);
+        await screen.findByText("brew install git");
+        // No install call fired just from resolving/rendering the preview.
+        expect(installMock).not.toHaveBeenCalled();
+    });
+
+    it("shows the elevation note only when the resolved step needs it", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "pkexec",
+            args: ["apt-get", "install", "-y", "git"],
+            needsElevation: true,
+            commandPreview: "pkexec apt-get install -y git",
+        });
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => <SystemToolInstallInline toolId="git" onInstalled={() => {}} />);
+        await screen.findByText(/system permission prompt/);
+    });
+
+    it("streams install_chunk lines and calls onInstalled on a successful done event", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "brew",
+            args: ["install", "git"],
+            needsElevation: false,
+            commandPreview: "brew install git",
+        });
+        installMock.mockResolvedValue({ sessionId: "sysinstall-1" });
+        const onInstalled = vi.fn();
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => <SystemToolInstallInline toolId="git" onInstalled={onInstalled} />);
+        await screen.findByText("brew install git");
+
+        fireEvent.click(screen.getByText("Install"));
+        await waitFor(() => expect(installMock).toHaveBeenCalledWith({}, { toolId: "git" }));
+        await waitFor(() => expect(chunkHandler).not.toBeNull());
+
+        chunkHandler!({ data: { line: "==> Installing git", stream: "stdout" } });
+        await screen.findByText("==> Installing git");
+
+        chunkHandler!({ data: { op: "done", ok: true } });
+        await screen.findByText("Installed");
+        expect(onInstalled).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows the error + a Retry button on a failed done event, without calling onInstalled", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "brew",
+            args: ["install", "git"],
+            needsElevation: false,
+            commandPreview: "brew install git",
+        });
+        installMock.mockResolvedValue({ sessionId: "sysinstall-2" });
+        const onInstalled = vi.fn();
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => <SystemToolInstallInline toolId="git" onInstalled={onInstalled} />);
+        await screen.findByText("brew install git");
+
+        fireEvent.click(screen.getByText("Install"));
+        await waitFor(() => expect(chunkHandler).not.toBeNull());
+
+        chunkHandler!({ data: { op: "done", ok: false, error: "brew: command failed" } });
+        await screen.findByText("Failed");
+        await screen.findByText("brew: command failed");
+        await screen.findByText("Retry");
+        expect(onInstalled).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/toolchain/SystemToolInstallInline.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.tsx
@@ -36,6 +36,13 @@ interface SystemToolInstallInlineProps {
     /** Fires once, on a successful install — the caller re-probes its
      *  own row/prereq state (this component doesn't know how). */
     onInstalled: () => void;
+    /** Fires once, when resolution completes as unavailable (no package
+     *  manager detected/usable on this machine) — callers use this to
+     *  collapse/hide whatever toggle exposed this panel so a user who
+     *  clicked "install now" doesn't end up staring at a permanently
+     *  blank expanded area with no visible fallback. reagent P2,
+     *  PR #2790. */
+    onUnavailable?: () => void;
 }
 
 export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JSX.Element => {
@@ -63,6 +70,7 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
             if (disposed) return;
             if (!r.available) {
                 setPhase("unavailable");
+                props.onUnavailable?.();
                 return;
             }
             setCommandPreview(r.commandPreview);
@@ -72,7 +80,10 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
             // Treat a failed probe the same as "unavailable" — the
             // caller's link+copy-command fallback is always a safe
             // landing spot, never a dead end.
-            if (!disposed) setPhase("unavailable");
+            if (!disposed) {
+                setPhase("unavailable");
+                props.onUnavailable?.();
+            }
         }
     });
 

--- a/frontend/app/view/toolchain/SystemToolInstallInline.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.tsx
@@ -1,0 +1,168 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SystemToolInstallInline — one-click install of a system tool (git,
+ * node/npm, python) through the platform's own package manager, shown
+ * inline below wherever a tool's "not found" row already renders (the
+ * Toolchain modal's core-tools list, `AgentPrereqModal`'s missing-prereq
+ * list). Not a nested modal — an expand-in-place panel, matching how
+ * this app already renders streamed tool output inline elsewhere.
+ *
+ * State machine: `checking` → (`unavailable` — renders nothing, caller
+ * keeps its existing link+copy-command fallback) | `idle` (shows the
+ * resolved command + an explicit consent step) → `installing` (streamed
+ * log, no cancel button — see below) → `done` | `failed`.
+ *
+ * Renders `null` whenever `toolchain.resolve_install_command` reports
+ * unavailable (no package manager detected/usable) — the caller's own
+ * existing fallback UI (install URL + copyable command) is what shows in
+ * that case; this component never tries to replace or hide that.
+ *
+ * SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md §3.3-§3.4.
+ */
+
+import { createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
+import "./SystemToolInstallInline.scss";
+
+type Phase = "checking" | "unavailable" | "idle" | "installing" | "done" | "failed";
+
+interface SystemToolInstallInlineProps {
+    toolId: string;
+    /** Fires once, on a successful install — the caller re-probes its
+     *  own row/prereq state (this component doesn't know how). */
+    onInstalled: () => void;
+}
+
+export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JSX.Element => {
+    const [phase, setPhase] = createSignal<Phase>("checking");
+    const [commandPreview, setCommandPreview] = createSignal("");
+    const [needsElevation, setNeedsElevation] = createSignal(false);
+    const [lines, setLines] = createSignal<Array<{ line: string; stream: "stdout" | "stderr" }>>([]);
+    const [error, setError] = createSignal<string | null>(null);
+
+    let unsub: (() => void) | null = null;
+    // Deliberately NOT auto-cancelled on unmount, unlike
+    // AgentInstallModalPanel's npm-into-an-isolated-dir install: once a
+    // system package-manager transaction has actually started (dpkg/MSI/
+    // brew mid-write), killing it because the user navigated away from
+    // this panel is the same "leave it in a broken half-installed state"
+    // risk this component's own UI already avoids by never offering a
+    // cancel button past this point (SPEC §3.4). It runs to completion in
+    // the background; the session cleans itself up server-side when the
+    // child exits, listener or not.
+    let disposed = false;
+
+    onMount(async () => {
+        try {
+            const r = await RpcApi.ToolchainResolveInstallCommandCommand(TabRpcClient, { toolId: props.toolId });
+            if (disposed) return;
+            if (!r.available) {
+                setPhase("unavailable");
+                return;
+            }
+            setCommandPreview(r.commandPreview);
+            setNeedsElevation(r.needsElevation);
+            setPhase("idle");
+        } catch {
+            // Treat a failed probe the same as "unavailable" — the
+            // caller's link+copy-command fallback is always a safe
+            // landing spot, never a dead end.
+            if (!disposed) setPhase("unavailable");
+        }
+    });
+
+    onCleanup(() => {
+        disposed = true;
+        if (unsub) {
+            unsub();
+            unsub = null;
+        }
+    });
+
+    const startInstall = async () => {
+        setPhase("installing");
+        setError(null);
+        setLines([]);
+        try {
+            const r = await RpcApi.ToolchainInstallSystemToolCommand(TabRpcClient, { toolId: props.toolId });
+            if (disposed) return;
+            unsub = waveEventSubscribe({
+                eventType: "install_chunk",
+                scope: `install:${r.sessionId}`,
+                handler: (event: any) => {
+                    const data = event?.data;
+                    if (!data || typeof data !== "object") return;
+                    if (typeof data.line === "string") {
+                        setLines((prev) => [...prev, { line: data.line, stream: data.stream === "stderr" ? "stderr" : "stdout" }]);
+                    } else if (data.op === "done") {
+                        if (data.ok) {
+                            setPhase("done");
+                            props.onInstalled();
+                        } else {
+                            setError(data.error ?? "install failed");
+                            setPhase("failed");
+                        }
+                    }
+                },
+            });
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setPhase("failed");
+        }
+    };
+
+    return (
+        <Show when={phase() !== "checking" && phase() !== "unavailable"}>
+            <div class="system-tool-install-inline">
+                <Show when={phase() === "idle"}>
+                    <div class="system-tool-install-consent">
+                        <p class="system-tool-install-consent-text">
+                            This will run:
+                        </p>
+                        <code class="system-tool-install-command">{commandPreview()}</code>
+                        <Show when={needsElevation()}>
+                            <p class="system-tool-install-elevation-note">
+                                <i class="fa-solid fa-shield-halved" aria-hidden="true" />{" "}
+                                This will ask for your password or show a system permission prompt.
+                            </p>
+                        </Show>
+                        <Button onClick={() => void startInstall()} className="green solid">
+                            Install
+                        </Button>
+                    </div>
+                </Show>
+                <Show when={phase() === "installing" || phase() === "done" || phase() === "failed"}>
+                    <div class="system-tool-install-log" classList={{ "is-done": phase() === "done", "is-failed": phase() === "failed" }}>
+                        <div class="system-tool-install-log-header">
+                            <Show when={phase() === "installing"}>
+                                <span class="system-tool-install-spinner" aria-hidden="true">⏳</span> Installing…
+                            </Show>
+                            <Show when={phase() === "done"}>
+                                <span class="system-tool-install-ok" aria-hidden="true">✓</span> Installed
+                            </Show>
+                            <Show when={phase() === "failed"}>
+                                <span class="system-tool-install-fail" aria-hidden="true">✗</span> Failed
+                            </Show>
+                        </div>
+                        <pre class="system-tool-install-log-body">
+                            {lines().map((l) => l.line).join("\n")}
+                        </pre>
+                        <Show when={error()}>
+                            <div class="system-tool-install-error">{String(error())}</div>
+                        </Show>
+                        <Show when={phase() === "failed"}>
+                            <Button onClick={() => void startInstall()}>Retry</Button>
+                        </Show>
+                    </div>
+                </Show>
+            </div>
+        </Show>
+    );
+};
+
+SystemToolInstallInline.displayName = "SystemToolInstallInline";

--- a/frontend/app/view/toolchain/SystemToolInstallInline.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.tsx
@@ -85,6 +85,14 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
     });
 
     const startInstall = async () => {
+        // Tear down any prior run (Retry path) — without this, retrying
+        // after a failure overwrites `unsub` with the new subscription's
+        // teardown, leaking the previous one (it's then never called,
+        // including on eventual component unmount). reagent P2, PR #2790.
+        if (unsub) {
+            unsub();
+            unsub = null;
+        }
         setPhase("installing");
         setError(null);
         setLines([]);

--- a/frontend/app/view/toolchain/toolchain-view.scss
+++ b/frontend/app/view/toolchain/toolchain-view.scss
@@ -257,3 +257,8 @@
         background: var(--panel-bg-alt, rgba(127, 127, 127, 0.12));
     }
 }
+
+.toolchain-link-btn--install-now {
+    display: flex;
+    padding-left: 0;
+}

--- a/frontend/app/view/toolchain/toolchain-view.tsx
+++ b/frontend/app/view/toolchain/toolchain-view.tsx
@@ -270,6 +270,24 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
             return next;
         });
     };
+    // Rows confirmed unavailable (no package manager detected/usable on
+    // this machine) — hides the "or install it now" toggle for that row
+    // once known, so a user who clicked it doesn't end up staring at a
+    // permanently blank expanded area with no visible fallback (the
+    // primary "Install ↗" button/link stays visible regardless either
+    // way — this only hides the SECONDARY one-click toggle). Populated
+    // reactively from SystemToolInstallInline's onUnavailable, so the
+    // very first click can still briefly expand before collapsing —
+    // this repo has no eager per-row pre-check today. reagent P2, PR #2790.
+    const [unavailableInstalls, setUnavailableInstalls] = createSignal<ReadonlySet<string>>(new Set());
+    const markUnavailable = (id: string) => {
+        setExpandedInstalls((prev) => {
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+        });
+        setUnavailableInstalls((prev) => new Set(prev).add(id));
+    };
 
     const renderRow = (row: ToolRow): JSX.Element => (
         <div class="toolchain-row" classList={{ "toolchain-row--missing": !row.loading && !row.found }}>
@@ -314,7 +332,12 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                         </button>
                     </div>
                 </Show>
-                <Show when={!row.loading && !row.found && row.kind === "core" && SYSTEM_INSTALLABLE_IDS.has(row.id)}>
+                <Show
+                    when={
+                        !row.loading && !row.found && row.kind === "core" &&
+                        SYSTEM_INSTALLABLE_IDS.has(row.id) && !unavailableInstalls().has(row.id)
+                    }
+                >
                     <button
                         type="button"
                         class="toolchain-link-btn toolchain-link-btn--install-now"
@@ -330,6 +353,7 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                                 const idx = rows.findIndex((r) => r.id === row.id);
                                 if (idx !== -1) void probe(idx, { force: true });
                             }}
+                            onUnavailable={() => markUnavailable(row.id)}
                         />
                     </Show>
                 </Show>

--- a/frontend/app/view/toolchain/toolchain-view.tsx
+++ b/frontend/app/view/toolchain/toolchain-view.tsx
@@ -12,6 +12,7 @@ import { EXTERNAL_WIDGETS, widgetCliCommandForPlatform } from "@/app/view/agent/
 import { getProviderList } from "@/app/view/agent/providers";
 import { ensureCapability, getCapability, isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
+import { SystemToolInstallInline } from "./SystemToolInstallInline";
 import type { ToolchainViewModel } from "./toolchain-model";
 import "./toolchain-view.scss";
 
@@ -248,6 +249,27 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
     // blocked under CEF's Permissions-Policy. See SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
     const copy = (cmd?: string) => { if (cmd) void clipboardWriteText(cmd).catch(() => {}); };
 
+    // Tool ids the backend's system-install catalog actually covers
+    // (system_install_handlers.rs) — everything else (today: docker,
+    // provider CLIs) keeps the existing open-URL-only "Install ↗"
+    // behavior unchanged. See docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md.
+    const SYSTEM_INSTALLABLE_IDS = new Set(["git", "node", "npm", "python"]);
+    const [expandedInstalls, setExpandedInstalls] = createSignal<ReadonlySet<string>>(new Set());
+    const toggleInstallPanel = (id: string) => {
+        setExpandedInstalls((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id); else next.add(id);
+            return next;
+        });
+    };
+    const handleInstallClick = (row: ToolRow) => {
+        if (row.kind === "core" && SYSTEM_INSTALLABLE_IDS.has(row.id)) {
+            toggleInstallPanel(row.id);
+        } else {
+            open(row.installUrl);
+        }
+    };
+
     const renderRow = (row: ToolRow): JSX.Element => (
         <div class="toolchain-row" classList={{ "toolchain-row--missing": !row.loading && !row.found }}>
             <i class={`toolchain-row-icon fa-solid fa-${row.icon}`} aria-hidden="true" />
@@ -291,11 +313,23 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                         </button>
                     </div>
                 </Show>
+                <Show when={expandedInstalls().has(row.id)}>
+                    <SystemToolInstallInline
+                        toolId={row.id}
+                        onInstalled={() => {
+                            toggleInstallPanel(row.id);
+                            const idx = rows.findIndex((r) => r.id === row.id);
+                            if (idx !== -1) void probe(idx, { force: true });
+                        }}
+                    />
+                </Show>
             </div>
             <div class="toolchain-row-actions">
                 <Show when={!row.loading && !row.found && row.installUrl}>
-                    <button class="toolchain-btn" onClick={() => open(row.installUrl)}>
-                        Install <i class="fa-solid fa-arrow-up-right-from-square" />
+                    <button class="toolchain-btn" onClick={() => handleInstallClick(row)}>
+                        {row.kind === "core" && SYSTEM_INSTALLABLE_IDS.has(row.id)
+                            ? "Install"
+                            : <>Install <i class="fa-solid fa-arrow-up-right-from-square" /></>}
                     </button>
                 </Show>
                 <Show when={row.docsUrl}>

--- a/frontend/app/view/toolchain/toolchain-view.tsx
+++ b/frontend/app/view/toolchain/toolchain-view.tsx
@@ -249,10 +249,18 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
     // blocked under CEF's Permissions-Policy. See SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
     const copy = (cmd?: string) => { if (cmd) void clipboardWriteText(cmd).catch(() => {}); };
 
-    // Tool ids the backend's system-install catalog actually covers
-    // (system_install_handlers.rs) — everything else (today: docker,
-    // provider CLIs) keeps the existing open-URL-only "Install ↗"
-    // behavior unchanged. See docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md.
+    // Tool ids the backend's system-install catalog COULD cover
+    // (system_install_handlers.rs) — this only ever ADDS a one-click
+    // option alongside the existing "Install ↗" link/copy-command UI,
+    // never replaces it. Even for these ids, the backend may still
+    // resolve `available: false` on this specific machine (macOS without
+    // brew, Linux without a recognized package manager) — in that case
+    // `SystemToolInstallInline` renders nothing and the existing
+    // installUrl button is the ONLY visible action, exactly as before
+    // this feature existed. Codex P2, PR #2790 (an earlier version of
+    // this file made the Install ↗ button itself conditionally stop
+    // opening the URL for these ids, which was a dead end whenever the
+    // backend couldn't resolve a command).
     const SYSTEM_INSTALLABLE_IDS = new Set(["git", "node", "npm", "python"]);
     const [expandedInstalls, setExpandedInstalls] = createSignal<ReadonlySet<string>>(new Set());
     const toggleInstallPanel = (id: string) => {
@@ -261,13 +269,6 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
             if (next.has(id)) next.delete(id); else next.add(id);
             return next;
         });
-    };
-    const handleInstallClick = (row: ToolRow) => {
-        if (row.kind === "core" && SYSTEM_INSTALLABLE_IDS.has(row.id)) {
-            toggleInstallPanel(row.id);
-        } else {
-            open(row.installUrl);
-        }
     };
 
     const renderRow = (row: ToolRow): JSX.Element => (
@@ -313,23 +314,30 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                         </button>
                     </div>
                 </Show>
-                <Show when={expandedInstalls().has(row.id)}>
-                    <SystemToolInstallInline
-                        toolId={row.id}
-                        onInstalled={() => {
-                            toggleInstallPanel(row.id);
-                            const idx = rows.findIndex((r) => r.id === row.id);
-                            if (idx !== -1) void probe(idx, { force: true });
-                        }}
-                    />
+                <Show when={!row.loading && !row.found && row.kind === "core" && SYSTEM_INSTALLABLE_IDS.has(row.id)}>
+                    <button
+                        type="button"
+                        class="toolchain-link-btn toolchain-link-btn--install-now"
+                        onClick={() => toggleInstallPanel(row.id)}
+                    >
+                        or install it now
+                    </button>
+                    <Show when={expandedInstalls().has(row.id)}>
+                        <SystemToolInstallInline
+                            toolId={row.id}
+                            onInstalled={() => {
+                                toggleInstallPanel(row.id);
+                                const idx = rows.findIndex((r) => r.id === row.id);
+                                if (idx !== -1) void probe(idx, { force: true });
+                            }}
+                        />
+                    </Show>
                 </Show>
             </div>
             <div class="toolchain-row-actions">
                 <Show when={!row.loading && !row.found && row.installUrl}>
-                    <button class="toolchain-btn" onClick={() => handleInstallClick(row)}>
-                        {row.kind === "core" && SYSTEM_INSTALLABLE_IDS.has(row.id)
-                            ? "Install"
-                            : <>Install <i class="fa-solid fa-arrow-up-right-from-square" /></>}
+                    <button class="toolchain-btn" onClick={() => open(row.installUrl)}>
+                        Install <i class="fa-solid fa-arrow-up-right-from-square" />
                     </button>
                 </Show>
                 <Show when={row.docsUrl}>


### PR DESCRIPTION
## Summary

Implements `docs/specs/SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md` (Phases 1+2). Users hitting the "git/npm not found" blocker now get a real **Install** action instead of just a download link, in both places that already knew about the problem but never acted on it:

- **`AgentPrereqModal`** — the pre-launch blocker.
- **Toolchain modal** — this was already scaffolded (`brewFormula` sitting unused in the catalog since `SPEC_TOOLCHAIN_MANAGER_2026-06-15.md`'s deferred "P3") and is now wired for real, generalized beyond brew-only to winget and Linux's own package managers.

**Backend — the security-critical part.** New `system_install_handlers.rs`: every command comes from a fixed, backend-owned catalog keyed only by a `tool_id` (`git`/`node`/`npm`/`python`) — the RPC boundary never accepts a raw command or package name from the frontend, and every catalog entry is a `Vec<String>` argv passed straight to `Command::new(program).args(args)`, never a shell string. Windows uses `winget` (own UAC prompt per package); macOS uses `brew` only when already present (never bootstraps Homebrew); Linux detects the system package manager (`apt-get`/`dnf`/`yum`/`pacman`/`zypper`/`apk`) and elevates via `pkexec`, which raises the desktop's native polkit dialog — this app never renders a password field itself. Reuses the exact `install_chunk` streaming shape and `InstallSessionRegistry` the existing `install.start` npm-install flow already uses — `install.cancel` works unchanged for these sessions too.

**Frontend.** `SystemToolInstallInline.tsx` — a shared inline consent+streaming panel: shows the exact resolved command before anything runs, explains when it needs elevation, streams output, and (deliberately) never offers a cancel button once the privileged command has actually started — interrupting a package-manager transaction mid-write can leave broken system state. Renders nothing when unavailable, so callers' existing link+copy-command fallback stays intact.

**Explicitly not included** (flagged in the spec, not silently decided): bootstrapping a package manager that's itself missing (installing Homebrew from scratch, guiding a pre-App-Installer Windows), the Node/Debian-Ubuntu NodeSource-vs-bare-package data decision (Debian/Ubuntu's default `nodejs` package is well-known to be stale — noted, not fixed here), and `uv`/Docker (script-based / interactive-GUI installers, a different risk profile than a package-manager install).

**One open item, stated plainly:** whether a UAC prompt raised by `winget` reliably attaches when spawned from this app's non-console GUI-launched process is **not yet verified on real Windows hardware** — the command construction is implemented and unit-tested, but this is a real-environment question no amount of unit testing answers. Flagged in the spec's status line.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` (isolated `AGENTMUX_DATA_DIR`/`CONFIG_DIR`/`SHARED_DIR`/`INSTANCE_DIR`) — 2774 passed, 0 failed (6 new: catalog resolution per platform/manager, argv correctness per Linux package manager's genuinely different flag syntax, and a defense-in-depth check that no catalog entry ever routes through a shell interpreter).
- [x] `npx tsc --noEmit -p .` — clean.
- [x] `npx vitest run` — 3092 passed, 0 failed (5 new: unavailable/consent/elevation-note/success/failure states).
- [ ] Manual, per real OS/distro — not done as part of this PR (no live multi-OS test environment available): Windows winget + UAC origin question above, macOS brew (confirm no sudo prompt), 2-3 real Linux distros (confirm correct package manager detected, not a blanket apt), and a machine with no polkit agent (confirm graceful fallback).

<!-- agentmux:agent_id=agent2 -->