### PR TITLE
Manoz@Area54: fix(agent-pane): composer strip stuck multi-row — stats zone wrapper measured instead of its content

### DIFF
--- a/.changesets/1787785987-fix-agent-pane-composer-strip-stuck-multi-row-stats-zone-wra-qyfs.md
+++ b/.changesets/1787785987-fix-agent-pane-composer-strip-stuck-multi-row-stats-zone-wra-qyfs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): composer strip stuck multi-row — stats zone wrapper measured instead of its content

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -904,14 +904,31 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     // actually have room for the real stats footprint — the same
     // "stale measurement crosses a structural transition" failure mode
     // already fixed for zoom/padding in this same PR, one layer up.
+    //
+    // Measures the zone's CONTENT (`firstElementChild`, the
+    // `.agent-composer-strip-stats` span inside the `<Show>`), NOT the
+    // zone wrapper itself — regression found live post-#2813: in the
+    // multi-row position the zone is a direct child of the column-flex
+    // strip, so default `align-items: stretch` blockifies it to the FULL
+    // strip width even when `rightText()` is empty and it renders
+    // nothing. Measuring the wrapper there fed `reservedWidth` ≈ the
+    // whole strip width into `computeComposerRows`, making the
+    // single-row fit check unsatisfiable at ANY pane width — a one-way
+    // trap: the first legitimate visit to multi-row state locked the
+    // strip multi-row forever (the widest tier stuck at 2 lines). The
+    // content span's own rect is the real footprint in BOTH positions
+    // (inline-block in the multi position; `flex: 0 0 auto` child in the
+    // single position), and is 0/absent exactly when there is nothing to
+    // reserve space for.
     let statsRefs: { single?: HTMLElement; multi?: HTMLElement } = {};
     const [statsWidth, setStatsWidth] = createSignal(0);
     createEffect(() => {
         rightText();
         stripWidth();
         slotWidths();
-        const el = statsRefs.single?.isConnected ? statsRefs.single : statsRefs.multi?.isConnected ? statsRefs.multi : undefined;
-        setStatsWidth(el ? Math.round(el.getBoundingClientRect().width / 8) * 8 : 0);
+        const zone = statsRefs.single?.isConnected ? statsRefs.single : statsRefs.multi?.isConnected ? statsRefs.multi : undefined;
+        const content = zone?.firstElementChild;
+        setStatsWidth(content ? Math.round(content.getBoundingClientRect().width / 8) * 8 : 0);
     });
 
     // reagent P1 on PR #2808: `<For>` (below) reconciles by referential


### PR DESCRIPTION
Follow-up to #2813 — the widest pane showed 2 lines where 1 trivially fits (~252px of content in a 425px strip), reported live right after #2813 merged.

## Root cause

The `statsWidth` effect measured the stats zone **wrapper** (`statsRefs.single`/`.multi`, `AgentComposerStrip.tsx`). In the multi-row mount position that wrapper is a direct child of the column-flex `.agent-composer-strip`, so default `align-items: stretch` blockifies it to the **full strip width even when empty** (`rightText()` falsy → the `<Show>` renders nothing inside it). That fed `reservedWidth ≈ stripWidth` into `computeComposerRows`, making the single-row fit check (`total + reserved <= available`) unsatisfiable at any pane width.

This is a **one-way trap**, which is why #2812/#2813's own width-sweep verifications never caught it: in single-row mode the zone is a `flex: 0 0 auto` row child measuring 0 when empty, so any sweep that starts single-row stays correct. The first legitimate visit to multi-row state arms the stale ~400px reservation, and the strip can never mathematically return to single-row afterward.

## Fix

Measure the zone's `firstElementChild` (the `.agent-composer-strip-stats` content span) instead of the wrapper — its rect is the real footprint in both mount positions (inline-block under the stretched multi wrapper; flex-auto child in the single row) and it is absent exactly when there is nothing to reserve space for.

## Verification (live CDP against the running dev build)

- Wide pane: back to 1 row in place immediately on HMR (the reported regression state).
- 300px/220px tiers: balanced 2-row layouts unchanged (220px one-sided row = spec §1 physical-capacity exception).
- The previously-deadlocked round-trip 920 → 300 → 920 now returns to a single row.
- All 28 `AgentComposerStrip.test.tsx` unit tests pass.

Addresses the remaining live regression on top of #2813 (zoom/gap unit mismatch) and #2812 (Rev 7 row-based layout) — this reservation bug was previously masked by #2813's gap overestimation, which kept the strip from ever *entering* the trapped state during wide-tier testing.

<!-- agentmux:agent_id=manoz -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)