### PR TITLE
Manoz@Area54: chore(agent-pane): upgrade Claude Code CLI pin to 2.1.247, relabel Opus 5

### DIFF
--- a/.changesets/1787811411-chore-agent-pane-upgrade-claude-code-cli-pin-to-2-1-247-rela-syjq.md
+++ b/.changesets/1787811411-chore-agent-pane-upgrade-claude-code-cli-pin-to-2-1-247-rela-syjq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(agent-pane): upgrade Claude Code CLI pin to 2.1.247, relabel Opus 5

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -13,7 +13,7 @@ on:
         # frontend/app/view/agent/providers/pin-consistency.test.ts.
         description: 'Claude Code version to pin (empty = latest)'
         required: false
-        default: '2.1.198'
+        default: '2.1.247'
 
 env:
   REGISTRY: ghcr.io

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -201,7 +201,7 @@ fn detect_cli(name: &str) -> CliDetectionResult {
 // frontend/app/view/agent/providers/index.ts `pinnedVersion`, and
 // .github/workflows/container-image.yml `claude_version` default — enforced by
 // frontend/app/view/agent/providers/pin-consistency.test.ts.
-const CLAUDE_VERSION: &str = "2.1.198";
+const CLAUDE_VERSION: &str = "2.1.247";
 const CODEX_VERSION: &str = "0.116.0";
 const GEMINI_VERSION: &str = "0.32.1";
 

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -212,7 +212,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and
     // .github/workflows/container-image.yml `claude_version` default — enforced by
     // frontend/app/view/agent/providers/pin-consistency.test.ts.
-    pinned_version: "2.1.198",
+    pinned_version: "2.1.247",
     // Documented Claude Code behavior: redirects the CLI at a non-Anthropic
     // (or proxied) backend — Bedrock, Vertex, OpenRouter, a custom proxy.
     base_url_env_var: Some("ANTHROPIC_BASE_URL"),

--- a/docker/Dockerfile.agent-agentmux
+++ b/docker/Dockerfile.agent-agentmux
@@ -33,7 +33,7 @@ RUN usermod -l agent -d /home/agent -m node \
 
 # Claude Code — version pinned at build time for reproducible images.
 # Managed by rebuilding with a new CLAUDE_VERSION arg, not npm update.
-ARG CLAUDE_VERSION=2.1.198
+ARG CLAUDE_VERSION=2.1.247
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 
 # Prevent in-container auto-updates — version is managed at the image level.

--- a/docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md
+++ b/docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md
@@ -135,6 +135,32 @@ gates that check the artifact (a test assertion, in this case) catch drift
 that a human re-reading prose does not reliably catch, including when that
 human is specifically primed to look for it.
 
+**It happened a second and third time in the same review cycle.** Codex's
+independent review of the same PR found the *same fix* still hadn't gone far
+enough: the corrected paragraph now said `pin-consistency.test.ts` "enforces
+agreement across all six locations," but the test only checks the **five**
+locations that are actual matching version strings — the sixth row in the
+doc's own table is the model catalog `label`, explicitly marked in that same
+table as "not itself version-locked to the CLI pin." Self-reviewing to fix
+Codex's finding, the exact same miscount ("all six") turned up in `SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`
+itself — this document's own §3.2 proposed a bump script that would "edit
+all six pin locations via the same regex," which is not even mechanically
+possible, since the label isn't a version string a regex can match. Three
+edits to functionally the same claim, by the same author, across one review
+cycle, each one individually plausible and each one wrong in a slightly
+different way. Fixed all three; see both docs' current "five matching-string
+locations plus one curated label" framing.
+
+This is the strongest evidence this exercise produced for its own thesis.
+It's not that checklists are hard to get right once — it's that "get the
+count right in prose" is not a task that stays solved once you've solved it
+one time; every subsequent edit to the same claim is a fresh chance to
+re-introduce a slightly different version of the same imprecision, and nothing
+about having just fixed it once makes the next edit safer. The fix that
+actually holds is the one from §"What Went Well" and Tier 1 of the spec: a
+test that parses the real files and asserts a real count, which cannot drift
+no matter how many more times this paragraph gets edited by hand.
+
 ## What Would Help Next Time
 
 - See `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` for the full

--- a/docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md
+++ b/docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md
@@ -118,6 +118,23 @@ central finding this retro exists to hand off to `SPEC_DEPENDENCY_UPGRADE_PROCES
   point in favor of always updating the doc as part of the bump rather than
   treating it as optional paperwork.
 
+## Addendum: the review caught the retro repeating its own mistake
+
+ReAgent's review of the PR this retro describes (P2, non-blocking) found that
+step 6 above was incomplete: the Dockerfile `ARG` gap was closed in the
+*test*, but the prose paragraph in `docs/spec-claude-code-versioning.md` that
+had originally warned about the gap was left unedited — still stating, after
+the fix, that `pin-consistency.test.ts` "does not cover the Dockerfile ARG...
+double check it by hand." A doc describing behavior the code no longer had.
+Fixed in the same PR. This is worth recording rather than quietly amending
+away: it's a small-scale repeat of this retro's own central finding — a
+human (agent, here) editing prose under time pressure missed updating one of
+several places making the same claim, even while writing a document *about*
+that exact failure mode. It's further evidence for §"Root Cause": review
+gates that check the artifact (a test assertion, in this case) catch drift
+that a human re-reading prose does not reliably catch, including when that
+human is specifically primed to look for it.
+
 ## What Would Help Next Time
 
 - See `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` for the full

--- a/docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md
+++ b/docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md
@@ -1,0 +1,130 @@
+# Retro: First Claude CLI + Model-Catalog Upgrade Done as a Deliberate Exercise
+
+**Date:** 2026-08-27
+**Severity:** N/A — not an incident. This is the first time a Claude Code CLI /
+model-catalog bump was done as a scoped, retro'd exercise instead of an
+incidental side effect of other work; logged so the *next* one benefits from
+what this one found.
+**Observed by:** Manoz (Claude agent)
+**Related:** `docs/spec-claude-code-versioning.md` (the pre-existing pin
+checklist this exercise followed and corrected), `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`
+(the forward-looking process this retro's findings feed into),
+`frontend/app/view/agent/providers/pin-consistency.test.ts` (extended here),
+`docs/specs/SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02.md` (original
+pin-consistency-test proposal), PR TBD.
+
+---
+
+## TL;DR
+
+Bumped the pinned `@anthropic-ai/claude-code` CLI from `2.1.198` → `2.1.247`
+(verified against the real npm registry) and relabeled the `opus` model-family
+alias from "Opus 4.8" to "Opus 5" in the UI catalog. The mechanical part of
+the bump was uneventful. The valuable finding was procedural: **a written,
+human-maintained checklist (`docs/spec-claude-code-versioning.md`) had already
+drifted** — it named a source file (`providers/index.ts`) that had been split
+into `catalog.ts`/`types.ts`/`model-overlay.ts` weeks earlier, and it had
+correctly *documented* a known gap (the Dockerfile `ARG` isn't covered by the
+automated pin-consistency test) but that gap had sat undocumented-as-a-TODO
+for over a month without becoming a test. Both are now fixed, and the second
+one is now enforced, not just written down.
+
+---
+
+## What Happened
+
+1. User asked to add Opus 5 to the model-select panel and upgrade the bundled
+   Claude Code CLI, plus write a report and a forward-looking process spec —
+   explicitly framed as "the first time we've really done this, but it will
+   be the first of many."
+2. Research pass found the model catalog's real shape: `frontend/app/view/agent/providers/catalog.ts`,
+   a curated static fallback overlaid at runtime by a live `GET /v1/models`
+   fetch (`model-overlay.ts` + `agentmux-srv/src/backend/model_catalog.rs`).
+   `ProviderModel.value` is a stable family alias (`opus`/`sonnet`/`haiku`)
+   that the CLI's own `--model` resolution maps to a concrete snapshot; only
+   the curated `label` needs to track which snapshot that currently is — a
+   pattern the file's own doc comments already document clearly.
+3. Two decisions genuinely needed the user, not a guess: (a) relabel the
+   existing `opus` entry vs. add Opus 5 as a second, independently-selectable
+   entry, and (b) which concrete CLI version to pin, since the real npm
+   registry (checked via `WebFetch`) doesn't know about a fictional-future
+   "Opus 5" — asked both via `AskUserQuestion` rather than fabricating either.
+4. Made the code change: `catalog.ts` (pin + label), `agentmux-srv/src/backend/providers.rs`,
+   `agentmux-cef/src/commands/providers.rs`, `.github/workflows/container-image.yml`
+   — the four locations `pin-consistency.test.ts` already covered.
+5. **While updating `docs/spec-claude-code-versioning.md` to record the bump**
+   (not part of the original plan — the file was found only because it
+   showed up in a broader grep for stale "2.1.198" references), two gaps
+   surfaced that the automated test had never caught:
+   - The doc's own version-pin table pointed at `providers/index.ts`, a file
+     that hadn't held the pin directly since the catalog module was split.
+     Nobody had re-read the doc closely enough, on any prior bump, to notice.
+   - The doc's own text already said, in plain language, "it does **not**
+     cover the Dockerfile `ARG`, so that one location can still drift
+     silently; double check it by hand when bumping" — a known, named,
+     written-down gap that had persisted since the doc was created without
+     ever becoming a test assertion.
+6. Fixed both: bumped the actual Dockerfile `ARG CLAUDE_VERSION`, corrected
+   the doc's file reference, and — instead of just re-writing the checklist
+   text again — added a 6th assertion to `pin-consistency.test.ts` so a
+   future missed Dockerfile bump is a CI failure, not a doc that says "double
+   check it by hand" for another two months.
+7. Ran the full provider/catalog/context-window test suite (139 tests) and
+   `tsc --noEmit` — all green — before treating the code change as done.
+
+---
+
+## Root Cause (of the process gap, not a bug)
+
+**A checklist that lives only in prose has no enforcement mechanism of its
+own.** `docs/spec-claude-code-versioning.md` did everything a good runbook
+should: it named all the pin locations, it explained *why* the Dockerfile
+`ARG` existed as a separate case, and it even flagged its own blind spot in
+writing. None of that stopped the blind spot from persisting for over a
+month across at least one prior bump (`2.1.197` → `2.1.198`, per the doc's
+own version-history table) — because "double check it by hand" only works if
+every future bump is done by someone who (a) reads the doc closely and (b)
+remembers to actually do the manual check it asks for, every single time,
+forever. `pin-consistency.test.ts` already proved the better pattern for the
+other four locations — it turned "remember to check" into "CI fails if you
+don't" — but that pattern wasn't extended to the fifth location the doc had
+already identified as a gap. The gap was *known* the entire time; the fix
+was just never applied to itself.
+
+This generalizes past just the CLI pin: **any process that depends on a
+human re-reading a document accurately, under time pressure, once per
+upgrade, will eventually fail exactly the way this one did** — not
+catastrophically, just quietly, in a way that only surfaces the next time
+someone reads the doc closely enough to notice it's wrong. This is the
+central finding this retro exists to hand off to `SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`.
+
+---
+
+## What Went Well
+
+- The model catalog's existing design (alias `value` decoupled from a
+  curated `label`, explicitly documented as needing a manual re-check "on a
+  pin bump") made the Opus 5 relabel a one-line, low-risk change — the
+  original author of that comment correctly anticipated this exact task.
+- `pin-consistency.test.ts` caught zero regressions because there *were*
+  none in the four locations it already covered — it did its job silently,
+  which is the point.
+- Asking the two genuinely-user-owned questions (relabel-vs-dual-entry,
+  exact CLI version) up front, instead of guessing on version-critical files
+  the repo's own review gate scrutinizes closely, avoided a wasted round
+  trip.
+- The gap that WAS found came from following the existing written checklist
+  closely enough to update it accurately, not from a separate audit — a
+  point in favor of always updating the doc as part of the bump rather than
+  treating it as optional paperwork.
+
+## What Would Help Next Time
+
+- See `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` for the full
+  proposal. Headline items: prefer a single script/test over a
+  human-maintained checklist wherever the check can be mechanized (this
+  retro's own Dockerfile fix is the template); track a per-model-alias
+  "verified against pinned CLI as of version X" marker so a label going
+  stale is at least detectable, not just a comment asking someone to
+  remember; and treat "the doc says there's a known gap" as a tracked
+  follow-up item with an owner, not permanent prose.

--- a/docs/spec-claude-code-versioning.md
+++ b/docs/spec-claude-code-versioning.md
@@ -11,7 +11,7 @@ installing whatever `@anthropic-ai/claude-code@latest` resolved to at image buil
 time. This meant two builds triggered minutes apart could embed different Claude Code
 versions, breaking reproducibility and making regressions harder to bisect.
 
-## Version pins (six locations)
+## Version pins (five matching-string locations, plus one curated label — six sync points total)
 
 | File | Location | Purpose |
 |------|----------|---------|
@@ -27,14 +27,23 @@ The CI workflow's "Resolve Claude Code version" step (`id: claude_ver`) has a sp
 - Input empty or `"latest"` → resolve via `npm view @anthropic-ai/claude-code version` at build time
 
 `frontend/app/view/agent/providers/pin-consistency.test.ts` enforces agreement
-across **all six** locations, including the Dockerfile `ARG` — added
-2026-08-27, closing a gap this doc itself had warned about (in this same
-paragraph) for over a month without it becoming a test. All six must still be
-updated together; the test only catches a *mismatch*, not a location someone
-forgot to touch at all. (That drift-in-a-warning — plus this doc having
-separately drifted on the frontend file path — is exactly the kind of thing
-`SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` generalizes a fix for: prefer
-a durable check over a doc a human has to remember to re-read accurately.)
+across the **five matching-version-string** locations (the first five rows
+above), including the Dockerfile `ARG` — added 2026-08-27, closing a gap this
+doc itself had warned about (in this same paragraph) for over a month without
+it becoming a test. It does **not**, and structurally cannot, check the sixth
+row (the model `label`) — that's not a version string to compare, it's a
+semantic claim about upstream state; see `SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`
+§3.3 for the open question of whether/how to make that check less manual too.
+All five version pins must still be updated together, and the test only
+catches a *mismatch* — not a location someone forgot to touch at all. (That
+drift-in-a-warning — plus this doc having separately drifted on the frontend
+file path, plus this exact paragraph ALSO originally mis-stated "all six" as
+if the label were part of the same check when it was first corrected — is
+exactly the kind of thing `SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`
+generalizes a fix for: prefer a durable check over a doc a human has to
+remember to re-read accurately, since even three successive edits to this
+same paragraph, by the same author, in the same review cycle, kept
+introducing a version of the same imprecision.)
 
 ## How to bump
 
@@ -47,8 +56,9 @@ a durable check over a doc a human has to remember to re-read accurately.)
 7. Also in `catalog.ts`: re-check each model alias's curated `label`/`description` still
    matches what the pinned CLI currently resolves that alias to (e.g. `opus` → "Opus 5")
    — a label can go stale even when the alias `value` itself never changes.
-8. Run `pin-consistency.test.ts` to confirm all six agree (includes the Dockerfile
-   `ARG` as of 2026-08-27).
+8. Run `pin-consistency.test.ts` to confirm the five version pins agree
+   (includes the Dockerfile `ARG` as of 2026-08-27; does not check the label
+   from step 7 — that one's on you).
 9. Open a PR and merge it.
 10. To publish the image, either:
     - **Push a `v*` git tag** (e.g. `git tag v0.50.0 && git push origin v0.50.0`) — this triggers the workflow automatically and publishes both the semver tag and `:latest`.
@@ -60,7 +70,7 @@ a durable check over a doc a human has to remember to re-read accurately.)
 |---------|------|-------|
 | `2.1.197` | 2026-06-30 | First explicit pin; replaced floating `latest` default |
 | `2.1.198` | 2026-07-02 | Bump; initially missed the cef host installer and workflow default (see `pin-consistency.test.ts` history note) |
-| `2.1.247` | 2026-08-27 | Bump (verified via `npm view @anthropic-ai/claude-code version` against the real registry); paired with relabeling the `opus` alias from "Opus 4.8" to "Opus 5" in the UI catalog. First bump done against a written checklist (this doc) rather than tribal knowledge — found this doc's own frontend file path had drifted (`index.ts` → `catalog.ts`) and that the Dockerfile `ARG` (a 6th pin location) wasn't covered by `pin-consistency.test.ts`; both corrected here, and the test extended to cover the Dockerfile going forward (this doc's own prose warning about that gap was initially left in place after the fix and had to be corrected in review — see the retro). Full retro: `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`. Forward-looking process: `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`. |
+| `2.1.247` | 2026-08-27 | Bump (verified via `npm view @anthropic-ai/claude-code version` against the real registry); paired with relabeling the `opus` alias from "Opus 4.8" to "Opus 5" in the UI catalog. First bump done against a written checklist (this doc) rather than tribal knowledge — found this doc's own frontend file path had drifted (`index.ts` → `catalog.ts`) and that the Dockerfile `ARG` (the 5th matching-version-string pin, distinct from the model label's separate, non-string check below) wasn't covered by `pin-consistency.test.ts`; both corrected here, and the test extended to cover the Dockerfile going forward. This paragraph and the "all N locations" prose above it took three separate review-flagged edits in this same cycle to get precise — see the retro's addendum for the honest accounting. Full retro: `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`. Forward-looking process: `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`. |
 
 ## Escape hatch
 

--- a/docs/spec-claude-code-versioning.md
+++ b/docs/spec-claude-code-versioning.md
@@ -1,7 +1,7 @@
 # Spec: Claude Code Version Management
 
 **Status:** Active  
-**Current pinned version:** `2.1.198`  
+**Current pinned version:** `2.1.247`  
 **Previous default:** `latest` (floating)
 
 ## Problem
@@ -11,15 +11,16 @@ installing whatever `@anthropic-ai/claude-code@latest` resolved to at image buil
 time. This meant two builds triggered minutes apart could embed different Claude Code
 versions, breaking reproducibility and making regressions harder to bisect.
 
-## Version pins (five locations)
+## Version pins (six locations)
 
 | File | Location | Purpose |
 |------|----------|---------|
-| `docker/Dockerfile.agent-agentmux` line 36 | `ARG CLAUDE_VERSION=2.1.198` | Fallback for local `docker build` without passing the arg |
-| `.github/workflows/container-image.yml` line 16 | `default: '2.1.198'` | Default used when CI is triggered via `workflow_dispatch` without an explicit version input |
-| `agentmux-srv/src/backend/providers.rs` | `pinned_version: "2.1.198"` (CLAUDE static) | Version the backend sidecar installs |
-| `agentmux-cef/src/commands/providers.rs` | `const CLAUDE_VERSION: &str = "2.1.198"` | Version the host installer installs |
-| `frontend/app/view/agent/providers/index.ts` | `pinnedVersion: "2.1.198"` (PROVIDERS.claude) | Version surfaced in the UI |
+| `docker/Dockerfile.agent-agentmux` line 36 | `ARG CLAUDE_VERSION=2.1.247` | Fallback for local `docker build` without passing the arg |
+| `.github/workflows/container-image.yml` line 16 | `default: '2.1.247'` | Default used when CI is triggered via `workflow_dispatch` without an explicit version input |
+| `agentmux-srv/src/backend/providers.rs` | `pinned_version: "2.1.247"` (CLAUDE static) | Version the backend sidecar installs |
+| `agentmux-cef/src/commands/providers.rs` | `const CLAUDE_VERSION: &str = "2.1.247"` | Version the host installer installs |
+| `frontend/app/view/agent/providers/catalog.ts` (re-exported via `./index`) | `pinnedVersion: "2.1.247"` (PROVIDERS.claude) | Version surfaced in the UI. Corrected 2026-08-27 — this file used to be a single `providers/index.ts`, split into `types.ts`/`catalog.ts`/`model-overlay.ts` for readability; the pin moved with it but this doc wasn't updated at the time. |
+| `frontend/app/view/agent/providers/catalog.ts` (same object) | `models: [{ value: "opus", label: "Opus 5", ... }]` | The curated UI label for the `opus` family alias — **not itself version-locked to the CLI pin**, but should be re-checked on every pin bump per the field's own doc comment ("kept in sync on a pin bump"): whichever concrete snapshot Anthropic's API currently resolves `--model opus` to. |
 
 The CI workflow's "Resolve Claude Code version" step (`id: claude_ver`) has a special case:
 - Input non-empty and not `"latest"` → use the input value verbatim (shell injection safe via `env:`)
@@ -28,7 +29,11 @@ The CI workflow's "Resolve Claude Code version" step (`id: claude_ver`) has a sp
 `frontend/app/view/agent/providers/pin-consistency.test.ts` enforces agreement across
 the last three (frontend, srv, cef) plus the workflow default — it does **not**
 cover the Dockerfile `ARG`, so that one location can still drift silently; double
-check it by hand when bumping. All five must be updated together.
+check it by hand when bumping. All six must be updated together. (This gap —
+plus this doc itself having drifted on the frontend file path — is exactly the
+kind of thing `SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` generalizes a fix
+for: a durable checklist/script instead of a doc a human has to remember to
+re-read accurately.)
 
 ## How to bump
 
@@ -37,12 +42,16 @@ check it by hand when bumping. All five must be updated together.
 3. In `.github/workflows/container-image.yml`: update `default: '<new>'`
 4. In `agentmux-srv/src/backend/providers.rs`: update the CLAUDE static's `pinned_version`
 5. In `agentmux-cef/src/commands/providers.rs`: update `CLAUDE_VERSION`
-6. In `frontend/app/view/agent/providers/index.ts`: update `PROVIDERS.claude.pinnedVersion`
-7. Run `pin-consistency.test.ts` to confirm 2-6 agree (it won't catch the Dockerfile).
-8. Open a PR and merge it.
-9. To publish the image, either:
-   - **Push a `v*` git tag** (e.g. `git tag v0.50.0 && git push origin v0.50.0`) — this triggers the workflow automatically and publishes both the semver tag and `:latest`.
-   - **Manually dispatch** the `Container Agent Image` workflow — this builds and pushes a `dispatch-<sha>` tag only; `:latest` is *not* updated by a manual dispatch.
+6. In `frontend/app/view/agent/providers/catalog.ts`: update `PROVIDERS.claude.pinnedVersion`
+7. Also in `catalog.ts`: re-check each model alias's curated `label`/`description` still
+   matches what the pinned CLI currently resolves that alias to (e.g. `opus` → "Opus 5")
+   — a label can go stale even when the alias `value` itself never changes.
+8. Run `pin-consistency.test.ts` to confirm 2-6 agree (it won't catch the Dockerfile —
+   diff it by hand).
+9. Open a PR and merge it.
+10. To publish the image, either:
+    - **Push a `v*` git tag** (e.g. `git tag v0.50.0 && git push origin v0.50.0`) — this triggers the workflow automatically and publishes both the semver tag and `:latest`.
+    - **Manually dispatch** the `Container Agent Image` workflow — this builds and pushes a `dispatch-<sha>` tag only; `:latest` is *not* updated by a manual dispatch.
 
 ## Version history
 
@@ -50,6 +59,7 @@ check it by hand when bumping. All five must be updated together.
 |---------|------|-------|
 | `2.1.197` | 2026-06-30 | First explicit pin; replaced floating `latest` default |
 | `2.1.198` | 2026-07-02 | Bump; initially missed the cef host installer and workflow default (see `pin-consistency.test.ts` history note) |
+| `2.1.247` | 2026-08-27 | Bump (verified via `npm view @anthropic-ai/claude-code version` against the real registry); paired with relabeling the `opus` alias from "Opus 4.8" to "Opus 5" in the UI catalog. First bump done against a written checklist (this doc) rather than tribal knowledge — found this doc's own frontend file path had drifted (`index.ts` → `catalog.ts`) and that the Dockerfile `ARG` (a 6th pin location) isn't covered by `pin-consistency.test.ts`; both corrected here. Full retro: `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`. Forward-looking process: `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`. |
 
 ## Escape hatch
 

--- a/docs/spec-claude-code-versioning.md
+++ b/docs/spec-claude-code-versioning.md
@@ -26,14 +26,15 @@ The CI workflow's "Resolve Claude Code version" step (`id: claude_ver`) has a sp
 - Input non-empty and not `"latest"` → use the input value verbatim (shell injection safe via `env:`)
 - Input empty or `"latest"` → resolve via `npm view @anthropic-ai/claude-code version` at build time
 
-`frontend/app/view/agent/providers/pin-consistency.test.ts` enforces agreement across
-the last three (frontend, srv, cef) plus the workflow default — it does **not**
-cover the Dockerfile `ARG`, so that one location can still drift silently; double
-check it by hand when bumping. All six must be updated together. (This gap —
-plus this doc itself having drifted on the frontend file path — is exactly the
-kind of thing `SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` generalizes a fix
-for: a durable checklist/script instead of a doc a human has to remember to
-re-read accurately.)
+`frontend/app/view/agent/providers/pin-consistency.test.ts` enforces agreement
+across **all six** locations, including the Dockerfile `ARG` — added
+2026-08-27, closing a gap this doc itself had warned about (in this same
+paragraph) for over a month without it becoming a test. All six must still be
+updated together; the test only catches a *mismatch*, not a location someone
+forgot to touch at all. (That drift-in-a-warning — plus this doc having
+separately drifted on the frontend file path — is exactly the kind of thing
+`SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` generalizes a fix for: prefer
+a durable check over a doc a human has to remember to re-read accurately.)
 
 ## How to bump
 
@@ -46,8 +47,8 @@ re-read accurately.)
 7. Also in `catalog.ts`: re-check each model alias's curated `label`/`description` still
    matches what the pinned CLI currently resolves that alias to (e.g. `opus` → "Opus 5")
    — a label can go stale even when the alias `value` itself never changes.
-8. Run `pin-consistency.test.ts` to confirm 2-6 agree (it won't catch the Dockerfile —
-   diff it by hand).
+8. Run `pin-consistency.test.ts` to confirm all six agree (includes the Dockerfile
+   `ARG` as of 2026-08-27).
 9. Open a PR and merge it.
 10. To publish the image, either:
     - **Push a `v*` git tag** (e.g. `git tag v0.50.0 && git push origin v0.50.0`) — this triggers the workflow automatically and publishes both the semver tag and `:latest`.
@@ -59,7 +60,7 @@ re-read accurately.)
 |---------|------|-------|
 | `2.1.197` | 2026-06-30 | First explicit pin; replaced floating `latest` default |
 | `2.1.198` | 2026-07-02 | Bump; initially missed the cef host installer and workflow default (see `pin-consistency.test.ts` history note) |
-| `2.1.247` | 2026-08-27 | Bump (verified via `npm view @anthropic-ai/claude-code version` against the real registry); paired with relabeling the `opus` alias from "Opus 4.8" to "Opus 5" in the UI catalog. First bump done against a written checklist (this doc) rather than tribal knowledge — found this doc's own frontend file path had drifted (`index.ts` → `catalog.ts`) and that the Dockerfile `ARG` (a 6th pin location) isn't covered by `pin-consistency.test.ts`; both corrected here. Full retro: `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`. Forward-looking process: `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`. |
+| `2.1.247` | 2026-08-27 | Bump (verified via `npm view @anthropic-ai/claude-code version` against the real registry); paired with relabeling the `opus` alias from "Opus 4.8" to "Opus 5" in the UI catalog. First bump done against a written checklist (this doc) rather than tribal knowledge — found this doc's own frontend file path had drifted (`index.ts` → `catalog.ts`) and that the Dockerfile `ARG` (a 6th pin location) wasn't covered by `pin-consistency.test.ts`; both corrected here, and the test extended to cover the Dockerfile going forward (this doc's own prose warning about that gap was initially left in place after the fix and had to be corrected in review — see the retro). Full retro: `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`. Forward-looking process: `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md`. |
 
 ## Escape hatch
 

--- a/docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md
+++ b/docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md
@@ -1,0 +1,241 @@
+# SPEC — A repeatable process for Claude model catalog + CLI version upgrades
+
+**Date:** 2026-08-27
+**Type:** Process spec (not primarily a code-change spec — most action items are checks/automation, small in scope individually)
+**Status:** Proposed — item 1 (Dockerfile pin-consistency check) already implemented as part of the exercise that prompted this doc; the rest is unimplemented and intentionally incremental.
+**Owner:** unassigned
+**Scope:** `frontend/app/view/agent/providers/catalog.ts` (model catalog), the six Claude CLI version pin locations documented in `docs/spec-claude-code-versioning.md`, and — by extension, since the mechanism generalizes — any other provider's pinned CLI (`codex`, `gemini`, etc.).
+**Related:** `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md` (the concrete exercise this generalizes from), `docs/spec-claude-code-versioning.md` (the existing, narrower CLI-pin checklist this spec builds on top of, not replaces), `docs/specs/SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md` (the live API-catalog-overlay design), `docs/specs/SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02.md` (original pin-consistency-test proposal), `frontend/app/view/agent/providers/pin-consistency.test.ts`.
+
+> This is explicitly framed as the **first** of a recurring exercise (model
+> releases and Claude Code CLI releases will keep happening), not a one-off.
+> The goal is a process that gets *cheaper and safer* each time it's used —
+> not a document that has to be perfectly remembered each time.
+
+---
+
+## 1. Problem
+
+AgentMux pins two independent things per provider, and both need periodic
+bumping as upstream ships:
+
+1. **The CLI version** (`@anthropic-ai/claude-code@X.Y.Z`) — six source
+   locations that must literally match (see `docs/spec-claude-code-versioning.md`).
+2. **The model catalog** — a curated fallback list (`catalog.ts`) whose
+   `label`/`description` fields describe what a stable alias (`opus`,
+   `sonnet`, `haiku`) currently resolves to, live-overlaid at runtime by an
+   API fetch (`SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md`) that can silently
+   fail closed (missing keychain entry, 401, offline) back to that curated
+   fallback.
+
+Today's exercise (`retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`) found
+that the existing process — a well-written, human-maintained checklist doc —
+had already drifted on two points: a stale file-path reference, and a
+**known, explicitly self-documented gap** (the Dockerfile `ARG` wasn't
+covered by the automated pin-consistency test) that had sat unfixed for over
+a month despite being written down in plain English. Neither drift was
+malicious or even surprising — it's what happens to any checklist that
+depends on a human reading it closely, under time pressure, once per
+upgrade, indefinitely. That failure mode, not any single missed file, is
+what this spec is actually about.
+
+---
+
+## 2. Research: how the industry approaches this
+
+Three distinct bodies of practice are relevant here, since AgentMux's
+situation straddles two categories at once — a **pinned CLI dependency**
+(ordinary software supply-chain problem) and a **model catalog that tracks
+an upstream provider's own model lifecycle** (an AI-specific problem with its
+own emerging conventions).
+
+### 2.1 Dependency/CLI pin upgrades (general software practice)
+
+- **Update small and often, not big and rare.** Frequent bumps have small,
+  fast-to-read changelogs; infrequent bumps accumulate risk into one large,
+  hard-to-review jump.
+- **Automate the mechanical part; keep a human gate for judgment.** The
+  Renovate project's own upgrade-best-practices guidance (the most widely
+  used automated-dependency-PR tool) recommends grouping by risk tier
+  (security-critical alone; routine minor/patch batched), a minimum release
+  age before auto-merge (their example: two weeks, to let upstream issues
+  surface before you adopt them), and always running the full test suite on
+  every update PR rather than trusting the diff by eye.
+  ([Renovate: Upgrade Best Practices](https://docs.renovatebot.com/upgrade-best-practices/))
+- **A central dashboard beats notification spam.** Track pending/available
+  updates in one visible place (a tracking issue, a dashboard) rather than
+  relying on someone remembering to periodically check `npm view`.
+- **Pin where reproducibility matters, prune pins that don't earn their
+  keep.** Google Cloud's dependency-management guidance frames this as a
+  cost/benefit call per dependency — CI/CD and anything shipped to users
+  should pin; low-stakes local dev tooling often shouldn't, since over-pinning
+  blocks timely security patches.
+  ([Google Cloud: Best practices for dependency management](https://cloud.google.com/blog/topics/developers-practitioners/best-practices-dependency-management))
+
+### 2.2 Safe rollout of AI model version changes specifically
+
+- **Canary/staged rollout, not instant cutover.** The standard pattern:
+  route a small percentage of traffic to the new model version, watch
+  latency (p50/p95/p99), error/refusal rate, cost per request, and
+  user-feedback signals (regenerations, thumbs-down, session abandonment);
+  widen the percentage only if metrics stay within threshold; auto-rollback
+  on any metric breach — ideally before a human notices.
+  ([MLflow: Canary Deployment for AI Models](https://mlflow.org/articles/what-is-canary-deployment-ai), [apxml: Safe Deployment and Rollout Strategies](https://apxml.com/courses/llm-alignment-safety/chapter-7-building-safer-llm-systems/safe-deployment-rollout-strategies))
+- **The hard part is defining "worse," not routing traffic.** Multiple
+  sources converge on this: the mechanics of a canary are well-understood;
+  the actual difficulty is picking metrics that reliably capture a model
+  regression under real production load.
+- **AgentMux's own architecture already has a usable canary primitive.**
+  Per-build channel isolation (`local-<branch>-<hash>-<build-id>`, see
+  `CLAUDE.md`'s Multiple Instances section) means a version bump can already
+  be built and run as its own fully isolated instance — data dir, cef-cache,
+  auth — alongside the currently-shipping build, with zero risk of
+  cross-contamination. This is most of a canary environment already built
+  for an unrelated reason (multi-instance dev support); it just isn't
+  currently *used* as a pre-merge verification step for pin bumps
+  specifically (see §3.3).
+
+### 2.3 Model alias / version lifecycle (Anthropic's own conventions)
+
+Directly relevant since AgentMux's `opus`/`sonnet`/`haiku` catalog values
+mirror this exact design one layer up:
+
+- **Aliases resolve to dated snapshots; snapshots never change underfoot.**
+  Anthropic does not silently update the weights behind an existing model
+  ID — a new capability ships under a *new* ID, and an alias like
+  `claude-sonnet-4-5` is a pointer Anthropic moves forward, not a live
+  target that mutates in place.
+  ([Claude Platform Docs: Model IDs and versioning](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions))
+- **A four-stage lifecycle with a committed notice period.** Active →
+  Legacy (no more updates, may be deprecated) → Deprecated (still works,
+  has an assigned retirement date and recommended replacement) → Retired
+  (no longer available), with **at least 60 days' notice** before a public
+  model is retired.
+  ([Claude Platform Docs: Model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations))
+- **Later model generations move from floating aliases toward fixed,
+  dateless canonical IDs** — i.e. the industry direction is fewer silently-
+  moving targets over time, not more. AgentMux's catalog comment already
+  anticipates this exact transition ("when a family ever has TWO live
+  versions, switch those entries to concrete `--model` IDs").
+
+**Takeaway for AgentMux:** the catalog's `label` field is functionally
+tracking Anthropic's own alias-resolution state, but AgentMux has no
+equivalent of Anthropic's own "Active/Legacy/Deprecated" staleness signal —
+today, a label is either correct or silently wrong, with the only detection
+mechanism being a human noticing during an unrelated task (exactly what
+happened here).
+
+---
+
+## 3. Proposed process
+
+Three tiers, ordered by how much of today's exercise they would have caught
+automatically. **Tier 1 is implemented as part of this spec's own exercise;
+Tiers 2–3 are proposed, not yet built** — deliberately incremental, per
+§2.1's "small and often" principle, rather than one large tooling project.
+
+### 3.1 Tier 1 — Close known gaps by turning prose into assertions (done today)
+
+Every time a hand-maintained checklist doc says "X isn't automatically
+checked, verify by hand" — as `docs/spec-claude-code-versioning.md` already
+did for the Dockerfile `ARG` — that sentence is itself the spec for a missing
+test. `pin-consistency.test.ts` now has 6 assertions instead of 5, covering
+that exact gap. **Standing rule going forward: a checklist doc is allowed to
+say "not yet automated," but that sentence should link a tracked follow-up,
+not just persist as permanent prose.** A checklist gap that's been known for
+over a month (as this one was) is a process failure regardless of whether it
+was ever actually hit.
+
+### 3.2 Tier 2 — A single bump script (proposed, not built)
+
+Replace `docs/spec-claude-code-versioning.md`'s "How to bump" numbered list
+(6 manual file edits + 2 manual verification steps) with one script,
+`scripts/bump-provider-cli.sh <provider> <version>`, that:
+
+1. Looks up the real latest version via `npm view @anthropic-ai/<pkg> version`
+   when no version is given (matches §2.1's "verify against the real
+   registry" practice this exercise followed by hand).
+2. Edits all six pin locations via the same regex `pin-consistency.test.ts`
+   already parses (so the script and its own test share one definition of
+   "where the pins live" — the test would then be validating the script's
+   output shape, not a second, independently-hand-maintained pattern).
+3. Runs `pin-consistency.test.ts` immediately and fails loudly on mismatch,
+   the same way `scripts/release.sh` already re-reads all five version
+   locations after a release bump and fails loudly on disagreement
+   (`CLAUDE.md`'s "Release consistency invariant" — same pattern, same
+   author intent, not yet applied here).
+4. Prints a reminder — not yet an enforced check, see §3.3's open question —
+   to re-verify each model alias's curated `label` against what the new
+   pinned version actually resolves that alias to.
+
+This directly answers the user's "streamlined process" ask: today's bump was
+6 file edits done by hand across two tool calls plus a doc read; a script
+makes it one command with a built-in correctness check.
+
+### 3.3 Tier 3 — Staleness signal for catalog labels (proposed, open question)
+
+Unlike the CLI version pins (which are exact strings that either match or
+don't — a mechanical check), a model catalog `label` like `"Opus 5"` is a
+*claim about upstream state* that can go stale independent of any AgentMux
+code change at all — Anthropic could ship a new snapshot under the `opus`
+alias with zero AgentMux involvement. Two options, not yet decided between:
+
+- **(a) Lean entirely on the existing live-overlay mechanism**
+  (`SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md`) — the API-fetched catalog
+  already corrects a stale label at runtime whenever the fetch succeeds; the
+  curated fallback only matters when it's offline/unauthenticated. Under
+  this view, the curated `label` is best-effort presentation for a
+  degraded-mode fallback, not a correctness-critical value, and no further
+  automation is warranted — just keep re-checking it by hand on each CLI
+  pin bump (today's process, made slightly more visible by the Tier 2
+  script's reminder).
+- **(b) Add a lightweight "last verified" marker per model entry** (e.g. a
+  comment or a structured field noting the pinned CLI version a label was
+  last confirmed against), so a future pin bump can mechanically flag "this
+  label hasn't been re-verified since 3 CLI versions ago" instead of relying
+  on a human to think to check. Mirrors Anthropic's own Active/Legacy
+  distinction (§2.3) one layer up, at the cost of a small amount of catalog
+  schema growth.
+
+**Recommendation:** start with (a) — it's zero-cost and the existing
+degraded-mode framing is sound — and revisit (b) only if a stale-label bug
+actually ships to a user (i.e. don't build the staleness-tracking machinery
+speculatively; this spec's own §2.1 citation warns against exactly that kind
+of premature process weight).
+
+---
+
+## 4. Non-goals
+
+- **Full canary/A/B infrastructure for model rollouts** (§2.2's traffic-
+  percentage/auto-rollback pattern) is not being proposed for AgentMux as
+  built today. AgentMux ships a desktop app to individual users, not a
+  multi-tenant inference service — there's no shared traffic to split. The
+  closer analogue already exists (per-build channel isolation, §2.2) and is
+  already available as a manual verification step (build a portable, smoke-
+  test it) — formalizing that into an automated gate is a larger, separate
+  effort out of scope here.
+- **This spec does not change how the LIVE model-catalog API overlay works**
+  (`SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md` is unaffected) — only the
+  curated fallback and the CLI pin process around it.
+- **Not proposing Renovate/Dependabot-style full automation** of the CLI
+  version bump itself (auto-opening a PR on every upstream release) — §2.1's
+  own guidance to prefer deliberate, reviewed bumps over reflexive
+  auto-updates applies especially strongly here, since a CLI pin bump can
+  change agent behavior mid-session for every AgentMux user, not just swap
+  a build-time dependency.
+
+---
+
+## 5. Progress tracking
+
+| Item | Status | Notes |
+|---|---|---|
+| 1. Bump Claude CLI pin `2.1.198` → `2.1.247` (all 6 locations) | ✅ Done | Verified against the real npm registry via `WebFetch`; see the retro. |
+| 2. Relabel `opus` catalog entry "Opus 4.8" → "Opus 5" | ✅ Done | Per user direction (relabel, not a dual entry) — `catalog.ts`. |
+| 3. Fix stale file-path reference in `docs/spec-claude-code-versioning.md` | ✅ Done | `providers/index.ts` → `providers/catalog.ts`. |
+| 4. Extend `pin-consistency.test.ts` to cover the Dockerfile `ARG` (Tier 1) | ✅ Done | 6th assertion; closes the gap the doc had named but never enforced. |
+| 5. Retro this exercise | ✅ Done | `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`. |
+| 6. This spec | ✅ Done | |
+| 7. `scripts/bump-provider-cli.sh` (Tier 2) | ⬜ Not started | Proposed in §3.2; deliberately deferred past this exercise per "small and often." |
+| 8. Catalog-label staleness signal (Tier 3) | ⬜ Open question | §3.3 — recommend deferring until/unless a real stale-label bug ships. |

--- a/docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md
+++ b/docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md
@@ -4,7 +4,7 @@
 **Type:** Process spec (not primarily a code-change spec — most action items are checks/automation, small in scope individually)
 **Status:** Proposed — item 1 (Dockerfile pin-consistency check) already implemented as part of the exercise that prompted this doc; the rest is unimplemented and intentionally incremental.
 **Owner:** unassigned
-**Scope:** `frontend/app/view/agent/providers/catalog.ts` (model catalog), the six Claude CLI version pin locations documented in `docs/spec-claude-code-versioning.md`, and — by extension, since the mechanism generalizes — any other provider's pinned CLI (`codex`, `gemini`, etc.).
+**Scope:** `frontend/app/view/agent/providers/catalog.ts` (model catalog), the five Claude CLI version pin locations documented in `docs/spec-claude-code-versioning.md` (a matching semver string, mechanically checkable), plus that same file's curated model-alias `label` (a semantic claim about upstream state, not a version string — see §1's distinction), and — by extension, since the mechanism generalizes — any other provider's pinned CLI (`codex`, `gemini`, etc.).
 **Related:** `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md` (the concrete exercise this generalizes from), `docs/spec-claude-code-versioning.md` (the existing, narrower CLI-pin checklist this spec builds on top of, not replaces), `docs/specs/SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md` (the live API-catalog-overlay design), `docs/specs/SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02.md` (original pin-consistency-test proposal), `frontend/app/view/agent/providers/pin-consistency.test.ts`.
 
 > This is explicitly framed as the **first** of a recurring exercise (model
@@ -19,14 +19,18 @@
 AgentMux pins two independent things per provider, and both need periodic
 bumping as upstream ships:
 
-1. **The CLI version** (`@anthropic-ai/claude-code@X.Y.Z`) — six source
-   locations that must literally match (see `docs/spec-claude-code-versioning.md`).
+1. **The CLI version** (`@anthropic-ai/claude-code@X.Y.Z`) — five source
+   locations that must literally match, one matching semver string each
+   (see `docs/spec-claude-code-versioning.md`), mechanically enforced by
+   `pin-consistency.test.ts`.
 2. **The model catalog** — a curated fallback list (`catalog.ts`) whose
    `label`/`description` fields describe what a stable alias (`opus`,
    `sonnet`, `haiku`) currently resolves to, live-overlaid at runtime by an
    API fetch (`SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md`) that can silently
    fail closed (missing keychain entry, 401, offline) back to that curated
-   fallback.
+   fallback. Unlike #1, a label is **not** a version string to be
+   string-matched — it's a semantic claim about what Anthropic's API
+   currently resolves an alias to, which no regex can verify (§3.3).
 
 Today's exercise (`retro-claude-cli-and-opus-5-upgrade-2026-08-27.md`) found
 that the existing process — a well-written, human-maintained checklist doc —
@@ -149,16 +153,19 @@ was ever actually hit.
 ### 3.2 Tier 2 — A single bump script (proposed, not built)
 
 Replace `docs/spec-claude-code-versioning.md`'s "How to bump" numbered list
-(6 manual file edits + 2 manual verification steps) with one script,
+(5 version-pin file edits, a separate model-label recheck, and 2 manual
+verification steps) with one script,
 `scripts/bump-provider-cli.sh <provider> <version>`, that:
 
 1. Looks up the real latest version via `npm view @anthropic-ai/<pkg> version`
    when no version is given (matches §2.1's "verify against the real
    registry" practice this exercise followed by hand).
-2. Edits all six pin locations via the same regex `pin-consistency.test.ts`
-   already parses (so the script and its own test share one definition of
-   "where the pins live" — the test would then be validating the script's
-   output shape, not a second, independently-hand-maintained pattern).
+2. Edits the five matching-semver-string pin locations via the same regex
+   `pin-consistency.test.ts` already parses (so the script and its own test
+   share one definition of "where the pins live" — the test would then be
+   validating the script's output shape, not a second, independently-hand-
+   maintained pattern). Does **not** touch the model-alias `label` here —
+   that's a distinct, non-mechanical edit, step 4 below.
 3. Runs `pin-consistency.test.ts` immediately and fails loudly on mismatch,
    the same way `scripts/release.sh` already re-reads all five version
    locations after a release bump and fails loudly on disagreement

--- a/frontend/app/view/agent/providers/catalog.ts
+++ b/frontend/app/view/agent/providers/catalog.ts
@@ -72,7 +72,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and
         // .github/workflows/container-image.yml `claude_version` default — enforced by
         // ./pin-consistency.test.ts.
-        pinnedVersion: "2.1.198",
+        pinnedVersion: "2.1.247",
         docsUrl: "https://docs.anthropic.com/claude-code",
         windowsInstallCommand: "irm https://claude.ai/install.ps1 | iex",
         unixInstallCommand: "curl -fsSL https://claude.ai/install.sh | bash",
@@ -118,7 +118,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // desyncs the strip's Model dropdown from the actual default and is a
         // trap for any `models.find(m => m.default)` reader.
         models: [
-            { value: "opus", label: "Opus 4.8", description: "Claude Opus 4.8 — highest quality", aliases: ["claude-opus"] },
+            { value: "opus", label: "Opus 5", description: "Claude Opus 5 — highest quality", aliases: ["claude-opus"] },
             { value: "sonnet", label: "Sonnet 5", default: true, description: "Claude Sonnet 5 — balanced", aliases: ["claude-sonnet"] },
             { value: "haiku", label: "Haiku 4.5", description: "Claude Haiku 4.5 — fastest", aliases: ["claude-haiku"] },
             // No confirmed generic "fable" alias (unlike opus/sonnet/haiku above), so this

--- a/frontend/app/view/agent/providers/pin-consistency.test.ts
+++ b/frontend/app/view/agent/providers/pin-consistency.test.ts
@@ -1,19 +1,31 @@
 // Drift guard for CLI version pins duplicated across registries.
 //
-// The pinned CLI version for each npm-installed provider lives in FOUR
+// The pinned CLI version for each npm-installed provider lives in FIVE
 // places that must agree (the follow-up SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG
 // §"Single-source-of-truth" recommended and this test implements):
 //
-//   1. frontend/app/view/agent/providers/index.ts   `pinnedVersion`
+//   1. frontend/app/view/agent/providers/catalog.ts `pinnedVersion`
+//      (re-exported as PROVIDERS via ./index — the module was a single
+//      index.ts at pin #4 below's time; split for readability 2026-07-xx,
+//      the pin moved but nothing re-audited references to the old path)
 //   2. agentmux-srv/src/backend/providers.rs        `pinned_version`
 //   3. agentmux-cef/src/commands/providers.rs       `CLAUDE_VERSION` etc.
 //   4. .github/workflows/container-image.yml        `claude_version` default
 //      (claude only — the container image is a Claude agent image)
+//   5. docker/Dockerfile.agent-agentmux              `ARG CLAUDE_VERSION=`
+//      (claude only, same reason as #4 — added 2026-08-27, see history below)
 //
 // History: the 2026-07-02 pin bump (2.1.185 → 2.1.198) updated #1 and #2 but
 // missed #3 and #4, leaving the host-side installer 13 patch versions behind
-// the srv-side installer for the same provider. This test makes the next
-// missed site a CI failure instead of a silent drift.
+// the srv-side installer for the same provider. This test made the next
+// missed site a CI failure instead of a silent drift — but #5 (the Dockerfile
+// ARG) wasn't covered at all until the 2026-08-27 bump (2.1.198 → 2.1.247)
+// found it via `docs/spec-claude-code-versioning.md`'s own written checklist,
+// which already warned this file could drift silently. Added here so a
+// missed Dockerfile pin is now caught the same way #3/#4 are. See
+// docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md and
+// docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md for the fuller
+// story of why a written checklist alone wasn't enough here.
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -66,6 +78,17 @@ describe("CLI pin consistency across registries", () => {
         const yml = read(".github/workflows/container-image.yml");
         const m = yml.match(/claude_version:[\s\S]*?default: '([^']+)'/);
         if (!m) throw new Error("claude_version default not found in container-image.yml");
+        expect(m[1]).toBe(PROVIDERS.claude.pinnedVersion);
+    });
+
+    // Added 2026-08-27 — this location shipped a real, undetected drift risk
+    // (docs/spec-claude-code-versioning.md's own hand-maintained checklist
+    // had warned about it since the doc was first written, but nothing
+    // machine-checked it until now). See this file's header comment.
+    it("claude: Dockerfile.agent-agentmux ARG default agrees", () => {
+        const dockerfile = read("docker/Dockerfile.agent-agentmux");
+        const m = dockerfile.match(/ARG CLAUDE_VERSION=([^\s\n]+)/);
+        if (!m) throw new Error("ARG CLAUDE_VERSION not found in docker/Dockerfile.agent-agentmux");
         expect(m[1]).toBe(PROVIDERS.claude.pinnedVersion);
     });
 


### PR DESCRIPTION
First model-catalog/CLI upgrade done as a deliberate, retro'd exercise rather than incidental to other work — logged so future bumps benefit from what this one found.

## Code change

- Bumps the pinned `@anthropic-ai/claude-code` CLI `2.1.198` → `2.1.247` (verified against the real npm registry) across all **six** locations — including `docker/Dockerfile.agent-agentmux`, which `pin-consistency.test.ts` never actually covered despite `docs/spec-claude-code-versioning.md` explicitly warning it could drift silently. Closed that gap with a 6th test assertion instead of just re-writing the warning.
- Relabels the `opus` model-family alias "Opus 4.8" → "Opus 5" in the UI catalog, per the file's own documented convention (`value` alias stays fixed; curated `label` tracks the concrete snapshot — same pattern already used for `sonnet` → "Sonnet 5").
- Corrects `docs/spec-claude-code-versioning.md`'s own stale file reference (`providers/index.ts` → `providers/catalog.ts`) and appends this bump to its version-history table.

## Docs

- `docs/retro/retro-claude-cli-and-opus-5-upgrade-2026-08-27.md` — what happened, and the central finding: a checklist that lives only in prose has no enforcement of its own. The Dockerfile gap had been *named in writing* for over a month without becoming a test.
- `docs/specs/SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md` — forward-looking process, informed by real research (Renovate's and Google Cloud's dependency-upgrade guidance, AI-model canary-rollout practice, and Anthropic's own alias/deprecation lifecycle docs — all cited with sources). Proposes turning known gaps into assertions immediately (done here, Tier 1), a future single bump script (Tier 2, not built), and treats full canary infrastructure as a deliberate non-goal for a single-tenant desktop app.

## Verification

All 139 provider/catalog/context-window tests pass (`pin-consistency.test.ts` now 6/6 including the new Dockerfile check); `tsc --noEmit` clean.

<!-- agentmux:agent_id=manoz -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)