### PR TITLE
Manoz@Area54: fix(armory): rename ambient CLAUDE.md block, group External Claude Code files clearly

### DIFF
--- a/.changesets/1787668309-fix-armory-rename-ambient-claude-md-block-group-external-cla-6vq0.md
+++ b/.changesets/1787668309-fix-armory-rename-ambient-claude-md-block-group-external-cla-6vq0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): rename ambient CLAUDE.md block, group External Claude Code files clearly

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -233,21 +233,34 @@ pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
 /// Read-only. Returns the CLAUDE.md at AgentMux's shared Claude provider
 /// config dir (`DataPaths::provider_auth_dir("claude")` — the
 /// `CLAUDE_CONFIG_DIR` a non-identity-bound spawned Claude agent actually
-/// gets, NOT the ambient `~/.claude/CLAUDE.md`) so the Armory Memory tab
-/// can show the operator where their real "highest priority" instructions
-/// actually live. No parameters (the path is fixed, not caller-supplied —
-/// no path-traversal surface) and no write counterpart. See
-/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5.
+/// gets). NOTE: this is Claude Code's own home-relocation path, NOT the
+/// file AgentMux's Global Memory actually composes into — that's
+/// `<agent working_directory>/CLAUDE.md` (or its `AGENTMUX_MEMORY.md`
+/// companion when foreign), written by `agent_config.rs`'s
+/// `write_claude_md_respecting_ownership`, a per-agent path this command
+/// does not cover. This command exists purely to surface a
+/// Claude-Code-managed reference file for operator visibility ("External
+/// Claude Code files" section — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+/// §7 is the main feature this whole spec chain converged on). No
+/// parameters (the path is fixed, not caller-supplied — no
+/// path-traversal surface) and no write counterpart. See
+/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5, §7.
 pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
-/// Read-only. Returns the ambient `~/.claude/CLAUDE.md` — Claude Code's
-/// own global config, read by a host-level Claude Code CLI running
-/// outside AgentMux's `CLAUDE_CONFIG_DIR` isolation (e.g. an external
+/// Read-only. Returns `~/.claude/CLAUDE.md` — Claude Code's own global
+/// config, read by a host-level Claude Code CLI running outside
+/// AgentMux's `CLAUDE_CONFIG_DIR` isolation entirely (e.g. an external
 /// coding-agent harness). Deliberately a SEPARATE command/block from
-/// `getclaudeglobalconfig` (§5's shared-provider-config path) rather than
-/// a replacement — the two paths have different audiences and neither
-/// implies coverage of the other. No parameters, no write counterpart.
-/// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6.
-pub const COMMAND_GET_CLAUDE_AMBIENT_CONFIG: &str = "getclaudeambientconfig";
+/// `getclaudeglobalconfig` above rather than a replacement — the two
+/// paths have different audiences and neither implies coverage of the
+/// other; both are "External Claude Code files" reference displays, not
+/// part of AgentMux's own Global Memory composition (see that command's
+/// doc comment). Renamed from `getclaudeambientconfig` (§7) — "ambient"
+/// already means something else in this codebase (`term:ambient_summary`,
+/// a per-turn activity paraphrase — see `activitySummary.ts`), so this
+/// command/its UI badge dropped the word entirely rather than picking a
+/// second meaning for it. No parameters, no write counterpart. See
+/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
+pub const COMMAND_GET_CLAUDE_HOST_CONFIG: &str = "getclaudehostconfig";
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -12,7 +12,7 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
     COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY, COMMAND_REORDER_GLOBAL_BRAIN,
     COMMAND_UPSERT_SYSTEM_MEMORY, COMMAND_DELETE_SYSTEM_MEMORY,
-    COMMAND_GET_CLAUDE_GLOBAL_CONFIG, COMMAND_GET_CLAUDE_AMBIENT_CONFIG,
+    COMMAND_GET_CLAUDE_GLOBAL_CONFIG, COMMAND_GET_CLAUDE_HOST_CONFIG,
     CommandGetMemoryData, CommandDeleteMemoryData, CommandReorderGlobalBrainData,
 };
 use crate::backend::storage::store::Memory;
@@ -249,17 +249,17 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
-    // ---- Read-only: the ambient ~/.claude/CLAUDE.md — Claude Code's own
-    // global config, read by a host-level CLI outside AgentMux's
-    // CLAUDE_CONFIG_DIR isolation. A SEPARATE block from the one above, not
-    // a replacement — see docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6.
+    // ---- Read-only: ~/.claude/CLAUDE.md — Claude Code's own global
+    // config, read by a host-level CLI outside AgentMux's CLAUDE_CONFIG_DIR
+    // isolation. A SEPARATE block from the one above, not a replacement —
+    // see docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
     engine.register_handler(
-        COMMAND_GET_CLAUDE_AMBIENT_CONFIG,
+        COMMAND_GET_CLAUDE_HOST_CONFIG,
         Box::new(move |_data, _ctx| {
             Box::pin(async move {
                 let claude_dir = crate::backend::base::get_home_dir().join(".claude");
                 let result = read_claude_global_config(&claude_dir)
-                    .map_err(|e| format!("getclaudeambientconfig: {e}"))?;
+                    .map_err(|e| format!("getclaudehostconfig: {e}"))?;
                 Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
             })
         }),
@@ -274,8 +274,8 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// identical `~/.agentmux/shared/providers/claude` fallback when
 /// `DataPaths::from_env()` fails — so the path shown here is genuinely the
 /// one AgentMux itself uses when launching a Claude agent, not a guess.
-/// codex P1, PR #2794: the original version read the ambient
-/// `~/.claude/CLAUDE.md`, which `SPEC_PROVIDER_ISOLATION_2026_06_20.md`
+/// codex P1, PR #2794: the original version read `~/.claude/CLAUDE.md`
+/// directly, which `SPEC_PROVIDER_ISOLATION_2026_06_20.md`
 /// §5b confirms is NOT what a `CLAUDE_CONFIG_DIR`-redirected spawned agent
 /// actually loads as its "user CLAUDE.md" — `CLAUDE_CONFIG_DIR` relocates
 /// Claude Code's entire home, `<CLAUDE_CONFIG_DIR>/CLAUDE.md` included.
@@ -316,10 +316,10 @@ fn read_claude_global_config(claude_dir: &std::path::Path) -> std::io::Result<Cl
 }
 
 // Covers both getclaudeglobalconfig (resolve_shared_claude_provider_dir)
-// and getclaudeambientconfig (~/.claude) — both handlers call this same
+// and getclaudehostconfig (~/.claude) — both handlers call this same
 // generic function against different directories, so exists/missing/
 // empty-file coverage here applies to both call sites. See
-// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6.
+// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
 #[cfg(test)]
 mod claude_global_config_tests {
     use super::*;

--- a/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+++ b/docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
@@ -6,10 +6,19 @@ out to be the wrong one — see §5 for the corrected design (the CLAUDE.md
 at AgentMux's shared Claude provider config dir, not the ambient
 `~/.claude/CLAUDE.md`). Filename kept as-is since it's already referenced
 by the PR/commits; read §5 for what actually shipped. **§6 (2026-08-25)
-re-adds the ambient file after all — as a SECOND, separately-labeled
-block alongside §5's, not a replacement.** Current shipped/target state:
-Global Memory shows TWO independent read-only blocks — the shared
-provider config (§5) and the ambient host CLI config (§6).
+re-adds that file after all — as a SECOND, separately-labeled block
+alongside §5's, not a replacement. §7 (2026-08-25, same day) renames
+"ambient"→"host CLI config" (real term collision with
+`term:ambient_summary`), corrects an architecture claim §6 got wrong
+(working-directory `CLAUDE.md` files ARE part of AgentMux's spawned-agent
+system — see §7.2), and reframes both blocks as "External Claude Code
+files" — confirmed to be the actual point of this whole spec chain, not
+an incidental addition.** Current shipped/target state: Global Memory's
+"External Claude Code files" section shows TWO independent read-only
+blocks — the shared provider config (§5) and the host CLI config (§6,
+§7.1) — neither of which is, or claims to be, AgentMux's own Global
+Memory composition target (that's `<agent working_directory>/CLAUDE.md`,
+§7.2, already previewed via "Combined preview" elsewhere in the tab).
 
 ---
 
@@ -300,11 +309,12 @@ or be missing independently without affecting the other's rendering.
 **Out of scope (same reasoning as §3, re-affirmed after the explicit
 choice above):** per-identity `CLAUDE_CONFIG_DIR` dirs (still a known,
 flagged gap — would require enumerating every identity, a materially
-larger feature); this harness's own working-directory files (not part of
-AgentMux's spawned-agent system at all, would misrepresent what the
-feature does the same way the original §1-§4 design did before §5's
-correction); any equivalent file for other providers (still no evidence
-one exists the way `~/.claude/CLAUDE.md` does for Claude Code).
+larger feature); this harness's own working-directory files (**INCORRECT
+CLAIM — see §7**: these files are NOT "unrelated to AgentMux's
+spawned-agent system"; `<agent working_directory>/CLAUDE.md` is exactly
+where AgentMux's own Global Memory composition writes to); any
+equivalent file for other providers (still no evidence one exists the
+way `~/.claude/CLAUDE.md` does for Claude Code).
 
 **Test plan (additive, mirrors §4 exactly for the new path):**
 - [ ] Rust: `getclaudeambientconfig` against a `HOME` pointed at a tempdir
@@ -318,3 +328,117 @@ one exists the way `~/.claude/CLAUDE.md` does for Claude Code).
       textarea/button in either).
 - [ ] Manual (`task dev`): confirm both blocks render, each with its own
       correct path/content/empty-state, positioned adjacently.
+
+---
+
+## 7. Third revision (2026-08-25) — terminology cleanup, architecture correction, and the actual point of this whole spec chain
+
+**The ask, verbatim, across a conversation that stepped back and re-derived
+the model from the code instead of prose:**
+
+> ambient already means the tokens used for descriptive information in
+> the application .. can we clean up the terminology? [...] Global Memory
+> are the files all agents read. Personal memory are the files the agent
+> reads. is that clear? [...] right .. but that isnt really accurate when
+> you say "composed into every spawned..." because there are additional
+> global ~/.claude/CLAUDE.md files .. do you see that disconnect? [...]
+> so the external claude code files need to appear in Global Memory, in
+> fact, that's the main feature
+
+Three separate corrections came out of this, in order:
+
+### 7.1 "Ambient" was a real terminology collision — renamed
+
+`term:ambient_summary` (`frontend/app/store/activitySummary.ts`) already
+means "the Haiku-derived per-turn activity paraphrase shown as a pane's
+status text" — an established, unrelated concept. (There is also a
+`crate::ambient` "Ambient Model Call gateway" backend module — a *third*
+distinct meaning.) Naming a CLAUDE.md display block "ambient" reused an
+already-loaded word for something unrelated. Renamed throughout:
+
+| Old | New |
+|---|---|
+| `getclaudeambientconfig` (RPC command) | `getclaudehostconfig` |
+| `COMMAND_GET_CLAUDE_AMBIENT_CONFIG` | `COMMAND_GET_CLAUDE_HOST_CONFIG` |
+| `GetClaudeAmbientConfigCommand` | `GetClaudeHostConfigCommand` |
+| `claudeAmbientConfigAtom` / `fetchClaudeAmbientConfig` | `claudeHostConfigAtom` / `fetchClaudeHostConfig` |
+| Badge: "Claude Code — host CLI config (ambient)" | "Claude Code — host CLI config" |
+
+No behavior change — same RPC shape, same resolved path
+(`~/.claude/CLAUDE.md`), same read-once-at-mount/independent-atom
+semantics as §6. Pure rename.
+
+### 7.2 Architecture correction — §6's "out of scope" claim about working-directory files was WRONG
+
+§6 claimed this coding-agent harness's own working-directory
+`CLAUDE.md`/`AGENTMUX_MEMORY.md` files were "not part of AgentMux's
+spawned-agent system at all." **Traced the actual code — false:**
+
+- `agent_open.rs:288-292`: a spawned agent's working directory defaults
+  to `~/.agentmux/agents/<agent-slug>/` when no explicit project
+  directory is configured (the common case).
+- `agent_open.rs:851` calls
+  `agent_config::write_claude_md_respecting_ownership(base_path, ...)`
+  where `base_path` is exactly that working directory.
+- That function (`agent_config.rs:1106`) writes AgentMux's own composed
+  Global Memory content (system tier + `is_global` bundles + the
+  launching agent's own bundle instructions + skills index) directly
+  into `<working_dir>/CLAUDE.md` — UNLESS a `CLAUDE.md` already exists
+  there without the `<!-- agentmux:managed-claude-md -->` marker
+  (`CLAUDE_MD_MANAGED_MARKER`, `agent_config.rs:904`), in which case it
+  backs off to a single `@import` line and puts the actual content in a
+  companion `<working_dir>/.claude/AGENTMUX_MEMORY.md` instead
+  (`SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md`).
+
+**So `<agent working_directory>/CLAUDE.md` (or its `AGENTMUX_MEMORY.md`
+companion) is the actual, primary answer to "what does Global Memory
+compose into" — a THIRD file location, distinct from both blocks §5/§6
+show (which only cover Claude Code's own `CLAUDE_CONFIG_DIR`-relocated
+*home*/auth paths, never AgentMux's composition target).** This also
+resolves the loose thread §5 explicitly left open ("whatever separate
+mechanism surfaced that file's content into this agent's own context...
+is not resolved here") — that mechanism is exactly this one.
+
+**Consequence:** neither §5's nor §6's block is, or was ever meant to be,
+a preview of "what Global Memory composes into." Both are — and have
+always actually been — reference displays of files *Claude Code itself*
+manages, unrelated to the composition pipeline. The existing
+`previewAtom` (`formatGlobalBrainBlock(sectionsAtom())`, rendered as
+"Combined preview" in the same tab) already shows the real composed
+content accurately, computed client-side from the same bundle data — and
+is representative for every agent equally, since composition is
+per-launch, not per-file-path. **No third block was added for the
+working-directory file** — it's per-agent (path varies with each agent's
+own working directory), so a single fixed-path block in this *global*
+tab would misrepresent it exactly the way §1-§4 and §6 almost did twice
+already. If per-agent visibility is ever wanted, that's a different,
+agent-scoped UI — not a fix to this tab.
+
+### 7.3 Reframe — these two blocks are "External Claude Code files," and that section IS the main feature
+
+Confirmed directly: showing files Claude Code itself manages (as opposed
+to anything AgentMux composes) is not incidental to this spec chain —
+it's the actual point of it. Reflecting that:
+
+- New wrapper section, `global-brain-external-files` /
+  `global-brain-external-files-heading`, rendered only when at least one
+  of the two blocks has data: **"External Claude Code files — managed by
+  Claude Code itself, not AgentMux. Shown for visibility only; not part
+  of the Global Memory composed above."**
+- Each block gains a visible one-line caption (`global-brain-machine-config-caption`,
+  not just a hover tooltip): shared provider config → *"What a default
+  spawned agent's Claude Code auth/home uses."*; host CLI config →
+  *"What Claude Code uses outside AgentMux entirely."*
+- Rust/frontend doc comments on both RPC commands updated to state
+  plainly that neither is the Global Memory composition target, pointing
+  at `<working_dir>/CLAUDE.md` instead (§7.2).
+
+**Test plan (additive):**
+- [ ] Frontend: both blocks render under the shared
+      `global-brain-external-files` heading; the heading only appears
+      once at least one atom has data.
+- [ ] Frontend: all prior §4/§6 test names/mocks renamed
+      ambient→host-config, behavior unchanged.
+- [ ] Rust: no new coverage needed — `getclaudehostconfig` is a rename of
+      an already-tested handler (`read_claude_global_config` is
+      untouched); confirmed via `cargo check` + full suite re-run.

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -71,10 +71,13 @@ export const MemoryApi = {
     // Read-only. Returns the CLAUDE.md at AgentMux's shared Claude
     // provider config dir (~/.agentmux/shared/providers/claude/CLAUDE.md
     // via DataPaths::provider_auth_dir — the CLAUDE_CONFIG_DIR a
-    // non-identity-bound spawned Claude agent actually gets), NOT the
-    // ambient ~/.claude/CLAUDE.md — see
-    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5. No
-    // parameters, no write counterpart.
+    // non-identity-bound spawned Claude agent actually gets). NOTE: this
+    // is Claude Code's own home-relocation path, NOT the file AgentMux's
+    // Global Memory actually composes into (that's
+    // <agent working_directory>/CLAUDE.md, a per-agent path this doesn't
+    // cover) — this is an "External Claude Code files" reference display
+    // only. See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+    // §5, §7. No parameters, no write counterpart.
     GetClaudeGlobalConfigCommand(
         client: RpcClient,
         data: Record<string, never> = {},
@@ -83,18 +86,22 @@ export const MemoryApi = {
         return client.rpcCall("getclaudeglobalconfig", data, opts);
     },
 
-    // Read-only. Returns the ambient ~/.claude/CLAUDE.md — Claude Code's
-    // own global config, read by a host-level CLI outside AgentMux's
+    // Read-only. Returns ~/.claude/CLAUDE.md — Claude Code's own global
+    // config, read by a host-level CLI outside AgentMux's
     // CLAUDE_CONFIG_DIR isolation. A SEPARATE block from
-    // GetClaudeGlobalConfigCommand above, not a replacement — see
-    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6. No
-    // parameters, no write counterpart.
-    GetClaudeAmbientConfigCommand(
+    // GetClaudeGlobalConfigCommand above, not a replacement — both are
+    // "External Claude Code files" reference displays, not part of
+    // AgentMux's own Global Memory composition. Renamed from
+    // GetClaudeAmbientConfigCommand — "ambient" already means something
+    // else in this codebase (term:ambient_summary, activitySummary.ts).
+    // See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
+    // No parameters, no write counterpart.
+    GetClaudeHostConfigCommand(
         client: RpcClient,
         data: Record<string, never> = {},
         opts?: RpcOpts,
     ): Promise<{ path: string; content: string | null; exists: boolean }> {
-        return client.rpcCall("getclaudeambientconfig", data, opts);
+        return client.rpcCall("getclaudehostconfig", data, opts);
     },
 
     NativeMemoryListCommand(client: RpcClient, data: { agent_id: string }, opts?: RpcOpts): Promise<NativeMemoryListResult> {

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -1,10 +1,11 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Covers the read-only shared-provider-config display in
-// GlobalBrainManager (the CLAUDE.md at AgentMux's shared Claude provider
-// config dir, NOT the ambient ~/.claude/CLAUDE.md — codex P1, PR #2794).
-// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4.
+// Covers the read-only "External Claude Code files" displays in
+// GlobalBrainManager (files Claude Code itself manages, NOT part of
+// AgentMux's own Global Memory composition — codex P1, PR #2794; renamed
+// from "ambient" in PR follow-up, see §7 for why).
+// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4, §7.
 
 import { cleanup, render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -15,7 +16,7 @@ const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({
     content: null,
     exists: false,
 });
-const getClaudeAmbientConfigMock = vi.fn().mockResolvedValue({
+const getClaudeHostConfigMock = vi.fn().mockResolvedValue({
     path: "/home/user/.claude/CLAUDE.md",
     content: null,
     exists: false,
@@ -24,7 +25,7 @@ vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
         GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
-        GetClaudeAmbientConfigCommand: (...args: unknown[]) => getClaudeAmbientConfigMock(...args),
+        GetClaudeHostConfigCommand: (...args: unknown[]) => getClaudeHostConfigMock(...args),
     },
 }));
 
@@ -39,8 +40,8 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
-        getClaudeAmbientConfigMock.mockClear();
-        getClaudeAmbientConfigMock.mockResolvedValue({
+        getClaudeHostConfigMock.mockClear();
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
             content: null,
             exists: false,
@@ -64,7 +65,7 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
         expect(screen.getByText("/home/user/.agentmux/shared/providers/claude/CLAUDE.md")).toBeInTheDocument();
         expect(screen.getByText("# Global rules")).toBeInTheDocument();
-        // Scoped to this block — the sibling ambient block legitimately
+        // Scoped to this block — the sibling host-config block legitimately
         // renders its own "No file..." empty state under the beforeEach
         // default, which is not this block's concern.
         const block = screen.getByText("Claude Code — shared provider config").closest(".global-brain-machine-config");
@@ -77,12 +78,12 @@ describe("GlobalBrainManager shared-provider-config block", () => {
             content: null,
             exists: false,
         });
-        // Sibling ambient block set to exists:true so only this block's
+        // Sibling host-config block set to exists:true so only this block's
         // empty state renders — avoids a duplicate-text ambiguity when
         // both blocks are empty simultaneously.
-        getClaudeAmbientConfigMock.mockResolvedValue({
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
-            content: "# Ambient rules\n",
+            content: "# Host CLI rules\n",
             exists: true,
         });
         render(() => <GlobalBrainManager />);
@@ -106,38 +107,39 @@ describe("GlobalBrainManager shared-provider-config block", () => {
     });
 });
 
-// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6 — a
+// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6/§7 — a
 // SEPARATE block, independently fetched, rendered alongside the
-// shared-provider-config block above.
-describe("GlobalBrainManager ambient-config block", () => {
+// shared-provider-config block above, under the same "External Claude
+// Code files" heading.
+describe("GlobalBrainManager host-config block", () => {
     beforeEach(() => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
-        getClaudeAmbientConfigMock.mockClear();
+        getClaudeHostConfigMock.mockClear();
     });
 
     test("renders nothing before the fetch resolves", () => {
-        getClaudeAmbientConfigMock.mockReturnValue(new Promise(() => {})); // never resolves within this test
+        getClaudeHostConfigMock.mockReturnValue(new Promise(() => {})); // never resolves within this test
         render(() => <GlobalBrainManager />);
-        expect(screen.queryByText("Claude Code — host CLI config (ambient)")).not.toBeInTheDocument();
+        expect(screen.queryByText("Claude Code — host CLI config")).not.toBeInTheDocument();
     });
 
     test("renders the path and content when the file exists", async () => {
-        getClaudeAmbientConfigMock.mockResolvedValue({
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
-            content: "# Ambient rules\n",
+            content: "# Host CLI rules\n",
             exists: true,
         });
         render(() => <GlobalBrainManager />);
 
-        expect(await screen.findByText("Claude Code — host CLI config (ambient)")).toBeInTheDocument();
+        expect(await screen.findByText("Claude Code — host CLI config")).toBeInTheDocument();
         expect(screen.getByText("/home/user/.claude/CLAUDE.md")).toBeInTheDocument();
-        expect(screen.getByText("# Ambient rules")).toBeInTheDocument();
+        expect(screen.getByText("# Host CLI rules")).toBeInTheDocument();
     });
 
     test("renders the empty-state fallback when no file exists at that path", async () => {
-        getClaudeAmbientConfigMock.mockResolvedValue({
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
             content: null,
             exists: false,
@@ -152,20 +154,20 @@ describe("GlobalBrainManager ambient-config block", () => {
         });
         render(() => <GlobalBrainManager />);
 
-        const block = (await screen.findByText("Claude Code — host CLI config (ambient)")).closest(".global-brain-machine-config");
+        const block = (await screen.findByText("Claude Code — host CLI config")).closest(".global-brain-machine-config");
         expect(block?.querySelector(".global-brain-machine-config-empty")?.textContent).toBe("No file at this path yet.");
     });
 
     test("is read-only — no textarea or save affordance inside the block", async () => {
-        getClaudeAmbientConfigMock.mockResolvedValue({
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
-            content: "# Ambient rules\n",
+            content: "# Host CLI rules\n",
             exists: true,
         });
         render(() => <GlobalBrainManager />);
-        await screen.findByText("Claude Code — host CLI config (ambient)");
+        await screen.findByText("Claude Code — host CLI config");
 
-        const block = screen.getByText("Claude Code — host CLI config (ambient)").closest(".global-brain-machine-config");
+        const block = screen.getByText("Claude Code — host CLI config").closest(".global-brain-machine-config");
         expect(block?.querySelector("textarea")).toBeNull();
         expect(block?.querySelector("button")).toBeNull();
     });
@@ -176,14 +178,33 @@ describe("GlobalBrainManager ambient-config block", () => {
             content: "# Shared rules\n",
             exists: true,
         });
-        getClaudeAmbientConfigMock.mockResolvedValue({
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
-            content: "# Ambient rules\n",
+            content: "# Host CLI rules\n",
             exists: true,
         });
         render(() => <GlobalBrainManager />);
 
         expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
-        expect(await screen.findByText("Claude Code — host CLI config (ambient)")).toBeInTheDocument();
+        expect(await screen.findByText("Claude Code — host CLI config")).toBeInTheDocument();
+    });
+
+    test("both blocks render under the shared 'External Claude Code files' heading", async () => {
+        getClaudeGlobalConfigMock.mockResolvedValue({
+            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
+            content: "# Shared rules\n",
+            exists: true,
+        });
+        getClaudeHostConfigMock.mockResolvedValue({
+            path: "/home/user/.claude/CLAUDE.md",
+            content: "# Host CLI rules\n",
+            exists: true,
+        });
+        render(() => <GlobalBrainManager />);
+
+        const heading = await screen.findByText(/External Claude Code files/);
+        const wrapper = heading.closest(".global-brain-external-files");
+        expect(wrapper?.textContent).toContain("Claude Code — shared provider config");
+        expect(wrapper?.textContent).toContain("Claude Code — host CLI config");
     });
 });

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -146,62 +146,72 @@ export const GlobalBrainManager = (): JSX.Element => {
                 <div class="global-brain-error">{model.errorAtom()}</div>
             </Show>
 
-            {/* The CLAUDE.md a spawned Claude agent's CLAUDE_CONFIG_DIR
-                actually points at by default — hand-maintained, read-only,
-                not the same thing as this Global Memory tab. Shown first so
-                an operator sees the full picture before the "here's where
-                you'd add AgentMux's own policy" section below. codex P1, PR
-                #2794: NOT the ambient ~/.claude/CLAUDE.md — that file isn't
-                what a CLAUDE_CONFIG_DIR-isolated agent loads. See
-                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5. */}
-            <Show when={model.claudeGlobalConfigAtom()}>
-                {(cfg) => (
-                    <div class="global-brain-machine-config">
-                        <div class="global-brain-machine-config-header">
-                            <span
-                                class="global-brain-machine-config-badge"
-                                title="Hand-maintained on disk, not managed by AgentMux. Read by default-provider Claude agents (identity-bound agents use a separate, per-identity config dir not shown here)."
-                            >
-                                Claude Code — shared provider config
-                            </span>
-                            <code class="global-brain-machine-config-path">{cfg().path}</code>
-                        </div>
-                        <Show
-                            when={cfg().exists}
-                            fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
-                        >
-                            <pre class="global-brain-machine-config-content">{cfg().content}</pre>
-                        </Show>
-                    </div>
-                )}
-            </Show>
+            {/* "External Claude Code files" — read-only reference displays
+                of files Claude Code itself manages, NOT part of AgentMux's
+                own Global Memory composition (that's
+                <agent working_directory>/CLAUDE.md, a per-agent path
+                already previewed accurately above via the "Combined
+                preview"). This section is the main feature this spec chain
+                converged on — an operator explicitly asked to be able to
+                peruse these files here. See
+                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7. */}
+            <Show when={model.claudeGlobalConfigAtom() || model.claudeHostConfigAtom()}>
+                <div class="global-brain-external-files">
+                    <p class="global-brain-external-files-heading">
+                        External Claude Code files — managed by Claude Code itself, not AgentMux. Shown for
+                        visibility only; not part of the Global Memory composed above.
+                    </p>
 
-            {/* The ambient ~/.claude/CLAUDE.md — Claude Code's own global
-                config, read by a host-level CLI outside AgentMux's
-                CLAUDE_CONFIG_DIR isolation (e.g. an external coding-agent
-                harness). A SEPARATE block from the one above, not a
-                replacement — a spawned in-app agent does NOT read this
-                file. See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6. */}
-            <Show when={model.claudeAmbientConfigAtom()}>
-                {(cfg) => (
-                    <div class="global-brain-machine-config">
-                        <div class="global-brain-machine-config-header">
-                            <span
-                                class="global-brain-machine-config-badge"
-                                title="Claude Code's own global config on this machine — read by a host-level Claude Code CLI running outside AgentMux's isolation. A spawned in-app agent does NOT read this file; see the shared provider config block above for what it actually reads."
-                            >
-                                Claude Code — host CLI config (ambient)
-                            </span>
-                            <code class="global-brain-machine-config-path">{cfg().path}</code>
-                        </div>
-                        <Show
-                            when={cfg().exists}
-                            fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
-                        >
-                            <pre class="global-brain-machine-config-content">{cfg().content}</pre>
-                        </Show>
-                    </div>
-                )}
+                    <Show when={model.claudeGlobalConfigAtom()}>
+                        {(cfg) => (
+                            <div class="global-brain-machine-config">
+                                <div class="global-brain-machine-config-header">
+                                    <span
+                                        class="global-brain-machine-config-badge"
+                                        title="Hand-maintained on disk, not managed by AgentMux. Read by default-provider Claude agents (identity-bound agents use a separate, per-identity config dir not shown here)."
+                                    >
+                                        Claude Code — shared provider config
+                                    </span>
+                                    <code class="global-brain-machine-config-path">{cfg().path}</code>
+                                </div>
+                                <p class="global-brain-machine-config-caption">
+                                    What a default spawned agent's Claude Code auth/home uses.
+                                </p>
+                                <Show
+                                    when={cfg().exists}
+                                    fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+                                >
+                                    <pre class="global-brain-machine-config-content">{cfg().content}</pre>
+                                </Show>
+                            </div>
+                        )}
+                    </Show>
+
+                    <Show when={model.claudeHostConfigAtom()}>
+                        {(cfg) => (
+                            <div class="global-brain-machine-config">
+                                <div class="global-brain-machine-config-header">
+                                    <span
+                                        class="global-brain-machine-config-badge"
+                                        title="Claude Code's own global config on this machine — read by a host-level Claude Code CLI running outside AgentMux's isolation. A spawned in-app agent does NOT read this file; see the shared provider config block above for what it actually reads."
+                                    >
+                                        Claude Code — host CLI config
+                                    </span>
+                                    <code class="global-brain-machine-config-path">{cfg().path}</code>
+                                </div>
+                                <p class="global-brain-machine-config-caption">
+                                    What Claude Code uses outside AgentMux entirely.
+                                </p>
+                                <Show
+                                    when={cfg().exists}
+                                    fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+                                >
+                                    <pre class="global-brain-machine-config-content">{cfg().content}</pre>
+                                </Show>
+                            </div>
+                        )}
+                    </Show>
+                </div>
             </Show>
 
             {/* System tier — pinned above ordinary sections, always injected

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -70,12 +70,12 @@ describe("formatGlobalBrainBlock", () => {
 // frontend/app/view/memory/memory-model.test.ts.
 const listMemoriesMock = vi.fn().mockResolvedValue([]);
 const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
-const getClaudeAmbientConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
+const getClaudeHostConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
         GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
-        GetClaudeAmbientConfigCommand: (...args: unknown[]) => getClaudeAmbientConfigMock(...args),
+        GetClaudeHostConfigCommand: (...args: unknown[]) => getClaudeHostConfigMock(...args),
     },
 }));
 
@@ -85,8 +85,8 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
         getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
-        getClaudeAmbientConfigMock.mockClear();
-        getClaudeAmbientConfigMock.mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
+        getClaudeHostConfigMock.mockClear();
+        getClaudeHostConfigMock.mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
     });
 
     test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {
@@ -179,46 +179,48 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         expect(model.errorAtom()).toBeNull();
     });
 
-    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6 — the
-    // ambient block is a SEPARATE atom/fetch from claudeGlobalConfigAtom.
-    test("claudeAmbientConfigAtom starts null and populates from GetClaudeAmbientConfigCommand", async () => {
-        getClaudeAmbientConfigMock.mockResolvedValue({
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6/§7 —
+    // the host CLI config block is a SEPARATE atom/fetch from
+    // claudeGlobalConfigAtom (renamed from "ambient" — that word already
+    // means something else in this codebase, term:ambient_summary).
+    test("claudeHostConfigAtom starts null and populates from GetClaudeHostConfigCommand", async () => {
+        getClaudeHostConfigMock.mockResolvedValue({
             path: "/home/user/.claude/CLAUDE.md",
-            content: "# Ambient rules\n",
+            content: "# Host CLI rules\n",
             exists: true,
         });
         const { GlobalBrainViewModel } = await import("./global-brain-model");
         const model = new GlobalBrainViewModel();
 
-        expect(model.claudeAmbientConfigAtom()).toBeNull();
+        expect(model.claudeHostConfigAtom()).toBeNull();
         await Promise.resolve();
         await Promise.resolve();
 
-        expect(model.claudeAmbientConfigAtom()).toEqual({
+        expect(model.claudeHostConfigAtom()).toEqual({
             path: "/home/user/.claude/CLAUDE.md",
-            content: "# Ambient rules\n",
+            content: "# Host CLI rules\n",
             exists: true,
         });
     });
 
-    test("claudeAmbientConfigAtom stays null (not an error) when the fetch rejects", async () => {
-        getClaudeAmbientConfigMock.mockRejectedValue(new Error("boom"));
+    test("claudeHostConfigAtom stays null (not an error) when the fetch rejects", async () => {
+        getClaudeHostConfigMock.mockRejectedValue(new Error("boom"));
         const { GlobalBrainViewModel } = await import("./global-brain-model");
         const model = new GlobalBrainViewModel();
         await Promise.resolve();
         await Promise.resolve();
 
-        expect(model.claudeAmbientConfigAtom()).toBeNull();
+        expect(model.claudeHostConfigAtom()).toBeNull();
         expect(model.errorAtom()).toBeNull();
     });
 
-    test("a rejected ambient fetch does not clear or block the shared-provider-config atom, and vice versa", async () => {
+    test("a rejected host-config fetch does not clear or block the shared-provider-config atom, and vice versa", async () => {
         getClaudeGlobalConfigMock.mockResolvedValue({
             path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Shared rules\n",
             exists: true,
         });
-        getClaudeAmbientConfigMock.mockRejectedValue(new Error("boom"));
+        getClaudeHostConfigMock.mockRejectedValue(new Error("boom"));
         const { GlobalBrainViewModel } = await import("./global-brain-model");
         const model = new GlobalBrainViewModel();
         await Promise.resolve();
@@ -229,7 +231,7 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
             content: "# Shared rules\n",
             exists: true,
         });
-        expect(model.claudeAmbientConfigAtom()).toBeNull();
+        expect(model.claudeHostConfigAtom()).toBeNull();
     });
 });
 

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -153,6 +153,14 @@ export class GlobalBrainViewModel {
      *  to" callout rather than silently omitted. */
     noFileProvidersAtom: Accessor<string[]>;
 
+    // Both signals below back the "External Claude Code files" section —
+    // read-only reference displays of files Claude Code itself manages,
+    // NOT the file AgentMux's own Global Memory actually composes into
+    // (that's <agent working_directory>/CLAUDE.md, a per-agent path
+    // neither of these covers — already previewed accurately via
+    // previewAtom above). See
+    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7.
+
     private _claudeGlobalConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
     /** The CLAUDE.md at AgentMux's shared Claude provider config dir — the
      *  path a spawned Claude agent's CLAUDE_CONFIG_DIR points at by
@@ -160,27 +168,26 @@ export class GlobalBrainViewModel {
      *  covered here). Hand-maintained, independent of AgentMux's own
      *  Global Memory. `null` until the fetch resolves; fetched once at
      *  construction, not re-fetched on `memories:changed` (nothing in this
-     *  app can write to this file, so there's no event to react to).
-     *  NOT the ambient ~/.claude/CLAUDE.md — codex P1, PR #2794: that file
-     *  isn't what a CLAUDE_CONFIG_DIR-isolated spawned agent actually
-     *  loads. See
+     *  app can write to this file, so there's no event to react to). See
      *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5. */
     claudeGlobalConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
         this._claudeGlobalConfig[0];
     private setClaudeGlobalConfig = this._claudeGlobalConfig[1];
 
-    private _claudeAmbientConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
-    /** The ambient ~/.claude/CLAUDE.md — Claude Code's own global config,
-     *  read by a host-level Claude Code CLI running outside AgentMux's
+    private _claudeHostConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
+    /** ~/.claude/CLAUDE.md — Claude Code's own global config, read by a
+     *  host-level Claude Code CLI running outside AgentMux's
      *  CLAUDE_CONFIG_DIR isolation (e.g. an external coding-agent
      *  harness). A spawned in-app Claude agent does NOT read this file —
      *  see claudeGlobalConfigAtom above for what it actually reads.
      *  Independent atom, independent fetch: neither block's success or
-     *  failure affects the other. See
-     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6. */
-    claudeAmbientConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
-        this._claudeAmbientConfig[0];
-    private setClaudeAmbientConfig = this._claudeAmbientConfig[1];
+     *  failure affects the other. Named claudeHostConfigAtom, not
+     *  "ambient" — that word already means something else in this
+     *  codebase (term:ambient_summary, activitySummary.ts). See
+     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7. */
+    claudeHostConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
+        this._claudeHostConfig[0];
+    private setClaudeHostConfig = this._claudeHostConfig[1];
 
     constructor() {
         this.sectionsAtom = createMemo(() =>
@@ -212,7 +219,7 @@ export class GlobalBrainViewModel {
         );
         void this.refresh();
         void this.fetchClaudeGlobalConfig();
-        void this.fetchClaudeAmbientConfig();
+        void this.fetchClaudeHostConfig();
     }
 
     /** Fetches the shared Claude provider config's CLAUDE.md once. Failure
@@ -231,14 +238,14 @@ export class GlobalBrainViewModel {
         }
     }
 
-    /** Fetches the ambient ~/.claude/CLAUDE.md once. Same silent-failure
-     *  and read-once-at-mount reasoning as fetchClaudeGlobalConfig above —
+    /** Fetches ~/.claude/CLAUDE.md once. Same silent-failure and
+     *  read-once-at-mount reasoning as fetchClaudeGlobalConfig above —
      *  independent of it, so a failure here doesn't touch
      *  claudeGlobalConfigAtom or the ordinary Global Memory sections. */
-    private async fetchClaudeAmbientConfig(): Promise<void> {
+    private async fetchClaudeHostConfig(): Promise<void> {
         try {
-            const cfg = await RpcApi.GetClaudeAmbientConfigCommand(TabRpcClient, {});
-            this.setClaudeAmbientConfig(cfg);
+            const cfg = await RpcApi.GetClaudeHostConfigCommand(TabRpcClient, {});
+            this.setClaudeHostConfig(cfg);
         } catch {
             // Silent — see doc comment above.
         }

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -45,7 +45,22 @@
     font-size: var(--text-sm);
 }
 
-// ── Machine-wide config (read-only — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md) ──
+// ── External Claude Code files (read-only — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7) ──
+// Files Claude Code itself manages, NOT part of AgentMux's own Global
+// Memory composition (that's <agent working_directory>/CLAUDE.md,
+// previewed above via the "Combined preview" — a per-agent path this
+// section does not represent).
+
+.global-brain-external-files {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.global-brain-external-files-heading {
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+}
 
 .global-brain-machine-config {
     display: flex;
@@ -79,6 +94,12 @@
     font-size: var(--text-xs);
     color: var(--secondary-text-color);
     word-break: break-all;
+}
+
+.global-brain-machine-config-caption {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
 }
 
 .global-brain-machine-config-empty {


### PR DESCRIPTION
## Summary
Follow-up to #2797 based on direct feedback on the terminology and framing.

- **Real term collision, fixed:** "ambient" already means something else in this codebase (`term:ambient_summary` — the per-turn activity-summary tokens, `activitySummary.ts`; there's also an unrelated `crate::ambient` "Ambient Model Call gateway" backend module). Renamed end-to-end: `getclaudeambientconfig` -> `getclaudehostconfig` (RPC command, Rust constant, frontend wrapper, atom, all tests). Badge text: "Claude Code — host CLI config (ambient)" -> "Claude Code — host CLI config".
- **Architecture claim corrected:** #2797's spec claimed a coding-agent harness's own working-directory `CLAUDE.md` files are "not part of AgentMux's spawned-agent system at all." Traced the actual code — that's wrong. `agent_open.rs:288-292` defaults a spawned agent's working directory to `~/.agentmux/agents/<slug>/`, and `agent_open.rs:851` -> `agent_config.rs`'s `write_claude_md_respecting_ownership` writes AgentMux's own composed Global Memory content directly into `<working_dir>/CLAUDE.md` (or its `AGENTMUX_MEMORY.md` companion when foreign). That's a third file location, distinct from both blocks in this tab — neither of which is, or was ever meant to be, a preview of AgentMux's actual composition target (that's already shown accurately via the existing "Combined preview").
- **Reframed as the actual point of the feature, confirmed directly:** grouped both blocks under a new "External Claude Code files" heading — "managed by Claude Code itself, not AgentMux. Shown for visibility only; not part of the Global Memory composed above." — with a visible one-line caption per block (not just a hover tooltip).
- Full writeup in `docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md` §7, including a correction note left in §6 pointing at the fix (not rewriting history).

## Test plan
- [x] `cargo test --bin agentmux-srv` — 2797 passed, 0 failed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/brain/` — 26/26 pass, including a new test confirming both blocks render under the shared heading
- [x] `npx vitest run` (full suite) — 3131 passed, 1 pre-existing flake confirmed unrelated (passes in isolation, same `tool-renderer registry` timeout seen on #2796/#2797)
- [x] Repo-wide grep sweep confirms no stray `ambient`-named identifiers remain (only intentional rename-rationale comments)

<!-- agentmux:agent_id=manoz -->