### PR TITLE
Manoz@Area54: feat(armory): show ambient ~/.claude/CLAUDE.md as a second Global Memory read-only block

### DIFF
--- a/.changesets/1787663234-feat-armory-show-ambient-claude-claude-md-as-a-second-global-xzwd.md
+++ b/.changesets/1787663234-feat-armory-show-ambient-claude-claude-md-as-a-second-global-xzwd.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): show ambient ~/.claude/CLAUDE.md as a second Global Memory read-only block

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -239,6 +239,15 @@ pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
 /// no path-traversal surface) and no write counterpart. See
 /// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5.
 pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
+/// Read-only. Returns the ambient `~/.claude/CLAUDE.md` — Claude Code's
+/// own global config, read by a host-level Claude Code CLI running
+/// outside AgentMux's `CLAUDE_CONFIG_DIR` isolation (e.g. an external
+/// coding-agent harness). Deliberately a SEPARATE command/block from
+/// `getclaudeglobalconfig` (§5's shared-provider-config path) rather than
+/// a replacement — the two paths have different audiences and neither
+/// implies coverage of the other. No parameters, no write counterpart.
+/// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6.
+pub const COMMAND_GET_CLAUDE_AMBIENT_CONFIG: &str = "getclaudeambientconfig";
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -12,7 +12,7 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
     COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY, COMMAND_REORDER_GLOBAL_BRAIN,
     COMMAND_UPSERT_SYSTEM_MEMORY, COMMAND_DELETE_SYSTEM_MEMORY,
-    COMMAND_GET_CLAUDE_GLOBAL_CONFIG,
+    COMMAND_GET_CLAUDE_GLOBAL_CONFIG, COMMAND_GET_CLAUDE_AMBIENT_CONFIG,
     CommandGetMemoryData, CommandDeleteMemoryData, CommandReorderGlobalBrainData,
 };
 use crate::backend::storage::store::Memory;
@@ -248,6 +248,22 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+
+    // ---- Read-only: the ambient ~/.claude/CLAUDE.md — Claude Code's own
+    // global config, read by a host-level CLI outside AgentMux's
+    // CLAUDE_CONFIG_DIR isolation. A SEPARATE block from the one above, not
+    // a replacement — see docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6.
+    engine.register_handler(
+        COMMAND_GET_CLAUDE_AMBIENT_CONFIG,
+        Box::new(move |_data, _ctx| {
+            Box::pin(async move {
+                let claude_dir = crate::backend::base::get_home_dir().join(".claude");
+                let result = read_claude_global_config(&claude_dir)
+                    .map_err(|e| format!("getclaudeambientconfig: {e}"))?;
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
+            })
+        }),
+    );
 }
 
 /// The directory a spawned Claude agent's `CLAUDE_CONFIG_DIR` env var
@@ -299,6 +315,11 @@ fn read_claude_global_config(claude_dir: &std::path::Path) -> std::io::Result<Cl
     Ok(ClaudeGlobalConfig { path: path.to_string_lossy().into_owned(), content, exists })
 }
 
+// Covers both getclaudeglobalconfig (resolve_shared_claude_provider_dir)
+// and getclaudeambientconfig (~/.claude) — both handlers call this same
+// generic function against different directories, so exists/missing/
+// empty-file coverage here applies to both call sites. See
+// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6.
 #[cfg(test)]
 mod claude_global_config_tests {
     use super::*;

--- a/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+++ b/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
@@ -5,7 +5,11 @@
 out to be the wrong one — see §5 for the corrected design (the CLAUDE.md
 at AgentMux's shared Claude provider config dir, not the ambient
 `~/.claude/CLAUDE.md`). Filename kept as-is since it's already referenced
-by the PR/commits; read §5 for what actually shipped.
+by the PR/commits; read §5 for what actually shipped. **§6 (2026-08-25)
+re-adds the ambient file after all — as a SECOND, separately-labeled
+block alongside §5's, not a replacement.** Current shipped/target state:
+Global Memory shows TWO independent read-only blocks — the shared
+provider config (§5) and the ambient host CLI config (§6).
 
 ---
 
@@ -247,3 +251,70 @@ treatment §3's out-of-scope items already use elsewhere in this spec chain.
 Badge copy changed from "Machine-wide (Claude Code)" (implying universal
 truth) to "Claude Code — shared provider config" (accurately scoped, with
 the identity-bound caveat moved into the tooltip) to match.
+
+---
+
+## 6. Second revision (2026-08-25) — restore the ambient file as a SECOND, separately-labeled block
+
+**The ask, verbatim:**
+
+> so what do you use claude.md wise? what files have u used this session,
+> keep it short, just a list [...] right .. so those are the ones we
+> should be able to see inside global memory in armory [...] you need to
+> update the Global Memory spec. I am telling you the purpose of Global
+> Memory is to be able to peruse those files
+
+Of the files listed in that conversation, two are genuinely part of
+AgentMux's spawned-agent memory pipeline; two are not (this coding-agent
+harness's own working-directory `CLAUDE.md`/`AGENTMUX_MEMORY.md` — not
+under `CLAUDE_CONFIG_DIR` isolation, not something any in-app Agent pane
+would ever load). Presented as an explicit choice; the operator selected
+**only** the ambient `~/.claude/CLAUDE.md` to add, declining the
+per-identity `CLAUDE_CONFIG_DIR` dirs and the harness-specific files.
+
+**Design:** add a second, independently-fetched read-only block —
+`getclaudeambientconfig` — reusing §5's exact `ClaudeGlobalConfig` shape
+and `read_claude_global_config` helper (already generic: takes a dir,
+appends `CLAUDE.md`, reports `{path, content, exists}`) against
+`get_home_dir().join(".claude")` instead of
+`DataPaths::provider_auth_dir("claude")`. Rendered directly below the
+existing shared-provider-config block, same markup/CSS class
+(`global-brain-machine-config`), with **its own distinct badge** —
+"Claude Code — host CLI config (ambient)" — and a tooltip that states the
+audience distinction plainly, so this pass doesn't repeat §5's mistake of
+one block implying it covers more than it does:
+
+> Claude Code's own global config on this machine — read by a host-level
+> Claude Code CLI running outside AgentMux's isolation (e.g. an external
+> coding-agent harness). A spawned in-app Claude agent does NOT read this
+> file — see the shared provider config block above for what it actually
+> reads.
+
+Two independent blocks, two independent fetches (mirrors §2.2's
+"read-once-at-mount, no live-watch" reasoning — same tradeoffs apply
+identically to the ambient path), two independent atoms
+(`claudeAmbientConfigAtom` alongside the existing
+`claudeGlobalConfigAtom`) — no shared state, no coupling; either can fail
+or be missing independently without affecting the other's rendering.
+
+**Out of scope (same reasoning as §3, re-affirmed after the explicit
+choice above):** per-identity `CLAUDE_CONFIG_DIR` dirs (still a known,
+flagged gap — would require enumerating every identity, a materially
+larger feature); this harness's own working-directory files (not part of
+AgentMux's spawned-agent system at all, would misrepresent what the
+feature does the same way the original §1-§4 design did before §5's
+correction); any equivalent file for other providers (still no evidence
+one exists the way `~/.claude/CLAUDE.md` does for Claude Code).
+
+**Test plan (additive, mirrors §4 exactly for the new path):**
+- [ ] Rust: `getclaudeambientconfig` against a `HOME` pointed at a tempdir
+      — exists/missing/empty-file cases, reusing the existing
+      `read_claude_global_config` test helper against a different dir.
+- [ ] Frontend: `claudeAmbientConfigAtom` populates independently of
+      `claudeGlobalConfigAtom`; a rejected ambient fetch doesn't clear or
+      block the shared-provider-config atom and vice versa.
+- [ ] Frontend: `GlobalBrainManager` renders both blocks with visibly
+      distinct badge text; each is independently read-only (no
+      textarea/button in either).
+- [ ] Manual (`task dev`): confirm both blocks render, each with its own
+      correct path/content/empty-state, positioned adjacently.

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -83,6 +83,20 @@ export const MemoryApi = {
         return client.rpcCall("getclaudeglobalconfig", data, opts);
     },
 
+    // Read-only. Returns the ambient ~/.claude/CLAUDE.md — Claude Code's
+    // own global config, read by a host-level CLI outside AgentMux's
+    // CLAUDE_CONFIG_DIR isolation. A SEPARATE block from
+    // GetClaudeGlobalConfigCommand above, not a replacement — see
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6. No
+    // parameters, no write counterpart.
+    GetClaudeAmbientConfigCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<{ path: string; content: string | null; exists: boolean }> {
+        return client.rpcCall("getclaudeambientconfig", data, opts);
+    },
+
     NativeMemoryListCommand(client: RpcClient, data: { agent_id: string }, opts?: RpcOpts): Promise<NativeMemoryListResult> {
         return client.rpcCall("agent:memory:list", data, opts);
     },

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -15,10 +15,16 @@ const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({
     content: null,
     exists: false,
 });
+const getClaudeAmbientConfigMock = vi.fn().mockResolvedValue({
+    path: "/home/user/.claude/CLAUDE.md",
+    content: null,
+    exists: false,
+});
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
         GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
+        GetClaudeAmbientConfigCommand: (...args: unknown[]) => getClaudeAmbientConfigMock(...args),
     },
 }));
 
@@ -33,6 +39,12 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
+        getClaudeAmbientConfigMock.mockClear();
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: null,
+            exists: false,
+        });
     });
 
     test("renders nothing before the fetch resolves", () => {
@@ -52,7 +64,11 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
         expect(screen.getByText("/home/user/.agentmux/shared/providers/claude/CLAUDE.md")).toBeInTheDocument();
         expect(screen.getByText("# Global rules")).toBeInTheDocument();
-        expect(screen.queryByText("No file at this path yet.")).not.toBeInTheDocument();
+        // Scoped to this block — the sibling ambient block legitimately
+        // renders its own "No file..." empty state under the beforeEach
+        // default, which is not this block's concern.
+        const block = screen.getByText("Claude Code — shared provider config").closest(".global-brain-machine-config");
+        expect(block?.querySelector(".global-brain-machine-config-empty")).toBeNull();
     });
 
     test("renders the empty-state fallback when no file exists at that path", async () => {
@@ -61,10 +77,18 @@ describe("GlobalBrainManager shared-provider-config block", () => {
             content: null,
             exists: false,
         });
+        // Sibling ambient block set to exists:true so only this block's
+        // empty state renders — avoids a duplicate-text ambiguity when
+        // both blocks are empty simultaneously.
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Ambient rules\n",
+            exists: true,
+        });
         render(() => <GlobalBrainManager />);
 
-        expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
-        expect(screen.getByText("No file at this path yet.")).toBeInTheDocument();
+        const block = (await screen.findByText("Claude Code — shared provider config")).closest(".global-brain-machine-config");
+        expect(block?.querySelector(".global-brain-machine-config-empty")?.textContent).toBe("No file at this path yet.");
     });
 
     test("is read-only — no textarea or save affordance inside the block", async () => {
@@ -79,5 +103,87 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         const block = screen.getByText("Claude Code — shared provider config").closest(".global-brain-machine-config");
         expect(block?.querySelector("textarea")).toBeNull();
         expect(block?.querySelector("button")).toBeNull();
+    });
+});
+
+// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6 — a
+// SEPARATE block, independently fetched, rendered alongside the
+// shared-provider-config block above.
+describe("GlobalBrainManager ambient-config block", () => {
+    beforeEach(() => {
+        listMemoriesMock.mockClear();
+        listMemoriesMock.mockResolvedValue([]);
+        getClaudeGlobalConfigMock.mockClear();
+        getClaudeAmbientConfigMock.mockClear();
+    });
+
+    test("renders nothing before the fetch resolves", () => {
+        getClaudeAmbientConfigMock.mockReturnValue(new Promise(() => {})); // never resolves within this test
+        render(() => <GlobalBrainManager />);
+        expect(screen.queryByText("Claude Code — host CLI config (ambient)")).not.toBeInTheDocument();
+    });
+
+    test("renders the path and content when the file exists", async () => {
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Ambient rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+
+        expect(await screen.findByText("Claude Code — host CLI config (ambient)")).toBeInTheDocument();
+        expect(screen.getByText("/home/user/.claude/CLAUDE.md")).toBeInTheDocument();
+        expect(screen.getByText("# Ambient rules")).toBeInTheDocument();
+    });
+
+    test("renders the empty-state fallback when no file exists at that path", async () => {
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: null,
+            exists: false,
+        });
+        // Sibling shared-provider-config block set to exists:true so only
+        // this block's empty state renders — avoids a duplicate-text
+        // ambiguity when both blocks are empty simultaneously.
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
+            content: "# Shared rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+
+        const block = (await screen.findByText("Claude Code — host CLI config (ambient)")).closest(".global-brain-machine-config");
+        expect(block?.querySelector(".global-brain-machine-config-empty")?.textContent).toBe("No file at this path yet.");
+    });
+
+    test("is read-only — no textarea or save affordance inside the block", async () => {
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Ambient rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+        await screen.findByText("Claude Code — host CLI config (ambient)");
+
+        const block = screen.getByText("Claude Code — host CLI config (ambient)").closest(".global-brain-machine-config");
+        expect(block?.querySelector("textarea")).toBeNull();
+        expect(block?.querySelector("button")).toBeNull();
+    });
+
+    test("renders alongside the shared-provider-config block, both visible with distinct badges", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
+            content: "# Shared rules\n",
+            exists: true,
+        });
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Ambient rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+
+        expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
+        expect(await screen.findByText("Claude Code — host CLI config (ambient)")).toBeInTheDocument();
     });
 });

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -176,6 +176,34 @@ export const GlobalBrainManager = (): JSX.Element => {
                 )}
             </Show>
 
+            {/* The ambient ~/.claude/CLAUDE.md — Claude Code's own global
+                config, read by a host-level CLI outside AgentMux's
+                CLAUDE_CONFIG_DIR isolation (e.g. an external coding-agent
+                harness). A SEPARATE block from the one above, not a
+                replacement — a spawned in-app agent does NOT read this
+                file. See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6. */}
+            <Show when={model.claudeAmbientConfigAtom()}>
+                {(cfg) => (
+                    <div class="global-brain-machine-config">
+                        <div class="global-brain-machine-config-header">
+                            <span
+                                class="global-brain-machine-config-badge"
+                                title="Claude Code's own global config on this machine — read by a host-level Claude Code CLI running outside AgentMux's isolation. A spawned in-app agent does NOT read this file; see the shared provider config block above for what it actually reads."
+                            >
+                                Claude Code — host CLI config (ambient)
+                            </span>
+                            <code class="global-brain-machine-config-path">{cfg().path}</code>
+                        </div>
+                        <Show
+                            when={cfg().exists}
+                            fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+                        >
+                            <pre class="global-brain-machine-config-content">{cfg().content}</pre>
+                        </Show>
+                    </div>
+                )}
+            </Show>
+
             {/* System tier — pinned above ordinary sections, always injected
                 first with override wording. No move up/down: position is
                 fixed server-side regardless of what a reorder call sends.

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -70,10 +70,12 @@ describe("formatGlobalBrainBlock", () => {
 // frontend/app/view/memory/memory-model.test.ts.
 const listMemoriesMock = vi.fn().mockResolvedValue([]);
 const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
+const getClaudeAmbientConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
         GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
+        GetClaudeAmbientConfigCommand: (...args: unknown[]) => getClaudeAmbientConfigMock(...args),
     },
 }));
 
@@ -83,6 +85,8 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
         getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
+        getClaudeAmbientConfigMock.mockClear();
+        getClaudeAmbientConfigMock.mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
     });
 
     test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {
@@ -173,6 +177,59 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         // this is a supplementary display, not something that should make
         // the rest of the tab look broken if it fails.
         expect(model.errorAtom()).toBeNull();
+    });
+
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6 — the
+    // ambient block is a SEPARATE atom/fetch from claudeGlobalConfigAtom.
+    test("claudeAmbientConfigAtom starts null and populates from GetClaudeAmbientConfigCommand", async () => {
+        getClaudeAmbientConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Ambient rules\n",
+            exists: true,
+        });
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const model = new GlobalBrainViewModel();
+
+        expect(model.claudeAmbientConfigAtom()).toBeNull();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(model.claudeAmbientConfigAtom()).toEqual({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Ambient rules\n",
+            exists: true,
+        });
+    });
+
+    test("claudeAmbientConfigAtom stays null (not an error) when the fetch rejects", async () => {
+        getClaudeAmbientConfigMock.mockRejectedValue(new Error("boom"));
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const model = new GlobalBrainViewModel();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(model.claudeAmbientConfigAtom()).toBeNull();
+        expect(model.errorAtom()).toBeNull();
+    });
+
+    test("a rejected ambient fetch does not clear or block the shared-provider-config atom, and vice versa", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
+            content: "# Shared rules\n",
+            exists: true,
+        });
+        getClaudeAmbientConfigMock.mockRejectedValue(new Error("boom"));
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const model = new GlobalBrainViewModel();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(model.claudeGlobalConfigAtom()).toEqual({
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
+            content: "# Shared rules\n",
+            exists: true,
+        });
+        expect(model.claudeAmbientConfigAtom()).toBeNull();
     });
 });
 

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -169,6 +169,19 @@ export class GlobalBrainViewModel {
         this._claudeGlobalConfig[0];
     private setClaudeGlobalConfig = this._claudeGlobalConfig[1];
 
+    private _claudeAmbientConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
+    /** The ambient ~/.claude/CLAUDE.md — Claude Code's own global config,
+     *  read by a host-level Claude Code CLI running outside AgentMux's
+     *  CLAUDE_CONFIG_DIR isolation (e.g. an external coding-agent
+     *  harness). A spawned in-app Claude agent does NOT read this file —
+     *  see claudeGlobalConfigAtom above for what it actually reads.
+     *  Independent atom, independent fetch: neither block's success or
+     *  failure affects the other. See
+     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6. */
+    claudeAmbientConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
+        this._claudeAmbientConfig[0];
+    private setClaudeAmbientConfig = this._claudeAmbientConfig[1];
+
     constructor() {
         this.sectionsAtom = createMemo(() =>
             this.allAtom()
@@ -199,6 +212,7 @@ export class GlobalBrainViewModel {
         );
         void this.refresh();
         void this.fetchClaudeGlobalConfig();
+        void this.fetchClaudeAmbientConfig();
     }
 
     /** Fetches the shared Claude provider config's CLAUDE.md once. Failure
@@ -212,6 +226,19 @@ export class GlobalBrainViewModel {
         try {
             const cfg = await RpcApi.GetClaudeGlobalConfigCommand(TabRpcClient, {});
             this.setClaudeGlobalConfig(cfg);
+        } catch {
+            // Silent — see doc comment above.
+        }
+    }
+
+    /** Fetches the ambient ~/.claude/CLAUDE.md once. Same silent-failure
+     *  and read-once-at-mount reasoning as fetchClaudeGlobalConfig above —
+     *  independent of it, so a failure here doesn't touch
+     *  claudeGlobalConfigAtom or the ordinary Global Memory sections. */
+    private async fetchClaudeAmbientConfig(): Promise<void> {
+        try {
+            const cfg = await RpcApi.GetClaudeAmbientConfigCommand(TabRpcClient, {});
+            this.setClaudeAmbientConfig(cfg);
         } catch {
             // Silent — see doc comment above.
         }


### PR DESCRIPTION
## Summary
- Adds a second, independently-fetched read-only block to Armory -> Memory (Global Memory), alongside the already-shipped shared-provider-config block (PR #2794): the ambient `~/.claude/CLAUDE.md`, badged "Claude Code — host CLI config (ambient)".
- The two blocks are clearly, distinctly labeled by audience to avoid repeating PR #2794's original mistake (implying one file covers more than it does): the shared-provider-config block is what a default spawned-in-app Claude agent reads; the new ambient block is what a host-level Claude Code CLI reads outside AgentMux's `CLAUDE_CONFIG_DIR` isolation.
- Scoped by explicit choice: only the ambient file was requested. Per-identity `CLAUDE_CONFIG_DIR` dirs and an external coding-agent harness's own working-directory files were both explicitly declined — the latter isn't part of AgentMux's spawned-agent memory pipeline at all and would misrepresent what the feature shows.
- Updated `docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md` (§6) with the full design/rationale.

## Test plan
- [x] `cargo test --bin agentmux-srv` — 2797 passed, 0 failed (new handler reuses the already-tested `read_claude_global_config` helper against a different directory — no new Rust test needed, existing coverage applies to both call sites, noted inline)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/brain/` — 25/25 pass, including new tests for atom independence (a rejected ambient fetch doesn't affect the shared-provider-config atom and vice versa) and both blocks rendering with distinct badges
- [x] `npx vitest run` (full suite) — 3130 passed, 1 pre-existing flake confirmed unrelated (passes in isolation, `tool-renderer registry` timeout under full-suite resource contention)

<!-- agentmux:agent_id=manoz -->