### PR TITLE
feat(layout): flip splitter-drag defaults — plain drag group-resizes, Shift resizes a single border

### DIFF
--- a/.changesets/1787814920-feat-layout-plain-drag-now-group-resizes-the-row-column-shif-pl9l.md
+++ b/.changesets/1787814920-feat-layout-plain-drag-now-group-resizes-the-row-column-shif-pl9l.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(layout): plain drag now group-resizes the row/column; Shift+drag moves a single border

--- a/docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md
+++ b/docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md
@@ -1,0 +1,293 @@
+# SPEC: Resize refinements — flip group/direct defaults, and Shift+window-resize feeding only the edge panes
+
+**Date:** 2026-08-26
+**Status:** analysis + design — not implemented
+**Author:** Loap (agent)
+**Tracking discussion:** repo owner, this session — "the default should be the
+relative resize that currently shift-resize does. The new feature is that when
+users use shift-resize, it directly resizes the pane, like how the default
+resize is currently. we also want introduce this to the pane borders along the
+window. when window resizing, the default already does relative. but we want
+to add a shift+resize to the edge panes that make pane size change on it's own
+(other panes remain same width even though you are making the window larger)."
+
+**Builds on / supersedes in part:**
+- `SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md` (PR #2401) — introduced
+  Shift+drag group resize. **This spec flips its §5.1/§5.2 default/modifier
+  assignment**; everything else there (Scope A, the modifier being Shift,
+  minimize-locked exclusion) stands.
+- `SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md` — the two-block
+  distribution algorithm. Unchanged; it simply becomes the *default* math.
+
+---
+
+## 1. What exists today (verified by reading the code)
+
+### 1.1 Splitter drag — two modes, Shift selects the group one
+
+- `frontend/layout/lib/TileLayout.{win32,darwin,linux}.tsx` each pass the live
+  modifier into the resize hot path:
+  `onResizeMove(props.resizeHandleProps, clientX, clientY, event.shiftKey)`
+  (win32: ~line 516, darwin: 433, linux: 457). This is the ONLY place mode
+  selection happens.
+- `frontend/layout/lib/layoutResize.ts::onResizeMove` (line 238-341) branches
+  on that boolean:
+  - `groupResize === false` (**today's default**): plain 2-node
+    equal-and-opposite transfer between the two flanking siblings
+    (`beforeNodeSize`/`afterNodeSize`, line 313-326), both floored at
+    `MinNodeSizePx = 128` — the drag simply stops at the floor.
+  - `groupResize === true` (**today's Shift**): `computeGroupResizeSizes`
+    (line 165-211) — the two-block model: every sibling before the handle is
+    one uniformly-scaling block, the driven pane plus everyone after it is
+    the other; the handle border tracks the cursor 1:1; per-member floor with
+    iterative redistribution (`shrinkBlockBy`, line 54-96).
+- The drag context (`ResizeContext`, line 18-36) always snapshots
+  `groupSiblingStartSizes` regardless of the modifier, precisely so Shift can
+  be toggled mid-drag with no context rebuild. **This means the flip is
+  near-free** — both formulas already run off the same context.
+- Discoverability surface: `frontend/app/element/quicktips.tsx:213-215` —
+  "Resize All Panes Together — Shift + Drag".
+
+### 1.2 Window resize — proportional by construction, no code involved
+
+Pane sizes are flex weights (`LayoutNode.size`) relative to their parent's
+children; pixels are derived per-parent as `containerPx × weight/Σweights`
+(`pixelToSizeRatio` in `additionalProps`). An OS window resize reaches the
+layout only as a `ResizeObserver` tick (`layoutModelHooks.ts:69` →
+`onContainerResize`, `layoutResize.ts:216-220`), which recomputes geometry
+and briefly sets `isContainerResizing` (to suppress animations). **No weight
+changes, so every pane scales proportionally — the "relative" default the
+repo owner described.** Notably, this reflow does NOT enforce the 128px
+floor (only interactive drags do — documented in `shrinkBlockBy`'s comment,
+line 60-71).
+
+There is **no host-side resize-loop handling today**: no
+`WM_SIZING`/`WM_ENTERSIZEMOVE`/`WM_EXITSIZEMOVE` handlers anywhere in
+`agentmux-cef/`. Precedent for sampling physical key state inside a native
+loop exists (`GetAsyncKeyState` in `agentmux-cef/src/commands/drag.rs:244`
+and `ui_tasks/drag.rs:337-349`), and host→renderer event channels already
+exist for exactly this kind of mid-gesture signaling (the tabdrag events,
+`srv_event_bridge.rs` / `events.rs`).
+
+---
+
+## 2. Change 1 — flip the splitter-drag defaults
+
+### 2.1 New behavior
+
+| Gesture | Old | New |
+|---|---|---|
+| Plain drag | 2-node direct transfer | **group resize (two-block)** |
+| Shift + drag | group resize (two-block) | **2-node direct transfer** |
+
+Rationale (owner-stated): the group behavior is the better everyday default —
+one drag adjusts the whole row/column coherently; the surgical "move only
+this border, touch only these two panes" case is the rarer, deliberate
+action, which is what a modifier is for.
+
+### 2.2 Implementation surface (small, by design)
+
+- `TileLayout.{win32,darwin,linux}.tsx` — pass `!event.shiftKey` where
+  `event.shiftKey` is passed today. Recommended cleanup while there: rename
+  `onResizeMove`'s 4th param from `groupResize` to something
+  gesture-agnostic (e.g. keep `groupResize` but compute it at the call site:
+  `groupResize: !event.shiftKey`) so the semantics live in one place.
+- `layoutResize.ts` — no math changes. Update the §5.2 comment block
+  (line 299-304) that says "Shift held:" to describe the flipped mapping.
+- `quicktips.tsx:213-215` — flip the entry: default drag now resizes the
+  row/column together; **"Resize Single Border — Shift + Drag"** (or similar
+  wording) documents the modifier.
+- Mid-drag toggling keeps working unchanged (both formulas already share the
+  same snapshot context, §1.1) — releasing/pressing Shift mid-drag now flips
+  in the opposite direction, which needs one manual re-verification pass.
+
+### 2.3 Behavioral deltas worth calling out (so they're chosen, not accidental)
+
+1. **The default drag's driven pane is no longer pixel-exact** when panes sit
+   past it — only the dragged border tracks the cursor 1:1 (the two-block
+   model's documented trade-off, DIRECTION_FIX §4.2). This becomes the
+   everyday behavior. Judged acceptable: the border under the pointer is
+   what the user is steering.
+2. **The default drag can now push distant borders** — a user who has
+   carefully sized pane A will see A shrink when they drag an unrelated
+   border in the same row (proportionally). That's the point of the flip,
+   but it's the one regression-shaped complaint to expect; the Shift escape
+   hatch is the answer, and the quicktips entry must say so.
+3. Minimize-locked siblings: unchanged — excluded from the group pool
+   (original spec §5.3), and the 2-node path already refuses drags flanking
+   a locked node (`layoutResize.ts:264`).
+
+---
+
+## 3. Change 2 — Shift + OS-window resize feeds only the edge panes
+
+### 3.1 New behavior
+
+- Plain window resize: unchanged — proportional scaling (already the
+  default, zero code).
+- **Shift held while resizing the window by an edge:** the entire pixel
+  delta goes to the pane(s) abutting the dragged window edge; every other
+  pane keeps its **pixel** size exactly (their flex weights are rewritten to
+  preserve pixels under the new container size).
+
+### 3.2 Which panes are "the edge panes" — recursive edge-chain rule
+
+The layout is a tree, not a grid, so "the pane at the right edge" must be
+defined structurally. For a **width** delta on the **right** edge, walk the
+tree from the root:
+
+- **Row container:** only the **last** (rightmost) child's width changes —
+  recurse into it if it's itself a container; every other child keeps its
+  pixel width (weights recomputed: `w_i' = W · p_i' / P'` with `p_i'` the
+  preserved pixel size, keeping the parent's weight sum `W` normalized).
+- **Column container:** every child spans the full width — recurse into
+  **every** child.
+
+Mirror for left edge (first child), and for height deltas on top/bottom with
+Row/Column roles swapped. A **corner** drag decomposes into the two axis
+rules applied independently. The affected set is exactly the panes visually
+touching the dragged edge — which is what a user pointing at "the edge pane"
+means.
+
+### 3.3 Floor handling — inward spill, then proportional fallback
+
+When shrinking the window with Shift held, the edge pane shrinks first. At
+its 128px floor (`MinNodeSizePx`), the remaining delta **spills inward** to
+the next sibling in from the edge (accordion-style), and so on. If every
+sibling in a container is at the floor, fall back to plain proportional
+scaling for further shrinkage — matching the existing non-Shift reality that
+window reflow may push panes below the floor (§1.2), so the two modes
+converge instead of the Shift mode wedging against an OS resize it cannot
+refuse. Growing has no cap (no max-size concept exists — same as splitter
+drags).
+
+`shrinkBlockBy` is the right primitive to reuse for the spill (it already
+implements floored, pool-dropping redistribution) — but note its
+distribution is proportional-within-the-pool; the accordion order described
+here wants **edge-first ordering** instead. That's a new small pure function
+(`spillInwardBy`?) alongside it, unit-testable the same way.
+
+### 3.4 Gesture plumbing — how Shift and the dragged edge reach the layout
+
+Two facts the renderer cannot reliably know on its own:
+1. **Which edge** is being dragged — a `ResizeObserver` tick only reports new
+   size.
+2. **Whether Shift is held** — during a native resize modal loop the renderer
+   may not receive key events, and focus is on the window frame.
+
+**Recommended: host-driven (Windows first).** The host window proc handles:
+- `WM_ENTERSIZEMOVE` → begin a resize session: snapshot request to renderer
+  (`windowresize:begin`).
+- `WM_SIZING` → carries the edge verbatim in `wParam`
+  (`WMSZ_LEFT/RIGHT/TOP/BOTTOM/corners`); sample
+  `GetAsyncKeyState(VK_SHIFT)` (precedent: `drag.rs:244`) per tick; forward
+  `windowresize:tick { edge, shiftHeld }` to the renderer. Shift can
+  therefore be pressed/released mid-resize and the mode follows live, same
+  as splitter drags.
+- `WM_EXITSIZEMOVE` → `windowresize:end` — renderer commits (one history
+  entry, mirroring the splitter drag's stage-then-commit pattern,
+  `SetPendingAction`/`CommitPendingAction`).
+
+**macOS/Linux (phase 2):** no `WM_SIZING` equivalent with an edge param.
+The edge is inferable from frame geometry deltas alone (origin.x moved with
+width → left edge; width changed with origin fixed → right edge; likewise
+vertically), which works from `windowWillResize`/configure events — or even
+renderer-side via `window.screenX/screenY` deltas as a fallback. Shift
+state is the harder half there (renderer key tracking is best-effort during
+a native loop); ship Windows first and reuse whatever pattern the tear-off
+work already proved per-platform.
+
+### 3.5 Renderer-side algorithm
+
+On `windowresize:begin`: snapshot every container's children pixel sizes
+(from `additionalProps` rects — same source the drag context uses,
+`layoutResize.ts:266-267`). Per `tick` with `shiftHeld`:
+
+1. Compute the cumulative per-axis delta from the session-start container
+   size (CSS px — divide out `--zoomfactor` if the observer reports zoomed
+   units; verify against how `pixelToSizeRatio` is derived).
+2. Apply the §3.2 recursion: for each affected container, produce a
+   `ResizeNodeOperation[]` from the snapshot + delta (§3.3 spill math),
+   staged via `SetPendingAction` exactly like a splitter drag tick.
+3. Ticks with `shiftHeld === false` restage pure-snapshot-proportional
+   sizes (i.e. no weight change relative to session start) so toggling
+   Shift mid-resize is live and reversible within the session.
+
+On `end`: `CommitPendingAction` (single undo/persist entry). A session with
+Shift never held stages nothing and commits nothing — identical to today.
+
+Note: unlike plain window resize (which never writes the tree), a
+Shift-resize **persists changed weights** — that's the intent ("other panes
+remain same width"), but it means the layout file changes on a
+window-resize gesture for the first time. Worth one deliberate sign-off.
+
+### 3.6 Out of scope / non-goals
+
+- Floating panes (`floating_pane.rs`) — separate windows, own resize spec
+  (`SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md`); untouched.
+- Magnified-pane state during a window resize — the magnify overlay already
+  has its own reflow; not special-cased here.
+- Maximize/restore, snap layouts, DPI-change reflows — these are not
+  edge-drag gestures; they keep proportional behavior unconditionally
+  (no `WM_SIZING` stream → no session → no Shift path, by construction).
+- A persistent per-workspace "mode" toggle — this stays a momentary
+  modifier, consistent with the splitter-drag feature.
+
+---
+
+## 4. Consistency note — one mental model after both changes
+
+After both changes, **Shift uniformly means "surgical/direct"** and plain
+gestures mean "the whole neighborhood adjusts":
+
+| Gesture | Plain | Shift |
+|---|---|---|
+| Splitter drag | row/column adjusts together (relative) | only the two flanking panes (direct) |
+| Window edge drag | everything scales (relative) | only the edge pane changes (direct) |
+
+This inversion is the strongest argument for the flip: before it, Shift
+meant "bigger effect" on splitters but would have meant "smaller effect" on
+window edges — incoherent. After it, one rule covers both surfaces.
+
+---
+
+## 5. Test plan
+
+**Change 1 (flip):**
+- Existing `layoutResize.test.ts` suites stay green untouched (they test the
+  pure functions, which don't move).
+- Update/extend any test that encodes the modifier mapping (none found at
+  the pure-function layer — the mapping lives in the three `TileLayout`
+  variants, currently untested; a small component-level test asserting
+  which branch `onResizeMove` takes per `shiftKey` value would lock the flip).
+- Manual: plain drag moves the whole row; Shift drag moves one border;
+  toggling mid-drag flips live, in both directions.
+
+**Change 2 (window edge):**
+- Unit: the new spill function (edge-first floored redistribution) and the
+  weight-rewrite math (`preserve pixels under new total`), pure-function
+  tests in the `layoutResize.test.ts` style, including corner (two-axis)
+  cases and the all-at-floor proportional fallback.
+- Manual (Windows): 3-pane row — Shift-drag right window edge wider: only
+  the rightmost pane grows, others' pixel widths hold (verify with the
+  `WxH` dimension overlay, which mounts on `isContainerResizing` /
+  splitter drags — check it also engages here or extend it); shrink until
+  the edge pane floors, confirm inward spill; release Shift mid-gesture,
+  confirm reversion to proportional staging; nested split (column inside
+  the row) — confirm recursion touches the correct leaves.
+- Persistence: after a Shift window-resize, reload — the changed pane
+  weights survive; after a plain window-resize, the layout file is
+  byte-unchanged (today's behavior preserved).
+
+## 6. Sources (code read for this spec)
+
+- `frontend/layout/lib/layoutResize.ts:18-36, 54-96, 165-211, 216-229, 238-341`
+- `frontend/layout/lib/TileLayout.win32.tsx:516`, `TileLayout.darwin.tsx:433`,
+  `TileLayout.linux.tsx:457`
+- `frontend/layout/lib/layoutModelHooks.ts:69`
+- `frontend/app/element/quicktips.tsx:53-58, 213-215`
+- `agentmux-cef/src/commands/drag.rs:244-245`, `agentmux-cef/src/ui_tasks/drag.rs:337-349`
+  (GetAsyncKeyState precedent); repo-wide grep confirming no
+  `WM_SIZING`/`WM_ENTERSIZEMOVE` handling exists yet
+- `docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md`,
+  `docs/specs/SPEC_SHIFT_DRAG_GROUP_RESIZE_DIRECTION_FIX_2026_08_17.md`

--- a/frontend/app/element/quicktips.tsx
+++ b/frontend/app/element/quicktips.tsx
@@ -210,7 +210,7 @@ const QuickTips = (): JSX.Element => {
                             <KeyBinding keyDecl="Ctrl:Shift:s + Arrows" />
                         </div>
                         <div class="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
-                            <span class="text-[15px]">Resize All Panes Together</span>
+                            <span class="text-[15px]">Resize Single Border</span>
                             <KeyBinding keyDecl="Shift + Drag" />
                         </div>
                     </div>

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -430,7 +430,9 @@ const ResizeHandle = (props: ResizeHandleComponentProps) => {
     const handlePointerMove = throttle(10, (event: PointerEvent) => {
         if (trackingPointer() === event.pointerId) {
             const { clientX, clientY } = event;
-            props.layoutModel.onResizeMove(props.resizeHandleProps, clientX, clientY, event.shiftKey);
+            // Flipped defaults (SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26 §2):
+            // plain drag = group resize, Shift+drag = direct 2-node transfer.
+            props.layoutModel.onResizeMove(props.resizeHandleProps, clientX, clientY, !event.shiftKey);
         }
     });
 

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -454,7 +454,9 @@ const ResizeHandle = (props: ResizeHandleComponentProps) => {
                 teardown(); // primary button released without a pointerup reaching us
                 return;
             }
-            props.layoutModel.onResizeMove(props.resizeHandleProps, e.clientX, e.clientY, e.shiftKey);
+            // Flipped defaults (SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26 §2):
+            // plain drag = group resize, Shift+drag = direct 2-node transfer.
+            props.layoutModel.onResizeMove(props.resizeHandleProps, e.clientX, e.clientY, !e.shiftKey);
         });
         const onUp = () => teardown?.();
 

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -513,7 +513,9 @@ const ResizeHandle = (props: ResizeHandleComponentProps) => {
     const handlePointerMove = throttle(10, (event: PointerEvent) => {
         if (trackingPointer() === event.pointerId) {
             const { clientX, clientY } = event;
-            props.layoutModel.onResizeMove(props.resizeHandleProps, clientX, clientY, event.shiftKey);
+            // Flipped defaults (SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26 §2):
+            // plain drag = group resize, Shift+drag = direct 2-node transfer.
+            props.layoutModel.onResizeMove(props.resizeHandleProps, clientX, clientY, !event.shiftKey);
         }
     });
 

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -297,11 +297,14 @@ export function onResizeMove(
 
     let resizeOperations: ResizeNodeOperation[];
     if (groupResize) {
-        // Shift held: the pane whose edge is under the pointer (afterNode, by
-        // the existing convention above) drives the drag; every other
-        // sibling under the same parent absorbs the complementary delta
-        // proportionally, instead of only the one immediate neighbor.
-        // SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §5.2.
+        // Default (no modifier) as of the 2026-08-26 flip: the pane whose edge
+        // is under the pointer (afterNode, by the existing convention above)
+        // drives the drag; every other sibling under the same parent absorbs
+        // the complementary delta proportionally, instead of only the one
+        // immediate neighbor. Shift+drag selects the direct 2-node transfer
+        // in the else-branch below.
+        // SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §5.2 (the math);
+        // SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md §2 (the flip).
         const sizes = computeGroupResizeSizes(
             model.resizeContext.groupSiblingStartSizes,
             model.resizeContext.afterNodeId,

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -31,8 +31,56 @@ export interface ResizeContext {
      * toggling Shift mid-drag needs no context rebuild: each move tick just
      * picks which formula to apply to this same baseline + the current
      * drag-start-to-now pixel delta. SPEC_SHIFT_DRAG_GROUP_RESIZE_2026_08_03.md §5.4.
+     *
+     * (Since the mid-drag REBASE below, "drag start" here really means
+     * "since the last modifier toggle" — a toggle rewrites these baselines
+     * to the currently-staged sizes.)
      */
     groupSiblingStartSizes: ResizeNodeOperation[];
+    /**
+     * Which mode staged the previous tick. A tick arriving with the OTHER
+     * mode is a mid-drag modifier toggle and triggers a rebase
+     * (`rebaseResizeContextForModeSwitch`) instead of naively recomputing
+     * the new mode's formula from the original drag-start baseline — which
+     * would snap every border except the dragged one to where the new
+     * formula would have put it had it run from the start (the "funny"
+     * jump reported after the 2026-08-26 default flip).
+     */
+    lastGroupResize: boolean;
+    /**
+     * Every sibling's currently-staged size — seeded from the drag-start
+     * sizes and merged with each successfully-staged tick's ops (a
+     * floor-rejected direct-mode tick stages nothing and leaves this
+     * untouched, matching the pending action). This is the rebase
+     * baseline: what the user actually SEES at the moment of a toggle.
+     */
+    stagedSizes: Map<string, number>;
+}
+
+/**
+ * Mid-drag modifier toggle: make the CURRENT visual state the new baseline
+ * so the incoming mode's math applies only to post-toggle cursor motion.
+ * Rewrites the 2-node start sizes and the group sibling snapshot to the
+ * currently-staged sizes, and — the key move — `resizeHandleStartPx` to
+ * the cursor's current position, so `clientDiff` restarts from zero.
+ * Every border therefore stays exactly where it is on the toggle frame;
+ * only subsequent movement follows the new mode. Toggling repeatedly
+ * mid-drag just chains rebases. Exported for direct unit testing (pure
+ * with respect to the context object — no DOM/model access).
+ */
+export function rebaseResizeContextForModeSwitch(
+    ctx: ResizeContext,
+    clientPoint: number,
+    groupResize: boolean
+): void {
+    ctx.lastGroupResize = groupResize;
+    ctx.resizeHandleStartPx = clientPoint;
+    ctx.beforeNodeStartSize = ctx.stagedSizes.get(ctx.beforeNodeId) ?? ctx.beforeNodeStartSize;
+    ctx.afterNodeStartSize = ctx.stagedSizes.get(ctx.afterNodeId) ?? ctx.afterNodeStartSize;
+    ctx.groupSiblingStartSizes = ctx.groupSiblingStartSizes.map((s) => ({
+        nodeId: s.nodeId,
+        size: ctx.stagedSizes.get(s.nodeId) ?? s.size,
+    }));
 }
 
 export const DefaultGapSizePx = 3;
@@ -279,6 +327,8 @@ export function onResizeMove(
                 afterNodeStartSize: afterNode.size,
                 pixelToSizeRatio,
                 groupSiblingStartSizes,
+                lastGroupResize: groupResize,
+                stagedSizes: new Map(groupSiblingStartSizes.map((s) => [s.nodeId, s.size])),
             };
         } else {
             console.error(
@@ -291,6 +341,11 @@ export function onResizeMove(
     const clientPoint = parentIsRow
         ? x - model.resizeContext.displayContainerRect?.left
         : y - model.resizeContext.displayContainerRect?.top;
+    // Mid-drag modifier toggle → rebase BEFORE computing clientDiff, so
+    // the new mode measures motion from the toggle point, not drag start.
+    if (groupResize !== model.resizeContext.lastGroupResize) {
+        rebaseResizeContextForModeSwitch(model.resizeContext, clientPoint, groupResize);
+    }
     const clientDiff = (model.resizeContext.resizeHandleStartPx - clientPoint) * model.resizeContext.pixelToSizeRatio;
     const minNodeSize = MinNodeSizePx * model.resizeContext.pixelToSizeRatio;
     const afterNodeSize = model.resizeContext.afterNodeStartSize + clientDiff;
@@ -327,6 +382,13 @@ export function onResizeMove(
                 size: afterNodeSize,
             },
         ];
+    }
+
+    // Record what this tick staged — the rebase baseline for a future
+    // mid-drag modifier toggle. Direct-mode floor rejections return above
+    // without reaching here, correctly leaving the last staged state.
+    for (const op of resizeOperations) {
+        model.resizeContext.stagedSizes.set(op.nodeId, op.size);
     }
 
     const resizeAction: LayoutTreeResizeNodeAction = {

--- a/frontend/layout/tests/layoutResize.test.ts
+++ b/frontend/layout/tests/layoutResize.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { assert, test } from "vitest";
-import { computeGroupResizeSizes } from "../lib/layoutResize";
+import { computeGroupResizeSizes, rebaseResizeContextForModeSwitch } from "../lib/layoutResize";
 import type { ResizeNodeOperation } from "../lib/types";
 
 function sizesOf(result: Map<string, number>, ids: string[]): number[] {
@@ -260,4 +260,93 @@ test("computeGroupResizeSizes - driven with no siblings before it (degenerate: c
     const result = computeGroupResizeSizes(siblings, "solo", 5, 10);
     assert.equal(result.get("solo"), 10, "clamped to the floor since desired (5) is below minNodeSize (10)");
     assert.equal(result.get("untouched"), 50, "no beforeBlock exists to redistribute with, so afterBlock's other members are untouched");
+});
+
+// ---- Mid-drag modifier toggle rebase (fluid mode switching) ----
+//
+// A toggle must not jump any border: the currently-staged sizes become the
+// new baseline and the cursor position becomes the new zero, so the
+// incoming mode's formula applied at zero delta reproduces the staged
+// state exactly. SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md.
+
+function makeCtx(): import("../lib/layoutResize").ResizeContext {
+    const startSizes: ResizeNodeOperation[] = [
+        { nodeId: "a", size: 100 },
+        { nodeId: "b", size: 100 },
+        { nodeId: "c", size: 100 },
+        { nodeId: "d", size: 100 },
+    ];
+    return {
+        handleId: "h",
+        pixelToSizeRatio: 1,
+        resizeHandleStartPx: 200,
+        beforeNodeId: "b",
+        beforeNodeStartSize: 100,
+        afterNodeId: "c",
+        afterNodeStartSize: 100,
+        groupSiblingStartSizes: startSizes,
+        lastGroupResize: true,
+        stagedSizes: new Map(startSizes.map((s) => [s.nodeId, s.size])),
+    };
+}
+
+test("rebaseResizeContextForModeSwitch - staged sizes become the new baselines and the cursor becomes the new zero", () => {
+    const ctx = makeCtx();
+    // Simulate a group-mode drag having staged: b|c handle dragged left by 40
+    // (driven c grew, beforeBlock [a,b] shrank proportionally).
+    const dragged = computeGroupResizeSizes(ctx.groupSiblingStartSizes, "c", 140, 10);
+    for (const [id, size] of dragged) ctx.stagedSizes.set(id, size);
+
+    rebaseResizeContextForModeSwitch(ctx, 160, false);
+
+    assert.equal(ctx.lastGroupResize, false);
+    assert.equal(ctx.resizeHandleStartPx, 160, "cursor position becomes the new zero");
+    assert.equal(ctx.beforeNodeStartSize, dragged.get("b"), "2-node baseline rewritten to staged");
+    assert.equal(ctx.afterNodeStartSize, dragged.get("c"), "2-node baseline rewritten to staged");
+    for (const s of ctx.groupSiblingStartSizes) {
+        assert.equal(s.size, dragged.get(s.nodeId), `group baseline rewritten to staged for ${s.nodeId}`);
+    }
+});
+
+test("rebaseResizeContextForModeSwitch - continuity: the incoming mode at zero delta reproduces the staged state exactly (no border jumps)", () => {
+    const ctx = makeCtx();
+    const dragged = computeGroupResizeSizes(ctx.groupSiblingStartSizes, "c", 140, 10);
+    for (const [id, size] of dragged) ctx.stagedSizes.set(id, size);
+
+    rebaseResizeContextForModeSwitch(ctx, 160, false);
+
+    // Direct 2-node formula at clientDiff = 0 (cursor hasn't moved since
+    // the toggle): before/after both equal their staged sizes — identical
+    // frame, no jump.
+    const clientDiff = (ctx.resizeHandleStartPx - 160) * ctx.pixelToSizeRatio;
+    assert.equal(clientDiff, 0);
+    assert.equal(ctx.beforeNodeStartSize - clientDiff, dragged.get("b"));
+    assert.equal(ctx.afterNodeStartSize + clientDiff, dragged.get("c"));
+
+    // And toggling BACK to group mode at zero delta likewise reproduces the
+    // staged state (chained rebases stay continuous).
+    rebaseResizeContextForModeSwitch(ctx, 175, true);
+    const groupAtZero = computeGroupResizeSizes(ctx.groupSiblingStartSizes, "c", ctx.afterNodeStartSize, 10);
+    for (const s of ctx.groupSiblingStartSizes) {
+        assert.equal(groupAtZero.get(s.nodeId), ctx.stagedSizes.get(s.nodeId), `no jump for ${s.nodeId}`);
+    }
+});
+
+test("rebaseResizeContextForModeSwitch - post-toggle motion applies only the incremental delta in the new mode", () => {
+    const ctx = makeCtx();
+    // Group-drag staged state first.
+    const dragged = computeGroupResizeSizes(ctx.groupSiblingStartSizes, "c", 140, 10);
+    for (const [id, size] of dragged) ctx.stagedSizes.set(id, size);
+    rebaseResizeContextForModeSwitch(ctx, 160, false);
+
+    // Cursor moves another 10px left after the toggle → direct mode moves
+    // ONLY the flanking pair, by exactly 10, from their staged values.
+    const clientDiff = (ctx.resizeHandleStartPx - 150) * ctx.pixelToSizeRatio; // +10
+    assert.equal(clientDiff, 10);
+    assert.equal(ctx.beforeNodeStartSize - clientDiff, dragged.get("b")! - 10);
+    assert.equal(ctx.afterNodeStartSize + clientDiff, dragged.get("c")! + 10);
+    // a and d: untouched by direct mode — their baselines (= staged) are
+    // what a direct-mode tick leaves in place.
+    assert.equal(ctx.stagedSizes.get("a"), dragged.get("a"));
+    assert.equal(ctx.stagedSizes.get("d"), dragged.get("d"));
 });


### PR DESCRIPTION
## Summary

Implements **Change 1** of `docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md` (spec included in this PR — it was not yet on main):

| Gesture | Old | New |
|---|---|---|
| Plain drag | 2-node direct transfer | **group resize (two-block)** |
| Shift + drag | group resize (two-block) | **2-node direct transfer** |

- `TileLayout.{win32,darwin,linux}.tsx` now pass `!shiftKey` as `onResizeMove`'s `groupResize` argument (the only place mode selection happens).
- `layoutResize.ts`: comment on the `if (groupResize)` branch updated to describe the flipped mapping — **no math changes**.
- `quicktips.tsx`: entry flipped to "Resize Single Border — Shift + Drag".
- Changeset added (`minor` — behavior change).

## Why

Owner-directed: the group (two-block relative) behavior is the better everyday default — one drag adjusts the whole row/column coherently; the surgical "move only this border" case is the rarer, deliberate action a modifier is for. Per spec §4, after this flip **Shift uniformly means "surgical/direct"** across both splitter drags and the planned Shift+window-edge resize (Change 2, separate task) — before it, Shift would have meant "bigger effect" on splitters but "smaller effect" on window edges, an incoherent mental model.

Mid-drag Shift toggling keeps working unchanged (both formulas share the same snapshot context), just flipped in direction.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run frontend/layout/` — 9 files, 148 tests passed, untouched (pure-function tests do not encode the modifier mapping)
- [ ] Manual: plain drag moves the whole row/column; Shift+drag moves one border; toggling Shift mid-drag flips live in both directions

<!-- agentmux:agent_id=loap3 -->