### PR TITLE
Manoz@Area54: Move the responsive tab bar to the top (Armory, Warden, Settings); highlight ABF

### DIFF
--- a/.changesets/1787627944-fix-armory-warden-settings-move-the-narrow-width-responsive--f82m.md
+++ b/.changesets/1787627944-fix-armory-warden-settings-move-the-narrow-width-responsive--f82m.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory,warden,settings): move the narrow-width responsive tab bar to the top of the pane; highlight ABF

--- a/docs/specs/SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md
+++ b/docs/specs/SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md
@@ -1,0 +1,126 @@
+# SPEC: Move the narrow-width responsive tab bar to the top (from the bottom)
+
+**Date:** 2026-08-24
+**Status:** proposed
+**Scope:** Armory, Warden, Settings — every pane with the rail↔bottom-tab-bar
+responsive pattern.
+
+---
+
+## 0. Ask
+
+> do a quick usability tweak. move the thinnest responsive menu to the top
+> (from the bottom) it may apply to other panes too
+
+---
+
+## 1. Current behavior (audited against source, 2026-08-24)
+
+Three panes share the same responsive pattern: a full left-hand rail nav at
+normal widths, collapsing at a narrow container-query breakpoint into a
+horizontal tab bar rendered as the **last** child of the pane (below the
+content), positioned purely by DOM order in a `flex-direction: column`
+container — no `order`/`position`/`bottom` CSS anywhere.
+
+| Pane | JSX (root component) | Tab-bar CSS rule | Breakpoint (`@container ... max-width`) |
+|---|---|---|---|
+| Armory | `frontend/app/view/armory/armory-view.tsx:118` — `<nav class="bundle-manager-tab-bar">`, last child of `.armory-view` | `frontend/app/view/armory/armory-view.scss:91-98` (`.bundle-manager-tab-bar`, `border-top: 1px solid var(--border-color)`) | `armory-view.scss:161-170`, `≤479px` |
+| Warden | `frontend/app/view/warden/warden-view.tsx:105` — same class name, own `<nav>`, last child of `.warden-view` | **Reuses Armory's `.bundle-manager-tab-bar` rule by convention** (no local border rule — `warden-view.scss`'s own file-header comment explains this is deliberate, not an oversight) | `warden-view.scss:79-96`, `≤479px` (own `@container warden` block, breakpoint values duplicated, class rules aren't) |
+| Settings | `frontend/app/view/settings/settings-view.tsx:110` — `<nav class="settings-tab-bar">`, last child of `.settings-view` | `frontend/app/view/settings/settings.scss:425-432` (`.settings-tab-bar`, `border-top: 1px solid var(--border-color)`) — fully independent class, own rule | `settings.scss:~560-566`, own breakpoint |
+
+No shared `<TabBar>` component — three independently-authored `<nav>` blocks
+(Warden's JSX is its own, only its *CSS class* is shared with Armory's).
+Moving position requires touching each pane's JSX individually; the CSS
+`border-top`→`border-bottom` flip only needs to happen twice (Armory's rule
+covers Warden too via the shared class).
+
+---
+
+## 2. Design
+
+**Move each `<nav class="...-tab-bar">` to be the FIRST child of its pane
+root** (before the rail and before the content), for all three panes.
+Positioning stays pure DOM order — no `order`/`position:sticky` needed, same
+mechanism as today, just reordered. The rail (`.bundle-manager-rail` /
+`.settings-rail`) itself is unaffected — it's `display: none` at the same
+breakpoint the tab bar becomes visible, so their relative order in the DOM
+never matters visually; only the tab-bar-vs-content order does.
+
+Each affected `.../-tab-bar` CSS rule's `border-top` becomes `border-bottom`
+— separating the bar from the content now rendered *below* it, matching the
+same visual "hairline between nav and content" intent, just on the other
+edge. Since Armory's rule covers Warden too, this is one CSS edit for both,
+plus one for Settings.
+
+No breakpoint values, no `display`/`flex` properties, no button markup
+inside each `<nav>` change — purely a reorder + one border-side flip per
+pane.
+
+### 2.1 Test updates
+
+`armory-view.test.tsx:173` and `warden-view.test.tsx:162` both have tests
+titled `"clicking a bottom tab-bar item writes ..."` — the assertions
+themselves (query by `aria-label` + `nav.bundle-manager-tab-bar` selector,
+click, assert the RPC call) are unaffected by DOM order, but the test names
+go stale ("bottom" no longer accurate). Rename to `"clicking a tab-bar
+item..."` — no behavioral test changes needed, this is a pure position
+move with identical click/RPC behavior.
+
+### 2.2 Active-tab indicator flips with the bar
+
+The tab-bar's active-item indicator (`&.is-active { border-top: 2px solid
+var(--accent-color); }` in `armory-view.scss`/`settings.scss`) was designed
+for a bottom-positioned bar — the top border visually "attaches" the active
+tab to the content rendered above it. Now that the bar renders at the top,
+that indicator flips to `border-bottom` too, so it still attaches to the
+content it's showing (now rendered below), not the far edge away from it.
+Settings' tab bar has no equivalent per-item active-border rule (its
+`.is-active` only recolors the icon), so nothing to flip there.
+
+### 2.3 ABF gets a standing accent highlight (both responsive forms)
+
+Follow-up ask in the same conversation: give the Armory rail's "ABF"
+entry (`RAIL`'s `id: "bundles"` in `armory-view.tsx:29`, tooltip "Armory
+Bundle Format (ABF)") a highlighted color, in both `.bundle-manager-rail`
+(full width) and `.bundle-manager-tab-bar` (narrow) — i.e. regardless of
+which responsive form is currently showing.
+
+New class `is-abf-highlight`, applied only to the `id === "bundles"` button
+in both `<For>` loops (`armory-view.tsx`). CSS in `armory-view.scss`, on
+both `.bundle-manager-rail-item` and `.bundle-manager-tab-bar button`:
+`&.is-abf-highlight:not(.is-active) { i { color: var(--accent-color); } }`
+— tints just the icon when NOT the active section (so it stands out at
+rest), and steps aside when active (the existing `.is-active` rule already
+provides full-button contrast via `background`/`color`, so stacking a
+second accent treatment on top would be redundant, not additive). Warden
+and Settings are unaffected — this is Armory-specific, not part of the
+shared tab-bar pattern.
+
+---
+
+## 3. Out of scope
+
+- No new panes get this responsive pattern added — purely repositioning the
+  three that already have it.
+- No shared `<TabBar>` component extraction — a real, separate cleanup
+  opportunity (three copy-pasted implementations), not requested here and
+  not needed to satisfy this ask.
+- No breakpoint value changes — narrow-width thresholds stay exactly as they
+  are today.
+
+---
+
+## 4. Test plan
+
+- [ ] Armory: `<nav class="bundle-manager-tab-bar">` renders before
+      `.bundle-manager-section` in the DOM; existing click/RPC test passes
+      unmodified (renamed, not rewritten).
+- [ ] Warden: same, `<nav>` before `.bundle-manager-section`.
+- [ ] Settings: `<nav class="settings-tab-bar">` renders before
+      `.settings-body`.
+- [ ] Manual (`task dev`, narrow the Armory/Warden/Settings pane below
+      479px): confirm the tab bar visually appears at the top with a
+      bottom-edge hairline, rail is still hidden, content still scrolls
+      correctly below it.
+- [ ] ABF's rail button and tab-bar button both carry `is-abf-highlight`;
+      no other `RAIL` entry does.

--- a/frontend/app/view/armory/armory-view.scss
+++ b/frontend/app/view/armory/armory-view.scss
@@ -95,7 +95,7 @@
     }
 }
 
-// ── Bottom tab bar (xs only) ─────────────────────────────────────────────────
+// ── Tab bar, top of pane (xs only) ────────────────────────────────────────────
 
 .bundle-manager-tab-bar {
     display: none;
@@ -170,7 +170,7 @@
     }
 }
 
-// xs: hide rail, show bottom tab bar, switch to column layout
+// xs: hide rail, show the top tab bar, switch to column layout
 @container armory (max-width: 479px) {
     .armory-view {
         flex-direction: column;

--- a/frontend/app/view/armory/armory-view.scss
+++ b/frontend/app/view/armory/armory-view.scss
@@ -68,6 +68,15 @@
             opacity: 1;
         }
     }
+
+    // ABF gets a standing accent highlight regardless of selection state —
+    // see SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md §5.
+    &.is-abf-highlight:not(.is-active) {
+        i {
+            color: var(--accent-color);
+            opacity: 1;
+        }
+    }
 }
 
 .bundle-manager-section {
@@ -92,7 +101,9 @@
     display: none;
     flex-direction: row;
     align-items: stretch;
-    border-top: 1px solid var(--border-color);
+    // Rendered at the TOP of the pane (see SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md)
+    // — the hairline separates it from the content rendered below, not above.
+    border-bottom: 1px solid var(--border-color);
     background: var(--panel-bg-color, var(--main-bg-color));
     flex-shrink: 0;
     overflow-x: auto;
@@ -120,12 +131,22 @@
         &.is-active {
             opacity: 1;
             color: var(--accent-color);
-            border-top: 2px solid var(--accent-color);
+            // Bottom edge, not top — the bar sits at the TOP of the pane now
+            // (SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md), so the
+            // active-tab indicator should touch the content it's showing,
+            // rendered below, not the far edge away from it.
+            border-bottom: 2px solid var(--accent-color);
         }
 
         &:hover:not(.is-active) {
             opacity: 0.85;
             background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+        }
+
+        // ABF gets a standing accent highlight regardless of selection state —
+        // see SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md §5.
+        &.is-abf-highlight:not(.is-active) {
+            i { color: var(--accent-color); }
         }
     }
 }

--- a/frontend/app/view/armory/armory-view.test.tsx
+++ b/frontend/app/view/armory/armory-view.test.tsx
@@ -170,7 +170,7 @@ describe("ArmoryView pane title", () => {
         expect(skillsPane?.classList.contains("is-hidden")).toBe(false);
     });
 
-    it("clicking a bottom tab-bar item writes armory:section via SetMetaCommand and updates viewName()", () => {
+    it("clicking a tab-bar item writes armory:section via SetMetaCommand and updates viewName()", () => {
         const { model } = renderArmory();
         const tabBar = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-tab-bar" });
         const mcpButton = Array.from(tabBar.querySelectorAll("button")).find(
@@ -182,6 +182,25 @@ describe("ArmoryView pane title", () => {
             { oref: "block:test-block", meta: { "armory:section": "mcp" } },
         );
         expect(model.viewName()).toBe("MCP Servers");
+    });
+
+    // SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md
+    it("renders the tab-bar before the content section, so it sits at the top of the pane", () => {
+        renderArmory();
+        const tabBar = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-tab-bar" });
+        const section = document.querySelector(".bundle-manager-section");
+        expect(tabBar.compareDocumentPosition(section as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("highlights only the ABF entry in both the rail and the tab-bar", () => {
+        renderArmory();
+        const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
+        const tabBar = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-tab-bar" });
+        for (const nav of [rail, tabBar]) {
+            const highlighted = Array.from(nav.querySelectorAll("button.is-abf-highlight"));
+            expect(highlighted).toHaveLength(1);
+            expect(highlighted[0].textContent).toContain("ABF");
+        }
     });
 
     it("viewName() reflects a pre-seeded armory:section meta value", () => {

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -73,6 +73,28 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
         // A container element cannot respond to its own container query.
         <div class="armory-container">
             <div class="armory-view" ref={viewRef} style={{ zoom: model.zoomAtom() }}>
+                {/* Narrow-width fallback for .bundle-manager-rail below — rendered
+                    FIRST (not last) so it sits at the top of the pane, not the
+                    bottom, at the same breakpoint the rail hides. See
+                    docs/specs/SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md. */}
+                <nav class="bundle-manager-tab-bar" aria-label="Armory section">
+                    <For each={RAIL}>
+                        {(item) => (
+                            <button
+                                type="button"
+                                classList={{
+                                    "is-active": section() === item.id,
+                                    "is-abf-highlight": item.id === "bundles",
+                                }}
+                                aria-pressed={section() === item.id}
+                                onClick={() => setSection(item.id)}
+                            >
+                                <i class={`fa-sharp fa-solid fa-${item.icon}`} aria-hidden="true" />
+                                <span>{item.label}</span>
+                            </button>
+                        )}
+                    </For>
+                </nav>
                 <nav class="bundle-manager-rail" aria-label="Armory section">
                     <For each={RAIL}>
                         {(item) => (
@@ -80,7 +102,10 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                                 <button
                                     type="button"
                                     class="bundle-manager-rail-item"
-                                    classList={{ "is-active": section() === item.id }}
+                                    classList={{
+                                        "is-active": section() === item.id,
+                                        "is-abf-highlight": item.id === "bundles",
+                                    }}
                                     aria-pressed={section() === item.id}
                                     onClick={() => setSection(item.id)}
                                 >
@@ -115,21 +140,6 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                         <NativeMemoryManager />
                     </div>
                 </div>
-                <nav class="bundle-manager-tab-bar" aria-label="Armory section">
-                    <For each={RAIL}>
-                        {(item) => (
-                            <button
-                                type="button"
-                                classList={{ "is-active": section() === item.id }}
-                                aria-pressed={section() === item.id}
-                                onClick={() => setSection(item.id)}
-                            >
-                                <i class={`fa-sharp fa-solid fa-${item.icon}`} aria-hidden="true" />
-                                <span>{item.label}</span>
-                            </button>
-                        )}
-                    </For>
-                </nav>
             </div>
         </div>
     );

--- a/frontend/app/view/settings/settings-view.test.tsx
+++ b/frontend/app/view/settings/settings-view.test.tsx
@@ -69,6 +69,14 @@ describe("SettingsView rail", () => {
         expect(screen.queryByTestId("terminal-section")).not.toBeInTheDocument();
     });
 
+    // SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md
+    it("renders the tab-bar before the content body, so it sits at the top of the pane", () => {
+        renderSettings();
+        const tabBar = screen.getByLabelText("Settings section", { selector: "nav.settings-tab-bar" });
+        const body = document.querySelector(".settings-body");
+        expect(tabBar.compareDocumentPosition(body as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
     it("clicking a rail item switches the visible section", () => {
         const { model } = renderSettings();
         const rail = screen.getByLabelText("Settings section", { selector: "nav.settings-rail" });

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -69,6 +69,25 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
     return (
         <div class="settings-view-container">
         <div class="settings-view">
+            {/* Narrow-width fallback for .settings-rail below — rendered FIRST
+                (not last) so it sits at the top of the pane, not the bottom, at
+                the same breakpoint the rail hides. See
+                docs/specs/SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md. */}
+            <nav class="settings-tab-bar" aria-label="Settings section">
+                <For each={RAIL}>
+                    {(item) => (
+                        <button
+                            type="button"
+                            aria-label={item.label}
+                            classList={{ "is-active": section() === item.id }}
+                            aria-pressed={section() === item.id}
+                            onClick={() => setSection(item.id)}
+                        >
+                            <i class={`fa-solid fa-${item.icon}`} aria-hidden="true" />
+                        </button>
+                    )}
+                </For>
+            </nav>
             <nav class="settings-rail" aria-label="Settings section">
                 <For each={RAIL}>
                     {(item) => (
@@ -113,21 +132,6 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
                     </button>
                 </footer>
             </div>
-            <nav class="settings-tab-bar" aria-label="Settings section">
-                <For each={RAIL}>
-                    {(item) => (
-                        <button
-                            type="button"
-                            aria-label={item.label}
-                            classList={{ "is-active": section() === item.id }}
-                            aria-pressed={section() === item.id}
-                            onClick={() => setSection(item.id)}
-                        >
-                            <i class={`fa-solid fa-${item.icon}`} aria-hidden="true" />
-                        </button>
-                    )}
-                </For>
-            </nav>
         </div>
         </div>
     );

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -420,7 +420,7 @@
     }
 }
 
-// ── Bottom tab bar (xs only) ──────────────────────────────────────────────────
+// ── Tab bar, top of pane (xs only) ────────────────────────────────────────────
 
 .settings-tab-bar {
     display: none;
@@ -557,7 +557,7 @@
     }
 }
 
-// xs: bottom tab bar, stacked rows, full-width controls
+// xs: top tab bar, stacked rows, full-width controls
 @container settings (max-width: 479px) {
     .settings-view {
         flex-direction: column;

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -426,7 +426,9 @@
     display: none;
     flex-direction: row;
     align-items: stretch;
-    border-top: 1px solid var(--border-color);
+    // Rendered at the TOP of the pane (see SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md)
+    // — the hairline separates it from the content rendered below, not above.
+    border-bottom: 1px solid var(--border-color);
     background: var(--panel-bg-color, var(--main-bg-color));
     flex-shrink: 0;
     overflow-x: auto;

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -442,7 +442,11 @@
         justify-content: center;
         padding: 8px 2px;
         border: none;
-        border-top: 2px solid transparent;
+        // Bottom edge, not top — the bar sits at the TOP of the pane now
+        // (SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md), so the
+        // active-tab indicator should touch the content it's showing,
+        // rendered below, not the far edge away from it. codex P2, PR #2793.
+        border-bottom: 2px solid transparent;
         background: transparent;
         color: var(--main-text-color);
         cursor: default;
@@ -453,7 +457,7 @@
         &.is-active {
             opacity: 1;
             color: var(--accent-color);
-            border-top-color: var(--accent-color);
+            border-bottom-color: var(--accent-color);
         }
 
         &:hover:not(.is-active) {

--- a/frontend/app/view/warden/warden-view.scss
+++ b/frontend/app/view/warden/warden-view.scss
@@ -75,7 +75,7 @@
     }
 }
 
-// xs: hide rail, show bottom tab bar, switch to column layout
+// xs: hide rail, show the top tab bar, switch to column layout
 @container warden (max-width: 479px) {
     .warden-view {
         flex-direction: column;

--- a/frontend/app/view/warden/warden-view.test.tsx
+++ b/frontend/app/view/warden/warden-view.test.tsx
@@ -159,7 +159,7 @@ describe("WardenView pane title", () => {
         expect(auditPane?.classList.contains("is-hidden")).toBe(false);
     });
 
-    it("clicking a bottom tab-bar item writes warden:section via SetMetaCommand and updates viewName()", () => {
+    it("clicking a tab-bar item writes warden:section via SetMetaCommand and updates viewName()", () => {
         const { model } = renderWarden();
         const tabBar = screen.getByLabelText("Warden section", { selector: "nav.bundle-manager-tab-bar" });
         const supervisorButton = Array.from(tabBar.querySelectorAll("button")).find(
@@ -171,6 +171,14 @@ describe("WardenView pane title", () => {
             { oref: "block:test-block", meta: { "warden:section": "supervisor" } },
         );
         expect(model.viewName()).toBe("Supervisor");
+    });
+
+    // SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md
+    it("renders the tab-bar before the content section, so it sits at the top of the pane", () => {
+        renderWarden();
+        const tabBar = screen.getByLabelText("Warden section", { selector: "nav.bundle-manager-tab-bar" });
+        const section = document.querySelector(".bundle-manager-section");
+        expect(tabBar.compareDocumentPosition(section as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
     it("viewName() reflects a pre-seeded warden:section meta value", () => {

--- a/frontend/app/view/warden/warden-view.tsx
+++ b/frontend/app/view/warden/warden-view.tsx
@@ -62,6 +62,25 @@ export function WardenView(props: ViewComponentProps<WardenViewModel>): JSX.Elem
         // container element cannot respond to its own container query.
         <div class="warden-container">
             <div class="warden-view" ref={viewRef} style={{ zoom: model.zoomAtom() }}>
+                {/* Narrow-width fallback for .bundle-manager-rail below — rendered
+                    FIRST (not last) so it sits at the top of the pane, not the
+                    bottom, at the same breakpoint the rail hides. See
+                    docs/specs/SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md. */}
+                <nav class="bundle-manager-tab-bar" aria-label="Warden section">
+                    <For each={RAIL}>
+                        {(item) => (
+                            <button
+                                type="button"
+                                classList={{ "is-active": section() === item.id }}
+                                aria-pressed={section() === item.id}
+                                onClick={() => setSection(item.id)}
+                            >
+                                <i class={`fa-sharp fa-solid fa-${item.icon}`} aria-hidden="true" />
+                                <span>{item.label}</span>
+                            </button>
+                        )}
+                    </For>
+                </nav>
                 <nav class="bundle-manager-rail" aria-label="Warden section">
                     <For each={RAIL}>
                         {(item) => (
@@ -102,21 +121,6 @@ export function WardenView(props: ViewComponentProps<WardenViewModel>): JSX.Elem
                         <WardenSupervisorManager />
                     </div>
                 </div>
-                <nav class="bundle-manager-tab-bar" aria-label="Warden section">
-                    <For each={RAIL}>
-                        {(item) => (
-                            <button
-                                type="button"
-                                classList={{ "is-active": section() === item.id }}
-                                aria-pressed={section() === item.id}
-                                onClick={() => setSection(item.id)}
-                            >
-                                <i class={`fa-sharp fa-solid fa-${item.icon}`} aria-hidden="true" />
-                                <span>{item.label}</span>
-                            </button>
-                        )}
-                    </For>
-                </nav>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- Moves the narrow-width fallback tab bar (shown when a pane is too narrow for the full rail) from the bottom of the pane to the top, across all three panes that have it: Armory, Warden, Settings. Pure DOM reorder + a border-side flip on the outer hairline and the active-tab indicator — no breakpoint or behavior changes.
- Gives Armory's ABF rail/tab-bar entry a standing accent-color highlight (icon tint), in both the full rail and the narrow tab bar, so it stands out at rest (not just when selected).

See `docs/specs/SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md` for the full audit of all three affected files (no shared `<TabBar>` component exists — each pane's `<nav>` is independently authored, though Warden reuses Armory's CSS class by convention).

## Test plan
- [x] New tests confirming the tab-bar renders before the content section/body in the DOM, for all three panes.
- [x] New test confirming exactly one `is-abf-highlight` button exists in each of Armory's rail and tab-bar, and it's the ABF entry.
- [x] Existing click/RPC tests (renamed from "bottom tab-bar" to "tab-bar" — same assertions, no behavior change).
- [x] Full suite (3115 tests) green, `npx tsc --noEmit` clean.
- [ ] Manual (`task dev`, narrow each pane below ~479px): confirm the tab bar visually sits at the top with a bottom-edge hairline and the active-tab underline touches the content below it.

<!-- agentmux:agent_id=manoz -->