### PR TITLE
Manoz@Area54: Surface ~/.claude/CLAUDE.md (read-only) in Global Memory

### DIFF
--- a/.changesets/1787629229-feat-armory-surface-claude-claude-md-read-only-in-global-mem-ommd.md
+++ b/.changesets/1787629229-feat-armory-surface-claude-claude-md-read-only-in-global-mem-ommd.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): surface ~/.claude/CLAUDE.md (read-only) in Global Memory

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -230,13 +230,14 @@ pub const COMMAND_REORDER_GLOBAL_BRAIN: &str = "reorderglobalbrain";
 /// moment they see an existing `is_system=1` row.
 pub const COMMAND_UPSERT_SYSTEM_MEMORY: &str = "upsertsystemmemory";
 pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
-/// Read-only. Returns `~/.claude/CLAUDE.md` (Claude Code's own global
-/// user-level config file — independent of AgentMux, independent of any
-/// per-project CLAUDE.md) so the Armory Memory tab can show the operator
-/// where their real "highest priority" instructions actually live. No
-/// parameters (the path is fixed, not caller-supplied — no path-traversal
-/// surface) and no write counterpart. See
-/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md.
+/// Read-only. Returns the CLAUDE.md at AgentMux's shared Claude provider
+/// config dir (`DataPaths::provider_auth_dir("claude")` — the
+/// `CLAUDE_CONFIG_DIR` a non-identity-bound spawned Claude agent actually
+/// gets, NOT the ambient `~/.claude/CLAUDE.md`) so the Armory Memory tab
+/// can show the operator where their real "highest priority" instructions
+/// actually live. No parameters (the path is fixed, not caller-supplied —
+/// no path-traversal surface) and no write counterpart. See
+/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5.
 pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
 
 // Agent instances

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -230,6 +230,14 @@ pub const COMMAND_REORDER_GLOBAL_BRAIN: &str = "reorderglobalbrain";
 /// moment they see an existing `is_system=1` row.
 pub const COMMAND_UPSERT_SYSTEM_MEMORY: &str = "upsertsystemmemory";
 pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
+/// Read-only. Returns `~/.claude/CLAUDE.md` (Claude Code's own global
+/// user-level config file — independent of AgentMux, independent of any
+/// per-project CLAUDE.md) so the Armory Memory tab can show the operator
+/// where their real "highest priority" instructions actually live. No
+/// parameters (the path is fixed, not caller-supplied — no path-traversal
+/// surface) and no write counterpart. See
+/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md.
+pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -233,14 +233,15 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
-    // ---- Read-only: the machine-global ~/.claude/CLAUDE.md — see
-    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. No
-    // parameters (fixed path, not caller-supplied), no write counterpart.
+    // ---- Read-only: the CLAUDE.md at AgentMux's shared Claude provider
+    // config dir — see docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+    // §5 (post-review revision). No parameters (fixed path, not
+    // caller-supplied), no write counterpart.
     engine.register_handler(
         COMMAND_GET_CLAUDE_GLOBAL_CONFIG,
         Box::new(move |_data, _ctx| {
             Box::pin(async move {
-                let claude_dir = crate::backend::base::get_home_dir().join(".claude");
+                let claude_dir = resolve_shared_claude_provider_dir();
                 let result = read_claude_global_config(&claude_dir)
                     .map_err(|e| format!("getclaudeglobalconfig: {e}"))?;
                 Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
@@ -249,13 +250,38 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// `~/.claude/CLAUDE.md`'s path + content, read-only. `claude_dir` is
-/// injected (not resolved internally via `get_home_dir()`) so this is
-/// testable against a tempdir without mutating `$HOME`/`%USERPROFILE%`
-/// for the whole test process. `content: None, exists: false` for a
-/// genuinely missing file (the common case on a host where the user never
-/// created one) — real I/O errors (permission denied, etc.) still
-/// propagate as `Err`, not silently folded into "missing."
+/// The directory a spawned Claude agent's `CLAUDE_CONFIG_DIR` env var
+/// points at by DEFAULT (non-identity-bound agents — the common case;
+/// explicit multi-account identity bundles use a separate, per-identity
+/// dir this does not cover). Mirrors `agent_open.rs`'s own `auth_dir`
+/// resolution exactly — `DataPaths::provider_auth_dir("claude")`, with the
+/// identical `~/.agentmux/shared/providers/claude` fallback when
+/// `DataPaths::from_env()` fails — so the path shown here is genuinely the
+/// one AgentMux itself uses when launching a Claude agent, not a guess.
+/// codex P1, PR #2794: the original version read the ambient
+/// `~/.claude/CLAUDE.md`, which `SPEC_PROVIDER_ISOLATION_2026_06_20.md`
+/// §5b confirms is NOT what a `CLAUDE_CONFIG_DIR`-redirected spawned agent
+/// actually loads as its "user CLAUDE.md" — `CLAUDE_CONFIG_DIR` relocates
+/// Claude Code's entire home, `<CLAUDE_CONFIG_DIR>/CLAUDE.md` included.
+fn resolve_shared_claude_provider_dir() -> std::path::PathBuf {
+    agentmux_common::DataPaths::from_env()
+        .map(|p| p.provider_auth_dir("claude"))
+        .unwrap_or_else(|| {
+            crate::backend::base::get_home_dir()
+                .join(".agentmux")
+                .join("shared")
+                .join("providers")
+                .join("claude")
+        })
+}
+
+/// The resolved shared-provider-dir's `CLAUDE.md` path + content,
+/// read-only. `claude_dir` is injected (not resolved internally) so this
+/// is testable against a tempdir. `content: None, exists: false` for a
+/// genuinely missing file (the common case — no AgentMux-spawned Claude
+/// agent on this host has one today, confirmed 2026-08-24) — real I/O
+/// errors (permission denied, etc.) still propagate as `Err`, not
+/// silently folded into "missing."
 #[derive(serde::Serialize)]
 struct ClaudeGlobalConfig {
     path: String,

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -12,6 +12,7 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
     COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY, COMMAND_REORDER_GLOBAL_BRAIN,
     COMMAND_UPSERT_SYSTEM_MEMORY, COMMAND_DELETE_SYSTEM_MEMORY,
+    COMMAND_GET_CLAUDE_GLOBAL_CONFIG,
     CommandGetMemoryData, CommandDeleteMemoryData, CommandReorderGlobalBrainData,
 };
 use crate::backend::storage::store::Memory;
@@ -231,4 +232,83 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+
+    // ---- Read-only: the machine-global ~/.claude/CLAUDE.md — see
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. No
+    // parameters (fixed path, not caller-supplied), no write counterpart.
+    engine.register_handler(
+        COMMAND_GET_CLAUDE_GLOBAL_CONFIG,
+        Box::new(move |_data, _ctx| {
+            Box::pin(async move {
+                let claude_dir = crate::backend::base::get_home_dir().join(".claude");
+                let result = read_claude_global_config(&claude_dir)
+                    .map_err(|e| format!("getclaudeglobalconfig: {e}"))?;
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
+            })
+        }),
+    );
+}
+
+/// `~/.claude/CLAUDE.md`'s path + content, read-only. `claude_dir` is
+/// injected (not resolved internally via `get_home_dir()`) so this is
+/// testable against a tempdir without mutating `$HOME`/`%USERPROFILE%`
+/// for the whole test process. `content: None, exists: false` for a
+/// genuinely missing file (the common case on a host where the user never
+/// created one) — real I/O errors (permission denied, etc.) still
+/// propagate as `Err`, not silently folded into "missing."
+#[derive(serde::Serialize)]
+struct ClaudeGlobalConfig {
+    path: String,
+    content: Option<String>,
+    exists: bool,
+}
+
+fn read_claude_global_config(claude_dir: &std::path::Path) -> std::io::Result<ClaudeGlobalConfig> {
+    let path = claude_dir.join("CLAUDE.md");
+    let (content, exists) = match std::fs::read_to_string(&path) {
+        Ok(c) => (Some(c), true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (None, false),
+        Err(e) => return Err(e),
+    };
+    Ok(ClaudeGlobalConfig { path: path.to_string_lossy().into_owned(), content, exists })
+}
+
+#[cfg(test)]
+mod claude_global_config_tests {
+    use super::*;
+
+    #[test]
+    fn returns_content_and_exists_true_when_the_file_is_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "# My global rules\n").unwrap();
+
+        let result = read_claude_global_config(dir.path()).unwrap();
+        assert!(result.exists);
+        assert_eq!(result.content.as_deref(), Some("# My global rules\n"));
+        assert_eq!(result.path, dir.path().join("CLAUDE.md").to_string_lossy());
+    }
+
+    #[test]
+    fn returns_none_content_and_exists_false_when_the_file_is_missing_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Deliberately no CLAUDE.md written — the common case on a host
+        // where the user never created one.
+
+        let result = read_claude_global_config(dir.path()).unwrap();
+        assert!(!result.exists);
+        assert!(result.content.is_none());
+        // The path is still reported even when nothing exists there yet —
+        // useful information on its own (SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §2.3).
+        assert_eq!(result.path, dir.path().join("CLAUDE.md").to_string_lossy());
+    }
+
+    #[test]
+    fn returns_content_for_an_empty_file_not_treated_as_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("CLAUDE.md"), "").unwrap();
+
+        let result = read_claude_global_config(dir.path()).unwrap();
+        assert!(result.exists);
+        assert_eq!(result.content.as_deref(), Some(""));
+    }
 }

--- a/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+++ b/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
@@ -1,0 +1,193 @@
+# SPEC: Surface `~/.claude/CLAUDE.md` (read-only) in Global Memory
+
+**Date:** 2026-08-24
+**Status:** proposed
+
+---
+
+## 0. Ask
+
+> right ... but do you use the system claude.md even though you run inside
+> of agentmux? / right .. so that needs to appear, the global one, as well
+> as all the others, including their paths.
+
+Followed by a scoping question, answered: show **only** the machine-global
+`~/.claude/CLAUDE.md` file — its real path plus a content preview,
+read-only. (Example per-provider paths and a live per-agent path listing
+were both explicitly declined for this pass.)
+
+---
+
+## 1. Current behavior (audited against source, 2026-08-24)
+
+Confirmed by directly reading this agent's own startup files earlier in the
+same conversation: Claude Code loads `~/.claude/CLAUDE.md` as a global,
+user-level config file, independent of any per-project `CLAUDE.md` and
+independent of AgentMux entirely — it's Claude Code's own convention, not
+something AgentMux writes or manages.
+
+`SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md` §1 describes "a working,
+informally 'highest priority' instructions file" at a *different* path
+(`~/.agentmux/agents/CLAUDE.md`) and states it has "no representation in
+the Armory UI at all." Re-verified in this conversation: that exact path
+**does not exist on this host** — `ls ~/.agentmux/agents/CLAUDE.md` →
+`No such file or directory`. The real file matching that spec's own
+description (hand-maintained, no UI, no audit trail, actually loaded) is
+`~/.claude/CLAUDE.md`. That spec's factual claim about the path was wrong
+for this deployment (stale or imprecise, not re-verified here); this spec
+doesn't attempt to fix that document, just surfaces the file that's
+actually real.
+
+No RPC command reads this file today. No frontend code references its path
+or content anywhere in the Armory UI.
+
+---
+
+## 2. Design
+
+### 2.1 Backend: one new read-only RPC command
+
+```rust
+// rpc_types/commands.rs, alongside the memory-bundle commands
+pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
+```
+
+```rust
+// agent_handlers/memory.rs — registered alongside the other memory commands
+engine.register_handler(
+    COMMAND_GET_CLAUDE_GLOBAL_CONFIG,
+    Box::new(move |_data, _ctx| {
+        Box::pin(async move {
+            let path = crate::backend::base::get_home_dir().join(".claude").join("CLAUDE.md");
+            let (content, exists) = match std::fs::read_to_string(&path) {
+                Ok(c) => (Some(c), true),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => (None, false),
+                Err(e) => return Err(format!("getclaudeglobalconfig: {e}")),
+            };
+            Ok(Some(json!({
+                "path": path.to_string_lossy(),
+                "content": content,
+                "exists": exists,
+            })))
+        })
+    }),
+);
+```
+
+No parameters — the path is fixed, not a caller-supplied argument (no
+path-traversal surface: this reads exactly one hardcoded, well-known
+location, nothing else). Read-only: no write/delete counterpart, matching
+the scoping decision (§0) that this is display-only, not an editing
+surface. A non-`NotFound` I/O error (e.g. permission denied) surfaces as an
+RPC error rather than being silently swallowed — distinct from "file
+doesn't exist," which is a normal, expected state on a host where the user
+never created one.
+
+### 2.2 Frontend: one new RPC wrapper + one new atom
+
+```ts
+// frontend/app/store/rpc-api/memory.ts, alongside ListMemoriesCommand
+GetClaudeGlobalConfigCommand(
+    client: RpcClient,
+    data: Record<string, never> = {},
+    opts?: RpcOpts,
+): Promise<{ path: string; content: string | null; exists: boolean }> {
+    return client.rpcCall("getclaudeglobalconfig", data, opts);
+},
+```
+
+`GlobalBrainViewModel` gains:
+
+```ts
+private _claudeGlobalConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
+claudeGlobalConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> = this._claudeGlobalConfig[0];
+```
+
+Fetched once in the constructor alongside the existing `refresh()` call —
+a static, machine-wide fact, not something that needs re-fetching on every
+`memories:changed` event the way the DB-backed sections do (nothing in
+this app can currently *write* to this file, so there's no event to react
+to; a manual page reload picks up an out-of-band hand-edit, same as any
+other read-once-at-mount display).
+
+### 2.3 UI: a distinct, clearly-labeled, read-only block
+
+Rendered in `global-brain-manager.tsx`, **above** the system tier (it's
+the thing the system tier was conceptually meant to replace/complement —
+seeing it first gives the operator the full picture before the "here's
+where you'd add AgentMux's own policy" section):
+
+```tsx
+<Show when={model.claudeGlobalConfigAtom()}>
+    {(cfg) => (
+        <div class="global-brain-machine-config">
+            <div class="global-brain-machine-config-header">
+                <span class="global-brain-machine-config-badge" title="Hand-maintained on disk, not managed by AgentMux, shared by every agent on this machine">
+                    Machine-wide (Claude Code)
+                </span>
+                <code class="global-brain-machine-config-path">{cfg().path}</code>
+            </div>
+            <Show
+                when={cfg().exists}
+                fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+            >
+                <pre class="global-brain-machine-config-content">{cfg().content}</pre>
+            </Show>
+        </div>
+    )}
+</Show>
+```
+
+Read-only by construction — no textarea, no save button, no edit affordance
+of any kind. The badge tooltip states the "why" (hand-maintained, not
+AgentMux's, shared machine-wide) so a human doesn't wonder why this one
+block behaves differently from every editable section around it.
+
+`exists: false` (no file at that path on this host) renders a plain
+"No file at this path yet" message rather than hiding the block entirely —
+the path itself, and the fact that Claude Code would pick up a file there
+if one existed, is useful information even when empty.
+
+---
+
+## 3. Out of scope
+
+- Editing this file through the UI — §0's scoping decision, read-only only.
+- Migrating/copying this content into the system tier — a separate,
+  explicit action a human would take deliberately (copy-paste from this
+  new preview into "+ Add AgentMux system entry"), not automated here.
+- Any equivalent "global config" file for other providers (Codex, Gemini,
+  etc.) — out of scope, not researched, no evidence such a thing exists
+  for them the way `~/.claude/CLAUDE.md` does for Claude Code.
+- Live-updating the preview if the file changes on disk while the pane is
+  open (no filesystem watcher) — matches this being a read-once-at-mount
+  display, §2.2.
+- Fixing `SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md`'s own incorrect
+  path claim — noted in §1, not corrected in that document by this spec.
+
+---
+
+## 4. Test plan
+
+**Rust:**
+- [ ] `getclaudeglobalconfig` against a `HOME` pointed at a tempdir with a
+      real `.claude/CLAUDE.md` present: returns `{path, content: Some(...),
+      exists: true}` with the exact file content.
+- [ ] Same, but no `.claude/CLAUDE.md` file: `{path, content: None, exists:
+      false}`, not an error.
+- [ ] Returns an error (not a silent empty result) for a genuine I/O error
+      other than not-found (simulate via an unreadable file, if the test
+      harness can construct one cross-platform; otherwise document as
+      manually-verified only).
+
+**Frontend:**
+- [ ] `GlobalBrainViewModel.claudeGlobalConfigAtom()` populates after
+      construction from a mocked `GetClaudeGlobalConfigCommand`.
+- [ ] Component renders the path and content when `exists: true`; renders
+      the "No file at this path yet" fallback when `exists: false`; renders
+      nothing (no block at all) while the atom is still `null`
+      (pre-fetch).
+
+**Manual (`task dev`):**
+- [ ] Confirm the block shows this machine's real `~/.claude/CLAUDE.md`
+      path and content, positioned above the system tier.

--- a/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+++ b/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
@@ -1,7 +1,11 @@
 # SPEC: Surface `~/.claude/CLAUDE.md` (read-only) in Global Memory
 
 **Date:** 2026-08-24
-**Status:** proposed
+**Status:** proposed. **Note:** the file this spec targets in §1-§4 turned
+out to be the wrong one — see §5 for the corrected design (the CLAUDE.md
+at AgentMux's shared Claude provider config dir, not the ambient
+`~/.claude/CLAUDE.md`). Filename kept as-is since it's already referenced
+by the PR/commits; read §5 for what actually shipped.
 
 ---
 
@@ -189,5 +193,57 @@ if one existed, is useful information even when empty.
       (pre-fetch).
 
 **Manual (`task dev`):**
-- [ ] Confirm the block shows this machine's real `~/.claude/CLAUDE.md`
-      path and content, positioned above the system tier.
+- [ ] Confirm the block shows this machine's real shared-provider-config
+      `CLAUDE.md` path and content (see §5 — not the ambient
+      `~/.claude/CLAUDE.md`), positioned above the system tier.
+
+---
+
+## 5. Post-review revision (2026-08-24, PR #2794 — codex P1)
+
+**The original design (§1-§4 above) was wrong about which file a spawned
+Claude agent actually loads as its "global" config.** Codex caught it,
+citing `agent_open.rs:303-312` and
+`SPEC_PROVIDER_ISOLATION_2026_06_20.md` §5b directly:
+
+- Every AgentMux-spawned Claude agent gets `CLAUDE_CONFIG_DIR` set to an
+  AgentMux-owned directory (`agent_open.rs`'s `auth_dir` — by default
+  `DataPaths::provider_auth_dir("claude")`, i.e.
+  `~/.agentmux/shared/providers/claude`; identity-bound agents use a
+  separate per-identity dir instead).
+- `SPEC_PROVIDER_ISOLATION_2026_06_20.md` §5b, already "confirmed on disk"
+  before this spec existed: *"`CLAUDE_CONFIG_DIR` relocates the **entire**
+  Claude home... User `CLAUDE.md` → `<CLAUDE_CONFIG_DIR>/CLAUDE.md`."*
+- So the ambient `~/.claude/CLAUDE.md` this spec originally targeted is
+  simply **not** what a `CLAUDE_CONFIG_DIR`-isolated spawned agent reads —
+  displaying it under "shared by every agent on this machine" was false
+  for the common case, not just imprecise.
+
+**Re-verified empirically (2026-08-24), which also resolved an apparent
+contradiction:** this agent's own `CLAUDE_CONFIG_DIR` is a per-identity
+directory (`~/.agentmux/channels/.../identities/<uuid>/claude`) with no
+`CLAUDE.md` in it at all — and neither does the default shared dir
+(`~/.agentmux/shared/providers/claude/`). So on this host, as of this
+date, **no AgentMux-spawned Claude agent has a populated global
+`CLAUDE.md` anywhere** — the only real, populated file matching that
+description is the ambient `~/.claude/CLAUDE.md` this spec originally
+found, which (per the isolation architecture) isn't actually in the read
+path for a normal spawned agent. Whatever separate mechanism surfaced that
+file's content into *this* agent's own context earlier in the conversation
+that prompted this spec is not resolved here — out of scope, a distinct
+question from what this UI block should display.
+
+**Fix:** resolve the path via the exact same logic `agent_open.rs` uses
+for the DEFAULT (non-identity-bound) case —
+`DataPaths::provider_auth_dir("claude")`, falling back to
+`~/.agentmux/shared/providers/claude` when `DataPaths::from_env()` fails,
+mirroring `agent_open.rs`'s own fallback verbatim. This is the file that
+actually IS shared across every default-provider Claude agent on this
+machine, closing the gap between the block's claim and its behavior for
+the common case. Identity-bound agents (a separate per-identity dir) are
+still not covered — flagged, not fixed, same "known gap, not blocking"
+treatment §3's out-of-scope items already use elsewhere in this spec chain.
+
+Badge copy changed from "Machine-wide (Claude Code)" (implying universal
+truth) to "Claude Code — shared provider config" (accurately scoped, with
+the identity-bound caveat moved into the tooltip) to match.

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -68,9 +68,12 @@ export const MemoryApi = {
         return client.rpcCall("deletesystemmemory", data, opts);
     },
 
-    // Read-only. Returns ~/.claude/CLAUDE.md (Claude Code's own global
-    // user-level config file, independent of AgentMux) — see
-    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. No
+    // Read-only. Returns the CLAUDE.md at AgentMux's shared Claude
+    // provider config dir (~/.agentmux/shared/providers/claude/CLAUDE.md
+    // via DataPaths::provider_auth_dir — the CLAUDE_CONFIG_DIR a
+    // non-identity-bound spawned Claude agent actually gets), NOT the
+    // ambient ~/.claude/CLAUDE.md — see
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5. No
     // parameters, no write counterpart.
     GetClaudeGlobalConfigCommand(
         client: RpcClient,

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -68,6 +68,18 @@ export const MemoryApi = {
         return client.rpcCall("deletesystemmemory", data, opts);
     },
 
+    // Read-only. Returns ~/.claude/CLAUDE.md (Claude Code's own global
+    // user-level config file, independent of AgentMux) — see
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. No
+    // parameters, no write counterpart.
+    GetClaudeGlobalConfigCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<{ path: string; content: string | null; exists: boolean }> {
+        return client.rpcCall("getclaudeglobalconfig", data, opts);
+    },
+
     NativeMemoryListCommand(client: RpcClient, data: { agent_id: string }, opts?: RpcOpts): Promise<NativeMemoryListResult> {
         return client.rpcCall("agent:memory:list", data, opts);
     },

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Covers the machine-wide ~/.claude/CLAUDE.md read-only display in
+// GlobalBrainManager. See
+// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4.
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const listMemoriesMock = vi.fn().mockResolvedValue([]);
+const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
+        GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
+    },
+}));
+
+import { GlobalBrainManager } from "./global-brain-manager";
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("GlobalBrainManager machine-wide config block", () => {
+    beforeEach(() => {
+        listMemoriesMock.mockClear();
+        listMemoriesMock.mockResolvedValue([]);
+        getClaudeGlobalConfigMock.mockClear();
+    });
+
+    test("renders nothing before the fetch resolves", () => {
+        getClaudeGlobalConfigMock.mockReturnValue(new Promise(() => {})); // never resolves within this test
+        render(() => <GlobalBrainManager />);
+        expect(screen.queryByText("Machine-wide (Claude Code)")).not.toBeInTheDocument();
+    });
+
+    test("renders the path and content when the file exists", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Global rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+
+        expect(await screen.findByText("Machine-wide (Claude Code)")).toBeInTheDocument();
+        expect(screen.getByText("/home/user/.claude/CLAUDE.md")).toBeInTheDocument();
+        expect(screen.getByText("# Global rules")).toBeInTheDocument();
+        expect(screen.queryByText("No file at this path yet.")).not.toBeInTheDocument();
+    });
+
+    test("renders the empty-state fallback when no file exists at that path", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: null,
+            exists: false,
+        });
+        render(() => <GlobalBrainManager />);
+
+        expect(await screen.findByText("Machine-wide (Claude Code)")).toBeInTheDocument();
+        expect(screen.getByText("No file at this path yet.")).toBeInTheDocument();
+    });
+
+    test("is read-only — no textarea or save affordance inside the block", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Global rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+        await screen.findByText("Machine-wide (Claude Code)");
+
+        const block = screen.getByText("Machine-wide (Claude Code)").closest(".global-brain-machine-config");
+        expect(block?.querySelector("textarea")).toBeNull();
+        expect(block?.querySelector("button")).toBeNull();
+    });
+});

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -1,15 +1,20 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Covers the machine-wide ~/.claude/CLAUDE.md read-only display in
-// GlobalBrainManager. See
-// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4.
+// Covers the read-only shared-provider-config display in
+// GlobalBrainManager (the CLAUDE.md at AgentMux's shared Claude provider
+// config dir, NOT the ambient ~/.claude/CLAUDE.md — codex P1, PR #2794).
+// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4.
 
 import { cleanup, render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const listMemoriesMock = vi.fn().mockResolvedValue([]);
-const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
+const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({
+    path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
+    content: null,
+    exists: false,
+});
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
@@ -23,7 +28,7 @@ afterEach(() => {
     cleanup();
 });
 
-describe("GlobalBrainManager machine-wide config block", () => {
+describe("GlobalBrainManager shared-provider-config block", () => {
     beforeEach(() => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
@@ -33,45 +38,45 @@ describe("GlobalBrainManager machine-wide config block", () => {
     test("renders nothing before the fetch resolves", () => {
         getClaudeGlobalConfigMock.mockReturnValue(new Promise(() => {})); // never resolves within this test
         render(() => <GlobalBrainManager />);
-        expect(screen.queryByText("Machine-wide (Claude Code)")).not.toBeInTheDocument();
+        expect(screen.queryByText("Claude Code — shared provider config")).not.toBeInTheDocument();
     });
 
     test("renders the path and content when the file exists", async () => {
         getClaudeGlobalConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Global rules\n",
             exists: true,
         });
         render(() => <GlobalBrainManager />);
 
-        expect(await screen.findByText("Machine-wide (Claude Code)")).toBeInTheDocument();
-        expect(screen.getByText("/home/user/.claude/CLAUDE.md")).toBeInTheDocument();
+        expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
+        expect(screen.getByText("/home/user/.agentmux/shared/providers/claude/CLAUDE.md")).toBeInTheDocument();
         expect(screen.getByText("# Global rules")).toBeInTheDocument();
         expect(screen.queryByText("No file at this path yet.")).not.toBeInTheDocument();
     });
 
     test("renders the empty-state fallback when no file exists at that path", async () => {
         getClaudeGlobalConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: null,
             exists: false,
         });
         render(() => <GlobalBrainManager />);
 
-        expect(await screen.findByText("Machine-wide (Claude Code)")).toBeInTheDocument();
+        expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
         expect(screen.getByText("No file at this path yet.")).toBeInTheDocument();
     });
 
     test("is read-only — no textarea or save affordance inside the block", async () => {
         getClaudeGlobalConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Global rules\n",
             exists: true,
         });
         render(() => <GlobalBrainManager />);
-        await screen.findByText("Machine-wide (Claude Code)");
+        await screen.findByText("Claude Code — shared provider config");
 
-        const block = screen.getByText("Machine-wide (Claude Code)").closest(".global-brain-machine-config");
+        const block = screen.getByText("Claude Code — shared provider config").closest(".global-brain-machine-config");
         expect(block?.querySelector("textarea")).toBeNull();
         expect(block?.querySelector("button")).toBeNull();
     });

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -146,6 +146,33 @@ export const GlobalBrainManager = (): JSX.Element => {
                 <div class="global-brain-error">{model.errorAtom()}</div>
             </Show>
 
+            {/* Machine-wide, hand-maintained, read-only — the file the system
+                tier below was conceptually meant to replace/complement.
+                Shown first so an operator sees the full picture before the
+                "here's where you'd add AgentMux's own policy" section. See
+                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. */}
+            <Show when={model.claudeGlobalConfigAtom()}>
+                {(cfg) => (
+                    <div class="global-brain-machine-config">
+                        <div class="global-brain-machine-config-header">
+                            <span
+                                class="global-brain-machine-config-badge"
+                                title="Hand-maintained on disk, not managed by AgentMux, shared by every agent on this machine"
+                            >
+                                Machine-wide (Claude Code)
+                            </span>
+                            <code class="global-brain-machine-config-path">{cfg().path}</code>
+                        </div>
+                        <Show
+                            when={cfg().exists}
+                            fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+                        >
+                            <pre class="global-brain-machine-config-content">{cfg().content}</pre>
+                        </Show>
+                    </div>
+                )}
+            </Show>
+
             {/* System tier — pinned above ordinary sections, always injected
                 first with override wording. No move up/down: position is
                 fixed server-side regardless of what a reorder call sends.

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -146,20 +146,23 @@ export const GlobalBrainManager = (): JSX.Element => {
                 <div class="global-brain-error">{model.errorAtom()}</div>
             </Show>
 
-            {/* Machine-wide, hand-maintained, read-only — the file the system
-                tier below was conceptually meant to replace/complement.
-                Shown first so an operator sees the full picture before the
-                "here's where you'd add AgentMux's own policy" section. See
-                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. */}
+            {/* The CLAUDE.md a spawned Claude agent's CLAUDE_CONFIG_DIR
+                actually points at by default — hand-maintained, read-only,
+                not the same thing as this Global Memory tab. Shown first so
+                an operator sees the full picture before the "here's where
+                you'd add AgentMux's own policy" section below. codex P1, PR
+                #2794: NOT the ambient ~/.claude/CLAUDE.md — that file isn't
+                what a CLAUDE_CONFIG_DIR-isolated agent loads. See
+                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5. */}
             <Show when={model.claudeGlobalConfigAtom()}>
                 {(cfg) => (
                     <div class="global-brain-machine-config">
                         <div class="global-brain-machine-config-header">
                             <span
                                 class="global-brain-machine-config-badge"
-                                title="Hand-maintained on disk, not managed by AgentMux, shared by every agent on this machine"
+                                title="Hand-maintained on disk, not managed by AgentMux. Read by default-provider Claude agents (identity-bound agents use a separate, per-identity config dir not shown here)."
                             >
-                                Machine-wide (Claude Code)
+                                Claude Code — shared provider config
                             </span>
                             <code class="global-brain-machine-config-path">{cfg().path}</code>
                         </div>

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -69,7 +69,7 @@ describe("formatGlobalBrainBlock", () => {
 // unawaited GetClaudeGlobalConfigCommand fetch, same pattern as
 // frontend/app/view/memory/memory-model.test.ts.
 const listMemoriesMock = vi.fn().mockResolvedValue([]);
-const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
+const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
@@ -82,7 +82,7 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
-        getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
+        getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
     });
 
     test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {
@@ -143,7 +143,7 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
     // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4.
     test("claudeGlobalConfigAtom starts null and populates from GetClaudeGlobalConfigCommand", async () => {
         getClaudeGlobalConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Global rules\n",
             exists: true,
         });
@@ -155,7 +155,7 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         await Promise.resolve();
 
         expect(model.claudeGlobalConfigAtom()).toEqual({
-            path: "/home/user/.claude/CLAUDE.md",
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Global rules\n",
             exists: true,
         });

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -65,12 +65,15 @@ describe("formatGlobalBrainBlock", () => {
 });
 
 // GlobalBrainViewModel's section split — mocks RpcApi entirely since the
-// constructor fires an unawaited ListMemoriesCommand refresh(), same
-// pattern as frontend/app/view/memory/memory-model.test.ts.
+// constructor fires an unawaited ListMemoriesCommand refresh() AND an
+// unawaited GetClaudeGlobalConfigCommand fetch, same pattern as
+// frontend/app/view/memory/memory-model.test.ts.
 const listMemoriesMock = vi.fn().mockResolvedValue([]);
+const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
+        GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
     },
 }));
 
@@ -78,6 +81,8 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
     beforeEach(() => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
+        getClaudeGlobalConfigMock.mockClear();
+        getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
     });
 
     test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {
@@ -133,6 +138,41 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         await model.refresh();
 
         expect(model.noFileProvidersAtom()).toEqual(["Kimi Code CLI"]);
+    });
+
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4.
+    test("claudeGlobalConfigAtom starts null and populates from GetClaudeGlobalConfigCommand", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Global rules\n",
+            exists: true,
+        });
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const model = new GlobalBrainViewModel();
+
+        expect(model.claudeGlobalConfigAtom()).toBeNull();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(model.claudeGlobalConfigAtom()).toEqual({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Global rules\n",
+            exists: true,
+        });
+    });
+
+    test("claudeGlobalConfigAtom stays null (not an error) when the fetch rejects", async () => {
+        getClaudeGlobalConfigMock.mockRejectedValue(new Error("boom"));
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const model = new GlobalBrainViewModel();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(model.claudeGlobalConfigAtom()).toBeNull();
+        // Doesn't surface through the unrelated Global Memory error banner —
+        // this is a supplementary display, not something that should make
+        // the rest of the tab look broken if it fails.
+        expect(model.errorAtom()).toBeNull();
     });
 });
 

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -201,8 +201,9 @@ export class GlobalBrainViewModel {
         void this.fetchClaudeGlobalConfig();
     }
 
-    /** Fetches ~/.claude/CLAUDE.md once. Failure is silent (leaves the atom
-     *  `null`, so the block just doesn't render) rather than surfacing
+    /** Fetches the shared Claude provider config's CLAUDE.md once. Failure
+     *  is silent (leaves the atom `null`, so the block just doesn't render)
+     *  rather than surfacing
      *  through `errorAtom` — this is a supplementary, read-only display, not
      *  something that should block or alarm-color the rest of the Global
      *  Memory tab if it can't be read (e.g. a permissions issue on this one

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -153,6 +153,18 @@ export class GlobalBrainViewModel {
      *  to" callout rather than silently omitted. */
     noFileProvidersAtom: Accessor<string[]>;
 
+    private _claudeGlobalConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
+    /** `~/.claude/CLAUDE.md` — Claude Code's own global user-level config
+     *  file, hand-maintained, independent of AgentMux and of any per-project
+     *  CLAUDE.md, shared by every agent on this machine. `null` until the
+     *  fetch resolves; fetched once at construction, not re-fetched on
+     *  `memories:changed` (nothing in this app can write to this file, so
+     *  there's no event to react to). See
+     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. */
+    claudeGlobalConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
+        this._claudeGlobalConfig[0];
+    private setClaudeGlobalConfig = this._claudeGlobalConfig[1];
+
     constructor() {
         this.sectionsAtom = createMemo(() =>
             this.allAtom()
@@ -182,6 +194,22 @@ export class GlobalBrainViewModel {
                 .map((p) => p.displayName),
         );
         void this.refresh();
+        void this.fetchClaudeGlobalConfig();
+    }
+
+    /** Fetches ~/.claude/CLAUDE.md once. Failure is silent (leaves the atom
+     *  `null`, so the block just doesn't render) rather than surfacing
+     *  through `errorAtom` — this is a supplementary, read-only display, not
+     *  something that should block or alarm-color the rest of the Global
+     *  Memory tab if it can't be read (e.g. a permissions issue on this one
+     *  file shouldn't look like Global Memory itself is broken). */
+    private async fetchClaudeGlobalConfig(): Promise<void> {
+        try {
+            const cfg = await RpcApi.GetClaudeGlobalConfigCommand(TabRpcClient, {});
+            this.setClaudeGlobalConfig(cfg);
+        } catch {
+            // Silent — see doc comment above.
+        }
     }
 
     async refresh(): Promise<void> {

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -154,13 +154,17 @@ export class GlobalBrainViewModel {
     noFileProvidersAtom: Accessor<string[]>;
 
     private _claudeGlobalConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
-    /** `~/.claude/CLAUDE.md` — Claude Code's own global user-level config
-     *  file, hand-maintained, independent of AgentMux and of any per-project
-     *  CLAUDE.md, shared by every agent on this machine. `null` until the
-     *  fetch resolves; fetched once at construction, not re-fetched on
-     *  `memories:changed` (nothing in this app can write to this file, so
-     *  there's no event to react to). See
-     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md. */
+    /** The CLAUDE.md at AgentMux's shared Claude provider config dir — the
+     *  path a spawned Claude agent's CLAUDE_CONFIG_DIR points at by
+     *  DEFAULT (identity-bound agents use a separate, per-identity dir not
+     *  covered here). Hand-maintained, independent of AgentMux's own
+     *  Global Memory. `null` until the fetch resolves; fetched once at
+     *  construction, not re-fetched on `memories:changed` (nothing in this
+     *  app can write to this file, so there's no event to react to).
+     *  NOT the ambient ~/.claude/CLAUDE.md — codex P1, PR #2794: that file
+     *  isn't what a CLAUDE_CONFIG_DIR-isolated spawned agent actually
+     *  loads. See
+     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5. */
     claudeGlobalConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
         this._claudeGlobalConfig[0];
     private setClaudeGlobalConfig = this._claudeGlobalConfig[1];

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -45,6 +45,62 @@
     font-size: var(--text-sm);
 }
 
+// ── Machine-wide config (read-only — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md) ──
+
+.global-brain-machine-config {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-2);
+    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    border: 1px solid var(--border-color);
+}
+
+.global-brain-machine-config-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    flex-wrap: wrap;
+}
+
+.global-brain-machine-config-badge {
+    flex-shrink: 0;
+    padding: 1px var(--space-1-5);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--secondary-text-color);
+    border: 1px solid var(--border-color);
+}
+
+.global-brain-machine-config-path {
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+    word-break: break-all;
+}
+
+.global-brain-machine-config-empty {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+}
+
+.global-brain-machine-config-content {
+    margin: 0;
+    padding: var(--space-2);
+    max-height: 240px;
+    overflow: auto;
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-xs);
+    color: var(--main-text-color);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
 // ── Section list ─────────────────────────────────────────────────────────────
 
 .global-brain-sections {


### PR DESCRIPTION
## Summary
- Adds a new read-only block at the top of Armory -> Memory (Global Memory) showing the real path and content of `~/.claude/CLAUDE.md` -- Claude Code's own global user-level config file, hand-maintained and independent of AgentMux, shared by every agent on this machine.
- Follows up on this conversation's earlier finding: the system-tier spec (`SPEC_GLOBAL_MEMORY_SYSTEM_TIER_2026_08_24.md` §1) claims a "highest priority" file exists at `~/.agentmux/agents/CLAUDE.md` -- that path doesn't actually exist on this host. The real file matching that description is `~/.claude/CLAUDE.md`, confirmed by directly reading my own startup files earlier in the session.
- New `getclaudeglobalconfig` RPC command: no parameters (fixed, hardcoded path -- no path-traversal surface), no write counterpart. `content: None, exists: false` for a missing file is a normal state, not an error; genuine I/O errors (permission denied, etc.) still propagate.
- Read-only by construction in the UI -- no textarea, no save button, no edit affordance. A tooltip on the badge explains why (hand-maintained, not AgentMux's, shared machine-wide).

See `docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md` for the full design (including the explicit scoping decision to keep this to just this one file, not per-provider example paths or a live per-agent path listing -- both considered and declined for this pass).

## Test plan
- [x] Rust: 3 new tests on the extracted `read_claude_global_config` helper (present, missing-not-error, empty-file-not-missing) -- full suite (2800 tests) green.
- [x] Frontend: model-level tests (`claudeGlobalConfigAtom` populates, fetch failure stays silent and doesn't pollute `errorAtom`) + new component-level tests (renders path/content, empty-state fallback, nothing before fetch resolves, no edit affordances) -- full suite (3120 tests) green.
- [x] `npx tsc --noEmit` clean.
- [ ] Manual (`task dev`): confirm the block shows this machine's real `~/.claude/CLAUDE.md` path and content above the system tier.

<!-- agentmux:agent_id=manoz -->