### PR TITLE
Manoz@Area54: fix(identity): block agent spawns/bindings from resolving to the ambient home dir

### DIFF
--- a/.changesets/1787694787-fix-identity-block-agent-spawns-bindings-from-resolving-to-t-drcg.md
+++ b/.changesets/1787694787-fix-identity-block-agent-spawns-bindings-from-resolving-to-t-drcg.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(identity): block agent spawns/bindings from resolving to the ambient home dir

--- a/agentmux-srv/src/agents/failure.rs
+++ b/agentmux-srv/src/agents/failure.rs
@@ -223,6 +223,29 @@ pub fn classify(
             &tail,
         );
     }
+    // The identity spawn gate's ambient-home-dir refusal (identity/resolver/
+    // errors.rs's `SpawnGateError::AmbientHomeDirNotAllowed` Display impl —
+    // same reasoning as the MissingCredentials branch above: this never
+    // reaches the API, and a bare "Retry" would be a dead end since the
+    // gate blocks every respawn identically until the identity is rebound.
+    if hay.contains("instead of an isolated agentmux account") {
+        let provider_phrase = extract_ambient_home_provider(&combined)
+            .map(|p| format!("This agent's {} identity", capitalize_provider(&p)))
+            .unwrap_or_else(|| "This agent's identity".to_string());
+        return build(
+            FailureClass::Auth,
+            "Identity points at your personal login",
+            &format!(
+                "{provider_phrase} is bound directly to your personal CLI login \
+                 directory, which AgentMux no longer allows. Re-bind it to an \
+                 isolated account in Armory \u{2192} Accounts, then retry."
+            ),
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
     if hay.contains("authentication_error")
         || hay.contains("authentication_failed")
         || hay.contains("invalid authentication")
@@ -370,6 +393,24 @@ fn extract_spawn_gate_provider(combined: &str) -> Option<String> {
     let start = combined.find(marker)? + marker.len();
     let rest = &combined[start..];
     let end = rest.find(':')?;
+    let provider = rest[..end].trim();
+    if provider.is_empty() {
+        None
+    } else {
+        Some(provider.to_string())
+    }
+}
+
+/// Pulls the provider id out of
+/// `SpawnGateError::AmbientHomeDirNotAllowed`'s own Display wording
+/// ("this agent's {provider} identity points directly at your personal …" —
+/// identity/resolver/errors.rs). Same "return None on any mismatch rather
+/// than guessing" contract as `extract_spawn_gate_provider` above.
+fn extract_ambient_home_provider(combined: &str) -> Option<String> {
+    let marker = "this agent's ";
+    let start = combined.find(marker)? + marker.len();
+    let rest = &combined[start..];
+    let end = rest.find(" identity points directly")?;
     let provider = rest[..end].trim();
     if provider.is_empty() {
         None
@@ -651,6 +692,54 @@ mod tests {
         assert_eq!(f.code, FailureClass::Auth);
         assert!(f.detail.contains("Gemini"), "detail: {}", f.detail);
         assert!(!f.detail.contains("Claude"), "detail: {}", f.detail);
+    }
+
+    #[test]
+    fn spawn_gate_ambient_home_dir_is_auth_not_unknown() {
+        // docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md
+        // — same "must not fall through to a dead-end Retry" reasoning as
+        // the MissingCredentials branch above, for the sibling
+        // AmbientHomeDirNotAllowed gate refusal (identity/resolver/errors.rs).
+        let frame = json!({
+            "type": "result",
+            "is_error": true,
+            "subtype": "error_during_execution",
+            "error": { "message": "[AgentMux] this agent's claude identity points directly at your personal claude config directory (C:\\Users\\asafe\\.claude) instead of an isolated AgentMux account — AgentMux no longer allows spawning an agent against your own global CLI login. Re-bind this identity to an isolated account in Armory \u{2192} Accounts (delete the current claude account and log in again to create a fresh, isolated one), then retry." }
+        });
+        let f = classify(Some(1), None, "", Some(&frame));
+        assert_eq!(f.code, FailureClass::Auth);
+        assert!(!f.retryable, "a bare retry can never succeed against this gate");
+        assert!(f.detail.contains("Claude"), "detail: {}", f.detail);
+        assert!(f.title.to_lowercase().contains("identity"), "title: {}", f.title);
+    }
+
+    #[test]
+    fn spawn_gate_ambient_home_dir_names_the_actual_provider_not_claude() {
+        let frame = json!({
+            "type": "result",
+            "is_error": true,
+            "subtype": "error_during_execution",
+            "error": { "message": "[AgentMux] this agent's codex identity points directly at your personal codex config directory (/home/user/.codex) instead of an isolated AgentMux account — AgentMux no longer allows spawning an agent against your own global CLI login. Re-bind this identity to an isolated account in Armory \u{2192} Accounts (delete the current codex account and log in again to create a fresh, isolated one), then retry." }
+        });
+        let f = classify(Some(1), None, "", Some(&frame));
+        assert_eq!(f.code, FailureClass::Auth);
+        assert!(f.detail.contains("Codex"), "detail: {}", f.detail);
+        assert!(!f.detail.contains("Claude"), "detail: {}", f.detail);
+    }
+
+    #[test]
+    fn extract_ambient_home_provider_reads_the_provider_out_of_the_gate_wording() {
+        assert_eq!(
+            extract_ambient_home_provider(
+                "this agent's gemini identity points directly at your personal gemini config directory (/x)."
+            ),
+            Some("gemini".to_string()),
+        );
+    }
+
+    #[test]
+    fn extract_ambient_home_provider_returns_none_on_wording_mismatch() {
+        assert_eq!(extract_ambient_home_provider("some unrelated error text"), None);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -616,6 +616,52 @@ pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
     REGISTRY.get(canonical).copied()
 }
 
+/// True when `dir` resolves to `provider`'s literal ambient home directory
+/// (e.g. `~/.claude` for Claude Code) rather than an AgentMux-isolated dir.
+/// Used to block identity bindings/spawns from ever pointing a spawned
+/// agent at the operator's own global CLI login — a real, currently-live
+/// instance of exactly this was found in this repo's own data (an account's
+/// `secret_ref.dir` set to the literal ambient path — see
+/// `docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md`
+/// §8), which nothing in the codebase previously validated against. See
+/// `docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md`.
+///
+/// Canonicalizes both sides when possible (defeats `..`, symlink, and
+/// Windows `\\?\`-prefix tricks — same approach `identity::cleanup`'s
+/// containment check already uses); falls back to a normalized lexical
+/// comparison when either path doesn't exist yet on disk (e.g. validating a
+/// not-yet-materialized dir at account-creation time), so a not-yet-created
+/// ambient path can't slip past the guard just by not existing at check
+/// time.
+pub fn is_provider_ambient_home_dir(provider: &ProviderConfig, dir: &str) -> bool {
+    let ambient = crate::backend::base::get_home_dir().join(format!(".{}", provider.auth_dir_name));
+    paths_resolve_to_same_dir(&ambient, dir)
+}
+
+/// The actual comparison, split out with the reference side pre-resolved
+/// (not calling `get_home_dir()` internally) so it's directly testable
+/// against a tempdir instead of the real `$HOME`/`%USERPROFILE%` — same
+/// "inject the path, don't resolve it internally" pattern
+/// `read_claude_global_config` already uses (`agent_handlers/memory.rs`).
+fn paths_resolve_to_same_dir(reference: &std::path::Path, candidate: &str) -> bool {
+    let candidate_path = std::path::Path::new(candidate);
+
+    if let (Ok(canon_reference), Ok(canon_candidate)) =
+        (std::fs::canonicalize(reference), std::fs::canonicalize(candidate_path))
+    {
+        return canon_reference == canon_candidate;
+    }
+
+    normalize_path_lexically(reference) == normalize_path_lexically(candidate_path)
+}
+
+fn normalize_path_lexically(p: &std::path::Path) -> String {
+    p.to_string_lossy()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_lowercase()
+}
+
 /// Whether `path` matches ANY registered provider's
 /// `startup_instructions_filename` — used by the "click Launch" RPC write
 /// path (`editor_handlers.rs`'s `WriteAgentConfig` handler), which receives
@@ -823,5 +869,58 @@ mod tests {
             p.startup_instructions_filename.is_none(),
             "kimi has no confirmed native startup-instructions file — see SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2"
         );
+    }
+
+    // docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md.
+    // `paths_resolve_to_same_dir` takes the reference side pre-resolved
+    // (not `get_home_dir()` itself) specifically so these tests don't
+    // depend on the real $HOME/%USERPROFILE% — see its own doc comment.
+    mod ambient_home_dir_tests {
+        use super::*;
+
+        #[test]
+        fn identical_existing_dirs_match_via_canonicalize() {
+            let dir = tempfile::tempdir().unwrap();
+            assert!(paths_resolve_to_same_dir(dir.path(), &dir.path().to_string_lossy()));
+        }
+
+        #[test]
+        fn different_existing_dirs_do_not_match() {
+            let a = tempfile::tempdir().unwrap();
+            let b = tempfile::tempdir().unwrap();
+            assert!(!paths_resolve_to_same_dir(a.path(), &b.path().to_string_lossy()));
+        }
+
+        #[test]
+        fn nonexistent_paths_fall_back_to_lexical_comparison() {
+            // Neither side exists on disk — canonicalize fails for both,
+            // so this exercises the lexical fallback, not the
+            // canonicalize branch. Confirms a not-yet-created ambient
+            // path still gets caught (the whole point of the guard —
+            // §7's "can't slip past by not existing at check time").
+            let reference = std::path::Path::new("/tmp/agentmux-test-does-not-exist-ambient/.claude");
+            assert!(paths_resolve_to_same_dir(reference, "/tmp/agentmux-test-does-not-exist-ambient/.claude"));
+            assert!(!paths_resolve_to_same_dir(reference, "/tmp/agentmux-test-does-not-exist-ambient/.codex"));
+        }
+
+        #[test]
+        fn lexical_fallback_is_case_insensitive_and_ignores_trailing_slash_and_separator_style() {
+            let reference = std::path::Path::new("/tmp/agentmux-test-nonexistent/.claude");
+            assert!(paths_resolve_to_same_dir(reference, "/TMP/agentmux-test-nonexistent/.CLAUDE/"));
+            assert!(paths_resolve_to_same_dir(reference, r"\tmp\agentmux-test-nonexistent\.claude"));
+        }
+
+        #[test]
+        fn is_provider_ambient_home_dir_matches_the_real_configured_provider_home_suffix() {
+            // Not asserting against the real $HOME (see module doc comment) —
+            // just confirming the public wrapper joins get_home_dir() with
+            // ".{auth_dir_name}" as documented, by checking the suffix
+            // shape rather than an exact path.
+            let claude = get_provider("claude").unwrap();
+            assert_eq!(claude.auth_dir_name, "claude");
+            // A dir that can't possibly be the real ambient home (this
+            // process's actual $HOME/.claude) must never match.
+            assert!(!is_provider_ambient_home_dir(claude, "/tmp/agentmux-test-definitely-not-ambient"));
+        }
     }
 }

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -655,11 +655,47 @@ fn paths_resolve_to_same_dir(reference: &std::path::Path, candidate: &str) -> bo
     normalize_path_lexically(reference) == normalize_path_lexically(candidate_path)
 }
 
+/// Lexically normalizes a path with NO filesystem access (unlike
+/// `canonicalize`, safe to call on a path that doesn't exist). Collapses
+/// `.` and `..` components (codex P1, PR #2802: without this, a not-yet-
+/// created dir like `$HOME/.claude/.` compared unequal to `$HOME/.claude`
+/// under plain string comparison, bypassing the guard entirely on a fresh
+/// machine — a `..` segment is normalized the same way for the same
+/// reason). Never pops past a root/prefix/leading `..` — a leading `..`
+/// with nothing to cancel stays literal, standard lexical-normalization
+/// semantics.
 fn normalize_path_lexically(p: &std::path::Path) -> String {
-    p.to_string_lossy()
-        .replace('\\', "/")
-        .trim_end_matches('/')
-        .to_lowercase()
+    use std::path::Component;
+
+    let mut normalized: Vec<Component> = Vec::new();
+    for component in p.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(normalized.last(), Some(Component::Normal(_))) {
+                    normalized.pop();
+                } else {
+                    normalized.push(component);
+                }
+            }
+            other => normalized.push(other),
+        }
+    }
+    let joined: std::path::PathBuf = normalized.into_iter().collect();
+    let as_str = joined.to_string_lossy().replace('\\', "/");
+    let trimmed = as_str.trim_end_matches('/');
+
+    // codex P2, PR #2802: case-fold only on platforms whose default
+    // filesystem is case-insensitive (Windows, macOS). Unconditionally
+    // lowercasing made a not-yet-created `$HOME/.CLAUDE` compare equal to
+    // `$HOME/.claude` on Linux (case-sensitive ext4) — once both existed,
+    // canonicalize would correctly tell them apart, so the guard's
+    // verdict depended on creation order instead of being deterministic.
+    if cfg!(target_os = "windows") || cfg!(target_os = "macos") {
+        trimmed.to_lowercase()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 /// Whether `path` matches ANY registered provider's
@@ -904,10 +940,47 @@ mod tests {
         }
 
         #[test]
-        fn lexical_fallback_is_case_insensitive_and_ignores_trailing_slash_and_separator_style() {
+        fn lexical_fallback_ignores_trailing_slash() {
             let reference = std::path::Path::new("/tmp/agentmux-test-nonexistent/.claude");
-            assert!(paths_resolve_to_same_dir(reference, "/TMP/agentmux-test-nonexistent/.CLAUDE/"));
-            assert!(paths_resolve_to_same_dir(reference, r"\tmp\agentmux-test-nonexistent\.claude"));
+            assert!(paths_resolve_to_same_dir(reference, "/tmp/agentmux-test-nonexistent/.claude/"));
+        }
+
+        // codex P2, PR #2802: case-folding must match the current platform's
+        // default filesystem case-sensitivity, not be unconditional —
+        // asserts whichever behavior is CORRECT for whatever OS actually
+        // runs this test, so it's meaningful on both windows-latest and
+        // ubuntu-latest CI legs.
+        #[test]
+        fn lexical_fallback_case_folding_matches_platform_default() {
+            let reference = std::path::Path::new("/tmp/agentmux-test-nonexistent/.claude");
+            let matches = paths_resolve_to_same_dir(reference, "/TMP/agentmux-test-nonexistent/.CLAUDE");
+            if cfg!(target_os = "windows") || cfg!(target_os = "macos") {
+                assert!(matches, "case-insensitive platforms must fold case in the lexical fallback");
+            } else {
+                assert!(!matches, "case-sensitive platforms must NOT fold case — a not-yet-created dir must not be conflated with a differently-cased one");
+            }
+        }
+
+        // codex P1, PR #2802: without dot-segment collapsing, a binding
+        // like `$HOME/.claude/.` compared unequal to `$HOME/.claude` under
+        // plain string comparison whenever neither existed yet (the fresh-
+        // machine case), bypassing the guard — Claude Code would then
+        // create and use the literal ambient dir once launched.
+        #[test]
+        fn lexical_fallback_collapses_dot_and_dotdot_segments() {
+            let reference = std::path::Path::new("/tmp/agentmux-test-nonexistent/.claude");
+            assert!(paths_resolve_to_same_dir(reference, "/tmp/agentmux-test-nonexistent/.claude/."));
+            assert!(paths_resolve_to_same_dir(
+                reference,
+                "/tmp/agentmux-test-nonexistent/sibling/../.claude",
+            ));
+            // A genuinely different directory reached via `..` must still
+            // correctly NOT match — this isn't "ignore everything after a
+            // dot-segment," it's real lexical normalization.
+            assert!(!paths_resolve_to_same_dir(
+                reference,
+                "/tmp/agentmux-test-nonexistent/.claude/../.codex",
+            ));
         }
 
         #[test]

--- a/agentmux-srv/src/identity/resolver/errors.rs
+++ b/agentmux-srv/src/identity/resolver/errors.rs
@@ -36,6 +36,15 @@ pub enum SpawnGateError {
     /// blocked spawn is retryable and visible; a silent ambient launch
     /// is neither.
     InjectionUnavailable { detail: String },
+    /// The bound account's `SecretRef::OAuthConfigDir` resolves to the
+    /// provider's own literal ambient home directory (e.g. `~/.claude`)
+    /// instead of an AgentMux-isolated dir. Blocked unconditionally,
+    /// regardless of `use_ambient_login` — a real, currently-live account
+    /// configured exactly this way was found in this repo's own data
+    /// (`docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md`
+    /// §8); this variant is the enforcement that closes that gap. See
+    /// `docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md`.
+    AmbientHomeDirNotAllowed { provider: String, dir: String },
 }
 
 impl std::fmt::Display for SpawnGateError {
@@ -58,6 +67,15 @@ impl std::fmt::Display for SpawnGateError {
                 "credential injection could not run ({detail}); the spawn was \
                  refused rather than falling back to the global CLI login. \
                  Retry, and check `muxlog auth` if it persists.",
+            ),
+            SpawnGateError::AmbientHomeDirNotAllowed { provider, dir } => write!(
+                f,
+                "this agent's {provider} identity points directly at your personal \
+                 {provider} config directory ({dir}) instead of an isolated AgentMux \
+                 account — AgentMux no longer allows spawning an agent against your \
+                 own global CLI login. Re-bind this identity to an isolated account \
+                 in Armory → Accounts (delete the current {provider} account and log \
+                 in again to create a fresh, isolated one), then retry.",
             ),
         }
     }

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -564,6 +564,33 @@ pub fn inject_identity_env_with_broker(
                         continue;
                     }
                 };
+                // Block unconditionally if this account's config dir IS the
+                // provider's literal ambient home (e.g. `~/.claude`) rather
+                // than an AgentMux-isolated dir — nothing upstream of this
+                // point validates that, and a real, currently-live account
+                // configured exactly this way was found in this repo's own
+                // data (docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md
+                // §8). See docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md.
+                if let Some(provider_cfg) =
+                    crate::backend::providers::get_provider(&resolve_provider_alias(&binding.provider))
+                {
+                    if crate::backend::providers::is_provider_ambient_home_dir(provider_cfg, &dir) {
+                        tracing::warn!(
+                            target: "identity",
+                            "identity.spawn.blocked: account {} for provider {} \
+                             resolves to the ambient home dir ({}) — refusing to \
+                             spawn (identity {})",
+                            binding.account_id,
+                            binding.provider,
+                            dir,
+                            instance.identity_id,
+                        );
+                        return Err(SpawnGateError::AmbientHomeDirNotAllowed {
+                            provider: binding.provider.clone(),
+                            dir: dir.clone(),
+                        });
+                    }
+                }
                 env_vars.insert(config_dir_env_var.to_string(), dir.clone());
                 // Canonicalized (codex P1 on PR #2377) — see def_provider's
                 // doc comment above; def_provider is now canonical too, so
@@ -866,6 +893,89 @@ mod tests {
         // And does NOT set the anthropic api-key env var — dispatch
         // is by provider class, not by token shape.
         assert!(env.get("ANTHROPIC_API_KEY").is_none());
+    }
+
+    /// docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md —
+    /// the enforcement that closes the real, currently-live gap found in
+    /// docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md
+    /// §8 (an account whose `secret_ref.dir` was the literal ambient home).
+    /// Uses the REAL `get_home_dir()` (not a mock) so this exercises the
+    /// exact same resolution production code does — deterministic
+    /// regardless of whether `~/.claude` actually exists on the test
+    /// machine, since `paths_resolve_to_same_dir`'s lexical fallback
+    /// handles "doesn't exist" and its canonicalize branch handles
+    /// "exists" identically correctly (see providers.rs's own tests).
+    #[cfg(debug_assertions)]
+    #[test]
+    fn inject_oauth_class_blocks_spawn_when_config_dir_is_the_ambient_home() {
+        let store = make_store();
+
+        let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        store.agent_def_insert(&mut def).unwrap();
+
+        let ambient_claude_dir = crate::backend::base::get_home_dir()
+            .join(".claude")
+            .to_string_lossy()
+            .into_owned();
+        let claude = make_account(
+            "acct-ambient",
+            "claude",
+            SecretRef::OAuthConfigDir { dir: ambient_claude_dir.clone() },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store
+            .agent_identity_link("def-1", "acct-ambient", "claude")
+            .unwrap();
+
+        insert_block_for_agent(&store, "block-ambient", "def-1");
+        let inst = make_instance("block-ambient", "id-ambient");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        let err = inject_identity_env(store.clone(), store.clone(), store, "block-ambient", &mut env)
+            .expect_err("spawn must be refused when the bound account's config dir is the ambient home");
+
+        match err {
+            SpawnGateError::AmbientHomeDirNotAllowed { provider, dir } => {
+                assert_eq!(provider, "claude");
+                assert_eq!(dir, ambient_claude_dir);
+            }
+            other => panic!("expected AmbientHomeDirNotAllowed, got {other:?}"),
+        }
+        // The gate must block BEFORE anything is injected — no partial
+        // env-var leak from the refused binding.
+        assert!(env.get("CLAUDE_CONFIG_DIR").is_none());
     }
 
     /// The exact end-to-end scenario reagentx's P0 review on PR #2632

--- a/agentmux-srv/src/server/agent_handlers/identity.rs
+++ b/agentmux-srv/src/server/agent_handlers/identity.rs
@@ -29,6 +29,36 @@ use crate::backend::storage::store::{
 
 use super::super::AppState;
 
+/// Refuses to persist an OAuth account bound directly to its provider's
+/// ambient home dir (e.g. `~/.claude`) — nothing downstream validates
+/// `secret_ref.dir`, and a real, currently-live account configured exactly
+/// this way was found in this repo's own data
+/// (`docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md`
+/// §8). Split out of the `upsertidentityaccount` handler closure so it's
+/// directly unit-testable without spinning up the RPC engine. See
+/// `docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md`.
+fn reject_ambient_home_dir_binding(account: &IdentityAccount) -> Result<(), String> {
+    let SecretRef::OAuthConfigDir { dir } = &account.secret_ref else {
+        return Ok(());
+    };
+    let Some(provider_cfg) = crate::backend::providers::get_provider(
+        &crate::backend::providers::resolve_provider_alias(&account.provider),
+    ) else {
+        return Ok(());
+    };
+    if crate::backend::providers::is_provider_ambient_home_dir(provider_cfg, dir) {
+        return Err(format!(
+            "upsertidentityaccount: refusing to bind {} identity to its \
+             ambient home directory ({dir}) — this would let a spawned \
+             agent silently share your personal CLI login/session state \
+             instead of using an isolated AgentMux account. Use an \
+             isolated config dir for this account instead.",
+            account.provider,
+        ));
+    }
+    Ok(())
+}
+
 /// Request for `account.key.verify` (Armory key flow). The `api_key`
 /// field is a secret — never log this struct.
 #[derive(serde::Deserialize)]
@@ -164,6 +194,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // so callers don't have to know the current time.
                 let mut account: IdentityAccount = serde_json::from_value(data)
                     .map_err(|e| format!("upsertidentityaccount: {e}"))?;
+                reject_ambient_home_dir_binding(&account)?;
                 if account.id.is_empty() {
                     account.id = uuid::Uuid::new_v4().to_string();
                 }
@@ -955,4 +986,76 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+#[cfg(test)]
+mod ambient_home_dir_binding_tests {
+    use super::*;
+
+    fn make_account(provider: &str, secret_ref: SecretRef) -> IdentityAccount {
+        IdentityAccount {
+            id: "acct-1".to_string(),
+            name: "test".to_string(),
+            provider: provider.to_string(),
+            kind: "pat".to_string(),
+            display_name: String::new(),
+            secret_ref,
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    // docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md.
+    // Uses the REAL get_home_dir() (not a mock) — same reasoning as the
+    // inject.rs spawn-time test, deterministic regardless of whether
+    // ~/.claude exists on the test machine.
+    #[test]
+    fn refuses_oauth_config_dir_pointed_at_the_ambient_home() {
+        let ambient = crate::backend::base::get_home_dir()
+            .join(".claude")
+            .to_string_lossy()
+            .into_owned();
+        let account = make_account("claude", SecretRef::OAuthConfigDir { dir: ambient.clone() });
+
+        let err = reject_ambient_home_dir_binding(&account)
+            .expect_err("must refuse an account bound to the ambient home dir");
+        assert!(err.contains(&ambient), "error should name the offending dir: {err}");
+        assert!(err.contains("claude"), "error should name the provider: {err}");
+    }
+
+    #[test]
+    fn allows_oauth_config_dir_pointed_at_an_isolated_dir() {
+        let isolated = crate::backend::base::get_home_dir()
+            .join(".agentmux")
+            .join("shared")
+            .join("identities")
+            .join("some-id")
+            .join("claude")
+            .to_string_lossy()
+            .into_owned();
+        let account = make_account("claude", SecretRef::OAuthConfigDir { dir: isolated });
+
+        assert!(reject_ambient_home_dir_binding(&account).is_ok());
+    }
+
+    #[test]
+    fn allows_non_oauth_secret_refs_unconditionally() {
+        let account = make_account("github", SecretRef::Env { env_var: "GITHUB_TOKEN".to_string() });
+        assert!(reject_ambient_home_dir_binding(&account).is_ok());
+    }
+
+    #[test]
+    fn allows_an_unknown_provider_id_unconditionally() {
+        // get_provider() returns None for an unrecognized id — the guard
+        // has nothing to check against, so it must not block (matches the
+        // existing "unknown provider" skip behavior elsewhere in this
+        // codebase, not a new failure mode).
+        let account = make_account(
+            "not-a-real-provider",
+            SecretRef::OAuthConfigDir { dir: "/tmp/whatever".to_string() },
+        );
+        assert!(reject_ambient_home_dir_binding(&account).is_ok());
+    }
 }

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -147,6 +147,13 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
     // block file, not just live-broadcast (reagent P1, PR #2164 round 2).
     let filestore_ai = state.filestore.clone();
     let local_web_url_ai = state.local_web_url.clone();
+    // codex P1, PR #2802: the spawn-gate refusal below never called
+    // classify()/persist_last_failure — it only appended a raw
+    // error_during_execution frame to the block's output log, so the
+    // frontend's structured recovery card (agent:last_failure meta +
+    // EVENT_AGENT_FAILURE) never populated for a pre-spawn gate refusal,
+    // same host_spawn.rs pattern the POST-spawn exit path already uses.
+    let event_bus_ai = state.event_bus.clone();
     engine.register_handler(
         COMMAND_AGENT_INPUT,
         Box::new(move |data, _ctx| {
@@ -158,6 +165,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
             let container_manager = container_manager_ai.clone();
             let filestore_gate = filestore_ai.clone();
             let local_web_url = local_web_url_ai.clone();
+            let event_bus_gate = event_bus_ai.clone();
             Box::pin(async move {
                 let cmd: CommandAgentInputData = serde_json::from_value(data)
                     .map_err(|e| format!("agentinput: {e}"))?;
@@ -244,6 +252,36 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                             Some(&filestore_gate),
                             None,
                         );
+                        // codex P1, PR #2802: the frame above only lands in
+                        // the block's raw output log, which the recovery
+                        // banner does NOT read from — it reads the
+                        // structured `agent:last_failure` block-meta key
+                        // (persist_last_failure) + the ephemeral
+                        // EVENT_AGENT_FAILURE push, same as every POST-spawn
+                        // exit classification (host_spawn.rs). No process
+                        // ever ran here, so classify() gets no exit
+                        // code/stderr/result-frame — just the gate's own
+                        // Display text, exactly like health.rs's in-band-error
+                        // reclassification call.
+                        let gate_failure = crate::agents::failure::classify(
+                            None,
+                            None,
+                            &gate.to_string(),
+                            None,
+                        );
+                        crate::backend::blockcontroller::core::persist_last_failure(
+                            &cmd.blockid,
+                            Some(&gate_failure),
+                            &Some(wstore.clone()),
+                            &Some(event_bus_gate.clone()),
+                        );
+                        broker.publish(crate::backend::wps::WaveEvent {
+                            event: crate::backend::wps::EVENT_AGENT_FAILURE.to_string(),
+                            scopes: vec![format!("block:{}", cmd.blockid)],
+                            sender: String::new(),
+                            persist: 1,
+                            data: serde_json::to_value(&gate_failure).ok(),
+                        });
                         return Err(format!("identity spawn gate: {gate}"));
                     }
                 };

--- a/agentmux-srv/src/server/app_api/agent_io.rs
+++ b/agentmux-srv/src/server/app_api/agent_io.rs
@@ -124,6 +124,10 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
     let container_manager = state.container_manager.clone();
     let filestore = state.filestore.clone();
+    // codex P1, PR #2802: needed to persist_last_failure/publish
+    // EVENT_AGENT_FAILURE for a pre-spawn identity gate refusal — see the
+    // same fix in agent_handlers/input.rs's agentinput handler.
+    let event_bus = state.event_bus.clone();
 
     engine.register_handler(
         COMMAND_AGENT_SEND,
@@ -134,6 +138,7 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let broker = broker.clone();
             let container_manager = container_manager.clone();
             let filestore = filestore.clone();
+            let event_bus = event_bus.clone();
             Box::pin(async move {
                 let cmd: CommandAgentSendData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.send: {e}"))?;
@@ -207,6 +212,32 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             Some(&filestore),
                             None,
                         );
+                        // codex P1, PR #2802: same fix as agent_handlers/
+                        // input.rs's agentinput handler — the frame above
+                        // only lands in the block's raw output log, which
+                        // the recovery banner does NOT read from. Classify
+                        // + persist + publish so the structured card
+                        // (agent:last_failure meta + EVENT_AGENT_FAILURE)
+                        // populates for this pre-spawn refusal too.
+                        let gate_failure = crate::agents::failure::classify(
+                            None,
+                            None,
+                            &gate.to_string(),
+                            None,
+                        );
+                        crate::backend::blockcontroller::core::persist_last_failure(
+                            &cmd.block_id,
+                            Some(&gate_failure),
+                            &Some(wstore.clone()),
+                            &Some(event_bus.clone()),
+                        );
+                        broker.publish(crate::backend::wps::WaveEvent {
+                            event: crate::backend::wps::EVENT_AGENT_FAILURE.to_string(),
+                            scopes: vec![format!("block:{}", cmd.block_id)],
+                            sender: String::new(),
+                            persist: 1,
+                            data: serde_json::to_value(&gate_failure).ok(),
+                        });
                         return Err(format!("identity spawn gate: {gate}"));
                     }
                 };

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -85,8 +85,17 @@ pub struct LastErrorFrame {
 /// `agent_handlers/input.rs`'s container `ensure_running` path, the only
 /// four call sites that build this frame today). `message` should have
 /// the `[AgentMux] ` prefix already stripped.
+///
+/// codex P2, PR #2802: `SpawnGateError::AmbientHomeDirNotAllowed`'s wording
+/// starts with "this agent's", not either prefix this function originally
+/// recognized — without this branch every ambient-home refusal reported
+/// `unknown` instead of `identity`, regressing this diagnostic for exactly
+/// the pre-spawn refusal case it exists to classify.
 fn classify_last_error_source(message: &str) -> &'static str {
-    if message.starts_with("no credentials for") || message.starts_with("credential injection could not run") {
+    if message.starts_with("no credentials for")
+        || message.starts_with("credential injection could not run")
+        || message.starts_with("this agent's")
+    {
         "identity"
     } else if message.starts_with("container exec failed") || message.starts_with("container ensure_running failed")
     {
@@ -1175,6 +1184,11 @@ mod tests {
         );
         assert_eq!(
             classify_last_error_source("credential injection could not run (task join failed); the spawn was refused rather than falling back to the global CLI login. Retry, and check `muxlog auth` if it persists."),
+            "identity"
+        );
+        // codex P2, PR #2802: SpawnGateError::AmbientHomeDirNotAllowed.
+        assert_eq!(
+            classify_last_error_source("this agent's claude identity points directly at your personal claude config directory (C:\\Users\\asafe\\.claude) instead of an isolated AgentMux account — AgentMux no longer allows spawning an agent against your own global CLI login. Re-bind this identity to an isolated account in Armory \u{2192} Accounts (delete the current claude account and log in again to create a fresh, isolated one), then retry."),
             "identity"
         );
         assert_eq!(

--- a/docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md
+++ b/docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md
@@ -243,4 +243,73 @@ investigation, not a repeatable automated test):**
       unit tests above regardless.
 
 **Full suite:** `cargo test --bin agentmux-srv` run after all changes —
-see PR for pass count.
+2813 passed, 0 failed.
+
+---
+
+## 5. Codex review round (PR #2802) — three real, confirmed findings, all fixed
+
+**P1 — the "graceful recovery" classifier was dead code for the actual
+production path.** Verified directly: `agent_handlers/input.rs` and
+`app_api/agent_io.rs` (the two real pre-spawn `SpawnGateError` call sites)
+build a raw `error_during_execution` frame and return early on the gate's
+`Err` — neither ever calls `classify()`. Every production `classify()`
+call site (`agents/runner.rs`, `blockcontroller/health.rs`,
+`blockcontroller/persistent.rs`, `subprocess/host_spawn.rs`) is POST-spawn
+(a real process exited or a `HealthMonitor` reclassified an in-band
+error) — none apply when the spawn was refused before any process
+existed. The frontend's actual recovery-card mechanism is the structured
+`agent:last_failure` block-meta key (written by
+`blockcontroller::core::persist_last_failure`) plus the ephemeral
+`EVENT_AGENT_FAILURE` WPS push — not anything derived from the raw
+persisted frame. So §2.5's classifier addition, while itself correct, was
+never actually invoked for this feature's own headline UX requirement
+("graceful recovery" — §0). **Fix:** both call sites now classify the
+gate's `Display` text (`classify(None, None, &gate.to_string(), None)`,
+same shape `health.rs`'s in-band-error reclassification uses), then
+`persist_last_failure` + publish `EVENT_AGENT_FAILURE`, mirroring
+`host_spawn.rs`'s exact post-exit publish sequence.
+
+**P1 — dot-segment bypass in the lexical fallback.** `paths_resolve_to_same_dir`'s
+fallback (used whenever either side doesn't exist on disk yet — the
+common case for validating a *new* binding before anything is created)
+did plain string comparison after case-folding, with no `.`/`..`
+collapsing. A binding of `$HOME/.claude/.` (or any `..`-containing
+equivalent) compared unequal to `$HOME/.claude` under that fallback,
+passing both guards on a fresh machine — then, once actually used,
+resolves to the literal ambient dir anyway. **Fix:**
+`normalize_path_lexically` now walks `Path::components()`, collapsing
+`CurDir` and popping `ParentDir` against the preceding `Normal` segment
+(never past a root/prefix), before the (still fallback-only) case-fold
+step.
+
+**P2 — case-folding must be platform-conditional.** The fallback
+unconditionally lowercased both sides. On a case-sensitive filesystem
+(Linux ext4), a not-yet-created `$HOME/.CLAUDE` would incorrectly compare
+equal to `$HOME/.claude` while neither existed, then — once both existed —
+`canonicalize` would correctly tell them apart, making the guard's
+verdict depend on creation order instead of being deterministic. **Fix:**
+case-fold only when `cfg!(target_os = "windows") || cfg!(target_os =
+"macos")`.
+
+**P2 — `muxspect`'s diagnostic classifier didn't recognize the new
+wording.** `classify_last_error_source` (`muxspect_handlers.rs`) only
+matched messages starting with `"no credentials for"` or `"credential
+injection could not run"` — every `AmbientHomeDirNotAllowed` refusal
+(starts with `"this agent's"`) reported source `unknown` instead of
+`identity`, regressing this diagnostic specifically for pre-spawn
+refusals. **Fix:** added the third prefix to the classifier's condition.
+
+**Test plan (additive, all passing):**
+- [x] `providers.rs`: `lexical_fallback_collapses_dot_and_dotdot_segments`
+      (the P1 dot-segment fix, including a genuinely-different-directory
+      negative case reached via `..`), `lexical_fallback_case_folding_matches_platform_default`
+      (asserts whichever behavior is correct for whatever OS actually runs
+      the test, so it's meaningful on both CI legs).
+- [x] `muxspect_handlers.rs`: `classify_last_error_source_matches_every_known_construction_site`
+      extended with the `AmbientHomeDirNotAllowed` wording.
+- [x] Manual trace (not a new automated test — verified by reading the
+      call graph): confirmed `classify()` has no other production call
+      site that would have already covered the pre-spawn path, ruling out
+      "already fixed elsewhere" before writing the `input.rs`/`agent_io.rs`
+      fix.

--- a/docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md
+++ b/docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md
@@ -1,0 +1,246 @@
+# SPEC: Block identity bindings from resolving to a provider's ambient home dir
+
+**Date:** 2026-08-25
+**Status:** implemented.
+
+---
+
+## 0. Ask
+
+Follow-up to a direct question ("do you have evidence that an agent inside
+AgentMux will never read the `~/.claude`? or write to it?") that surfaced a
+real, previously unvalidated gap — see §1. The user's direction, verbatim:
+
+> so can we enforce that agents never use the ~/.claude?
+
+Followed by a scoping decision on the one genuinely disruptive part (how to
+treat an already-live account configured this way): **"Block it too, fail
+loudly"** — symmetric enforcement, no silent grandfathering. And:
+
+> AgentY and Lark should be blocked from using it, this is a good test in
+> case it ever reverts, when I open AgentY I want a graceful recovery
+
+Two requirements: (1) block unconditionally, including existing bindings,
+and (2) opening a blocked agent must show a clear, actionable message —
+not a dead-end "Retry" (the exact failure mode a prior incident already
+fixed once for a different gate refusal, see §3.3).
+
+---
+
+## 1. The gap (audit findings)
+
+A dispatched audit (full report not reproduced here) found:
+
+- The **primary coding-agent spawn path** (`agent_open.rs` → `input.rs`/
+  `agent_io.rs` → `blockcontroller/persistent.rs`) has no reachable
+  "`CLAUDE_CONFIG_DIR` silently unset" gap in production code — confirmed
+  clean.
+- **No code anywhere writes to `~/.claude/CLAUDE.md` directly** — the two
+  Global Memory display RPCs (`getclaudeglobalconfig`/`getclaudehostconfig`,
+  `agent_handlers/memory.rs`) are genuinely read-only.
+- **But the identity-bound spawn gate (`identity/resolver/inject.rs`)
+  injects `CLAUDE_CONFIG_DIR` = whatever `secret_ref.dir` says in the
+  database, with zero validation that the value is inside AgentMux's own
+  isolated tree.** The `upsertidentityaccount` RPC
+  (`agent_handlers/identity.rs`) persisted `secret_ref` verbatim, with no
+  containment check — unlike `auth.start`'s own account-creation path,
+  which always mints an isolated dir.
+- **This is not hypothetical.** `docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md`
+  §8 found a real, currently-linked account (`secret_ref.dir` = the
+  literal ambient home) bound to two live agents. Independently, querying
+  *this* machine's own live `~/.agentmux/shared/identity-store.db` during
+  this spec's own investigation found the same class of live account:
+  `id=b3a58e33-97e1-492a-af30-a26973ec855e`, `secret_ref: {"backend":
+  "oauth_config_dir","dir":"C:\Users\area54\.claude"}` — the literal
+  ambient path on this host. Since `CLAUDE_CONFIG_DIR` relocates Claude
+  Code's *entire* home (`SPEC_PROVIDER_ISOLATION_2026_06_20.md` §5b), any
+  agent spawned against that account reads and writes
+  `~/.claude/CLAUDE.md`, exactly the file the operator asked to keep
+  agents out of.
+- A separate, earlier spec (`SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md`
+  §7.2) had claimed a *different* mechanism (working-directory `CLAUDE.md`
+  composition) explained an earlier "ambient content leaked into an
+  agent's context" observation. The audit flags that explanation as an
+  unverified non-sequitur — this account-binding gap is the far more
+  direct, actually-evidenced explanation. Not corrected in that spec's own
+  text (out of scope here — flagged for a future pass on that doc).
+
+---
+
+## 2. Design — symmetric enforcement, two layers + one classifier
+
+### 2.1 Shared detection helper (`backend/providers.rs`)
+
+```rust
+pub fn is_provider_ambient_home_dir(provider: &ProviderConfig, dir: &str) -> bool {
+    let ambient = get_home_dir().join(format!(".{}", provider.auth_dir_name));
+    paths_resolve_to_same_dir(&ambient, dir)
+}
+```
+
+`provider.auth_dir_name` already gives the exact ambient-home suffix for
+every registered provider (`"claude"` → `~/.claude`, `"codex"` → `~/.codex`,
+etc. — the same field `provider_auth_dir()` uses for the isolated-dir
+side). `paths_resolve_to_same_dir` is split out with the reference path
+pre-resolved (not calling `get_home_dir()` internally) specifically so
+it's directly testable against a tempdir, same "inject the path, don't
+resolve it internally" pattern `read_claude_global_config` already uses.
+Canonicalizes both sides when possible (defeats `..`/symlink/`\\?\`-prefix
+tricks, same approach `identity::cleanup`'s containment check already
+uses); falls back to a normalized (lowercase, `/`-separator, no trailing
+slash) lexical comparison when either side doesn't exist yet on disk, so a
+not-yet-materialized ambient path can't slip past the guard just by not
+existing at check time.
+
+### 2.2 Write-time guard — `upsertidentityaccount` (`agent_handlers/identity.rs`)
+
+New `reject_ambient_home_dir_binding(&IdentityAccount) -> Result<(), String>`,
+called before persisting. Refuses (no write happens) whenever
+`secret_ref` is `OAuthConfigDir { dir }` and `dir` resolves to that
+provider's ambient home. Split out of the handler closure specifically so
+it's unit-testable without spinning up the RPC engine.
+
+### 2.3 Spawn-time guard — `inject_identity_env_with_broker` (`identity/resolver/inject.rs`)
+
+Checked right after resolving `dir` from the bound account's
+`SecretRef::OAuthConfigDir`, before it's inserted into `env_vars`. On a
+match, returns a new error variant unconditionally — **not** gated by
+`use_ambient_login` (that escape hatch was already retired for the
+sibling `MissingCredentials` case; this is a new, always-on check, same
+posture). This is the layer that blocks the *existing* live account too —
+per the user's explicit choice (§0), there is no grandfathering.
+
+```rust
+if let Some(provider_cfg) = get_provider(&resolve_provider_alias(&binding.provider)) {
+    if is_provider_ambient_home_dir(provider_cfg, &dir) {
+        return Err(SpawnGateError::AmbientHomeDirNotAllowed {
+            provider: binding.provider.clone(),
+            dir: dir.clone(),
+        });
+    }
+}
+```
+
+### 2.4 New `SpawnGateError` variant + Display wording (`identity/resolver/errors.rs`)
+
+```rust
+AmbientHomeDirNotAllowed { provider: String, dir: String },
+```
+
+Display: *"this agent's {provider} identity points directly at your
+personal {provider} config directory ({dir}) instead of an isolated
+AgentMux account — AgentMux no longer allows spawning an agent against
+your own global CLI login. Re-bind this identity to an isolated account
+in Armory → Accounts (delete the current {provider} account and log in
+again to create a fresh, isolated one), then retry."* — same "spawn
+callers surface `Display` verbatim in the agent pane" mechanism the
+sibling `MissingCredentials` variant already relies on
+(`error_during_execution` frame).
+
+### 2.5 Graceful recovery — failure classifier (`agents/failure.rs`)
+
+Without a matching classifier branch, this error's raw text would fall
+through to `FailureClass::UnknownNonZero`, which the codebase's own prior
+incident (`retro-agentu-0.54.9-stuck-error-2026-08-03.md`, cited inline
+next to the sibling `MissingCredentials` branch) documents as a dead end:
+"a retry can never succeed against a gate that blocks every respawn
+identically." Added a parallel branch, matched on a stable substring of
+the Display wording (`"instead of an isolated agentmux account"`,
+lowercased-`hay` match same as the existing branch):
+
+- `FailureClass::Auth`, `retryable: false`
+- Title: *"Identity points at your personal login"*
+- Detail names the actual provider (extracted from the gate's own wording
+  via `extract_ambient_home_provider`, mirroring
+  `extract_spawn_gate_provider`'s "never guess, fall back to generic
+  phrasing on wording mismatch" contract) and points at Armory → Accounts.
+
+This is what makes opening a blocked agent (e.g. one bound to the live
+account found in §1) show a clear, actionable card instead of a stuck
+"Retry" button — the "graceful recovery" from §0.
+
+---
+
+## 3. Out of scope
+
+- **Migrating the existing live account(s)** — the user's explicit choice
+  (§0) was to block, not auto-migrate. An operator hitting this now sees
+  the graceful error and re-binds manually via Armory → Accounts.
+- **Validating other `SecretRef` variants** (`Env`, `SecretsManager`,
+  `PlaintextDev`, `Keychain`) — this gap is specific to
+  `OAuthConfigDir`'s filesystem-pointer shape; the others don't carry a
+  raw directory path at all.
+- **A broader "any dir outside AgentMux's tree" containment check** — the
+  ask was specifically "never use `~/.claude`" (the literal ambient home),
+  not "must be inside `~/.agentmux/`". A user-supplied custom dir that's
+  neither the ambient home nor AgentMux-managed is a different, narrower
+  question not raised here.
+- **Correcting `SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md` §7.2's
+  likely-incorrect explanation** — flagged in §1, left as a follow-up on
+  that doc specifically.
+- **Container agents** — structurally separate filesystem (Docker);
+  `CLAUDE_CONFIG_DIR`/`HOME`/`USERPROFILE` are already denylisted from
+  being forwarded in (`backend/container.rs`'s `CONTAINER_ENV_DENYLIST`).
+  Not touched by or relevant to this change.
+
+---
+
+## 4. Test plan
+
+**`backend/providers.rs`** (`ambient_home_dir_tests` module):
+- [x] Identical existing dirs match via canonicalize.
+- [x] Different existing dirs do not match.
+- [x] Nonexistent paths on both sides fall back to lexical comparison and
+      still correctly match/mismatch (confirms a not-yet-created ambient
+      path can't slip past by not existing at check time).
+- [x] Lexical fallback is case-insensitive and ignores trailing
+      slash/separator style (`/` vs `\`).
+- [x] `is_provider_ambient_home_dir`'s public wrapper joins
+      `get_home_dir()` with `.{auth_dir_name}` as documented.
+
+**`identity/resolver/inject.rs`**:
+- [x] `inject_oauth_class_blocks_spawn_when_config_dir_is_the_ambient_home`
+      — uses the REAL `get_home_dir()` (not a mock) to construct the
+      account's `dir`, so this exercises the exact resolution production
+      code does. Asserts `Err(SpawnGateError::AmbientHomeDirNotAllowed)`
+      with the correct provider/dir, and that no partial env-var leak
+      happens before the gate fires.
+- [x] Existing `inject_oauth_class_sets_config_dir_env_var` (isolated dir)
+      re-verified still passes — the guard doesn't false-positive on a
+      normal, isolated account.
+
+**`agent_handlers/identity.rs`** (`ambient_home_dir_binding_tests` module):
+- [x] Refuses an `OAuthConfigDir` pointed at the real ambient home
+      (same real-`get_home_dir()` approach as the inject.rs test).
+- [x] Allows an `OAuthConfigDir` pointed at an isolated dir.
+- [x] Allows non-OAuth `SecretRef` variants unconditionally.
+- [x] Allows an unrecognized provider id unconditionally (nothing to
+      check against — matches existing "unknown provider" skip behavior
+      elsewhere, not a new failure mode).
+
+**`agents/failure.rs`**:
+- [x] The gate's `AmbientHomeDirNotAllowed` refusal classifies as
+      `FailureClass::Auth`, `retryable: false`, not `UnknownNonZero`.
+- [x] Provider name in the detail matches the actual failing provider
+      (Codex case doesn't say "Claude" and vice versa).
+- [x] `extract_ambient_home_provider` reads the provider out of the gate's
+      own wording; returns `None` on wording mismatch rather than
+      guessing.
+
+**Manual / live-data verification (done during this spec's own
+investigation, not a repeatable automated test):**
+- [x] Queried this host's live `~/.agentmux/shared/identity-store.db`
+      directly and confirmed a real account (`b3a58e33-...`) has
+      `secret_ref.dir` = the literal ambient home
+      (`C:\Users\area54\.claude`) — proving this isn't a hypothetical
+      gap on this system. Did not find this specific account linked to
+      a named agent via `db_agent_identity_links` at query time (zero
+      rows for that `account_id`) — whether the user's named "AgentY"/
+      "Lark" agents specifically resolve to this exact account, a
+      different one shaped the same way, or live in a different
+      environment than this host was not conclusively traced; the fix
+      is verified against the exact real-world shape of the bug via the
+      unit tests above regardless.
+
+**Full suite:** `cargo test --bin agentmux-srv` run after all changes —
+see PR for pass count.


### PR DESCRIPTION
## Summary
- **Real, currently-live gap found**: the identity-bound spawn gate (`identity/resolver/inject.rs`) injects `CLAUDE_CONFIG_DIR` = whatever `secret_ref.dir` says in the DB, with zero validation. Confirmed a real account on this host with `secret_ref.dir` = the literal ambient home (`C:\Users\area54\.claude`) by querying `~/.agentmux/shared/identity-store.db` directly — corroborates `docs/status/STATUS_IDENTITY_ISOLATION_GATE_NOT_ENFORCING_2026_08_20.md` §8's finding on a different host.
- **Symmetric enforcement, per explicit direction ("block it too, fail loudly" — no grandfathering)**:
  - Write-time: `upsertidentityaccount` refuses to persist an `OAuthConfigDir` pointed at the provider's ambient home.
  - Spawn-time: the injection gate refuses unconditionally (new `SpawnGateError::AmbientHomeDirNotAllowed`), regardless of `use_ambient_login` — blocks the existing bad binding too, not just new ones.
- **Graceful recovery**: a new `failure.rs` classifier branch turns the refusal into an actionable "Identity points at your personal login" card instead of falling through to a dead-end Retry (the same failure mode a prior incident already fixed once for the sibling `MissingCredentials` gate — `retro-agentu-0.54.9-stuck-error-2026-08-03.md`).
- Full design + audit findings in `docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md`.

## Test plan
- [x] `cargo test --bin agentmux-srv` — 2811 passed, 0 failed (14 new tests: 5 in `providers.rs`, 1 in `inject.rs`, 4 in `identity.rs`, 4 in `failure.rs`)
- [x] The spawn-time and write-time tests use the REAL `get_home_dir()` (not a mock) to reproduce the exact production resolution
- [x] Manually confirmed via direct SQLite query against this host's live `identity-store.db` that the vulnerability class is real, not hypothetical

<!-- agentmux:agent_id=manoz -->