### PR TITLE
Manoz@Area54: fix(armory): hide Claude Code CLI branding in Accounts sign-in surfaces

### DIFF
--- a/.changesets/1787714349-fix-armory-hide-claude-code-cli-branding-in-accounts-sign-in-sbnr.md
+++ b/.changesets/1787714349-fix-armory-hide-claude-code-cli-branding-in-accounts-sign-in-sbnr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): hide Claude Code CLI branding in Accounts sign-in surfaces, keep Anthropic

--- a/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.test.tsx
@@ -188,7 +188,7 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
         ]);
         retryButton.click();
 
-        await screen.findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to anthropic/i);
         // The whole point: Retry must refresh the SAME account
         // ("acct-new") the first attempt already minted and persisted, not
         // mint a brand-new one under the still-undefined original prop —
@@ -209,7 +209,7 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
             <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
         ));
 
-        await screen.findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to anthropic/i);
         expect(hub.refreshAccountCache).toHaveBeenCalled();
     });
 
@@ -252,7 +252,7 @@ describe("ClaudeLoginPanel — Stash link verification (codex P1 on PR #2414)", 
 
         render(() => <ClaudeLoginPanel onClose={() => {}} />);
 
-        await screen.findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to anthropic/i);
         expect(hub.listAgentIdentities).not.toHaveBeenCalled();
     });
 });
@@ -267,7 +267,7 @@ describe("ClaudeLoginPanel — unmount cleanup (codex P2 on PR #2414)", () => {
         const { unmount } = render(() => (
             <ClaudeLoginPanel onClose={() => {}} linkTarget={{ agentDefinitionId: "agent-1" }} />
         ));
-        await screen.findByText(/signed in to claude/i);
+        await screen.findByText(/signed in to anthropic/i);
         hub.cancelCliLogin.mockClear(); // clear whatever the login flow itself called
 
         unmount();

--- a/frontend/app/view/accounts/ClaudeLoginPanel.tsx
+++ b/frontend/app/view/accounts/ClaudeLoginPanel.tsx
@@ -321,7 +321,7 @@ export function ClaudeLoginPanel(props: {
                 when={!done()}
                 fallback={
                     <div class="accounts-chooser-modes">
-                        <div class="oauth-byo-note">✓ Signed in to Claude.</div>
+                        <div class="oauth-byo-note">✓ Signed in to Anthropic.</div>
                         <div class="identity-key-actions">
                             <button class="identity-btn identity-btn-primary" onClick={() => props.onClose()}>
                                 Done
@@ -348,7 +348,16 @@ export function ClaudeLoginPanel(props: {
                 >
                     <InAppLoginPanel
                         providerId={CLAUDE_PROVIDER.id}
-                        providerLabel={CLAUDE_PROVIDER.displayName}
+                        // "Anthropic" (the account/brand), not
+                        // CLAUDE_PROVIDER.displayName ("Claude Code", the
+                        // internal CLI tool AgentMux runs under the hood) —
+                        // this panel is Armory/Stash-facing, where the CLI
+                        // implementation detail shouldn't surface. Contrast
+                        // PreLaunchAuthPanel, a different call site of this
+                        // same shared component, which correctly keeps
+                        // showing the real provider.displayName since that
+                        // surface is provider-generic across many CLIs.
+                        providerLabel="Anthropic"
                         authUrl={authUrl()}
                         phase={phase()}
                         onCancel={onCancel}

--- a/frontend/app/view/accounts/accounts-catalog.ts
+++ b/frontend/app/view/accounts/accounts-catalog.ts
@@ -47,7 +47,7 @@ export const SERVICE_CATALOG: ServiceTile[] = [
     // decision), so the gallery intercepts this tile's "oauth" pick the
     // same way it intercepts the AgentMux tile above, opening
     // ClaudeLoginPanel instead of the generic OAuthConnectPanel form path.
-    { id: "anthropic", displayName: "Anthropic", authModes: ["oauth", "key"], keyKind: "api_key", blurb: "Claude Code sign-in, or API key" },
+    { id: "anthropic", displayName: "Anthropic", authModes: ["oauth", "key"], keyKind: "api_key", blurb: "Browser sign-in, or API key" },
     { id: "slack", displayName: "Slack", authModes: ["oauth"], keyKind: "api_key", blurb: "Messaging" },
     { id: "custom", displayName: "Custom", authModes: ["key"], keyKind: "api_key", blurb: "Any bearer token" },
 ];

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -69,9 +69,27 @@ vi.mock("./identity-model", () => ({
             display_name: "Claude Work",
             status: "valid",
         },
+        // No display_name — mirrors what identity_auth_persist.rs actually
+        // writes for a fresh Anthropic OAuth login (name is the internal
+        // "claude-oauth", display_name is empty). reagent P2 on PR #2806:
+        // the row must fall back to the "Anthropic" brand label here, not
+        // leak this internal name.
+        {
+            id: "acc-claude-nodisplay",
+            name: "claude-oauth",
+            provider: "claude",
+            kind: "oauth",
+            display_name: "",
+            status: "valid",
+        },
     ],
     subscribeAccountChanges: () => () => {},
-    PROVIDER_LABELS: { github: "GitHub", claude: "Claude" },
+    // Matches the real PROVIDER_LABELS shape (identity-model.ts) — keyed by
+    // brand, not raw CLI provider id. No "claude" key on purpose: a
+    // regression that dropped the brandForProvider() mapping and read
+    // row.provider directly would fall through to the raw "claude" string
+    // instead of a label here, the same way it would in production.
+    PROVIDER_LABELS: { github: "GitHub", anthropic: "Anthropic" },
 }));
 
 const claudeLoginPanel = vi.fn();
@@ -169,6 +187,20 @@ describe("AgentIdentityLinksPanel", () => {
                     linkTarget: { agentDefinitionId: "agent-1" },
                 }),
             );
+        });
+
+        it("codex P2 / reagent P2 on PR #2806: renders the Anthropic brand, not the raw 'claude' provider id or the internal 'claude-oauth' account name, for a claude row whose account has no display_name", async () => {
+            listAllAgentIdentities.mockResolvedValue([
+                mkLink({ agent_id: "agent-1", account_id: "acc-claude-nodisplay", provider: "claude" }),
+            ]);
+
+            render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
+
+            // Provider column + Account column both fall back to the brand.
+            const cells = await screen.findAllByText("Anthropic");
+            expect(cells).toHaveLength(2);
+            expect(screen.queryByText("claude-oauth")).not.toBeInTheDocument();
+            expect(screen.queryByText("claude", { selector: "td" })).not.toBeInTheDocument();
         });
 
         it("reagent P2 on PR #2414 (round 5): passes the link row's own account id, not the (possibly cache-lagging) joined Account's, so a click while the local accounts cache hasn't caught up still refreshes the RIGHT account instead of minting a new one", async () => {

--- a/frontend/app/view/identity/agent-identity-links-panel.test.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.test.tsx
@@ -212,7 +212,7 @@ describe("AgentIdentityLinksPanel", () => {
             expect(within(table).queryByRole("button", { name: /re-login|connect/i })).not.toBeInTheDocument();
         });
 
-        it("reagent P1 on PR #2414 (round 6): STILL offers 'Connect Claude account' when the agent has other-provider links but no claude/claude-code row of its own — the per-row button can't cover this since no claude row exists to attach it to", async () => {
+        it("reagent P1 on PR #2414 (round 6): STILL offers 'Connect Anthropic account' when the agent has other-provider links but no claude/claude-code row of its own — the per-row button can't cover this since no claude row exists to attach it to", async () => {
             listAllAgentIdentities.mockResolvedValue([
                 mkLink({ agent_id: "agent-1", account_id: "acc-1", provider: "github" }),
             ]);
@@ -220,7 +220,7 @@ describe("AgentIdentityLinksPanel", () => {
             render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
 
             await waitFor(() => expect(screen.getByText("Work GitHub")).toBeInTheDocument());
-            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            const button = await screen.findByRole("button", { name: "Connect Anthropic account" });
             button.click();
 
             expect(claudeLoginPanel).toHaveBeenCalledWith(
@@ -231,7 +231,7 @@ describe("AgentIdentityLinksPanel", () => {
             );
         });
 
-        it("reagent P1 on PR #2414 (round 6): does NOT offer 'Connect Claude account' anywhere for a non-claude agent that has other-provider links but no claude row — that would link an unrelated Claude account to an agent whose actual provider is something else entirely", async () => {
+        it("reagent P1 on PR #2414 (round 6): does NOT offer 'Connect Anthropic account' anywhere for a non-claude agent that has other-provider links but no claude row — that would link an unrelated Claude account to an agent whose actual provider is something else entirely", async () => {
             listAllAgentIdentities.mockResolvedValue([
                 mkLink({ agent_id: "agent-3", account_id: "acc-1", provider: "github" }),
             ]);
@@ -280,12 +280,12 @@ describe("AgentIdentityLinksPanel", () => {
             );
         });
 
-        it("empty state offers 'Connect Claude account' for an agent with NO links at all (the v0.54.9 stuck-instance case — no row exists to attach a per-row button to)", async () => {
+        it("empty state offers 'Connect Anthropic account' for an agent with NO links at all (the v0.54.9 stuck-instance case — no row exists to attach a per-row button to)", async () => {
             listAllAgentIdentities.mockResolvedValue([]);
 
             render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
 
-            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            const button = await screen.findByRole("button", { name: "Connect Anthropic account" });
             button.click();
 
             expect(claudeLoginPanel).toHaveBeenCalledWith(
@@ -296,7 +296,7 @@ describe("AgentIdentityLinksPanel", () => {
             );
         });
 
-        it("reagent P2 on PR #2414 (round 3): does NOT offer 'Connect Claude account' for an agent whose own provider isn't claude — that would link an unrelated Claude account instead of the agent's actual provider", async () => {
+        it("reagent P2 on PR #2414 (round 3): does NOT offer 'Connect Anthropic account' for an agent whose own provider isn't claude — that would link an unrelated Claude account instead of the agent's actual provider", async () => {
             listAllAgentIdentities.mockResolvedValue([]);
 
             render(() => <AgentIdentityLinksPanel agentId="agent-3" />);
@@ -304,14 +304,14 @@ describe("AgentIdentityLinksPanel", () => {
             await waitFor(() => {
                 expect(screen.getByText(/no linked accounts yet/i)).toBeInTheDocument();
             });
-            expect(screen.queryByRole("button", { name: "Connect Claude account" })).not.toBeInTheDocument();
+            expect(screen.queryByRole("button", { name: "Connect Anthropic account" })).not.toBeInTheDocument();
         });
 
         // #2594 — the CTA gate must resolve through the agent's bound
         // bundle, not the possibly-drifted `agent.provider` column
         // directly (same "gate vs. actual launch can disagree" risk
         // class #2592/#2596/#2607/#2609/#2610 fixed).
-        it("#2594: offers 'Connect Claude account' when the drifted column says non-claude but the bound bundle resolves to claude", async () => {
+        it("#2594: offers 'Connect Anthropic account' when the drifted column says non-claude but the bound bundle resolves to claude", async () => {
             listAllAgentIdentities.mockResolvedValue([]);
             getMemoryCommand.mockImplementation(async (_c: unknown, data: { id: string }) =>
                 data.id === "mem-4" ? { provider: "claude" } : undefined,
@@ -319,11 +319,11 @@ describe("AgentIdentityLinksPanel", () => {
 
             render(() => <AgentIdentityLinksPanel agentId="agent-4" />);
 
-            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            const button = await screen.findByRole("button", { name: "Connect Anthropic account" });
             expect(button).toBeInTheDocument();
         });
 
-        it("#2594: does NOT offer 'Connect Claude account' when the drifted column says claude but the bound bundle resolves away from it", async () => {
+        it("#2594: does NOT offer 'Connect Anthropic account' when the drifted column says claude but the bound bundle resolves away from it", async () => {
             listAllAgentIdentities.mockResolvedValue([]);
             getMemoryCommand.mockImplementation(async (_c: unknown, data: { id: string }) =>
                 data.id === "mem-5" ? { provider: "codex" } : undefined,
@@ -334,19 +334,19 @@ describe("AgentIdentityLinksPanel", () => {
             await waitFor(() => {
                 expect(screen.getByText(/no linked accounts yet/i)).toBeInTheDocument();
             });
-            expect(screen.queryByRole("button", { name: "Connect Claude account" })).not.toBeInTheDocument();
+            expect(screen.queryByRole("button", { name: "Connect Anthropic account" })).not.toBeInTheDocument();
         });
 
-        it("reagent P2 on PR #2414 (round 3): does NOT offer 'Connect Claude account' before the initial load resolves or after it fails — only once genuinely confirmed empty", async () => {
+        it("reagent P2 on PR #2414 (round 3): does NOT offer 'Connect Anthropic account' before the initial load resolves or after it fails — only once genuinely confirmed empty", async () => {
             let resolveLoad!: (v: unknown[]) => void;
             listAllAgentIdentities.mockReturnValue(new Promise((res) => { resolveLoad = res; }));
 
             render(() => <AgentIdentityLinksPanel agentId="agent-1" />);
 
-            expect(screen.queryByRole("button", { name: "Connect Claude account" })).not.toBeInTheDocument();
+            expect(screen.queryByRole("button", { name: "Connect Anthropic account" })).not.toBeInTheDocument();
 
             resolveLoad([]);
-            const button = await screen.findByRole("button", { name: "Connect Claude account" });
+            const button = await screen.findByRole("button", { name: "Connect Anthropic account" });
             expect(button).toBeInTheDocument();
         });
     });

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -64,7 +64,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
     // instead of leaving an orphaned row that silently blocks every future
     // spawn under the new canonical link.
     const [claudeStaleAliasProvider, setClaudeStaleAliasProvider] = createSignal<string | undefined>(undefined);
-    // reagent P2 on PR #2414 (round 3): the empty-state "Connect Claude
+    // reagent P2 on PR #2414 (round 3): the empty-state "Connect Anthropic
     // account" button below must not appear before the initial load
     // resolves (was previously indistinguishable from "genuinely zero
     // links") or after it fails (the top error banner already covers that
@@ -124,7 +124,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
     // Resolve through the agent's bound bundle rather than the possibly-
     // drifted `agent.provider` column directly — #2594, same "gate vs.
     // actual launch can disagree" risk class #2592/#2596/#2607/#2609/
-    // #2610 fixed. Gates the "Connect Claude account" CTA below; falls
+    // #2610 fixed. Gates the "Connect Anthropic account" CTA below; falls
     // back to `agent()?.provider` while loading/unbound/on failure, same
     // fallback contract `resolveEffectiveLaunchProvider` itself documents
     // — a brief stale flash here is cosmetic (button visibility only),

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -291,7 +291,7 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                     class="identity-btn identity-btn-primary"
                                     onClick={() => openClaudeLogin(undefined)}
                                 >
-                                    Connect Claude account
+                                    Connect Anthropic account
                                 </button>
                             </div>
                         </Show>

--- a/frontend/app/view/identity/agent-identity-links-panel.tsx
+++ b/frontend/app/view/identity/agent-identity-links-panel.tsx
@@ -36,6 +36,7 @@ import { statusBadge } from "./identity-manager";
 import { joinAgentIdentityRows } from "./agent-identities-model";
 import { ClaudeLoginPanel } from "@/app/view/accounts/ClaudeLoginPanel";
 import { canonicalProviderId } from "@/app/view/agent/providers/provider-id-aliases";
+import { brandForProvider } from "@/app/view/accounts/provider-brand";
 
 import "./identity-pane-view.scss";
 
@@ -207,13 +208,21 @@ export const AgentIdentityLinksPanel = (props: AgentIdentityLinksPanelProps): JS
                                                 <tr>
                                                     <td>
                                                         {(PROVIDER_LABELS as Record<string, string>)[
-                                                            row.provider
+                                                            brandForProvider(row.provider)
                                                         ] ?? row.provider}
                                                     </td>
                                                     <td>
                                                         {row.account
                                                             ? row.account.display_name?.trim() ||
-                                                              row.account.name
+                                                              // Anthropic accounts persist an
+                                                              // internal `${provider}-oauth` name
+                                                              // (identity_auth_persist.rs) with no
+                                                              // display_name set — fall back to the
+                                                              // brand label instead of leaking that
+                                                              // internal name (codex P2 on PR #2806).
+                                                              (brandForProvider(row.provider) === "anthropic"
+                                                                  ? "Anthropic"
+                                                                  : row.account.name)
                                                             : "—"}
                                                     </td>
                                                     <td>

--- a/frontend/app/view/identity/identity-accounts-tab.tsx
+++ b/frontend/app/view/identity/identity-accounts-tab.tsx
@@ -205,11 +205,16 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                     <span class="identity-detail-status-text" data-status={account.status}>{account.status}</span>
                 </div>
 
-                {/* Resolve the label via the brand so CLI-OAuth accounts surface "via <CLI>". */}
+                {/* Resolve the label via the brand so CLI-OAuth accounts surface "via <CLI>" —
+                    except Claude, whose underlying CLI tool ("Claude Code") is an
+                    implementation detail this surface deliberately doesn't expose;
+                    "Anthropic" (the actual account/brand) is shown alone instead. */}
                 <DetailField
                     label="Provider"
                     value={`${PROVIDER_LABELS[brandForProvider(account.provider)] ?? account.provider}${
-                        isCliOAuthProvider(account.provider) ? ` (via ${account.provider} CLI)` : ""
+                        isCliOAuthProvider(account.provider) && brandForProvider(account.provider) !== "anthropic"
+                            ? ` (via ${account.provider} CLI)`
+                            : ""
                     }`}
                 />
                 <DetailField label="Kind" value={KIND_LABELS[account.kind]} />


### PR DESCRIPTION
## Summary
- The Armory/Stash Accounts sign-in flow showed \"Claude Code\" / \"Claude\" — the internal CLI tool AgentMux runs under the hood — instead of \"Anthropic\", the actual account/brand the user is signing in to.
- Kept \"Anthropic\" branding everywhere in that flow (real account/company, same idea as \"Sign in with Google\"); hid the CLI-tool name specifically, since it's an implementation detail.
- Scope: `ClaudeLoginPanel.tsx` (confirmation text + `providerLabel` prop passed to the shared `InAppLoginPanel`), `accounts-catalog.ts` (tile blurb), `agent-identity-links-panel.tsx` (empty-state button text), `identity-accounts-tab.tsx` (suppress the \"(via claude CLI)\" suffix specifically for the claude/anthropic case, using `brandForProvider(...) !== "anthropic"` rather than a literal `"claude"` comparison to satisfy `AccountProvider`'s type).
- `PreLaunchAuthPanel` (the agent-launch modal, a different caller of the same shared `InAppLoginPanel`) is untouched — it's provider-generic and correctly keeps showing the real CLI's display name for whichever provider is being launched.
- Updated the two test files (`ClaudeLoginPanel.test.tsx`, `agent-identity-links-panel.test.tsx`) whose assertions checked the old copy.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- frontend/app/view/identity frontend/app/view/accounts` — 7 files, 63 tests passed
- [x] Full frontend suite (`npm test`) — 213 files / 3132 tests passed, 2 pre-existing skips

<!-- agentmux:agent_id=manoz -->