### PR TITLE
chore: release v0.55.25

### DIFF
--- a/.changesets/1787637492-feat-widgets-reorder-default-pinned-widgets-to-agent-swarm-a-imf9.md
+++ b/.changesets/1787637492-feat-widgets-reorder-default-pinned-widgets-to-agent-swarm-a-imf9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(widgets): reorder default pinned widgets to Agent, Swarm, Armory, Sysinfo

--- a/.changesets/1787663234-feat-armory-show-ambient-claude-claude-md-as-a-second-global-xzwd.md
+++ b/.changesets/1787663234-feat-armory-show-ambient-claude-claude-md-as-a-second-global-xzwd.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): show ambient ~/.claude/CLAUDE.md as a second Global Memory read-only block

--- a/.changesets/1787668309-fix-armory-rename-ambient-claude-md-block-group-external-cla-6vq0.md
+++ b/.changesets/1787668309-fix-armory-rename-ambient-claude-md-block-group-external-cla-6vq0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): rename ambient CLAUDE.md block, group External Claude Code files clearly

--- a/.changesets/1787694787-fix-identity-block-agent-spawns-bindings-from-resolving-to-t-drcg.md
+++ b/.changesets/1787694787-fix-identity-block-agent-spawns-bindings-from-resolving-to-t-drcg.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(identity): block agent spawns/bindings from resolving to the ambient home dir

--- a/.changesets/1787696117-fix-armory-tone-down-global-memory-explanations-shrink-text-ecjf.md
+++ b/.changesets/1787696117-fix-armory-tone-down-global-memory-explanations-shrink-text-ecjf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): tone down Global Memory explanations, shrink text

--- a/.changesets/1787711826-fix-splash-agent-pane-darkened-splash-border-agent-pane-tab--l5mx.md
+++ b/.changesets/1787711826-fix-splash-agent-pane-darkened-splash-border-agent-pane-tab--l5mx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(splash,agent-pane): darkened splash border + agent-pane tab-strip gap/centering

--- a/.changesets/1787712548-fix-agent-scroll-support-for-askuserquestion-panel-keep-butt-slgv.md
+++ b/.changesets/1787712548-fix-agent-scroll-support-for-askuserquestion-panel-keep-butt-slgv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): scroll support for AskUserQuestion panel, keep buttons reachable

--- a/.changesets/1787714349-fix-armory-hide-claude-code-cli-branding-in-accounts-sign-in-sbnr.md
+++ b/.changesets/1787714349-fix-armory-hide-claude-code-cli-branding-in-accounts-sign-in-sbnr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): hide Claude Code CLI branding in Accounts sign-in surfaces, keep Anthropic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.24"
+version = "0.55.25"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.24"
+version = "0.55.25"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.24"
+version = "0.55.25"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.24"
+version = "0.55.25"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.24"
+version = "0.55.25"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.24"
+version = "0.55.25"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.24"
+version = "0.55.25"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,17 @@
 # AgentMux Version History
 
+## 0.55.25 — 2026-08-25
+
+- feat(widgets): reorder default pinned widgets to Agent, Swarm, Armory, Sysinfo
+- feat(armory): show ambient ~/.claude/CLAUDE.md as a second Global Memory read-only block
+- fix(armory): rename ambient CLAUDE.md block, group External Claude Code files clearly
+- fix(identity): block agent spawns/bindings from resolving to the ambient home dir
+- fix(armory): tone down Global Memory explanations, shrink text
+- fix(splash,agent-pane): darkened splash border + agent-pane tab-strip gap/centering
+- fix(agent): scroll support for AskUserQuestion panel, keep buttons reachable
+- fix(armory): hide Claude Code CLI branding in Accounts sign-in surfaces, keep Anthropic
+
+
 ## 0.55.24 — 2026-08-24
 
 - fix(agent-pane): strip common indentation from mid-file tool previews

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.24",
+  "version": "0.55.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.24",
+      "version": "0.55.25",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.24",
+  "version": "0.55.25",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR — consumes all 8 pending changesets, forced to a **patch** bump (`--as patch`) per repo-owner request even though the changeset mix computed to `minor` (2 minor + 6 patch changesets present; the minor-level changes ship under this patch version, as the forcing script itself warns).

0.55.24 → 0.55.25. All 5 version-consistency locations confirmed in agreement by `scripts/release.sh` itself:
- `VERSION_HISTORY.md` top section
- `package.json.version`
- `Cargo.toml [workspace.package].version`
- `Cargo.lock` workspace-member versions
- `package-lock.json` root version

## Changes in this release
- feat(widgets): reorder default pinned widgets to Agent, Swarm, Armory, Sysinfo
- feat(armory): show ambient ~/.claude/CLAUDE.md as a second Global Memory read-only block
- fix(armory): rename ambient CLAUDE.md block, group External Claude Code files clearly
- fix(identity): block agent spawns/bindings from resolving to the ambient home dir
- fix(armory): tone down Global Memory explanations, shrink text
- fix(splash,agent-pane): darkened splash border + agent-pane tab-strip gap/centering
- fix(agent): scroll support for AskUserQuestion panel, keep buttons reachable
- fix(armory): hide Claude Code CLI branding in Accounts sign-in surfaces, keep Anthropic

## Test plan
- [x] `scripts/release.sh` — all 5 version locations confirmed in agreement
- [x] All 8 changesets consumed and removed
- [x] No source changes in this PR — version/changelog files only

<!-- agentmux:agent_id=agenty -->