### PR TITLE
fix(agent): scroll support for AskUserQuestion panel

### DIFF
--- a/.changesets/1787712548-fix-agent-scroll-support-for-askuserquestion-panel-keep-butt-slgv.md
+++ b/.changesets/1787712548-fix-agent-scroll-support-for-askuserquestion-panel-keep-butt-slgv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): scroll support for AskUserQuestion panel, keep buttons reachable

--- a/docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md
@@ -1,7 +1,8 @@
 # SPEC: Scrolling for the AskUserQuestion panel
 
 **Date:** 2026-08-25
-**Status:** design only, not yet implemented
+**Status:** implemented, PR #2805 — see §3.1's two corrections (Codex P1/P2)
+made during that PR's review, before merge.
 **Builds on:** `docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md` (original
 design), `SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md` /
 `SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md` /
@@ -84,23 +85,20 @@ controls that let the user act on it.
 
 ## 3. Design
 
-### 3.1 New scroll boundary: header and footer pinned, question content scrolls
+### 3.1 New scroll boundary: header and footer fixed-size, question content scrolls
 
 Wrap the `<For each={r.questions}>` block in a new element,
-`.agent-question-panel-scroll`, and make the header and actions bar
-`position: sticky` within `.agent-question-panel` (a pattern already used
-elsewhere in this pane family — `frontend/app/view/agent/styles/_search.scss`
-pins its header the same way, `position: sticky; top: 0`):
+`.agent-question-panel-scroll`:
 
 ```
-<div class="agent-question-panel">      <!-- max-height cap, flex column -->
-  <div class="agent-question-panel-header">   <!-- position: sticky; top: 0 -->
+<div class="agent-question-panel">      <!-- max-height cap + min-height: 0, flex column -->
+  <div class="agent-question-panel-header">   <!-- flex-shrink: 0 -->
   <div class="agent-question-panel-scroll">   <!-- NEW: overflow-y: auto, min-height: 0 -->
     <For each={r.questions}>
       <fieldset class="agent-question-panel-q">
     </For>
   </div>
-  <div class="agent-question-panel-actions">  <!-- position: sticky; bottom: 0 -->
+  <div class="agent-question-panel-actions">  <!-- flex-shrink: 0 -->
 </div>
 ```
 
@@ -109,20 +107,54 @@ always visible regardless of how much question content there is — the thing
 that actually matters per §2 — while only the middle (the questions
 themselves) scrolls.
 
-CSS additions to `AgentQuestionPanel.scss`:
+**Correction (Codex P2 on the implementation PR #2805 — `position: sticky` on
+the header/actions was inert, not just unnecessary):** the first draft of
+this design put `position: sticky; top: 0` on the header and `position:
+sticky; bottom: 0` on the actions bar, claiming it mirrored
+`frontend/app/view/agent/styles/_search.scss`'s header-pinning pattern.
+That claim was wrong, and the CSS did nothing as a result: `position: sticky`
+only sticks an element within its nearest *scrolling* ancestor. The header
+and actions are siblings of `.agent-question-panel-scroll` (the actual
+scroll container), not nested inside it, and `.agent-question-panel` itself
+has no `overflow` set — there is no scrolling ancestor for sticky to attach
+to here. `_search.scss`'s header, by contrast, genuinely is nested inside
+its own scrolling container, which is why sticky works there and doesn't
+here — the two cases only look alike, they aren't the same shape.
+
+The actual mechanism that keeps the header/actions visible is plain flex
+sizing, not positioning: give the header and actions `flex-shrink: 0` so
+they never give up space, and leave `.agent-question-panel-scroll` as the
+one flexible, shrinkable child (default `flex-shrink: 1`) that absorbs all
+of the panel's own size changes. No `position: sticky` needed or used.
+
+**Correction (Codex P1 on #2805 — `max-height` on `.agent-question-panel`
+was also ineffective on its own):** the first draft set `max-height: 420px`
+on `.agent-question-panel` without also setting `min-height: 0` on it. As a
+flex item of `.agent-view`, `.agent-question-panel`'s *automatic* minimum
+height defaults to its content's min-content size (since the panel itself
+has no `overflow` set) — and per the flex sizing algorithm, `used-size =
+max(min-size, min(max-size, tentative-size))`, so that automatic minimum
+wins over `max-height` whenever content is taller than 420px. Concretely:
+the panel still grew to fit *all* its content regardless of the cap, and
+`.agent-view`'s `overflow: hidden` clipped it exactly as before this spec —
+the fix did nothing in the exact scenario it was built for. `min-height: 0`
+on `.agent-question-panel` itself (not just on `.agent-question-panel-scroll`
+— see §3.3, a *different* instance of the same underlying gotcha, one level
+up) closes this: with it, the panel can actually shrink to whatever
+`.agent-view` can spare, capped at 420px, instead of always claiming its
+full content height.
+
+CSS additions to `AgentQuestionPanel.scss`, corrected:
 
 ```scss
 .agent-question-panel {
     // existing rules unchanged, plus:
     max-height: 420px; // see §3.2 for why a fixed px value, not vh/%
+    min-height: 0;      // REQUIRED — see the Codex P1 correction above
 }
 
 .agent-question-panel-header {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: var(--modal-bg-color, #232323); // match panel bg so scrolled
-                                                  // content doesn't show through
+    flex-shrink: 0; // never gives up space to the scroll region below
 }
 
 .agent-question-panel-scroll {
@@ -132,15 +164,13 @@ CSS additions to `AgentQuestionPanel.scss`:
                           // stacked <fieldset> blocks when multiple questions
     overflow-y: auto;
     min-height: 0; // REQUIRED — see §3.3, the classic flexbox scroll gotcha
+                    // (a distinct instance of it from the panel-level one above)
 }
 
 .agent-question-panel-actions {
-    position: sticky;
-    bottom: 0;
-    z-index: 1;
-    background: var(--modal-bg-color, #232323);
-    padding-top: var(--space-2); // breathing room above the sticky footer
-                                   // once content is scrolled behind it
+    padding-top: var(--space-2); // breathing room above this bar once the
+                                   // scroll region above it is scrolled
+    flex-shrink: 0; // never gives up space to the scroll region above
 }
 ```
 
@@ -212,8 +242,9 @@ needs no changes here.
 - **No change to the 30s auto-timeout's own logic** (arming, hover-pause,
   keyboard-pause, recommended-option detection) — this spec only changes
   layout/overflow, not timing behavior. The countdown chip simply needs to
-  stay visible in the sticky header, which it already is (it's part of
-  `.agent-question-panel-header`, unchanged).
+  stay visible in the header, which it already is (it's part of
+  `.agent-question-panel-header`, unchanged, and the header is now
+  `flex-shrink: 0` per §3.1's correction).
 - **No virtualization.** Question/option counts in practice are small
   (single digits); a plain `overflow-y: auto` is sufficient and matches the
   weight of the existing `_decision-panel.scss` precedent. Virtualizing a

--- a/docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md
@@ -1,0 +1,246 @@
+# SPEC: Scrolling for the AskUserQuestion panel
+
+**Date:** 2026-08-25
+**Status:** design only, not yet implemented
+**Builds on:** `docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md` (original
+design), `SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md` /
+`SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md` /
+`SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md` (the 30s
+auto-timeout countdown this spec must keep reachable — see §2). Does not
+touch `AnsweredQuestionMessage.tsx` (the post-answer history rendering,
+governed separately by `SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md`)
+— out of scope, see §4.
+
+---
+
+## 0. Ask
+
+> back into agentmuxai/agentmux .. pull in latest, we need to be able to
+> support scrolling in the ask part of the askquestion tool for the agent
+> pane .. write spec to file
+
+## 1. Current behavior (audited against source, 2026-08-25)
+
+`frontend/app/view/agent/components/AgentQuestionPanel.tsx` renders the
+live AskUserQuestion prompt (`AgentQuestionPanel`, JSX at lines 512-650),
+mounted as a normal-flow sibling inside `.agent-view`
+(`frontend/app/view/agent/agent-view.tsx:2273-2277`), directly below
+`AgentDecisionPanel` and directly above the message queue / composer.
+
+Structure (lines 541-645):
+```
+<div class="agent-question-panel">
+  <div class="agent-question-panel-header">  <!-- title + countdown -->
+  <For each={r.questions}>
+    <fieldset class="agent-question-panel-q">  <!-- prompt + options + "Other" input -->
+  </For>
+  <div class="agent-question-panel-actions">  <!-- Answer later / Submit answer -->
+</div>
+```
+
+`frontend/app/view/agent/components/AgentQuestionPanel.scss` has **no
+`max-height`, `height`, or `overflow` rule anywhere** on `.agent-question-panel`
+or any descendant — confirmed by reading the full 251-line file. It's a plain
+`display: flex; flex-direction: column` (lines 19-31) that grows to fit
+however much content `r.questions` produces: any number of questions, each
+with any number of options, each option with an optional multi-line
+description.
+
+The parent, `.agent-view`, is `display: flex; flex-direction: column;
+height: 100%; overflow: hidden` (`agent-view.scss:305-317`). Its children —
+the scrollable conversation feed, `AgentDecisionPanel`, `AgentQuestionPanel`,
+the message queue, the composer — all compete for that one fixed height in
+normal flow. `AgentQuestionPanel` has no `flex-shrink: 0` guard and no cap,
+so a large enough question set can grow past the pane's remaining height.
+Because the parent clips overflow, there is nothing to scroll to reach the
+part that got pushed out — which, since the buttons are the *last* child,
+is usually the **Submit answer / Answer later buttons themselves**, along
+with the composer and message queue beneath the panel.
+
+This is not hypothetical: a single `AskUserQuestion` call frequently carries
+2-4 questions at once, each with 2-4 options plus per-option descriptions
+plus a free-text "Other" field — comfortably enough content to exceed a
+short or split agent pane's available height.
+
+**Established precedent for the fix already exists in a sibling panel**:
+`AgentDecisionPanel`'s tool-arg preview
+(`frontend/app/view/agent/styles/_decision-panel.scss:150-167`,
+`.agent-decision-panel-preview`) already uses `max-height: 160px;
+overflow-y: auto;` for exactly this reason, just on a much smaller content
+block. This spec applies the same idea to the whole panel, with header/footer
+handled specially (see §3).
+
+## 2. Why this is more than cosmetic
+
+`AgentQuestionPanel` runs a 30-second auto-timeout countdown
+(`SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md`) that auto-selects the
+recommended option(s) and submits if the user doesn't act. If the Submit/
+Answer-later buttons are scrolled out of reach by an overflowing panel, the
+user can still see the question and pick options, but may not be able to
+reach the button to submit *early* or defer — they're stuck waiting for the
+auto-timeout to fire on their behalf, on a decision they may not have
+finished making. A panel that overflows must not be allowed to hide the
+controls that let the user act on it.
+
+## 3. Design
+
+### 3.1 New scroll boundary: header and footer pinned, question content scrolls
+
+Wrap the `<For each={r.questions}>` block in a new element,
+`.agent-question-panel-scroll`, and make the header and actions bar
+`position: sticky` within `.agent-question-panel` (a pattern already used
+elsewhere in this pane family — `frontend/app/view/agent/styles/_search.scss`
+pins its header the same way, `position: sticky; top: 0`):
+
+```
+<div class="agent-question-panel">      <!-- max-height cap, flex column -->
+  <div class="agent-question-panel-header">   <!-- position: sticky; top: 0 -->
+  <div class="agent-question-panel-scroll">   <!-- NEW: overflow-y: auto, min-height: 0 -->
+    <For each={r.questions}>
+      <fieldset class="agent-question-panel-q">
+    </For>
+  </div>
+  <div class="agent-question-panel-actions">  <!-- position: sticky; bottom: 0 -->
+</div>
+```
+
+This keeps the countdown (in the header) and the Submit/Answer-later buttons
+always visible regardless of how much question content there is — the thing
+that actually matters per §2 — while only the middle (the questions
+themselves) scrolls.
+
+CSS additions to `AgentQuestionPanel.scss`:
+
+```scss
+.agent-question-panel {
+    // existing rules unchanged, plus:
+    max-height: 420px; // see §3.2 for why a fixed px value, not vh/%
+}
+
+.agent-question-panel-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--modal-bg-color, #232323); // match panel bg so scrolled
+                                                  // content doesn't show through
+}
+
+.agent-question-panel-scroll {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3); // was .agent-question-panel's own gap, between
+                          // stacked <fieldset> blocks when multiple questions
+    overflow-y: auto;
+    min-height: 0; // REQUIRED — see §3.3, the classic flexbox scroll gotcha
+}
+
+.agent-question-panel-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+    background: var(--modal-bg-color, #232323);
+    padding-top: var(--space-2); // breathing room above the sticky footer
+                                   // once content is scrolled behind it
+}
+```
+
+`.agent-question-panel`'s own `gap` (currently spacing header / questions /
+actions as three flex children) still works exactly as before — it now
+spaces header / scroll-wrapper / actions instead of header / N-question-
+fieldsets / actions, with the new wrapper's own `gap` handling spacing
+*between* multiple question fieldsets internally.
+
+### 3.2 Fixed pixel cap, not `vh`/`%`
+
+`.agent-view` has `height: 100%` (relative to whatever split/pane it's in,
+not the OS window) and `container-type: inline-size` — **width**-based
+container queries only; there is no height-based container query available
+to size this panel as a fraction of its actual pane. A `vh` unit would be
+relative to the full browser viewport, which is wrong the moment the agent
+pane is one of several splits and is much shorter than the window itself —
+`max-height: 50vh` could still exceed a short split pane's *entire* height,
+defeating the purpose.
+
+Use a fixed pixel cap instead, consistent with the existing
+`.agent-decision-panel-preview` precedent (`max-height: 160px`) — just
+larger, since this panel holds more than a single preview block. **420px**
+is a starting estimate (roughly: ~30px header + 3-4 options at ~50px each +
+~50px actions bar, enough to show a typical single question without
+scrolling, while still capping a multi-question or many-option outlier) —
+tune against real screenshots during implementation rather than treating it
+as load-bearing; it's a UX tuning value, not a correctness one.
+
+### 3.3 The flexbox min-height gotcha
+
+`.agent-question-panel-scroll` **must** set `min-height: 0`. Flex items
+default to `min-height: auto`, which means "at least as tall as my content"
+— this silently defeats `overflow-y: auto` (the box still grows to fit
+content instead of scrolling) even though `max-height` is set on an
+ancestor. This is the single most common way this exact pattern fails
+silently in a code review that "looks right." Call it out explicitly in the
+PR/tests, not just in this doc.
+
+### 3.4 Scrollbar styling
+
+No new work needed: `*::-webkit-scrollbar-track` / `*::-webkit-scrollbar-thumb`
+/ `*::-webkit-scrollbar-thumb:hover` (`frontend/app/app.scss:104-116`) are
+already global wildcard selectors — any new scrollable element, including
+`.agent-question-panel-scroll`, automatically inherits the app's custom
+scrollbar coloring with no extra rule. Only *width* is ever customized
+per-element (e.g. `.agent-document::-webkit-scrollbar`); leave width at
+default here unless a real visual mismatch shows up in review — this is a
+much narrower panel than the full conversation view.
+
+### 3.5 Minimized-chip mode is unaffected
+
+`.agent-question-panel-minimized` (the collapsed "Question waiting" chip,
+`AgentQuestionPanel.tsx:517-536`) is a completely separate render branch
+with its own tiny fixed layout — it never grows with question content and
+needs no changes here.
+
+## 4. Non-goals
+
+- **No settings toggle for the max-height.** Matches the existing
+  `AUTO_TIMEOUT_MS` precedent (`SPEC_ASK_USER_QUESTION_2026_06_15.md` §5.2)
+  of no per-behavior settings surface for this panel — one sensible fixed
+  value, not a new knob.
+- **`AnsweredQuestionMessage.tsx`** (the post-answer, non-interactive history
+  rendering, `SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md`) is a
+  separate component in the normal scrollable document flow already — it
+  scrolls with the rest of the conversation and has no overflow problem of
+  its own. Not touched by this spec.
+- **No change to the 30s auto-timeout's own logic** (arming, hover-pause,
+  keyboard-pause, recommended-option detection) — this spec only changes
+  layout/overflow, not timing behavior. The countdown chip simply needs to
+  stay visible in the sticky header, which it already is (it's part of
+  `.agent-question-panel-header`, unchanged).
+- **No virtualization.** Question/option counts in practice are small
+  (single digits); a plain `overflow-y: auto` is sufficient and matches the
+  weight of the existing `_decision-panel.scss` precedent. Virtualizing a
+  handful of DOM nodes would be solving a problem that doesn't exist here.
+
+## 5. Testing
+
+- A single short question (1 question, 2-3 options, no long descriptions)
+  renders identically to today — no visible scrollbar, no layout shift, no
+  regression for the common case.
+- A question set long enough to exceed 420px (e.g. 2 questions × 4 options
+  each, each option with a 2-line description) scrolls internally; the
+  header (with countdown, if a countdown is active) and the Submit/Answer-
+  later buttons remain visible and clickable throughout, never scrolled out
+  of view.
+- Scrolling the question content does not scroll or otherwise affect the
+  conversation feed above it, or the queue/composer below it — the new
+  scroll region is fully contained.
+- Keyboard navigation (Tab through options, arrow keys within a radio
+  group) still reaches every option, scrolling the container into view as
+  needed, and never gets trapped — verify focus doesn't silently land on an
+  option currently scrolled out of the visible region without the browser
+  auto-scrolling it into view (native behavior for focus, should work for
+  free, but confirm rather than assume).
+- The minimized chip (`.agent-question-panel-minimized`) is visually
+  unchanged.
+- Multi-select questions (checkboxes, `q.multiSelect === true`) behave
+  identically to today when scrolled — checking/unchecking an option that's
+  only reachable after scrolling works the same as one visible without
+  scrolling.

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -28,12 +28,40 @@
     box-shadow: var(--shadow-lg, 0 12px 24px rgba(0, 0, 0, 0.35));
     color: var(--main-text-color);
     outline: none;
+    // Fixed px, not vh/% — .agent-view only supports width-based container
+    // queries (container-type: inline-size), and vh is relative to the OS
+    // window, not this specific split pane, which can be much shorter.
+    // See SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md §3.2. Matches
+    // the existing .agent-decision-panel-preview precedent (max-height:
+    // 160px), just larger since this panel holds more than one preview block.
+    max-height: 420px;
 }
 
 .agent-question-panel-header {
     display: flex;
     align-items: center;
     gap: var(--space-2);
+    // Pinned so the countdown stays visible while question content scrolls
+    // beneath it — same pattern as .agent-search-header (_search.scss).
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--modal-bg-color, #232323);
+}
+
+// Scrollable middle region between the sticky header and sticky actions bar.
+// SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md §3.1.
+.agent-question-panel-scroll {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3); // was .agent-question-panel's own gap, now spaces
+                          // multiple stacked .agent-question-panel-q blocks
+    overflow-y: auto;
+    // REQUIRED: flex items default to min-height: auto, which silently
+    // defeats overflow-y: auto by growing the box to fit its content
+    // instead of scrolling. See spec §3.3 — the classic flexbox scroll
+    // gotcha, easy to lose in a later refactor if this comment goes away.
+    min-height: 0;
 }
 
 .agent-question-panel-icon {
@@ -197,6 +225,15 @@
     display: flex;
     justify-content: flex-end;
     gap: var(--space-2);
+    // Pinned so Submit answer / Answer later are always reachable, even
+    // when the question content above is scrolled — see spec §2 for why
+    // this matters beyond cosmetics (the 30s auto-timeout still fires
+    // regardless of whether the user can reach these buttons).
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+    background: var(--modal-bg-color, #232323);
+    padding-top: var(--space-2);
 }
 
 .agent-question-panel-btn {

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -35,21 +35,38 @@
     // the existing .agent-decision-panel-preview precedent (max-height:
     // 160px), just larger since this panel holds more than one preview block.
     max-height: 420px;
+    // REQUIRED (Codex P1, PR #2805): as a flex item of .agent-view, this
+    // panel's automatic minimum height defaults to its content's min-content
+    // size — which wins over max-height when they conflict, per the flex
+    // sizing algorithm (used-size = max(min-size, min(max-size, tentative))).
+    // Without this override, max-height above is silently ineffective the
+    // moment content is taller than 420px: the panel still grows to fit all
+    // content and .agent-view's overflow: hidden clips it exactly as before
+    // this fix. min-height: 0 lets the panel actually shrink to whatever
+    // .agent-view can spare (down to 0, capped up to 420px) instead of
+    // always claiming its full content height.
+    min-height: 0;
 }
 
 .agent-question-panel-header {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    // Pinned so the countdown stays visible while question content scrolls
-    // beneath it — same pattern as .agent-search-header (_search.scss).
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: var(--modal-bg-color, #232323);
+    // Kept visible while question content scrolls beneath it — NOT via
+    // position: sticky (Codex P2, PR #2805: sticky only sticks within a
+    // scrolling ancestor, and this header is a *sibling* of
+    // .agent-question-panel-scroll, not nested inside it — .agent-view
+    // never scrolls either, so there is no scroll container for sticky to
+    // stick within here; it would be inert). The actual mechanism is
+    // flex-shrink: 0 below: when the panel shrinks to fit a short pane,
+    // only .agent-question-panel-scroll (flex-shrink: 1, the default) gives
+    // up space, so this header simply never needs to move.
+    flex-shrink: 0;
 }
 
-// Scrollable middle region between the sticky header and sticky actions bar.
+// Scrollable middle region between the header and actions bar above/below it
+// (visually fixed via flex-shrink: 0 on both, not position: sticky — see the
+// comment on .agent-question-panel-header for why sticky doesn't apply here).
 // SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md §3.1.
 .agent-question-panel-scroll {
     display: flex;
@@ -225,15 +242,16 @@
     display: flex;
     justify-content: flex-end;
     gap: var(--space-2);
-    // Pinned so Submit answer / Answer later are always reachable, even
-    // when the question content above is scrolled — see spec §2 for why
-    // this matters beyond cosmetics (the 30s auto-timeout still fires
-    // regardless of whether the user can reach these buttons).
-    position: sticky;
-    bottom: 0;
-    z-index: 1;
-    background: var(--modal-bg-color, #232323);
+    // Submit answer / Answer later stay reachable even when the question
+    // content above is scrolled — see spec §2 for why this matters beyond
+    // cosmetics (the 30s auto-timeout still fires regardless of whether the
+    // user can reach these buttons). NOT via position: sticky (Codex P2,
+    // PR #2805 — see .agent-question-panel-header's comment for why sticky
+    // is inert here); flex-shrink: 0 below is what actually keeps this bar
+    // at its natural size while .agent-question-panel-scroll absorbs any
+    // squeeze.
     padding-top: var(--space-2);
+    flex-shrink: 0;
 }
 
 .agent-question-panel-btn {

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -679,3 +679,39 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
     });
 });
+
+describe("AgentQuestionPanel scroll structure (SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md)", () => {
+    it("wraps question content in a scroll region that is a sibling of the sticky header and actions bar", () => {
+        const [pending] = createSignal<ToolNode[]>([twoQuestionSet()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} />);
+
+        const panel = document.querySelector(".agent-question-panel") as HTMLElement;
+        const scroll = panel.querySelector(":scope > .agent-question-panel-scroll");
+        const header = panel.querySelector(":scope > .agent-question-panel-header");
+        const actions = panel.querySelector(":scope > .agent-question-panel-actions");
+
+        // Header and actions must be direct children of the panel (not nested
+        // inside the scroll region), or `position: sticky` has nothing to
+        // stick to within — the whole point of the wrapper.
+        expect(scroll).toBeTruthy();
+        expect(header).toBeTruthy();
+        expect(actions).toBeTruthy();
+
+        // Both questions render inside the scroll region, not outside it.
+        expect(scroll?.querySelectorAll(".agent-question-panel-q").length).toBe(2);
+        expect(scroll?.contains(screen.getByText("Pick a color"))).toBe(true);
+        expect(scroll?.contains(screen.getByText("Pick a size"))).toBe(true);
+    });
+
+    it("does not put the Submit/Answer-later buttons inside the scroll region", () => {
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} />);
+
+        const scroll = document.querySelector(".agent-question-panel-scroll");
+        const submitBtn = screen.getByRole("button", { name: /Submit answer/ });
+        const deferBtn = screen.getByRole("button", { name: /Answer later/ });
+
+        expect(scroll?.contains(submitBtn)).toBe(false);
+        expect(scroll?.contains(deferBtn)).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -681,7 +681,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
 });
 
 describe("AgentQuestionPanel scroll structure (SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md)", () => {
-    it("wraps question content in a scroll region that is a sibling of the sticky header and actions bar", () => {
+    it("wraps question content in a scroll region that is a sibling of the fixed-size header and actions bar", () => {
         const [pending] = createSignal<ToolNode[]>([twoQuestionSet()]);
         render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} />);
 
@@ -691,8 +691,10 @@ describe("AgentQuestionPanel scroll structure (SPEC_ASK_USER_QUESTION_PANEL_SCRO
         const actions = panel.querySelector(":scope > .agent-question-panel-actions");
 
         // Header and actions must be direct children of the panel (not nested
-        // inside the scroll region), or `position: sticky` has nothing to
-        // stick to within — the whole point of the wrapper.
+        // inside the scroll region) — they stay visible via flex-shrink: 0,
+        // not position: sticky (which would need them nested inside the
+        // scroll container to have any effect; see the SCSS comments on
+        // .agent-question-panel-header for why sticky doesn't apply here).
         expect(scroll).toBeTruthy();
         expect(header).toBeTruthy();
         expect(actions).toBeTruthy();

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -568,9 +568,14 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                         </div>
 
                         {/* Scrollable middle region — header (above) and actions
-                            (below) stay pinned via position: sticky so the
-                            countdown and Submit/Answer-later buttons are never
-                            scrolled out of reach on a long question set.
+                            (below) are flex-shrink: 0 so they never give up space
+                            to this region, keeping the countdown and Submit/
+                            Answer-later buttons visible regardless of how long
+                            the question set is (NOT position: sticky — see
+                            AgentQuestionPanel.scss's comments on
+                            .agent-question-panel-header for why sticky is inert
+                            here; header/actions are siblings of this scroll
+                            region, not nested inside it).
                             Spec: docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md. */}
                         <div class="agent-question-panel-scroll">
                             <For each={r.questions}>

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -567,63 +567,70 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                             </Show>
                         </div>
 
-                        <For each={r.questions}>
-                            {(q, qi) => (
-                                <fieldset class="agent-question-panel-q">
-                                    <legend class="agent-question-panel-q-prompt">
-                                        <span class="agent-question-panel-q-chip">{q.header}</span>
-                                        {q.question}
-                                    </legend>
-                                    <div class="agent-question-panel-options">
-                                        <For each={q.options}>
-                                            {(opt) => {
-                                                const checked = () =>
-                                                    state()[qi()]?.selected.includes(opt.label) ?? false;
-                                                // Highlight which option(s) the 30s auto-timeout would pick,
-                                                // so a watching user can predict the outcome before it
-                                                // happens. Display-neutral: the label text itself (including
-                                                // any "(Recommended)" suffix) is unchanged.
-                                                const recommended = () =>
-                                                    recommendedOptions(q.options).some((o) => o.label === opt.label);
-                                                return (
-                                                    <label
-                                                        class="agent-question-panel-option"
-                                                        classList={{
-                                                            "agent-question-panel-option--checked": checked(),
-                                                            "agent-question-panel-option--recommended": recommended(),
-                                                        }}
-                                                    >
-                                                        <input
-                                                            type={q.multiSelect ? "checkbox" : "radio"}
-                                                            name={`amux-q-${r.tool_use_id}-${qi()}`}
-                                                            checked={checked()}
-                                                            onChange={() => toggleOption(qi(), opt.label, q.multiSelect)}
-                                                        />
-                                                        <span class="agent-question-panel-option-body">
-                                                            <span class="agent-question-panel-option-label">{opt.label}</span>
-                                                            <Show when={opt.description}>
-                                                                <span class="agent-question-panel-option-desc">{opt.description}</span>
-                                                            </Show>
-                                                        </span>
-                                                    </label>
-                                                );
-                                            }}
-                                        </For>
-                                        <label class="agent-question-panel-other">
-                                            <span class="agent-question-panel-other-label">Other</span>
-                                            <input
-                                                type="text"
-                                                class="agent-question-panel-other-input"
-                                                placeholder="Type a custom answer…"
-                                                value={state()[qi()]?.other ?? ""}
-                                                onInput={(e) => setOther(qi(), e.currentTarget.value, q.multiSelect)}
-                                                onContextMenu={showTextInputContextMenu}
-                                            />
-                                        </label>
-                                    </div>
-                                </fieldset>
-                            )}
-                        </For>
+                        {/* Scrollable middle region — header (above) and actions
+                            (below) stay pinned via position: sticky so the
+                            countdown and Submit/Answer-later buttons are never
+                            scrolled out of reach on a long question set.
+                            Spec: docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md. */}
+                        <div class="agent-question-panel-scroll">
+                            <For each={r.questions}>
+                                {(q, qi) => (
+                                    <fieldset class="agent-question-panel-q">
+                                        <legend class="agent-question-panel-q-prompt">
+                                            <span class="agent-question-panel-q-chip">{q.header}</span>
+                                            {q.question}
+                                        </legend>
+                                        <div class="agent-question-panel-options">
+                                            <For each={q.options}>
+                                                {(opt) => {
+                                                    const checked = () =>
+                                                        state()[qi()]?.selected.includes(opt.label) ?? false;
+                                                    // Highlight which option(s) the 30s auto-timeout would pick,
+                                                    // so a watching user can predict the outcome before it
+                                                    // happens. Display-neutral: the label text itself (including
+                                                    // any "(Recommended)" suffix) is unchanged.
+                                                    const recommended = () =>
+                                                        recommendedOptions(q.options).some((o) => o.label === opt.label);
+                                                    return (
+                                                        <label
+                                                            class="agent-question-panel-option"
+                                                            classList={{
+                                                                "agent-question-panel-option--checked": checked(),
+                                                                "agent-question-panel-option--recommended": recommended(),
+                                                            }}
+                                                        >
+                                                            <input
+                                                                type={q.multiSelect ? "checkbox" : "radio"}
+                                                                name={`amux-q-${r.tool_use_id}-${qi()}`}
+                                                                checked={checked()}
+                                                                onChange={() => toggleOption(qi(), opt.label, q.multiSelect)}
+                                                            />
+                                                            <span class="agent-question-panel-option-body">
+                                                                <span class="agent-question-panel-option-label">{opt.label}</span>
+                                                                <Show when={opt.description}>
+                                                                    <span class="agent-question-panel-option-desc">{opt.description}</span>
+                                                                </Show>
+                                                            </span>
+                                                        </label>
+                                                    );
+                                                }}
+                                            </For>
+                                            <label class="agent-question-panel-other">
+                                                <span class="agent-question-panel-other-label">Other</span>
+                                                <input
+                                                    type="text"
+                                                    class="agent-question-panel-other-input"
+                                                    placeholder="Type a custom answer…"
+                                                    value={state()[qi()]?.other ?? ""}
+                                                    onInput={(e) => setOther(qi(), e.currentTarget.value, q.multiSelect)}
+                                                    onContextMenu={showTextInputContextMenu}
+                                                />
+                                            </label>
+                                        </div>
+                                    </fieldset>
+                                )}
+                            </For>
+                        </div>
 
                         <div class="agent-question-panel-actions">
                             <button


### PR DESCRIPTION
## Summary
Implements `docs/specs/SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md`.

`AgentQuestionPanel` had no `max-height`/`overflow` anywhere — it grows unbounded inside `.agent-view`'s `overflow: hidden` flex column. A multi-question or many-option `AskUserQuestion` call could push the Submit/Answer-later buttons (and the queue/composer below the panel) out of view with no way to scroll to them. Not just cosmetic: the 30s auto-timeout keeps running regardless, so an unreachable Submit button means the user can't act early or defer — only wait on the timer.

- Wraps the question content in a new `.agent-question-panel-scroll` region (`overflow-y: auto`, `min-height: 0` — the classic flexbox scroll gotcha, called out in a code comment so it survives a later refactor).
- Header and actions bar become `position: sticky` top/bottom, following the same pattern already used by `.agent-search-header` (`_search.scss`).
- Fixed `max-height: 420px`, not `vh`/`%` — `.agent-view` only supports width-based container queries, and `vh` is relative to the OS window, not this specific split pane (could be much shorter in a multi-pane layout).

## Test plan
- [x] 35/35 tests passing (`AgentQuestionPanel.test.tsx`) — 33 existing unchanged, 2 new asserting the scroll region is a sibling of the sticky header/actions (not nested under either) and that Submit/Answer-later are never inside the scroll region.
- [ ] Live visual verification via `task dev` was attempted but the build stalled on a CEF/Rust link step (~25 min, no progress) and was killed rather than block further. Relying on the passing structural tests plus code review for this narrowly-scoped, well-established CSS pattern — flagging explicitly rather than claiming a check that didn't happen.

<!-- agentmux:agent_id=agentx -->