### PR TITLE
fix(agent): Activity Dock backfill suppression + background-task registry reconciliation

### DIFF
--- a/.changesets/1787690334-fix-agent-suppress-activity-dock-refresh-during-backfill-bur-sew9.md
+++ b/.changesets/1787690334-fix-agent-suppress-activity-dock-refresh-during-backfill-bur-sew9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): suppress Activity Dock refresh during backfill bursts and reconcile registry-known background tasks into dock rows

--- a/docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md
+++ b/docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md
@@ -1,0 +1,398 @@
+# Architecture Analysis: Why the Agent Pane Keeps Regressing (Activity Dock Flicker as a Case Study)
+
+**Date:** 2026-08-25
+**Trigger:** repo owner: *"we are regressing on different elements, especially
+regarding the agent pane... it sounds like we may need an architecture rethink
+or modularization. for example, we still see flickers of old long-running task
+docks when the agent pane loads. why is that, after all the work we did? it
+sounds like perhaps we have spaghetti that needs to be cleaned up."*
+**Method:** three independent deep-dive investigations (git archaeology across
+every retro/report/spec touching this symptom family; live read of the current
+Activity Dock data-flow architecture, frontend and backend; a structural survey
+of the whole `frontend/app/view/agent/` module and its prior architecture
+assessments), plus direct verification of the current release/version state.
+**Scope:** analysis only, per the request — no code changes. Recommendations at
+the end are unimplemented, for discussion.
+
+---
+
+## TL;DR
+
+Two things are simultaneously true, and they should not be conflated:
+
+1. **The specific flicker you're describing very likely has an already-merged
+   fix sitting unreleased.** `VERSION_HISTORY.md`'s top entry on `main` is
+   already `0.55.24` and includes *"fix(agent): gate the BrainSpinner on
+   subagent backfill so the Activity Dock never flickers"* (PR #2781,
+   2026-08-24) — but **no tag newer than `v0.55.21` has ever been pushed.**
+   The only real, downloadable, published build is 33+ commits and three
+   patch versions behind `main`. If you're running the actual released
+   AppImage/portable, you are, by construction, running a build from before
+   this exact fix (and before the debounce fix, and before the shell-flash
+   fix). This alone would fully explain "we did all this work and I still see
+   it" without any deeper architecture problem at all. **§1 covers this and
+   the recommended immediate action.**
+
+2. **Independently of the release gap, there is a real, recurring architectural
+   pattern behind this entire bug family — not just an unlucky string of
+   isolated bugs.** At least 10 distinct incidents in this exact symptom
+   family have shipped fixes over the last 5 weeks, concentrated in the same
+   ~2,100-line `activity/` subdirectory and its counterpart backend
+   subsystems. The root cause, confirmed independently by two different
+   investigation angles, is narrow and specific: **the backend never tells
+   the frontend whether an event is a historical replay or a genuinely live
+   update**, and this one missing piece of information has already produced
+   at least two structurally identical bugs (a subagent-storm flicker and a
+   shell-status flicker), each "fixed" with its own bespoke, independently-
+   invented workaround instead of once, generically, at the source. On top of
+   that, the specific frontend modules behind the dock (`subagent-source.ts`,
+   `dispatch-source.ts`) were built in June 2026 — a month *after* this
+   codebase's own architecture team audited the agent pane as "100%
+   reducer-routed" and blessed a specific, disciplined state-management
+   pattern — and were built entirely *outside* that discipline, missing
+   exactly the settlement/audit guarantees that pattern exists to provide.
+   **§2-4 cover this in full, with the complete incident timeline.**
+
+Neither finding excuses the other. Cut a release now to get the already-fixed
+bugs into users' hands (§1), *and* treat the architectural gap as real,
+scoped, tractable work (§5's recommendations) — not a full "rethink," but not
+nothing either.
+
+---
+
+## 1. The mundane explanation: check this first
+
+Confirmed directly against the repo:
+
+```
+$ git tag --sort=-creatordate | head -3
+v0.55.21
+v0.55.18
+v0.55.14
+
+$ git rev-list v0.55.21..main --count
+33
+
+$ head -3 VERSION_HISTORY.md
+# AgentMux Version History
+## 0.55.24 — 2026-08-24
+```
+
+`VERSION_HISTORY.md`'s current top section (version 0.55.24, dated 2026-08-24)
+already includes, verbatim:
+
+- `fix(agent): gate the BrainSpinner on subagent backfill so the Activity Dock
+  never flickers` (PR #2781) — the most recent, most targeted fix in the
+  entire incident chain below.
+- The 2026-08-23 debounce-coalescing fix (PR #2773) shipped even earlier, in
+  the still-unreleased `0.55.22`.
+
+**The actual published GitHub Release is `v0.55.21`.** `v0.55.22`'s own
+release commit exists on `main` (`01cb05d3e`) but was never tagged; a later
+`chore: release v0.55.24` commit superseded it, also untagged. Nothing past
+`v0.55.21` has ever been built and distributed as an actual downloadable
+artifact.
+
+**Recommended immediate action, separate from anything below:** cut a real
+release now (`task release` already computed through `0.55.24`; tag and
+publish it) so the fixes that already exist reach an actual running build.
+This is a five-minute action that may resolve the reported symptom on its own,
+and doing it first will make it much easier to tell whether any *further*
+flicker you observe afterward is a genuinely new (fifth) incident in this
+family, or just the release lag catching up.
+
+---
+
+## 2. Full incident timeline
+
+Ten distinct incidents in this exact symptom family (docks/subagent rows/shell
+rows appearing then vanishing or misreporting on load), spanning 2026-07-17 to
+2026-08-24 — about 5 weeks:
+
+| Date | PR / Commit | Symptom | Root cause | Fix scope | Deeper fix left undone? |
+|---|---|---|---|---|---|
+| 07-17 | Fix A (subagent_watcher) + companion launcher Fix B | Whole-app OOM crash ×3 on cold restart | Unbounded historical replay: every subagent JSONL ever written for a session was replayed on every reopen/restart | **Narrow.** Capped replay to `BACKFILL_MAX_FILES=200` | Yes — corpus never pruned; Unix/macOS srv has no OOM-retry parity at all |
+| 07-23 | PR #2286 | A subagent's activity leaked into 5 unrelated, already-closed panes | fs watcher not scoped to the calling agent's own files; leaked watchers never torn down on ungraceful close | **Structural, narrowly scoped** to this one leak | A *different* watcher-scoping bug (wrong config dir) recurred 4 weeks later (08-22 row below) |
+| 07-24 | PR #2293 | Error rows in the dock accumulated forever | `RETENTION_MS.error` was `Infinity` by original design | **Narrow.** 15s retention + flash animation | Yes — 4 independent near-identical "flash" implementations exist codebase-wide with no shared primitive |
+| 08-06 | (root cause hypothesized, fix status unclear) | Phantom "Agent" placeholder rows / ghosts in Swarm tree | Hypothesized: tree-builder renders any `parent_block_id` referenced by a subagent record even with no real registered block | **Unclear — retro explicitly says "NOT yet live-confirmed" at time of writing** | Yes, by definition — worth confirming whether this was ever actually closed |
+| 08-10 | PR #2519 + #2520 | 17 dock rows stuck "running" for hours after backgrounded shells finished | `run_in_background:true` trusted as proof of a detached process; harness sometimes resolves synchronously instead | **Narrow, well-scoped** | Yes, twice — `bg` visibility silently expires after 1h with no refresh; no automated pre-push staleness check |
+| **08-22** | **PR #2770** | **Shell rows flash "running" on pane load, then vanish** | `shell_node_create` replays verbatim on every mount with no status field; the correction (an "exit" event) arrives via a slower, independent round trip | **Narrow** — added a fast synchronous status-correction RPC. Took 3 review rounds, each catching a new race the fix itself introduced | Yes, explicitly — flash window narrowed, not eliminated by a hard guarantee; a "pending" status variant or WPS-replay rework judged "disproportionate" |
+| 08-22 | (spec, implemented) | Subagent watcher watched the wrong config dir for identity-bound agents | Config dir resolved once at launch, diverges from the real per-turn dir | **Structural for this case** | Yes — no backfill/refresh if identity rebinds mid-session |
+| 08-22/23 | PR #2761/#2768, then same-day fix | Pane flickers through spinner→picker→content on tab actions; then (fix regression) spinner got stuck **permanently visible** | No reveal gate for pane-local mounts, only whole-tab switches; the fix's own cross-fade rewrite had a construction-vs-effect timing race | **Structural** (the gate), then **narrow** (the regression fix) | Yes — declined to extract a shared reveal-gate primitive or sweep for the same timing pattern elsewhere |
+| **08-23** | **PR #2773** | **Reopening a heavily-used pane: 155 backfill events → ~300 overlapping RPC calls → 7.6s stall, rows appear/vanish repeatedly** | Two frontend singletons (`dispatch-source.ts`, `subagent-source.ts`) each fired an uncoalesced refresh on *every single event* | **Narrow, explicitly named as option 1 of 4** — shared 100ms/1s debounce | **Yes, explicitly, twice-named** — "thread the `live`/replay flag to the wire" and "in-flight RPC de-dup" both deferred as "larger, separate" work |
+| **08-24** | **PR #2781** | **Owner reports the exact same symptom again, on a build that already had both prior fixes** — "docked items still show, then disappear" | Root cause is explicitly two-part: (1) the debounce coalesces request *volume*, not visual *settlement* — the 2-3 remaining refreshes are still genuinely different real snapshots; (2) the BrainSpinner's readiness gate had **zero** awareness of the dock's data sources at all, ever, by original design | **Structural — and it's the first incident in this whole family where the previously-deferred fix (from 08-23, one day earlier) was actually picked back up rather than left to rot.** New persisted `subagent:backfill_status` event; BrainSpinner now gates on it | Partially — a narrower slice of "thread replay-status to the wire" shipped (scoped to gating the spinner specifically); the more general version (tagging every `subagent:spawned`/`completed` broadcast itself as replay-vs-live) still does not exist |
+
+**Tally of "we should really fix this properly later" notes across this
+timeline: 8 distinct, named, still-open architectural deferrals.** Only one
+(08-24, PR #2781) was picked back up promptly (the next day) rather than left
+sitting. This 1-in-9 follow-through rate is itself worth noting as a process
+pattern, separate from the technical root cause below.
+
+**Confirmed hot-spot files, by commit count** (not just doc cross-references
+— actual `git log` counts):
+
+| File | Commits | |
+|---|---|---|
+| `agentmux-srv/src/backend/subagent_watcher.rs` (+ later module split) | **41** | The single hottest file in this entire bug family |
+| `frontend/app/view/agent/components/ActivityDock.tsx` | **~14** | Every dock-visible symptom touches this one file |
+| `frontend/app/view/agent/activity/subagent-source.ts` | 5 | Every commit since creation has been a bug fix, none a clean feature add |
+| `frontend/app/view/agent/activity/dispatch-source.ts` | 3 | 2 of 3 commits are fixes; same shape as its sibling |
+| `frontend/app/block/block.tsx` (`ready()` gate) | 3 incidents in 3 consecutive days (08-22 to 08-24), same ~10-line region | |
+
+---
+
+## 3. Why this keeps recurring: the current architecture, precisely
+
+### 3.1 No single authoritative "what's running" source exists
+
+Four structurally independent backend subsystems each answer some version of
+"is this thing still active," with **no shared data model, no shared event
+vocabulary, and no shared consistency guarantees**:
+
+| Subsystem | Owns | Consistency model |
+|---|---|---|
+| `agentmux-srv/src/backend/subagent_watcher/` | Subagents + dispatches, via fs-watching Claude Code's own transcript files | **Lazy timer**: a dispatch only flips running→completed on the *next* event or read, 60s after quiet — no backend timer fires this on its own. The frontend has to reimplement this exact 60s constant client-side, kept in sync by comment convention only (no shared constant). |
+| `agentmux-srv/src/backend/shell_node.rs` | Persistent shell processes | **Registry-status lookup**, entirely separate map/event names/eviction policy from the above |
+| `agentmux-srv/src/backend/storage/background_tasks.rs` | Durable (SQLite) background-task rows — the *only* one of the four that survives an srv restart | Explicitly built because the frontend's own signal chain is "entirely ephemeral... silently evicted after one hour" (its own header comment) |
+| `agentmux-srv/src/backend/process_tracker/` | Raw OS process count | Genuinely orthogonal concern, not duplicative of the above three |
+
+These are unified **only at the very last mile**, client-side, by
+`ActivityDock.tsx`'s three-way array concatenation of `shellActivities()` +
+`subagentActivities()` + `toolActivities()`, and separately re-derived a
+second time by `attached-task.ts` for an unrelated liveness boolean — that
+file's own doc comment explicitly flags this as duplication that *should*
+consume the dock's own signal rather than recompute it, and doesn't.
+
+### 3.2 On the frontend, at least 11 independent modules each maintain their own refresh cycle
+
+A full inventory (not just the 2-3 already implicated in recent bugs) found
+11 distinct modules under `frontend/app/view/agent/` that independently
+subscribe to backend/WPS events for "what's currently running"-adjacent state.
+Most are legitimately separate concerns (process count, controller status,
+tab-title text) — but a few are genuine, unreconciled duplication of the same
+underlying fact:
+
+- **`dispatch-source.ts` vs `subagent-source.ts`**: two independent
+  singletons, two separate RPCs (`ListDispatches` vs `ListActive`), two
+  separately-debounced timers, answering overlapping questions derived from
+  the *same* underlying backend records. During a backfill burst these two
+  singletons' snapshots are not guaranteed to agree with each other at any
+  given instant — this is the exact, confirmed mechanism behind the 08-23
+  storm's flicker.
+- **The durable background-task registry vs. the dock's transcript-derived
+  background-task rows**: never reconciled at all, not even via the careful
+  union-with-earliest-start-wins pattern used elsewhere in this same codebase
+  for a structurally identical problem (see 3.3). A background task that
+  survives a session restart — the registry's entire reason for existing — is
+  provably invisible as an actual dock row; only a side-effect boolean leaks
+  through.
+
+### 3.3 The actual root cause: one missing signal, invented around independently, twice
+
+`subagent_watcher`'s own code already computes a `live: bool` distinguishing
+historical replay from a genuine new event (`jsonl.rs`) — but that flag is
+used **only** to gate an unrelated side effect (eager Haiku naming) and never
+reaches the wire. The WebSocket payload for a replayed 2026-07-01 event is
+byte-for-byte identical in shape to a payload for something that just
+happened.
+
+Two independent teams/PRs then invented two independent, bespoke workarounds
+for the identical underlying gap:
+
+- `dispatch-source.ts`/`subagent-source.ts` got an **event-count debounce**
+  (08-23) — masks *volume*, not *content correctness*. This is precisely why
+  it did not fully fix the flicker (08-24's retro is explicit about this).
+- `useShellNodeStream.ts` got a **bespoke synchronous status-correction RPC**
+  plus an ad hoc `reallyResolved` race-guard Set (08-22) — a completely
+  different fix, for the same replay-vs-live ambiguity, just for shells
+  instead of subagents.
+
+This is a strong, specific structural signal: **two teams independently
+discovered the same missing primitive and each built their own local patch
+around it**, rather than either one adding the one thing that would have
+helped both — a `live`/`replay` field on the relevant WPS event payloads. The
+08-24 fix (PR #2781) is the first crack at this, but scoped narrowly to a
+single new `subagent:backfill_status` event used only to gate the
+BrainSpinner — not the general case of tagging every individual
+`subagent:spawned`/`completed` broadcast.
+
+### 3.4 This is not "the whole design is wrong" — it's specific and bounded
+
+Worth being precise here, since "architecture rethink" can be read as
+"rewrite everything." It shouldn't be. The *domain* split — shells, subagents,
+and promoted tool calls are genuinely different backend concepts with
+different lifecycles — is a legitimate distinction, not accidental
+duplication. Unifying them only at the final render layer via small, pure,
+independently-tested adapter functions (`shell-adapter.ts`,
+`subagent-adapter.ts`, `tool-adapter.ts` — each has its own test file) is a
+sound shape, and collapsing all three into one unified backend model would be
+a large, likely premature undertaking nobody is asking for.
+
+The actual leverage is narrow: **add the missing replay-vs-live signal once,
+generically, at the wire level**, and reconcile the two genuinely-unreconciled
+duplications named in 3.2. That is real, scoped, understandable work — not a
+rewrite.
+
+---
+
+## 4. The broader "modularization" question: is the agent pane itself too big/tangled?
+
+Yes, by the codebase's *own* prior, documented standards — this isn't a new
+external judgment being imposed:
+
+### 4.1 `agent-view.tsx` broke its own documented budget by 8.3x
+
+`docs/specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md` set a hard cap of
+**≤300 lines** for this file. A verification pass the same week measured it at
+302 ("2 lines over, not urgent"). **Today it is 2,496 lines**, with **216
+commits** touching it historically — the single most-churned file in the
+entire pane module. No later doc revisits or re-authorizes this regrowth; it
+simply happened, uncontested, over four months.
+
+It is not alone. `docs/analysis/ANALYSIS_LARGE_FILE_MODULARIZATION_CANDIDATES_2026_05_28.md`
+flagged `AgentLaunchModal.tsx` (1,020 lines then) and `agent-view.tsx` (958
+lines then, already 3x its own budget) as carve candidates in May, alongside
+six Rust files that *did* get modularized the same day (e.g. `store.rs`:
+6,226 → 3,306 lines). The TypeScript side of that plan was never executed —
+`AgentLaunchModal.tsx` is 900 lines today (roughly flat), `agent-view.tsx` is
+2.6x larger than when it was flagged.
+
+Other files currently over 500 lines and mixing concerns:
+`useAgentCommands.ts` (1,644), `useAgentControllerStatus.ts` (1,265),
+`AgentFooter.tsx`/the composer (1,053 — originally sized small per the April
+2026 typing-lag investigation's own "3 principles"), `AgentDocumentVirtualList.tsx`
+(1,049), `AgentPicker.tsx` (1,022), `PreLaunchAuthPanel.tsx` (902),
+`auth-state.ts` (878).
+
+### 4.2 The team already, explicitly, self-diagnosed scope creep in this exact module
+
+`docs/analysis/agent-pane-rich-features-structure-2026-04-13.md`'s own
+author, investigating an unrelated bug, wrote: *"I added seven features the
+user didn't ask for... The right longer-term move is probably to remove all
+four banners and the two panels entirely... and re-introduce them one by one
+only when the user actually asks."* This is a direct, contemporaneous,
+first-party admission of the exact pattern you're describing — not a new
+outside observation.
+
+### 4.3 The codebase does have a real, disciplined, audited state-management architecture — it's just not what the Activity Dock uses
+
+This is the single most important structural finding for the "do we need an
+architecture rethink" question, and the answer is nuanced: **no, you already
+built one — a specific new subsystem was built outside it.**
+
+`docs/specs/frontend-reducer-conventions-2026-05-03.md` establishes an
+explicit, principled pattern (modeled on the Rust backend's own
+`agentmux-srv/src/reducer.rs`): pure `update(state, command) -> {state,
+events}` slices, mandatory "negative events" for every suppressed/dropped
+command (specifically for audit-ability — exactly the kind of guarantee that
+would surface "this refresh was suppressed because a burst was in flight"
+instead of silently racing), an echo-loop guard for slices mirroring backend
+state, required tests. A companion audit
+(`docs/analysis/AGENT_PANE_REDUCER_AUDIT_2026_05_12.md`) confirmed, as of
+2026-05-12, that **100% of the agent pane's rendering-relevant state was
+already reducer-routed** — a deliberate, verified architecture.
+
+`subagent-source.ts` and `dispatch-source.ts` were built **in June 2026** —
+after that audit — to solve a genuinely different problem the reducer
+conventions never targeted (a cross-pane shared read cache, since every open
+pane's dock needs the same list and a per-pane reducer slot would mean N
+redundant polls). That's a legitimate reason not to use the *per-pane-keyed*
+slot pattern. But the team then built the shared-singleton case with **none**
+of the reducer discipline's other guarantees — no negative/suppressed events,
+no audit trail, no invariant enforcement, just a bare `try {} catch {
+/* silently ignore */ }` around each refresh. This gap is directly named as
+root cause in the 08-24 retro itself: *"there is no principled way to
+distinguish 'still converging, don't render this yet' from 'this is the real,
+final state' — it can only ever guess via timing."* That is exactly the
+invariant the reducer pattern's suppressed-event rule exists to provide.
+
+**14 other files repo-wide** use the same bare-singleton-signal pattern
+legitimately for genuinely global, non-keyed state (`global.ts`,
+`flash-notifications.ts`, `tab-reveal.ts`, etc.) — so the pattern itself isn't
+illegitimate. It's specifically wrong for *this* case, because Activity Dock
+data renders a keyed list whose membership visibly changes between snapshots,
+which is exactly the scenario the reducer pattern's settlement/audit
+guarantees were designed for.
+
+### 4.4 Confirming this is the current hot zone, independent of the docs
+
+**54.5% of all frontend commits since 2026-06-01 (399 of 732) touched
+`frontend/app/view/agent/`.** Four distinct flicker-on-load bugs shipped in
+this one subsystem within a single 48-hour window (Aug 22-24), each retro
+explicitly noting "not the same bug as the last one, a different-but-adjacent
+race in the same neighborhood." This is the clearest available signal that
+the *architecture* of this one subdirectory — not any individual bug — is the
+actual limiting factor.
+
+---
+
+## 5. Recommendations (not implemented — for discussion)
+
+**Tier 0 — do regardless of anything else, costs almost nothing:**
+- Cut a release now (§1). Get the already-merged fixes into an actual
+  distributed build before investing further effort chasing what might
+  already be fixed.
+
+**Tier 1 — narrow, scoped, directly closes the confirmed root cause (§3.3):**
+- Add a `live`/`replay` boolean to the WPS payload for
+  `subagent:spawned`/`completed`/`activity` broadcasts (the data already
+  exists server-side in `jsonl.rs`'s `live` parameter — it just needs to
+  reach the wire). Let `dispatch-source.ts`/`subagent-source.ts` skip
+  per-event refresh entirely for replay-tagged events, doing exactly one
+  fetch once backfill completes — removing the need for the debounce
+  heuristic, the `DOCK_SETTLE_BUFFER_MS` guess, and the shell-specific
+  synchronous correction RPC as three independent approximations of the same
+  missing fact.
+- Reconcile the durable background-task registry with the dock's own
+  transcript-derived rows (§3.2), using the same union-with-earliest-wins
+  pattern already proven for `attachedTask`/`registryAttachedTaskSince`
+  elsewhere in this exact codebase — not a new pattern, just applying an
+  existing, working one to a second unreconciled case.
+
+**Tier 2 — real but smaller-scoped modularization, not a rewrite:**
+- Extract `agent-view.tsx`'s absorbed responsibilities (drag-overlay wiring,
+  context-menu wiring, tab-reveal gating) back toward dedicated hooks,
+  revisiting the already-written (and already-once-verified-then-abandoned)
+  `SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md` plan rather than starting
+  fresh.
+- Consider whether `activity/`'s two near-identical singleton sources
+  (`dispatch-source.ts`/`subagent-source.ts`) should be factored into one
+  shared `createPolledEventSource(service, method, events, merge)` helper —
+  their own doc comments already admit they're hand-kept-in-sync copies of
+  each other; the `subagent:abandoned` wiring bug (PR #2676) already had to
+  be fixed twice because of this, once per file.
+
+**Tier 3 — process, not code:**
+- Of the 8 "we should fix this properly later" notes accumulated across this
+  incident family, only 1 was ever picked back up (and only the next day).
+  Worth deciding, as a team norm, whether a deferred-fix note should get a
+  tracked follow-up item rather than living only inside a retro doc nobody
+  revisits.
+
+**Explicitly not recommended:** a full rearchitecture of the backend
+subagent/shell/background-task subsystems into one unified model. The domain
+split is legitimate (§3.4); the actual gap is one missing signal plus two
+specific unreconciled duplications, not the overall shape.
+
+---
+
+## 6. What this report didn't cover
+
+- The 08-06 phantom-rows incident's fix status was never confirmed as closed
+  in any doc found — worth a direct check before assuming it's resolved.
+- `stream-parser.ts`'s "no separator between consecutive thinking/text
+  deltas" gap, named as Suspect A in the original 2026-05-10 architecture doc,
+  is still unaddressed in the code today (verified directly,
+  `stream-parser.ts:396-438`) — unrelated to the dock-flicker family, but a
+  second confirmed instance of a named, scoped, never-picked-up fix in this
+  same module.
+- Whether `BACKFILL_MAX_FILES` (200, tuned against the 07-17 OOM crash) is
+  still the right cap now that the *consumption*-side cost (this report's
+  focus) is better understood was flagged as an open question in the 08-23
+  report and not re-examined here.
+- No live reproduction of the current symptom was performed as part of this
+  report — findings are from code/doc archaeology, not a fresh trace. If the
+  flicker persists on a build that actually includes PR #2781, a fresh live
+  trace (the same method `REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md`
+  used) would be the right next step to confirm whether it's a genuinely new,
+  fifth incident.

--- a/frontend/app/view/agent/activity/backfill-tracker.test.ts
+++ b/frontend/app/view/agent/activity/backfill-tracker.test.ts
@@ -1,0 +1,239 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * backfill-tracker.ts — see docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md
+ * and this repo's own docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md
+ * Tier 1 recommendation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+}));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        hub.handlers.set(sub.eventType, sub.handler);
+        return () => hub.handlers.delete(sub.eventType);
+    }),
+}));
+
+import {
+    createBackfillAwareTrigger,
+    handleBackfillStatusEvent,
+    isAnyBlockBackfilling,
+    onNextBackfillSettle,
+    parseBackfillStatusEvent,
+} from "./backfill-tracker";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("parseBackfillStatusEvent", () => {
+    it("parses a valid started event", () => {
+        expect(parseBackfillStatusEvent(["block:b1"], { status: "started" })).toEqual({
+            blockId: "b1",
+            status: "started",
+        });
+    });
+
+    it("parses a valid done event", () => {
+        expect(parseBackfillStatusEvent(["block:b1"], { status: "done" })).toEqual({
+            blockId: "b1",
+            status: "done",
+        });
+    });
+
+    it("finds the block: scope among several unrelated scopes", () => {
+        expect(parseBackfillStatusEvent(["other:x", "block:b2", "another:y"], { status: "done" })).toEqual({
+            blockId: "b2",
+            status: "done",
+        });
+    });
+
+    it("returns null when there's no block: scope at all", () => {
+        expect(parseBackfillStatusEvent(["other:x"], { status: "started" })).toBeNull();
+        expect(parseBackfillStatusEvent(undefined, { status: "started" })).toBeNull();
+        expect(parseBackfillStatusEvent([], { status: "started" })).toBeNull();
+    });
+
+    it("returns null for a malformed/unexpected status value", () => {
+        expect(parseBackfillStatusEvent(["block:b1"], { status: "bogus" })).toBeNull();
+        expect(parseBackfillStatusEvent(["block:b1"], {})).toBeNull();
+        expect(parseBackfillStatusEvent(["block:b1"], null)).toBeNull();
+        expect(parseBackfillStatusEvent(["block:b1"], undefined)).toBeNull();
+    });
+});
+
+describe("isAnyBlockBackfilling / handleBackfillStatusEvent", () => {
+    it("is false with nothing tracked", () => {
+        expect(isAnyBlockBackfilling()).toBe(false);
+    });
+
+    it("becomes true on started, false again on done for the same block", () => {
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        expect(isAnyBlockBackfilling()).toBe(true);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(isAnyBlockBackfilling()).toBe(false);
+    });
+
+    it("stays true while ANY of several concurrently-backfilling blocks hasn't finished", () => {
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        handleBackfillStatusEvent(["block:b2"], { status: "started" });
+        expect(isAnyBlockBackfilling()).toBe(true);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(isAnyBlockBackfilling()).toBe(true); // b2 still in flight
+
+        handleBackfillStatusEvent(["block:b2"], { status: "done" });
+        expect(isAnyBlockBackfilling()).toBe(false);
+    });
+
+    it("a malformed event is silently ignored, not treated as a state transition", () => {
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        handleBackfillStatusEvent(["not-a-block-scope"], { status: "done" });
+        expect(isAnyBlockBackfilling()).toBe(true); // b1 unaffected by the bogus event
+        handleBackfillStatusEvent(["block:b1"], { status: "done" }); // cleanup for other tests
+    });
+
+    it("the safety-net timeout auto-clears a block whose done never arrives", () => {
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        expect(isAnyBlockBackfilling()).toBe(true);
+
+        vi.advanceTimersByTime(19_000);
+        expect(isAnyBlockBackfilling()).toBe(true); // still under the 20s ceiling
+
+        vi.advanceTimersByTime(2000); // total 21s — past it
+        expect(isAnyBlockBackfilling()).toBe(false);
+    });
+});
+
+describe("onNextBackfillSettle", () => {
+    it("fires once, the next time the tracked set becomes empty", () => {
+        const listener = vi.fn();
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        onNextBackfillSettle(listener);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        // A later, unrelated settle must NOT re-fire the same (already
+        // consumed) listener.
+        handleBackfillStatusEvent(["block:b2"], { status: "started" });
+        handleBackfillStatusEvent(["block:b2"], { status: "done" });
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire until EVERY tracked block has settled", () => {
+        const listener = vi.fn();
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        handleBackfillStatusEvent(["block:b2"], { status: "started" });
+        onNextBackfillSettle(listener);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(listener).not.toHaveBeenCalled();
+
+        handleBackfillStatusEvent(["block:b2"], { status: "done" });
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("an unsubscribed listener never fires", () => {
+        const listener = vi.fn();
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        const unsub = onNextBackfillSettle(listener);
+        unsub();
+
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(listener).not.toHaveBeenCalled();
+    });
+});
+
+describe("createBackfillAwareTrigger", () => {
+    it("delegates straight to the debounced scheduler when nothing is backfilling", () => {
+        const scheduleDebounced = vi.fn();
+        const refreshNow = vi.fn();
+        const trigger = createBackfillAwareTrigger(scheduleDebounced, refreshNow);
+
+        trigger();
+        trigger();
+        expect(scheduleDebounced).toHaveBeenCalledTimes(2);
+        expect(refreshNow).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the debounced scheduler entirely while a backfill is in flight", () => {
+        const scheduleDebounced = vi.fn();
+        const refreshNow = vi.fn();
+        const trigger = createBackfillAwareTrigger(scheduleDebounced, refreshNow);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        for (let i = 0; i < 50; i++) trigger();
+        expect(scheduleDebounced).not.toHaveBeenCalled();
+        expect(refreshNow).not.toHaveBeenCalled();
+
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(refreshNow).toHaveBeenCalledTimes(1);
+        expect(scheduleDebounced).not.toHaveBeenCalled();
+    });
+
+    it("only registers ONE settle listener no matter how many events arrive mid-backfill", () => {
+        const scheduleDebounced = vi.fn();
+        const refreshNow = vi.fn();
+        const trigger = createBackfillAwareTrigger(scheduleDebounced, refreshNow);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        trigger();
+        trigger();
+        trigger();
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+
+        expect(refreshNow).toHaveBeenCalledTimes(1); // not 3
+    });
+
+    it("resumes normal debounced behavior for events arriving after a backfill settles", () => {
+        const scheduleDebounced = vi.fn();
+        const refreshNow = vi.fn();
+        const trigger = createBackfillAwareTrigger(scheduleDebounced, refreshNow);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        trigger();
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(refreshNow).toHaveBeenCalledTimes(1);
+
+        trigger(); // a genuinely live event, well after settle
+        expect(scheduleDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    it("a second backfill window after the first settled is handled independently", () => {
+        const scheduleDebounced = vi.fn();
+        const refreshNow = vi.fn();
+        const trigger = createBackfillAwareTrigger(scheduleDebounced, refreshNow);
+
+        handleBackfillStatusEvent(["block:b1"], { status: "started" });
+        trigger();
+        handleBackfillStatusEvent(["block:b1"], { status: "done" });
+        expect(refreshNow).toHaveBeenCalledTimes(1);
+
+        handleBackfillStatusEvent(["block:b2"], { status: "started" });
+        trigger();
+        expect(refreshNow).toHaveBeenCalledTimes(1); // still 1 — suppressed again
+        handleBackfillStatusEvent(["block:b2"], { status: "done" });
+        expect(refreshNow).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("the live WPS subscription wired at module load", () => {
+    it("registered a handler for subagent:backfill_status", () => {
+        expect(hub.handlers.has("subagent:backfill_status")).toBe(true);
+    });
+
+    it("routes a real event through to state, exactly like calling handleBackfillStatusEvent directly", () => {
+        const handler = hub.handlers.get("subagent:backfill_status")!;
+        handler({ scopes: ["block:live-test"], data: { status: "started" } });
+        expect(isAnyBlockBackfilling()).toBe(true);
+        handler({ scopes: ["block:live-test"], data: { status: "done" } });
+        expect(isAnyBlockBackfilling()).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/activity/backfill-tracker.ts
+++ b/frontend/app/view/agent/activity/backfill-tracker.ts
@@ -1,0 +1,149 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tracks which blocks currently have a subagent/dispatch backfill in
+ * progress (`subagent:backfill_status`, `subagent_watcher/scan.rs`),
+ * globally across every open pane — shared by `dispatch-source.ts` and
+ * `subagent-source.ts` so both app-wide singletons can suppress their own
+ * per-event refresh WHILE a backfill is running and fire exactly one
+ * settle-refresh once it's genuinely done, instead of relying purely on
+ * `debounced-refresh.ts`'s timing window to approximate settlement.
+ *
+ * Root cause this closes: per
+ * docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md
+ * §4, "the debounce coalesces request *volume*, not visual *settlement*" —
+ * even the 2-3 refreshes that survive the debounce during a backfill burst
+ * are each a genuinely different, real, but still-converging snapshot, so
+ * Activity Dock rows still visibly appear-then-vanish as each one lands.
+ * Suppressing refreshes entirely until the backend itself reports the
+ * backfill done, then firing exactly one, removes those intermediate
+ * partial-snapshot renders rather than just reducing their count.
+ *
+ * Deliberately much simpler than `useSubagentBackfillGate.ts`'s per-block
+ * gate (8 review rounds of edge cases closed there, per that file's own
+ * history): this is a best-effort refresh-suppression optimization, not a
+ * correctness-critical gate blocking pane reveal. If a block's "done" event
+ * is somehow missed entirely (e.g. a dropped WS connection, or the owning
+ * pane closes mid-backfill with no further activity), `PANE_CLOSED_OR_LOST_MS`
+ * below fails that one block open again on a timer — unlike the spinner
+ * gate there's no user-visible "stuck forever" failure mode to guard
+ * against (worst case without this fallback: dock refreshes stay suppressed
+ * app-wide, which `debounced-refresh.ts`'s own `maxWaitMs` ceiling would
+ * still eventually override for any consumer that kept receiving events —
+ * but a block that stops producing events entirely, e.g. because its pane
+ * closed, would never trigger even that ceiling, so the fallback still
+ * matters).
+ */
+
+import { waveEventSubscribe } from "@/app/store/wps";
+
+const backfillingBlocks = new Map<string, ReturnType<typeof setTimeout>>();
+const settleListeners = new Set<() => void>();
+
+/** See this module's doc comment — bounds how long a single block can keep
+ *  every dock refresh app-wide suppressed if its own "done" event is lost. */
+const PANE_CLOSED_OR_LOST_MS = 20_000;
+
+function fireSettleListeners(): void {
+    if (settleListeners.size === 0) return;
+    const listeners = Array.from(settleListeners);
+    settleListeners.clear();
+    for (const listener of listeners) listener();
+}
+
+/** Pure — exported for direct unit coverage, same rationale as
+ *  `resolveBackfillStatus` in `useSubagentBackfillGate.ts` (deliberately not
+ *  imported from there: that module owns the per-block spinner gate, this
+ *  one owns an unrelated refresh-suppression optimization; sharing the
+ *  parse function alone isn't worth a cross-concern dependency). */
+export function parseBackfillStatusEvent(scopes: string[] | undefined, data: unknown): { blockId: string; status: "started" | "done" } | null {
+    const scope = scopes?.find((s) => s.startsWith("block:"));
+    if (!scope) return null;
+    const blockId = scope.slice("block:".length);
+    if (!blockId) return null;
+    const status = (data as Record<string, unknown> | null | undefined)?.status;
+    if (status !== "started" && status !== "done") return null;
+    return { blockId, status };
+}
+
+/** True while any open pane's subagent/dispatch history is still
+ *  backfilling — `dispatch-source.ts`/`subagent-source.ts` consult this to
+ *  decide whether to suppress an event-triggered refresh. */
+export function isAnyBlockBackfilling(): boolean {
+    return backfillingBlocks.size > 0;
+}
+
+/** Register a one-shot callback fired the next time every currently-tracked
+ *  backfill finishes (`backfillingBlocks` transitions to empty). A caller
+ *  with nothing in flight right now (`isAnyBlockBackfilling()` already
+ *  false) has nothing to wait for and should not register. */
+export function onNextBackfillSettle(listener: () => void): () => void {
+    settleListeners.add(listener);
+    return () => settleListeners.delete(listener);
+}
+
+export function handleBackfillStatusEvent(scopes: string[] | undefined, data: unknown): void {
+    const parsed = parseBackfillStatusEvent(scopes, data);
+    if (!parsed) return;
+    const { blockId, status } = parsed;
+
+    if (status === "started") {
+        clearTimeout(backfillingBlocks.get(blockId));
+        backfillingBlocks.set(
+            blockId,
+            setTimeout(() => {
+                backfillingBlocks.delete(blockId);
+                if (backfillingBlocks.size === 0) fireSettleListeners();
+            }, PANE_CLOSED_OR_LOST_MS)
+        );
+        return;
+    }
+
+    // status === "done"
+    clearTimeout(backfillingBlocks.get(blockId));
+    backfillingBlocks.delete(blockId);
+    if (backfillingBlocks.size === 0) fireSettleListeners();
+}
+
+/**
+ * Wrap an event-triggered refresh trigger so that, while any block is
+ * backfilling, no refresh fires at all for this event — it's silently
+ * absorbed — and exactly one refresh fires once every tracked backfill
+ * settles. When nothing is backfilling, delegates straight through to
+ * `scheduleDebouncedRefresh` (today's existing debounce behavior, unchanged,
+ * for live responsiveness once backfill isn't a factor).
+ *
+ * Shared by `dispatch-source.ts` and `subagent-source.ts` — each still owns
+ * its own `createDebouncedRefresh` instance (passed in as
+ * `scheduleDebouncedRefresh`) and its own `refresh()` (passed in as
+ * `refreshNow`); this only decides WHICH of the two to call per event.
+ */
+export function createBackfillAwareTrigger(scheduleDebouncedRefresh: () => void, refreshNow: () => void): () => void {
+    let pendingSettleUnsub: (() => void) | null = null;
+    return function trigger(): void {
+        if (isAnyBlockBackfilling()) {
+            if (!pendingSettleUnsub) {
+                pendingSettleUnsub = onNextBackfillSettle(() => {
+                    pendingSettleUnsub = null;
+                    refreshNow();
+                });
+            }
+            return;
+        }
+        scheduleDebouncedRefresh();
+    };
+}
+
+// Started once at module load (ES modules are singletons — every importer
+// shares this one subscription and the one `backfillingBlocks` map behind
+// it), mirroring `dispatch-source.ts`/`subagent-source.ts`'s own lifecycle.
+// No `scope` — this needs every open pane's block, not just one, unlike
+// `useSubagentBackfillGate.ts`'s per-block-scoped subscription (that hook
+// and this tracker both listen to the same backend event independently and
+// safely: `wps.ts`'s `dispatchToSubjects` fans one incoming message out to
+// every registered listener, filtering by each listener's own `scope`).
+waveEventSubscribe({
+    eventType: "subagent:backfill_status",
+    handler: (event: { scopes?: string[]; data?: unknown }) => handleBackfillStatusEvent(event?.scopes, event?.data),
+});

--- a/frontend/app/view/agent/activity/background-adapter.test.ts
+++ b/frontend/app/view/agent/activity/background-adapter.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { backgroundTaskActivities, backgroundTaskToActivity } from "./background-adapter";
+
+function task(overrides: Partial<BackgroundTaskView> = {}): BackgroundTaskView {
+    return {
+        id: "bg-1",
+        block_id: "block-1",
+        label: "task dev",
+        pid: 4242,
+        started_at_ms: 1000,
+        status: "running",
+        last_seen_ms: 1000,
+        ended_at_ms: null,
+        ...overrides,
+    };
+}
+
+describe("backgroundTaskToActivity", () => {
+    it("maps a running registry row to a running, non-stoppable activity", () => {
+        const a = backgroundTaskToActivity(task({ id: "bg-1", label: "task dev", started_at_ms: 5000 }));
+        expect(a.id).toBe("bg-1");
+        expect(a.kind).toBe("tool");
+        expect(a.title).toBe("task dev");
+        expect(a.status).toBe("running");
+        expect(a.startedAt).toBe(5000);
+        expect(a.endedAt).toBeUndefined();
+        expect(a.canStop).toBe(false);
+        expect(a.tool).toBeUndefined();
+    });
+
+    it("carries a terminal status and endedAt straight through", () => {
+        const a = backgroundTaskToActivity(task({ status: "error", ended_at_ms: 9000 }));
+        expect(a.status).toBe("error");
+        expect(a.endedAt).toBe(9000);
+    });
+
+    it("maps a null ended_at_ms to undefined, not null", () => {
+        const a = backgroundTaskToActivity(task({ status: "done", ended_at_ms: null }));
+        expect(a.endedAt).toBeUndefined();
+    });
+});
+
+describe("backgroundTaskActivities", () => {
+    it("returns every registry row when nothing is already known", () => {
+        const tasks = [task({ id: "bg-1" }), task({ id: "bg-2" })];
+        const out = backgroundTaskActivities(tasks, new Set());
+        expect(out.map((a) => a.id)).toEqual(["bg-1", "bg-2"]);
+    });
+
+    it("filters out a row whose id already appears among the transcript-derived activities", () => {
+        // BackgroundTaskView.id mirrors the originating tool_use_id
+        // (background_tasks.rs's own doc comment) — a task the transcript
+        // still has a record of (no restart) already has a PinnedActivity
+        // from tool-adapter.ts's toolActivities under this exact id.
+        const tasks = [task({ id: "bg-1" }), task({ id: "bg-2" })];
+        const out = backgroundTaskActivities(tasks, new Set(["bg-1"]));
+        expect(out.map((a) => a.id)).toEqual(["bg-2"]);
+    });
+
+    it("returns nothing when every row is already known", () => {
+        const tasks = [task({ id: "bg-1" }), task({ id: "bg-2" })];
+        const out = backgroundTaskActivities(tasks, new Set(["bg-1", "bg-2"]));
+        expect(out).toEqual([]);
+    });
+
+    it("returns nothing for an empty task list", () => {
+        expect(backgroundTaskActivities([], new Set())).toEqual([]);
+    });
+});

--- a/frontend/app/view/agent/activity/background-adapter.ts
+++ b/frontend/app/view/agent/activity/background-adapter.ts
@@ -1,0 +1,56 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Background-task-registry adapter — surfaces a durable `db_background_tasks`
+ * row (`BackgroundTaskView`, via `useBackgroundTaskRegistry.ts`'s
+ * `ListBackgroundTasksCommand`) as a dock row when the transcript itself has
+ * no record of it. Closes the gap `useBackgroundTaskRegistry.ts` left open:
+ * that hook only ever fed the AGGREGATE `registryAttachedTaskSince` boolean
+ * axis, never a rendered ROW — a task that survived a session restart (a
+ * fresh session has no transcript history of ever launching it) was
+ * invisible in the dock even though `attachedTask` correctly reported it.
+ *
+ * `BackgroundTaskView.id` mirrors the frontend dock's `node_id` — normally
+ * the originating `tool_use_id` (see `background_tasks.rs`'s own module doc
+ * comment) — so a task the transcript DOES still know about (same session,
+ * no restart) already has a `PinnedActivity` from `tool-adapter.ts`'s
+ * `toolActivities`, keyed by that same id. Filtering the registry's rows
+ * against the ids already produced by the transcript-derived adapters is
+ * enough to avoid double-rendering it; no other join key is needed.
+ *
+ * report: docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md
+ * Tier 1 recommendation ("reconcile the durable background-task registry
+ * with the dock's own transcript-derived rows").
+ */
+
+import type { PinnedActivity } from "./types";
+
+/** Pure: one registry row as a dock row. No `tool`/`shell`/`subagent` source
+ *  field is populated — a registry-only row has no live transcript log to
+ *  show, so `ActivityRow`'s expand panel renders nothing for it (same as
+ *  any other kind's `Show` gate failing). `canStop: false` mirrors
+ *  `tool-adapter.ts`'s own reasoning for an accepted background launch: no
+ *  stop path exists for a single detached task today. */
+export function backgroundTaskToActivity(task: BackgroundTaskView): PinnedActivity {
+    return {
+        id: task.id,
+        kind: "tool",
+        title: task.label,
+        status: task.status,
+        startedAt: task.started_at_ms,
+        endedAt: task.ended_at_ms ?? undefined,
+        canStop: false,
+    };
+}
+
+/** Every registry row NOT already represented among `knownIds` (the ids of
+ *  the activities already produced by the transcript-derived adapters this
+ *  render pass). Exported separately from `backgroundTaskToActivity` so the
+ *  dedup rule is independently testable from the row-shape mapping. */
+export function backgroundTaskActivities(
+    tasks: readonly BackgroundTaskView[],
+    knownIds: ReadonlySet<string>
+): PinnedActivity[] {
+    return tasks.filter((t) => !knownIds.has(t.id)).map(backgroundTaskToActivity);
+}

--- a/frontend/app/view/agent/activity/dispatch-source.test.ts
+++ b/frontend/app/view/agent/activity/dispatch-source.test.ts
@@ -129,3 +129,52 @@ describe("dispatch-source — refresh coalescing", () => {
         expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
     });
 });
+
+// docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md:
+// the debounce above coalesces request VOLUME, but each surviving call
+// during a burst is still a genuinely different, real, still-converging
+// snapshot — rows still visibly appear/vanish. backfill-tracker.ts closes
+// this by suppressing refresh entirely while ANY block's backfill is
+// reported in flight, firing exactly one once it's genuinely done.
+describe("dispatch-source — backfill-aware suppression", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    async function flushMicrotasks(): Promise<void> {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    it("suppresses refresh entirely for events arriving while a backfill is in flight, firing exactly one once it settles", async () => {
+        await flushMicrotasks();
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+
+        const backfillStatus = hub.handlers.get("subagent:backfill_status")!;
+        expect(backfillStatus).toBeDefined();
+        backfillStatus({ scopes: ["block:b1"], data: { status: "started" } });
+
+        const spawned = hub.handlers.get("subagent:spawned")!;
+        for (let i = 0; i < 50; i++) spawned({ data: {} });
+        await vi.advanceTimersByTimeAsync(1200); // well past both debounce windows
+        expect(callBackendServiceSpy).not.toHaveBeenCalled(); // suppressed, not just debounced
+
+        backfillStatus({ scopes: ["block:b1"], data: { status: "done" } });
+        await flushMicrotasks();
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1); // exactly one, on settle
+    });
+
+    it("resumes ordinary debounced behavior for events after the backfill settles", async () => {
+        await flushMicrotasks();
+        const backfillStatus = hub.handlers.get("subagent:backfill_status")!;
+        backfillStatus({ scopes: ["block:b2"], data: { status: "started" } });
+        backfillStatus({ scopes: ["block:b2"], data: { status: "done" } });
+        await flushMicrotasks();
+
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+        hub.handlers.get("subagent:spawned")!({ data: {} });
+        await vi.advanceTimersByTimeAsync(150);
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/app/view/agent/activity/dispatch-source.ts
+++ b/frontend/app/view/agent/activity/dispatch-source.ts
@@ -21,6 +21,7 @@ import { callBackendService } from "@/app/store/wos";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { createSignal, type Accessor } from "solid-js";
 import type { AgentDispatch } from "../../swarm/swarm-model";
+import { createBackfillAwareTrigger } from "./backfill-tracker";
 import { createDebouncedRefresh } from "./debounced-refresh";
 
 /** The backend's own quiet window (`refresh_dispatch_status`,
@@ -90,17 +91,23 @@ async function refresh(): Promise<void> {
 // (docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md).
 const scheduleRefresh = createDebouncedRefresh(() => void refresh(), 100, 1000);
 
+// Suppresses even the debounced refresh entirely while a backfill is in
+// flight anywhere, firing exactly one refresh once it settles — see
+// backfill-tracker.ts's doc comment for why the debounce alone isn't
+// sufficient (docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md).
+const trigger = createBackfillAwareTrigger(scheduleRefresh, () => void refresh());
+
 // Started once at module load (ES modules are singletons — every importer
 // shares this one subscription set), never torn down — mirrors
 // `subagent-source.ts`'s own lifecycle rationale. The module-load-time
 // refresh itself stays immediate (undebounced) — see that module's
 // identical comment for why.
 void refresh();
-waveEventSubscribe({ eventType: "subagent:spawned", handler: () => scheduleRefresh() });
-waveEventSubscribe({ eventType: "subagent:completed", handler: () => scheduleRefresh() });
-waveEventSubscribe({ eventType: "subagent:named", handler: () => scheduleRefresh() });
-waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => scheduleRefresh() });
-waveEventSubscribe({ eventType: "dispatch:updated", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:spawned", handler: () => trigger() });
+waveEventSubscribe({ eventType: "subagent:completed", handler: () => trigger() });
+waveEventSubscribe({ eventType: "subagent:named", handler: () => trigger() });
+waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => trigger() });
+waveEventSubscribe({ eventType: "dispatch:updated", handler: () => trigger() });
 
 /** Every tracked dispatch (Solo or Workflow) currently known, across the
  *  whole app. Callers filter by `parent_block_id` for their own pane. */

--- a/frontend/app/view/agent/activity/subagent-source.test.ts
+++ b/frontend/app/view/agent/activity/subagent-source.test.ts
@@ -150,3 +150,45 @@ describe("subagent-source — refresh coalescing", () => {
         expect(callBackendServiceSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
     });
 });
+
+// docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md:
+// the debounce above coalesces request VOLUME, but each surviving call
+// during a burst is still a genuinely different, real, still-converging
+// snapshot — rows still visibly appear/vanish. backfill-tracker.ts closes
+// this by suppressing refresh entirely while ANY block's backfill is
+// reported in flight, firing exactly one once it's genuinely done. Mirrors
+// dispatch-source.test.ts's identical coverage for the sibling singleton.
+describe("subagent-source — backfill-aware suppression", () => {
+    it("suppresses refresh entirely for events arriving while a backfill is in flight, firing exactly one once it settles", async () => {
+        await flushMicrotasks();
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+
+        const backfillStatus = hub.handlers.get("subagent:backfill_status")!;
+        expect(backfillStatus).toBeDefined();
+        backfillStatus({ scopes: ["block:b1"], data: { status: "started" } });
+
+        const spawned = hub.handlers.get("subagent:spawned")!;
+        for (let i = 0; i < 50; i++) spawned({ data: {} });
+        await vi.advanceTimersByTimeAsync(1200); // well past both debounce windows
+        expect(callBackendServiceSpy).not.toHaveBeenCalled(); // suppressed, not just debounced
+
+        backfillStatus({ scopes: ["block:b1"], data: { status: "done" } });
+        await flushMicrotasks();
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1); // exactly one, on settle
+    });
+
+    it("resumes ordinary debounced behavior for events after the backfill settles", async () => {
+        await flushMicrotasks();
+        const backfillStatus = hub.handlers.get("subagent:backfill_status")!;
+        backfillStatus({ scopes: ["block:b2"], data: { status: "started" } });
+        backfillStatus({ scopes: ["block:b2"], data: { status: "done" } });
+        await flushMicrotasks();
+
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValue([]);
+        hub.handlers.get("subagent:spawned")!({ data: {} });
+        await vi.advanceTimersByTimeAsync(150);
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/app/view/agent/activity/subagent-source.ts
+++ b/frontend/app/view/agent/activity/subagent-source.ts
@@ -19,6 +19,7 @@ import { callBackendService } from "@/app/store/wos";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { createSignal, type Accessor } from "solid-js";
 import { mergeSubagentsPreservingIdentity, type ActiveSubagent } from "../../swarm/swarm-model";
+import { createBackfillAwareTrigger } from "./backfill-tracker";
 import { createDebouncedRefresh } from "./debounced-refresh";
 
 const [allSubagents, setAllSubagents] = createSignal<ActiveSubagent[]>([]);
@@ -40,6 +41,12 @@ async function refresh(): Promise<void> {
 // (docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md).
 const scheduleRefresh = createDebouncedRefresh(() => void refresh(), 100, 1000);
 
+// Suppresses even the debounced refresh entirely while a backfill is in
+// flight anywhere, firing exactly one refresh once it settles — see
+// backfill-tracker.ts's doc comment for why the debounce alone isn't
+// sufficient (docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md).
+const trigger = createBackfillAwareTrigger(scheduleRefresh, () => void refresh());
+
 // Started once at module load (ES modules are singletons — every importer
 // shares this one subscription set), never torn down: the dock's subagent
 // rows should reflect swarm-wide activity for the lifetime of the app, same
@@ -48,8 +55,8 @@ const scheduleRefresh = createDebouncedRefresh(() => void refresh(), 100, 1000);
 // should reflect real data as soon as possible, not wait out a debounce
 // window with nothing yet to coalesce against.
 void refresh();
-waveEventSubscribe({ eventType: "subagent:spawned", handler: () => scheduleRefresh() });
-waveEventSubscribe({ eventType: "subagent:completed", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:spawned", handler: () => trigger() });
+waveEventSubscribe({ eventType: "subagent:completed", handler: () => trigger() });
 // Without this, a subagent the backend reconciles from active to abandoned
 // (parent turn already ended — see `reconcile_stale_subagents`, which runs
 // on every pane reopen with a persisted session id, i.e. exactly the app-
@@ -59,7 +66,7 @@ waveEventSubscribe({ eventType: "subagent:completed", handler: () => scheduleRef
 // refresh — which, for an otherwise-idle pane, may never happen. Mirrors
 // `dispatch-source.ts`'s identical fix (reagent/codex, PR #2676) for the
 // sibling dispatch-card singleton, which this module predates.
-waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => scheduleRefresh() });
+waveEventSubscribe({ eventType: "subagent:abandoned", handler: () => trigger() });
 waveEventSubscribe({
     eventType: "subagent:named",
     handler: (event: WaveEvent) => {

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1492,7 +1492,10 @@ const AgentPresentationView = ({
     // owns dedup against in-flight history loads and the truncate-suppress
     // invariant that prevents the mid-session wipe bug.
     const pendingMessagesAtom = agentAtoms().pendingMessagesAtom;
-    useAgentStream({
+    // Forwarded to ActivityDock so it can render registry-known background
+    // tasks the transcript itself has no record of (Tier 1 of
+    // docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md).
+    const backgroundTasksAtom = useAgentStream({
         blockId: model.blockId,
         // Pass the per-pane model so the hook's dispatch sites are
         // default-safe against post-unmount races — the disposed-flag
@@ -2345,7 +2348,11 @@ const AgentPresentationView = ({
                 subagents) sit just above the composer so task status is adjacent
                 to where the user's attention already is. Moved from the top per
                 SPEC_ACTIVITY_DOCK_BOTTOM_MOVE_2026_06_20. */}
-            <ActivityDock documentAtom={agentAtoms().documentAtom} blockId={model.blockId} />
+            <ActivityDock
+                documentAtom={agentAtoms().documentAtom}
+                blockId={model.blockId}
+                backgroundTasksAtom={backgroundTasksAtom}
+            />
 
             {/* Composer status strip — single 28-32px row with live
                 activity ticker and Log button that toggles the log panel.

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -24,6 +24,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { callBackendService } from "@/app/store/wos";
 import { recordTurn } from "@/app/store/token-usage";
 import { ActivityRow } from "./ActivityRow";
+import { backgroundTaskActivities } from "../activity/background-adapter";
 import { shellActivities } from "../activity/shell-adapter";
 import { subagentActivities } from "../activity/subagent-adapter";
 import { allSubagentsAtom } from "../activity/subagent-source";
@@ -53,6 +54,11 @@ interface ActivityDockProps {
      *  spawned by THIS agent (D5: the dock is block-scoped), same as shells
      *  are already scoped by living in this pane's own document. */
     blockId: string;
+    /** Raw `db_background_tasks` rows for this block, from
+     *  `useBackgroundTaskRegistry`'s returned accessor — see
+     *  `activity/background-adapter.ts` for why these need reconciling
+     *  against the transcript-derived rows below rather than just appended. */
+    backgroundTasksAtom: () => BackgroundTaskView[];
 }
 
 export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
@@ -88,11 +94,18 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
 
     const allActivities = createMemo(() => {
         toolPromotionNonce();
-        return [
+        const transcriptDerived = [
             ...shellActivities(nodes()),
             ...subagentActivities(allSubagentsAtom(), props.blockId),
             ...toolActivities(nodes(), Date.now()),
         ];
+        // Registry rows fill the gap left by a session restart (no
+        // transcript history exists for a task that survived one) —
+        // filtered against ids the transcript already produced so a task
+        // still visible in THIS session's transcript isn't rendered twice.
+        // See activity/background-adapter.ts's doc comment.
+        const knownIds = new Set(transcriptDerived.map((a) => a.id));
+        return [...transcriptDerived, ...backgroundTaskActivities(props.backgroundTasksAtom(), knownIds)];
     });
 
     const activityById = createMemo(() => {

--- a/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.ts
+++ b/frontend/app/view/agent/hooks/useBackgroundTaskRegistry.ts
@@ -43,9 +43,17 @@
  * Installed at BODY scope by the caller (mirrors `useToolChunkStream`/
  * `useCompactionStream`'s own convention) so the subscription tears down
  * even if the caller's own `onMount` early-returns.
+ *
+ * Returns the raw task list itself (not just the derived `since`) so a
+ * caller can also render registry-known rows the dock's own
+ * transcript-derived adapters have no way to see — see
+ * `activity/background-adapter.ts` and the report's Tier 1 recommendation
+ * (docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md).
+ * A failed refresh leaves the previously-returned list untouched (same
+ * best-effort posture as the `since` axis above) rather than clearing it.
  */
 
-import { onCleanup, onMount } from "solid-js";
+import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -67,7 +75,10 @@ export function resolveAttachedTaskObservation(tasks: BackgroundTaskView[]): num
     return Math.min(...running.map((t) => t.started_at_ms));
 }
 
-async function refresh(opts: UseBackgroundTaskRegistryOptions): Promise<void> {
+async function refresh(
+    opts: UseBackgroundTaskRegistryOptions,
+    setTasks: (tasks: BackgroundTaskView[]) => void
+): Promise<void> {
     let tasks: BackgroundTaskView[];
     try {
         tasks = await RpcApi.ListBackgroundTasksCommand(TabRpcClient, { blockid: opts.blockId });
@@ -77,6 +88,7 @@ async function refresh(opts: UseBackgroundTaskRegistryOptions): Promise<void> {
         // nothing user-visible to report on a single failed query.
         return;
     }
+    setTasks(tasks);
     const since = resolveAttachedTaskObservation(tasks);
     opts.model.dispatchPane(
         since != null ? { type: "RegistryAttachedTaskObserved", at: since } : { type: "RegistryAttachedTaskCleared" },
@@ -90,8 +102,9 @@ addWSReconnectHandler(() => {
     for (const cb of activeRefreshCallbacks) cb();
 });
 
-export function useBackgroundTaskRegistry(opts: UseBackgroundTaskRegistryOptions): void {
-    const doRefresh = () => { void refresh(opts); };
+export function useBackgroundTaskRegistry(opts: UseBackgroundTaskRegistryOptions): Accessor<BackgroundTaskView[]> {
+    const [tasks, setTasks] = createSignal<BackgroundTaskView[]>([]);
+    const doRefresh = () => { void refresh(opts, setTasks); };
 
     onMount(doRefresh);
 
@@ -104,4 +117,6 @@ export function useBackgroundTaskRegistry(opts: UseBackgroundTaskRegistryOptions
         handler: doRefresh,
     });
     onCleanup(() => { try { unsub(); } catch { /* ignore */ } });
+
+    return tasks;
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -37,7 +37,7 @@
 
 import { getFileSubject } from "@/app/store/wps";
 import { base64ToArray } from "@/util/util";
-import { onCleanup, onMount } from "solid-js";
+import { onCleanup, onMount, type Accessor } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import type { PendingMessage, SignalPair } from "./state";
 import { ClaudeCodeStreamParser } from "./stream-parser";
@@ -213,7 +213,7 @@ export function useAgentStream({
     provider,
     agentName,
     onTurnStartFromQueue,
-}: UseAgentStreamOpts): void {
+}: UseAgentStreamOpts): Accessor<BackgroundTaskView[]> {
     // Mutable state that doesn't trigger re-renders. Kept here (not
     // extracted) because it's tightly coupled to the NDJSON parse loop
     // below: lineBuffer/translator/parser accumulate per-byte parse state
@@ -251,7 +251,10 @@ export function useAgentStream({
     // Seeds/refreshes attachedTask from the durable db_background_tasks
     // registry — see that hook's own module doc comment for why this is
     // additive-only (never clears) relative to the transcript-derived path.
-    useBackgroundTaskRegistry({ blockId, model });
+    // Returns the raw task list too, forwarded to the caller so the dock can
+    // render registry-known rows the transcript has no record of (Tier 1 of
+    // docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md).
+    const backgroundTasksAtom = useBackgroundTaskRegistry({ blockId, model });
 
     onMount(() => {
         if (!enabled || !blockId) return;
@@ -654,4 +657,6 @@ export function useAgentStream({
             queueMicrotask(() => model.dispatchDoc({ type: "SessionEnd", at }));
         });
     });
+
+    return backgroundTasksAtom;
 }


### PR DESCRIPTION
## Summary

Implements Tier 1 of `docs/reports/REPORT_AGENT_PANE_ACTIVITY_DOCK_ARCHITECTURE_ANALYSIS_2026_08_25.md` (Tier 0 — cutting a release — turned out to already be done by `gh-reporter`'s automated tagging before this PR started).

- **Backfill-aware refresh suppression** (`activity/backfill-tracker.ts`): PR #2773's debounce coalesces refresh *volume* during a subagent backfill burst, but each surviving call is still a genuinely different, still-converging snapshot — dock rows kept visibly appearing/vanishing (`docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md`). This reuses the already-shipped `subagent:backfill_status` event to suppress `dispatch-source.ts`/`subagent-source.ts` refreshes entirely while any block's backfill is in flight, firing exactly one refresh once it settles.
- **Background-task registry reconciliation** (`activity/background-adapter.ts`): a background task that survived a session restart has no transcript history, so it was invisible as a dock ROW even though `useBackgroundTaskRegistry.ts` already tracked it for the `attachedTask` boolean axis. The hook now also returns its raw task list; `ActivityDock.tsx` renders registry rows not already covered by `tool-adapter.ts`'s transcript-derived classification, deduped by `BackgroundTaskView.id` (which mirrors the originating `tool_use_id` — confirmed via `background_tasks.rs`'s own doc comment).

Both are additive/suppression-only changes — no backend wire protocol changes, no touch to Tier 2/3 (explicitly out of scope per this session's scoping decision).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run frontend/app/view/agent/` — 1434/1435 pass (1 pre-existing flaky timeout in `tool-renderers/registry.test.ts`, confirmed unrelated — passes in isolation)
- [x] New unit tests: `backfill-tracker.test.ts` (20 tests), `background-adapter.test.ts` (7 tests), plus new coverage in `dispatch-source.test.ts`/`subagent-source.test.ts` for backfill-aware suppression wiring

<!-- agentmux:agent_id=agent1 -->