### PR TITLE
feat(layout): Shift+window-edge resize — delta feeds only the edge panes (Windows-first)

### DIFF
--- a/.changesets/1787815686-feat-layout-shift-window-edge-resize-feeds-only-the-edge-pan-p6co.md
+++ b/.changesets/1787815686-feat-layout-shift-window-edge-resize-feeds-only-the-edge-pan-p6co.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(layout): Shift+window-edge resize feeds only the edge panes (Windows)

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -294,6 +294,19 @@ impl AgentMuxHandler {
                 // Install on every top-level — both `main` and Subwindow.
                 if is_top_level_window && !is_popup {
                     unsafe { install_top_level_focus_restore_hook(hwnd); }
+
+                    // Shift+window-edge resize (spec SPEC_RESIZE_DEFAULT_FLIP_
+                    // AND_WINDOW_EDGE_SHIFT_2026_08_26.md §3.4): observe the
+                    // native size loop (WM_SIZING/WM_EXITSIZEMOVE) and forward
+                    // windowresize:* events to this window's renderer. Pure
+                    // observer-passthrough — safe on main and Subwindows alike.
+                    unsafe {
+                        super::wndproc::install_window_edge_resize_hook(
+                            &self.state,
+                            hwnd,
+                            &label,
+                        );
+                    }
                 }
 
                 // OS-close routing (task #30): Alt+F4 / taskbar-close

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -226,6 +226,230 @@ pub(crate) unsafe fn install_main_window_floater_cascade_hook(
     }
 }
 
+/// Per-HWND entry for the window-edge-resize hook: original WndProc,
+/// install-time window label (fallback for event routing), and whether a
+/// `windowresize:begin` has been emitted for the in-progress size loop.
+#[cfg(target_os = "windows")]
+struct WindowEdgeResizeHookEntry {
+    original: isize,
+    install_label: String,
+    session_began: bool,
+}
+
+/// Map of top-level HWND -> hook entry for the Shift+window-edge-resize
+/// subclass (`install_window_edge_resize_hook`). Self-prunes on
+/// WM_NCDESTROY (HWND-reuse safety, same discipline as
+/// `CLOSE_ROUTING_WNDPROCS`).
+#[cfg(target_os = "windows")]
+static WINDOW_EDGE_RESIZE_WNDPROCS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, WindowEdgeResizeHookEntry>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Handle to host AppState for the static window-edge-resize wndproc (same
+/// pattern as `close_routing_app_state`). Set on first
+/// `install_window_edge_resize_hook` call.
+#[cfg(target_os = "windows")]
+fn window_edge_resize_app_state() -> &'static std::sync::OnceLock<std::sync::Arc<crate::state::AppState>> {
+    static S: std::sync::OnceLock<std::sync::Arc<crate::state::AppState>> = std::sync::OnceLock::new();
+    &S
+}
+
+/// Emit one `windowresize:*` event to THIS window's top-level renderer.
+/// The label is resolved fresh from the HWND (`AppState::label_for_hwnd`)
+/// so a promoted pool window routes correctly even if its registered label
+/// changed after install; falls back to the install-time label.
+#[cfg(target_os = "windows")]
+fn emit_window_edge_resize_event(
+    hwnd: *mut std::ffi::c_void,
+    install_label: &str,
+    event: &str,
+    payload: &serde_json::Value,
+) {
+    let Some(state) = window_edge_resize_app_state().get() else {
+        return;
+    };
+    let label = state
+        .label_for_hwnd(hwnd)
+        .unwrap_or_else(|| install_label.to_string());
+    crate::events::emit_event_to_window(state, &label, event, payload);
+}
+
+/// Window-edge-resize hook body — observes the native size loop and
+/// forwards it to the renderer so Shift+window-edge resize can feed the
+/// entire delta to the edge pane(s):
+///
+/// - `WM_SIZING` — carries the dragged edge verbatim in `wParam`
+///   (`WMSZ_*`). First tick of a loop emits `windowresize:begin {}` (begin
+///   is lazy here rather than on `WM_ENTERSIZEMOVE`, which also fires for
+///   plain window MOVES — a move must not open a resize session). Every
+///   tick then samples `GetAsyncKeyState(VK_SHIFT)` (precedent:
+///   `commands/drag.rs::get_mouse_button_state`) and emits
+///   `windowresize:tick { edge, shiftHeld }`, so Shift can be
+///   pressed/released mid-resize and the renderer mode follows live.
+/// - `WM_EXITSIZEMOVE` — emits `windowresize:end {}` iff a begin was sent.
+///
+/// The renderer computes the pixel delta itself from its own container
+/// rect (no coordinates are forwarded — that sidesteps every
+/// physical-px/DPR/zoom unit question). Pure observer: every message
+/// ALWAYS passes through to the original WndProc.
+///
+/// Spec: `docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md` §3.4.
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn window_edge_resize_wndproc(
+    hwnd: *mut std::ffi::c_void,
+    msg: u32,
+    wparam: usize,
+    lparam: isize,
+) -> isize {
+    use windows_sys::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, VK_SHIFT};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CallWindowProcW, DefWindowProcW, WM_EXITSIZEMOVE, WM_NCDESTROY, WM_SIZING,
+    };
+
+    if msg == WM_SIZING {
+        // WMSZ_* — the dragged edge/corner, verbatim from the OS.
+        let edge = match wparam {
+            1 => "left",        // WMSZ_LEFT
+            2 => "right",       // WMSZ_RIGHT
+            3 => "top",         // WMSZ_TOP
+            4 => "topleft",     // WMSZ_TOPLEFT
+            5 => "topright",    // WMSZ_TOPRIGHT
+            6 => "bottom",      // WMSZ_BOTTOM
+            7 => "bottomleft",  // WMSZ_BOTTOMLEFT
+            8 => "bottomright", // WMSZ_BOTTOMRIGHT
+            _ => "",
+        };
+        if !edge.is_empty() {
+            // Read/update session state under the lock, emit AFTER releasing
+            // it (same discipline as tear_off_hook's handle_mouse_move).
+            let session = WINDOW_EDGE_RESIZE_WNDPROCS.lock().ok().and_then(|mut m| {
+                m.get_mut(&(hwnd as usize)).map(|entry| {
+                    let first_tick = !entry.session_began;
+                    entry.session_began = true;
+                    (entry.install_label.clone(), first_tick)
+                })
+            });
+            if let Some((install_label, first_tick)) = session {
+                if first_tick {
+                    emit_window_edge_resize_event(
+                        hwnd,
+                        &install_label,
+                        "windowresize:begin",
+                        &serde_json::json!({}),
+                    );
+                }
+                let shift_held =
+                    (GetAsyncKeyState(VK_SHIFT as i32) as u16 & 0x8000) != 0;
+                emit_window_edge_resize_event(
+                    hwnd,
+                    &install_label,
+                    "windowresize:tick",
+                    &serde_json::json!({ "edge": edge, "shiftHeld": shift_held }),
+                );
+            }
+        }
+    } else if msg == WM_EXITSIZEMOVE {
+        let ended = WINDOW_EDGE_RESIZE_WNDPROCS.lock().ok().and_then(|mut m| {
+            m.get_mut(&(hwnd as usize)).and_then(|entry| {
+                if entry.session_began {
+                    entry.session_began = false;
+                    Some(entry.install_label.clone())
+                } else {
+                    None // plain move loop — no session, nothing to end
+                }
+            })
+        });
+        if let Some(install_label) = ended {
+            emit_window_edge_resize_event(
+                hwnd,
+                &install_label,
+                "windowresize:end",
+                &serde_json::json!({}),
+            );
+        }
+    }
+
+    // ALWAYS pass through — pure observer, CEF still owns every message.
+    let original = WINDOW_EDGE_RESIZE_WNDPROCS
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&(hwnd as usize)).map(|e| e.original))
+        .unwrap_or(0);
+    let result = if original != 0 {
+        CallWindowProcW(Some(std::mem::transmute(original)), hwnd, msg, wparam, lparam)
+    } else {
+        DefWindowProcW(hwnd, msg, wparam, lparam)
+    };
+
+    // Prune AFTER passthrough so the original proc still receives
+    // WM_NCDESTROY (HWND-reuse safety, same as close_routing_wndproc).
+    if msg == WM_NCDESTROY {
+        if let Ok(mut m) = WINDOW_EDGE_RESIZE_WNDPROCS.lock() {
+            m.remove(&(hwnd as usize));
+        }
+    }
+
+    result
+}
+
+/// Subclass a top-level window's WndProc to observe the native size loop
+/// (`WM_SIZING` / `WM_EXITSIZEMOVE`) and forward `windowresize:*` events to
+/// the renderer — the host half of Shift+window-edge resize (see
+/// `window_edge_resize_wndproc` for the message flow and the spec pointer).
+///
+/// Installed from `on_after_created` (UI thread — the thread that owns the
+/// window, per Win32 subclassing rules) on every top-level non-popup
+/// window, `main` included: unlike close routing this hook never
+/// short-circuits a message, so it is safe on main. Idempotent per HWND.
+/// Coexists with the other subclasses in any order: each hook records and
+/// chains to whatever wndproc it displaced.
+#[cfg(target_os = "windows")]
+pub(crate) unsafe fn install_window_edge_resize_hook(
+    state: &std::sync::Arc<crate::state::AppState>,
+    hwnd: *mut std::ffi::c_void,
+    label: &str,
+) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{SetWindowLongPtrW, GWLP_WNDPROC};
+
+    let _ = window_edge_resize_app_state().set(state.clone());
+
+    let already_hooked = WINDOW_EDGE_RESIZE_WNDPROCS
+        .lock()
+        .ok()
+        .map(|m| m.contains_key(&(hwnd as usize)))
+        .unwrap_or(false);
+    if already_hooked {
+        return;
+    }
+
+    let original = SetWindowLongPtrW(
+        hwnd,
+        GWLP_WNDPROC,
+        window_edge_resize_wndproc as *const () as isize,
+    );
+    if original != 0 {
+        if let Ok(mut m) = WINDOW_EDGE_RESIZE_WNDPROCS.lock() {
+            m.insert(
+                hwnd as usize,
+                WindowEdgeResizeHookEntry {
+                    original,
+                    install_label: label.to_string(),
+                    session_began: false,
+                },
+            );
+        }
+        tracing::info!(
+            "[window-edge-resize] installed WM_SIZING observer on HWND {:p} label={}",
+            hwnd, label,
+        );
+    } else {
+        tracing::warn!(
+            "[window-edge-resize] SetWindowLongPtrW returned 0 for HWND {:p} label={} — hook not installed",
+            hwnd, label,
+        );
+    }
+}
+
 /// Hide the given top-level HWND from the Windows taskbar via
 /// `ITaskbarList::DeleteTab`. The window remains fully usable — Alt-Tab still
 /// finds it, it takes focus, repaints, etc. — but the shell paints no taskbar

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -12,7 +12,7 @@ import { modalsModel } from "@/app/store/modalmodel";
 import { ClientService, ObjectService, WindowService, WorkspaceService } from "@/app/store/services";
 import { RpcApi } from "@/app/store/rpc-api";
 import { initWshrpc, TabRpcClient } from "@/app/store/rpc-util";
-import { getLayoutModelForStaticTab } from "@/layout/index";
+import { getLayoutModelForStaticTab, installWindowEdgeResizeListener } from "@/layout/index";
 import {
     atoms,
     countersClear,
@@ -1032,6 +1032,10 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     initGlobalEventSubs(initOpts);
     subscribeToConnEvents();
     installFloatingRedockHoverListener();
+    // Shift + OS-window-edge resize (Windows host emits windowresize:*
+    // during the native size loop; inert elsewhere). See
+    // SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md §3.
+    installWindowEdgeResizeListener();
     tlog("initEventSubs", t);
 
     // Prime the identity-account cache from the DB so synchronous callers

--- a/frontend/layout/index.ts
+++ b/frontend/layout/index.ts
@@ -12,6 +12,7 @@ import { newLayoutNode } from "./lib/layoutNode";
 import { clearCrossTabDrop, redockDraggedPane } from "./lib/crossTabDrag";
 import { markBlockRecentlyCreated } from "./lib/layoutPersistence";
 import { closeBlockInStack, pushBlockOntoStack, setActiveBlockInStack } from "./lib/layoutStack";
+import { installWindowEdgeResizeListener } from "./lib/windowEdgeResize";
 import type {
     ContentRenderer,
     LayoutTreeDeleteNodeAction,
@@ -29,6 +30,7 @@ export {
     deleteLayoutModelForTab,
     getLayoutModelForStaticTab,
     getLayoutModelForTabById,
+    installWindowEdgeResizeListener,
     LayoutTreeActionType,
     markBlockRecentlyCreated,
     NavigateDirection,

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -39,7 +39,9 @@ export const DefaultGapSizePx = 3;
 // 128px minimum in both directions — this same constant floors both Row (width)
 // and Column (height) drags, since minNodeSize is derived generically from
 // whichever parent's pixelToSizeRatio is active (see onResizeMove below).
-const MinNodeSizePx = 128;
+// Exported for the Shift+window-edge resize path (windowEdgeResize.ts), which
+// applies the same floor directly in CSS px.
+export const MinNodeSizePx = 128;
 
 /**
  * Shrinks `block` by `amount` in total, distributed proportionally to each

--- a/frontend/layout/lib/windowEdgeResize.ts
+++ b/frontend/layout/lib/windowEdgeResize.ts
@@ -1,0 +1,397 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shift + OS-window-edge resize — feed the entire size delta to the pane(s)
+// abutting the dragged window edge; every other pane keeps its exact pixel
+// size (flex weights rewritten to preserve pixels under the new container
+// size). Plain window resize stays proportional (zero code — weights
+// untouched, exactly as before).
+//
+// Host plumbing (Windows-first): the CEF host's window-edge-resize wndproc
+// hook (agentmux-cef/src/client/wndproc.rs) forwards three renderer events
+// during a native size loop:
+//
+//   windowresize:begin {}                     — first WM_SIZING of a session
+//   windowresize:tick  { edge, shiftHeld }    — per WM_SIZING; edge from
+//                                               wParam (WMSZ_*), shift from
+//                                               GetAsyncKeyState(VK_SHIFT)
+//   windowresize:end   {}                     — WM_EXITSIZEMOVE
+//
+// The renderer computes the actual pixel delta itself, from the layout
+// container's own bounding rect (session-start snapshot vs. now). This keeps
+// every quantity in the SAME unit — the CSS-pixel space additionalProps
+// rects already live in (both come from getBoundingClientRect of the same
+// display container) — so no physical-px/DPR/--zoomfactor conversion is
+// ever needed or performed here.
+//
+// Spec: docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md §3.
+
+import { fireAndForget } from "@/util/util";
+import { isEffectivelyMinimized } from "./layoutMinimize";
+import { getLayoutModelForStaticTab } from "./layoutModelHooks";
+import { MinNodeSizePx } from "./layoutResize";
+import type { LayoutModel } from "./layoutModel";
+import type { LayoutNode } from "./types";
+import {
+    FlexDirection,
+    LayoutTreeActionType,
+    LayoutTreeResizeNodeAction,
+    LayoutTreeSetPendingAction,
+    ResizeNodeOperation,
+} from "./types";
+
+/** Dragged-edge identifier, verbatim from the host's WMSZ_* mapping. */
+export type WindowResizeEdge =
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "topleft"
+    | "topright"
+    | "bottomleft"
+    | "bottomright";
+
+/** Pixel comparisons below this are treated as "no change". */
+const EPS_PX = 0.5;
+
+/**
+ * Distributes an axis delta across one container's ordered sibling pixel
+ * sizes, edge-first (spec §3.2/§3.3). `sizes` is in the children's layout
+ * order; `edgeIsFirst` says which end of that order touches the dragged
+ * window edge (left/top → first child, right/bottom → last child).
+ *
+ * - Growing (`delta > 0`): the edge member takes the entire delta. No cap —
+ *   no max-size concept exists (same as splitter drags).
+ * - Shrinking (`delta < 0`): the edge member shrinks first, floored at
+ *   `minSizePx`; the remainder spills INWARD to the next sibling in from
+ *   the edge (accordion-style), and so on. A member already at/under the
+ *   floor has zero headroom and is skipped, never enlarged (same discipline
+ *   as `shrinkBlockBy` — see its doc comment for why that matters).
+ * - If every member is at the floor and shrink remains, fall back to plain
+ *   proportional scaling for the remainder — matching the existing
+ *   non-Shift reality that window reflow may push panes below the floor
+ *   (spec §3.3), so the two modes converge instead of the Shift mode
+ *   wedging against an OS resize it cannot refuse.
+ *
+ * Deliberately a NEW pure function rather than a reuse of `shrinkBlockBy`:
+ * that helper distributes proportionally within its pool, while this one
+ * needs strict edge-first ordering. Pure — directly unit-testable.
+ */
+export function spillInwardBy(sizes: number[], delta: number, minSizePx: number, edgeIsFirst: boolean): number[] {
+    const result = [...sizes];
+    if (result.length === 0 || delta === 0) {
+        return result;
+    }
+    const order = result.map((_, i) => i);
+    if (!edgeIsFirst) {
+        order.reverse();
+    }
+    if (delta > 0) {
+        result[order[0]] += delta;
+        return result;
+    }
+    let remaining = -delta;
+    for (const i of order) {
+        if (remaining <= 0) {
+            break;
+        }
+        const headroom = Math.max(result[i] - minSizePx, 0);
+        const take = Math.min(headroom, remaining);
+        result[i] -= take;
+        remaining -= take;
+    }
+    if (remaining > 0) {
+        // All members at (or already below) the floor — proportional fallback
+        // for the remainder, clamped so the container never goes negative.
+        const total = result.reduce((a, b) => a + b, 0);
+        if (total > 0) {
+            const factor = Math.max(total - remaining, 0) / total;
+            for (let i = 0; i < result.length; i++) {
+                result[i] *= factor;
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Immutable snapshot of the layout tree taken at `windowresize:begin`:
+ * per-node flex weight (`size`) plus the node's rect extent in container
+ * CSS px (from `additionalProps` rects — the same source the splitter-drag
+ * context uses). Minimize-locked nodes are EXCLUDED entirely: they occupy
+ * fixed chip-sized allocations outside the flex pool (and `resizeNode`
+ * rejects any action touching them), so they neither absorb delta nor need
+ * weight rewrites.
+ */
+export interface EdgeResizeSnapshotNode {
+    id: string;
+    flexDirection: FlexDirection;
+    /** Flex weight in the parent (LayoutNode.size), snapshotted at begin. */
+    size: number;
+    /** Main/cross extents in container CSS px, snapshotted at begin. */
+    width: number;
+    height: number;
+    children?: EdgeResizeSnapshotNode[];
+}
+
+/**
+ * Computes the ResizeNode operations for one Shift-resize tick (spec §3.2):
+ * cumulative container deltas since session start, applied via the
+ * recursive edge-chain rule.
+ *
+ * For a width delta with the RIGHT edge dragged, walking from the root:
+ * - Row container: only the LAST child's width changes (edge-first spill on
+ *   shrink); every other child keeps its pixel width, with weights
+ *   recomputed as `w_i' = W · p_i' / P'` (`W` = parent's snapshot weight
+ *   sum, preserved so sibling weights stay in the same scale; `p_i'` = the
+ *   child's preserved/adjusted pixel size; `P'` = new total). Recurse into
+ *   any child whose extent changed.
+ * - Column container: every child spans the full width — recurse into every
+ *   child; the column's own weights (heights) are untouched.
+ *
+ * Mirror for left (first child) and top/bottom (Row/Column roles swapped).
+ * A corner decomposes into the two axis rules applied independently — a
+ * node's weight lives on exactly one parent axis, so the two passes can
+ * never write conflicting operations for the same node.
+ *
+ * Pure — operates only on the snapshot; unit-testable.
+ */
+export function computeWindowEdgeResizeOps(
+    root: EdgeResizeSnapshotNode,
+    edge: WindowResizeEdge,
+    deltaX: number,
+    deltaY: number,
+    minSizePx: number = MinNodeSizePx
+): ResizeNodeOperation[] {
+    const ops = new Map<string, number>();
+    if (edge.includes("left") || edge.includes("right")) {
+        recurseAxis(root, deltaX, "x", edge.includes("left"), minSizePx, ops);
+    }
+    if (edge.includes("top") || edge.includes("bottom")) {
+        recurseAxis(root, deltaY, "y", edge.includes("top"), minSizePx, ops);
+    }
+    return Array.from(ops.entries()).map(([nodeId, size]) => ({ nodeId, size }));
+}
+
+function recurseAxis(
+    node: EdgeResizeSnapshotNode,
+    delta: number,
+    axis: "x" | "y",
+    edgeIsFirst: boolean,
+    minSizePx: number,
+    ops: Map<string, number>
+): void {
+    if (!node.children?.length || Math.abs(delta) < EPS_PX) {
+        return;
+    }
+    const axisIsMainAxis = (node.flexDirection === FlexDirection.Row) === (axis === "x");
+    if (!axisIsMainAxis) {
+        // Every child spans the full extent on this axis — the delta reaches
+        // each of them whole; their weights on THIS parent (the other axis)
+        // are untouched.
+        for (const child of node.children) {
+            recurseAxis(child, delta, axis, edgeIsFirst, minSizePx, ops);
+        }
+        return;
+    }
+    const startPx = node.children.map((c) => (axis === "x" ? c.width : c.height));
+    const newPx = spillInwardBy(startPx, delta, minSizePx, edgeIsFirst);
+    const newTotal = newPx.reduce((a, b) => a + b, 0);
+    const weightSum = node.children.reduce((s, c) => s + c.size, 0);
+    node.children.forEach((child, i) => {
+        // Preserve the parent's weight SUM so relative scale is stable:
+        // w_i' = W · p_i' / P'. Children with unchanged pixels still get new
+        // weights whenever the total changed — that's the whole point
+        // (pixels preserved under a different denominator).
+        if (newTotal > 0 && weightSum > 0) {
+            const newWeight = (weightSum * newPx[i]) / newTotal;
+            if (Math.abs(newWeight - child.size) > 1e-9) {
+                ops.set(child.id, newWeight);
+            }
+        }
+        const childDelta = newPx[i] - startPx[i];
+        if (Math.abs(childDelta) >= EPS_PX) {
+            recurseAxis(child, childDelta, axis, edgeIsFirst, minSizePx, ops);
+        }
+    });
+}
+
+/**
+ * Builds the session snapshot from the live model: tree shape + per-node
+ * weights + additionalProps rects, participants only (minimize-locked
+ * children excluded — see `EdgeResizeSnapshotNode`). Returns null when any
+ * participant is missing a rect (e.g. mid-mount) — the session is simply
+ * not started and the resize stays proportional.
+ */
+export function buildEdgeResizeSnapshot(model: LayoutModel): EdgeResizeSnapshotNode | null {
+    const addlProps = model.getter(model.additionalProps);
+    const boundingRect = model.getBoundingRect();
+
+    const build = (node: LayoutNode, rect: { width: number; height: number }): EdgeResizeSnapshotNode | null => {
+        const snap: EdgeResizeSnapshotNode = {
+            id: node.id,
+            flexDirection: node.flexDirection,
+            size: node.size,
+            width: rect.width,
+            height: rect.height,
+        };
+        if (node.children?.length) {
+            const children: EdgeResizeSnapshotNode[] = [];
+            for (const child of node.children) {
+                if (isEffectivelyMinimized(child)) {
+                    continue;
+                }
+                const childRect = addlProps[child.id]?.rect;
+                if (!childRect) {
+                    return null;
+                }
+                const childSnap = build(child, childRect);
+                if (!childSnap) {
+                    return null;
+                }
+                children.push(childSnap);
+            }
+            snap.children = children;
+        }
+        return snap;
+    };
+
+    return build(model.treeState.rootNode, boundingRect);
+}
+
+/** Collect every participant's snapshot weight — the restage payload for
+ *  ticks with Shift released (spec §3.5 point 3: weights back to their
+ *  session-start values = pure proportional scaling, live and reversible). */
+function collectSnapshotWeights(root: EdgeResizeSnapshotNode): ResizeNodeOperation[] {
+    const ops: ResizeNodeOperation[] = [];
+    const walk = (node: EdgeResizeSnapshotNode) => {
+        for (const child of node.children ?? []) {
+            ops.push({ nodeId: child.id, size: child.size });
+            walk(child);
+        }
+    };
+    walk(root);
+    return ops;
+}
+
+interface WindowEdgeResizeSession {
+    model: LayoutModel;
+    snapshotRoot: EdgeResizeSnapshotNode;
+    snapshotWeights: ResizeNodeOperation[];
+    startWidth: number;
+    startHeight: number;
+    lastEdge: WindowResizeEdge | null;
+    lastShiftHeld: boolean;
+    /** True once any pending ResizeNode has been staged this session. */
+    staged: boolean;
+}
+
+let session: WindowEdgeResizeSession | null = null;
+
+function stageOps(model: LayoutModel, resizeOperations: ResizeNodeOperation[]): void {
+    const resizeAction: LayoutTreeResizeNodeAction = {
+        type: LayoutTreeActionType.ResizeNode,
+        resizeOperations,
+    };
+    const setPendingAction: LayoutTreeSetPendingAction = {
+        type: LayoutTreeActionType.SetPendingAction,
+        action: resizeAction,
+    };
+    model.treeReducer(setPendingAction);
+    model.updateTree(false);
+}
+
+function onSessionBegin(): void {
+    session = null;
+    const model = getLayoutModelForStaticTab();
+    if (!model?.treeState?.rootNode || !model.displayContainerRef?.current) {
+        return;
+    }
+    const snapshotRoot = buildEdgeResizeSnapshot(model);
+    if (!snapshotRoot) {
+        return;
+    }
+    const boundingRect = model.getBoundingRect();
+    session = {
+        model,
+        snapshotRoot,
+        snapshotWeights: collectSnapshotWeights(snapshotRoot),
+        startWidth: boundingRect.width,
+        startHeight: boundingRect.height,
+        lastEdge: null,
+        lastShiftHeld: false,
+        staged: false,
+    };
+}
+
+/** Recompute + restage from the current container size. Called per tick and
+ *  once more on end (WM_SIZING precedes the size actually applying, so the
+ *  final tick's rect read lags one step — the end pass settles it). */
+function applySessionTick(): void {
+    if (!session?.lastEdge) {
+        return;
+    }
+    const { model, snapshotRoot, snapshotWeights, startWidth, startHeight, lastEdge, lastShiftHeld } = session;
+    const rect = model.getBoundingRect();
+    const deltaX = rect.width - startWidth;
+    const deltaY = rect.height - startHeight;
+    if (lastShiftHeld) {
+        const ops = computeWindowEdgeResizeOps(snapshotRoot, lastEdge, deltaX, deltaY);
+        if (ops.length > 0) {
+            stageOps(model, ops);
+            session.staged = true;
+        }
+    } else if (session.staged) {
+        // Shift released mid-resize: restage the session-start weights so the
+        // layout falls back to pure proportional scaling, live.
+        stageOps(model, snapshotWeights);
+    }
+}
+
+function onSessionTick(payload: { edge: WindowResizeEdge; shiftHeld: boolean }): void {
+    if (!session || !payload?.edge) {
+        return;
+    }
+    session.lastEdge = payload.edge;
+    session.lastShiftHeld = !!payload.shiftHeld;
+    applySessionTick();
+}
+
+function onSessionEnd(): void {
+    if (!session) {
+        return;
+    }
+    const endingSession = session;
+    if (endingSession.staged) {
+        // Settle on the final container size, then commit or clear.
+        applySessionTick();
+        if (endingSession.lastShiftHeld) {
+            // One history/persist entry, mirroring the splitter drag's
+            // stage-then-commit pattern.
+            endingSession.model.treeReducer({ type: LayoutTreeActionType.CommitPendingAction });
+        } else {
+            // Ended with Shift released — weights are back at their
+            // session-start values; drop the pending action instead of
+            // committing a no-op (keeps plain-resize sessions write-free).
+            endingSession.model.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+        }
+    }
+    // A session where Shift was never held stages nothing and commits
+    // nothing — identical to today's proportional-only behavior.
+    session = null;
+}
+
+/**
+ * Install the host-event listeners. Call once per window at startup (from
+ * initWave, alongside the other host-event listener installs). On platforms
+ * whose host never emits `windowresize:*` (mac/linux — spec §3.4 phase 2)
+ * the listeners are inert.
+ */
+export function installWindowEdgeResizeListener(): void {
+    fireAndForget(async () => {
+        const { listenEvent } = await import("@/app/platform/ipc");
+        await listenEvent("windowresize:begin", onSessionBegin);
+        await listenEvent<{ edge: WindowResizeEdge; shiftHeld: boolean }>("windowresize:tick", onSessionTick);
+        await listenEvent("windowresize:end", onSessionEnd);
+    });
+}

--- a/frontend/layout/tests/windowEdgeResize.test.ts
+++ b/frontend/layout/tests/windowEdgeResize.test.ts
@@ -1,0 +1,212 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { assert, test } from "vitest";
+import {
+    computeWindowEdgeResizeOps,
+    spillInwardBy,
+    type EdgeResizeSnapshotNode,
+} from "../lib/windowEdgeResize";
+import { FlexDirection, ResizeNodeOperation } from "../lib/types";
+
+const MIN = 128;
+
+function sum(values: number[]): number {
+    return values.reduce((a, b) => a + b, 0);
+}
+
+function leaf(id: string, size: number, width: number, height: number): EdgeResizeSnapshotNode {
+    return { id, flexDirection: FlexDirection.Column, size, width, height };
+}
+
+function branch(
+    id: string,
+    flexDirection: FlexDirection,
+    size: number,
+    width: number,
+    height: number,
+    children: EdgeResizeSnapshotNode[]
+): EdgeResizeSnapshotNode {
+    return { id, flexDirection, size, width, height, children };
+}
+
+function opsMap(ops: ResizeNodeOperation[]): Map<string, number> {
+    return new Map(ops.map((op) => [op.nodeId, op.size]));
+}
+
+/** Resolve the pixel size each child of `parent` would get under the new
+ *  weights (ops overriding snapshot weights), for a new parent extent —
+ *  mirrors computeMainAxisAllocation's `size / (flexTotal / totalPx)`. */
+function resolvedPx(parent: EdgeResizeSnapshotNode, ops: ResizeNodeOperation[], newTotalPx: number): number[] {
+    const m = opsMap(ops);
+    const weights = parent.children!.map((c) => m.get(c.id) ?? c.size);
+    const weightSum = sum(weights);
+    return weights.map((w) => (w / weightSum) * newTotalPx);
+}
+
+// ---------------------------------------------------------------------------
+// spillInwardBy — the pure edge-first spill primitive
+// ---------------------------------------------------------------------------
+
+test("spillInwardBy - grow routes the entire delta to the edge member (last)", () => {
+    assert.deepEqual(spillInwardBy([300, 300, 300], 150, MIN, false), [300, 300, 450]);
+});
+
+test("spillInwardBy - grow routes the entire delta to the edge member (first)", () => {
+    assert.deepEqual(spillInwardBy([300, 300, 300], 150, MIN, true), [450, 300, 300]);
+});
+
+test("spillInwardBy - shrink within the edge member's headroom touches only it", () => {
+    assert.deepEqual(spillInwardBy([200, 300, 400], -150, MIN, false), [200, 300, 250]);
+});
+
+test("spillInwardBy - shrink past the edge member's floor spills inward, accordion-style", () => {
+    // c gives 272 (400 -> 128), remaining 78 comes from b (300 -> 222); a untouched.
+    assert.deepEqual(spillInwardBy([200, 300, 400], -350, MIN, false), [200, 222, 128]);
+});
+
+test("spillInwardBy - left-edge shrink spills from the first member inward", () => {
+    // a gives 72 (200 -> 128), b gives 172 (300 -> 128), c gives the last 106 (400 -> 294).
+    assert.deepEqual(spillInwardBy([200, 300, 400], -350, MIN, true), [128, 128, 294]);
+});
+
+test("spillInwardBy - a member already below the floor has zero headroom and is skipped, never enlarged", () => {
+    // Below-floor states are reachable (split/minimize-restore/window reflow
+    // don't enforce the floor) — same discipline as shrinkBlockBy.
+    assert.deepEqual(spillInwardBy([300, 100, 300], -200, MIN, false), [272, 100, 128]);
+});
+
+test("spillInwardBy - all members at the floor falls back to proportional scaling", () => {
+    const result = spillInwardBy([128, 128, 128], -84, MIN, false);
+    // (384 - 84) / 384 applied uniformly.
+    result.forEach((v) => assert.approximately(v, 100, 1e-9));
+    assert.approximately(sum(result), 300, 1e-9);
+});
+
+test("spillInwardBy - partial floor headroom is consumed first, then proportional fallback for the rest", () => {
+    const result = spillInwardBy([200, 128, 128], -100, MIN, false);
+    // Edge-first pass: c and b have no headroom, a gives 72 (200 -> 128).
+    // Remaining 28 scales all three proportionally: 356/384 each.
+    const factor = (384 - 28) / 384;
+    assert.approximately(result[0], 128 * factor, 1e-9);
+    assert.approximately(result[1], 128 * factor, 1e-9);
+    assert.approximately(result[2], 128 * factor, 1e-9);
+    assert.approximately(sum(result), 456 - 100, 1e-9);
+});
+
+test("spillInwardBy - never returns negative sizes even when the shrink exceeds the container", () => {
+    const result = spillInwardBy([200, 200], -1000, MIN, false);
+    result.forEach((v) => assert.isAtLeast(v, 0));
+});
+
+// ---------------------------------------------------------------------------
+// computeWindowEdgeResizeOps — the recursive edge-chain rule
+// ---------------------------------------------------------------------------
+
+test("computeWindowEdgeResizeOps - right-edge grow on a Row routes all delta to the last child; siblings keep pixels", () => {
+    const root = branch("root", FlexDirection.Row, 10, 900, 600, [
+        leaf("a", 10, 300, 600),
+        leaf("b", 10, 300, 600),
+        leaf("c", 10, 300, 600),
+    ]);
+    const ops = computeWindowEdgeResizeOps(root, "right", 150, 0, MIN);
+    // Every child's weight changes (the denominator changed), but resolved
+    // pixels preserve a and b exactly and give c the full 150.
+    const px = resolvedPx(root, ops, 1050);
+    assert.approximately(px[0], 300, 1e-6, "a keeps its pixel width");
+    assert.approximately(px[1], 300, 1e-6, "b keeps its pixel width");
+    assert.approximately(px[2], 450, 1e-6, "c absorbs the entire delta");
+    // Weight sum is preserved so sibling weights stay in the same scale.
+    const m = opsMap(ops);
+    assert.approximately(sum(root.children!.map((c) => m.get(c.id) ?? c.size)), 30, 1e-9);
+});
+
+test("computeWindowEdgeResizeOps - left-edge grow routes all delta to the FIRST child", () => {
+    const root = branch("root", FlexDirection.Row, 10, 900, 600, [
+        leaf("a", 10, 300, 600),
+        leaf("b", 10, 300, 600),
+        leaf("c", 10, 300, 600),
+    ]);
+    const ops = computeWindowEdgeResizeOps(root, "left", 150, 0, MIN);
+    const px = resolvedPx(root, ops, 1050);
+    assert.approximately(px[0], 450, 1e-6, "a absorbs the entire delta");
+    assert.approximately(px[1], 300, 1e-6);
+    assert.approximately(px[2], 300, 1e-6);
+});
+
+test("computeWindowEdgeResizeOps - nested column-in-row: width delta recurses into EVERY column child but leaves column weights alone", () => {
+    const root = branch("root", FlexDirection.Row, 10, 900, 600, [
+        leaf("a", 10, 300, 600),
+        branch("col", FlexDirection.Column, 20, 600, 600, [
+            leaf("b", 10, 600, 300),
+            leaf("c", 10, 600, 300),
+        ]),
+    ]);
+    const ops = computeWindowEdgeResizeOps(root, "right", 150, 0, MIN);
+    const m = opsMap(ops);
+    // Row level: a keeps 300px, col grows to 750px.
+    const px = resolvedPx(root, ops, 1050);
+    assert.approximately(px[0], 300, 1e-6, "a keeps its pixel width");
+    assert.approximately(px[1], 750, 1e-6, "col absorbs the entire width delta");
+    // Column level: b and c both span the full width — the delta reaches
+    // them via geometry, NOT via weight ops; their (height) weights on the
+    // column are untouched.
+    assert.isFalse(m.has("b"), "column child heights are untouched by a width delta");
+    assert.isFalse(m.has("c"), "column child heights are untouched by a width delta");
+});
+
+test("computeWindowEdgeResizeOps - shrink past the edge pane's floor spills inward at the Row level", () => {
+    const root = branch("root", FlexDirection.Row, 10, 900, 600, [
+        leaf("a", 10, 200, 600),
+        leaf("b", 15, 300, 600),
+        leaf("c", 20, 400, 600),
+    ]);
+    const ops = computeWindowEdgeResizeOps(root, "right", -350, 0, MIN);
+    const px = resolvedPx(root, ops, 550);
+    assert.approximately(px[0], 200, 1e-6, "a untouched — spill stopped at b");
+    assert.approximately(px[1], 222, 1e-6, "b absorbs what c could not give past its floor");
+    assert.approximately(px[2], 128, 1e-6, "c floored at MinNodeSizePx");
+});
+
+test("computeWindowEdgeResizeOps - all children at the floor falls back to proportional (no weight ops)", () => {
+    const root = branch("root", FlexDirection.Row, 10, 384, 600, [
+        leaf("a", 10, 128, 600),
+        leaf("b", 10, 128, 600),
+        leaf("c", 10, 128, 600),
+    ]);
+    const ops = computeWindowEdgeResizeOps(root, "right", -84, 0, MIN);
+    // Proportional fallback keeps the pixel ratios identical, so every
+    // recomputed weight equals its snapshot value — no ops at all. This is
+    // exactly "converge with the plain proportional mode" from spec §3.3.
+    assert.lengthOf(ops, 0);
+});
+
+test("computeWindowEdgeResizeOps - corner drag decomposes into both axis rules independently", () => {
+    const root = branch("root", FlexDirection.Row, 10, 900, 600, [
+        leaf("a", 10, 300, 600),
+        branch("col", FlexDirection.Column, 20, 600, 600, [
+            leaf("b", 10, 600, 300),
+            leaf("c", 10, 600, 300),
+        ]),
+    ]);
+    const ops = computeWindowEdgeResizeOps(root, "bottomright", 150, 100, MIN);
+    // X pass: a keeps 300, col -> 750 (as in the nested test).
+    const rowPx = resolvedPx(root, ops, 1050);
+    assert.approximately(rowPx[0], 300, 1e-6);
+    assert.approximately(rowPx[1], 750, 1e-6);
+    // Y pass: the height delta passes through the Row (cross axis) into
+    // every child; inside the column only the LAST child (c) grows.
+    const colPx = resolvedPx(root.children![1], ops, 700);
+    assert.approximately(colPx[0], 300, 1e-6, "b keeps its pixel height");
+    assert.approximately(colPx[1], 400, 1e-6, "c absorbs the entire height delta");
+});
+
+test("computeWindowEdgeResizeOps - a zero/sub-pixel delta produces no operations", () => {
+    const root = branch("root", FlexDirection.Row, 10, 900, 600, [
+        leaf("a", 10, 450, 600),
+        leaf("b", 10, 450, 600),
+    ]);
+    assert.lengthOf(computeWindowEdgeResizeOps(root, "right", 0, 0, MIN), 0);
+    assert.lengthOf(computeWindowEdgeResizeOps(root, "right", 0.25, 0, MIN), 0);
+    assert.lengthOf(computeWindowEdgeResizeOps(root, "top", 0, 0.25, MIN), 0);
+});


### PR DESCRIPTION
## Summary

Implements **Change 2** of `docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md` (§3 — the spec doc itself lands with the flip agent's PR and is not duplicated here):

- **Plain window resize: unchanged.** Proportional scaling, zero weight writes, layout file untouched — a session where Shift is never held stages nothing and commits nothing.
- **Shift held while dragging an OS window edge:** the entire pixel delta goes to the pane(s) abutting the dragged edge; every other pane keeps its exact **pixel** size (flex weights rewritten as `w_i' = W·p_i'/P'` under the new container size). Shift can be pressed/released mid-resize and the mode follows live; releasing Shift restages the session-start weights (pure proportional), so the gesture is reversible within the session.
- **Windows-only for now** — spec §3.4 phase 2 covers mac/linux (no `WM_SIZING` equivalent); the renderer listener is simply inert where the host never emits `windowresize:*`.

## Plumbing

**Host (`agentmux-cef`, Windows):**
- New pure-observer wndproc subclass `install_window_edge_resize_hook` in `client/wndproc.rs`, pattern-copied from the existing close-routing subclass (per-HWND original-proc map, `WM_NCDESTROY` self-prune, AppState `OnceLock`). Installed from `on_after_created` (`client/lifecycle.rs`) on every top-level non-popup window, `main` included — it never short-circuits a message.
- `WM_SIZING` → first tick of a loop emits `windowresize:begin {}` (begin is **lazy** here, not on `WM_ENTERSIZEMOVE`, which also fires for plain window *moves*); every tick samples `GetAsyncKeyState(VK_SHIFT)` (precedent: `commands/drag.rs`) and emits `windowresize:tick { edge, shiftHeld }` with the edge verbatim from `wParam` (`WMSZ_*` → `"left" | ... | "bottomright"`). `WM_EXITSIZEMOVE` → `windowresize:end {}` iff a begin was sent.
- Events route via the existing `emit_event_to_window` channel; the label is resolved fresh per emit via `AppState::label_for_hwnd` (install-time label as fallback), so promoted pool windows route correctly.

**Frontend (`frontend/layout/lib/windowEdgeResize.ts`, installed from `app-init.ts` alongside the other host-event listeners):**
- On `begin`: snapshot the active tab's tree (weights + `additionalProps` rects + container size; minimize-locked nodes excluded — they're fixed chips outside the flex pool and `resizeNode` rejects actions touching them).
- Per `tick` with Shift: cumulative axis delta since begin → recursive edge-chain rule (spec §3.2): in a Row container only the edge-most child's width changes (recursing into it if it's a container); siblings keep pixels with weights recomputed (parent weight **sum** preserved); in a Column container every child spans the axis, so recurse into each. Corners decompose per-axis — a node's weight lives on exactly one parent axis, so the two passes can't conflict.
- Floors at `MinNodeSizePx = 128` via a **new pure primitive `spillInwardBy`** (edge-first inward spill, then proportional fallback when the whole container is at the floor — converging with plain-resize behavior instead of wedging against an OS resize it can't refuse; spec §3.3). `shrinkBlockBy` untouched (its distribution is proportional-within-pool, not edge-first).
- Stages via `SetPendingAction`/`ResizeNode` + `updateTree(false)` exactly like a splitter-drag tick (so the WxH badge engages via `isSplitterDragging`); commits once on `end` (single history/persist entry). An end with Shift released clears the pending action instead of committing a no-op.
- **Units:** all deltas are computed renderer-side from the layout container's own `getBoundingClientRect` — the same source the `additionalProps` rects come from — so everything stays in one CSS-px space and no physical-px/DPR/`--zoomfactor` conversion exists in this path at all. The host forwards no coordinates, only `edge` + `shiftHeld`.

## Tested

- `npx vitest run frontend/layout/` — **164/164 pass** (10 files), including the new `frontend/layout/tests/windowEdgeResize.test.ts` (16 tests): right-edge grow routes all delta to the last child while siblings keep pixels; left-edge (first-child) variant; nested column-in-row recursion (width delta never touches column-child height weights); floor + inward spill; partial-headroom + proportional fallback; all-at-floor fallback producing **zero** weight ops (proportional = weight-neutral by construction); corner two-axis decomposition; below-floor members skipped, never enlarged; sub-pixel deltas are no-ops.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `cargo check -p agentmux-cef` — clean (no new warnings).

## Needs live manual verification (Windows)

The host→renderer event flow has **not** been exercised in a live build (cargo *check* only, per task scope):

1. 3-pane row, Shift-drag right window edge wider → only the rightmost pane grows; others' pixel widths hold (WxH badge should engage).
2. Shrink until the edge pane floors → confirm inward spill, then proportional convergence.
3. Release/press Shift mid-gesture → live flip between edge-fed and proportional staging, reversible.
4. Nested column inside the row → recursion touches the correct leaves; corner drags affect both axes independently.
5. Persistence: Shift-resize weights survive reload; plain resize leaves the layout file byte-unchanged.
6. WM_SIZING timing: renderer rect reads lag the in-flight tick by one message; the `end` pass restages at the final size before committing — verify no visible snap at release.

## Spec assumptions that didn't survive contact with the code

- **§3.3 suggested reusing `shrinkBlockBy` "as the right primitive"** then corrected itself — confirmed: its proportional-within-pool distribution is wrong for accordion order; `spillInwardBy` is new and standalone as the spec's own follow-up sentence suggests.
- **§3.5's `--zoomfactor` caution turned out to be moot**: chrome zoom never mixes units here because both the session-start rects and the per-tick container size come from the same `getBoundingClientRect` space, and the host forwards no pixel quantities.
- **`WM_ENTERSIZEMOVE` cannot open the session** (spec §3.4 sketch): it fires for window *moves* too; begin had to be lazy on the first `WM_SIZING`.
- **`resizeNode` rejects any op set touching a minimize-locked node and any size outside 0..100** (`layoutTree.ts:431`) — snapshot excludes locked nodes entirely, and the weight rewrite preserves each parent's weight *sum*, keeping values in the same scale the tree already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=loap3 -->
