### PR TITLE
Manoz@Area54: chore: release v0.55.26

### DIFF
--- a/.changesets/1787690334-fix-agent-suppress-activity-dock-refresh-during-backfill-bur-sew9.md
+++ b/.changesets/1787690334-fix-agent-suppress-activity-dock-refresh-during-backfill-bur-sew9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): suppress Activity Dock refresh during backfill bursts and reconcile registry-known background tasks into dock rows

--- a/.changesets/1787690356-feat-agent-pane-hover-to-peek-now-fires-on-every-transcript--zhb1.md
+++ b/.changesets/1787690356-feat-agent-pane-hover-to-peek-now-fires-on-every-transcript--zhb1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): hover-to-peek now fires on every transcript node kind, 50ms delay

--- a/.changesets/1787718976-feat-agentmux-mcp-discoverwindows-tool-pid-based-capturewind-k9ka.md
+++ b/.changesets/1787718976-feat-agentmux-mcp-discoverwindows-tool-pid-based-capturewind-k9ka.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agentmux-mcp): DiscoverWindows tool + pid-based CaptureWindow targeting

--- a/.changesets/1787721366-fix-agent-pane-real-dom-measurement-based-composer-strip-zon-y02y.md
+++ b/.changesets/1787721366-fix-agent-pane-real-dom-measurement-based-composer-strip-zon-y02y.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): real DOM-measurement-based composer strip zone balance

--- a/.changesets/1787746616-fix-agent-pane-row-based-composer-strip-layout-so-every-rend-r6jl.md
+++ b/.changesets/1787746616-fix-agent-pane-row-based-composer-strip-layout-so-every-rend-r6jl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): row-based composer strip layout so every rendered line has both a left and right occupant

--- a/.changesets/1787784285-fix-agent-pane-composer-strip-zoom-gap-unit-mismatch-and-sta-f254.md
+++ b/.changesets/1787784285-fix-agent-pane-composer-strip-zoom-gap-unit-mismatch-and-sta-f254.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): composer strip zoom/gap unit mismatch and stale shed-slot measurement on resize

--- a/.changesets/1787785987-fix-agent-pane-composer-strip-stuck-multi-row-stats-zone-wra-qyfs.md
+++ b/.changesets/1787785987-fix-agent-pane-composer-strip-stuck-multi-row-stats-zone-wra-qyfs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): composer strip stuck multi-row — stats zone wrapper measured instead of its content

--- a/.changesets/1787786849-fix-tab-eliminate-tab-close-flash-batch-multi-object-ws-upda-c877.md
+++ b/.changesets/1787786849-fix-tab-eliminate-tab-close-flash-batch-multi-object-ws-upda-c877.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tab): eliminate tab-close flash — batch multi-object WS updates into one frame, emit parent-before-child on deletes

--- a/.changesets/1787786919-feat-agent-pane-composer-strip-edge-priority-interactive-ele-amba.md
+++ b/.changesets/1787786919-feat-agent-pane-composer-strip-edge-priority-interactive-ele-amba.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): composer strip edge priority — interactive elements flush against row edges

--- a/.changesets/1787788835-feat-agent-pane-element-level-edge-priority-conservative-fit-89ac.md
+++ b/.changesets/1787788835-feat-agent-pane-element-level-edge-priority-conservative-fit-89ac.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): element-level edge priority + conservative fit rounding in composer strip

--- a/.changesets/1787791326-fix-agent-pane-composer-strip-stats-eviction-middle-tier-no--60mp.md
+++ b/.changesets/1787791326-fix-agent-pane-composer-strip-stats-eviction-middle-tier-no--60mp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): composer strip stats eviction middle tier — no more 1-to-3-line jump

--- a/.changesets/1787803504-fix-agent-pane-evicted-composer-strip-stats-float-above-the--q9b1.md
+++ b/.changesets/1787803504-fix-agent-pane-evicted-composer-strip-stats-float-above-the--q9b1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): evicted composer strip stats float above the rows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.25"
+version = "0.55.26"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.25"
+version = "0.55.26"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.25"
+version = "0.55.26"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.25"
+version = "0.55.26"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.25"
+version = "0.55.26"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.25"
+version = "0.55.26"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.25"
+version = "0.55.26"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,21 @@
 # AgentMux Version History
 
+## 0.55.26 — 2026-08-26
+
+- fix(agent): suppress Activity Dock refresh during backfill bursts and reconcile registry-known background tasks into dock rows
+- feat(agent-pane): hover-to-peek now fires on every transcript node kind, 50ms delay
+- feat(agentmux-mcp): DiscoverWindows tool + pid-based CaptureWindow targeting
+- fix(agent-pane): real DOM-measurement-based composer strip zone balance
+- fix(agent-pane): row-based composer strip layout so every rendered line has both a left and right occupant
+- fix(agent-pane): composer strip zoom/gap unit mismatch and stale shed-slot measurement on resize
+- fix(agent-pane): composer strip stuck multi-row — stats zone wrapper measured instead of its content
+- fix(tab): eliminate tab-close flash — batch multi-object WS updates into one frame, emit parent-before-child on deletes
+- feat(agent-pane): composer strip edge priority — interactive elements flush against row edges
+- feat(agent-pane): element-level edge priority + conservative fit rounding in composer strip
+- fix(agent-pane): composer strip stats eviction middle tier — no more 1-to-3-line jump
+- fix(agent-pane): evicted composer strip stats float above the rows
+
+
 ## 0.55.25 — 2026-08-25
 
 - feat(widgets): reorder default pinned widgets to Agent, Swarm, Armory, Sysinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.25",
+  "version": "0.55.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.25",
+      "version": "0.55.26",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.25",
+  "version": "0.55.26",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release PR consuming all 12 pending changesets (forced `--as patch` per user direction — the queued `feat` changesets ride along under the patch bump).

Highlights: the full composer-strip series from today (#2808/#2812/#2813/#2814/#2815/#2816/#2817/#2819 — row-based layout, edge priority, stats eviction tiers), tab-close flash fix (#2811), Activity Dock backfill fix (#2801), hover-to-peek (#2800), and the DiscoverWindows MCP tool (#2810).

All five version locations verified in agreement at 0.55.26 by `scripts/release.sh`.

<!-- agentmux:agent_id=manoz -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)