### PR TITLE
Manoz@Area54: fix(armory): tone down Global Memory explanations, shrink text

### DIFF
--- a/.changesets/1787696117-fix-armory-tone-down-global-memory-explanations-shrink-text-ecjf.md
+++ b/.changesets/1787696117-fix-armory-tone-down-global-memory-explanations-shrink-text-ecjf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): tone down Global Memory explanations, shrink text

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -131,16 +131,11 @@ export const GlobalBrainManager = (): JSX.Element => {
     return (
         <div class="global-brain">
             <p class="global-brain-intro">
-                Every agent inherits these sections at launch. They compose into the
-                agent's startup instructions file (e.g. <code>CLAUDE.md</code>,{" "}
-                <code>GEMINI.md</code>) in order, each under a{" "}
-                <code># [Workspace]</code> heading.
+                Inherited by every agent at launch — composed into <code>CLAUDE.md</code>/
+                <code>GEMINI.md</code> in order.
             </p>
 
-            <div class="global-brain-restart-note">
-                Changes take effect when agents restart. Running agents keep the version
-                from their last launch.
-            </div>
+            <div class="global-brain-restart-note">Takes effect on next agent restart.</div>
 
             <Show when={model.errorAtom()}>
                 <div class="global-brain-error">{model.errorAtom()}</div>
@@ -158,8 +153,7 @@ export const GlobalBrainManager = (): JSX.Element => {
             <Show when={model.claudeGlobalConfigAtom() || model.claudeHostConfigAtom()}>
                 <div class="global-brain-external-files">
                     <p class="global-brain-external-files-heading">
-                        External Claude Code files — managed by Claude Code itself, not AgentMux. Shown for
-                        visibility only; not part of the Global Memory composed above.
+                        External Claude Code files — reference only, not part of Global Memory.
                     </p>
 
                     <Show when={model.claudeGlobalConfigAtom()}>
@@ -168,15 +162,13 @@ export const GlobalBrainManager = (): JSX.Element => {
                                 <div class="global-brain-machine-config-header">
                                     <span
                                         class="global-brain-machine-config-badge"
-                                        title="Hand-maintained on disk, not managed by AgentMux. Read by default-provider Claude agents (identity-bound agents use a separate, per-identity config dir not shown here)."
+                                        title="Hand-maintained on disk. Identity-bound agents use a separate dir, not shown here."
                                     >
                                         Claude Code — shared provider config
                                     </span>
                                     <code class="global-brain-machine-config-path">{cfg().path}</code>
                                 </div>
-                                <p class="global-brain-machine-config-caption">
-                                    What a default spawned agent's Claude Code auth/home uses.
-                                </p>
+                                <p class="global-brain-machine-config-caption">Used by default spawned agents.</p>
                                 <Show
                                     when={cfg().exists}
                                     fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
@@ -193,15 +185,13 @@ export const GlobalBrainManager = (): JSX.Element => {
                                 <div class="global-brain-machine-config-header">
                                     <span
                                         class="global-brain-machine-config-badge"
-                                        title="Claude Code's own global config on this machine — read by a host-level Claude Code CLI running outside AgentMux's isolation. A spawned in-app agent does NOT read this file; see the shared provider config block above for what it actually reads."
+                                        title="Claude Code's own config on this machine. Not read by spawned in-app agents — see the block above for what they use."
                                     >
                                         Claude Code — host CLI config
                                     </span>
                                     <code class="global-brain-machine-config-path">{cfg().path}</code>
                                 </div>
-                                <p class="global-brain-machine-config-caption">
-                                    What Claude Code uses outside AgentMux entirely.
-                                </p>
+                                <p class="global-brain-machine-config-caption">Used outside AgentMux.</p>
                                 <Show
                                     when={cfg().exists}
                                     fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
@@ -347,9 +337,7 @@ export const GlobalBrainManager = (): JSX.Element => {
                 </Show>
 
                 <Show when={model.ordinarySectionsAtom().length === 0 && model.editingIdAtom() === null}>
-                    <div class="global-brain-empty">
-                        No global sections yet. Add one to give every agent shared context.
-                    </div>
+                    <div class="global-brain-empty">No global sections yet.</div>
                 </Show>
             </div>
 
@@ -406,11 +394,11 @@ export const GlobalBrainManager = (): JSX.Element => {
                     class="global-brain-preview-toggle"
                     onClick={() => model.setShowPreview(!model.showPreviewAtom())}
                 >
-                    {model.showPreviewAtom() ? "▾" : "▸"} Combined preview (same content, every applicable file)
+                    {model.showPreviewAtom() ? "▾" : "▸"} Combined preview
                 </button>
                 <Show when={model.showPreviewAtom()}>
                     <pre class="global-brain-preview-content">
-                        {model.previewAtom() || "(no content — sections have no instructions yet)"}
+                        {model.previewAtom() || "(empty)"}
                     </pre>
                 </Show>
             </div>

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -131,8 +131,8 @@ export const GlobalBrainManager = (): JSX.Element => {
     return (
         <div class="global-brain">
             <p class="global-brain-intro">
-                Inherited by every agent at launch — composed into <code>CLAUDE.md</code>/
-                <code>GEMINI.md</code> in order.
+                Inherited by every agent at launch — composed into its startup file (e.g.{" "}
+                <code>CLAUDE.md</code>) in order.
             </p>
 
             <div class="global-brain-restart-note">Takes effect on next agent restart.</div>

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -18,7 +18,7 @@
 
 .global-brain-intro {
     margin: 0;
-    font-size: var(--text-sm);
+    font-size: 10px;
     color: var(--secondary-text-color);
     line-height: 1.5;
 
@@ -31,7 +31,7 @@
 
 .global-brain-restart-note {
     padding: var(--space-1-5) var(--space-2);
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--secondary-text-color);
     background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
     border-left: 2px solid var(--accent-color);
@@ -58,7 +58,7 @@
 }
 
 .global-brain-external-files-heading {
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--secondary-text-color);
 }
 
@@ -91,20 +91,20 @@
 
 .global-brain-machine-config-path {
     font-family: var(--fixed-font, monospace);
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--secondary-text-color);
     word-break: break-all;
 }
 
 .global-brain-machine-config-caption {
     margin: 0;
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--secondary-text-color);
 }
 
 .global-brain-machine-config-empty {
     margin: 0;
-    font-size: var(--text-sm);
+    font-size: 10px;
     color: var(--secondary-text-color);
 }
 
@@ -116,7 +116,7 @@
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     font-family: var(--fixed-font, monospace);
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--main-text-color);
     white-space: pre-wrap;
     overflow-wrap: break-word;
@@ -155,7 +155,7 @@
 }
 
 .global-brain-section-name {
-    font-size: var(--text-sm);
+    font-size: 10px;
     font-weight: 600;
     color: var(--main-text-color);
     white-space: nowrap;
@@ -164,7 +164,7 @@
 }
 
 .global-brain-section-desc {
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--secondary-text-color);
     white-space: nowrap;
     overflow: hidden;
@@ -181,7 +181,7 @@
 .global-brain-empty {
     padding: var(--space-3);
     text-align: center;
-    font-size: var(--text-sm);
+    font-size: 10px;
     color: var(--secondary-text-color);
     font-style: italic;
     border: 1px dashed var(--border-color);
@@ -253,7 +253,7 @@
 .global-brain-textarea {
     width: 100%;
     padding: var(--space-1-5) var(--space-2);
-    font-size: var(--text-sm);
+    font-size: 10px;
     color: var(--main-text-color);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
@@ -359,7 +359,7 @@
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     font-family: var(--fixed-font, monospace);
-    font-size: var(--text-xs);
+    font-size: 9px;
     color: var(--main-text-color);
     white-space: pre-wrap;
     overflow-wrap: break-word;


### PR DESCRIPTION
## Summary
Requested directly: the Armory -> Memory (Global Memory) tab's explanatory copy was too verbose, and its text too large.

- Shortened every explanatory string to one line: intro, restart note, "External Claude Code files" heading, both per-block captions, both badge tooltips, empty state, and the preview-toggle label.
- Reduced font size a couple notches across actual memory content: section names/descriptions, editable input/textarea, combined preview, and the two external-file content displays — from `--text-sm`/`--text-xs` (12px/11px) down to explicit 10px/9px.
- No behavior change, no copy that any existing test asserts on (checked via grep before editing).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/brain/` — 26/26 pass, unmodified

<!-- agentmux:agent_id=manoz -->