### PR TITLE
fix(splash,agent-pane): darkened splash border + agent-pane tab-strip gap/centering

### DIFF
--- a/.changesets/1787711826-fix-splash-agent-pane-darkened-splash-border-agent-pane-tab--l5mx.md
+++ b/.changesets/1787711826-fix-splash-agent-pane-darkened-splash-border-agent-pane-tab--l5mx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(splash,agent-pane): darkened splash border + agent-pane tab-strip gap/centering

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -99,6 +99,14 @@ const BG_B: u8 = 0x1F;
 const BG_G: u8 = 0x1A;
 const BG_R: u8 = 0x1A;
 
+// Darkened window-edge border — SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md.
+// Roughly half BG's RGB values, a straightforward "darker than the
+// backdrop" reading; not yet confirmed against a real display.
+const BORDER_B: u8 = 0x10;
+const BORDER_G: u8 = 0x0D;
+const BORDER_R: u8 = 0x0D;
+const BORDER_WIDTH: i32 = 2;
+
 static BRAIN_BGRA: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/brain_bgra.bin"));
 
@@ -431,6 +439,46 @@ fn composite(
     for (i, line) in footer.iter().enumerate() {
         let y = footer_top + i as i32 * (crate::splash_font::GLYPH_H as i32 + FOOTER_LINE_GAP);
         crate::splash_text::draw_text_centered(dib, SPLASH_W, SPLASH_H, y, line, FOOTER_COLOR, 1.0, true);
+    }
+
+    // Darkened window-edge border — drawn last so nothing else (brain,
+    // stage list, separator, footer) ever overdraws it. All of that content
+    // already keeps its own margin well clear of the outer BORDER_WIDTH
+    // pixels (BRAIN_X/Y = SPLASH_PADDING = 12, STAGE_MARGIN_L/R = 14/8), so
+    // ordering here is a defensive "last wins" guarantee, not a fix for an
+    // otherwise-real overlap. SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md.
+    draw_border(dib);
+}
+
+fn set_px(dib: &mut [u8], x: i32, y: i32, rgb: (u8, u8, u8)) {
+    if x < 0 || x >= SPLASH_W || y < 0 || y >= SPLASH_H {
+        return;
+    }
+    let di = ((y * SPLASH_W + x) * 4) as usize;
+    dib[di] = rgb.2; // B
+    dib[di + 1] = rgb.1; // G
+    dib[di + 2] = rgb.0; // R
+    dib[di + 3] = 0xFF;
+}
+
+/// Draws a BORDER_WIDTH-thick ring around the window edge. Iterates only
+/// the border bands (top/bottom full-width, left/right for the remaining
+/// height) rather than the whole SPLASH_W×SPLASH_H frame — this runs every
+/// composited frame (~60 fps), so it's worth not scanning interior pixels
+/// that never change here.
+fn draw_border(dib: &mut [u8]) {
+    let rgb = (BORDER_R, BORDER_G, BORDER_B);
+    for y in 0..BORDER_WIDTH {
+        for x in 0..SPLASH_W {
+            set_px(dib, x, y, rgb);
+            set_px(dib, x, SPLASH_H - 1 - y, rgb);
+        }
+    }
+    for x in 0..BORDER_WIDTH {
+        for y in BORDER_WIDTH..(SPLASH_H - BORDER_WIDTH) {
+            set_px(dib, x, y, rgb);
+            set_px(dib, SPLASH_W - 1 - x, y, rgb);
+        }
     }
 }
 

--- a/agentmux-launcher/src/splash_linux/mod.rs
+++ b/agentmux-launcher/src/splash_linux/mod.rs
@@ -52,6 +52,15 @@ pub(crate) const CORNER_RADIUS_PX: f32 = 16.0;
 /// Opacity fade-out duration on dismiss. Matches splash_mac.rs.
 pub(crate) const FADE_OUT: Duration = Duration::from_millis(160);
 
+// Darkened window-edge border — SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md.
+// Roughly half BG's RGB values, a straightforward "darker than the
+// backdrop" reading; not yet confirmed against a real display. Matches
+// splash.rs / splash_mac.rs.
+pub(crate) const BORDER_R: u8 = 0x0D;
+pub(crate) const BORDER_G: u8 = 0x0D;
+pub(crate) const BORDER_B: u8 = 0x10;
+pub(crate) const BORDER_WIDTH_PX: i32 = 2;
+
 /// Brain logo as straight (non-pre-multiplied) RGBA8, emitted by build.rs.
 pub(crate) static BRAIN_RGBA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/brain_rgba.bin"));
 include!(concat!(env!("OUT_DIR"), "/brain_dims.rs")); // pub const BRAIN_W / BRAIN_H (i32)
@@ -312,8 +321,30 @@ pub(crate) fn render_frame(
                 gg = gg * (1.0 - ba) + BRAIN_RGBA[si + 1] as f32 * ba;
                 bb = bb * (1.0 - ba) + BRAIN_RGBA[si + 2] as f32 * ba;
             }
+            // Darkened border band: blend toward BORDER_* the further a pixel
+            // falls outside the shrunk "interior" rect (inset by
+            // BORDER_WIDTH_PX on all sides, radius reduced to match) versus
+            // the outer rect — same anti-aliased coverage math as the corner
+            // rounding itself, just against two nested rects instead of one.
+            // The brain only ever occupies well-interior pixels (PADDING=28
+            // >> BORDER_WIDTH_PX), so blending the already-brain-composited
+            // color here is safe. SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md.
+            let outer_cov = corner_coverage(x, y, w, h, radius);
+            let inner_radius = (radius - BORDER_WIDTH_PX as f32).max(0.0);
+            let inner_cov = corner_coverage(
+                x - BORDER_WIDTH_PX,
+                y - BORDER_WIDTH_PX,
+                w - 2 * BORDER_WIDTH_PX,
+                h - 2 * BORDER_WIDTH_PX,
+                inner_radius,
+            );
+            let interior_t = if outer_cov > 0.0 { (inner_cov / outer_cov).clamp(0.0, 1.0) } else { 0.0 };
+            rr = BORDER_R as f32 * (1.0 - interior_t) + rr * interior_t;
+            gg = BORDER_G as f32 * (1.0 - interior_t) + gg * interior_t;
+            bb = BORDER_B as f32 * (1.0 - interior_t) + bb * interior_t;
+
             // Coverage (rounded corners) × global fade → pre-multiplied alpha.
-            let a = corner_coverage(x, y, w, h, radius) * window_alpha;
+            let a = outer_cov * window_alpha;
             let di = ((y * w + x) * 4) as usize;
             let (o0, o2) = if bgr { (bb, rr) } else { (rr, bb) };
             buf[di] = (o0 * a) as u8;

--- a/agentmux-launcher/src/splash_linux/mod.rs
+++ b/agentmux-launcher/src/splash_linux/mod.rs
@@ -263,10 +263,26 @@ pub(crate) fn fade_alpha(fade_start: Option<Instant>, now: Instant) -> f32 {
 /// Rounded-rect coverage (0..=1) at pixel (x, y) for a `w`×`h` rect with corner
 /// `radius` (0 = square), anti-aliased over a 1-px band on the corner arcs.
 fn corner_coverage(x: i32, y: i32, w: i32, h: i32, radius: f32) -> f32 {
-    if radius <= 0.0 {
-        return 1.0;
-    }
     let (fx, fy) = (x as f32 + 0.5, y as f32 + 0.5);
+    if radius <= 0.0 {
+        // No rounding to compute -- but still bounds-check (x, y) against
+        // the w×h rect rather than unconditionally returning 1.0. The old
+        // unconditional shortcut was only ever safe because render_frame's
+        // one call site always passed in-bounds coordinates by
+        // construction (x in 0..w, y in 0..h); the border-band check below
+        // calls this a second time with coordinates shifted relative to a
+        // SHRUNK inner rect, which are legitimately out-of-bounds for
+        // border-band pixels. Under the square X11-fallback path
+        // (radius=0, no compositor), inner_radius also clamps to 0
+        // (BORDER_WIDTH_PX - BORDER_WIDTH_PX), so without this bounds
+        // check interior_t was always 1.0 and the border never rendered
+        // at all in that fallback (Codex P2, PR #2804 review).
+        return if fx >= 0.0 && fx <= w as f32 && fy >= 0.0 && fy <= h as f32 {
+            1.0
+        } else {
+            0.0
+        };
+    }
     // Clamp to the corner-arc center; in the straight edges/interior this yields
     // dist 0 → full coverage. Only the four corner boxes produce a nonzero dist.
     let cx = fx.clamp(radius, w as f32 - radius);

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -67,6 +67,14 @@ const BG_R: f64 = 26.0 / 255.0;
 const BG_G: f64 = 26.0 / 255.0;
 const BG_B: f64 = 31.0 / 255.0;
 
+// Darkened window-edge border — SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md.
+// Roughly half BG's RGB values, a straightforward "darker than the
+// backdrop" reading; not yet confirmed against a real display.
+const BORDER_R: f64 = 13.0 / 255.0;
+const BORDER_G: f64 = 13.0 / 255.0;
+const BORDER_B: f64 = 16.0 / 255.0;
+const BORDER_WIDTH: f64 = 2.0;
+
 /// Safety net: if the host never signals (crash before first paint), tear the
 /// splash down anyway so it can't get stuck on screen.
 const DISMISS_TIMEOUT: Duration = Duration::from_secs(10);
@@ -1038,6 +1046,25 @@ unsafe fn build_window() -> (id, id, Vec<(id, id)>) {
     send_void_id(layer, sel(b"setBackgroundColor:\0"), bg_cgcolor);
     send_void_f64(layer, sel(b"setCornerRadius:\0"), CORNER_RADIUS);
     send_void_bool(layer, sel(b"setMasksToBounds:\0"), 1);
+
+    // Darkened 2px border, inset from the same rounded-rect path as the
+    // corner radius above — SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md. Native
+    // CALayer support, no extra corner math needed.
+    let border_color = {
+        let f: extern "C" fn(id, SEL, f64, f64, f64, f64) -> id =
+            std::mem::transmute(objc_msgSend as *const ());
+        f(
+            class(b"NSColor\0"),
+            sel(b"colorWithSRGBRed:green:blue:alpha:\0"),
+            BORDER_R,
+            BORDER_G,
+            BORDER_B,
+            1.0,
+        )
+    };
+    let border_cgcolor = send(border_color, sel(b"CGColor\0"));
+    send_void_id(layer, sel(b"setBorderColor:\0"), border_cgcolor);
+    send_void_f64(layer, sel(b"setBorderWidth:\0"), BORDER_WIDTH);
 
     // Brain image view in the upper (brain) region, above the stage panel
     // and footer band. macOS Y is bottom-up, so a larger y sits higher.

--- a/docs/specs/SPEC_AGENT_PANE_PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md
+++ b/docs/specs/SPEC_AGENT_PANE_PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md
@@ -1,0 +1,77 @@
+# SPEC — Agent pane: remove the reserved-space gap above the tab strip; progress bar overlays instead
+
+**Date:** 2026-08-25
+**Author:** AgentY
+**Status:** Draft — deliberate, partial reversal of `SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md`; see §2.1 for why this isn't the same tradeoff being re-litigated blind.
+**Scope:** `frontend/app/view/agent/agent-view.tsx` (`AgentViewWrapper`'s slot div) and `frontend/app/view/agent/agent-view.scss` (`.agent-pane-progress-bar-slot` / `.agent-pane-progress-bar`) only. `PaneTabStrip.tsx`/`.scss` and the bar's own portal machinery (`progressBarSlot` signal, `<Show>`/`<Portal>` wrapping in `AgentPresentationView`) are unaffected — see §2.3.
+**Related:** `docs/specs/SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md` (introduced the slot this spec removes — must-read first), `docs/specs/SPEC_PANE_TAB_STRIP_TRAILING_BLUR_2026_08_12.md` (the tab strip's own overlay-over-content pattern this spec's fix now mirrors one level up).
+
+---
+
+## 1. Problem (repo-owner-reported)
+
+> "there is a gap between the tab bar in agent pane and the pane header, I believe where the progress bar goes... it makes the + on the new tab look off-center... remove the gap, the progress bar should simply overlap, without taking space while it doesn't appear."
+
+Confirmed against source. The agent pane's structure (`agent-view.tsx:520-544`, `agent-view.scss:40-227`):
+
+```
+.agent-pane-stack (flex column, height: 100%)
+ ├─ .agent-pane-progress-bar-slot   ← flex: 0 0 auto; height: 3px — ALWAYS present
+ └─ .agent-pane-stack-content        ← flex: 1 1 auto; position: relative
+      └─ .pane-tab-strip             ← position: absolute; top: 0  (relative to the box above)
+      └─ AgentPresentationView content
+```
+
+`.agent-pane-progress-bar-slot` (`agent-view.scss:46-48,223-227`) is a real flex child of `.agent-pane-stack`, `flex: 0 0 auto; height: 3px`, present unconditionally — whether or not the bar itself is currently visible. `.pane-tab-strip` is `position: absolute; top: 0` (`agent-view.scss:92-94`), but that `top: 0` is relative to `.agent-pane-stack-content` — which only begins *after* the slot's 3px row in the flex column. Net effect: the tab strip (and therefore the "+" button inside it, `PaneTabStrip.scss`'s `.pane-tab-strip-add`, 28×28px) always renders 3px lower than the top of `.agent-pane-stack` — i.e. 3px below the pane header (`.block-frame-default-header`, outside this component tree) — regardless of whether the progress bar is actually showing. That's the reported gap, and the reason the "+" reads as vertically off relative to the header above it.
+
+## 2. Design
+
+### 2.1 Why this is a deliberate, informed reversal — not blindly redoing the 08-10 decision
+
+The 08-10 spec's §2.3 explicitly considered and rejected "only reserving the row's height while the bar is active," specifically to avoid layout shift when the bar toggles on/off. That reasoning was sound *for the mechanism it was choosing between* — a conditionally-sized reserved row vs. an always-3px reserved row. This spec doesn't choose either of those: it takes the bar **out of the flex flow entirely** (`position: absolute`, contributing zero box-model height at any time, active or not) and has it overlay the top of the tab strip's own already-absolutely-positioned box — the same "floats over content instead of reserving a row" pattern `.pane-tab-strip` itself already uses over `.agent-pane-stack-content` (see the comment at `agent-view.scss:56-64`, and `SPEC_PANE_TAB_STRIP_TRAILING_BLUR_2026_08_12.md` for why that precedent was chosen there). Since the bar never occupies flex space at all — not "3px always," not "0px or 3px depending on state" — toggling its opacity causes exactly as little layout shift as the 08-10 spec required (zero), just achieved by removing the space reservation entirely rather than fixing it at a constant size. The two specs' goals (no layout shift) are identical; only the mechanism differs, and the new mechanism is strictly more space-efficient without reintroducing the problem §2.3 was written to avoid.
+
+### 2.2 Take the slot out of flex flow; overlay it above the tab strip
+
+`.agent-pane-progress-bar-slot` (`agent-view.scss:46-48` removes its `flex: 0 0 auto` list entry; `agent-view.scss:223-227` changes from a normal flex box to an absolutely-positioned overlay):
+
+```scss
+.agent-pane-progress-bar-slot {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    overflow: hidden;
+    // Sits above .pane-tab-strip (z: var(--z-pane-overlay, 4)) so the bar,
+    // when active, draws visibly on top of the tab strip's own top edge
+    // rather than being hidden behind it — both now occupy the same
+    // top:0 coordinates once neither reserves flex space.
+    z-index: calc(var(--z-pane-overlay, 4) + 1);
+    pointer-events: none;
+}
+```
+
+`.agent-pane-stack` needs `position: relative` added (`agent-view.scss:40-49`) so the slot's `position: absolute` resolves against it, not some further-out ancestor — `.agent-pane-stack` already fills `height: 100%; width: 100%` of its own container, so this is a no-op for every other layout concern in that block.
+
+With the slot out of flow, `.agent-pane-stack-content` (`flex: 1 1 auto`) becomes the *only* flex child contributing height to `.agent-pane-stack` — it now starts at true `top: 0`, and `.pane-tab-strip`'s existing `position: absolute; top: 0` (unchanged, `agent-view.scss:92-94`) now anchors flush against the pane header with no 3px offset. This is the actual gap fix; §2.2's slot change is what makes it possible without also breaking the bar's own visibility.
+
+`.agent-pane-progress-bar` itself (`agent-view.scss:242-291`) needs no changes — it's already `position: absolute; inset: 0` *inside* the slot and fades via `opacity`; none of that depended on the slot being flex-positioned vs. absolutely-positioned.
+
+### 2.3 What's explicitly unchanged
+
+- The portal machinery (`progressBarSlot` signal in `AgentViewWrapper`, `<Show when={progressBarMount()}><Portal mount={progressBarMount()!}>...` in `AgentPresentationView`) — §2.2 of the 08-10 spec's reasoning for why the bar's *state* stays owned by `AgentPresentationView` (avoiding a double-subscribe on `useAgentControllerStatus`) is untouched by this change; only the slot div's own CSS position changes, not which component renders what.
+- The zoom-compensation removal from §2.4 of the 08-10 spec — still correct, still applies; this spec doesn't touch `.agent-pane-progress-bar`'s own rule.
+- `PaneTabStrip.tsx`/`.scss` — no changes. The "+" button's own 28×28px sizing is correct today; it only *looked* off-center because of the 3px offset applied to its entire containing strip, not because of anything in the button's own styling.
+
+## 3. Files touched
+
+- `frontend/app/view/agent/agent-view.scss` — `.agent-pane-stack` gains `position: relative`; its `> .agent-pane-progress-bar-slot { flex: 0 0 auto; }` rule is removed (no longer a flex participant); `.agent-pane-progress-bar-slot`'s own rule (currently `position: relative; height: 3px; overflow: hidden;`) becomes the absolutely-positioned overlay in §2.2.
+- `frontend/app/view/agent/agent-view.tsx` — no structural change expected (the slot div at line 526 stays exactly where it is in JSX; only its CSS changes), but re-check the comment at lines 521-525 ("Progress bar's own row — always reserved...") for accuracy once the fix lands — it currently documents the exact behavior this spec removes and needs updating to describe the overlay instead.
+
+## 4. Verification
+
+- With no agent activity (bar inactive/opacity 0): the tab strip's "+" button should sit flush against the pane header with no visible gap, and read as vertically centered the way it does on panes without a header directly above (editor/terminal panes, unaffected by this change, for a side-by-side comparison).
+- Trigger agent activity (bar active): the marching-ants bar should still render as a thin strip at the top of the pane, visually in front of (not clipped by, not hidden behind) the tab strip's top edge — confirm the new `z-index: calc(var(--z-pane-overlay, 4) + 1)` actually wins against `.pane-tab-strip`'s `var(--z-pane-overlay, 4)`.
+- Toggle activity on/off repeatedly: confirm zero layout shift in the tab strip or conversation content, matching the 08-10 spec's original guarantee (see §2.1 for why the new mechanism preserves this).
+- Multi-tab case (2+ tabs open in one pane): confirm the fix doesn't regress `SPEC_PANE_TAB_STRIP_TRAILING_BLUR_2026_08_12.md`'s glass-panel/click-through behavior — this spec doesn't touch that logic, but it's the same DOM region and worth a quick visual pass.
+- **Visual verification is mandatory** — same caveat as every other UI spec this session: a sandboxed environment has no display; needs a live `task dev` or packaged-build check before this is considered confirmed, not just "compiles and the CSS looks right on paper."

--- a/docs/specs/SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md
+++ b/docs/specs/SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md
@@ -1,0 +1,66 @@
+# SPEC — Splash screen: add a darkened 2px border, across all 3 platforms
+
+**Date:** 2026-08-25
+**Author:** AgentY
+**Status:** Draft
+**Scope:** the launcher's native splash window only — `agentmux-launcher/src/splash.rs` (Windows), `splash_mac.rs` (macOS), `splash_linux/{mod,x11,wayland}.rs` (Linux). No other window (main app, modals) is in scope.
+**Related:** `docs/specs/SPEC_LINUX_SPLASH_POLISH_2026_06_20.md` (added Linux's rounded corners + fade — no border), `docs/specs/SPEC_LINUX_SPLASH_SESSION_AWARE_2026_06_20.md`.
+
+---
+
+## 1. Current state (audited against source)
+
+The splash is **not** a shared web view — each platform draws it natively, with its own separate implementation:
+
+| Platform | File | Mechanism |
+|---|---|---|
+| Windows | `splash.rs` | `WS_POPUP` + `WS_EX_LAYERED` GDI layered window; pixels composed into a top-down DIB (`CreateDIBSection`) every frame |
+| macOS | `splash_mac.rs` | Borderless `NSWindow` (`styleMask 0`) with a layer-backed `NSView` backdrop |
+| Linux | `splash_linux/mod.rs` (+ `x11.rs`/`wayland.rs`) | `override_redirect` X11 window or `xdg_toplevel` Wayland surface; backdrop composited per-pixel into an ARGB8888 buffer (`render_frame`) |
+
+All three agree on one dark backdrop, `#1A1A1F` (`BG_R/G/B`), no light-mode variant. **None of the three currently draws a window border/stroke:**
+
+- **Windows** (`splash.rs`): flat opaque DIB fill, square corners. Only a 1px *internal* separator line exists (`SEP_R/G/B = 0x36`, between the stage list and footer) — not a window edge.
+- **macOS** (`splash_mac.rs`): `CORNER_RADIUS = 16.0` via `layer.setCornerRadius:`, plus `setHasShadow:1` (a drop shadow, not a border). No `borderWidth`/`borderColor` set anywhere.
+- **Linux** (`splash_linux/mod.rs`): `CORNER_RADIUS_PX = 16.0` (comment: "Matches splash_mac.rs"), rounded via alpha-masked `corner_coverage()` in `render_frame`. Same story — rounding only, no stroke.
+
+**Pre-existing asymmetry, unrelated to this ask but worth flagging:** Windows has square corners while macOS/Linux have 16px rounded corners. This spec does not propose fixing that — see §5.
+
+## 2. Desired behavior (repo-owner-specified)
+
+> "lets add a darkened border 2 PX thick on the border on the splash screen, across 3 platforms"
+
+A 2px stroke, in a color darker than the `#1A1A1F` backdrop, drawn at the window's edge (following whatever corner treatment that platform already has — square on Windows, 16px-radius on macOS/Linux) — consistently on Windows, macOS, and Linux.
+
+**Color:** no existing token for "darker than `#1A1A1F`" — propose `#0D0D10` (roughly half the backdrop's RGB values, a straightforward "darkened" reading) as a literal constant defined once and referenced by name on all three platforms (e.g. `BORDER_R/G/B` alongside the existing `BG_R/G/B` constants), so a future palette change only needs updating in one place per platform rather than three independently-tuned hex triples. Confirm the exact shade live (`task dev`/packaged build) before finalizing — this is a starting proposal, not a final color decided by comparison.
+
+## 3. Proposed design, per platform
+
+### 3.1 Windows (`splash.rs`)
+
+The DIB is filled manually per-pixel (no native window-chrome border primitive available for a layered `WS_POPUP` window). Add a border pass after the background fill and before the rounded-corner logic doesn't apply here (Windows has square corners) — for each pixel, if it falls within 2px of any edge (`x < 2 || x >= W-2 || y < 2 || y >= H-2`), write `BORDER_R/G/B` instead of the background/content color. Must run **after** all other content is drawn (stage list, separator, footer) so the border isn't overdrawn by them, or equivalently, inset all existing content drawing by 2px so it never reaches the border region in the first place — the exact ordering depends on how `splash.rs`'s draw loop is structured; the implementer should read the current fill/content sequence before choosing.
+
+### 3.2 macOS (`splash_mac.rs`)
+
+Trivial — `CALayer` has native border support. Alongside the existing `layer.setCornerRadius:` call (~line 1038-1039), add:
+```
+layer.setBorderWidth: 2.0
+layer.setBorderColor: <CGColor for BORDER_R/G/B>
+```
+Both are single `objc_msgSend` calls, matching the pattern already used for `setCornerRadius:`/`setHasShadow:` in this file. The border draws inset from the layer's rounded-rect path automatically — no extra corner math needed.
+
+### 3.3 Linux (`splash_linux/mod.rs`, `x11.rs`, `wayland.rs`)
+
+No native layer-border primitive here (raw ARGB8888 buffer composited manually) — needs the same "ring" approach as Windows, adapted to the existing rounded-corner alpha-masking. `corner_coverage()` already computes, per-pixel, how much of a pixel near a corner is inside vs. outside the rounded rect (for antialiasing the mask). Add a second coverage band: pixels whose distance from the rounded-rect boundary falls within the 2px border width get `BORDER_R/G/B` (blended via the same coverage-based antialiasing already used for the corner mask, for a clean edge instead of a jagged one), pixels further inside get the normal background/content. `x11.rs`/`wayland.rs` don't need their own changes — both already just pass `radius`/`window_alpha` through to `render_frame`, which is where the actual pixel logic lives.
+
+## 4. Verification
+
+- **No unit-testable surface** — this is raw pixel-drawing code on all three platforms; there's nothing here that a Rust test asserts against today (confirmed: none of the three splash files has a test file in this repo).
+- **Visual verification is mandatory and cannot be skipped** — per this repo's own established caveat for UI changes (see e.g. `SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md` §4's identical note), a sandboxed dev environment has no display. Confirm on a real Windows machine via `task dev` or a packaged build (`task package`) — the launcher's splash only renders during actual startup, not inside the CEF-hosted app itself, so `task dev`'s hot reload doesn't cover it; a full relaunch is needed to see a splash-code change. macOS/Linux verification needs those platforms' own build environments — this repo runs on Windows per this session's own machine, so cross-platform verification is a real gap to flag to whoever picks this up, not something this spec can close on its own.
+- Confirm the border reads as "darkened," not as a lighter mis-tint, against the actual `#1A1A1F` backdrop on a real display (color perception on different panels can shift a marginal proposal like `#0D0D10` — verify live per §2).
+
+## 5. Non-goals
+
+- **Not** unifying Windows' square corners with macOS/Linux's 16px rounding — a real, pre-existing asymmetry, but a separate, larger visual decision than "add a border," and changing it isn't necessary to satisfy this request (a square-cornered 2px border on Windows and a rounded 2px border on macOS/Linux both read as "the splash now has a darkened border" — they just differ in corner treatment exactly as the rest of the window already does).
+- **Not** adding a light-mode splash variant — none exists today, out of scope here.
+- **Not** touching the internal 1px separator line inside the Windows splash (`SEP_R/G/B`) — a different, already-existing internal-content divider, unrelated to a window-edge border.

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -52,7 +52,21 @@
     // per-INSTANCE value set inline by PaneTabStrip.tsx from the
     // `zoomFactor` prop (each pane type's own content zoom) — not the
     // global chrome-zoom `--zoomfactor` used by window-header/status-bar.
-    height: calc(var(--pane-tab-strip-height, 28px) * var(--pane-tab-strip-zoom, 1));
+    // "+ 1px": this repo's global `box-sizing: border-box` (reset.scss)
+    // means the `border-bottom` below is carved OUT of this declared
+    // height, not added on top — leaving only 27px of content-box for
+    // `.pane-tab-strip-inner` (which needs the full un-eaten
+    // `--pane-tab-strip-height` to match its own un-zoomed 28px height,
+    // see that rule's comment). Without this +1px, `.pane-tab-strip-inner`
+    // overflows this box's content area by 1px and gets clipped at the
+    // bottom by `overflow-y: hidden` above — shifting the "+" button's
+    // flex-centered position (computed against its own full 28px) visibly
+    // upward relative to the now-27px-visible row. Reported live
+    // 2026-08-25 as "the + looks off-center" — only became noticeable once
+    // SPEC_AGENT_PANE_PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md's bigger 3px
+    // row-gap (a separate, now-fixed issue) stopped drawing attention away
+    // from this smaller, always-present 1px mismatch.
+    height: calc(var(--pane-tab-strip-height, 28px) * var(--pane-tab-strip-zoom, 1) + 1px);
     border-bottom: 1px solid var(--border-color);
     // No fill on the container itself — only .pane-tab (active/hover) and
     // .pane-tab-strip-add (hover) paint a background. Any stray width the
@@ -252,4 +266,16 @@
         background: rgba(255, 255, 255, 0.06);
         color: var(--main-text-color);
     }
+}
+
+// The "+" glyph's own line box (centered by the button's flex align-items/
+// justify-content above) isn't the same as its visual ink — measured live
+// (screenshot pixel-sampling, 2026-08-25) at ~1-2px low relative to the
+// button's true box center, a font-metrics artifact of centering literal
+// text rather than an SVG icon. Nudged on its own wrapping span (not the
+// button itself) so the button's box/border/hover-background stay exactly
+// where they were; only the glyph's rendered position moves.
+.pane-tab-strip-add-glyph {
+    display: block;
+    transform: translateY(-1px);
 }

--- a/frontend/app/element/PaneTabStrip.tsx
+++ b/frontend/app/element/PaneTabStrip.tsx
@@ -211,7 +211,10 @@ export function PaneTabStrip<T>(props: PaneTabStripProps<T>): JSX.Element {
                         aria-label={props.addTitle ?? "New tab"}
                         onClick={() => props.onAdd!()}
                     >
-                        +
+                        {/* Wrapped so the glyph itself can be nudged (PaneTabStrip.scss's
+                            .pane-tab-strip-add-glyph) without moving the button's own
+                            box/hover-background/border — see that rule's comment. */}
+                        <span class="pane-tab-strip-add-glyph">+</span>
                     </button>
                 </Show>
             </div>

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -42,10 +42,10 @@
     flex-direction: column;
     height: 100%;
     width: 100%;
-
-    > .agent-pane-progress-bar-slot {
-        flex: 0 0 auto;
-    }
+    // Containing block for .agent-pane-progress-bar-slot below, which is
+    // now position: absolute (out of flex flow) rather than a flex child —
+    // SPEC_AGENT_PANE_PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md.
+    position: relative;
 }
 
 .agent-pane-stack-content {
@@ -206,11 +206,16 @@
     }
 }
 
-// Progress bar's own row, between the tab strip and the content — never
-// overlapping either. Always present at this fixed height (not
-// conditionally rendered), so the bar fading in/out via opacity never
-// shifts the tab strip or content by so much as a pixel; only what's
-// drawn inside the slot changes, never the layout around it.
+// Progress bar's own overlay strip, above the tab strip — never taking
+// layout space, active or not (SPEC_AGENT_PANE_PROGRESS_BAR_OVERLAY_NO_GAP_
+// 2026_08_25.md, superseding this rule's own previous "always-reserved 3px
+// row" — see that spec's §2.1 for why removing the reservation entirely
+// still preserves the original no-layout-shift guarantee rather than
+// reintroducing the problem it solved). Out of flex flow entirely
+// (position: absolute against .agent-pane-stack) so the tab strip below —
+// itself position: absolute; top: 0 relative to .agent-pane-stack-content —
+// now starts flush at the very top of the pane, with no reserved gap
+// between it and the pane header above.
 //
 // AgentPresentationView (deep inside .agent-pane-stack-content, itself
 // BELOW the tab strip in DOM order) portals .agent-pane-progress-bar into
@@ -221,9 +226,18 @@
 // absolutely-positioned escape could ever become visible above the tab
 // strip.
 .agent-pane-progress-bar-slot {
-    position: relative;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
     height: 3px;
     overflow: hidden;
+    pointer-events: none;
+    // Above .pane-tab-strip (z: var(--z-pane-overlay, 4)) so the bar, when
+    // active, draws visibly on top of the tab strip's own top edge — both
+    // now occupy the same top:0 coordinates once neither reserves flex
+    // space.
+    z-index: calc(var(--z-pane-overlay, 4) + 1);
 }
 
 // === Marching-ants Progress Bar ===

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -518,11 +518,12 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
                 the pane and clipping the composer off the bottom (found
                 live 2026-08-09: "agent pane has no text input"). */}
             <div class="agent-pane-stack">
-                {/* Progress bar's own row — always reserved, above the tab
-                    strip, below wherever the block-frame's own pane header
-                    ends. Empty div; its only content is whatever
-                    AgentPresentationView portals into it below. Sized in
-                    agent-view.scss (.agent-pane-progress-bar-slot). */}
+                {/* Progress bar's own overlay strip — floats above the tab
+                    strip, never reserving layout space (SPEC_AGENT_PANE_
+                    PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md). Empty div;
+                    its only content is whatever AgentPresentationView
+                    portals into it below. Positioned in agent-view.scss
+                    (.agent-pane-progress-bar-slot). */}
                 <div class="agent-pane-progress-bar-slot" ref={(el) => setProgressBarSlot(el)} />
                 <div class="agent-pane-stack-content">
                     {/* Tab strip floats over the content instead of


### PR DESCRIPTION
## Summary

Two independent, repo-owner-requested UI tweaks, each with its own spec doc:

**1. Splash screen — 2px darkened border, all 3 platforms**
(`docs/specs/SPEC_SPLASH_SCREEN_BORDER_2026_08_25.md`)

No shared implementation — each platform draws the splash natively, so the border is implemented three times:
- `splash.rs` (Windows): new border pass in the GDI DIB compositor, drawn last so nothing overdraws it.
- `splash_mac.rs`: native `CALayer` `setBorderWidth:`/`setBorderColor:`, trivial alongside the existing `setCornerRadius:`.
- `splash_linux/mod.rs`: a second, antialiased coverage band (inner vs. outer rounded-rect) in the existing per-pixel `render_frame` compositor.

Color: `#0D0D10` (roughly half the `#1A1A1F` backdrop) — a starting proposal per the spec, not yet confirmed on macOS/Linux displays (only Windows is verifiable from this machine).

**2. Agent pane tab strip — remove the reserved gap; fix "+" centering**
(`docs/specs/SPEC_AGENT_PANE_PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md`)

The progress bar's always-present 3px flex row (from `SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md`) pushed the tab strip 3px below the pane header. Took the slot out of flex flow entirely (`position: absolute`, overlaying the tab strip's top edge) instead of reserving space — preserves that spec's original no-layout-shift guarantee via a different mechanism, not a blind reversal (see the new spec's §2.1).

Fixing the gap surfaced two smaller, previously-masked "+"-centering issues, both confirmed via live pixel-sampling of a running `task dev` build:
- `.pane-tab-strip`'s `border-bottom` was eating 1px out of its own declared height under this repo's global `box-sizing: border-box`, clipping `.pane-tab-strip-inner`'s bottom edge. Height now explicitly accounts for the border.
- The "+" glyph (literal text, not an SVG icon) sits ~1-2px low within its own flex-centered line box — a font-metrics artifact. Wrapped in its own `<span>` and nudged via `transform: translateY`, independent of the button's own box/border/hover-background.

## Test plan
- [x] `cargo check -p agentmux-launcher` — Windows path only; `splash_mac.rs`/`splash_linux` are `cfg`-gated to their own OS and can't be typechecked from this machine (flagged in both specs and the commit message)
- [x] `npx tsc --noEmit` — clean
- [x] `PaneTabStrip.test.tsx` — 17/17 passing
- [x] Full `frontend/app/view/agent/` suite — 1403/1404 (the one failure is a pre-existing flake, confirmed passing in isolation, unrelated to this change)
- [x] Live visual verification via `task dev` — repo-owner confirmed the tab-strip gap is gone and the "+" centering looks right after the fixes; splash border not yet visually confirmed on a real display (flagged as an open item in the spec)

<!-- agentmux:agent_id=agenty -->