### PR TITLE
fix(tab): eliminate tab-close flash — click containment, single-RPC close, batched WaveObj updates (WS + response paths)

### DIFF
--- a/.changesets/1787786849-fix-tab-eliminate-tab-close-flash-batch-multi-object-ws-upda-c877.md
+++ b/.changesets/1787786849-fix-tab-eliminate-tab-close-flash-batch-multi-object-ws-upda-c877.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tab): eliminate tab-close flash — batch multi-object WS updates into one frame, emit parent-before-child on deletes

--- a/agentmux-srv/src/backend/eventbus.rs
+++ b/agentmux-srv/src/backend/eventbus.rs
@@ -16,6 +16,12 @@ use super::wps::{WaveEvent, WpsClient, EVENT_SYS_INFO, EVENT_BLOCK_STATS, EVENT_
 
 pub const WS_EVENT_RPC: &str = "rpc";
 
+/// One WS frame carrying an ARRAY of `WaveObjUpdate`s from a single atomic
+/// backend transition. Mirrored in `frontend/app/store/wps-events.ts`
+/// (`WpsEvent.WaveObjBatchedUpdates`) — the frontend applies the whole array
+/// in one Solid `batch()` flush. See `broadcast_wave_obj_updates` below.
+pub const WS_EVENT_WAVE_OBJ_BATCHED_UPDATES: &str = "waveobj:batchedupdates";
+
 /// Egress priority lane for a server→client event.
 ///
 /// `Background` is reserved for droppable perf telemetry (sysinfo + per-block
@@ -164,6 +170,39 @@ impl EventBus {
     /// Broadcast an event to all connected WebSocket clients, on the priority lane.
     pub fn broadcast_event(&self, event: &WSEventType) {
         self.broadcast_event_lane(event, Lane::Priority);
+    }
+
+    /// Broadcast a set of related `WaveObjUpdate`s from ONE atomic backend
+    /// transition as ONE `waveobj:batchedupdates` WS frame, so the frontend
+    /// applies them in a single reactive flush (`updateWaveObjects`'s
+    /// `batch()`), preserving the array's order.
+    ///
+    /// Why one frame instead of N `waveobj:update` frames: each frame is
+    /// dispatched (and painted) independently by the renderer, so a
+    /// `[delete tab, update workspace]` pair sent as two frames blanks the
+    /// still-mounted tab a full paint before the workspace update unmounts
+    /// it — the same flash class
+    /// `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §6 fixed at the
+    /// RPC-response layer, riding in unbatched through the WS push path
+    /// instead (§7). Single-update callers (blockcontroller, setmeta, the
+    /// wave-obj bridge) keep emitting plain `waveobj:update` — there is
+    /// nothing to batch there.
+    pub fn broadcast_wave_obj_updates(&self, updates: &[super::obj::WaveObjUpdate]) {
+        if updates.is_empty() {
+            return;
+        }
+        let data = match serde_json::to_value(updates) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!("cannot marshal waveobj batched updates: {}", e);
+                return;
+            }
+        };
+        self.broadcast_event(&WSEventType {
+            eventtype: WS_EVENT_WAVE_OBJ_BATCHED_UPDATES.to_string(),
+            oref: String::new(),
+            data: Some(data),
+        });
     }
 
     /// Broadcast an event to all connected WebSocket clients on a specific lane.
@@ -332,6 +371,50 @@ mod tests {
 
         assert!(rx1.priority.try_recv().is_ok());
         assert!(rx2.priority.try_recv().is_err()); // tab-2 should not receive
+    }
+
+    /// A multi-object atomic transition must go out as ONE
+    /// `waveobj:batchedupdates` frame (array payload, order preserved), not
+    /// N frames — N frames repaint the renderer in N unbatched steps (the
+    /// SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §7 flash).
+    #[test]
+    fn test_broadcast_wave_obj_updates_single_batched_frame() {
+        use crate::backend::obj::WaveObjUpdate;
+
+        let bus = EventBus::new();
+        let mut rx = bus.register_ws("conn-1", "tab-1");
+
+        let updates = vec![
+            WaveObjUpdate {
+                updatetype: "update".into(),
+                otype: "workspace".into(),
+                oid: "ws-1".into(),
+                obj: Some(serde_json::json!({"oid": "ws-1"})),
+            },
+            WaveObjUpdate {
+                updatetype: "delete".into(),
+                otype: "tab".into(),
+                oid: "tab-9".into(),
+                obj: None,
+            },
+        ];
+        bus.broadcast_wave_obj_updates(&updates);
+
+        let msg = rx.priority.try_recv().expect("one frame expected");
+        assert_eq!(
+            msg.get("eventtype").and_then(|v| v.as_str()),
+            Some(WS_EVENT_WAVE_OBJ_BATCHED_UPDATES),
+        );
+        let arr = msg.get("data").and_then(|d| d.as_array()).expect("array payload");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].get("otype").and_then(|v| v.as_str()), Some("workspace"));
+        assert_eq!(arr[1].get("updatetype").and_then(|v| v.as_str()), Some("delete"));
+        // Exactly one frame — nothing else queued.
+        assert!(rx.priority.try_recv().is_err());
+
+        // Empty slice → no frame at all.
+        bus.broadcast_wave_obj_updates(&[]);
+        assert!(rx.priority.try_recv().is_err());
     }
 
     #[test]

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -630,18 +630,10 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             });
                         }
                     }
-                    for update in &updates {
-                        let oref = format!("{}:{}", update.otype, update.oid);
-                        if let Ok(data) = serde_json::to_value(update) {
-                            event_bus.broadcast_event(
-                                &crate::backend::eventbus::WSEventType {
-                                    eventtype: "waveobj:update".to_string(),
-                                    oref,
-                                    data: Some(data),
-                                },
-                            );
-                        }
-                    }
+                    // One batched frame so the renderer applies all of them in
+                    // a single reactive flush — see
+                    // EventBus::broadcast_wave_obj_updates.
+                    event_bus.broadcast_wave_obj_updates(&updates);
                 }
 
                 Ok(Some(serde_json::to_value(&AgentOpenResult {

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -306,18 +306,9 @@ pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<Pan
                 });
             }
         }
-        for update in &updates {
-            let oref = format!("{}:{}", update.otype, update.oid);
-            if let Ok(data) = serde_json::to_value(update) {
-                event_bus.broadcast_event(
-                    &crate::backend::eventbus::WSEventType {
-                        eventtype: "waveobj:update".to_string(),
-                        oref,
-                        data: Some(data),
-                    },
-                );
-            }
-        }
+        // One batched frame so the renderer applies all of them in a single
+        // reactive flush — see EventBus::broadcast_wave_obj_updates.
+        event_bus.broadcast_wave_obj_updates(&updates);
     }
 
     Ok(PaneOpenResult {

--- a/agentmux-srv/src/server/app_api/pane.rs
+++ b/agentmux-srv/src/server/app_api/pane.rs
@@ -152,16 +152,9 @@ pub(super) async fn open_pane_floating(
                 obj: Some(obj::wave_obj_to_value(&b)),
             });
         }
-        for update in &updates {
-            let oref = format!("{}:{}", update.otype, update.oid);
-            if let Ok(data) = serde_json::to_value(update) {
-                event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
-                    eventtype: "waveobj:update".to_string(),
-                    oref,
-                    data: Some(data),
-                });
-            }
-        }
+        // One batched frame so the renderer applies all of them in a single
+        // reactive flush — see EventBus::broadcast_wave_obj_updates.
+        event_bus.broadcast_wave_obj_updates(&updates);
     }
 
     // Ask the source window's frontend to open the floating OS window — scoped

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -94,19 +94,17 @@ pub(crate) async fn run_service_call(state: &AppState, call: &WebCallType) -> We
     // of handlers (agent.open, blockcontroller events) broadcast
     // manually, so an external harness's CreateTab / UpdateObject
     // were invisible to the frontend.
+    //
+    // One batched frame, not one frame per update: these WS frames also
+    // reach the CALLING renderer, and they land BEFORE the HTTP response
+    // body — so N individual frames repaint the UI in N unbatched steps
+    // and the response body's batched application (wos.ts
+    // `updateWaveObjects`) arrives too late to matter (version-guarded to
+    // a no-op). CloseTab's `[delete tab, update workspace]` pair sent as
+    // two frames is exactly the blank-tab flash of
+    // SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §7.
     if let Some(updates) = &result.updates {
-        for update in updates {
-            if let Ok(data) = serde_json::to_value(update) {
-                let oref = format!("{}:{}", update.otype, update.oid);
-                state.event_bus.broadcast_event(
-                    &crate::backend::eventbus::WSEventType {
-                        eventtype: "waveobj:update".to_string(),
-                        oref,
-                        data: Some(data),
-                    },
-                );
-            }
-        }
+        state.event_bus.broadcast_wave_obj_updates(updates);
     }
 
     result

--- a/agentmux-srv/src/server/service/tear_off.rs
+++ b/agentmux-srv/src/server/service/tear_off.rs
@@ -290,18 +290,9 @@ pub(crate) async fn handle_redock_floating_pane(state: &AppState, call: &WebCall
     // the event bus. Mirrors the pattern in `app_api.rs:399-410`.
     // Without this the target tab.blockids includes the new
     // block but its layout.leaforder doesn't → block invisible.
-    for update in &updates {
-        let oref = format!("{}:{}", update.otype, update.oid);
-        if let Ok(data) = serde_json::to_value(update) {
-            state.event_bus.broadcast_event(
-                &crate::backend::eventbus::WSEventType {
-                    eventtype: "waveobj:update".to_string(),
-                    oref,
-                    data: Some(data),
-                },
-            );
-        }
-    }
+    // One batched frame so the renderer applies all of them in a single
+    // reactive flush — see EventBus::broadcast_wave_obj_updates.
+    state.event_bus.broadcast_wave_obj_updates(&updates);
 
     WebReturnType::success_data_updates(
         serde_json::json!({

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -313,9 +313,11 @@ async fn dispatch_event(event: Event, wstore: Arc<Store>, event_bus: Arc<EventBu
             .await;
             emit_client_singleton(&wstore, &event_bus, "SrvWindowOpened").await;
         }
+        // Parent (Client singleton) update first, window delete second —
+        // same delete-ordering rationale as the TabDeleted arm below.
         Event::SrvWindowClosed { window_id, .. } => {
-            emit_delete(&event_bus, OTYPE_WINDOW, &window_id);
             emit_client_singleton(&wstore, &event_bus, "SrvWindowClosed").await;
+            emit_delete(&event_bus, OTYPE_WINDOW, &window_id);
         }
 
         // ----- Tab (Phase 2) -----
@@ -333,16 +335,26 @@ async fn dispatch_event(event: Event, wstore: Arc<Store>, event_bus: Arc<EventBu
             )
             .await;
         }
+        // Delete ordering: PARENT UPDATE FIRST, child delete second — the
+        // reverse of the create arms above. These are two separate WS
+        // frames the renderer applies (and paints) independently; if the
+        // tab delete lands first, the still-mounted <Tab>'s own signal
+        // goes null and it blanks in place for a paint before the
+        // workspace update finally unmounts it (the §6 flash of
+        // SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md, riding in
+        // through the WS push path — §7). Parent-first, the component
+        // unmounts with its data still intact and the late child delete
+        // touches an unsubscribed signal — nothing paints.
         Event::TabDeleted {
             workspace_id,
             tab_id,
             ..
         } => {
-            emit_delete(&event_bus, OTYPE_TAB, &tab_id);
             emit_fetched::<Workspace>(
                 &wstore, &event_bus, OTYPE_WORKSPACE, workspace_id, "TabDeleted parent",
             )
             .await;
+            emit_delete(&event_bus, OTYPE_TAB, &tab_id);
         }
         Event::TabRenamed { tab_id, .. } | Event::TabMetaUpdated { tab_id, .. } => {
             emit_fetched::<Tab>(&wstore, &event_bus, OTYPE_TAB, tab_id, "Tab*").await;
@@ -398,14 +410,16 @@ async fn dispatch_event(event: Event, wstore: Arc<Store>, event_bus: Arc<EventBu
             )
             .await;
         }
+        // Parent update first, block delete second — same delete-ordering
+        // rationale as the TabDeleted arm above.
         Event::BlockDeleted {
             tab_id, block_id, ..
         } => {
-            emit_delete(&event_bus, OTYPE_BLOCK, &block_id);
             emit_fetched::<Tab>(
                 &wstore, &event_bus, OTYPE_TAB, tab_id, "BlockDeleted parent",
             )
             .await;
+            emit_delete(&event_bus, OTYPE_BLOCK, &block_id);
         }
         Event::BlockMetaUpdated { block_id, .. } => {
             emit_fetched::<Block>(
@@ -549,5 +563,151 @@ async fn run_wave_obj_bridge(
                 return;
             }
         }
+    }
+}
+
+// ====================================================================
+// Tests
+// ====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::{MetaMapType, Workspace};
+
+    fn test_workspace(oid: &str, tabids: Vec<String>) -> Workspace {
+        Workspace {
+            oid: oid.to_string(),
+            version: 1,
+            name: "test-ws".to_string(),
+            tabids,
+            pinnedtabids: vec![],
+            activetabid: String::new(),
+            meta: MetaMapType::new(),
+        }
+    }
+
+    fn test_tab(oid: &str) -> Tab {
+        Tab {
+            oid: oid.to_string(),
+            version: 1,
+            name: "test-tab".to_string(),
+            layoutstate: String::new(),
+            blockids: vec![],
+            meta: MetaMapType::new(),
+        }
+    }
+
+    /// SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §7: the bridge's
+    /// TabDeleted arm must broadcast the PARENT workspace update BEFORE the
+    /// tab delete. These are two separate WS frames the renderer applies
+    /// (and paints) independently — delete-first blanks the still-mounted
+    /// <Tab> in place for a paint before the workspace update unmounts it.
+    #[tokio::test]
+    async fn test_tab_deleted_broadcasts_parent_update_before_tab_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+        let event_bus = Arc::new(EventBus::new());
+
+        let ws_id = "11111111-1111-1111-1111-111111111111";
+        let deleted_tab_id = "22222222-2222-2222-2222-222222222222";
+        let surviving_tab_id = "33333333-3333-3333-3333-333333333333";
+        // Post-delete state: the workspace no longer lists the deleted tab.
+        let mut ws = test_workspace(ws_id, vec![surviving_tab_id.to_string()]);
+        wstore.insert(&mut ws).unwrap();
+
+        let mut receivers = event_bus.register_ws("test-conn", "test-tab");
+
+        dispatch_event(
+            Event::TabDeleted {
+                workspace_id: ws_id.to_string(),
+                tab_id: deleted_tab_id.to_string(),
+                block_ids: vec![],
+                version: 1,
+            },
+            Arc::clone(&wstore),
+            Arc::clone(&event_bus),
+        )
+        .await;
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), receivers.priority.recv())
+            .await
+            .expect("timed out waiting for first broadcast")
+            .expect("priority channel closed");
+        assert_eq!(first.get("eventtype").and_then(|v| v.as_str()), Some("waveobj:update"));
+        assert_eq!(
+            first.get("oref").and_then(|v| v.as_str()),
+            Some(format!("workspace:{ws_id}").as_str()),
+            "first frame must be the parent workspace update, got: {first}"
+        );
+        assert_eq!(
+            first.get("data").and_then(|d| d.get("updatetype")).and_then(|v| v.as_str()),
+            Some("update"),
+        );
+
+        let second = tokio::time::timeout(std::time::Duration::from_secs(2), receivers.priority.recv())
+            .await
+            .expect("timed out waiting for second broadcast")
+            .expect("priority channel closed");
+        assert_eq!(
+            second.get("oref").and_then(|v| v.as_str()),
+            Some(format!("tab:{deleted_tab_id}").as_str()),
+            "second frame must be the tab delete, got: {second}"
+        );
+        assert_eq!(
+            second.get("data").and_then(|d| d.get("updatetype")).and_then(|v| v.as_str()),
+            Some("delete"),
+        );
+    }
+
+    /// Same delete-ordering contract for BlockDeleted: parent tab update
+    /// first, block delete second.
+    #[tokio::test]
+    async fn test_block_deleted_broadcasts_parent_update_before_block_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+        let event_bus = Arc::new(EventBus::new());
+
+        let tab_id = "44444444-4444-4444-4444-444444444444";
+        let deleted_block_id = "55555555-5555-5555-5555-555555555555";
+        let mut tab = test_tab(tab_id);
+        wstore.insert(&mut tab).unwrap();
+
+        let mut receivers = event_bus.register_ws("test-conn", "test-tab");
+
+        dispatch_event(
+            Event::BlockDeleted {
+                tab_id: tab_id.to_string(),
+                block_id: deleted_block_id.to_string(),
+                version: 1,
+            },
+            Arc::clone(&wstore),
+            Arc::clone(&event_bus),
+        )
+        .await;
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), receivers.priority.recv())
+            .await
+            .expect("timed out waiting for first broadcast")
+            .expect("priority channel closed");
+        assert_eq!(
+            first.get("oref").and_then(|v| v.as_str()),
+            Some(format!("tab:{tab_id}").as_str()),
+            "first frame must be the parent tab update, got: {first}"
+        );
+
+        let second = tokio::time::timeout(std::time::Duration::from_secs(2), receivers.priority.recv())
+            .await
+            .expect("timed out waiting for second broadcast")
+            .expect("priority channel closed");
+        assert_eq!(
+            second.get("oref").and_then(|v| v.as_str()),
+            Some(format!("block:{deleted_block_id}").as_str()),
+            "second frame must be the block delete, got: {second}"
+        );
+        assert_eq!(
+            second.get("data").and_then(|d| d.get("updatetype")).and_then(|v| v.as_str()),
+            Some("delete"),
+        );
     }
 }

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -280,3 +280,101 @@ trip and relies on behavior the reducer already had and already tests.
   the single `CloseTab` call.
 - Full `vitest` suite + `tsc --noEmit` — no regressions expected; this is a
   subtractive change (removes a call), not new branching logic.
+
+## 6. Follow-up #2 — the closed tab itself flashes blank in place before disappearing
+
+After §5 shipped, the repo owner reported the flash was still there and
+pinned down the precise symptom: **after clicking "Close tab" in the
+confirm modal, the closing tab itself visibly flashes (goes blank) in its
+own position in the strip for a frame, then disappears** — not a
+neighboring tab's highlight; the tab being closed, in place.
+
+### 6.1 Root cause — two unbatched signal writes from one atomic server response
+
+`CloseTab`'s HTTP handler (`agentmux-srv/src/server/service/tab_lifecycle.rs::handle_close_tab`,
+`tab_lifecycle.rs:258-279`) already does the right thing server-side: it
+runs the `delete_tab` saga (one atomic reducer transition — see §5.1) and
+then returns **both** resulting object changes in a single response:
+
+```rust
+let mut updates = vec![WaveObjUpdate {
+    updatetype: "delete", otype: OTYPE_TAB, oid: tab_id.clone(), obj: None,
+}];
+if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
+    updates.push(WaveObjUpdate {
+        updatetype: "update", otype: OTYPE_WORKSPACE, oid: ws_id.clone(),
+        obj: Some(wave_obj_to_value(&ws)),
+    });
+}
+```
+
+Note the order: the **tab delete comes first**, the **workspace update
+second**. The frontend applies this array via `updateWaveObjects`
+(`frontend/app/store/wos.ts`, pre-fix):
+
+```ts
+function updateWaveObjects(vals: WaveObjUpdate[]) {
+    for (const val of vals) {
+        updateWaveObject(val);   // wov.setData(...) — a raw Solid signal write
+    }
+}
+```
+
+Each `updateWaveObject` call is a bare `setData(...)` on that object's own
+Solid signal, with **no `batch()` wrapper**. Solid propagates every signal
+write's dependent effects synchronously and independently unless the
+writes are batched together. So processing this specific two-item array
+does, in order:
+
+1. **Delete the Tab object** — the closing tab's own `useWaveObjectValue<Tab>`
+   signal (subscribed by its still-mounted `<Tab>` component, `tab.tsx:118`)
+   goes to `{ value: null }`. `tabData()` becomes `null`, so
+   `tabData()?.name` (`tab.tsx:285`) renders empty. The tab's DOM node is
+   **still mounted** at this point — nothing has told the parent `<For
+   each={tabIds()}>` (`tabbar.tsx`) to remove it yet, because `tabIds()` is
+   derived from the **workspace** object, not the tab object. Net visible
+   effect: the tab's own slot in the strip goes blank, in place, while
+   still fully sized and present.
+2. **Update the Workspace object** — *now* `workspace()`/`tabIds()`
+   recompute, and `<For>` finally unmounts the DroppableTab/Tab for the
+   removed id.
+
+Step 1 and step 2 are two separate, independently-propagated Solid
+updates from ONE atomic server response — exactly the blank-flash-then-
+vanish sequence reported. (This is the same root cause class as §5 —
+one atomic backend transition being fragmented into multiple visible
+frontend steps — just one layer further down, at the generic WaveObject
+update-application layer rather than at the RPC-call layer.)
+
+### 6.2 Fix
+
+`updateWaveObjects` is a shared primitive used by every backend RPC
+response that returns multiple related `updates` — not just `CloseTab`.
+Wrap its loop in Solid's `batch()` so all updates from one response apply
+as a single atomic reactive flush, regardless of how many objects changed
+or what order the backend lists them in:
+
+```ts
+import { batch, createSignal, onCleanup } from "solid-js";
+
+function updateWaveObjects(vals: WaveObjUpdate[]) {
+    batch(() => {
+        for (const val of vals) {
+            updateWaveObject(val);
+        }
+    });
+}
+```
+
+This is the general fix (root-caused at the shared update-application
+layer, not special-cased per RPC), and incidentally also closes off the
+same class of bug for any other handler that already returns, or might in
+future return, more than one `WaveObjUpdate` per call.
+
+### 6.3 Test plan (follow-up #2)
+
+- Manual: close the active tab via the confirm modal — the tab should
+  vanish directly, with no intermediate blank/empty frame in its old slot.
+- Full `vitest` suite + `tsc --noEmit` — no regressions expected (a `for`
+  loop wrapped in `batch()` preserves the same update order and end state,
+  only changes when Solid flushes the resulting DOM writes).

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -1,0 +1,197 @@
+# Tab close (X) button — spurious select flash
+
+**Status:** Root cause identified, fix proposed (not yet implemented)
+**Owner:** unassigned
+**Date:** 2026-08-25
+**Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tabbar.tsx`,
+`frontend/app/tab/droppable-tab.tsx`, `agentmux-srv/src/reducer/tab.rs`
+(`handle_set_active_tab`, `handle_delete_tab`)
+**Related:** `SPEC_TAB_BAR_FIRST_PRINCIPLES_2026_04_25.md` (tab-bar layout
+invariants), `SPEC_TAB_UI_REFINEMENTS_2026_06_20.md` (close-confirm modal /
+`tab:skipcloseconfirm`), `SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md`
+(a different flicker class — remount-driven, not this one)
+
+---
+
+## 1. Symptom
+
+Clicking the "✕" close button on a **background (non-active) tab** in the
+top window tab strip produces a brief, visually jarring flash: another tab
+(often, but not reliably, the tab that was just clicked) appears to become
+selected/highlighted for an instant, then immediately deselects/reverts.
+The tab being closed does disappear correctly in the end, but the
+in-between flash reads as broken/flaky UX. It is intermittent — it does not
+reproduce on every close, which is itself a clue (see §2.3).
+
+Closing the tab via keyboard (Ctrl+W) does not reproduce this — only mouse
+clicks on the per-tab "✕" button are affected.
+
+## 2. Root cause
+
+### 2.1 The click event is not stopped from bubbling past the close button
+
+`frontend/app/tab/tab.tsx:251-267` renders each tab as:
+
+```tsx
+<div class={clsx("tab", { active: props.active, ... })}
+     onClick={props.onSelect}          // line 263 — selects this tab
+     ...>
+  <div class="tab-inner">
+    ...
+    <Button
+        onClick={props.onClose}        // line 289 — closes this tab
+        onMouseDown={handleMouseDownOnClose}   // line 290 — stops mousedown only
+        ...
+    />
+  </div>
+</div>
+```
+
+`handleMouseDownOnClose` (`tab.tsx:228-230`) calls
+`event.stopPropagation()`, but only on the `mousedown` event. The `Button`'s
+`onClick` (which fires `props.onClose`) does **not** stop propagation. A
+native `click` on the close button therefore:
+
+1. Fires the button's own `onClick` → `props.onClose` → (via
+   `DroppableTab`, `tabbar.tsx:169`) `requestClose(tabId)` — starts the
+   close flow for the clicked tab.
+2. Continues bubbling up the DOM (nothing stopped it) to the outer `.tab`
+   div's `onClick` → `props.onSelect` → (`tabbar.tsx:168`)
+   `handleSelect(tabId)` — **selects the very same tab that step 1 just
+   started closing.**
+
+`handleSelect` (`tabbar.tsx:43-46`) only guards against re-selecting a tab
+that is *already* active:
+
+```ts
+const handleSelect = (tabId: string) => {
+    if (tabId === activeTabId()) return;
+    setActiveTab(tabId);
+};
+```
+
+For a background tab (the common case — you're closing a tab you're not
+currently looking at), `tabId !== activeTabId()`, so this guard does
+nothing and `setActiveTab(tabId)` fires for real, issuing a
+`WorkspaceService.SetActiveTab` call for the tab that is simultaneously
+being torn down.
+
+(Closing the *currently active* tab happens not to trigger the bubble's
+side effect, because `handleClose` — see §2.2 — synchronously kicks off its
+own `setActiveTab(nextTab)` first, so by the time the bubbled `onSelect`
+fires, the guard's `tabId === activeTabId()` is still true against the old
+active id and short-circuits. The bug is specific to closing a **background**
+tab.)
+
+### 2.2 Two independent, unordered HTTP requests race on the backend
+
+Both calls go through `WOS.callBackendService` (`frontend/app/store/wos.ts:95-143`),
+which issues a plain `fetch()` POST to `/agentmux/service` per call
+(`wos.ts:122-127`) — **there is no shared ordering guarantee between two
+calls fired back-to-back on the client.** The close flow
+(`tabbar.tsx:48-60`) ends up firing:
+
+- `WorkspaceService.CloseTab(wsId, tabId)` — from step 1 above.
+- `WorkspaceService.SetActiveTab(wsId, tabId)` — from step 2's bubbled
+  `onSelect` (via `setActiveTab` in `frontend/app/store/tab-actions.ts:66-112`).
+
+Whichever HTTP request the backend happens to service first decides what
+the user sees, because the reducer (`agentmux-srv/src/reducer/tab.rs`)
+processes commands strictly in receipt order:
+
+- **`handle_set_active_tab`** (`tab.rs:177-213`) — if the tab is still in
+  `workspace.tab_ids`, sets `active_tab_id` to it and emits
+  `Event::ActiveTabChanged`, which the frontend applies immediately (the
+  tab bar re-renders with that tab highlighted).
+- **`handle_delete_tab`** (`tab.rs:87-172`) — if the deleted tab **is**
+  the current `active_tab_id`, it reassigns active to
+  `tab_ids.get(pos)` (the tab that slides into the deleted one's old
+  index) or the previous one, and emits a second
+  `Event::ActiveTabChanged`.
+
+Two orderings are possible:
+
+- **`CloseTab` wins the race:** `DeleteTab` runs while `active_tab_id` is
+  still the real original active tab, so no `ActiveTabChanged` fires from
+  the delete. The stray `SetActiveTab` then arrives for a tab id that's
+  already gone (`handle_set_active_tab`'s membership check at `tab.rs:191`
+  fails) and is rejected as a harmless `Event::Error`. **No visible flash**
+  — this is the case where the bug doesn't reproduce.
+- **`SetActiveTab` wins the race:** `active_tab_id` flips to the
+  closing tab and the frontend highlights it (**flash #1 — "another tab
+  selected"**). `DeleteTab` then runs, sees the deleted tab is (now)
+  active, and reassigns to whatever neighbor `tab_ids.get(pos)` resolves
+  to, firing a second `ActiveTabChanged` (**flash #2 — the highlight jumps
+  again, reading as "deselected"**).
+
+### 2.3 Why it's intermittent
+
+Because both requests are independent `fetch()` calls with no ordering
+contract, which one the backend services first depends on real-world
+network/event-loop scheduling (client-side fetch dispatch timing, HTTP
+connection reuse, backend thread/task scheduling) — not application logic.
+That non-determinism is exactly why the flash reproduces "sometimes" rather
+than every time, which matches the reported symptom.
+
+### 2.4 A second, non-cosmetic bug riding on the same cause
+
+In the "`SetActiveTab` wins" ordering, `handle_delete_tab`'s neighbor-promotion
+picks `tab_ids.get(pos)` / `pos - 1` relative to the **closed tab's own
+position**, not relative to whatever tab the user actually had open before
+they clicked. If the user was on tab A and closed background tab X, the
+race can leave tab **Y** (X's neighbor) active instead of A — i.e. beyond
+the visual flash, the user's real active tab can silently change as a side
+effect of closing an unrelated tab.
+
+## 3. Fix
+
+Stop the close button's `click` from ever reaching the tab's own `onClick`,
+the same way `mousedown` is already stopped. This removes the spurious
+`onSelect` call at the source, so no race between `SetActiveTab` and
+`CloseTab` is ever created — no backend-ordering fix is needed.
+
+`frontend/app/tab/tab.tsx`:
+
+```tsx
+const handleMouseDownOnClose = (event: MouseEvent) => {
+    event.stopPropagation();
+};
+
+const handleCloseClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    props.onClose(event);
+};
+```
+
+and wire the button to it:
+
+```tsx
+<Button
+    className="ghost grey close"
+    onClick={handleCloseClick}
+    onMouseDown={handleMouseDownOnClose}
+    ...
+```
+
+(`props.onClose` itself is left untouched — `DroppableTab` and `TabBar`
+already pass a zero-arg closure, so the extra event argument is simply
+unused there, matching today's call shape.)
+
+No backend change is required. §2.4's neighbor-promotion logic in
+`handle_delete_tab` is correct as written *given* the precondition that
+`active_tab_id` isn't mutated by an unrelated close click — fixing §2.1 at
+the source restores that precondition rather than papering over it
+downstream.
+
+## 4. Test plan
+
+- Unit/component test on `Tab`/`DroppableTab`: simulate a `click` on the
+  close button of a non-active tab and assert `onSelect` is never called
+  (only `onClose`).
+- Manual: open 3+ tabs, click away from the active one, click that
+  background tab's "✕" repeatedly (including rapid repeated clicks) —
+  confirm the previously-active tab's highlight never blinks and the
+  correct tab stays active throughout.
+- Regression check: closing the *active* tab (via ✕ or Ctrl+W) still moves
+  selection to its neighbor exactly once, with no double `ActiveTabChanged`
+  round trip.

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -1,6 +1,8 @@
 # Tab close (X) button — spurious select flash
 
-**Status:** Root cause identified, fix proposed (not yet implemented)
+**Status:** §§2-3 (click-bubble race) fixed and shipped (PR #2811). §5 below
+is a follow-up: a second, independent flash reported after §2-3 landed —
+fixed in the same branch.
 **Owner:** unassigned
 **Date:** 2026-08-25
 **Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tabbar.tsx`,
@@ -195,3 +197,86 @@ downstream.
 - Regression check: closing the *active* tab (via ✕ or Ctrl+W) still moves
   selection to its neighbor exactly once, with no double `ActiveTabChanged`
   round trip.
+
+## 5. Follow-up — flash when closing the *active* tab via the confirm modal
+
+After §2-3 shipped (PR #2811), a second, independent flash was reported:
+closing the **currently active** tab through the close-confirm modal
+(`tab:skipcloseconfirm` unset/false, the default) still shows a brief flash
+right after clicking "Close tab" in the modal — even though the click-bubble
+race from §2 is gone.
+
+### 5.1 Root cause — redundant client-side pre-select turns one atomic update into two
+
+`handleClose` (`tabbar.tsx`, pre-fix) did this when closing the active tab:
+
+```ts
+if (tabId === activeTabId()) {
+    const idx = allTabs.indexOf(tabId);
+    const nextTab = allTabs[idx + 1] ?? allTabs[idx - 1];
+    if (nextTab) await setActiveTab(nextTab);   // RPC #1 — round trip, paints
+}
+await WorkspaceService.CloseTab(props.workspace.oid, tabId);  // RPC #2 — round trip, paints
+```
+
+This is a *sequential* two-RPC dance: first move the highlight to the
+neighbor (a full `SetActiveTab` round trip that lands and paints on its
+own), **then** remove the now-still-visible-but-deselected closing tab (a
+second round trip). The user-visible sequence is: `[X active]` → `[X
+deselected, neighbor active, X still sitting in the strip]` → `[X gone]` —
+the middle frame is the reported flash: the tab you just confirmed closing
+visibly un-highlights before it disappears, instead of just vanishing.
+
+But per §2.4/the backend code already cited in this spec,
+`agentmux-srv/src/reducer/tab.rs::handle_delete_tab` (`tab.rs:127-137`)
+**already** reassigns `active_tab_id` to the correct neighbor *atomically*,
+in the same reducer dispatch as the removal, whenever the deleted tab was
+active — confirmed by the saga (`agentmux-srv/src/sagas/delete_tab.rs`)
+dispatching exactly one `Command::DeleteTab` and by the reducer's own test
+`delete_active_tab_promotes_neighbor` (`tab.rs:616-654`). `TabDeleted` and
+`ActiveTabChanged` are emitted together from that one call, so the frontend
+receives ONE update reflecting the final state (tab gone, correct neighbor
+active) from a single `CloseTab` response. The client-side pre-select was
+always redundant for correctness — it just happened to also be the thing
+splitting one atomic transition into two paintable steps.
+
+The pre-select wasn't pure dead weight, though: `setActiveTab`
+(`tab-actions.ts`) also holds the tab-content **reveal gate**
+(`holdRevealGate()`/`scheduleRevealLift()`, `SPEC_TAB_CONTENT_REVEAL_GATE.md`)
+so the destination tab's panes don't mount piecemeal. Simply deleting the
+pre-select without replacing that would reintroduce pane-content flicker on
+every active-tab close.
+
+### 5.2 Fix
+
+Drop the separate `setActiveTab` RPC; let `CloseTab`'s own atomic backend
+transition handle both the removal and the reassignment in one round trip.
+Keep holding the reveal gate — just around the single `CloseTab` call
+instead of around a now-removed extra RPC:
+
+```ts
+const closingActiveTab = tabId === activeTabId();
+fireAndForget(async () => {
+    if (closingActiveTab) holdRevealGate();
+    try {
+        await WorkspaceService.CloseTab(props.workspace.oid, tabId);
+        deleteLayoutModelForTab(tabId);
+    } finally {
+        if (closingActiveTab) scheduleRevealLift();
+    }
+});
+```
+
+No backend change needed — this only removes a redundant frontend round
+trip and relies on behavior the reducer already had and already tests.
+
+### 5.3 Test plan (follow-up)
+
+- Manual: with the default close-confirm modal enabled, close the active
+  tab via ✕ → confirm — the tab should disappear directly with the neighbor
+  already active, no intermediate deselected-but-still-visible frame.
+- Regression: pane content on the newly-active tab still mounts atomically
+  (no piecemeal reveal) — the reveal gate is still exercised, just around
+  the single `CloseTab` call.
+- Full `vitest` suite + `tsc --noEmit` — no regressions expected; this is a
+  subtractive change (removes a call), not new branching logic.

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -1,8 +1,10 @@
 # Tab close (X) button — spurious select flash
 
-**Status:** §§2-3 (click-bubble race) fixed and shipped (PR #2811). §5 below
-is a follow-up: a second, independent flash reported after §2-3 landed —
-fixed in the same branch.
+**Status:** §§2-3 (click-bubble race), §5 (double round trip), §6
+(unbatched RPC-response application), and §7 (unbatched WS-push
+application — the reason the flash survived §§5-6) are all implemented on
+branch `fix/tab-close-select-flash` (PR #2811, open — not yet merged to
+`main`, so no release build contains any of this yet).
 **Owner:** unassigned
 **Date:** 2026-08-25
 **Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tabbar.tsx`,
@@ -378,3 +380,84 @@ future return, more than one `WaveObjUpdate` per call.
 - Full `vitest` suite + `tsc --noEmit` — no regressions expected (a `for`
   loop wrapped in `batch()` preserves the same update order and end state,
   only changes when Solid flushes the resulting DOM writes).
+
+## 7. Follow-up #3 — the flash survives §6 because the WS push path applies the same pair unbatched, and it always paints first
+
+After §6, the repo owner reported the flash was STILL there, right after
+the close-confirm modal dismisses. §6's `batch()` was correct but fixed
+only one of the delivery paths — and, as it turns out, the one that never
+actually paints.
+
+### 7.1 Root cause — three delivery paths, two of them unbatched, both faster than the one §6 fixed
+
+A `CloseTab`'s `[delete tab, update workspace]` pair reaches the calling
+renderer THREE separate ways:
+
+1. **The wave-obj bridge** (`agentmux-srv/src/server/wave_obj_bridge.rs`,
+   `Event::TabDeleted` arm): broadcast as **two separate WS frames** —
+   tab delete first, then (after an async `spawn_blocking` SQLite fetch)
+   the workspace update. Fired the moment the reducer publishes the event,
+   i.e. *while the HTTP handler is still running*.
+2. **The response-broadcast loop** (`run_service_call`,
+   `agentmux-srv/src/server/service/mod.rs`): pre-fix, one WS frame **per
+   update**, in the handler's array order — tab delete first. Fired after
+   the handler returns but before the HTTP response body is serialized to
+   the caller; the comment said "for everybody else on the event bus," but
+   `broadcast_event` sends to every connection, including the caller.
+3. **The HTTP response body** (`respData.updates` in `wos.ts`
+   `callBackendService`) — the only path §6 batched. Arrives last.
+
+Server-side, `forward_event` (`server/websocket.rs`) wraps each raw
+`waveobj:update` frame as an `eventrecv` RPC message, so each frame lands
+in `handleWaveEvent` → the scope-less `WaveObjUpdate` subscription in
+`initGlobalEventSubs` (`global.ts`) → a **bare, per-frame
+`WOS.updateWaveObject()` call** — no `batch()` anywhere on this path.
+
+So the actual paint sequence was: WS frame "delete tab:X" → the
+still-mounted `<Tab>` blanks in place (the §6 flash, verbatim) → WS frame
+"update workspace" → tab unmounts → HTTP body's batched pair arrives and
+is a no-op (`updateWaveObject`'s version guard skips the same-version
+workspace update; the tab delete is already applied). §6's `batch()` never
+had a chance to win the paint — the flash was deterministic, not even a
+race.
+
+### 7.2 Fix — batch the response broadcast; order the bridge parent-first
+
+Two changes, mirroring §6's "fix it at the shared layer" principle:
+
+- **`EventBus::broadcast_wave_obj_updates`** (`backend/eventbus.rs`): a
+  response's whole `updates` array now goes out as ONE
+  `waveobj:batchedupdates` WS frame (order preserved). The frontend
+  subscribes to it in `initGlobalEventSubs` and applies via the
+  already-batched `updateWaveObjects`. All five multi-update broadcast
+  sites switched to it: `run_service_call`, `app_api/pane.rs`,
+  `app_api/mod.rs`, `app_api/agent_open.rs`, `service/tear_off.rs`.
+  Single-update emitters (blockcontroller, setmeta, the bridge) keep the
+  plain `waveobj:update` frame — nothing to batch.
+- **Bridge delete ordering** (`wave_obj_bridge.rs`): the `TabDeleted`,
+  `BlockDeleted`, and `SrvWindowClosed` arms now emit the **parent update
+  BEFORE the child delete** (the mirror of the create arms' child-first
+  order). The bridge's two emissions are genuinely separate frames (one
+  requires an async fetch), so they can't be batched into one — but
+  parent-first, the child unmounts with its data still intact and the late
+  delete lands on an unsubscribed signal: nothing paints. General rule
+  worth keeping: **create child-first, delete parent-first.**
+
+With both in place, every arrival order is flash-free: bridge frames are
+parent-first, the response broadcast is atomic, the response body is
+atomic (§6).
+
+### 7.3 Test plan (follow-up #3)
+
+- `wave_obj_bridge.rs::tests` — `TabDeleted` broadcasts the workspace
+  update before the tab delete; `BlockDeleted` broadcasts the tab update
+  before the block delete (asserted on a real `EventBus` connection's
+  receive order).
+- `eventbus.rs::tests` — `broadcast_wave_obj_updates` emits exactly one
+  `waveobj:batchedupdates` frame with the array order preserved, and no
+  frame for an empty slice.
+- `frontend/app/tab/tab.test.tsx` — §4's long-owed component test: a click
+  on a background tab's close button fires `onClose` only (never
+  `onSelect`); a click on the tab body still selects.
+- Manual: close the active tab via the confirm modal — the tab vanishes
+  with the neighbor already active; no blank frame, no highlight blink.

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -230,6 +230,18 @@ export function initGlobalEventSubs(initOpts: AgentMuxInitOpts) {
             },
         },
         {
+            eventType: WpsEvent.WaveObjBatchedUpdates,
+            handler: (event) => {
+                // All updates from one atomic backend transition, applied in
+                // one batch() flush (updateWaveObjects) so the UI can't paint
+                // a half-applied state — e.g. CloseTab's tab delete blanking
+                // the still-mounted tab before the workspace update unmounts
+                // it. See SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §7.
+                const updates: WaveObjUpdate[] = event.data ?? [];
+                WOS.updateWaveObjects(updates);
+            },
+        },
+        {
             eventType: WpsEvent.Config,
             handler: (event) => {
                 const fullConfig = (event.data as WatcherUpdate).fullconfig;

--- a/frontend/app/store/wos.ts
+++ b/frontend/app/store/wos.ts
@@ -8,7 +8,7 @@ import { WpsEvent } from "@/app/store/wps-events";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { fetch } from "@/util/fetchutil";
 import { type SignalAtom, fireAndForget } from "@/util/util";
-import { createSignal, onCleanup } from "solid-js";
+import { batch, createSignal, onCleanup } from "solid-js";
 import { ObjectService } from "./services";
 import { getApi } from "./app-api";
 
@@ -287,9 +287,19 @@ function updateWaveObject(update: WaveObjUpdate) {
 }
 
 function updateWaveObjects(vals: WaveObjUpdate[]) {
-    for (const val of vals) {
-        updateWaveObject(val);
-    }
+    // batch() so a single RPC response carrying multiple related updates
+    // (e.g. CloseTab's [delete Tab, update Workspace] pair) applies as one
+    // atomic reactive flush. Without it, each setData() below propagates
+    // synchronously and independently: the deleted tab's own signal went
+    // null (blanking its still-mounted <Tab>'s name) a full reactive
+    // update BEFORE the workspace update removed it from the tab strip's
+    // <For> list, so the tab visibly flashed blank in place before
+    // disappearing. See docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §6.
+    batch(() => {
+        for (const val of vals) {
+            updateWaveObject(val);
+        }
+    });
 }
 
 function cleanWaveObjectCache() {

--- a/frontend/app/store/wos.ts
+++ b/frontend/app/store/wos.ts
@@ -340,6 +340,7 @@ export {
     reloadWaveObject,
     setObjectValue,
     updateWaveObject,
+    updateWaveObjects,
     useWaveObjectValue,
     wpsSubscribeToObject,
 };

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -12,6 +12,14 @@ export const WpsEvent = {
     SysInfo: "sysinfo",
     ControllerStatus: "controllerstatus",
     WaveObjUpdate: "waveobj:update",
+    // One WS frame carrying an ARRAY of WaveObjUpdates from a single atomic
+    // backend transition (e.g. CloseTab's [update workspace, delete tab]
+    // pair) — applied in one Solid batch() flush so the UI can't paint a
+    // half-applied intermediate state. Mirrors
+    // WS_EVENT_WAVE_OBJ_BATCHED_UPDATES in
+    // agentmux-srv/src/backend/eventbus.rs. See
+    // docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §7.
+    WaveObjBatchedUpdates: "waveobj:batchedupdates",
     InstallProgress: "install_progress",
     Config: "config",
     UserInput: "userinput",

--- a/frontend/app/tab/tab.test.tsx
+++ b/frontend/app/tab/tab.test.tsx
@@ -1,0 +1,86 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the window tab strip's <Tab> — specifically the close-button
+ * click-containment contract from
+ * docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §§2-3: a click
+ * on the "✕" must fire onClose ONLY, never bubble to the tab's own
+ * onClick={onSelect}. The bubbled select is what raced SetActiveTab against
+ * CloseTab on the backend and produced the select/deselect flash.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/global", () => ({
+    atoms: {},
+    recordTEvent: vi.fn(),
+    refocusNode: vi.fn(),
+}));
+vi.mock("@/app/store/rpc-api", () => ({ RpcApi: {} }));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/services", () => ({
+    ObjectService: {
+        UpdateTabName: vi.fn(() => Promise.resolve()),
+        UpdateObjectMeta: vi.fn(() => Promise.resolve()),
+    },
+}));
+vi.mock("@/app/store/wos", () => ({
+    makeORef: (otype: string, oid: string) => `${otype}:${oid}`,
+    useWaveObjectValue: () => [
+        () => ({ otype: "tab", oid: "tab-1", version: 1, name: "Tab One", meta: {} }),
+        () => false,
+    ],
+}));
+vi.mock("@/app/tab/tab-measure", () => ({ measureTabWidth: () => 100 }));
+
+import { Tab } from "./tab";
+
+afterEach(() => cleanup());
+
+function renderTab(overrides: { onSelect?: () => void; onClose?: (e: MouseEvent | null) => void } = {}) {
+    const onSelect = overrides.onSelect ?? vi.fn();
+    const onClose = overrides.onClose ?? vi.fn();
+    const utils = render(() => (
+        <Tab
+            id="tab-1"
+            active={false}
+            isFirst={false}
+            isBeforeActive={false}
+            isDragging={false}
+            tabWidth={0}
+            isNew={false}
+            onSelect={onSelect}
+            onClose={onClose}
+            onDragStart={vi.fn()}
+            onLoaded={vi.fn()}
+        />
+    ));
+    return { ...utils, onSelect, onClose };
+}
+
+describe("Tab close button", () => {
+    it("fires onClose and never onSelect when the close button of a background tab is clicked", async () => {
+        const { container, onSelect, onClose } = renderTab();
+        const closeButton = container.querySelector<HTMLButtonElement>("[title='Close Tab']");
+        expect(closeButton).not.toBeNull();
+
+        await userEvent.click(closeButton!);
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("still fires onSelect for a click on the tab body itself", async () => {
+        const { container, onSelect, onClose } = renderTab();
+        const tabEl = container.querySelector<HTMLDivElement>(".tab");
+        expect(tabEl).not.toBeNull();
+
+        await userEvent.click(tabEl!.querySelector(".name")!);
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -229,6 +229,17 @@ function Tab(props: TabProps): JSX.Element {
         event.stopPropagation();
     };
 
+    // Without this, a click on the close button bubbles past the button's
+    // own onClick to the parent .tab div's onClick={props.onSelect} (only
+    // mousedown propagation is stopped above), spuriously selecting the tab
+    // that's simultaneously being closed. That races SetActiveTab against
+    // CloseTab on the backend and produces a visible select/deselect flash —
+    // see docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md.
+    const handleCloseClick = (event: MouseEvent) => {
+        event.stopPropagation();
+        props.onClose(event);
+    };
+
     const handleColorSelect = (hex: string | null) => {
         const oref = makeORef("tab", props.id);
         fireAndForget(async () => {
@@ -286,7 +297,7 @@ function Tab(props: TabProps): JSX.Element {
                     </div>
                     <Button
                         className="ghost grey close"
-                        onClick={props.onClose}
+                        onClick={handleCloseClick}
                         onMouseDown={handleMouseDownOnClose}
                         title="Close Tab"
                         draggable={false}

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -8,6 +8,7 @@ import { settingsAtom } from "@/store/config-signals";
 import { atoms, setActiveTab } from "@/store/global";
 import { RpcApi } from "@/store/rpc-api";
 import { TabRpcClient } from "@/store/rpc-util";
+import { holdRevealGate, scheduleRevealLift } from "@/store/tab-reveal";
 import { isMacOS } from "@/util/platformutil";
 import { fireAndForget } from "@/util/util";
 import type { JSX } from "solid-js";
@@ -48,14 +49,28 @@ function TabBar(props: TabBarProps): JSX.Element {
     const handleClose = (tabId: string) => {
         const allTabs = tabIds();
         if (allTabs.length <= 1) return;
+        // Don't pre-select the neighbor via a separate SetActiveTab RPC
+        // before closing: CloseTab's own DeleteTab reducer command already
+        // reassigns the workspace's active tab to the correct neighbor
+        // atomically (agentmux-srv/src/reducer/tab.rs::handle_delete_tab)
+        // when the closed tab was active, in the SAME state transition as
+        // the removal. Doing it ourselves first turned one atomic update
+        // into two sequential round trips — neighbor selected (paint),
+        // THEN the closing tab visibly deselects while still sitting there
+        // un-removed, THEN it finally disappears — a visible flash. Just
+        // hold the content reveal gate (same primitive setActiveTab uses)
+        // around the single CloseTab call so the destination pane still
+        // can't paint piecemeal. See
+        // docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §5.
+        const closingActiveTab = tabId === activeTabId();
         fireAndForget(async () => {
-            if (tabId === activeTabId()) {
-                const idx = allTabs.indexOf(tabId);
-                const nextTab = allTabs[idx + 1] ?? allTabs[idx - 1];
-                if (nextTab) await setActiveTab(nextTab);
+            if (closingActiveTab) holdRevealGate();
+            try {
+                await WorkspaceService.CloseTab(props.workspace.oid, tabId);
+                deleteLayoutModelForTab(tabId);
+            } finally {
+                if (closingActiveTab) scheduleRevealLift();
             }
-            await WorkspaceService.CloseTab(props.workspace.oid, tabId);
-            deleteLayoutModelForTab(tabId);
         });
     };
 


### PR DESCRIPTION
## Summary
- Clicking a background tab's ✕ close button let the `click` event bubble past the button into the parent tab's `onClick={onSelect}` (only `mousedown` propagation was stopped, not `click`), firing a spurious `SetActiveTab` for the tab that was simultaneously being closed.
- That raced an unordered `SetActiveTab` request against the `CloseTab` request over independent `fetch()` calls; depending on which the backend serviced first, the tab bar would flash-highlight the closing tab and then jump again as `DeleteTab`'s own neighbor-promotion reassigned active — the reported "flash of another tab selected and then deselected." In the worst case it could also silently leave the wrong tab active.
- Fix: stop `click` propagation on the close button the same way `mousedown` already is, so the spurious select never fires and no race is created.
- Full root-cause writeup: `docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run` — 3132 passed, 3 skipped (full suite, no regressions)
- [ ] Manual: open 3+ tabs, click a background tab's ✕ repeatedly and confirm the active tab's highlight never flashes/jumps

<!-- agentmux:agent_id=loap3 -->