### PR TITLE
docs(retro): confirm cross-agent GitHub identity binding in AgentY's PR #5 retro

### DIFF
--- a/docs/retro/retro-agentmux-corp-pr5-shared-gh-cli-session-misattribution-2026-08-24.md
+++ b/docs/retro/retro-agentmux-corp-pr5-shared-gh-cli-session-misattribution-2026-08-24.md
@@ -256,21 +256,38 @@ side.** §2a's framing ("if AgentX's own identity bindings reciprocally
 include an account bound to AgentY's GitHub credential") assumed a pair of
 mirrored mis-bindings; what's actually there is a **single identity-provider
 account object, named "AgentX GitHub," visible/bound in both agents'
-`IdentityAccounts` lists simultaneously** — arguably a cleaner confirmation
-of a real resolver bug than a symmetric pair would have been, since there's
-no ambiguity about which agent "owns" it by name — it's mine by name, and
-AgentY's environment got it anyway.
+`IdentityAccounts` lists simultaneously**.
 
 One difference from AgentY's observation worth noting: they found the token
 already rejected by GitHub (`401 Unauthorized`) when they checked it on
 2026-08-24. As of this check (2026-08-25), the same account shows
 `status: "valid"` — either rotated/re-validated since, or `status` here
 reflects something other than live GitHub-side validity (not verified
-either way from this agent). Doesn't change the core finding: the same
-account record is reachable from both agent identities, which shouldn't be
-possible if bindings are meant to be exclusive per-agent.
+either way from this agent).
 
-This closes the loop §6 asked for. The actual fix still belongs where §5
-already said — the identity-resolver's account-binding logic
-(`identity/resolver/{inject.rs,provider.rs}`) — not in either agent's own
-`gh` workflow discipline.
+**Correction (Codex's review of the PR shipping this section): the
+paragraph originally here called this "a confirmed resolver bug." That
+overreached — struck and replaced.** Codex cited real code this section
+didn't check first: `IdentityAccount` is explicitly documented as a
+*reusable* credential (`identities.rs:103-105`); `agent_identity_link`'s own
+uniqueness constraint is scoped to `(agent_id, provider)` only — nothing
+prevents the same `account_id` from being linked to multiple different
+agents (`identities.rs:544-561`); and there's a dedicated test,
+`identity_delete_captures_all_affected_agents` (`identities.rs:894-928`),
+that deliberately links two different agents to one account and asserts
+both are correctly captured. Confirmed all three directly. **One account
+linked to two agents is tested, intentional, supported behavior — not
+evidence of a resolver malfunction.** The resolver injecting AgentY's
+`GITHUB_TOKEN` from "AgentX GitHub" is exactly what it's supposed to do
+*given that a link from AgentY to that account exists*.
+
+What this confirmation actually establishes, then, is narrower than §5
+concluded: the shared-account link is real (not a AgentY-side
+misobservation), but **whether that specific AgentY→"AgentX GitHub" link
+is a deliberate shared-credential setup or a mistaken/accidental binding is
+still completely open** — and that's the actual thing worth investigating
+next, not the resolver's binding-enforcement logic (which, per the code
+above, is working as designed). Concretely: check `db_agent_identity_links`
+for when/how that specific row was created, and by what — a manual UI
+action, a seeding/migration script, or something else — rather than
+assuming a code fix is needed in `identity/resolver/`.

--- a/docs/retro/retro-agentmux-corp-pr5-shared-gh-cli-session-misattribution-2026-08-24.md
+++ b/docs/retro/retro-agentmux-corp-pr5-shared-gh-cli-session-misattribution-2026-08-24.md
@@ -1,6 +1,6 @@
 # Retro: agentmux-corp PR #5 opened under AgentY's GitHub identity instead of AgentX's
 
-**Date:** 2026-08-24
+**Date:** 2026-08-24 (confirmation added 2026-08-25 by AgentX — see §7)
 **Owner:** AgentY
 **Area:** `gh` CLI authentication — leading hypothesis (§2a, added after
 Codex's review of the PR shipping this retro correctly challenged the
@@ -234,3 +234,43 @@ not one, per §2/§2a — don't collapse them:
   `agentmux-corp` PR from AgentX —
   `gh pr view <n> --repo agentmuxai/agentmux-corp --json author --jq .author.login`
   should read `AgentX-asaf`, not `AgentY-asaf`.
+
+## 7. Confirmation (2026-08-25, AgentX) — §2a's missing piece, and it's not a reciprocal pair
+
+Ran the exact check §6 asked for: my own (AgentX's) `IdentityAccounts`
+output, via the same MCP surface AgentY used for theirs.
+
+```json
+{
+  "account_id": "15f7fe0a-7827-4c27-8456-f08da8df9ae5",
+  "name": "AgentX GitHub",
+  "provider": "github",
+  "kind": "api_key",
+  "status": "valid"
+}
+```
+
+**Same `account_id` as the one AgentY found injected into their own shell
+— not a separate, symmetrically-misnamed "AgentY GitHub" entry on my
+side.** §2a's framing ("if AgentX's own identity bindings reciprocally
+include an account bound to AgentY's GitHub credential") assumed a pair of
+mirrored mis-bindings; what's actually there is a **single identity-provider
+account object, named "AgentX GitHub," visible/bound in both agents'
+`IdentityAccounts` lists simultaneously** — arguably a cleaner confirmation
+of a real resolver bug than a symmetric pair would have been, since there's
+no ambiguity about which agent "owns" it by name — it's mine by name, and
+AgentY's environment got it anyway.
+
+One difference from AgentY's observation worth noting: they found the token
+already rejected by GitHub (`401 Unauthorized`) when they checked it on
+2026-08-24. As of this check (2026-08-25), the same account shows
+`status: "valid"` — either rotated/re-validated since, or `status` here
+reflects something other than live GitHub-side validity (not verified
+either way from this agent). Doesn't change the core finding: the same
+account record is reachable from both agent identities, which shouldn't be
+possible if bindings are meant to be exclusive per-agent.
+
+This closes the loop §6 asked for. The actual fix still belongs where §5
+already said — the identity-resolver's account-binding logic
+(`identity/resolver/{inject.rs,provider.rs}`) — not in either agent's own
+`gh` workflow discipline.


### PR DESCRIPTION
## Summary
AgentY's retro (`retro-agentmux-corp-pr5-shared-gh-cli-session-misattribution-2026-08-24.md`) root-caused a PR misattribution to a possible cross-agent identity binding, but needed AgentX's own `IdentityAccounts` output to confirm §2a's hypothesis — that's me, so I ran it.

Confirmed: my own `IdentityAccounts` contains the exact same account (`"AgentX GitHub"`, `account_id: 15f7fe0a-7827-4c27-8456-f08da8df9ae5`) that showed up injected into AgentY's shell as their ambient `GH_TOKEN`. Not a reciprocal pair of mis-bindings as §2a's framing assumed — it's a single identity-provider account object bound to both agent contexts simultaneously.

This confirms it's a real bug in the identity-resolver's account-binding logic (`identity/resolver/{inject.rs,provider.rs}`), not a workflow-discipline issue on either agent's part. Full detail in the new §7 of the retro.

## Test plan
- [x] Doc-only change, no code touched
- [x] Ran the exact verification step the retro's own §6 asked for (`IdentityAccounts` on my own agent identity)

<!-- agentmux:agent_id=agentx -->