### PR TITLE
fix(tab): optimistic tab removal on close — flash structurally impossible

### DIFF
--- a/.changesets/1787814801-fix-tab-optimistic-tab-removal-on-close-close-flash-structur-ocnk.md
+++ b/.changesets/1787814801-fix-tab-optimistic-tab-removal-on-close-close-flash-structur-ocnk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tab): optimistic tab removal on close — close flash structurally impossible

--- a/docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md
+++ b/docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md
@@ -1,0 +1,293 @@
+# SPEC: Resize refinements — flip group/direct defaults, and Shift+window-resize feeding only the edge panes
+
+**Date:** 2026-08-26
+**Status:** analysis + design — not implemented
+**Author:** Loap (agent)
+**Tracking discussion:** repo owner, this session — "the default should be the
+relative resize that currently shift-resize does. The new feature is that when
+users use shift-resize, it directly resizes the pane, like how the default
+resize is currently. we also want introduce this to the pane borders along the
+window. when window resizing, the default already does relative. but we want
+to add a shift+resize to the edge panes that make pane size change on it's own
+(other panes remain same width even though you are making the window larger)."
+
+**Builds on / supersedes in part:**
+- `SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md` (PR #2401) — introduced
+  Shift+drag group resize. **This spec flips its §5.1/§5.2 default/modifier
+  assignment**; everything else there (Scope A, the modifier being Shift,
+  minimize-locked exclusion) stands.
+- `SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md` — the two-block
+  distribution algorithm. Unchanged; it simply becomes the *default* math.
+
+---
+
+## 1. What exists today (verified by reading the code)
+
+### 1.1 Splitter drag — two modes, Shift selects the group one
+
+- `frontend/layout/lib/TileLayout.{win32,darwin,linux}.tsx` each pass the live
+  modifier into the resize hot path:
+  `onResizeMove(props.resizeHandleProps, clientX, clientY, event.shiftKey)`
+  (win32: ~line 516, darwin: 433, linux: 457). This is the ONLY place mode
+  selection happens.
+- `frontend/layout/lib/layoutResize.ts::onResizeMove` (line 238-341) branches
+  on that boolean:
+  - `groupResize === false` (**today's default**): plain 2-node
+    equal-and-opposite transfer between the two flanking siblings
+    (`beforeNodeSize`/`afterNodeSize`, line 313-326), both floored at
+    `MinNodeSizePx = 128` — the drag simply stops at the floor.
+  - `groupResize === true` (**today's Shift**): `computeGroupResizeSizes`
+    (line 165-211) — the two-block model: every sibling before the handle is
+    one uniformly-scaling block, the driven pane plus everyone after it is
+    the other; the handle border tracks the cursor 1:1; per-member floor with
+    iterative redistribution (`shrinkBlockBy`, line 54-96).
+- The drag context (`ResizeContext`, line 18-36) always snapshots
+  `groupSiblingStartSizes` regardless of the modifier, precisely so Shift can
+  be toggled mid-drag with no context rebuild. **This means the flip is
+  near-free** — both formulas already run off the same context.
+- Discoverability surface: `frontend/app/element/quicktips.tsx:213-215` —
+  "Resize All Panes Together — Shift + Drag".
+
+### 1.2 Window resize — proportional by construction, no code involved
+
+Pane sizes are flex weights (`LayoutNode.size`) relative to their parent's
+children; pixels are derived per-parent as `containerPx × weight/Σweights`
+(`pixelToSizeRatio` in `additionalProps`). An OS window resize reaches the
+layout only as a `ResizeObserver` tick (`layoutModelHooks.ts:69` →
+`onContainerResize`, `layoutResize.ts:216-220`), which recomputes geometry
+and briefly sets `isContainerResizing` (to suppress animations). **No weight
+changes, so every pane scales proportionally — the "relative" default the
+repo owner described.** Notably, this reflow does NOT enforce the 128px
+floor (only interactive drags do — documented in `shrinkBlockBy`'s comment,
+line 60-71).
+
+There is **no host-side resize-loop handling today**: no
+`WM_SIZING`/`WM_ENTERSIZEMOVE`/`WM_EXITSIZEMOVE` handlers anywhere in
+`agentmux-cef/`. Precedent for sampling physical key state inside a native
+loop exists (`GetAsyncKeyState` in `agentmux-cef/src/commands/drag.rs:244`
+and `ui_tasks/drag.rs:337-349`), and host→renderer event channels already
+exist for exactly this kind of mid-gesture signaling (the tabdrag events,
+`srv_event_bridge.rs` / `events.rs`).
+
+---
+
+## 2. Change 1 — flip the splitter-drag defaults
+
+### 2.1 New behavior
+
+| Gesture | Old | New |
+|---|---|---|
+| Plain drag | 2-node direct transfer | **group resize (two-block)** |
+| Shift + drag | group resize (two-block) | **2-node direct transfer** |
+
+Rationale (owner-stated): the group behavior is the better everyday default —
+one drag adjusts the whole row/column coherently; the surgical "move only
+this border, touch only these two panes" case is the rarer, deliberate
+action, which is what a modifier is for.
+
+### 2.2 Implementation surface (small, by design)
+
+- `TileLayout.{win32,darwin,linux}.tsx` — pass `!event.shiftKey` where
+  `event.shiftKey` is passed today. Recommended cleanup while there: rename
+  `onResizeMove`'s 4th param from `groupResize` to something
+  gesture-agnostic (e.g. keep `groupResize` but compute it at the call site:
+  `groupResize: !event.shiftKey`) so the semantics live in one place.
+- `layoutResize.ts` — no math changes. Update the §5.2 comment block
+  (line 299-304) that says "Shift held:" to describe the flipped mapping.
+- `quicktips.tsx:213-215` — flip the entry: default drag now resizes the
+  row/column together; **"Resize Single Border — Shift + Drag"** (or similar
+  wording) documents the modifier.
+- Mid-drag toggling keeps working unchanged (both formulas already share the
+  same snapshot context, §1.1) — releasing/pressing Shift mid-drag now flips
+  in the opposite direction, which needs one manual re-verification pass.
+
+### 2.3 Behavioral deltas worth calling out (so they're chosen, not accidental)
+
+1. **The default drag's driven pane is no longer pixel-exact** when panes sit
+   past it — only the dragged border tracks the cursor 1:1 (the two-block
+   model's documented trade-off, DIRECTION_FIX §4.2). This becomes the
+   everyday behavior. Judged acceptable: the border under the pointer is
+   what the user is steering.
+2. **The default drag can now push distant borders** — a user who has
+   carefully sized pane A will see A shrink when they drag an unrelated
+   border in the same row (proportionally). That's the point of the flip,
+   but it's the one regression-shaped complaint to expect; the Shift escape
+   hatch is the answer, and the quicktips entry must say so.
+3. Minimize-locked siblings: unchanged — excluded from the group pool
+   (original spec §5.3), and the 2-node path already refuses drags flanking
+   a locked node (`layoutResize.ts:264`).
+
+---
+
+## 3. Change 2 — Shift + OS-window resize feeds only the edge panes
+
+### 3.1 New behavior
+
+- Plain window resize: unchanged — proportional scaling (already the
+  default, zero code).
+- **Shift held while resizing the window by an edge:** the entire pixel
+  delta goes to the pane(s) abutting the dragged window edge; every other
+  pane keeps its **pixel** size exactly (their flex weights are rewritten to
+  preserve pixels under the new container size).
+
+### 3.2 Which panes are "the edge panes" — recursive edge-chain rule
+
+The layout is a tree, not a grid, so "the pane at the right edge" must be
+defined structurally. For a **width** delta on the **right** edge, walk the
+tree from the root:
+
+- **Row container:** only the **last** (rightmost) child's width changes —
+  recurse into it if it's itself a container; every other child keeps its
+  pixel width (weights recomputed: `w_i' = W · p_i' / P'` with `p_i'` the
+  preserved pixel size, keeping the parent's weight sum `W` normalized).
+- **Column container:** every child spans the full width — recurse into
+  **every** child.
+
+Mirror for left edge (first child), and for height deltas on top/bottom with
+Row/Column roles swapped. A **corner** drag decomposes into the two axis
+rules applied independently. The affected set is exactly the panes visually
+touching the dragged edge — which is what a user pointing at "the edge pane"
+means.
+
+### 3.3 Floor handling — inward spill, then proportional fallback
+
+When shrinking the window with Shift held, the edge pane shrinks first. At
+its 128px floor (`MinNodeSizePx`), the remaining delta **spills inward** to
+the next sibling in from the edge (accordion-style), and so on. If every
+sibling in a container is at the floor, fall back to plain proportional
+scaling for further shrinkage — matching the existing non-Shift reality that
+window reflow may push panes below the floor (§1.2), so the two modes
+converge instead of the Shift mode wedging against an OS resize it cannot
+refuse. Growing has no cap (no max-size concept exists — same as splitter
+drags).
+
+`shrinkBlockBy` is the right primitive to reuse for the spill (it already
+implements floored, pool-dropping redistribution) — but note its
+distribution is proportional-within-the-pool; the accordion order described
+here wants **edge-first ordering** instead. That's a new small pure function
+(`spillInwardBy`?) alongside it, unit-testable the same way.
+
+### 3.4 Gesture plumbing — how Shift and the dragged edge reach the layout
+
+Two facts the renderer cannot reliably know on its own:
+1. **Which edge** is being dragged — a `ResizeObserver` tick only reports new
+   size.
+2. **Whether Shift is held** — during a native resize modal loop the renderer
+   may not receive key events, and focus is on the window frame.
+
+**Recommended: host-driven (Windows first).** The host window proc handles:
+- `WM_ENTERSIZEMOVE` → begin a resize session: snapshot request to renderer
+  (`windowresize:begin`).
+- `WM_SIZING` → carries the edge verbatim in `wParam`
+  (`WMSZ_LEFT/RIGHT/TOP/BOTTOM/corners`); sample
+  `GetAsyncKeyState(VK_SHIFT)` (precedent: `drag.rs:244`) per tick; forward
+  `windowresize:tick { edge, shiftHeld }` to the renderer. Shift can
+  therefore be pressed/released mid-resize and the mode follows live, same
+  as splitter drags.
+- `WM_EXITSIZEMOVE` → `windowresize:end` — renderer commits (one history
+  entry, mirroring the splitter drag's stage-then-commit pattern,
+  `SetPendingAction`/`CommitPendingAction`).
+
+**macOS/Linux (phase 2):** no `WM_SIZING` equivalent with an edge param.
+The edge is inferable from frame geometry deltas alone (origin.x moved with
+width → left edge; width changed with origin fixed → right edge; likewise
+vertically), which works from `windowWillResize`/configure events — or even
+renderer-side via `window.screenX/screenY` deltas as a fallback. Shift
+state is the harder half there (renderer key tracking is best-effort during
+a native loop); ship Windows first and reuse whatever pattern the tear-off
+work already proved per-platform.
+
+### 3.5 Renderer-side algorithm
+
+On `windowresize:begin`: snapshot every container's children pixel sizes
+(from `additionalProps` rects — same source the drag context uses,
+`layoutResize.ts:266-267`). Per `tick` with `shiftHeld`:
+
+1. Compute the cumulative per-axis delta from the session-start container
+   size (CSS px — divide out `--zoomfactor` if the observer reports zoomed
+   units; verify against how `pixelToSizeRatio` is derived).
+2. Apply the §3.2 recursion: for each affected container, produce a
+   `ResizeNodeOperation[]` from the snapshot + delta (§3.3 spill math),
+   staged via `SetPendingAction` exactly like a splitter drag tick.
+3. Ticks with `shiftHeld === false` restage pure-snapshot-proportional
+   sizes (i.e. no weight change relative to session start) so toggling
+   Shift mid-resize is live and reversible within the session.
+
+On `end`: `CommitPendingAction` (single undo/persist entry). A session with
+Shift never held stages nothing and commits nothing — identical to today.
+
+Note: unlike plain window resize (which never writes the tree), a
+Shift-resize **persists changed weights** — that's the intent ("other panes
+remain same width"), but it means the layout file changes on a
+window-resize gesture for the first time. Worth one deliberate sign-off.
+
+### 3.6 Out of scope / non-goals
+
+- Floating panes (`floating_pane.rs`) — separate windows, own resize spec
+  (`SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md`); untouched.
+- Magnified-pane state during a window resize — the magnify overlay already
+  has its own reflow; not special-cased here.
+- Maximize/restore, snap layouts, DPI-change reflows — these are not
+  edge-drag gestures; they keep proportional behavior unconditionally
+  (no `WM_SIZING` stream → no session → no Shift path, by construction).
+- A persistent per-workspace "mode" toggle — this stays a momentary
+  modifier, consistent with the splitter-drag feature.
+
+---
+
+## 4. Consistency note — one mental model after both changes
+
+After both changes, **Shift uniformly means "surgical/direct"** and plain
+gestures mean "the whole neighborhood adjusts":
+
+| Gesture | Plain | Shift |
+|---|---|---|
+| Splitter drag | row/column adjusts together (relative) | only the two flanking panes (direct) |
+| Window edge drag | everything scales (relative) | only the edge pane changes (direct) |
+
+This inversion is the strongest argument for the flip: before it, Shift
+meant "bigger effect" on splitters but would have meant "smaller effect" on
+window edges — incoherent. After it, one rule covers both surfaces.
+
+---
+
+## 5. Test plan
+
+**Change 1 (flip):**
+- Existing `layoutResize.test.ts` suites stay green untouched (they test the
+  pure functions, which don't move).
+- Update/extend any test that encodes the modifier mapping (none found at
+  the pure-function layer — the mapping lives in the three `TileLayout`
+  variants, currently untested; a small component-level test asserting
+  which branch `onResizeMove` takes per `shiftKey` value would lock the flip).
+- Manual: plain drag moves the whole row; Shift drag moves one border;
+  toggling mid-drag flips live, in both directions.
+
+**Change 2 (window edge):**
+- Unit: the new spill function (edge-first floored redistribution) and the
+  weight-rewrite math (`preserve pixels under new total`), pure-function
+  tests in the `layoutResize.test.ts` style, including corner (two-axis)
+  cases and the all-at-floor proportional fallback.
+- Manual (Windows): 3-pane row — Shift-drag right window edge wider: only
+  the rightmost pane grows, others' pixel widths hold (verify with the
+  `WxH` dimension overlay, which mounts on `isContainerResizing` /
+  splitter drags — check it also engages here or extend it); shrink until
+  the edge pane floors, confirm inward spill; release Shift mid-gesture,
+  confirm reversion to proportional staging; nested split (column inside
+  the row) — confirm recursion touches the correct leaves.
+- Persistence: after a Shift window-resize, reload — the changed pane
+  weights survive; after a plain window-resize, the layout file is
+  byte-unchanged (today's behavior preserved).
+
+## 6. Sources (code read for this spec)
+
+- `frontend/layout/lib/layoutResize.ts:18-36, 54-96, 165-211, 216-229, 238-341`
+- `frontend/layout/lib/TileLayout.win32.tsx:516`, `TileLayout.darwin.tsx:433`,
+  `TileLayout.linux.tsx:457`
+- `frontend/layout/lib/layoutModelHooks.ts:69`
+- `frontend/app/element/quicktips.tsx:53-58, 213-215`
+- `agentmux-cef/src/commands/drag.rs:244-245`, `agentmux-cef/src/ui_tasks/drag.rs:337-349`
+  (GetAsyncKeyState precedent); repo-wide grep confirming no
+  `WM_SIZING`/`WM_ENTERSIZEMOVE` handling exists yet
+- `docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md`,
+  `docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md`

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -541,3 +541,70 @@ no optimistic layer in front of it.
 - 2-tab workspace: modal open on one tab → Confirm still closes (raw-list
   guard); the surviving tab cannot be closed (✕ hidden / guard).
 - `tsc --noEmit` + full `vitest` — no regressions.
+
+## 9. Follow-up #5 — the promoted neighbor's PANE flashes after §8
+
+With §8 in a verified build, the repo owner confirmed the strip flash is
+gone but reported: "after the modal, when the tab is gone, the next tab's
+entire pane flashes."
+
+### 9.1 Root cause — the reveal gate blanks the SOURCE for the whole round trip
+
+`workspace.tsx` keeps every tab's content mounted (`display:none` when
+inactive) and applies the reveal gate as `visibility:hidden`/`opacity:0`
+to whichever tab is **currently active** while `tabSwitching` is up
+(`tid === tabId() && tabSwitching()`). On close-promotion:
+
+1. Confirm → `handleClose` → `holdRevealGate()`. `tabId()` is still the
+   CLOSING tab X → **X's fully-rendered pane blanks instantly.**
+2. CloseTab RPC round-trips (~tens of ms). Content region shows blank.
+3. Update lands: X unmounts, neighbor Y flips `display:none → flex` and —
+   `tid === tabId()` now matching Y — stays hidden under the gate.
+4. `scheduleRevealLift()`'s settle detector waits for 80ms of
+   long-task-free frames. Tab teardown (block/terminal disposal, layout
+   model deletion) emits long tasks that keep resetting that clock, so
+   the blank stretches toward the 800ms hard cap before Y fades in over
+   120ms.
+
+Net effect: blank-from-confirm → (long settle) → fade-in = "the next
+tab's entire pane flashes." The same source-blanking happens on ordinary
+tab switches (the gate has always keyed on the current active tab), but
+the switch case is shorter (no teardown long-tasks) and so was never
+reported.
+
+### 9.2 Fix — destination-targeted gate
+
+The holder usually KNOWS the destination tab. Let it say so:
+
+- `tab-reveal.ts`: `holdRevealGate(targetTabId?: string|null)` records a
+  `gateTargetTabId` signal; every lift path (settle, hard cap, safety
+  net) clears it. Untargeted holds keep the legacy behavior.
+- `workspace.tsx`: hide only when
+  `tid === tabId() && tabSwitching() && (target == null || target === tid)`.
+- `tabbar.tsx handleClose`: passes `displayActiveTabId()` (computed after
+  the optimistic hide, so it resolves to the neighbor the backend is
+  about to promote — §8's same promotion mirror).
+- `tab-actions.ts setActiveTab`: passes its destination `tabId` — regular
+  tab switches get the same improvement (source keeps painting through
+  the RPC; only the destination is FOUC-gated, from the flip until
+  settle).
+- `createTab` stays untargeted: its destination id doesn't exist until
+  the RPC returns, and hiding the current tab during creation is the
+  established behavior.
+
+What the user now sees on close-promotion: X's content stays on screen
+through the RPC; at the flip, Y is hidden only for its own settle window
+(teardown tasks overlap it), then fades in. The blank no longer starts at
+confirm-click and no longer covers the round trip.
+
+### 9.3 Test plan
+
+- `tab-reveal.test.ts`: targeted hold records the target; untargeted hold
+  resets a stale target; every lift path (schedule fallback, MAX_GATE
+  safety net) clears it.
+- Manual: close the active tab via the modal — the closing pane stays
+  visible until the moment of the switch; the neighbor appears with at
+  most its own brief settle, no full-region blank from the confirm click.
+- Manual regression: ordinary tab switch — source no longer blanks during
+  the RPC; destination still reveals atomically (no piecemeal paint).
+  Startup reveal (app-init's untargeted `scheduleRevealLift`) unchanged.

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -461,3 +461,83 @@ atomic (§6).
   `onSelect`); a click on the tab body still selects.
 - Manual: close the active tab via the confirm modal — the tab vanishes
   with the neighbor already active; no blank frame, no highlight blink.
+
+## 8. Follow-up #4 — optimistic removal: make the flash structurally impossible
+
+§§2-7 each closed one specific ordering hole, and after all four the flash
+was STILL reproducible on the repo owner's machine ("after I click ok on
+the modal, the closed tab will flash in its place before disappearing").
+Two lessons:
+
+1. **Verification gap:** none of §§5-7 was ever verified against a build
+   actually containing all of them at once (v0.55.25 predates the merge;
+   the dev instance used for testing had only §§3-6). Some sightings may
+   have been of incomplete builds. But regardless —
+2. **Wrong fix class:** every fix so far tries to *win an ordering race*
+   between the HTTP response, individual WS frames, reveal-gate timing,
+   and Solid's flush boundaries. Each new transport, event arm, or
+   scheduler change can reopen the class. The strip's rendering of the
+   closing tab should not *depend* on backend update ordering at all.
+
+### 8.1 The directive (repo owner, verbatim intent)
+
+> "the closed tab should leave right when the modal is open, if the user
+> cancels, put the tab back"
+
+That is optimistic UI, and it is ordering-immune by construction: a tab
+that is not rendered cannot flash, whatever order the backend's updates
+arrive in.
+
+### 8.2 Design (`frontend/app/tab/tabbar.tsx`)
+
+- `pendingHiddenTabIds: Signal<ReadonlySet<string>>` — ids hidden from the
+  strip while a close is pending. A Set so overlapping skip-confirm closes
+  of different tabs each stay hidden.
+- `allTabIds()` — the raw workspace list (logic/guards);
+  `tabIds()` — the rendered list, `allTabIds()` minus hidden ids.
+- **Hide points:** modal path — `requestClose` hides the tab the moment it
+  opens the modal (the directive); skip-confirm path — `handleClose` hides
+  before firing the RPC.
+- **Restore points:** modal `onCancel` unhides; `handleClose`'s `finally`
+  unhides — on success the RPC response has already applied the workspace
+  update synchronously (the id is gone from `allTabIds()`, unhide is a
+  no-op), on failure the tab visibly returns rather than leaking as
+  invisibly-alive.
+- **Guards use the raw list:** `requestClose`/`handleClose` check
+  `allTabIds().length <= 1`. Checking the filtered list would make a
+  2-tab workspace read as 1 tab after the modal hid one, and refuse every
+  confirmed close.
+- **`displayActiveTabId()`** — while the real active tab is hidden
+  mid-close, the strip highlights the neighbor the backend is about to
+  promote (next in list, else previous — mirroring `handle_delete_tab`'s
+  `tab_ids.get(pos) ?? pos-1`). The strip shows the final post-close state
+  from the first frame; the backend's update then changes nothing visibly.
+  `activeIndex`/`isActive`/`isBeforeActive` all key off it.
+- Re-entry guard: `requestClose` no-ops for a tab already pending close.
+
+The reveal gate (§5) is unchanged and still covers the *content* region on
+active-tab close; this section covers the strip.
+
+### 8.3 What §§3-7 still buy us
+
+Optimistic hiding makes the strip immune, but §§3-7 remain correct and
+load-bearing: §3 (click containment) prevents a spurious SetActiveTab RPC
+entirely; §5 keeps the close a single atomic backend transition; §6/§7
+(batched application + parent-first delete ordering) protect every OTHER
+multi-object update path (block close, window close, tab create) that has
+no optimistic layer in front of it.
+
+### 8.4 Test plan
+
+- Modal path: ✕ on active tab → tab disappears from strip immediately,
+  neighbor highlighted, modal open → Cancel → tab reappears in place, its
+  highlight state restored.
+- Modal path: ✕ → Confirm → no visible change in the strip at all (it
+  already showed the final state); content area switches atomically under
+  the reveal gate.
+- Skip-confirm path: rapid ✕ clicks on several background tabs — each
+  vanishes on click, none reappears, no flash.
+- Failure injection: CloseTab RPC rejects → tab returns to the strip.
+- 2-tab workspace: modal open on one tab → Confirm still closes (raw-list
+  guard); the surviving tab cannot be closed (✕ hidden / guard).
+- `tsc --noEmit` + full `vitest` — no regressions.

--- a/frontend/app/store/tab-actions.ts
+++ b/frontend/app/store/tab-actions.ts
@@ -92,7 +92,12 @@ export async function setActiveTab(tabId: string): Promise<void> {
     // destination mount window, not the longtask-free RPC duration.
     // Honours rapid Ctrl-Tab spam — each call resets the detector.
     // See issue #774 / SPEC_TAB_CONTENT_REVEAL_GATE.md.
-    holdRevealGate();
+    //
+    // Targeted at the DESTINATION tab (SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH
+    // §9): the source tab keeps painting during the RPC instead of
+    // blanking the content region the moment the switch starts; only the
+    // destination is FOUC-gated, from the activetabid flip until settle.
+    holdRevealGate(tabId);
     try {
         await WorkspaceService.SetActiveTab(ws.oid, tabId);
     } finally {

--- a/frontend/app/store/tab-reveal.test.ts
+++ b/frontend/app/store/tab-reveal.test.ts
@@ -10,6 +10,7 @@ import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { createRoot } from "solid-js";
 import {
     clearLeafRevealGate,
+    gateTargetTabId,
     gatingNodeIds,
     holdLeafRevealGate,
     holdRevealGate,
@@ -60,6 +61,35 @@ describe("tab-reveal gate", () => {
         expect(read(tabSwitching)).toBe(false);
         holdRevealGate();
         expect(read(tabSwitching)).toBe(true);
+    });
+
+    // Destination-targeted gate (SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH §9):
+    // a targeted hold records which tab should hide; an untargeted hold
+    // records null (legacy hide-current-active); every lift path clears
+    // the target so a stale target can't leak into the next transition.
+    test("holdRevealGate records the destination target and lifting clears it", () => {
+        holdRevealGate("tab-dest");
+        expect(read(gateTargetTabId)).toBe("tab-dest");
+        expect(read(tabSwitching)).toBe(true);
+        scheduleRevealLift();
+        vi.advanceTimersByTime(1000); // drain to the fallback lift
+        expect(read(tabSwitching)).toBe(false);
+        expect(read(gateTargetTabId)).toBe(null);
+    });
+
+    test("untargeted holdRevealGate resets a stale target from a prior hold", () => {
+        holdRevealGate("tab-a");
+        expect(read(gateTargetTabId)).toBe("tab-a");
+        holdRevealGate();
+        expect(read(gateTargetTabId)).toBe(null);
+        expect(read(tabSwitching)).toBe(true);
+    });
+
+    test("safety-net lift after MAX_GATE_MS also clears the target", () => {
+        holdRevealGate("tab-b");
+        vi.advanceTimersByTime(900); // past MAX_GATE_MS with no schedule call
+        expect(read(tabSwitching)).toBe(false);
+        expect(read(gateTargetTabId)).toBe(null);
     });
 
     test("holdRevealGate keeps the gate up across long awaits", () => {

--- a/frontend/app/store/tab-reveal.ts
+++ b/frontend/app/store/tab-reveal.ts
@@ -157,6 +157,17 @@ function startDetector(handle: DetectorHandle, onSettle: () => void): void {
 const [tabSwitching, setTabSwitching] = createSignal(false);
 export { tabSwitching };
 
+// When non-null, the gate hides ONLY this tab id (once it becomes the
+// active tab) instead of whichever tab is currently active. Set by
+// destination-aware holders (tab close promotion, tab switches): the
+// SOURCE tab then stays visible right up to the activetabid flip instead
+// of blanking the content region the moment the gate goes up — the
+// "neighbor pane flash" of SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH §9. Null
+// (legacy) hides the current active tab, which createTab still wants
+// (its destination id doesn't exist until the RPC returns).
+const [gateTargetTabId, setGateTargetTabId] = createSignal<string | null>(null);
+export { gateTargetTabId };
+
 const tabHandle = newHandle();
 
 /** Lift the whole-tab gate AND cross-fade the startup splash. The gate's
@@ -168,6 +179,7 @@ const tabHandle = newHandle();
  *  safe. */
 function liftTabGate(): void {
     setTabSwitching(false);
+    setGateTargetTabId(null);
     fadeOutStartupSplash();
 }
 
@@ -186,8 +198,16 @@ function liftTabGate(): void {
  * MAX_GATE_MS fallback so the gate eventually lifts and the window can't
  * be left blank indefinitely. The normal-path `scheduleRevealLift()`
  * cancels this timer before installing its own detector.
+ *
+ * @param targetTabId when the destination tab of the transition is known
+ *   up front (tab switch, close-promotion), pass it: the gate then hides
+ *   only that tab once it becomes active, and the source keeps painting
+ *   until the actual activetabid flip — no premature blank. Omit (null)
+ *   for the legacy hide-current-active behavior (createTab, where the
+ *   destination id doesn't exist yet).
  */
-export function holdRevealGate(): void {
+export function holdRevealGate(targetTabId: string | null = null): void {
+    setGateTargetTabId(targetTabId);
     setTabSwitching(true);
     cancelDetector(tabHandle);
     armFallback(tabHandle, liftTabGate, MAX_GATE_MS);

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -35,10 +35,60 @@ function TabBar(props: TabBarProps): JSX.Element {
     // Pin feature removed — merge any legacy pinnedtabids into the regular list
     // so existing workspaces don't lose tabs. A one-time UpdateTabIds (below)
     // drains pinnedtabids server-side so this concat becomes a no-op.
-    const tabIds = () => {
+    const allTabIds = () => {
         const ws = props.workspace;
         if (!ws) return [];
         return [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])];
+    };
+
+    // Optimistic close (SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH §8): ids hidden
+    // from the strip while a close is pending — from the moment the confirm
+    // modal opens (or the close fires, on the skip-confirm path) until the
+    // backend workspace update lands or the close is cancelled / fails.
+    // A hidden tab is UNMOUNTED, so no ordering of the backend's HTTP
+    // response vs WS push frames can ever paint it again — this is what
+    // makes the close flash structurally impossible rather than a race we
+    // keep winning (§§2-7 each closed one ordering hole; this closes the
+    // class). A Set (not a single id) so overlapping skip-confirm closes
+    // of different tabs each stay hidden.
+    const [pendingHiddenTabIds, setPendingHiddenTabIds] = createSignal<ReadonlySet<string>>(new Set());
+    const hideTab = (tabId: string) =>
+        setPendingHiddenTabIds((prev) => {
+            if (prev.has(tabId)) return prev;
+            const next = new Set(prev);
+            next.add(tabId);
+            return next;
+        });
+    const unhideTab = (tabId: string) =>
+        setPendingHiddenTabIds((prev) => {
+            if (!prev.has(tabId)) return prev;
+            const next = new Set(prev);
+            next.delete(tabId);
+            return next;
+        });
+
+    // What the strip renders: the workspace's tabs minus any mid-close ones.
+    const tabIds = () => {
+        const hidden = pendingHiddenTabIds();
+        if (hidden.size === 0) return allTabIds();
+        return allTabIds().filter((id) => !hidden.has(id));
+    };
+
+    // While the REAL active tab is optimistically hidden (mid-close), the
+    // strip highlights the neighbor the backend is about to promote —
+    // next tab in the list, else previous, mirroring handle_delete_tab's
+    // `tab_ids.get(pos) ?? pos-1` (agentmux-srv/src/reducer/tab.rs). The
+    // strip therefore shows the FINAL post-close state from the first
+    // frame; the backend's update then changes nothing visibly.
+    const displayActiveTabId = () => {
+        const real = activeTabId();
+        const hidden = pendingHiddenTabIds();
+        if (!hidden.has(real)) return real;
+        const all = allTabIds();
+        const idx = all.indexOf(real);
+        for (let i = idx + 1; i < all.length; i++) if (!hidden.has(all[i])) return all[i];
+        for (let i = idx - 1; i >= 0; i--) if (!hidden.has(all[i])) return all[i];
+        return real;
     };
 
     const handleSelect = (tabId: string) => {
@@ -47,22 +97,20 @@ function TabBar(props: TabBarProps): JSX.Element {
     };
 
     const handleClose = (tabId: string) => {
-        const allTabs = tabIds();
-        if (allTabs.length <= 1) return;
+        // Guard on the RAW list — the filtered tabIds() already excludes a
+        // tab the modal path hid, so filtering here would make a 2-tab
+        // workspace read as 1 and refuse every confirmed close.
+        if (allTabIds().length <= 1) {
+            unhideTab(tabId);
+            return;
+        }
         // Don't pre-select the neighbor via a separate SetActiveTab RPC
         // before closing: CloseTab's own DeleteTab reducer command already
         // reassigns the workspace's active tab to the correct neighbor
         // atomically (agentmux-srv/src/reducer/tab.rs::handle_delete_tab)
-        // when the closed tab was active, in the SAME state transition as
-        // the removal. Doing it ourselves first turned one atomic update
-        // into two sequential round trips — neighbor selected (paint),
-        // THEN the closing tab visibly deselects while still sitting there
-        // un-removed, THEN it finally disappears — a visible flash. Just
-        // hold the content reveal gate (same primitive setActiveTab uses)
-        // around the single CloseTab call so the destination pane still
-        // can't paint piecemeal. See
-        // docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md §5.
+        // in the SAME state transition as the removal (§5).
         const closingActiveTab = tabId === activeTabId();
+        hideTab(tabId); // no-op when the modal path already hid it
         fireAndForget(async () => {
             if (closingActiveTab) holdRevealGate();
             try {
@@ -70,6 +118,12 @@ function TabBar(props: TabBarProps): JSX.Element {
                 deleteLayoutModelForTab(tabId);
             } finally {
                 if (closingActiveTab) scheduleRevealLift();
+                // Success: the RPC response applied the workspace update
+                // synchronously before the await resolved, so the id is no
+                // longer in allTabIds() and unhiding cannot resurrect it.
+                // Failure: restores the tab — a close that didn't happen
+                // must not leave the tab invisibly alive.
+                unhideTab(tabId);
             }
         });
     };
@@ -77,10 +131,14 @@ function TabBar(props: TabBarProps): JSX.Element {
     const [pendingCloseTabId, setPendingCloseTabId] = createSignal<string | null>(null);
 
     const requestClose = (tabId: string) => {
-        if (tabIds().length <= 1) return;
+        if (allTabIds().length <= 1) return;
+        if (pendingHiddenTabIds().has(tabId)) return; // close already pending
         if ((settingsAtom() as any)["tab:skipcloseconfirm"]) {
             handleClose(tabId);
         } else {
+            // Repo-owner-directed UX (§8): the tab leaves the strip the
+            // moment the modal opens; cancel puts it back.
+            hideTab(tabId);
             setPendingCloseTabId(tabId);
         }
     };
@@ -137,7 +195,7 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     if (!props.workspace) return null;
 
-    const activeIndex = () => tabIds().indexOf(activeTabId());
+    const activeIndex = () => tabIds().indexOf(displayActiveTabId());
 
     return (
         <div ref={tabBarRef!} class="tab-bar" {...dragProps}>
@@ -173,8 +231,8 @@ function TabBar(props: TabBarProps): JSX.Element {
                             <DroppableTab
                                 tabId={tabId}
                                 workspaceId={props.workspace.oid}
-                                activeTabId={activeTabId()}
-                                isActive={tabId === activeTabId()}
+                                activeTabId={displayActiveTabId()}
+                                isActive={tabId === displayActiveTabId()}
                                 isFirst={i() === 0}
                                 isBeforeActive={i() === activeIndex() - 1}
                                 allTabCount={tabIds().length}
@@ -208,7 +266,11 @@ function TabBar(props: TabBarProps): JSX.Element {
                         }
                         handleClose(tabId);
                     }}
-                    onCancel={() => setPendingCloseTabId(null)}
+                    onCancel={() => {
+                        // Cancel restores the optimistically-hidden tab (§8).
+                        unhideTab(pendingCloseTabId()!);
+                        setPendingCloseTabId(null);
+                    }}
                 />
             </Show>
         </div>

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -111,8 +111,16 @@ function TabBar(props: TabBarProps): JSX.Element {
         // in the SAME state transition as the removal (§5).
         const closingActiveTab = tabId === activeTabId();
         hideTab(tabId); // no-op when the modal path already hid it
+        // Destination-targeted gate (§9): hideTab already ran, so
+        // displayActiveTabId() resolves to the neighbor the backend is
+        // about to promote. Passing it keeps the CLOSING tab's content on
+        // screen through the RPC round trip (only the neighbor hides,
+        // once it becomes active, until it settles) — an untargeted hold
+        // here blanked the whole content region at confirm-click, which
+        // read as the neighbor pane "flashing".
+        const promotedTabId = closingActiveTab ? displayActiveTabId() : null;
         fireAndForget(async () => {
-            if (closingActiveTab) holdRevealGate();
+            if (closingActiveTab) holdRevealGate(promotedTabId);
             try {
                 await WorkspaceService.CloseTab(props.workspace.oid, tabId);
                 deleteLayoutModelForTab(tabId);

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -131,7 +131,13 @@ function TabBar(props: TabBarProps): JSX.Element {
     const [pendingCloseTabId, setPendingCloseTabId] = createSignal<string | null>(null);
 
     const requestClose = (tabId: string) => {
-        if (allTabIds().length <= 1) return;
+        // Guard on the VISIBLE count here (unlike handleClose's raw-list
+        // guard): with N closes already pending, the raw list still counts
+        // the hidden tabs until their RPCs land, so rapid skip-confirm
+        // clicks could pass a raw guard and hide every last tab, leaving an
+        // empty strip until an RPC failed (reagent P2 on PR #2818). A new
+        // close may only START while more than one tab is actually visible.
+        if (tabIds().length <= 1) return;
         if (pendingHiddenTabIds().has(tabId)) return; // close already pending
         if ((settingsAtom() as any)["tab:skipcloseconfirm"]) {
             handleClose(tabId);
@@ -235,7 +241,15 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 isActive={tabId === displayActiveTabId()}
                                 isFirst={i() === 0}
                                 isBeforeActive={i() === activeIndex() - 1}
-                                allTabCount={tabIds().length}
+                                // RAW count, not the filtered one: while a
+                                // close is pending the workspace still HAS
+                                // the hidden tab, and undercounting here
+                                // would flip droppable-tab's isLoneTabDrag/
+                                // canDrag on the survivor of a 2-tab
+                                // workspace, spuriously disabling its drag
+                                // until the RPC resolves (reagent P2 on
+                                // PR #2818).
+                                allTabCount={allTabIds().length}
                                 tabIndex={i()}
                                 tabIds={tabIds()}
                                 onSelect={() => handleSelect(tabId)}

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -197,14 +197,23 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     // In-strip reorder DnD + pane-drag-over-strip cleanup + Windows
     // tear-off-cursor workaround + wheel-scroll.
-    useTabDragAndDrop({ tabBarScrollRef: () => tabBarScrollRef }, () => props.workspace, tabIds, tearOffTabAtRelease);
+    //
+    // RAW list, not the filtered one: these hooks compute BACKEND indices
+    // (executeReorder's insertion math, tear-off merge/restore positions)
+    // against the workspace's real tab_ids, which still contains any
+    // optimistically-hidden mid-close tab until its RPC lands. Feeding
+    // them the filtered list shifts every computed index by the number of
+    // hidden tabs and silently misplaces a concurrently dragged tab
+    // (reagent P1 on PR #2818). The filtered tabIds() is for RENDERING
+    // only.
+    useTabDragAndDrop({ tabBarScrollRef: () => tabBarScrollRef }, () => props.workspace, allTabIds, tearOffTabAtRelease);
 
     // Phase 4/5 — cross-window tear-off event listeners (hover/merge/
-    // standalone/cancel-back).
+    // standalone/cancel-back). Raw list for the same reason as above.
     useTabTearOffEvents(
         () => props.workspace,
         () => tabBarScrollRef,
-        tabIds
+        allTabIds
     );
 
     if (!props.workspace) return null;
@@ -258,8 +267,16 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 // until the RPC resolves (reagent P2 on
                                 // PR #2818).
                                 allTabCount={allTabIds().length}
-                                tabIndex={i()}
-                                tabIds={tabIds()}
+                                // Backend-facing index/list (drag payload's
+                                // tabIndex feeds ReorderTab math): use the
+                                // RAW list so indices line up with the
+                                // workspace's real tab_ids even while a
+                                // mid-close tab is hidden from rendering
+                                // (reagent P1 on PR #2818). i() stays for
+                                // the visual props above (isFirst /
+                                // isBeforeActive / separators).
+                                tabIndex={allTabIds().indexOf(tabId)}
+                                tabIds={allTabIds()}
                                 onSelect={() => handleSelect(tabId)}
                                 onClose={() => requestClose(tabId)}
                             />

--- a/frontend/app/workspace/workspace.tsx
+++ b/frontend/app/workspace/workspace.tsx
@@ -8,7 +8,7 @@ import { StatusBar } from "@/app/statusbar/StatusBar";
 import { WindowHeader } from "@/app/window/window-header";
 import { TabContent } from "@/app/tab/tabcontent";
 import { atoms } from "@/store/global";
-import { tabSwitching } from "@/store/tab-reveal";
+import { gateTargetTabId, tabSwitching } from "@/store/tab-reveal";
 import { For, Show, createMemo } from "solid-js";
 import type { JSX } from "solid-js";
 
@@ -16,6 +16,19 @@ function WorkspaceElem(): JSX.Element {
     const tabId = atoms.activeTabId;
     const ws = atoms.workspace;
     const prefersReducedMotion = atoms.prefersReducedMotionAtom;
+
+    // Reveal gate, destination-aware (SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH §9):
+    // when the holder announced WHICH tab is being revealed
+    // (gateTargetTabId), only that tab hides while gated — the SOURCE tab
+    // keeps painting right up to the activetabid flip instead of blanking
+    // the whole content region for the RPC round trip. An untargeted hold
+    // (gateTargetTabId null — createTab) falls back to hiding whichever
+    // tab is active, the original behavior.
+    const gateHides = (tid: string) => {
+        if (tid !== tabId() || !tabSwitching()) return false;
+        const target = gateTargetTabId();
+        return target == null || target === tid;
+    };
 
     // All tab IDs (pinned + regular). Keep every tab mounted so terminals
     // preserve their xterm.js instance and scrollback across tab switches.
@@ -62,11 +75,10 @@ function WorkspaceElem(): JSX.Element {
                                         // on PR #1108.
                                         // Spec:
                                         // SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md.
-                                        visibility:
-                                            tid === tabId() && tabSwitching() ? "hidden" : null,
+                                        visibility: gateHides(tid) ? "hidden" : null,
                                         opacity: prefersReducedMotion()
                                             ? "1"
-                                            : tid === tabId() && tabSwitching() ? "0" : "1",
+                                            : gateHides(tid) ? "0" : "1",
                                         transition: prefersReducedMotion()
                                             ? "none"
                                             : "opacity 120ms ease-out",


### PR DESCRIPTION
## Summary
- The close flash survived all four ordering fixes in #2811 (click containment, single-RPC close, batched response application, WS parent-first ordering). Root problem: every fix in that PR tries to **win an ordering race** between the HTTP response, individual WS push frames, and Solid flush boundaries — any new transport/event arm can reopen the class.
- This PR flips to the repo owner's directed UX: **the tab leaves the strip the moment the close-confirm modal opens** (or immediately on the skip-confirm path); **cancel or RPC failure puts it back**. A hidden tab is unmounted, so no backend update ordering can ever paint it — the flash becomes structurally impossible rather than a race we keep winning.
- While the real active tab is mid-close, `displayActiveTabId()` highlights the neighbor the backend is about to promote (mirrors `handle_delete_tab`'s promotion), so the strip shows the final post-close state from the very first frame and the backend's update changes nothing visibly.
- Guards (`length <= 1`) deliberately stay on the raw list — a filtered guard would make a 2-tab workspace refuse every confirmed close.
- Full analysis in `docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §8, including why §§3-7 remain load-bearing for non-tab update paths.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 3164 passed / 1 failed: `tool-renderers/registry.test.ts` timeout, pre-existing flake (passes in isolation, also flagged in #2801, untouched by this diff)
- [ ] Manual (needs a dev build of THIS branch — note v0.55.25 does not contain #2811 either): ✕ on active tab → tab gone from strip instantly, neighbor highlighted, modal open → Cancel → tab returns in place. Confirm → strip doesn't change (already showed final state); content switches atomically under the reveal gate.

<!-- agentmux:agent_id=loap3 -->