### PR TITLE
feat(agentmux-mcp): DiscoverWindows tool + pid-based CaptureWindow targeting

### DIFF
--- a/.changesets/1787718976-feat-agentmux-mcp-discoverwindows-tool-pid-based-capturewind-k9ka.md
+++ b/.changesets/1787718976-feat-agentmux-mcp-discoverwindows-tool-pid-based-capturewind-k9ka.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agentmux-mcp): DiscoverWindows tool + pid-based CaptureWindow targeting

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -263,20 +263,20 @@ const UI_QUERY_TOOL: &str = r#"{
 // something to back into accidentally via a narrower tool's scope creep.
 const CAPTURE_WINDOW_TOOL: &str = r#"{
   "name": "CaptureWindow",
-  "description": "Screenshot a DIFFERENT AgentMux window/instance — by pid (preferred; get one from DiscoverWindows) or by (partial, case-insensitive) title match, e.g. a separate task dev build running alongside this one. Prefer pid: AgentMux's own frontend actively manages its window title (tab switches, workspace renames, even other AgentMux windows opening/closing elsewhere can all rewrite it), so a title match can go stale mid-session in a way a pid never does. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool), and never your own instance's window. If title_contains matches more than one window and you didn't pass an explicit index, this returns every candidate (pid + title) instead of guessing — pass one of those pids back in, or use DiscoverWindows first. Every call is logged (who, what, outcome) to an audit trail in this instance's own data dir — a full approval/capability-flag gate is tracked separately, not yet built. Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user. If the target window was created very recently, the result may note likely_unrendered — the tool already retried a couple of times internally, but the window may still not have painted its first real frame.",
+  "description": "Screenshot a DIFFERENT AgentMux window/instance — by pid (preferred; get one from DiscoverWindows) or by (partial, case-insensitive) title match, e.g. a separate task dev build running alongside this one. Prefer pid: AgentMux's own frontend actively manages its window title (tab switches, workspace renames, even other AgentMux windows opening/closing elsewhere can all rewrite it), so a title match can go stale mid-session in a way a pid never does. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool), and never your own instance's window. If title_contains matches more than one window and you didn't pass an explicit index, this returns every candidate (pid + title) instead of guessing — pass one of those pids back in, or use DiscoverWindows first. A single process can also own multiple top-level windows sharing the same pid — if pid matches more than one, pass an explicit index alongside it the same way. Every call is logged (who, what, outcome) to an audit trail in this instance's own data dir — a full approval/capability-flag gate is tracked separately, not yet built. Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user. The result may note likely_unrendered if the captured frame looks solid/near-solid-color even after a couple of internal retries — that CAN mean the window hasn't painted its first real frame yet, but it's only a heuristic (a legitimately solid-colored window trips it too), not a reliable signal of how old the window is.",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "pid": { "type": "number", "description": "Process id of the target window's owning process — from DiscoverWindows. Preferred over title_contains: stable for the process's whole lifetime, unlike its title." },
+      "pid": { "type": "number", "description": "Process id of the target window's owning process — from DiscoverWindows. Preferred over title_contains: stable for the process's whole lifetime, unlike its title. If more than one window shares this pid, also pass index to disambiguate." },
       "title_contains": { "type": "string", "description": "Substring to match against other AgentMux windows' titles, case-insensitive. Ignored if pid is given." },
-      "index": { "type": "number", "description": "If multiple AgentMux windows match title_contains, which one to capture (0-based). Omit this when you expect exactly one match — if more than one actually matches, the tool returns the full candidate list (pid + title) instead of silently picking one." }
+      "index": { "type": "number", "description": "If multiple AgentMux windows match title_contains (or share the given pid), which one to capture (0-based). Omit this when you expect exactly one match — if more than one actually matches, the tool returns the full candidate list instead of silently picking one." }
     }
   }
 }"#;
 
 const DISCOVER_WINDOWS_TOOL: &str = r#"{
   "name": "DiscoverWindows",
-  "description": "List every AgentMux-owned top-level window currently open on this machine — read-only: no screenshot taken, nothing written to disk, nothing audit-logged. Use this BEFORE CaptureWindow so you have real candidates (pid, title, exe_path) instead of guessing a title substring or an index. Pass the pid of whichever window you want straight into CaptureWindow(pid: ...) — a pid stays valid for that process's whole lifetime, unlike its title, which AgentMux's own frontend can rewrite at any time (tab switches, workspace renames, even unrelated AgentMux windows opening/closing elsewhere on the machine).",
+  "description": "List every AgentMux-owned top-level window currently open on this machine — read-only: no screenshot taken, nothing written to disk. Use this BEFORE CaptureWindow so you have real candidates (pid, title, exe_path) instead of guessing a title substring or an index. Pass the pid of whichever window you want straight into CaptureWindow(pid: ...) — a pid stays valid for that process's whole lifetime, unlike its title, which AgentMux's own frontend can rewrite at any time (tab switches, workspace renames, even unrelated AgentMux windows opening/closing elsewhere on the machine). exe_path can reveal the OS username of a different instance's owner on a shared machine, so — same as CaptureWindow — every call is logged (who, what, outcome) to this instance's own audit trail.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -1059,17 +1059,49 @@ fn capture_window_impl(
     let foreign: Vec<&AgentMuxWindowInfo> = all.iter().filter(|w| !w.is_self).collect();
 
     let target: &AgentMuxWindowInfo = if let Some(target_pid) = pid {
-        foreign
+        // A single host process can own multiple top-level windows sharing
+        // the same pid (agentmux-cef/src/browser_pane/hwnd.rs:200-204,
+        // agentmux-cef/src/commands/window/lifecycle.rs:410-426) — codex P1
+        // on PR #2810: the original `.find()` here silently captured
+        // whichever matching window enumerated first, which could be a
+        // pool/sub-window rather than the one the caller meant, reintroducing
+        // the wrong-window capture this PR exists to prevent. Same
+        // ambiguity-rejection shape as the title_contains branch below:
+        // `index` disambiguates, an unqualified ambiguous match does not.
+        let matches: Vec<&AgentMuxWindowInfo> = foreign
             .iter()
-            .find(|w| w.pid == target_pid)
+            .filter(|w| w.pid == target_pid)
             .copied()
-            .ok_or_else(|| {
+            .collect();
+        if matches.is_empty() {
+            anyhow::bail!(
+                "no AgentMux window found for pid {target_pid} (or it belongs to your \
+                 own instance, which CaptureWindow can never target) — call \
+                 DiscoverWindows to see current candidates"
+            );
+        }
+        match index {
+            Some(i) => *matches.get(i).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "no AgentMux window found for pid {target_pid} (or it belongs to your \
-                     own instance, which CaptureWindow can never target) — call \
-                     DiscoverWindows to see current candidates"
+                    "index {i} out of range — only {} window(s) matched pid {target_pid}",
+                    matches.len()
                 )
-            })?
+            })?,
+            None if matches.len() == 1 => matches[0],
+            None => {
+                let candidates: Vec<String> = matches
+                    .iter()
+                    .map(|w| format!("title={:?}", w.title))
+                    .collect();
+                anyhow::bail!(
+                    "{} windows matched pid {target_pid} — a single process can own \
+                     multiple top-level windows; pass an explicit index (0-based) \
+                     alongside pid to disambiguate. Candidates: {}",
+                    matches.len(),
+                    candidates.join("; ")
+                );
+            }
+        }
     } else {
         let title_contains = title_contains
             .ok_or_else(|| anyhow::anyhow!("must provide either pid or title_contains"))?;
@@ -1174,10 +1206,18 @@ fn capture_window_impl(
     // write path.
     prune_old_captures(&dir);
 
+    // codex P2 on PR #2810: no process start time is collected or checked
+    // anywhere, so claiming "this window was created recently" was
+    // unsupported and misleading for a mature window that just happens to
+    // render a near-uniform frame (looks_unrendered's own doc comment
+    // already acknowledges that legitimate case). State only what was
+    // actually observed.
     let hint = if likely_unrendered {
-        " (likely_unrendered: true — this window was created recently and may not have \
-           painted its first real frame yet even after retrying; consider calling \
-           CaptureWindow again shortly)"
+        " (likely_unrendered: true — the captured frame looks solid or \
+           near-solid-color even after retrying, which can mean the window \
+           hasn't painted its first real frame yet, or that it genuinely \
+           looks like this; consider calling CaptureWindow again shortly if \
+           that's unexpected)"
     } else {
         ""
     };
@@ -1217,6 +1257,41 @@ fn audit_log_capture_window(query_desc: &str, outcome: &Result<String>) {
             Err(e) => serde_json::json!({"result": "error", "detail": e.to_string()}),
         },
     });
+    append_window_audit_log_entry(&entry);
+}
+
+/// Audit trail for `DiscoverWindows` — reagent P1 on PR #2810: this tool
+/// discloses `exe_path` (a full filesystem path, typically embedding the OS
+/// username) for windows belonging to OTHER AgentMux instances/users on a
+/// shared machine — the exact same disclosure-across-a-human-boundary risk
+/// `audit_log_capture_window` above already exists to log, but this tool
+/// shipped with none. Same shape, same file (a single window-related audit
+/// trail is easier to review than two): best-effort, never blocks the
+/// tool's own result.
+fn audit_log_discover_windows(include_self: bool, windows: &[Value]) {
+    let entry = serde_json::json!({
+        "timestamp": std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        "agent_id": agent_slug().unwrap_or_else(|_| "unknown".to_string()),
+        "tool": "DiscoverWindows",
+        "query": format!("include_self={include_self}"),
+        "outcome": serde_json::json!({
+            "result": "success",
+            "window_count": windows.len(),
+            "windows": windows,
+        }),
+    });
+    append_window_audit_log_entry(&entry);
+}
+
+/// Shared append-only NDJSON writer for both window-tool audit trails above
+/// — best-effort (a logging failure must never break the tool itself),
+/// inside `capture_window_dir()` itself since `prune_old_captures`'s
+/// PNG-only extension filter already leaves a `.log` file in that same
+/// directory untouched, so this doesn't need (or want) its own directory.
+fn append_window_audit_log_entry(entry: &Value) {
     let dir = capture_window_dir();
     if std::fs::create_dir_all(&dir).is_err() {
         return;
@@ -2573,6 +2648,11 @@ async fn call_tool(
                     })
                 })
                 .collect();
+            // reagent P1 on PR #2810: exe_path (embeds the OS username) for
+            // OTHER instances/users on a shared machine is the same
+            // disclosure-across-a-human-boundary risk CaptureWindow already
+            // logs — this tool must too, not just the tool that follows it.
+            audit_log_discover_windows(include_self, &list);
             return Ok(serde_json::to_string_pretty(&json!({ "windows": list }))
                 .unwrap_or_else(|_| "{\"windows\":[]}".to_string()));
         }
@@ -3423,6 +3503,43 @@ mod tests {
         let second: Value = serde_json::from_str(lines[1]).unwrap();
         assert_eq!(second["query"], "second query");
         assert_eq!(second["outcome"]["result"], "error");
+    }
+
+    /// reagent P1 on PR #2810: `DiscoverWindows` discloses `exe_path`
+    /// (embeds the OS username for a foreign instance/user on a shared
+    /// machine) and shipped with zero audit logging, unlike `CaptureWindow`
+    /// which logs every call for exactly this reason. Pins that it now
+    /// does, into the SAME log file (one window-tool audit trail, not two).
+    #[test]
+    fn audit_log_discover_windows_appends_ndjson_with_window_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = DATA_HOME_ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("AGENTMUX_DATA_HOME", dir.path()) };
+
+        let windows = vec![json!({
+            "pid": 4242,
+            "title": "AgentMux",
+            "exe_path": "C:\\Users\\someone\\agentmux.exe",
+            "is_self": false,
+        })];
+        audit_log_discover_windows(false, &windows);
+
+        unsafe { std::env::remove_var("AGENTMUX_DATA_HOME") };
+
+        let log_path = dir.path().join("tmp/capture-window/capture-window-audit.log");
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1, "one NDJSON line for this call");
+
+        let entry: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(entry["tool"], "DiscoverWindows");
+        assert_eq!(entry["query"], "include_self=false");
+        assert_eq!(entry["outcome"]["result"], "success");
+        assert_eq!(entry["outcome"]["window_count"], 1);
+        assert_eq!(
+            entry["outcome"]["windows"][0]["exe_path"],
+            "C:\\Users\\someone\\agentmux.exe"
+        );
     }
 
     /// Every tool advertised by `tools/list` must be valid JSON with a `name`

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -263,14 +263,25 @@ const UI_QUERY_TOOL: &str = r#"{
 // something to back into accidentally via a narrower tool's scope creep.
 const CAPTURE_WINDOW_TOOL: &str = r#"{
   "name": "CaptureWindow",
-  "description": "Screenshot a DIFFERENT AgentMux window/instance by (partial, case-insensitive) title match — e.g. a separate task dev build running alongside this one. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool), and never your own instance's window. Every call is logged (who, what, outcome) to an audit trail in this instance's own data dir — a full approval/capability-flag gate is tracked separately, not yet built. Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user.",
+  "description": "Screenshot a DIFFERENT AgentMux window/instance — by pid (preferred; get one from DiscoverWindows) or by (partial, case-insensitive) title match, e.g. a separate task dev build running alongside this one. Prefer pid: AgentMux's own frontend actively manages its window title (tab switches, workspace renames, even other AgentMux windows opening/closing elsewhere can all rewrite it), so a title match can go stale mid-session in a way a pid never does. Scoped to AgentMux's own windows only, not arbitrary desktop applications (unlike a general OS computer-use tool), and never your own instance's window. If title_contains matches more than one window and you didn't pass an explicit index, this returns every candidate (pid + title) instead of guessing — pass one of those pids back in, or use DiscoverWindows first. Every call is logged (who, what, outcome) to an audit trail in this instance's own data dir — a full approval/capability-flag gate is tracked separately, not yet built. Returns a file path; use the Read tool on that path to view it yourself, or OpenMedia to show it to the user. If the target window was created very recently, the result may note likely_unrendered — the tool already retried a couple of times internally, but the window may still not have painted its first real frame.",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "title_contains": { "type": "string", "description": "Substring to match against other AgentMux windows' titles, case-insensitive" },
-      "index": { "type": "number", "description": "If multiple AgentMux windows match, which one to capture (0-based, default 0). The error message lists all matching AgentMux window titles when this is ambiguous." }
-    },
-    "required": ["title_contains"]
+      "pid": { "type": "number", "description": "Process id of the target window's owning process — from DiscoverWindows. Preferred over title_contains: stable for the process's whole lifetime, unlike its title." },
+      "title_contains": { "type": "string", "description": "Substring to match against other AgentMux windows' titles, case-insensitive. Ignored if pid is given." },
+      "index": { "type": "number", "description": "If multiple AgentMux windows match title_contains, which one to capture (0-based). Omit this when you expect exactly one match — if more than one actually matches, the tool returns the full candidate list (pid + title) instead of silently picking one." }
+    }
+  }
+}"#;
+
+const DISCOVER_WINDOWS_TOOL: &str = r#"{
+  "name": "DiscoverWindows",
+  "description": "List every AgentMux-owned top-level window currently open on this machine — read-only: no screenshot taken, nothing written to disk, nothing audit-logged. Use this BEFORE CaptureWindow so you have real candidates (pid, title, exe_path) instead of guessing a title substring or an index. Pass the pid of whichever window you want straight into CaptureWindow(pid: ...) — a pid stays valid for that process's whole lifetime, unlike its title, which AgentMux's own frontend can rewrite at any time (tab switches, workspace renames, even unrelated AgentMux windows opening/closing elsewhere on the machine).",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "include_self": { "type": "boolean", "description": "Include this agent's own AgentMux instance's window(s) in the results. Default false, matching CaptureWindow's own scope — CaptureWindow can never target your own instance even if you pass its pid here." }
+    }
   }
 }"#;
 
@@ -733,6 +744,8 @@ async fn main() {
                 let ui_query: Value = serde_json::from_str(UI_QUERY_TOOL).expect("static json");
                 let capture_window: Value =
                     serde_json::from_str(CAPTURE_WINDOW_TOOL).expect("static json");
+                let discover_windows: Value =
+                    serde_json::from_str(DISCOVER_WINDOWS_TOOL).expect("static json");
                 let fleet_list: Value = serde_json::from_str(FLEET_LIST_TOOL).expect("static json");
                 let fleet_broadcast: Value =
                     serde_json::from_str(FLEET_BROADCAST_TOOL).expect("static json");
@@ -761,7 +774,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -932,96 +945,220 @@ fn own_instance_pids() -> std::collections::HashSet<u32> {
     result
 }
 
-/// The actual `CaptureWindow` logic — window enumeration, own-instance and
-/// third-party-app exclusion, capture, and save. Extracted to its own
-/// function (rather than living inline in the `"CaptureWindow" =>` match
-/// arm) so its `Result` can be captured once and unconditionally audit-
-/// logged by the caller before propagating — see `audit_log_capture_window`.
-fn capture_window_impl(title_contains: &str, index: usize) -> Result<String> {
+/// One AgentMux-owned top-level window, with the metadata both
+/// `DiscoverWindows` and `CaptureWindow` need. Shared via
+/// `enumerate_agentmux_windows()` so the two tools can't drift on what
+/// counts as "AgentMux's own window" or "the calling agent's own instance"
+/// — see `own_instance_pids()`'s doc comment for how `is_self` is decided.
+struct AgentMuxWindowInfo {
+    window: xcap::Window,
+    pid: u32,
+    title: String,
+    exe_path: String,
+    is_self: bool,
+}
+
+/// Enumerate every top-level OS window belonging to an AgentMux process
+/// (matched via `app_name()`, not `title()` — AgentMux's own process names
+/// are version-stamped, e.g. `agentmux-0.55.18`, not a single fixed
+/// string, but they all share the `agentmux` prefix — reagent P1, PR
+/// #2709 round 2, which also found the original unscoped version could
+/// screenshot a KeePass password-manager window with zero gating).
+/// `is_self` marks windows belonging to the calling agent's OWN instance
+/// (`own_instance_pids()`) — surfaced as a flag here (for `DiscoverWindows`,
+/// which is read-only and fine showing "yes this is you"), then hard-
+/// excluded downstream by `capture_window_impl` (which must never let an
+/// agent screenshot its own instance — reagent P0, PR #2709 round 3: one
+/// AgentMux instance's top-level window contains every agent's pane in it,
+/// so that exclusion is the actual isolation boundary, not a nicety).
+fn enumerate_agentmux_windows() -> Result<Vec<AgentMuxWindowInfo>> {
     let windows =
         xcap::Window::all().map_err(|e| anyhow::anyhow!("failed to enumerate windows: {e}"))?;
-    // Scoped to AgentMux's own processes only — reagent P1 (PR #2709
-    // round 2): as originally written, this reached ANY top-level OS
-    // window (confirmed in testing: it could screenshot a KeePass
-    // password-manager window with zero gating), which is the
-    // "arbitrary third-party app" capability `docs/specs/computer-use-pane.md`
-    // already scoped out as needing its own per-app approval model —
-    // not this tool's actual motivating need, which was only ever
-    // "see a different AgentMux instance's window." `app_name()`
-    // matching (not `title()`) because AgentMux's own process names
-    // are version-stamped (`agentmux-0.55.18`, etc.), not a single
-    // fixed string, but they all share the `agentmux` prefix.
-    // Excludes the CALLING agent's own instance — reagent P0 (PR
-    // #2709 round 3): the app_name()-only filter above matches every
-    // AgentMux instance's windows, including this one. One AgentMux
-    // instance's top-level window contains every agent's pane in it
-    // (pane-level isolation is enforced only inside that window, via
-    // the signed-identity scheme UIScreenshot/UIClick/UIQuery use —
-    // see the doc comment above CAPTURE_WINDOW_TOOL). Without this
-    // exclusion, any agent could pass a title_contains matching its
-    // OWN instance's window and capture every other agent's pane
-    // content in that same window — exactly the isolation boundary
-    // this tool claims not to cross. See own_instance_pids()'s own
-    // doc comment for how "same instance" is determined.
     let own_pids = own_instance_pids();
-    let agentmux_windows: Vec<&xcap::Window> = windows
-        .iter()
-        .filter(|w| {
-            let is_agentmux = w
-                .app_name()
-                .map(|a| a.to_lowercase().starts_with("agentmux"))
-                .unwrap_or(false);
-            let is_own_instance = w.pid().map(|p| own_pids.contains(&p)).unwrap_or(true);
-            is_agentmux && !is_own_instance
-        })
-        .collect();
-    let needle = title_contains.to_lowercase();
-    let matches: Vec<&&xcap::Window> = agentmux_windows
-        .iter()
-        .filter(|w| {
-            w.title()
-                .map(|t| t.to_lowercase().contains(&needle))
-                .unwrap_or(false)
-        })
-        .collect();
+    let sys = sysinfo::System::new_all();
+    let mut out = Vec::new();
+    for window in windows {
+        let is_agentmux = window
+            .app_name()
+            .map(|a| a.to_lowercase().starts_with("agentmux"))
+            .unwrap_or(false);
+        if !is_agentmux {
+            continue;
+        }
+        // Fails safe, same discipline as the pre-existing own-instance
+        // check this replaces: an unresolvable pid is treated as "assume
+        // it's mine" (is_self: true) rather than silently dropped, so
+        // DiscoverWindows still surfaces that the window exists instead
+        // of hiding it, while capture_window_impl's hard exclusion of
+        // is_self windows still keeps it out of reach either way.
+        let pid = window.pid().unwrap_or(0);
+        let is_self = pid == 0 || own_pids.contains(&pid);
+        let title = window.title().unwrap_or_default();
+        let exe_path = sys
+            .process(sysinfo::Pid::from(pid as usize))
+            .and_then(|p| p.exe())
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        out.push(AgentMuxWindowInfo {
+            window,
+            pid,
+            title,
+            exe_path,
+            is_self,
+        });
+    }
+    Ok(out)
+}
 
-    if matches.is_empty() {
-        // Only lists OTHER AgentMux windows' titles, not every
-        // window on the desktop — reagent P2 (PR #2709 round 2):
-        // the original version dumped every visible window's title
-        // on any miss, which let a caller enumerate arbitrary
-        // window titles (confirmed in testing: this leaked a
-        // password manager's document title) with no real match
-        // required at all. Still helpful for the actual in-scope
-        // case (multiple AgentMux instances open) without that leak.
-        let titles: Vec<String> = agentmux_windows
+/// Cheap heuristic for "this capture is probably a blank/unpainted frame,
+/// not a real render" — sample ~200 evenly-spaced pixels and check they're
+/// all within a small tolerance of the first one. Not real image analysis
+/// (a legitimately solid-color themed window would also trip this) —
+/// deliberately cheap and approximate, used only to decide whether a short
+/// bounded retry is worth attempting, and to set `likely_unrendered` as a
+/// hint, never as a hard failure.
+fn looks_unrendered(img: &image::RgbaImage) -> bool {
+    let pixels = img.as_raw();
+    if pixels.len() < 4 {
+        return true;
+    }
+    let (r0, g0, b0) = (pixels[0], pixels[1], pixels[2]);
+    let pixel_count = pixels.len() / 4;
+    let step = (pixel_count / 200).max(1);
+    let mut sampled = 0usize;
+    for i in (0..pixel_count).step_by(step) {
+        let idx = i * 4;
+        sampled += 1;
+        if pixels[idx].abs_diff(r0) > 8 || pixels[idx + 1].abs_diff(g0) > 8 || pixels[idx + 2].abs_diff(b0) > 8 {
+            return false;
+        }
+    }
+    sampled > 0
+}
+
+/// The actual `CaptureWindow` logic — window enumeration, own-instance and
+/// third-party-app exclusion, targeting (by pid or by title), capture, and
+/// save. Extracted to its own function (rather than living inline in the
+/// `"CaptureWindow" =>` match arm) so its `Result` can be captured once and
+/// unconditionally audit-logged by the caller before propagating — see
+/// `audit_log_capture_window`.
+///
+/// `index: None` with more than one `title_contains` match is an error
+/// listing every candidate, NOT a silent pick of match 0 — see
+/// docs/reports/REPORT_AGENT_SCREENSHOT_WINDOW_CONTROL_BLOCKERS_2026_08_24.md
+/// §1 for the real incident (an ambiguous match silently captured an
+/// unrelated, sensitive window) this specifically fixes. `index: Some(i)`
+/// is still honored directly against whatever matched, unchanged from the
+/// original behavior, for callers who already disambiguate explicitly.
+fn capture_window_impl(
+    title_contains: Option<&str>,
+    index: Option<usize>,
+    pid: Option<u32>,
+) -> Result<String> {
+    let all = enumerate_agentmux_windows()?;
+    let foreign: Vec<&AgentMuxWindowInfo> = all.iter().filter(|w| !w.is_self).collect();
+
+    let target: &AgentMuxWindowInfo = if let Some(target_pid) = pid {
+        foreign
             .iter()
-            .filter_map(|w| w.title().ok())
-            .filter(|t| !t.is_empty())
+            .find(|w| w.pid == target_pid)
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no AgentMux window found for pid {target_pid} (or it belongs to your \
+                     own instance, which CaptureWindow can never target) — call \
+                     DiscoverWindows to see current candidates"
+                )
+            })?
+    } else {
+        let title_contains = title_contains
+            .ok_or_else(|| anyhow::anyhow!("must provide either pid or title_contains"))?;
+        let needle = title_contains.to_lowercase();
+        let matches: Vec<&AgentMuxWindowInfo> = foreign
+            .iter()
+            .filter(|w| w.title.to_lowercase().contains(&needle))
+            .copied()
             .collect();
-        if titles.is_empty() {
+
+        if matches.is_empty() {
+            // Only lists OTHER AgentMux windows' titles, not every
+            // window on the desktop — reagent P2 (PR #2709 round 2):
+            // the original version dumped every visible window's title
+            // on any miss, which let a caller enumerate arbitrary
+            // window titles (confirmed in testing: this leaked a
+            // password manager's document title) with no real match
+            // required at all. Still helpful for the actual in-scope
+            // case (multiple AgentMux instances open) without that leak.
+            let titles: Vec<&str> = foreign
+                .iter()
+                .map(|w| w.title.as_str())
+                .filter(|t| !t.is_empty())
+                .collect();
+            if titles.is_empty() {
+                anyhow::bail!(
+                    "no AgentMux window title contains {title_contains:?} — \
+                     no other AgentMux windows are currently open"
+                );
+            }
             anyhow::bail!(
-                "no AgentMux window title contains {title_contains:?} — \
-                 no other AgentMux windows are currently open"
+                "no AgentMux window title contains {title_contains:?}. \
+                 Open AgentMux window titles: {}",
+                titles.join(", ")
             );
         }
-        anyhow::bail!(
-            "no AgentMux window title contains {title_contains:?}. \
-             Open AgentMux window titles: {}",
-            titles.join(", ")
-        );
-    }
-    let window = matches.get(index).ok_or_else(|| {
-        anyhow::anyhow!(
-            "index {index} out of range — only {} window(s) matched {title_contains:?}",
-            matches.len()
-        )
-    })?;
-    let title = window.title().unwrap_or_default();
 
-    let image = window
+        match index {
+            Some(i) => *matches.get(i).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "index {i} out of range — only {} window(s) matched {title_contains:?}",
+                    matches.len()
+                )
+            })?,
+            None if matches.len() == 1 => matches[0],
+            None => {
+                // The fix for blocker #1 in the report: an ambiguous
+                // match with no explicit index used to silently capture
+                // index 0 despite this tool's own docstring claiming it
+                // would list candidates instead. It now actually does.
+                let candidates: Vec<String> = matches
+                    .iter()
+                    .map(|w| format!("pid={} title={:?}", w.pid, w.title))
+                    .collect();
+                anyhow::bail!(
+                    "{} windows matched {title_contains:?} — pass an explicit index (0-based), \
+                     or better, one of these pids directly (preferred: stable, unlike title). \
+                     Candidates: {}",
+                    matches.len(),
+                    candidates.join("; ")
+                );
+            }
+        }
+    };
+
+    let title = target.title.clone();
+
+    // Short bounded retry for a freshly-created window that hasn't
+    // painted its first real frame yet — see looks_unrendered()'s doc
+    // comment. std::thread::sleep (not tokio::time::sleep): this fn is
+    // plain sync code called from the async dispatch path, and the
+    // bounded ~800ms worst case is a deliberate, request-scoped wait
+    // directly serving this call, not background work stealing the
+    // runtime from anything else.
+    let mut image = target
+        .window
         .capture_image()
         .map_err(|e| anyhow::anyhow!("capture failed: {e}"))?;
+    let mut likely_unrendered = looks_unrendered(&image);
+    let mut attempts = 1;
+    while likely_unrendered && attempts < 3 {
+        std::thread::sleep(Duration::from_millis(400));
+        image = target
+            .window
+            .capture_image()
+            .map_err(|e| anyhow::anyhow!("capture failed: {e}"))?;
+        likely_unrendered = looks_unrendered(&image);
+        attempts += 1;
+    }
 
     let dir = capture_window_dir();
     std::fs::create_dir_all(&dir)
@@ -1037,8 +1174,15 @@ fn capture_window_impl(title_contains: &str, index: usize) -> Result<String> {
     // write path.
     prune_old_captures(&dir);
 
+    let hint = if likely_unrendered {
+        " (likely_unrendered: true — this window was created recently and may not have \
+           painted its first real frame yet even after retrying; consider calling \
+           CaptureWindow again shortly)"
+    } else {
+        ""
+    };
     Ok(format!(
-        "Captured window {title:?} to {} — use Read on that path to view it yourself, or OpenMedia to show it to the user.",
+        "Captured window {title:?} to {}{hint} — use Read on that path to view it yourself, or OpenMedia to show it to the user.",
         path.display()
     ))
 }
@@ -1056,7 +1200,7 @@ fn capture_window_impl(title_contains: &str, index: usize) -> Result<String> {
 /// itself — `prune_old_captures`'s PNG-only extension filter already
 /// leaves a `.log` file in that same directory untouched, so this doesn't
 /// need (or want) its own separate directory alongside it.
-fn audit_log_capture_window(title_contains: &str, outcome: &Result<String>) {
+fn audit_log_capture_window(query_desc: &str, outcome: &Result<String>) {
     let entry = serde_json::json!({
         "timestamp": std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1064,7 +1208,10 @@ fn audit_log_capture_window(title_contains: &str, outcome: &Result<String>) {
             .unwrap_or(0),
         "agent_id": agent_slug().unwrap_or_else(|_| "unknown".to_string()),
         "tool": "CaptureWindow",
-        "title_contains": title_contains,
+        // "pid=N" or "title_contains=\"...\"" — whichever targeting mode
+        // the caller used (SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md
+        // added pid-based targeting as an alternative to title matching).
+        "query": query_desc,
         "outcome": match outcome {
             Ok(msg) => serde_json::json!({"result": "success", "detail": msg}),
             Err(e) => serde_json::json!({"result": "error", "detail": e.to_string()}),
@@ -2366,15 +2513,31 @@ async fn call_tool(
             ))
         }
         "CaptureWindow" => {
+            // `index` stays an Option all the way into capture_window_impl —
+            // NOT defaulted to 0 here. Defaulting it here is exactly what
+            // let an ambiguous match silently capture the wrong (and once,
+            // a genuinely unrelated/sensitive) window with no warning —
+            // see docs/reports/REPORT_AGENT_SCREENSHOT_WINDOW_CONTROL_BLOCKERS_2026_08_24.md
+            // §1. Losing "the caller didn't specify an index at all" vs.
+            // "the caller explicitly asked for index 0" was the bug.
             let title_contains = arguments
                 .get("title_contains")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow::anyhow!("missing required parameter: title_contains"))?
-                .to_string();
+                .map(|s| s.to_string());
             let index = arguments
                 .get("index")
                 .and_then(|v| v.as_u64())
-                .unwrap_or(0) as usize;
+                .map(|v| v as usize);
+            let pid = arguments
+                .get("pid")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+
+            let query_desc = match (pid, title_contains.as_deref()) {
+                (Some(p), _) => format!("pid={p}"),
+                (None, Some(t)) => format!("title_contains={t:?}"),
+                (None, None) => "<no target given>".to_string(),
+            };
 
             // Audit trail, not a capability gate — reagent P1 (PR #2709
             // round 4): a real per-agent opt-in gate is a bigger feature
@@ -2388,9 +2551,30 @@ async fn call_tool(
             // one — logging every call (who, what was requested, what
             // happened) is the honest, shippable Phase-1 answer while the
             // real gate is tracked separately (operator-confirmed).
-            let outcome = capture_window_impl(&title_contains, index);
-            audit_log_capture_window(&title_contains, &outcome);
+            let outcome = capture_window_impl(title_contains.as_deref(), index, pid);
+            audit_log_capture_window(&query_desc, &outcome);
             return outcome;
+        }
+        "DiscoverWindows" => {
+            let include_self = arguments
+                .get("include_self")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let windows = enumerate_agentmux_windows()?;
+            let list: Vec<Value> = windows
+                .iter()
+                .filter(|w| include_self || !w.is_self)
+                .map(|w| {
+                    json!({
+                        "pid": w.pid,
+                        "title": w.title,
+                        "exe_path": w.exe_path,
+                        "is_self": w.is_self,
+                    })
+                })
+                .collect();
+            return Ok(serde_json::to_string_pretty(&json!({ "windows": list }))
+                .unwrap_or_else(|_| "{\"windows\":[]}".to_string()));
         }
         "UIClick" => {
             require_agent_env(local_url, auth_key, block_id)?;
@@ -3161,6 +3345,54 @@ mod tests {
         );
     }
 
+    /// `looks_unrendered()` is the retry/hint trigger for
+    /// `CaptureWindow` (SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md
+    /// Fix 4) — must flag a truly uniform-color frame (the "blank capture,
+    /// no signal" bug the report documents) and must NOT flag a frame with
+    /// real visual variation, even a subtle one, as long as it exceeds the
+    /// tolerance.
+    #[test]
+    fn looks_unrendered_flags_a_solid_color_frame() {
+        let img = image::RgbaImage::from_pixel(32, 32, image::Rgba([20, 20, 20, 255]));
+        assert!(looks_unrendered(&img), "a fully solid-color frame must be flagged");
+    }
+
+    #[test]
+    fn looks_unrendered_does_not_flag_a_varied_frame() {
+        let mut img = image::RgbaImage::from_pixel(32, 32, image::Rgba([20, 20, 20, 255]));
+        // A single differing pixel could land between two sampled indices
+        // (sampling is spaced across the image, not exhaustive — see
+        // looks_unrendered's doc comment) and be missed entirely. Fill a
+        // whole row instead, so several sampled indices are guaranteed to
+        // fall inside it regardless of the exact sample step for this
+        // image size.
+        for x in 0..32 {
+            img.put_pixel(x, 16, image::Rgba([220, 30, 30, 255]));
+        }
+        assert!(
+            !looks_unrendered(&img),
+            "a frame with a clearly differing region must not be flagged as unrendered"
+        );
+    }
+
+    #[test]
+    fn looks_unrendered_ignores_noise_within_tolerance() {
+        // Real compositor output isn't perfectly uniform even for a
+        // genuinely "blank" themed window (subpixel AA, slight gradient
+        // banding) — small per-channel noise within the tolerance must
+        // still read as unrendered, or every real blank frame would dodge
+        // the retry.
+        let mut img = image::RgbaImage::from_pixel(32, 32, image::Rgba([20, 20, 20, 255]));
+        for (i, px) in img.pixels_mut().enumerate() {
+            let jitter = (i % 5) as u8; // stays within the +/-8 tolerance
+            *px = image::Rgba([20 + jitter, 20, 20, 255]);
+        }
+        assert!(
+            looks_unrendered(&img),
+            "small within-tolerance noise must still read as unrendered"
+        );
+    }
+
     /// `audit_log_capture_window` must append one valid NDJSON line per
     /// call, for both success and failure outcomes, without ever panicking
     /// or returning an error to its caller (it's a fire-and-forget
@@ -3185,11 +3417,11 @@ mod tests {
 
         let first: Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(first["tool"], "CaptureWindow");
-        assert_eq!(first["title_contains"], "first query");
+        assert_eq!(first["query"], "first query");
         assert_eq!(first["outcome"]["result"], "success");
 
         let second: Value = serde_json::from_str(lines[1]).unwrap();
-        assert_eq!(second["title_contains"], "second query");
+        assert_eq!(second["query"], "second query");
         assert_eq!(second["outcome"]["result"], "error");
     }
 
@@ -3235,6 +3467,7 @@ mod tests {
             FLEET_BROADCAST_TOOL,
             FLEET_BULK_STOP_TOOL,
             CAPTURE_WINDOW_TOOL,
+            DISCOVER_WINDOWS_TOOL,
             LIST_CONVERSATIONS_TOOL,
         ];
         // This array (and its count) has drifted from the real `tools/list`
@@ -3250,7 +3483,10 @@ mod tests {
         // LIST_CONVERSATIONS_TOOL added here too
         // (SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md
         // Phase A) — same reasoning, not fixing the pre-existing drift.
-        assert_eq!(defs.len(), 35, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow + 1 ListConversations");
+        // DISCOVER_WINDOWS_TOOL added here too
+        // (SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md) — same
+        // reasoning, not fixing the pre-existing drift.
+        assert_eq!(defs.len(), 36, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/docs/reports/REPORT_AGENT_SCREENSHOT_WINDOW_CONTROL_BLOCKERS_2026_08_24.md
+++ b/docs/reports/REPORT_AGENT_SCREENSHOT_WINDOW_CONTROL_BLOCKERS_2026_08_24.md
@@ -1,0 +1,74 @@
+# REPORT: Blockers hit controlling/screenshotting another AgentMux window, live session
+
+**Date:** 2026-08-24
+**Author:** Claude (agent session), first-person account
+**Context:** While iterating on a composer-strip layout fix, I needed to (a) launch a `task dev` build of AgentMux itself to test the change, (b) identify/rename its window so the user could reliably find it among several open AgentMux windows, and (c) screenshot it myself to verify visual results before asking the user to re-check. Every one of these turned out to be harder than expected. This report documents exactly what happened and why, grounded in a follow-up read of the actual `agentmux-mcp`/`agentmux-srv`/`agentmux-cef` source. It's the input to `SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md`.
+
+---
+
+## 1. `CaptureWindow` matched an unrelated, unrelated-agent window before finding mine
+
+**What happened:** With three AgentMux windows open (my own session, a stale-branch `task dev` build I'd just launched, and — unbeknownst to me — a completely unrelated pre-existing AgentMux window running a different agent's live session), I called `CaptureWindow(title_contains: "AgentMux")` to find my dev build. It silently returned index 0: a screenshot of the *unrelated* window, showing another agent's live conversation — GitHub PAT/credential handling, repo names, account details. Not something I intended to look at, and not logged as ambiguous.
+
+**Why:** `CaptureWindow`'s docstring states *"The error message lists all matching AgentMux window titles when this is ambiguous"* — but in the actual implementation (`agentmux-mcp/src/main.rs:940-1044`, `capture_window_impl`), an ambiguous match (multiple windows matching `title_contains`) does **not** surface the candidate list; it silently captures whichever window sorts first at `index` (default 0). I only discovered there were 3 matches by manually trying `index: 1`, `index: 2` in sequence — guesswork, with a real chance of repeatedly hitting the wrong (and in this case, sensitive) window on each guess.
+
+**Severity:** real — this is a documented behavior gap between the tool's own docstring and its implementation, and it caused an actual unintended exposure to another agent's live session content, which I had to flag to the user mid-task.
+
+## 2. No way to enumerate candidate windows before calling CaptureWindow
+
+**What happened:** To find the *right* index, I had no option but to call `CaptureWindow` itself (index 0, 1, 2, …) and inspect the resulting image each time — spending real capture calls (each one audit-logged, each one producing an image file, each one a chance of hitting a wrong/sensitive window) just to discover what windows exist.
+
+**Why:** There's no read-only "list AgentMux windows across instances" tool. `Layout` returns window/tab/workspace structure, but only for the *calling* agent's own `agentmux-srv` instance (confirmed: it's a local IPC call against the caller's own state, not a cross-instance query). `CaptureWindow` is the only tool that reaches outside the caller's own instance at all, and it's screenshot-or-nothing — there's no cheap, non-image-producing "just tell me what's out there" step.
+
+## 3. A legitimately-running window screenshotted as solid black, twice, with no explanation
+
+**What happened:** After confirming (via `tasklist`/process enumeration) that my dev build's launcher + CEF processes were genuinely running, `CaptureWindow` still returned a fully black PNG — both immediately after launch and again ~30s later. I couldn't tell if this meant "not rendered yet, try again" or "something is actually broken."
+
+**Why (partially explained, partially open):** `capture_window_impl` calls `xcap`'s `window.capture_image()` with no retry and no post-capture sanity check (e.g. detecting a single-color frame) — it returns whatever the OS compositor happened to hand back at that instant. For a freshly-created CEF window that hasn't painted its first frame, or one occluded/minimized/off the visible desktop, a black or blank capture is a completely plausible outcome, but the tool gives the caller no way to distinguish "really nothing to see yet" from "capture is fine, the window itself is genuinely rendering black" from "capture mechanism failed silently."
+
+## 4. `SetName` cannot rename a window in a different `agentmux-srv` instance — confirmed structural, not a missing parameter
+
+**What happened:** The user asked me to rename the dev-build window. `SetName(target: "window", ...)` only accepts a `target_id` resolved against the *caller's own* `Layout`/`WhoAmI` — passing anything else fails, and the dev-build window (a separate `task dev` process, its own `agentmux-srv` sidecar) never appears in my own `Layout` query at all.
+
+**Why:** Confirmed at every layer this is load-bearing, not an oversight. `WindowNameRequest` (`agentmux-common/src/api_types.rs:258-264`) has exactly three fields (`block_id`, `name`, `window_id`) — no PID, no HWND, no cross-instance address. The MCP tool POSTs to `AGENTMUX_LOCAL_URL`, which is fixed once at MCP-process-start to *this* agent's own sidecar and never repointed (`docs/reports/REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md` §3.4). A separate `task dev` instance has its own sidecar, own auth key, own window IDs — reachable by nothing in the current tool surface. This exact limitation was already identified, by name, as "Option B" in a pre-`SetName` design doc (`docs/analysis/REPORT_AGENT_WINDOW_NAMING_2026_06_17.md` §4) and deliberately not built. I wasn't hitting a bug; I was hitting a documented, intentional boundary — but the tool gives no indication *why* the rename fails beyond "target_id required," so I spent real effort rediscovering a limitation that was already known.
+
+## 5. Dropping to raw Win32 `SetWindowText` "worked" then silently stopped working, with a genuinely confusing failure mode
+
+**What happened:** With no supported path, I wrote a throwaway PowerShell script using `user32.dll` P/Invoke (`EnumWindows`/`GetWindowThreadProcessId`/`SetWindowText`) to rename the dev-build window directly by PID. It worked — `Get-Process`/`Get-CimInstance` confirmed the OS-level title changed. Minutes later, `CaptureWindow` couldn't find the window under *any* substring I tried, including ones that should still have matched (the new title, and even "AgentMux" itself, which the new title still contained as a substring).
+
+**Why:** This is the most interesting finding from the follow-up research, and it revises my own live theory at the time (I'd guessed `CaptureWindow` used some kind of stale internal registry — it doesn't; `capture_window_impl` does a fresh `xcap::Window::all()` live OS query on every call, confirmed by reading it directly). The real mechanism: AgentMux's own frontend continuously **overwrites its own OS window title** via a reactive effect (`installWindowTitleEffect`, `frontend/app-init.ts:811-886`) that recomputes and writes `document.title` — which flows to a real `SetWindowTextW` call in `agentmux-cef/src/client/display.rs` (`on_title_change`) — on *any* change to: the active tab, the window's own `window:displayname` meta, its assigned workspace's name, **or its position in the cross-window `openWindowEntriesAtom` list** (which shifts whenever *any* AgentMux window on the machine opens or closes, not just this one). During the same window of time I was renaming this window, I was also killing and relaunching other dev-build process trees — each open/close is exactly the kind of event that re-triggers this reactive effect and overwrites the title back to AgentMux's own live-computed value, independent of what I'd just set it to externally. An externally-forced OS-level rename on this app is fighting a live process that will eventually win — it isn't durable, and the failure mode (silent, delayed, no error) makes it look like a `CaptureWindow` bug rather than what it actually is: a race against the app's own title-management system.
+
+## 6. Launching a long-running GUI dev-server process was unreliable across three different mechanisms
+
+**What happened, three attempts:**
+1. `mcp__agentmux__Shell(cmd: "npm run dev", ...)` — died with exit code 201 after ~558-559 lines of output, twice in a row, at reproducibly the same point in the build/startup sequence. No error message surfaced to me beyond the bare exit code.
+2. Plain `Bash(cmd: "npm run dev > log 2>&1 &"; disown)` — the backgrounded job didn't survive at all; the redirected log file stayed empty, no process ever appeared in `tasklist`. Silent no-op.
+3. `Bash(cmd: "npm run dev > log 2>&1", run_in_background: true)` — worked. The app built, launched, and ran successfully for ~10 minutes (confirmed via live log output showing full CEF/frontend startup) — then was killed by an external SIGTERM I never issued.
+
+**Why (mixed — two different systems, don't conflate them):** Follow-up research into `agentmux-srv`'s own background-shell engine (`ShellNodeRunner`, `agentmux-srv/src/backend/shell_node.rs` — the real implementation behind the `Shell`/`ShellStatus` MCP tools) found **no idle-timeout or max-runtime cap for it at all**. The only lifecycle-ending paths are natural process exit, an explicit `ShellStop`, or the whole `agentmux-srv` instance shutting down. The interactive-agent-pane PTY subsystem (`ShellController`) *does* have a watchdog with idle/wall-clock caps (`agentmux-srv/src/backend/blockcontroller/watchdog.rs`), but it explicitly skips anything that isn't `is_agent_pane` — `Shell`-tool processes aren't controllers at all and are invisible to that watchdog. So attempt #1's exit-201 failure is **not** explained by any lifetime cap in AgentMux's own code — its root cause is still unknown; flagging as an open item below. Attempt #3's SIGTERM-after-10-minutes is a **different system entirely** — the generic `Bash` tool's own background-execution mechanism (part of my own agent harness, not `mcp__agentmux__Shell`/`ShellNodeRunner`) — so whatever imposed that cutoff is out of scope for an AgentMux-side fix; noted here only so the two failures aren't mistaken for the same root cause.
+
+## 7. Cleaning up an orphaned process tree after the SIGTERM required manual PID archaeology
+
+**What happened:** After the attempt-#3 process got killed externally, its child processes (launcher + `agentmux-srv` + several `agentmux-cef.exe` renderer/gpu/utility children) survived as orphans and held a file lock on `agentmux-launcher.exe`, silently blocking every subsequent `npm run dev` attempt with `The process cannot access the file because it is being used by another process` — no indication *what* was holding the lock. I had to manually reconstruct the process tree via `Get-CimInstance Win32_Process` (parent/child + command-line matching on the dev build's own `dist/cef-dev` path, to avoid mis-identifying or killing sibling AgentMux instances that happen to share process *names*), then `taskkill /PID <root> /T /F` the correct root.
+
+**Why:** Confirmed `ShellNodeRunner` does have a proper, PID/process-group-scoped `kill_tree` for `ShellStop` (`shell_node.rs:176-186`) — the building block for clean teardown exists — but only reachable via the `shell_id` returned at launch time. If that id is lost (session interruption, or in this case a process that outlived the tool call that spawned it via a *different* backgrounding mechanism than `ShellNodeRunner`), there's no tool to discover "what did I spawn earlier that might still be running" independent of holding onto the original id.
+
+## 8. Unrelated but directly blocking: Windows-style CLI flags (`/PID`, `/T`, `/F`) got mangled by MSYS path conversion
+
+**What happened:** `taskkill /PID 68108 /T /F` failed with `Invalid argument/option - 'C:/Program Files/Git/PID'` — Git Bash's automatic Unix-path conversion rewrote `/PID` as if it were a filesystem path. Needed `MSYS_NO_PATHCONV=1` or routing through `cmd.exe /C "..."` explicitly to work around it. Not screenshot/window-control specific, but it directly blocked the cleanup in #7, and cost several failed attempts before I found the right invocation.
+
+---
+
+## Summary table
+
+| # | Blocker | Root cause confirmed? | In scope for the follow-up spec? |
+|---|---|---|---|
+| 1 | Ambiguous match silently returns index 0, no candidate list | Yes — docstring/implementation gap | Yes |
+| 2 | No cheap window-discovery/list tool | Yes — doesn't exist | Yes |
+| 3 | Black screenshot, no retry/explanation | Partially — no retry logic exists; can't confirm compositor-level cause | Yes (retry/flag) |
+| 4 | SetName can't reach a foreign instance | Yes — confirmed structural, already documented as deliberate elsewhere | Yes (propose a real solution, not a workaround) |
+| 5 | Raw external rename gets silently overwritten | Yes — AgentMux's own reactive title effect wins the race | Yes (via #4's real fix, not by hardening the workaround) |
+| 6 | `Shell`-tool GUI process died at exit 201 | **No — open, unresolved** | Flag as investigation item, not a proposed fix |
+| 6b | Bash-harness background job SIGTERM'd after ~10min | Out of scope — different system (agent harness, not AgentMux) | No |
+| 7 | Orphan cleanup needed manual PID archaeology | Yes — no discovery path once `shell_id` is lost | Yes |
+| 8 | MSYS path-mangling on Windows-style flags | Yes — known Git-Bash behavior | Out of scope (shell environment quirk, not an AgentMux tool) |

--- a/docs/specs/SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md
+++ b/docs/specs/SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md
@@ -1,0 +1,123 @@
+# SPEC: Robust cross-instance window discovery, capture, and naming
+
+**Date:** 2026-08-24
+**Status:** Phase 1 (Fixes 1-4, §2-5) implemented on branch `feat/agent-app-api-window-discovery`. Phase 2 (Fix 5, cross-instance naming, §6) and Fix 6 (§7, orphan discovery) remain draft/not started. §8's open item (Shell-tool exit-201 mystery) remains unresolved — not attempted here, per its own note.
+**Trigger:** `docs/reports/REPORT_AGENT_SCREENSHOT_WINDOW_CONTROL_BLOCKERS_2026_08_24.md` — a live session where an agent needed to find, screenshot, and rename a `task dev` build's window while working, and hit real blockers at every step: an ambiguous `CaptureWindow` match silently returned an unrelated (and in this case sensitive) window instead of the intended one; no tool exists to enumerate candidate windows before capturing; a legitimately-running window screenshotted as unexplained solid black; `SetName` cannot reach a window in a different `agentmux-srv` instance (confirmed structural); and a raw external Win32 rename used as a workaround got silently overwritten by AgentMux's own reactive title system, in a way that looked like a tool bug but wasn't.
+
+**Scope:** `agentmux-mcp/src/main.rs` (tool definitions + `capture_window_impl`), `agentmux-srv/src/server/mod.rs` (`handle_window_name` and a new cross-instance name-request path), plus a new lightweight local-instance discovery mechanism. No changes to the UI-automation click/input boundary (`SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md`'s screenshot-only design stays screenshot-only — this spec is about *finding and naming* windows more reliably, not adding input injection).
+
+---
+
+## 1. Why
+
+`CaptureWindow` is, by design, "the sole deliberately narrow exception" that reaches outside an agent's own `agentmux-srv` instance (`REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md`). That's the right scope boundary — this spec doesn't propose widening it to input injection or arbitrary cross-instance control. But within that narrow screenshot-only scope, the tool surface has real, fixable gaps: it can't be queried cheaply before spending a capture call, its own documented ambiguity-handling doesn't match its implementation, it gives no signal on a black/blank result, and there is no companion naming capability at all — forcing agents toward raw OS-level workarounds that don't actually work reliably against this specific app (because AgentMux's own frontend actively, reactively manages its window title and will silently overwrite an externally-forced rename).
+
+## 2. Fix 1 — `DiscoverWindows`: a read-only, no-image-cost enumeration tool
+
+New MCP tool. Same underlying enumeration `capture_window_impl` already does (`xcap::Window::all()` filtered by `app_name()` prefix `"agentmux"`), reused as a shared function, but returning structured data instead of a screenshot:
+
+```
+DiscoverWindows(include_self: bool = false) -> {
+  windows: [
+    { pid: u32, title: string, exe_path: string, is_self: bool }
+  ]
+}
+```
+
+- `exe_path` (already available from `xcap`'s underlying process query, same source `own_instance_pids()` already reads) lets a caller distinguish *which* AgentMux build/instance a window belongs to — e.g. a `task dev` build under `dist/cef-dev` vs. an installed portable build — without needing to guess from the title, which per §4/§5 below is not a stable signal for this app.
+- `is_self` reuses the existing `own_instance_pids()` exclusion logic, but as a flag rather than a hard filter, so a caller can still see (but clearly identify) their own window if they want to.
+- No image is written, nothing touches `capture_window_dir()`, no audit-log entry (nothing sensitive is disclosed beyond title/pid/path, which `CaptureWindow`'s own audit log already treats as safe to log).
+- Directly replaces the blind `index: 0, 1, 2, ...` guessing from blocker #1/#2 in the report — a caller runs this once, sees the real candidate list, then targets precisely.
+
+## 3. Fix 2 — `CaptureWindow` accepts a stable `pid` target, not just a racy title substring
+
+Add an optional `pid` parameter as an alternative to `title_contains`/`index`:
+
+```
+CaptureWindow(pid: u32) -> (same result as today)
+CaptureWindow(title_contains: string, index?: number) -> (existing behavior, kept for convenience)
+```
+
+When `pid` is given, skip title matching entirely — find the window(s) owned by that PID directly (same `GetWindowThreadProcessId`-equivalent xcap already does internally for the `app_name()` filter) and capture the (first) visible one. This is the single highest-value fix from the report: per §5's finding, an AgentMux window's *title* is under continuous reactive control by the app itself and is not a stable identifier to search by at all — a PID (obtained from `DiscoverWindows`, or already known because the caller launched the process themselves, as in the report's own scenario) doesn't have that problem for the lifetime of the process. `title_contains` remains supported for the case where a caller doesn't have a PID handy, but its docs should be updated to note it's inherently racy against this app's own title-management behavior, not just "case-insensitive substring, may be ambiguous."
+
+## 4. Fix 3 — ambiguous title match returns the real candidate list, matching the tool's own existing docstring
+
+Bug fix, not a new capability: `CAPTURE_WINDOW_TOOL`'s docstring already promises *"The error message lists all matching AgentMux window titles when this is ambiguous"* — `capture_window_impl` doesn't do this; it silently captures `index` (default 0) with no signal that other matches existed. Fix: when `title_contains` (without an explicit `pid`) matches more than one window and `index` was not explicitly provided, return an error listing every match (`title`, `pid`) instead of silently picking one. This alone would have prevented blocker #1 in the report — the accidental capture of an unrelated, sensitive session was possible specifically because the tool silently proceeded instead of surfacing the ambiguity it claims to detect.
+
+## 5. Fix 4 — blank/black-frame detection with a short bounded retry
+
+`capture_window_impl` calls `window.capture_image()` once, with no sanity check on the result. Add: after capture, cheaply check whether the image is a single solid color (or below a low variance/entropy threshold — a cheap check, not real image analysis) — if so, and the target process was created less than some short threshold ago (a few seconds; process start time is already obtainable via the same process-info call `own_instance_pids()` uses), retry the capture up to 2-3 times with a short delay (e.g. 300-500ms apart) before giving up. Whether or not the retry resolves it, include a `likely_unrendered: bool` flag in the tool result so a caller isn't left guessing (as in blocker #3) whether a black image means "try again shortly" or "this is really what the window shows."
+
+## 6. Fix 5 — the real fix for cross-instance naming: a local instance-discovery broker, not a hardened workaround
+
+This is the structurally bigger piece, and worth being explicit about the trade-off: **do not** try to make raw external `SetWindowText` reliable against this app. Per the report's §5 finding, AgentMux's frontend will keep winning that race by design (its title is reactively recomputed on tab switch / workspace rename / any window opening or closing anywhere on the machine) — hardening around that behavior means fighting the app's own architecture indefinitely. The actual fix is to let a rename request go through the *same* reactive pipeline the app already uses for its own instance (`window:displayname` meta → `document.title` effect → `SetWindowTextW`), just triggered from a different instance than the one the window belongs to.
+
+That requires solving what today's tools structurally can't: an agent in instance A doesn't know instance B's `AGENTMUX_LOCAL_URL`/auth key (each MCP process reads its own once at startup and never repoints — confirmed in the report). Proposed shape:
+
+1. Each `agentmux-srv` instance, on startup, registers a small local record — PID, `AGENTMUX_LOCAL_URL` (effectively just its bound port, since it's loopback-only), and a short-lived instance token — in a well-known local location (e.g. a file under a shared `AGENTMUX_DATA_HOME`-adjacent directory, keyed by PID, cleaned up on clean shutdown and treated as stale/ignorable if the PID no longer exists on a read — same liveness-check discipline `SPEC_WINDOW_HWND_CACHE_STALE_FIX_2026_05_28.md` had to retrofit onto the *unrelated* internal HWND cache after it shipped without one; worth building this broker with that lesson already applied rather than needing a follow-up fix).
+2. A new MCP tool, `SetForeignWindowName(pid: u32, name: string)`: resolves `pid` → owning `agentmux-srv` instance via that registry (an owning instance's PID is discoverable the same way `DiscoverWindows`/`CaptureWindow` already resolve `app_name()`-filtered windows to their owning process — the new piece is only the *registry lookup* from "which srv instance owns this browser-process PID," not the window-to-process resolution itself, which already exists), then makes the same `WindowNameRequest` POST `SetName` already makes today, just addressed at instance B's registered local URL/token instead of the caller's own.
+3. Server-side, `handle_window_name` needs no logic change — it already just resolves `window_id` and writes `window:displayname` meta on whichever instance receives the request; the only new requirement is accepting the request from a token issued by the discovery-registry step above rather than only from same-instance callers, scoped narrowly (loopback-only, short-lived token, rename-only — not a general cross-instance RPC channel).
+
+This is a real, multi-piece addition — flagging it as Phase 2, separate from Fixes 1-4, which need no new cross-instance channel at all and are independently shippable.
+
+## 7. Fix 6 — orphan discovery for `Shell`-tool processes independent of a held `shell_id`
+
+`ShellStop`'s `kill_tree` (PID/process-group scoped, `shell_node.rs:176-186`) is already the right primitive — the gap is discovery when the `shell_id` that would let you call it has been lost (session interruption, or a process that outlived the calling agent's own turn). Proposal: tag every `ShellNodeRunner`-spawned process with an identifiable marker at launch — an environment variable (e.g. `AGENTMUX_SHELL_TOOL_SESSION=<agent-id>:<shell_id>`) inherited by the whole process tree — and add a `ListOrphanedShells()` tool that enumerates currently-running processes carrying that marker whose `shell_id` is no longer present in the live `ShellSessionRegistry` (i.e., the registry entry expired/was evicted per `MAX_EXITED_STATUS`, or the srv instance that spawned it was restarted, but the child process itself survived). This directly replaces the manual `Get-CimInstance Win32_Process` + command-line pattern-matching archaeology from blocker #7 with a single, scoped, purpose-built call.
+
+## 8. Open item — NOT proposed here, needs its own investigation first
+
+Blocker #6 in the report (`mcp__agentmux__Shell`-launched `npm run dev` dying at exit code 201, reproducibly, at the same point, with no lifetime-cap code found anywhere in `ShellNodeRunner` to explain it) has no confirmed root cause. Recommend: add exit-detail logging to `ShellNodeRunner` (capture and surface the child's actual termination reason — exit code *and*, on Windows, whether it was `TerminateProcess`-style vs a clean exit — not just the wrapper's own generic code) so a future report can pin this down with real data instead of speculation. Do not attempt a fix in this spec without that diagnostic step first — guessing at a cause here (environment variable difference, stdio handling, working-directory resolution) would be exactly the kind of blind iteration this whole report is about avoiding.
+
+## 9. Files touched (Fixes 1-4, Phase 1)
+
+```
+agentmux-mcp/src/main.rs                    MODIFY — add DISCOVER_WINDOWS_TOOL + handler (reuses
+                                              capture_window_impl's enumeration as a shared fn);
+                                              add `pid` param to CAPTURE_WINDOW_TOOL; fix ambiguous-
+                                              match handling to return the candidate list; add
+                                              blank-frame retry + `likely_unrendered` flag to
+                                              capture_window_impl.
+```
+
+## 10. Files touched (Fix 5, Phase 2 — separate follow-up)
+
+```
+agentmux-srv/src/main.rs                    MODIFY — register/deregister this instance's local
+                                              discovery record on startup/clean shutdown.
+agentmux-srv/src/server/mod.rs              MODIFY — accept SetName-equivalent requests bearing a
+                                              valid cross-instance discovery token, in addition to
+                                              same-instance callers.
+agentmux-mcp/src/main.rs                    MODIFY — add SetForeignWindowName tool (discovery
+                                              lookup + cross-instance POST).
+(new) local instance-discovery registry     NEW — file-based, PID-keyed, liveness-checked on read.
+```
+
+## 11. Files touched (Fix 6)
+
+```
+agentmux-srv/src/backend/shell_node.rs      MODIFY — tag spawned process trees with an
+                                              AGENTMUX_SHELL_TOOL_SESSION env var; add orphan-
+                                              enumeration support (cross-reference tagged live
+                                              processes against the current ShellSessionRegistry).
+agentmux-mcp/src/main.rs                    MODIFY — add ListOrphanedShells tool.
+```
+
+## 11a. Implementation notes (Phase 1, as actually shipped)
+
+- `enumerate_agentmux_windows()` is the single shared enumeration function `DiscoverWindows` and `capture_window_impl` both call — replaces the old inline `xcap::Window::all()` + filter logic that used to live only inside `capture_window_impl`. Reuses `own_instance_pids()` unchanged.
+- Fix 4's retry gate is simpler than originally proposed: the spec draft suggested only retrying when the target process was recently created (needing process start-time plumbing). Shipped version drops that gate — `looks_unrendered()` triggers up to 2 retries (400ms apart, ~800ms worst case) whenever a captured frame is near-uniform color, regardless of process age. Simpler, and the worst case (a genuinely solid-color-themed window burns an extra ~800ms confirming it's really solid) was judged an acceptable trade-off against needing new process-age plumbing for a heuristic that's already approximate.
+- `looks_unrendered()` samples ~200 evenly-spaced pixels with an 8-per-channel tolerance — cheap and approximate by design (a real solid-color-themed window will also trip it; that's fine, it only gates a short retry and a hint flag, never a hard failure).
+- The pre-existing `title_contains` required-field validation moved from JSON-schema `"required"` to runtime: since `pid` is now a valid alternative target, the schema no longer marks either field as unconditionally required — `capture_window_impl` returns a clear error if neither is given.
+- `audit_log_capture_window`'s NDJSON field renamed `title_contains` → `query` (now `"pid=N"` or `"title_contains=\"...\""`, whichever targeting mode was used) — the one intentional behavior change to the audit log's shape, needed so a pid-targeted call logs something meaningful instead of an empty title_contains.
+- Added 3 new unit tests for `looks_unrendered()` (solid-color flagged, clearly-varied-region not flagged, within-tolerance noise still flagged) and updated 2 existing tests (`audit_log_capture_window_appends_ndjson_for_success_and_failure`'s field-name assertion; `all_tool_defs_are_valid_json_with_names`'s tool-count pin, 35→36).
+- Verified: `cargo build -p agentmux-mcp` clean, `cargo test -p agentmux-mcp` 16/16 passing, `cargo clippy -p agentmux-mcp --all-targets` zero new warnings (2 pre-existing warnings at lines ~3256/3258 are in unrelated code, confirmed unchanged by this diff). `cargo fmt --check` was NOT applied — the file already has 62 pre-existing formatting deviations from a clean rustfmt run, confirmed present in the untouched `origin/main` version before this change, so fmt isn't treated as enforced for this file; running it would have bundled an unrelated 62-hunk reformat into this diff.
+
+## 12. Acceptance criteria
+
+1. `DiscoverWindows` returns title/pid/exe_path/is_self for every AgentMux-owned top-level window on the machine, with no image written and no audit-log entry.
+2. `CaptureWindow(pid: N)` captures the window owned by PID `N` directly, with no title matching involved.
+3. `CaptureWindow(title_contains: "X")` where `X` matches 2+ windows and no `index` was given returns an error listing every match's title+pid, rather than silently capturing index 0. (Regression test: the exact scenario from blocker #1 — a generic substring matching an unrelated window plus the intended one — must surface both, not silently return one.)
+4. A capture of a solid/near-solid-color frame from a process created within the retry threshold triggers at least one retry before returning; the result always includes `likely_unrendered`.
+5. (Phase 2) `SetForeignWindowName` successfully renames a window belonging to a different, currently-running `agentmux-srv` instance, and the rename survives that instance's own reactive title recomputation (i.e., it went through `window:displayname`, not a raw OS call) — verified by triggering a tab switch on the target instance after the rename and confirming the title is unchanged.
+6. `ListOrphanedShells` finds a `Shell`-tool-spawned process tree whose owning agent session and `shell_id` have both been lost (simulated by killing the calling MCP process without calling `ShellStop` first), and the returned identifier is sufficient to `taskkill`/`kill_tree` it without manual PID cross-referencing.
+7. No change to the UI-automation input-injection boundary — `CaptureWindow` and its Phase-1 extensions remain screenshot-only, per `SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md`'s explicit scope decision.


### PR DESCRIPTION
## Summary

Adds robustness to the cross-instance window discovery/capture MCP tools, grounded in real blockers hit during a live session (`docs/reports/REPORT_AGENT_SCREENSHOT_WINDOW_CONTROL_BLOCKERS_2026_08_24.md`). Implements Phase 1 of `docs/specs/SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md`.

- **New `DiscoverWindows` tool** — read-only enumeration of every AgentMux-owned window (pid, title, exe_path, is_self), no screenshot taken, nothing written to disk, nothing audit-logged. Lets a caller see real candidates before calling `CaptureWindow`, instead of guessing `index` values.
- **`CaptureWindow` accepts `pid`** as an alternative to `title_contains`. Titles on this app are actively rewritten by its own frontend (tab switches, workspace renames, even unrelated windows opening/closing elsewhere trigger a re-render) — a pid is stable for a process's whole lifetime and doesn't have that problem.
- **Fixed a real bug:** an ambiguous `title_contains` match with no explicit `index` used to silently capture index 0 instead of surfacing the candidate list — despite the tool's own docstring already claiming it would list matches when ambiguous. Now it actually does.
- **Blank-frame retry:** a short bounded retry (up to 2x, ~800ms) when a capture looks like a solid/near-solid-color frame, plus a `likely_unrendered` hint in the result either way.

Phase 2 (a real fix for cross-instance window renaming, via a local instance-discovery broker) and an open Shell-tool reliability mystery (exit code 201, root cause not found) are documented as follow-ups in the spec — not attempted here.

## Test plan

- [x] `cargo build -p agentmux-mcp` clean
- [x] `cargo test -p agentmux-mcp` — 16/16 pass (3 new tests for the blank-frame heuristic, 2 existing tests updated for the new audit-log field/tool count)
- [x] `cargo clippy -p agentmux-mcp --all-targets` — zero new warnings (2 pre-existing warnings in unrelated code, confirmed unchanged by this diff)
- [x] Manually verified via direct `curl` against a running dev server that the served code matches source (used repeatedly during the session this was built for)

<!-- agentmux:agent_id=loap #2 -->