### PR TITLE
feat(agent-pane): hover-to-peek fires on every transcript node kind, 50ms delay [Naki@claudius]

### DIFF
--- a/.changesets/1787690356-feat-agent-pane-hover-to-peek-now-fires-on-every-transcript--zhb1.md
+++ b/.changesets/1787690356-feat-agent-pane-hover-to-peek-now-fires-on-every-transcript--zhb1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): hover-to-peek now fires on every transcript node kind, 50ms delay

--- a/docs/specs/SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25.md
+++ b/docs/specs/SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25.md
@@ -1,0 +1,141 @@
+# Spec: hover-to-peek on EVERY transcript node kind, 50ms delay
+
+**Status:** Implemented.
+
+**Trigger (verbatim):** "they actually always need to fire. reduce delay for
+50ms. Anytime you hover over the agent pane conversation history, there
+should be hover text, because you are always over a node."
+
+## 0. Context — the fourth pass at this feature
+
+`SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md` (PR #2392) shipped a peek
+tooltip (`PeekOverlay.tsx` — Portal-rendered, top-anchored, time + time-ago +
+token estimate) on exactly three anchors: the tool-call name span, a
+thinking-clump's header, and a regular user-input message row. That spec was
+deliberately narrow — two prior specs (`node-timestamp-hover.md`,
+`SPEC_TOOL_HOVER_CONSOLIDATION_2026_05_28.md`,
+`SPEC_REMOVE_NODE_HOVER_STRIP_2026_06_15.md`) had each shipped and then
+ripped out a generic per-row hover strip after user complaints about flicker
+and "the row dances around my cursor" — so §2.5/§6 of the Aug-3 spec
+explicitly scoped the feature down to three anchors and called "regular
+assistant text, section headers... out of scope."
+
+The user's follow-up request here reverses that scope decision: every node
+in the transcript should show a peek on hover, not just three kinds. This is
+safe to do now in a way the earlier, killed attempts weren't — `PeekOverlay`
+is a Portal-rendered floating tooltip (`position: fixed`, sized off
+`getBoundingClientRect()`) that never participates in document flow, so
+widening its triggers doesn't reintroduce the earlier "row dances" bug (that
+bug came from hover-driven *expand/collapse*, a layout-affecting state
+change, not from a read-only floating overlay). No further scope walk-back
+was needed here — the fix is additive coverage on the existing safe
+mechanism, not a new mechanism.
+
+## 1. What changed
+
+### 1.1 Delay: 150ms → 50ms, centralized
+
+The three existing implementations (`ToolBlock.tsx`, `MarkdownBlock.tsx`,
+`UserMessageBlock.tsx`) each declared their own local `150` constant,
+independently. Centralized to `PEEK_ENTER_DELAY_MS = 50` in
+`components/hover-anchor.ts`, imported everywhere — one place to change,
+not three to keep in sync.
+
+### 1.2 Shared hook: `hooks/useNodePeek.ts`
+
+Every implementation (old and new) hand-rolled the same
+`isPeeking`/timer/`rowEl` boilerplate. Factored into `useNodePeek()`,
+returning `{ isPeeking, rowEl, setRowEl, handlePeekEnter, handlePeekLeave }`.
+`rowEl` is a signal (not a closure `let`), so `<PeekOverlay rowEl={rowEl}>`
+needs no wrapper accessor at the call site.
+
+### 1.3 Widened anchors — existing three node kinds
+
+- **ToolBlock**: the peek anchor was a narrow `<span
+  class="agent-tool-name-peek-anchor">` wrapping only the tool-name text.
+  Moved the `handlePeekEnter`/`handlePeekLeave` calls onto the ROW's
+  existing `onMouseEnter`/`onMouseLeave` (which already drove `userHolding`
+  — "keep an already-expanded panel open while the mouse is still over
+  it"), so hovering anywhere in the row triggers the peek, not just the name
+  text. This couples the two behaviors: hovering a running tool now also
+  engages `userHolding`, so if it completes while the cursor is stationary,
+  the panel stays held open (correct — the user is visibly still reading
+  it) and the peek stays correctly suppressed until a fresh hover, per the
+  existing "peek is redundant once the panel is expanded" rule. See
+  `ToolBlock.test.tsx`'s updated test for the exact before/after.
+- **MarkdownBlock**: previously only thinking clumps got a peek (their
+  anchor already wrapped the whole block). Regular (non-thinking) assistant
+  text got NONE. Restructured so both branches share one anchor + overlay,
+  varying only the `thinking-block` CSS class inside.
+- **UserMessageBlock**: regular (non-startup) input already anchored on the
+  full row — no widening needed, just the delay swap.
+
+### 1.4 New peek coverage — nine node kinds that had none
+
+| Node kind | Where | Content |
+|---|---|---|
+| `agent_message` | `AgentMessageBlock.tsx` | time + estimate. Never shows its own timestamp anywhere else, collapsed or expanded, so not gated on collapsed state. |
+| `jekt_message` | `JektBubble.tsx` | time + estimate. Not gated on collapsed — the expanded view's timestamp line has no relative "ago", the peek adds that even when already expanded. |
+| `shell` | `PersistentShellBlock.tsx` | time (from `spawnedAt`) + estimate + the raw `cmd` body. Suppressed while pinned open — command already visible in the panel header, same rule as ToolBlock. |
+| `section` | inline in `DocumentRow.tsx` | time (if present — many historical nodes predate the field) + estimate(title). |
+| `agent_error` | inline in `DocumentRow.tsx` | estimate only — `AgentErrorNode` carries no timestamp field at all. |
+| `context_compacted` | inline in `DocumentRow.tsx` | time only — tokens/duration are already visible in the row; no free-text body to estimate. |
+| `compaction_started` | inline in `DocumentRow.tsx` | time only, from `startedAt` (not `timestamp`). |
+| `day_divider` | inline in `DocumentRow.tsx` | time only — the exact local-midnight instant; the visible label is already a human day name. |
+| `session_outcome` | inline in `DocumentRow.tsx` | time + a body showing `attempted`/`actual` session ids — real debug info not surfaced anywhere else on this node. |
+
+The six inline kinds share ONE `useNodePeek()` instance at the top of
+`DocumentNodeBody` (the function that dispatches all of them) rather than
+one each — safe because exactly one `<Show>` branch is ever mounted per
+node, so only one of the six anchors actually exists in the DOM at a time.
+
+### 1.5 The one deliberate exception: `history_link`
+
+`HistoryLinkNode` is a render-time-only synthetic CTA row (`{ type:
+"history_link", id: "history-link" }`) — no timestamp, no message, no
+content field of any kind, and its full text ("Open Agent History →") is
+already entirely visible without hovering. There is no data a peek could
+add. Left with no anchor at all, and a comment in `DocumentRow.tsx`
+documenting why — this is the one node kind that doesn't get the "always
+fires" treatment, and it's a data-availability limit, not a scope
+narrowing.
+
+## 2. Files touched
+
+```
+New:
+  frontend/app/view/agent/hooks/useNodePeek.ts
+  frontend/app/view/agent/hooks/useNodePeek.test.ts
+  frontend/app/view/agent/components/AgentMessageBlock.test.tsx
+  frontend/app/view/agent/components/JektBubble.test.tsx
+  frontend/app/view/agent/components/PersistentShellBlock.test.tsx
+
+Modified:
+  frontend/app/view/agent/components/hover-anchor.ts       (shared 50ms constant)
+  frontend/app/view/agent/components/ToolBlock.tsx          (widened anchor, shared hook)
+  frontend/app/view/agent/components/ToolBlock.test.tsx     (updated hover target + one behavior-change test)
+  frontend/app/view/agent/components/MarkdownBlock.tsx      (regular text now peeks too)
+  frontend/app/view/agent/components/MarkdownBlock.test.tsx
+  frontend/app/view/agent/components/UserMessageBlock.tsx   (shared hook/delay)
+  frontend/app/view/agent/components/UserMessageBlock.test.tsx
+  frontend/app/view/agent/components/AgentMessageBlock.tsx  (new peek)
+  frontend/app/view/agent/components/JektBubble.tsx         (new peek)
+  frontend/app/view/agent/components/PersistentShellBlock.tsx (new peek)
+  frontend/app/view/agent/virtualization/DocumentRow.tsx    (peek for 6 inline kinds + history_link exception comment)
+  frontend/app/view/agent/virtualization/DocumentRow.test.tsx
+```
+
+## 3. Verification
+
+- `tsc --noEmit`: clean.
+- `vitest run frontend/app/view/agent`: 1426/1426 passing across 115 files
+  (up from 1401 pre-change — 25 new tests: the hook + 3 new component test
+  files + 7 new DocumentRow cases, plus edits to existing suites).
+- `vitest run frontend/app/view/swarm`: 90/90 passing (no regression from
+  reusing `AgentDispatch`-adjacent types).
+- `task build:frontend`: production build succeeds (pre-existing chunk-size
+  warnings only, unrelated).
+- Not done: interactive/visual verification in a live running instance —
+  same constraint as the Aug-3/Aug-19 specs (shared, already-live AgentMux
+  instances on this machine; native Rust+CEF desktop app, not
+  screenshot-able via browser tooling).

--- a/frontend/app/view/agent/components/AgentMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/AgentMessageBlock.test.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentMessageBlock — peek tooltip added by
+ * SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25 (this node kind had
+ * none before; it never surfaces its own timestamp anywhere in the UI).
+ */
+
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentMessageBlock } from "./AgentMessageBlock";
+import type { AgentMessageNode } from "../types";
+
+afterEach(() => cleanup());
+
+const node: AgentMessageNode = {
+    type: "agent_message",
+    id: "am-1",
+    from: "claude-1",
+    to: "reviewer",
+    message: "hello there",
+    method: "mux",
+    direction: "incoming",
+    timestamp: Date.now() - 65_000,
+    collapsed: true,
+    summary: "📨 claude-1 → reviewer (mux)",
+};
+
+const hover = (container: HTMLElement) => {
+    const root = container.querySelector(".agent-message-block") as HTMLElement;
+    fireEvent.mouseEnter(root);
+    vi.advanceTimersByTime(100);
+};
+
+describe("AgentMessageBlock — peek tooltip", () => {
+    it("shows time + estimate on hover, regardless of collapsed state", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <AgentMessageBlock node={node} collapsed={true} onToggle={() => {}} />
+            ));
+            hover(container);
+            const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+            expect(metaLines.length).toBe(2);
+            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("hides on mouseleave", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <AgentMessageBlock node={node} collapsed={true} onToggle={() => {}} />
+            ));
+            hover(container);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+            fireEvent.mouseLeave(container.querySelector(".agent-message-block") as HTMLElement);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("does not fire onToggle on hover — click and hover stay independent", () => {
+        vi.useFakeTimers();
+        try {
+            const onToggle = vi.fn();
+            const { container } = render(() => (
+                <AgentMessageBlock node={node} collapsed={true} onToggle={onToggle} />
+            ));
+            hover(container);
+            expect(onToggle).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/app/view/agent/components/AgentMessageBlock.tsx
+++ b/frontend/app/view/agent/components/AgentMessageBlock.tsx
@@ -6,9 +6,14 @@
  */
 
 import clsx from "clsx";
-import { Show, type JSX } from "solid-js";
+import { Show, createMemo, type JSX } from "solid-js";
 import type { AgentMessageNode } from "../types";
 import { LinkifiedText } from "@/app/element/linkified-text";
+import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
+import { formatExactTime, formatTimeAgo } from "@/util/format-time";
+import { useTick } from "@/app/hook/useTick";
+import { useNodePeek } from "../hooks/useNodePeek";
+import { PeekOverlay } from "./PeekOverlay";
 
 interface AgentMessageBlockProps {
     node: AgentMessageNode;
@@ -22,8 +27,27 @@ export const AgentMessageBlock = (props: AgentMessageBlockProps): JSX.Element =>
     // each chunk. Destructured `node` would freeze at first ref.
     // Access props.X reactively at each site. (codex P1 on PR #786 +
     // family of issues on virt redesign — also fixed in MarkdownBlock.)
+
+    // Peek tooltip (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25) —
+    // this node type never surfaces its own timestamp anywhere, collapsed
+    // or expanded, so the peek isn't gated on `props.collapsed` (unlike
+    // ToolBlock's panel, expanding this block wouldn't make the peek
+    // redundant — the expanded view has no time at all).
+    const peekTick = useTick(1000);
+    const { isPeeking, rowEl: peekRowEl, setRowEl: setPeekRowEl, handlePeekEnter, handlePeekLeave } = useNodePeek();
+    const peekTimeText = createMemo(() => {
+        if (!isPeeking()) return null;
+        peekTick();
+        return `${formatExactTime(props.node.timestamp)} · ${formatTimeAgo(props.node.timestamp)}`;
+    });
+    const peekEstimateText = createMemo(() => {
+        const count = estimateTokenCount(props.node.message);
+        return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
+    });
+
     return (
         <div
+            ref={setPeekRowEl}
             class={clsx("agent-message-block", {
                 incoming: props.node.direction === "incoming",
                 outgoing: props.node.direction !== "incoming",
@@ -32,6 +56,8 @@ export const AgentMessageBlock = (props: AgentMessageBlockProps): JSX.Element =>
                 ject: props.node.method === "ject",
             })}
             onClick={props.onToggle}
+            onMouseEnter={handlePeekEnter}
+            onMouseLeave={handlePeekLeave}
         >
             <div class="agent-message-summary">
                 <span class="agent-message-chevron">{props.collapsed ? "▸" : "▾"}</span>
@@ -49,6 +75,14 @@ export const AgentMessageBlock = (props: AgentMessageBlockProps): JSX.Element =>
                     </pre>
                 </div>
             </Show>
+            <PeekOverlay show={isPeeking()} rowEl={peekRowEl}>
+                <Show when={peekTimeText()}>
+                    <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
+                </Show>
+                <Show when={peekEstimateText()}>
+                    <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
+                </Show>
+            </PeekOverlay>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/JektBubble.test.tsx
+++ b/frontend/app/view/agent/components/JektBubble.test.tsx
@@ -1,0 +1,71 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * JektBubble — peek tooltip added by
+ * SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25. Adds a relative
+ * "time ago" the expanded meta row's plain `toLocaleString()` doesn't have.
+ */
+
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { JektBubble } from "./JektBubble";
+import type { JektMessageNode } from "../types";
+
+afterEach(() => cleanup());
+
+const node: JektMessageNode = {
+    type: "jekt_message",
+    id: "jm-1",
+    from: "github-consumer",
+    to: "naki",
+    message: "PR #2676 reviewed — LGTM",
+    raw: "[JEKT:...][/JEKT]",
+    tier: "coord",
+    deliveryTier: "wan",
+    trust: "network-claimed",
+    msgId: "inj-1",
+    priority: "normal",
+    direction: "incoming",
+    timestamp: Date.now() - 65_000,
+};
+
+const hover = (container: HTMLElement) => {
+    const root = container.querySelector(".agent-jekt-bubble") as HTMLElement;
+    fireEvent.mouseEnter(root);
+    vi.advanceTimersByTime(100);
+};
+
+describe("JektBubble — peek tooltip", () => {
+    it("shows time + estimate on hover", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <JektBubble node={node} collapsed={true} onToggle={() => {}} />
+            ));
+            hover(container);
+            const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+            expect(metaLines.length).toBe(2);
+            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("hides on mouseleave", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <JektBubble node={node} collapsed={true} onToggle={() => {}} />
+            ));
+            hover(container);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+            fireEvent.mouseLeave(container.querySelector(".agent-jekt-bubble") as HTMLElement);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/app/view/agent/components/JektBubble.tsx
+++ b/frontend/app/view/agent/components/JektBubble.tsx
@@ -17,10 +17,15 @@
  */
 
 import clsx from "clsx";
-import { Show, type JSX } from "solid-js";
+import { Show, createMemo, type JSX } from "solid-js";
 import type { JektMessageNode } from "../types";
 import { JEKT_DELIVERY_ICONS, JEKT_TIER_ICONS } from "../types";
 import { LinkifiedText } from "@/app/element/linkified-text";
+import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
+import { formatExactTime, formatTimeAgo } from "@/util/format-time";
+import { useTick } from "@/app/hook/useTick";
+import { useNodePeek } from "../hooks/useNodePeek";
+import { PeekOverlay } from "./PeekOverlay";
 
 interface JektBubbleProps {
     node: JektMessageNode;
@@ -36,8 +41,26 @@ export const JektBubble = (props: JektBubbleProps): JSX.Element => {
     // Don't destructure props — see AgentMessageBlock/MarkdownBlock
     // for why (codex P1 on PR #786 + family of virt-redesign issues).
     // Same reactivity discipline applies here.
+
+    // Peek tooltip (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25).
+    // Not gated on `props.collapsed` — the expanded view's own timestamp
+    // line is plain `toLocaleString()`, no relative "ago"; the peek adds
+    // that even when already expanded.
+    const peekTick = useTick(1000);
+    const { isPeeking, rowEl: peekRowEl, setRowEl: setPeekRowEl, handlePeekEnter, handlePeekLeave } = useNodePeek();
+    const peekTimeText = createMemo(() => {
+        if (!isPeeking()) return null;
+        peekTick();
+        return `${formatExactTime(props.node.timestamp)} · ${formatTimeAgo(props.node.timestamp)}`;
+    });
+    const peekEstimateText = createMemo(() => {
+        const count = estimateTokenCount(props.node.message);
+        return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
+    });
+
     return (
         <div
+            ref={setPeekRowEl}
             class={clsx("agent-jekt-bubble", {
                 incoming: props.node.direction === "incoming",
                 outgoing: props.node.direction === "outgoing",
@@ -45,6 +68,8 @@ export const JektBubble = (props: JektBubbleProps): JSX.Element => {
                 [`tier-${props.node.tier}`]: true,
             })}
             onClick={props.onToggle}
+            onMouseEnter={handlePeekEnter}
+            onMouseLeave={handlePeekLeave}
         >
             <div class="agent-jekt-summary">
                 <span class="agent-jekt-chevron">{props.collapsed ? "▸" : "▾"}</span>
@@ -85,6 +110,14 @@ export const JektBubble = (props: JektBubbleProps): JSX.Element => {
                     </details>
                 </div>
             </Show>
+            <PeekOverlay show={isPeeking()} rowEl={peekRowEl}>
+                <Show when={peekTimeText()}>
+                    <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
+                </Show>
+                <Show when={peekEstimateText()}>
+                    <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
+                </Show>
+            </PeekOverlay>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/MarkdownBlock.test.tsx
+++ b/frontend/app/view/agent/components/MarkdownBlock.test.tsx
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * MarkdownBlock — thinking-clump peek tooltip
- * (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md §2.4). Regular (non-
- * thinking) markdown and the canceled-thinking path are unchanged by this
- * feature; covered here only enough to confirm neither regressed.
+ * MarkdownBlock — peek tooltip (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md
+ * §2.4, extended to regular assistant text by
+ * SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25 — "regular assistant
+ * text... remain out of scope" no longer holds). Thinking clumps and regular
+ * text now share the same anchor/overlay; the canceled-thinking path is
+ * unchanged, covered here only enough to confirm it didn't regress.
  */
 
 import { cleanup, fireEvent, render } from "@solidjs/testing-library";
@@ -25,35 +27,50 @@ const thinkingNode: MarkdownNode = {
     metadata: { thinking: true },
 };
 
-describe("MarkdownBlock — regular text (unaffected)", () => {
-    it("renders plain content with no tooltip anchor", () => {
+// The peek overlay is Portal-rendered at document.body (PeekOverlay.tsx
+// — escapes each virtualized row's own CSS stacking context, see that
+// file's doc comment), so it lives in `document.body`, not `container`.
+// A real 50ms enter-delay gates its DOM presence, so these tests use fake
+// timers and advance past it.
+const hoverBlock = (container: HTMLElement) => {
+    const anchor = container.querySelector(".agent-markdown-peek-anchor") as HTMLElement;
+    fireEvent.mouseEnter(anchor);
+    vi.advanceTimersByTime(100);
+};
+
+describe("MarkdownBlock — regular (non-thinking) text now gets a peek too", () => {
+    it("renders plain content with no thinking-block styling", () => {
         const node: MarkdownNode = { type: "markdown", id: "md-2", content: "Hello" };
         const { container, unmount } = render(() => <MarkdownBlock node={node} />);
         expect(container.querySelector(".thinking-block")).toBeNull();
         unmount();
     });
+
+    it("shows a peek with time + estimate on hover, same as a thinking clump", () => {
+        const node: MarkdownNode = { type: "markdown", id: "md-2", content: "Hello", timestamp: Date.now() - 65_000 };
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => <MarkdownBlock node={node} />);
+            expect(container.querySelector(".agent-markdown-peek-anchor")).not.toBeNull();
+            hoverBlock(container);
+            const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+            expect(metaLines.length).toBe(2);
+            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });
 
 describe("MarkdownBlock — thinking-clump peek tooltip", () => {
-    // The peek overlay is Portal-rendered at document.body (PeekOverlay.tsx
-    // — escapes each virtualized row's own CSS stacking context, see that
-    // file's doc comment), so it lives in `document.body`, not `container`.
-    // A real 150ms enter-delay gates its DOM presence (mirrors
-    // UserMessageBlock.tsx's "Session context" hover-to-peek), so these
-    // tests use fake timers and advance past it.
-    const hoverThinkingBlock = (container: HTMLElement) => {
-        const anchor = container.querySelector(".agent-thinking-peek-anchor") as HTMLElement;
-        fireEvent.mouseEnter(anchor);
-        vi.advanceTimersByTime(200);
-    };
-
     it("shows exact time + time-ago + an estimated token count when the node has a timestamp", () => {
         const timed: MarkdownNode = { ...thinkingNode, timestamp: Date.now() - 65_000 };
         vi.useFakeTimers();
         try {
             const { container } = render(() => <MarkdownBlock node={timed} />);
             expect(container.querySelector(".thinking-block")).not.toBeNull();
-            hoverThinkingBlock(container);
+            hoverBlock(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
             expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
@@ -68,7 +85,7 @@ describe("MarkdownBlock — thinking-clump peek tooltip", () => {
         vi.useFakeTimers();
         try {
             const { container } = render(() => <MarkdownBlock node={untimed} />);
-            hoverThinkingBlock(container);
+            hoverBlock(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(1);
             expect(metaLines[0].textContent).toMatch(/~\d+ tok \(est\.\)/);
@@ -92,8 +109,9 @@ describe("MarkdownBlock — thinking-clump peek tooltip", () => {
             ...thinkingNode,
             metadata: { thinking: true, canceled: true },
         };
-        const { getByText, unmount } = render(() => <MarkdownBlock node={canceled} />);
+        const { getByText, container, unmount } = render(() => <MarkdownBlock node={canceled} />);
         expect(getByText("Canceled — partial thought")).toBeInTheDocument();
+        expect(container.querySelector(".agent-markdown-peek-anchor")).toBeNull();
         unmount();
     });
 });

--- a/frontend/app/view/agent/components/MarkdownBlock.tsx
+++ b/frontend/app/view/agent/components/MarkdownBlock.tsx
@@ -5,17 +5,15 @@
  * MarkdownBlock - Renders markdown content from agent output
  */
 
+import clsx from "clsx";
 import { Markdown } from "@/app/element/markdown";
 import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
 import { formatExactTime, formatTimeAgo } from "@/util/format-time";
 import { createEffect, createMemo, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
+import { useNodePeek } from "../hooks/useNodePeek";
 import type { MarkdownNode } from "../types";
 import { PeekOverlay } from "./PeekOverlay";
-
-// 150ms enter-delay matches UserMessageBlock's hover-to-peek — prevents
-// accidental expansions during fast scroll-throughs.
-const PEEK_ENTER_DELAY_MS = 150;
 
 interface MarkdownBlockProps {
     node: MarkdownNode;
@@ -82,30 +80,27 @@ export const MarkdownBlock = (props: MarkdownBlockProps): JSX.Element => {
         if (trailing) clearTimeout(trailing);
     });
 
-    // Thinking-clump peek tooltip (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md
-    // §2.4). Mirrors ToolBlock.tsx's time + estimate pattern exactly. No
-    // duration line — deriving one from the next node's timestamp needs a new
-    // prop threaded down through the virtualization list's windowed-rows/
-    // streaming-buffer machinery (AgentDocumentVirtualList.tsx), which is
-    // performance-critical and carefully tuned; deferred as a follow-up
-    // rather than risked here for a nice-to-have (§4 resolution 1 of that
-    // spec still calls for it eventually).
-    // reagent P2 on PR #2392 (1st round): short-circuit BEFORE reading
-    // `peekTick()` for every non-thinking block (the far more common node
-    // kind) — a memo only subscribes to what it actually reads during a
-    // given run, so returning early here means regular assistant text never
-    // subscribes to the shared 1s ticker at all, instead of silently
-    // recomputing a value nothing ever renders.
+    // Peek tooltip (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md §2.4,
+    // extended to every markdown block — thinking clumps AND regular
+    // assistant text — by SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25;
+    // "regular assistant text... remain out of scope" no longer holds).
+    // Mirrors ToolBlock.tsx's time + estimate pattern. No duration line —
+    // deriving one from the next node's timestamp needs a new prop threaded
+    // through the virtualization list's windowed-rows/streaming-buffer
+    // machinery (AgentDocumentVirtualList.tsx), which is performance-critical
+    // and carefully tuned; deferred as a follow-up rather than risked here
+    // for a nice-to-have (§4 resolution 1 of that spec still calls for it
+    // eventually).
     //
-    // reagent P2 on PR #2392 (3rd round): the thinking-kind check alone
-    // isn't enough — every MOUNTED thinking clump still called peekTick()
-    // regardless of hover state, the same defect ToolBlock.tsx fixed via an
-    // explicit isPeeking signal. Mirror that fix here: only read peekTick()
-    // while this block is actually being hovered.
+    // reagent P2 on PR #2392 (3rd round): every MOUNTED block used to call
+    // peekTick() regardless of hover state — a memo only subscribes to what
+    // it actually reads during a given run, so gating on isPeeking() BEFORE
+    // reading peekTick() (not after) means only a genuinely-hovered block
+    // subscribes to the shared 1s ticker. Still applies now that every
+    // markdown block (not just thinking ones) participates.
     const peekTick = useTick(1000);
-    const [isPeeking, setIsPeeking] = createSignal(false);
+    const { isPeeking, rowEl: peekRowEl, setRowEl: setPeekRowEl, handlePeekEnter, handlePeekLeave } = useNodePeek();
     const peekTimeText = createMemo(() => {
-        if (!props.node.metadata?.thinking) return null;
         if (!isPeeking()) return null;
         peekTick();
         const ts = props.node.timestamp;
@@ -113,74 +108,52 @@ export const MarkdownBlock = (props: MarkdownBlockProps): JSX.Element => {
         return `${formatExactTime(ts)} · ${formatTimeAgo(ts)}`;
     });
     const peekEstimateText = createMemo(() => {
-        if (!props.node.metadata?.thinking) return null;
         const count = estimateTokenCount(props.node.content);
         return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
     });
-
-    // Peek overlay — Portal-rendered (see PeekOverlay.tsx's doc comment for
-    // why: each virtualized row is its own CSS stacking context, so a plain
-    // `position: absolute` child can never paint above a LATER row no
-    // matter its z-index). Styled and positioned like UserMessageBlock.tsx's
-    // "Session context" hover-to-peek, reusing the same `hover-anchor.ts`
-    // direction logic — just rendered outside the row's subtree.
-    let peekEnterTimer: ReturnType<typeof setTimeout> | undefined;
-    let rowEl: HTMLDivElement | undefined;
-
-    const handlePeekEnter = () => {
-        clearTimeout(peekEnterTimer);
-        peekEnterTimer = setTimeout(() => setIsPeeking(true), PEEK_ENTER_DELAY_MS);
-    };
-    const handlePeekLeave = () => {
-        clearTimeout(peekEnterTimer);
-        setIsPeeking(false);
-    };
-    onCleanup(() => clearTimeout(peekEnterTimer));
 
     return (
         <Show
             when={isCanceled()}
             fallback={
-                <Show
-                    when={props.node.metadata?.thinking}
-                    fallback={
-                        <div class="agent-markdown-block">
-                            {/* scrollable={false}: agent markdown streams (reactive). With
-                                scrollable, OverlayScrollbars relocates SolidJS's children into
-                                its viewport, so the next streaming reconcile calls replaceChild
-                                on a node it has moved → the long-standing replaceChild crash
-                                (#1326). Per-block scroll is also wrong inside the virtualized
-                                document, which owns the scroll. */}
-                            <Markdown text={view().text} highlight={view().highlight} scrollable={false} />
-                        </div>
-                    }
+                // Shared anchor + peek overlay for BOTH thinking clumps and
+                // regular assistant text — see the peekTimeText/peekEstimateText
+                // comment above for why this no longer special-cases thinking.
+                // Not gated on an `expanded()` check here — markdown blocks have
+                // no pin/expand state to collide with (unlike ToolBlock).
+                <div
+                    ref={setPeekRowEl}
+                    class="agent-markdown-peek-anchor"
+                    onMouseEnter={handlePeekEnter}
+                    onMouseLeave={handlePeekLeave}
                 >
                     <div
-                        ref={(el) => (rowEl = el)}
-                        class="agent-thinking-peek-anchor"
-                        onMouseEnter={handlePeekEnter}
-                        onMouseLeave={handlePeekLeave}
+                        class={clsx("agent-markdown-block", {
+                            "thinking-block": props.node.metadata?.thinking === true,
+                        })}
                     >
-                        <div class="agent-markdown-block thinking-block">
-                            <Markdown text={view().text} highlight={view().highlight} scrollable={false} />
-                        </div>
-                        {/* Peek overlay — see ToolBlock.tsx's identical pattern
-                            and PeekOverlay.tsx. Not gated on an `expanded()`
-                            check here — thinking clumps have no pin/expand
-                            state to collide with. */}
-                        <PeekOverlay
-                            show={isPeeking() && (peekTimeText() != null || peekEstimateText() != null)}
-                            rowEl={() => rowEl}
-                        >
-                            <Show when={peekTimeText()}>
-                                <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
-                            </Show>
-                            <Show when={peekEstimateText()}>
-                                <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
-                            </Show>
-                        </PeekOverlay>
+                        {/* scrollable={false}: agent markdown streams (reactive). With
+                            scrollable, OverlayScrollbars relocates SolidJS's children into
+                            its viewport, so the next streaming reconcile calls replaceChild
+                            on a node it has moved → the long-standing replaceChild crash
+                            (#1326). Per-block scroll is also wrong inside the virtualized
+                            document, which owns the scroll. */}
+                        <Markdown text={view().text} highlight={view().highlight} scrollable={false} />
                     </div>
-                </Show>
+                    {/* Peek overlay — see ToolBlock.tsx's identical pattern
+                        and PeekOverlay.tsx. */}
+                    <PeekOverlay
+                        show={isPeeking() && (peekTimeText() != null || peekEstimateText() != null)}
+                        rowEl={peekRowEl}
+                    >
+                        <Show when={peekTimeText()}>
+                            <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
+                        </Show>
+                        <Show when={peekEstimateText()}>
+                            <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
+                        </Show>
+                    </PeekOverlay>
+                </div>
             }
         >
             <div class="agent-markdown-block markdown-canceled">

--- a/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PersistentShellBlock — peek tooltip added by
+ * SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25. Suppressed once
+ * pinned/expanded — the full command is already visible in the panel header.
+ */
+
+import { cleanup, fireEvent, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PersistentShellBlock } from "./PersistentShellBlock";
+import type { ShellNode } from "../types";
+
+afterEach(() => cleanup());
+
+const node: ShellNode = {
+    type: "shell",
+    id: "sh-1",
+    cmd: "npm run dev",
+    title: "dev server",
+    status: "exited-ok",
+    exitCode: 0,
+    spawnedAt: Date.now() - 65_000,
+    exitedAt: Date.now() - 5_000,
+    log: { chunks: [], open: false },
+};
+
+const hover = (container: HTMLElement) => {
+    const root = container.querySelector(".agent-shell-block") as HTMLElement;
+    fireEvent.mouseEnter(root);
+    vi.advanceTimersByTime(100);
+};
+
+describe("PersistentShellBlock — peek tooltip", () => {
+    it("shows time + estimate + the command on hover while collapsed", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <PersistentShellBlock node={node} pinned={false} onTogglePin={() => {}} />
+            ));
+            hover(container);
+            const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+            expect(metaLines.length).toBe(2);
+            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
+            const body = document.body.querySelector(".agent-node-peek-tooltip-body");
+            expect(body?.textContent).toBe("npm run dev");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("suppresses the overlay while pinned open — the command is already visible in the panel", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <PersistentShellBlock node={node} pinned={true} onTogglePin={() => {}} />
+            ));
+            hover(container);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("hides on mouseleave", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <PersistentShellBlock node={node} pinned={false} onTogglePin={() => {}} />
+            ));
+            hover(container);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+            fireEvent.mouseLeave(container.querySelector(".agent-shell-block") as HTMLElement);
+            expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -14,10 +14,13 @@
 import clsx from "clsx";
 import { For, Show, createMemo, createSignal, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
-import { formatElapsedClock } from "@/util/format-time";
+import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
+import { formatElapsedClock, formatExactTime, formatTimeAgo } from "@/util/format-time";
+import { useNodePeek } from "../hooks/useNodePeek";
 import { capChars, createChunkCapper, createSpinnerCollapser, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { LinkifiedText } from "@/app/element/linkified-text";
+import { PeekOverlay } from "./PeekOverlay";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import type { ShellNode, ToolLogChunk } from "../types";
@@ -66,6 +69,21 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
 
     const expanded = () => props.pinned;
 
+    // Peek tooltip (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25).
+    // Suppressed once expanded — the full command is already visible in the
+    // panel header (`.agent-shell-header-cmd`), same rule ToolBlock uses.
+    const peekTick = useTick(1000);
+    const { isPeeking, rowEl: peekRowEl, setRowEl: setPeekRowEl, handlePeekEnter, handlePeekLeave } = useNodePeek();
+    const peekTimeText = createMemo(() => {
+        if (!isPeeking()) return null;
+        peekTick();
+        return `${formatExactTime(props.node.spawnedAt)} · ${formatTimeAgo(props.node.spawnedAt)}`;
+    });
+    const peekEstimateText = createMemo(() => {
+        const count = estimateTokenCount(props.node.cmd);
+        return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
+    });
+
     // Stop button (Phase 3): tree-kills the running process. Status updates
     // arrive via the `stopped` exit event, so we don't optimistically mutate.
     const [stopping, setStopping] = createSignal(false);
@@ -106,6 +124,7 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
 
     return (
         <div
+            ref={setPeekRowEl}
             class={clsx("agent-shell-block", {
                 "running": props.node.status === "running",
                 "exited-ok": props.node.status === "exited-ok",
@@ -114,6 +133,8 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
                 "expanded": expanded(),
                 "collapsed": !expanded(),
             })}
+            onMouseEnter={handlePeekEnter}
+            onMouseLeave={handlePeekLeave}
         >
             <div class="agent-shell-summary" onClick={props.onTogglePin}>
                 <span class="agent-shell-sigil">{statusSigil()}</span>
@@ -173,6 +194,15 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
                     </div>
                 </div>
             </div>
+            <PeekOverlay show={isPeeking() && !expanded()} rowEl={peekRowEl}>
+                <Show when={peekTimeText()}>
+                    <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
+                </Show>
+                <Show when={peekEstimateText()}>
+                    <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
+                </Show>
+                <div class="agent-node-peek-tooltip-body">{props.node.cmd}</div>
+            </PeekOverlay>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -188,13 +188,16 @@ describe("ToolBlock — panel mode", () => {
         // The peek overlay is Portal-rendered at document.body (PeekOverlay.tsx
         // — escapes each virtualized row's own CSS stacking context, see that
         // file's doc comment), so it lives in `document.body`, not `container`.
-        // A real 150ms enter-delay gates its DOM presence (mirrors
+        // A real 50ms enter-delay gates its DOM presence (mirrors
         // UserMessageBlock.tsx's "Session context" hover-to-peek), so these
-        // tests use fake timers and advance past it.
+        // tests use fake timers and advance past it. Fires on `.agent-tool-block`
+        // (the whole row), not the narrower name span — the peek anchor was
+        // widened to the whole row per SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25
+        // ("always fires when hovering anywhere over the row").
         const hoverToolName = (container: HTMLElement) => {
-            const anchor = container.querySelector(".agent-tool-name-peek-anchor") as HTMLElement;
-            fireEvent.mouseEnter(anchor);
-            vi.advanceTimersByTime(200);
+            const row = container.querySelector(".agent-tool-block") as HTMLElement;
+            fireEvent.mouseEnter(row);
+            vi.advanceTimersByTime(100);
         };
 
         it("collapsed: hovering the name shows the bare command, not the decorated summary", () => {
@@ -303,28 +306,51 @@ describe("ToolBlock — panel mode", () => {
         });
 
         // ToolBlock instances are reused across status transitions via
-        // index-based virtualization (no remount) -- these two assert the
+        // index-based virtualization (no remount) -- this asserts the
         // suppression is reactive to a live status/pin change on an
         // ALREADY-MOUNTED instance, not just correct on first render.
-        it("shows the overlay once a running tool completes, with the cursor already stationary over it (no second mouseenter)", () => {
-            // The scenario a naive implementation misses: the user's cursor
-            // never moves, only the tool's own status (and hence
-            // `expanded()`) changes out from under it. If the anchor's hover
-            // handling only acted inside the mouseenter/mouseleave handlers
-            // themselves, this would require a SECOND mouseenter that never
-            // comes in real usage — a stationary cursor doesn't generate one
-            // just because an unrelated prop changed.
+        //
+        // Behavior change from SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25:
+        // the peek anchor used to be a narrow inner span, separate from the
+        // outer row's own mouseenter/mouseleave (which drives `userHolding` —
+        // "keep an already-expanded panel open while the mouse is still over
+        // it"). Since `mouseenter` doesn't bubble, hovering only the inner
+        // span never touched `userHolding`, so a running->success transition
+        // with a stationary cursor collapsed the panel and the peek could
+        // show. Now that peek fires from anywhere in the row (the whole
+        // point of "always fires"), the SAME hover also engages
+        // `userHolding` while the panel is auto-expanded — so it now stays
+        // held open (correctly: the user is visibly still reading it) and
+        // the peek correctly stays suppressed the whole time, per the
+        // existing "peek is redundant once the detail is already visible in
+        // the expanded panel" rule. Leaving and re-hovering afterward (a
+        // genuinely fresh hover over the now-collapsed row) still shows the
+        // peek — the "always fires" contract holds for real hover, not for
+        // a use hovering session that never actually revisits the row.
+        it("keeps a running tool's panel held open through completion when the cursor never moves, so the peek stays suppressed until a fresh hover", () => {
             const [node, setNode] = createSignal<ToolNode>({ ...baseTool, status: "running" });
             vi.useFakeTimers();
             try {
                 const { container } = render(() => (
                     <ToolBlock node={node()} pinned={false} onTogglePin={() => {}} />
                 ));
-                const anchor = container.querySelector(".agent-tool-name-peek-anchor") as HTMLElement;
-                fireEvent.mouseEnter(anchor); // cursor arrives while still running (panel auto-expanded)
-                vi.advanceTimersByTime(200);
+                const row = container.querySelector(".agent-tool-block") as HTMLElement;
+                fireEvent.mouseEnter(row); // cursor arrives while still running (panel auto-expanded)
+                vi.advanceTimersByTime(100);
                 expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
                 setNode({ ...baseTool, status: "success" }); // completes; cursor never moves
+                // Held open by userHolding (engaged at the mouseenter above,
+                // since the panel WAS auto-expanded at that moment) — no
+                // peek while the detail is already visible in-flow.
+                const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
+                expect(panel.classList.contains("agent-tool-panel--flow")).toBe(true);
+                expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+
+                // A genuine fresh hover (leave, then re-enter) after the row
+                // has actually collapsed still shows the peek.
+                fireEvent.mouseLeave(row);
+                fireEvent.mouseEnter(row);
+                vi.advanceTimersByTime(100);
                 const tip = document.body.querySelector(".agent-node-peek-tooltip-body");
                 expect(tip).not.toBeNull();
                 expect(tip!.textContent).toBe("ls");

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -44,6 +44,7 @@ import { formatExactTime, formatTimeAgo } from "@/util/format-time";
 import clsx from "clsx";
 import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import { extractToolDetail } from "../stream-parser";
+import { useNodePeek } from "../hooks/useNodePeek";
 import type { AgentDispatch } from "../../swarm/swarm-model";
 import type { BashResult, EditResult, GlobResult, GrepResult, ToolNode, WriteResult } from "../types";
 import { AnsweredQuestionMessage } from "./AnsweredQuestionMessage";
@@ -118,10 +119,6 @@ const STATUS_ICON: Record<ToolNode["status"], string> = {
 const PREVIEW_ZOOM_STEP = 0.05;
 const PREVIEW_ZOOM_MIN = 0.7;
 const PREVIEW_ZOOM_MAX = 2.0;
-
-// 150ms enter-delay matches UserMessageBlock's hover-to-peek — prevents
-// accidental expansions during fast scroll-throughs.
-const PEEK_ENTER_DELAY_MS = 150;
 
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // Drives the peek tooltip's live "time ago" text (§2.3 of
@@ -328,7 +325,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // ticker forever, not just the one actually being hovered right now.
     // Short-circuiting before peekTick() means only genuinely-hovered rows
     // subscribe.
-    const [isPeeking, setIsPeeking] = createSignal(false);
+    const { isPeeking, rowEl: peekRowEl, setRowEl: setPeekRowEl, handlePeekEnter, handlePeekLeave } = useNodePeek();
     const peekTimeText = createMemo(() => {
         if (!isPeeking()) return null;
         peekTick(); // re-run every second so "ago" stays live while hovered
@@ -360,18 +357,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // UserMessageBlock.tsx's "Session context" hover-to-peek (flush to the
     // row's edges, no gap), reusing the same `hover-anchor.ts` direction
     // logic — just rendered outside the row's subtree instead of inside it.
-    let peekEnterTimer: ReturnType<typeof setTimeout> | undefined;
-    let rowEl: HTMLDivElement | undefined;
-
-    const handlePeekEnter = () => {
-        clearTimeout(peekEnterTimer);
-        peekEnterTimer = setTimeout(() => setIsPeeking(true), PEEK_ENTER_DELAY_MS);
-    };
-    const handlePeekLeave = () => {
-        clearTimeout(peekEnterTimer);
-        setIsPeeking(false);
-    };
-    onCleanup(() => clearTimeout(peekEnterTimer));
+    // Timer/signal state lives in the shared useNodePeek() hook above.
 
     // A resolved AskUserQuestion renders as a user message instead of the
     // generic collapsed tool row below — it substantively IS user input.
@@ -384,7 +370,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     return (
         <Show when={!isAnsweredQuestion()} fallback={<AnsweredQuestionMessage node={props.node} />}>
             <div
-                ref={(el) => (rowEl = el)}
+                ref={setPeekRowEl}
                 class={clsx("agent-tool-block", {
                     collapsed: !expanded(),
                     expanded: expanded(),
@@ -404,18 +390,23 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 // names CSS needs to target one specific open-ended tool without touching the
                 // shared "other" styling every other unrecognized tool also falls back to.
                 data-tool-name={props.node.toolName?.toLowerCase()}
+                // Peek-hover fires from anywhere in the row (not just the tool-name
+                // text) per SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25 —
+                // merged with the pre-existing userHolding handlers below rather
+                // than adding a second listener pair, since SolidJS only keeps the
+                // last onMouseEnter/onMouseLeave assigned to a given element.
                 onMouseEnter={() => {
                     if (props.pinned || autoExpanded()) setUserHolding(true);
+                    handlePeekEnter();
                 }}
-                onMouseLeave={() => setUserHolding(false)}
+                onMouseLeave={() => {
+                    setUserHolding(false);
+                    handlePeekLeave();
+                }}
             >
                 <div class="agent-tool-summary" onClick={props.onTogglePin}>
                     <span class="agent-tool-status-icon">{statusIcon()}</span>
-                    <span
-                        class="agent-tool-name-peek-anchor"
-                        onMouseEnter={handlePeekEnter}
-                        onMouseLeave={handlePeekLeave}
-                    >
+                    <span class="agent-tool-name-peek-anchor">
                         <span class="agent-tool-name">{props.node.summary}</span>
                     </span>
                     <Show when={props.node.duration}>
@@ -470,7 +461,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 panel is already expanded, since the command/time are
                 visible in context there — same condition the old
                 Tooltip-based version used. */}
-                <PeekOverlay show={isPeeking() && hasAnyPeekContent() && !expanded()} rowEl={() => rowEl}>
+                <PeekOverlay show={isPeeking() && hasAnyPeekContent() && !expanded()} rowEl={peekRowEl}>
                     <Show when={peekTimeText()}>
                         <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
                     </Show>

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -8,7 +8,7 @@
  *     gets a hover-to-peek time/estimate overlay (2026-08-03 user request,
  *     same treatment ToolBlock/MarkdownBlock already have).
  *   - startup injection (`isStartup === true`): collapsed by default,
- *     hover-expand after 150ms, click-to-pin. The hover-expand body is
+ *     hover-expand after 50ms, click-to-pin. The hover-expand body is
  *     PeekOverlay (Portal-rendered at document.body, top-anchored to the
  *     row) — migrated off its own bespoke position:absolute overlay,
  *     which had the same virtualized-row stacking-context bug PeekOverlay
@@ -109,7 +109,7 @@ describe("UserMessageBlock — regular user input", () => {
             ));
             const root = container.querySelector(".agent-user-message") as HTMLElement;
             fireEvent.mouseEnter(root);
-            // No advanceTimersByTime — still within the 150ms delay.
+            // No advanceTimersByTime — still within the 50ms delay.
             expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
         });
 
@@ -200,7 +200,7 @@ describe("UserMessageBlock — startup injection", () => {
         // Drives the codex round-3 flow: hover to expand the body,
         // then click 📌 to pin. Without this affordance, the user
         // would have to leave + re-enter the collapsed summary
-        // before the 150ms enter-delay restarted — defeating the
+        // before the 50ms enter-delay restarted — defeating the
         // "hover to peek · click to pin" hint. Hovering (not pinned)
         // → overlay mode → Portal-rendered at document.body.
         vi.useFakeTimers();
@@ -250,7 +250,7 @@ describe("UserMessageBlock — startup injection", () => {
         expect(root.classList.contains("agent-user-message--expanded")).toBe(true);
     });
 
-    it("hover (mouseenter→delay) expands the body after 150ms", async () => {
+    it("hover (mouseenter→delay) expands the body after 50ms", async () => {
         // The summary is now ALWAYS mounted. Only the BODY's
         // presence changes across the hover transition. `screen`
         // queries the whole document (including document.body, where
@@ -266,11 +266,11 @@ describe("UserMessageBlock — startup injection", () => {
             expect(screen.queryByText("Session context")).not.toBeNull();
             expect(screen.queryByText(/Identity/)).toBeNull();
             fireEvent.mouseEnter(root);
-            // 100ms in — still pre-threshold.
-            vi.advanceTimersByTime(100);
+            // 30ms in — still pre-threshold.
+            vi.advanceTimersByTime(30);
             expect(screen.queryByText(/Identity/)).toBeNull();
             // Past the threshold — body now visible alongside summary.
-            vi.advanceTimersByTime(60);
+            vi.advanceTimersByTime(20);
             expect(screen.queryByText(/Identity/)).not.toBeNull();
             expect(screen.queryByText("Session context")).not.toBeNull();
         } finally {
@@ -286,7 +286,7 @@ describe("UserMessageBlock — startup injection", () => {
             ));
             const root = container.querySelector(".agent-user-message") as HTMLElement;
             fireEvent.mouseEnter(root);
-            vi.advanceTimersByTime(100);
+            vi.advanceTimersByTime(30);
             fireEvent.mouseLeave(root);
             vi.advanceTimersByTime(200);
             // Still collapsed — the pending timer was cleared on leave.

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -48,6 +48,8 @@ import { LinkifiedText } from "@/app/element/linkified-text";
 import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
 import { formatExactTime, formatTimeAgo } from "@/util/format-time";
 import { useTick } from "@/app/hook/useTick";
+import { PEEK_ENTER_DELAY_MS } from "./hover-anchor";
+import { useNodePeek } from "../hooks/useNodePeek";
 import { PeekOverlay } from "./PeekOverlay";
 
 interface UserMessageBlockProps {
@@ -60,10 +62,6 @@ interface UserMessageBlockProps {
     onTogglePin: () => void;
 }
 
-// 150ms enter-delay matches ToolBlock — prevents accidental
-// expansions during fast scroll-throughs.
-const HOVER_ENTER_DELAY_MS = 150;
-
 export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     const [hovering, setHovering] = createSignal(false);
     let enterTimer: ReturnType<typeof setTimeout> | undefined;
@@ -71,7 +69,7 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
 
     const handleMouseEnter = () => {
         clearTimeout(enterTimer);
-        enterTimer = setTimeout(() => setHovering(true), HOVER_ENTER_DELAY_MS);
+        enterTimer = setTimeout(() => setHovering(true), PEEK_ENTER_DELAY_MS);
     };
     const handleMouseLeave = () => {
         clearTimeout(enterTimer);
@@ -104,7 +102,7 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
     // bodyMode() === "overlay" above) rather than a metadata summary, so
     // this is gated to the non-collapsible case only.
     const peekTick = useTick(1000);
-    const [isPeeking, setIsPeeking] = createSignal(false);
+    const { isPeeking, handlePeekEnter, handlePeekLeave } = useNodePeek();
     const peekTimeText = createMemo(() => {
         if (collapsible() || !isPeeking()) return null;
         peekTick(); // re-run every second so "ago" stays live while hovered
@@ -117,16 +115,6 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
         const count = estimateTokenCount(props.node.message);
         return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
     });
-    let peekEnterTimer: ReturnType<typeof setTimeout> | undefined;
-    const handlePeekEnter = () => {
-        clearTimeout(peekEnterTimer);
-        peekEnterTimer = setTimeout(() => setIsPeeking(true), HOVER_ENTER_DELAY_MS);
-    };
-    const handlePeekLeave = () => {
-        clearTimeout(peekEnterTimer);
-        setIsPeeking(false);
-    };
-    onCleanup(() => clearTimeout(peekEnterTimer));
 
     // Shared between the flow-mode in-DOM render and the Portal-rendered
     // PeekOverlay — same pin/unpin button + message body in both.

--- a/frontend/app/view/agent/components/hover-anchor.ts
+++ b/frontend/app/view/agent/components/hover-anchor.ts
@@ -14,6 +14,16 @@
  * needed. Removed as dead code once the last caller migrated off it.
  */
 
+// Shared hover-to-peek enter delay. Was 150ms (separately declared in
+// ToolBlock.tsx/MarkdownBlock.tsx/UserMessageBlock.tsx — three copies that
+// could silently drift). Lowered to 50ms per SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS
+// (2026-08-25): every node kind now gets a peek, so a snappier response
+// matters more than the old ToolBlock-only guard against "accidental
+// expansion during a fast scroll-through" — 50ms is still well above a
+// single scroll-wheel tick's dwell time, just no longer padded for a
+// feature that only existed on three anchor types.
+export const PEEK_ENTER_DELAY_MS = 50;
+
 export interface VerticalRect {
     /** Distance from viewport top to top edge, in px. */
     readonly top: number;

--- a/frontend/app/view/agent/hooks/useNodePeek.test.ts
+++ b/frontend/app/view/agent/hooks/useNodePeek.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNodePeek } from "./useNodePeek";
+
+describe("useNodePeek", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("does not peek before the delay elapses", () => {
+        createRoot((dispose) => {
+            const peek = useNodePeek(50);
+            peek.handlePeekEnter();
+            vi.advanceTimersByTime(49);
+            expect(peek.isPeeking()).toBe(false);
+            dispose();
+        });
+    });
+
+    it("peeks once the delay elapses", () => {
+        createRoot((dispose) => {
+            const peek = useNodePeek(50);
+            peek.handlePeekEnter();
+            vi.advanceTimersByTime(50);
+            expect(peek.isPeeking()).toBe(true);
+            dispose();
+        });
+    });
+
+    it("a leave before the delay elapses cancels the pending peek", () => {
+        createRoot((dispose) => {
+            const peek = useNodePeek(50);
+            peek.handlePeekEnter();
+            vi.advanceTimersByTime(30);
+            peek.handlePeekLeave();
+            vi.advanceTimersByTime(50);
+            expect(peek.isPeeking()).toBe(false);
+            dispose();
+        });
+    });
+
+    it("a leave after peeking has started closes it immediately", () => {
+        createRoot((dispose) => {
+            const peek = useNodePeek(50);
+            peek.handlePeekEnter();
+            vi.advanceTimersByTime(50);
+            expect(peek.isPeeking()).toBe(true);
+            peek.handlePeekLeave();
+            expect(peek.isPeeking()).toBe(false);
+            dispose();
+        });
+    });
+
+    it("defaults to the shared 50ms delay when none is passed", () => {
+        createRoot((dispose) => {
+            const peek = useNodePeek();
+            peek.handlePeekEnter();
+            vi.advanceTimersByTime(49);
+            expect(peek.isPeeking()).toBe(false);
+            vi.advanceTimersByTime(1);
+            expect(peek.isPeeking()).toBe(true);
+            dispose();
+        });
+    });
+
+    it("setRowEl/rowEl round-trip the hovered element", () => {
+        createRoot((dispose) => {
+            const peek = useNodePeek(50);
+            expect(peek.rowEl()).toBeUndefined();
+            const el = document.createElement("div");
+            peek.setRowEl(el);
+            expect(peek.rowEl()).toBe(el);
+            dispose();
+        });
+    });
+});

--- a/frontend/app/view/agent/hooks/useNodePeek.ts
+++ b/frontend/app/view/agent/hooks/useNodePeek.ts
@@ -1,0 +1,48 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useNodePeek — shared hover-to-peek timer/state.
+ *
+ * Factored out of ToolBlock.tsx/MarkdownBlock.tsx/UserMessageBlock.tsx,
+ * which each hand-rolled an identical isPeeking signal + enter-delay timer
+ * before SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25 extended the
+ * peek overlay to every document-node kind — three (soon many more)
+ * near-identical copies of this exact logic was the point where drift
+ * (a delay changed in one file but not the others, the exact bug this
+ * feature just went through) becomes a real risk rather than a
+ * hypothetical one.
+ *
+ * `rowEl` is a signal (not a plain `let` closure var, unlike the original
+ * three copies) so it can be handed straight to `<PeekOverlay rowEl={rowEl}>`
+ * without each caller re-deriving its own accessor wrapper.
+ */
+
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import { PEEK_ENTER_DELAY_MS } from "../components/hover-anchor";
+
+export interface NodePeek {
+    isPeeking: Accessor<boolean>;
+    rowEl: Accessor<HTMLElement | undefined>;
+    setRowEl: (el: HTMLElement) => void;
+    handlePeekEnter: () => void;
+    handlePeekLeave: () => void;
+}
+
+export function useNodePeek(delayMs: number = PEEK_ENTER_DELAY_MS): NodePeek {
+    const [isPeeking, setIsPeeking] = createSignal(false);
+    const [rowEl, setRowEl] = createSignal<HTMLElement>();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const handlePeekEnter = () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => setIsPeeking(true), delayMs);
+    };
+    const handlePeekLeave = () => {
+        clearTimeout(timer);
+        setIsPeeking(false);
+    };
+    onCleanup(() => clearTimeout(timer));
+
+    return { isPeeking, rowEl, setRowEl, handlePeekEnter, handlePeekLeave };
+}

--- a/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
@@ -11,13 +11,23 @@
  * errors have no in-place fix.
  */
 
-import { cleanup, render, screen } from "@solidjs/testing-library";
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DocumentRow } from "./DocumentRow";
-import type { AgentErrorNode, CompactionStartedNode, ContextCompactedNode, DocumentNode, DocumentState } from "../types";
+import type {
+    AgentErrorNode,
+    CompactionStartedNode,
+    ContextCompactedNode,
+    DayDividerNode,
+    DocumentNode,
+    DocumentState,
+    HistoryLinkNode,
+    SectionNode,
+    SessionOutcomeNode,
+} from "../types";
 
 afterEach(() => cleanup());
 
@@ -160,5 +170,132 @@ describe("DocumentRow — compaction nodes", () => {
         renderRow(startedNode("auto"));
         expect(screen.getByText(/Compacting conversation/i)).toBeInTheDocument();
         expect(screen.getByText(/context filled up/i)).toBeInTheDocument();
+    });
+});
+
+/**
+ * DocumentRow — peek tooltip for the inline node kinds
+ * (SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25). These six kinds
+ * (section/agent_error/context_compacted/compaction_started/day_divider/
+ * session_outcome) render inline in DocumentNodeBody rather than through
+ * their own dedicated component, and previously had NO peek at all.
+ * history_link is the one deliberate exception — no timestamp/content field
+ * exists on it to peek.
+ */
+describe("DocumentRow — peek tooltip on the inline node kinds", () => {
+    const hover = (container: HTMLElement, selector: string) => {
+        const el = container.querySelector(selector) as HTMLElement;
+        fireEvent.mouseEnter(el);
+        vi.advanceTimersByTime(100);
+    };
+
+    afterEach(() => vi.useRealTimers());
+
+    it("section: shows time + estimate(title) on hover", () => {
+        vi.useFakeTimers();
+        const node: SectionNode = {
+            type: "section",
+            id: "sec-1",
+            level: 1,
+            title: "Deploy pipeline",
+            collapsible: true,
+            collapsed: false,
+            timestamp: Date.now() - 65_000,
+        };
+        const { container } = renderRow(node);
+        hover(container, ".agent-section");
+        const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+        expect(metaLines.length).toBe(2);
+        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
+    });
+
+    it("agent_error: shows only the estimate line — no timestamp field exists on this node", () => {
+        vi.useFakeTimers();
+        const { container } = renderRow(errorNode(500, "a somewhat longer error message body"));
+        hover(container, ".agent-error-block");
+        const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+        expect(metaLines.length).toBe(1);
+        expect(metaLines[0].textContent).toMatch(/~\d+ tok \(est\.\)/);
+    });
+
+    it("context_compacted: shows a time-only peek", () => {
+        vi.useFakeTimers();
+        const node: ContextCompactedNode = {
+            type: "context_compacted",
+            id: "cc-3",
+            tokensBefore: 100_000,
+            tokensAfter: 5_000,
+            timestamp: Date.now() - 65_000,
+            source: "real",
+            trigger: "manual",
+        };
+        const { container } = renderRow(node);
+        hover(container, ".agent-context-compacted");
+        const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+        expect(metaLines.length).toBe(1);
+        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+    });
+
+    it("compaction_started: shows a time-only peek from startedAt", () => {
+        vi.useFakeTimers();
+        const node: CompactionStartedNode = {
+            type: "compaction_started",
+            id: "cs-2",
+            trigger: "manual",
+            startedAt: Date.now() - 65_000,
+        };
+        const { container } = renderRow(node);
+        hover(container, ".agent-compaction-started");
+        const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+        expect(metaLines.length).toBe(1);
+        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+    });
+
+    it("day_divider: shows the exact local-midnight instant on hover", () => {
+        vi.useFakeTimers();
+        const node: DayDividerNode = {
+            type: "day_divider",
+            id: "day-2026-08-25",
+            dayLabel: "Tue, Aug 25 2026",
+            timestamp: Date.now() - 65_000,
+        };
+        const { container } = renderRow(node);
+        hover(container, ".agent-day-divider");
+        const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+        expect(metaLines.length).toBe(1);
+        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+    });
+
+    it("session_outcome: shows time + attempted/actual session ids", () => {
+        vi.useFakeTimers();
+        const node: SessionOutcomeNode = {
+            type: "session_outcome",
+            id: "so-1",
+            outcome: "fresh",
+            attemptedSid: "sid-attempted",
+            actualSid: "sid-actual",
+            timestamp: Date.now() - 65_000,
+        };
+        const { container } = renderRow(node);
+        hover(container, ".agent-session-outcome");
+        expect(document.body.querySelector(".agent-node-peek-tooltip-meta")?.textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(document.body.querySelector(".agent-node-peek-tooltip-body")?.textContent).toBe(
+            "attempted: sid-attempted · actual: sid-actual"
+        );
+    });
+
+    it("history_link: no peek anchor at all — nothing to show", () => {
+        vi.useFakeTimers();
+        const node: HistoryLinkNode = { type: "history_link", id: "history-link" };
+        const [n] = createSignal<DocumentNode>(node);
+        const [state] = createSignal<DocumentState>(emptyState());
+        const { container } = render(() => (
+            <DocumentRow node={n} documentState={state} onToggleCollapse={() => {}} onTogglePin={() => {}} />
+        ));
+        const row = container.querySelector(".agent-history-link-row") as HTMLElement;
+        fireEvent.mouseEnter(row);
+        vi.advanceTimersByTime(100);
+        expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
     });
 });

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -14,17 +14,21 @@
  * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md.
  */
 
-import { onMount, Show, type Accessor, type JSX } from "solid-js";
+import { onMount, Show, createMemo, type Accessor, type JSX } from "solid-js";
 import type { AgentDispatch } from "../../swarm/swarm-model";
 import { AgentMessageBlock } from "../components/AgentMessageBlock";
 import { JektBubble } from "../components/JektBubble";
 import { MarkdownBlock } from "../components/MarkdownBlock";
+import { PeekOverlay } from "../components/PeekOverlay";
 import { PersistentShellBlock } from "../components/PersistentShellBlock";
 import { ToolBlock } from "../components/ToolBlock";
 import { UserMessageBlock } from "../components/UserMessageBlock";
+import { useNodePeek } from "../hooks/useNodePeek";
 import type { DocumentNode, DocumentState, ShellNode, UserMessageNode } from "../types";
 import { markRowMount } from "./perf-probe";
-import { formatCompactNumber } from "@/util/format-count";
+import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
+import { formatExactTime, formatTimeAgo } from "@/util/format-time";
+import { useTick } from "@/app/hook/useTick";
 
 export interface DocumentRowProps {
     /**
@@ -180,6 +184,18 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
     // the matching branch's children update when the underlying node
     // changes. This was committed on the Phase 2 PR but landed after
     // the squash-merge cutoff — adding back as a follow-up.
+
+    // Peek tooltip for the node kinds still rendered INLINE below
+    // (section/agent_error/context_compacted/compaction_started/
+    // day_divider/session_outcome) — SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25.
+    // markdown/tool/agent_message/jekt_message/user_message/shell own their
+    // own peek state inside their dedicated components; these six don't
+    // have one, so a SINGLE shared instance here covers all of them — only
+    // one `<Show>` branch (and hence only one of these six anchors) is ever
+    // actually mounted for a given node, so sharing is safe.
+    const peekTick = useTick(1000);
+    const { isPeeking, rowEl: peekRowEl, setRowEl: setPeekRowEl, handlePeekEnter, handlePeekLeave } = useNodePeek();
+
     return (
         <>
             <Show when={props.node() && props.node().type === "markdown"}>
@@ -228,8 +244,11 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     expand affordance the removed hover strip used to provide);
                     keyboard "e" on the focused row still toggles too. */}
                 <div
+                    ref={setPeekRowEl}
                     class={`agent-section agent-section--toggle level-${(props.node() as Extract<DocumentNode, { type: "section" }>).level}`}
                     onClick={() => props.onToggleCollapse(props.node().id)}
+                    onMouseEnter={handlePeekEnter}
+                    onMouseLeave={handlePeekLeave}
                 >
                     <Show when={(props.node() as Extract<DocumentNode, { type: "section" }>).level === 1}>
                         <h1>{(props.node() as Extract<DocumentNode, { type: "section" }>).title}</h1>
@@ -240,10 +259,32 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     <Show when={(props.node() as Extract<DocumentNode, { type: "section" }>).level === 3}>
                         <h3>{(props.node() as Extract<DocumentNode, { type: "section" }>).title}</h3>
                     </Show>
+                    {(() => {
+                        const n = props.node() as Extract<DocumentNode, { type: "section" }>;
+                        const timeText = createMemo(() => {
+                            if (!isPeeking() || n.timestamp == null) return null;
+                            peekTick();
+                            return `${formatExactTime(n.timestamp)} · ${formatTimeAgo(n.timestamp)}`;
+                        });
+                        const estimateText = createMemo(() => {
+                            const count = estimateTokenCount(n.title);
+                            return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
+                        });
+                        return (
+                            <PeekOverlay show={isPeeking() && (timeText() != null || estimateText() != null)} rowEl={peekRowEl}>
+                                <Show when={timeText()}>
+                                    <div class="agent-node-peek-tooltip-meta">{timeText()}</div>
+                                </Show>
+                                <Show when={estimateText()}>
+                                    <div class="agent-node-peek-tooltip-meta">{estimateText()}</div>
+                                </Show>
+                            </PeekOverlay>
+                        );
+                    })()}
                 </div>
             </Show>
             <Show when={props.node() && props.node().type === "agent_error"}>
-                <div class="agent-error-block">
+                <div class="agent-error-block" ref={setPeekRowEl} onMouseEnter={handlePeekEnter} onMouseLeave={handlePeekLeave}>
                     <span class="agent-error-code">
                         {(() => {
                             const n = props.node() as Extract<DocumentNode, { type: "agent_error" }>;
@@ -270,6 +311,23 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                             Login Again →
                         </button>
                     </Show>
+                    {(() => {
+                        // No timestamp field exists on AgentErrorNode — estimate only,
+                        // same "no time line" shape ToolBlock/MarkdownBlock use for an
+                        // untimed node.
+                        const n = props.node() as Extract<DocumentNode, { type: "agent_error" }>;
+                        const estimateText = createMemo(() => {
+                            const count = estimateTokenCount(n.message);
+                            return count > 0 ? `~${formatCompactNumber(count)} tok (est.)` : null;
+                        });
+                        return (
+                            <PeekOverlay show={isPeeking() && estimateText() != null} rowEl={peekRowEl}>
+                                <Show when={estimateText()}>
+                                    <div class="agent-node-peek-tooltip-meta">{estimateText()}</div>
+                                </Show>
+                            </PeekOverlay>
+                        );
+                    })()}
                 </div>
             </Show>
             <Show when={props.node() && props.node().type === "context_compacted"}>
@@ -288,8 +346,21 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     const durationLabel = n.durationMs != null
                         ? ` · took ${(n.durationMs / 1000).toFixed(1)}s`
                         : "";
+                    // Only a time line — tokensBefore/After/duration are already
+                    // visible in the row itself, and there's no free-text body to
+                    // estimate a token count from.
+                    const timeText = createMemo(() => {
+                        if (!isPeeking()) return null;
+                        peekTick();
+                        return `${formatExactTime(n.timestamp)} · ${formatTimeAgo(n.timestamp)}`;
+                    });
                     return (
-                        <div class="agent-context-compacted">
+                        <div
+                            ref={setPeekRowEl}
+                            class="agent-context-compacted"
+                            onMouseEnter={handlePeekEnter}
+                            onMouseLeave={handlePeekLeave}
+                        >
                             <div class="agent-context-compacted-rule">
                                 <span class="agent-context-compacted-label">
                                     context compacted{triggerLabel ? ` — ${triggerLabel}` : ""}
@@ -298,6 +369,9 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                             <div class="agent-context-compacted-detail">
                                 Earlier history summarized · {fmt(n.tokensBefore)} → {fmt(n.tokensAfter)} tokens{durationLabel}
                             </div>
+                            <PeekOverlay show={isPeeking() && timeText() != null} rowEl={peekRowEl}>
+                                <div class="agent-node-peek-tooltip-meta">{timeText()}</div>
+                            </PeekOverlay>
                         </div>
                     );
                 })()}
@@ -306,14 +380,29 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                 {(() => {
                     const n = props.node() as Extract<DocumentNode, { type: "compaction_started" }>;
                     const triggerLabel = n.trigger === "manual" ? "you ran /compact" : "context filled up";
+                    // Node uses `startedAt`, not `timestamp` — same time-only peek
+                    // shape as context_compacted above.
+                    const timeText = createMemo(() => {
+                        if (!isPeeking()) return null;
+                        peekTick();
+                        return `${formatExactTime(n.startedAt)} · ${formatTimeAgo(n.startedAt)}`;
+                    });
                     return (
-                        <div class="agent-compaction-started">
+                        <div
+                            ref={setPeekRowEl}
+                            class="agent-compaction-started"
+                            onMouseEnter={handlePeekEnter}
+                            onMouseLeave={handlePeekLeave}
+                        >
                             <div class="agent-compaction-started-label">
                                 Compacting conversation…
                             </div>
                             <div class="agent-compaction-started-detail">
                                 {triggerLabel}
                             </div>
+                            <PeekOverlay show={isPeeking() && timeText() != null} rowEl={peekRowEl}>
+                                <div class="agent-node-peek-tooltip-meta">{timeText()}</div>
+                            </PeekOverlay>
                         </div>
                     );
                 })()}
@@ -321,13 +410,35 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
             <Show when={props.node() && props.node().type === "day_divider"}>
                 {(() => {
                     const n = props.node() as Extract<DocumentNode, { type: "day_divider" }>;
+                    // Exact local-midnight instant — the visible label is already a
+                    // human day name, so this just adds precision, no estimate line
+                    // (a day label has no free-text body worth estimating).
+                    const timeText = createMemo(() => {
+                        if (!isPeeking()) return null;
+                        peekTick();
+                        return `${formatExactTime(n.timestamp)} · ${formatTimeAgo(n.timestamp)}`;
+                    });
                     return (
-                        <div class="agent-day-divider">
+                        <div
+                            ref={setPeekRowEl}
+                            class="agent-day-divider"
+                            onMouseEnter={handlePeekEnter}
+                            onMouseLeave={handlePeekLeave}
+                        >
                             <div class="agent-day-divider-label">{n.dayLabel}</div>
+                            <PeekOverlay show={isPeeking() && timeText() != null} rowEl={peekRowEl}>
+                                <div class="agent-node-peek-tooltip-meta">{timeText()}</div>
+                            </PeekOverlay>
                         </div>
                     );
                 })()}
             </Show>
+            {/* history_link intentionally has no peek — a render-time synthetic
+                CTA row (fixed id "history-link") with no timestamp/content field
+                at all, and its full text is already fully visible without
+                hovering. SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25
+                treats this as the one deliberate exception to "always fires":
+                there is no data here a peek could add. */}
             <Show when={props.node() && props.node().type === "history_link"}>
                 <div
                     class="agent-history-link-row"
@@ -355,8 +466,22 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     // sees `fresh` today. The resumed rendering is kept for
                     // the P2 Agent History view, which materializes both.
                     const resumed = n.outcome === "resumed";
+                    // Body shows the attempted vs. actual session id — real
+                    // debug info this node's own visible label doesn't surface
+                    // anywhere else.
+                    const timeText = createMemo(() => {
+                        if (!isPeeking()) return null;
+                        peekTick();
+                        return `${formatExactTime(n.timestamp)} · ${formatTimeAgo(n.timestamp)}`;
+                    });
+                    const bodyText = `attempted: ${n.attemptedSid} · actual: ${n.actualSid ?? "—"}`;
                     return (
-                        <div class={resumed ? "agent-session-outcome" : "agent-session-outcome agent-session-outcome-fresh"}>
+                        <div
+                            ref={setPeekRowEl}
+                            class={resumed ? "agent-session-outcome" : "agent-session-outcome agent-session-outcome-fresh"}
+                            onMouseEnter={handlePeekEnter}
+                            onMouseLeave={handlePeekLeave}
+                        >
                             <div class="agent-session-outcome-rule">
                                 <span class="agent-session-outcome-label">
                                     {resumed ? "Session continued" : "New session started"}
@@ -367,6 +492,12 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                                     Prior conversation isn't available to this agent — it's preserved in the agent's history
                                 </div>
                             </Show>
+                            <PeekOverlay show={isPeeking()} rowEl={peekRowEl}>
+                                <Show when={timeText()}>
+                                    <div class="agent-node-peek-tooltip-meta">{timeText()}</div>
+                                </Show>
+                                <div class="agent-node-peek-tooltip-body">{bodyText}</div>
+                            </PeekOverlay>
                         </div>
                     );
                 })()}


### PR DESCRIPTION
## Summary
- Widens the Aug-3 hover-peek feature (`SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md`, previously scoped to just tool calls, thinking clumps, and user input) to cover every remaining transcript node kind — `agent_message`, `jekt_message`, `shell`, `section`, `agent_error`, `context_compacted`, `compaction_started`, `day_divider`, `session_outcome`.
- Lowers the hover enter-delay from 150ms to 50ms, centralized into one shared constant (`hover-anchor.ts`) instead of three independently-declared copies.
- Factors the duplicated isPeeking/timer boilerplate into a shared `useNodePeek()` hook.
- Widens ToolBlock's and MarkdownBlock's existing anchors so the peek fires from anywhere in the row, not just a narrow inner span/thinking-only block.
- One deliberate exception: `history_link` (a synthetic CTA row with no timestamp/content field) gets no peek — there's no data to show.

See `docs/specs/SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25.md` for full design rationale, including why this doesn't repeat the two prior "generic hover strip" attempts that got ripped out for UX complaints (this is a read-only floating overlay, not a layout-affecting expand/collapse).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run frontend/app/view/agent`: 1426/1426 passing (115 files) — includes new tests for the hook, 3 new component test files, and 7 new DocumentRow cases
- [x] `vitest run frontend/app/view/swarm`: 90/90 passing
- [x] `task build:frontend` production build succeeds
- [ ] Interactive/visual verification not done — native desktop app, this machine runs shared live instances; see spec for details

<!-- agentmux:agent_id=naki -->