### PR TITLE
chore: release v0.55.24

### DIFF
--- a/.changesets/1787554977-fix-agent-pane-strip-common-indentation-from-mid-file-tool-p-9uya.md
+++ b/.changesets/1787554977-fix-agent-pane-strip-common-indentation-from-mid-file-tool-p-9uya.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): strip common indentation from mid-file tool previews

--- a/.changesets/1787555508-fix-agent-gate-the-brainspinner-on-subagent-backfill-so-the--q1w7.md
+++ b/.changesets/1787555508-fix-agent-gate-the-brainspinner-on-subagent-backfill-so-the--q1w7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): gate the BrainSpinner on subagent backfill so the Activity Dock never flickers

--- a/.changesets/1787561798-feat-armory-add-agentmux-controlled-highest-priority-system--u77c.md
+++ b/.changesets/1787561798-feat-armory-add-agentmux-controlled-highest-priority-system--u77c.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): add AgentMux-controlled, highest-priority system tier to Global Memory

--- a/.changesets/1787581780-feat-linux-recover-from-apparmor-s-unprivileged-userns-sandb-8k0p.md
+++ b/.changesets/1787581780-feat-linux-recover-from-apparmor-s-unprivileged-userns-sandb-8k0p.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(linux): recover from AppArmor's unprivileged-userns sandbox restriction

--- a/.changesets/1787583263-fix-ci-move-nightly-release-auto-tagging-to-gh-reporter-work-ezqe.md
+++ b/.changesets/1787583263-fix-ci-move-nightly-release-auto-tagging-to-gh-reporter-work-ezqe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): move nightly release auto-tagging to gh-reporter (workflow_run trigger never fired)

--- a/.changesets/1787583377-fix-agent-pane-render-tool-preview-tabs-at-2-spaces-instead--i3yd.md
+++ b/.changesets/1787583377-fix-agent-pane-render-tool-preview-tabs-at-2-spaces-instead--i3yd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): render tool-preview tabs at 2 spaces instead of the inherited 4

--- a/.changesets/1787584272-feat-agent-picker-on-demand-haiku-activity-summary-fallback--t0va.md
+++ b/.changesets/1787584272-feat-agent-picker-on-demand-haiku-activity-summary-fallback--t0va.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-picker): on-demand Haiku activity summary fallback when no conversation snapshot exists

--- a/.changesets/1787584354-feat-agent-view-pause-askuserquestion-auto-timeout-on-keyboa-iwv0.md
+++ b/.changesets/1787584354-feat-agent-view-pause-askuserquestion-auto-timeout-on-keyboa-iwv0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-view): pause AskUserQuestion auto-timeout on keyboard activity, not just mouse hover

--- a/.changesets/1787598677-feat-agent-armory-write-provider-specific-startup-instructio-9kpr.md
+++ b/.changesets/1787598677-feat-agent-armory-write-provider-specific-startup-instructio-9kpr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent,armory): write provider-specific startup instructions filenames (AGENTS.md, GEMINI.md, QWEN.md, ...) instead of always CLAUDE.md; surface the mapping in Global Memory

--- a/.changesets/1787599247-feat-agent-picker-sort-control-reordered-fields-distinct-acc-im7g.md
+++ b/.changesets/1787599247-feat-agent-picker-sort-control-reordered-fields-distinct-acc-im7g.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-picker): sort control, reordered fields, distinct account-failure text

--- a/.changesets/1787599434-feat-toolchain-one-click-install-of-git-node-npm-python-via--42on.md
+++ b/.changesets/1787599434-feat-toolchain-one-click-install-of-git-node-npm-python-via--42on.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(toolchain): one-click install of git/Node/npm/Python via winget/brew/system package manager

--- a/.changesets/1787627909-fix-tabs-remove-the-active-tab-color-line-spanning-the-whole-p2n8.md
+++ b/.changesets/1787627909-fix-tabs-remove-the-active-tab-color-line-spanning-the-whole-p2n8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): remove the active-tab color line spanning the whole tab strip

--- a/.changesets/1787627944-fix-armory-warden-settings-move-the-narrow-width-responsive--f82m.md
+++ b/.changesets/1787627944-fix-armory-warden-settings-move-the-narrow-width-responsive--f82m.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory,warden,settings): move the narrow-width responsive tab bar to the top of the pane; highlight ABF

--- a/.changesets/1787629229-feat-armory-surface-claude-claude-md-read-only-in-global-mem-ommd.md
+++ b/.changesets/1787629229-feat-armory-surface-claude-claude-md-read-only-in-global-mem-ommd.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): surface ~/.claude/CLAUDE.md (read-only) in Global Memory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.23"
+version = "0.55.24"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.23"
+version = "0.55.24"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.23"
+version = "0.55.24"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.23"
+version = "0.55.24"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.23"
+version = "0.55.24"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.23"
+version = "0.55.24"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.23"
+version = "0.55.24"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,23 @@
 # AgentMux Version History
 
+## 0.55.24 — 2026-08-24
+
+- fix(agent-pane): strip common indentation from mid-file tool previews
+- fix(agent): gate the BrainSpinner on subagent backfill so the Activity Dock never flickers
+- feat(armory): add AgentMux-controlled, highest-priority system tier to Global Memory
+- feat(linux): recover from AppArmor's unprivileged-userns sandbox restriction
+- fix(ci): move nightly release auto-tagging to gh-reporter (workflow_run trigger never fired)
+- fix(agent-pane): render tool-preview tabs at 2 spaces instead of the inherited 4
+- feat(agent-picker): on-demand Haiku activity summary fallback when no conversation snapshot exists
+- feat(agent-view): pause AskUserQuestion auto-timeout on keyboard activity, not just mouse hover
+- feat(agent,armory): write provider-specific startup instructions filenames (AGENTS.md, GEMINI.md, QWEN.md, ...) instead of always CLAUDE.md; surface the mapping in Global Memory
+- feat(agent-picker): sort control, reordered fields, distinct account-failure text
+- feat(toolchain): one-click install of git/Node/npm/Python via winget/brew/system package manager
+- fix(tabs): remove the active-tab color line spanning the whole tab strip
+- fix(armory,warden,settings): move the narrow-width responsive tab bar to the top of the pane; highlight ABF
+- feat(armory): surface ~/.claude/CLAUDE.md (read-only) in Global Memory
+
+
 ## 0.55.23 — 2026-08-23
 
 - fix(agent): surface a Reconnecting… status during stale-resume retry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.23",
+  "version": "0.55.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.23",
+      "version": "0.55.24",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.23",
+  "version": "0.55.24",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release consuming 14 pending changesets (`--as patch` override — several are `feat`/minor, forced to ship under a patch bump per request):

- fix(agent-pane): strip common indentation from mid-file tool previews
- fix(agent): gate the BrainSpinner on subagent backfill so the Activity Dock never flickers
- feat(armory): add AgentMux-controlled, highest-priority system tier to Global Memory
- feat(linux): recover from AppArmor's unprivileged-userns sandbox restriction
- fix(ci): move nightly release auto-tagging to gh-reporter (workflow_run trigger never fired)
- fix(agent-pane): render tool-preview tabs at 2 spaces instead of the inherited 4
- feat(agent-picker): on-demand Haiku activity summary fallback when no conversation snapshot exists
- feat(agent-view): pause AskUserQuestion auto-timeout on keyboard activity, not just mouse hover
- feat(agent,armory): write provider-specific startup instructions filenames (AGENTS.md, GEMINI.md, QWEN.md, ...) instead of always CLAUDE.md; surface the mapping in Global Memory
- feat(agent-picker): sort control, reordered fields, distinct account-failure text
- feat(toolchain): one-click install of git/Node/npm/Python via winget/brew/system package manager
- fix(tabs): remove the active-tab color line spanning the whole tab strip
- fix(armory,warden,settings): move the narrow-width responsive tab bar to the top of the pane; highlight ABF
- feat(armory): surface ~/.claude/CLAUDE.md (read-only) in Global Memory

`0.55.23 → 0.55.24`. All 5 version-tracked locations (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) verified in agreement.

## Test plan
- [x] `task release -- --as patch` — clean run, no errors, all 5 version locations confirmed in agreement.
- [x] CI (this PR) will run the full build/test matrix.

<!-- agentmux:agent_id=agent2 -->