### PR TITLE
feat(browser-pane): credential-isolated HTTP auth auto-fill

### DIFF
--- a/.changesets/1788031768-feat-browser-pane-credential-isolated-http-auth-auto-fill-hato.md
+++ b/.changesets/1788031768-feat-browser-pane-credential-isolated-http-auth-auto-fill-hato.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(browser-pane): credential-isolated HTTP auth auto-fill

--- a/agentmux-cef/src/client/crash_recovery.rs
+++ b/agentmux-cef/src/client/crash_recovery.rs
@@ -515,28 +515,23 @@ impl AgentMuxHandler {
             cb.clone(),
         );
 
-        // Broadcast to every TOP-LEVEL window — `emit_event_from_state`
-        // only dispatches to the "main" browser, so panes hosted in a
-        // tear-off / secondary window would never see the event and
-        // the CEF callback would wait until TTL/cancel. Filtering to
-        // top-level is critical: the payload carries origin/host/realm
-        // plus block_id correlation, which must not be visible to
-        // remote content loaded inside a sibling pane (whose main
-        // frame is an arbitrary URL). The host renderer filters on
-        // `payload.block_id` so only the window owning this pane
-        // surfaces the prompt.
-        crate::events::emit_event_to_top_level_windows(
-            &self.state,
-            "browser-pane-auth-required",
-            &serde_json::json!({
-                "block_id": block_id,
-                "request_id": request_id,
-                "origin": origin,
-                "host": host_str,
-                "port": port,
-                "realm": realm_str,
-                "is_proxy": is_proxy_bool,
-            }),
+        // Hand off to the credential broker: identity-resolve → stored-
+        // credential lookup → either a human-approval subwindow (never a
+        // `<Modal>` — see `credential_broker`'s own doc comment for why)
+        // or, on any friction at all (no bound identity, no stored
+        // credential, srv unreachable, etc.), the exact same
+        // `browser-pane-auth-required` broadcast this function emitted
+        // unconditionally before this feature existed. See
+        // `docs/status/majestic-painting-minsky` plan.
+        crate::credential_broker::on_auth_challenge(
+            self.state.clone(),
+            request_id,
+            block_id,
+            origin,
+            host_str,
+            port,
+            realm_str,
+            is_proxy_bool,
         );
 
         1

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -1020,6 +1020,33 @@ impl AgentMuxHandler {
             }
         }
 
+        // A credential-approval subwindow (opened via `open_subwindow`,
+        // `initial_view=credential-approval`) closing before the human
+        // decided — parent window closing cascades down to it same as any
+        // other subwindow. No-op (empty Vec) for every ordinary window
+        // close; the registry only ever has entries keyed by an actual
+        // approval subwindow's label. See `credential_broker::approval`'s
+        // own doc comment — this is the mirror of `browser_pane::auth`'s
+        // pane-close cleanup below, just window-close instead of
+        // pane-close.
+        if let Some(ref lbl) = label {
+            let cancelled = crate::credential_broker::approval::cancel_for_window(lbl);
+            if !cancelled.is_empty() {
+                use cef::ImplAuthCallback;
+                tracing::info!(
+                    "[credential-broker] approval window {} closed before a decision — \
+                     cancelling {} parked auth request(s)",
+                    lbl,
+                    cancelled.len(),
+                );
+                for request_id in &cancelled {
+                    if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                        cb.cancel();
+                    }
+                }
+            }
+        }
+
         // Pane-specific on_before_close work (drain lifecycle entry) lives
         // in `crate::browser_pane::callbacks` after Phase 4.
         if let Some(ref lbl) = label {

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -294,6 +294,8 @@ pub fn open_new_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
 pub fn open_subwindow(
     state: &Arc<AppState>,
     parent_instance_id: String,
+    initial_view: Option<&str>,
+    initial_meta: Option<&str>,
 ) -> Result<serde_json::Value, String> {
     // Reject if the parent isn't a known live FullInstance — prevents
     // orphan sub-windows and enforces the lifecycle rule in the spec.
@@ -328,8 +330,8 @@ pub fn open_subwindow(
         state,
         crate::state::WindowKind::Subwindow,
         Some(parent_instance_id),
-        None,
-        None,
+        initial_view,
+        initial_meta,
         None,
         false,
     )

--- a/agentmux-cef/src/credential_broker/approval.rs
+++ b/agentmux-cef/src/credential_broker/approval.rs
@@ -121,17 +121,29 @@ pub fn reserve_or_join(
 /// Record the approval subwindow's `window_id` once it has actually been
 /// created, so `cancel_for_window` can later find this entry when the
 /// window (or its parent, cascading down) closes.
-pub fn finalize_window(approval_id: &str, window_id: String) {
+/// Returns `false` when the approval was already gone — the reservation was
+/// cancelled (pane closed) or timed out during the window-creation gap, so
+/// the window the caller just opened belongs to nothing and **the caller
+/// must close it**. `#[must_use]` because ignoring that answer is exactly
+/// the bug this return value exists to prevent (reagent P1 on PR #2824):
+/// the entry is gone, so `cancel_for_window` will never match it, the IPC
+/// decide-handler's `take` returns `None` and closes nothing, and the TTL
+/// timer has no entry left to fire on — leaving a dead, unresponsive
+/// subwindow open until the human closes it by hand.
+#[must_use]
+pub fn finalize_window(approval_id: &str, window_id: String) -> bool {
     let mut g = pending().lock();
     if let Some(e) = g.get_mut(approval_id) {
         e.window_id = Some(window_id);
+        true
     } else {
         tracing::warn!(
             "[credential-broker] finalize_window: approval {} no longer pending \
-             (already resolved or timed out) — the just-opened subwindow is now \
-             orphaned and should be closed by the caller",
+             (already resolved or timed out) — the just-opened subwindow is \
+             orphaned; closing it",
             approval_id
         );
+        false
     }
 }
 
@@ -203,18 +215,30 @@ pub fn cancel_for_window(window_id: &str) -> Vec<String> {
 /// entirely, that whole approval is cancelled too (nothing left to
 /// resolve) and its `window_id` (if the subwindow already exists) is
 /// returned so the caller can close it.
-pub fn cancel_for_block(block_id: &str) -> Option<String> {
+/// Returns **every** emptied approval's `window_id`, not just the first.
+///
+/// The earlier cut `break`'d on the first entry that emptied, which silently
+/// skipped the rest (reagent P2 on PR #2824). One pane can legitimately ride
+/// two simultaneous approvals for *different* protection spaces — a
+/// proxy-auth and an origin-auth challenge from the same page is the obvious
+/// case — and `HashMap` iteration order decides which one the `break` lands
+/// on. The others kept a stale `AuthRequest` for an already-closed pane, and
+/// their subwindows stayed open, until the 60s TTL swept them.
+pub fn cancel_for_block(block_id: &str) -> Vec<String> {
     let mut g = pending().lock();
-    let mut emptied_id: Option<String> = None;
+    let mut emptied_ids: Vec<String> = Vec::new();
     for (id, entry) in g.iter_mut() {
         let before = entry.auth_requests.len();
         entry.auth_requests.retain(|r| r.block_id != block_id);
         if entry.auth_requests.len() != before && entry.auth_requests.is_empty() {
-            emptied_id = Some(id.clone());
-            break;
+            emptied_ids.push(id.clone());
         }
     }
-    emptied_id.and_then(|id| g.remove(&id)).and_then(|e| e.window_id)
+    emptied_ids
+        .into_iter()
+        .filter_map(|id| g.remove(&id))
+        .filter_map(|e| e.window_id)
+        .collect()
 }
 
 /// Same rationale as `browser_pane::auth`'s own TTL timer — this can be
@@ -248,12 +272,19 @@ fn arm_ttl(approval_id: String, epoch: u64) {
                             cb.cancel();
                         }
                     }
-                    // The subwindow (if it exists) is left for the IPC
-                    // decide-handler to close on the next interaction, or
-                    // for its own parent-close cascade — this module has
-                    // no direct window-management handle, only `window_id`
-                    // strings, by design (keeps this registry free of a
-                    // dependency on `commands::window`).
+                    // Close the subwindow too. It used to be left for "the
+                    // IPC decide-handler to close on the next interaction"
+                    // — but that handler's `take` returns `None` for an
+                    // already-expired approval and returns without closing
+                    // anything, so a late Approve/Deny click did nothing
+                    // and the window sat inert until closed by hand
+                    // (reagent P2 on PR #2824). Routed through
+                    // `super::close_approval_window` rather than calling
+                    // `commands::window` here, so this registry keeps its
+                    // design property of holding only `window_id` strings.
+                    if let Some(window_id) = entry.window_id {
+                        super::close_approval_window(&window_id);
+                    }
                 }
             });
         }
@@ -344,7 +375,7 @@ mod tests {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };
-        finalize_window(&approval_id, "win-1".into());
+        assert!(finalize_window(&approval_id, "win-1".into()));
         let resolved = take(&approval_id).expect("entry should exist");
         assert_eq!(resolved.window_id.as_deref(), Some("win-1"));
         assert!(take(&approval_id).is_none(), "take must remove the entry");
@@ -360,7 +391,7 @@ mod tests {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };
-        finalize_window(&approval_id, "win-1".into());
+        assert!(finalize_window(&approval_id, "win-1".into()));
         let ids = cancel_for_window("win-1");
         assert_eq!(ids, vec!["req-1".to_string()]);
         assert!(take(&approval_id).is_none());
@@ -378,7 +409,7 @@ mod tests {
         };
         reserve_or_join("id-a", "https://a", "realm", false, "req-2".into(), "block-2".into());
         let closed_window = cancel_for_block("block-1");
-        assert!(closed_window.is_none(), "sibling still pending — window must not close");
+        assert!(closed_window.is_empty(), "sibling still pending — window must not close");
         let resolved = take(&approval_id).expect("entry should still exist for block-2's request");
         assert_eq!(resolved.auth_request_ids, vec!["req-2".to_string()]);
         drain();
@@ -393,9 +424,9 @@ mod tests {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };
-        finalize_window(&approval_id, "win-1".into());
+        assert!(finalize_window(&approval_id, "win-1".into()));
         let closed_window = cancel_for_block("block-1");
-        assert_eq!(closed_window.as_deref(), Some("win-1"));
+        assert_eq!(closed_window, vec!["win-1".to_string()]);
         assert!(take(&approval_id).is_none());
         drain();
     }
@@ -412,6 +443,82 @@ mod tests {
         let ids = abandon(&approval_id);
         assert_eq!(ids, vec!["req-1".to_string()]);
         assert!(take(&approval_id).is_none());
+        drain();
+    }
+
+    /// reagent P2 on PR #2824: the old `cancel_for_block` `break`'d on the
+    /// first entry that emptied, so a pane riding TWO approvals for different
+    /// protection spaces (proxy-auth + origin-auth from the same page) left
+    /// the second one's stale request registered — and its window open —
+    /// until the 60s TTL swept it. Which one survived depended on HashMap
+    /// iteration order, so this failed intermittently rather than never.
+    #[test]
+    fn cancel_for_block_empties_every_approval_the_block_was_riding() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+
+        let origin_approval = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!("first request for this space"),
+        };
+        assert!(finalize_window(&origin_approval, "win-origin".into()));
+
+        // Same block, DIFFERENT protection space (is_proxy) — a separate entry.
+        let proxy_approval = match reserve_or_join("id-a", "https://a", "realm", true, "req-2".into(), "block-1".into()) {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!("different protection space must not coalesce"),
+        };
+        assert!(finalize_window(&proxy_approval, "win-proxy".into()));
+
+        let mut closed = cancel_for_block("block-1");
+        closed.sort();
+        assert_eq!(
+            closed,
+            vec!["win-origin".to_string(), "win-proxy".to_string()],
+            "both approvals emptied, so both windows must be returned for closing",
+        );
+        assert!(take(&origin_approval).is_none(), "origin approval must be gone");
+        assert!(take(&proxy_approval).is_none(), "proxy approval must be gone");
+        drain();
+    }
+
+    /// reagent P1 on PR #2824: no lock is held across `open_approval_window`,
+    /// so the reservation can be cancelled in that gap. `finalize_window`
+    /// must report that, or the caller leaves a window nothing will ever
+    /// close — `cancel_for_window` can't match it, the decide-handler's
+    /// `take` returns `None`, and the TTL entry is already gone.
+    #[test]
+    fn finalize_window_reports_a_reservation_that_vanished_during_the_gap() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        // The pane closes while the subwindow is still being created.
+        let closed = cancel_for_block("block-1");
+        assert!(closed.is_empty(), "no window_id yet — nothing for the caller to close from here");
+
+        assert!(
+            !finalize_window(&approval_id, "win-orphan".into()),
+            "the approval is gone, so the caller owns closing the window it just opened",
+        );
+        drain();
+    }
+
+    /// The ordinary path still reports success, so the caller doesn't close a
+    /// window that is legitimately in use.
+    #[test]
+    fn finalize_window_reports_success_for_a_live_reservation() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        assert!(finalize_window(&approval_id, "win-1".into()));
+        assert_eq!(take(&approval_id).and_then(|r| r.window_id).as_deref(), Some("win-1"));
         drain();
     }
 }

--- a/agentmux-cef/src/credential_broker/approval.rs
+++ b/agentmux-cef/src/credential_broker/approval.rs
@@ -39,9 +39,34 @@ struct AuthRequest {
     block_id: String,
 }
 
+/// One parked request handed back to a caller that now has to resolve it
+/// itself — on the abandon path (window creation failed) or the
+/// post-approval `Fill`-failed path. Carries `block_id` as well as
+/// `request_id` because coalesced requests can come from **different
+/// panes**: a fall-through prompt emitted with the wrong `block_id` would
+/// render in a pane that never raised the challenge (reagent P2 / codex P2
+/// on PR #2824).
+pub struct ParkedRequest {
+    pub request_id: String,
+    pub block_id: String,
+}
+
+impl From<AuthRequest> for ParkedRequest {
+    fn from(r: AuthRequest) -> Self {
+        Self { request_id: r.request_id, block_id: r.block_id }
+    }
+}
+
 struct Entry {
     identity_id: String,
     origin: String,
+    /// `host`/`port` are components of the protection space, identical for
+    /// every coalesced request. Stored because a fall-through emitted after
+    /// the entry is taken (post-approval `Fill` failure) still has to
+    /// reproduce the full `browser-pane-auth-required` payload, and by then
+    /// the original challenge's locals are long gone.
+    host: String,
+    port: i32,
     realm: String,
     is_proxy: bool,
     /// `None` until the approval subwindow has actually been created —
@@ -87,6 +112,8 @@ pub enum Reservation {
 pub fn reserve_or_join(
     identity_id: &str,
     origin: &str,
+    host: &str,
+    port: i32,
     realm: &str,
     is_proxy: bool,
     request_id: String,
@@ -107,6 +134,8 @@ pub fn reserve_or_join(
         Entry {
             identity_id: identity_id.to_string(),
             origin: origin.to_string(),
+            host: host.to_string(),
+            port,
             realm: realm.to_string(),
             is_proxy,
             window_id: None,
@@ -155,9 +184,15 @@ pub fn finalize_window(approval_id: &str, window_id: String) -> bool {
 pub struct ResolvedApproval {
     pub identity_id: String,
     pub origin: String,
+    pub host: String,
+    pub port: i32,
     pub realm: String,
     pub is_proxy: bool,
-    pub auth_request_ids: Vec<String>,
+    /// Every parked request riding this approval, each with its own
+    /// `block_id` — see [`ParkedRequest`]. Needed in full (not just the
+    /// ids) because the post-approval `Fill`-failure path has to emit a
+    /// per-pane fall-through prompt rather than cancelling.
+    pub auth_requests: Vec<ParkedRequest>,
     pub window_id: Option<String>,
 }
 
@@ -169,21 +204,30 @@ pub fn take(approval_id: &str) -> Option<ResolvedApproval> {
     pending().lock().remove(approval_id).map(|e| ResolvedApproval {
         identity_id: e.identity_id,
         origin: e.origin,
+        host: e.host,
+        port: e.port,
         realm: e.realm,
         is_proxy: e.is_proxy,
-        auth_request_ids: e.auth_requests.into_iter().map(|r| r.request_id).collect(),
+        auth_requests: e.auth_requests.into_iter().map(Into::into).collect(),
         window_id: e.window_id,
     })
 }
 
 /// Abandon a `New` reservation whose window creation failed — removes the
-/// entry outright (there's no window to ever finalize) and returns the
-/// request ids so the caller can fall each through to the normal prompt.
-pub fn abandon(approval_id: &str) -> Vec<String> {
+/// entry outright (there's no window to ever finalize) and returns **every**
+/// parked request so the caller can fall each through to the normal prompt.
+///
+/// Returns [`ParkedRequest`]s, not bare ids: by the time window creation
+/// fails, other challenges may have coalesced onto this reservation from
+/// *other panes*, and each needs a prompt addressed to its own `block_id`.
+/// Dropping this return value (or using only the caller's own request) is
+/// the bug this shape exists to prevent — the joined requests would sit
+/// parked with no prompt until `browser_pane::auth`'s own TTL fired.
+pub fn abandon(approval_id: &str) -> Vec<ParkedRequest> {
     pending()
         .lock()
         .remove(approval_id)
-        .map(|e| e.auth_requests.into_iter().map(|r| r.request_id).collect())
+        .map(|e| e.auth_requests.into_iter().map(Into::into).collect())
         .unwrap_or_default()
 }
 
@@ -317,7 +361,7 @@ mod tests {
     fn reserve_creates_new_entry_for_first_request() {
         let _guard = TEST_LOCK.lock();
         drain();
-        match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+        match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into()) {
             Reservation::New { approval_id } => assert!(!approval_id.is_empty()),
             Reservation::Joined => panic!("expected New for first request"),
         }
@@ -328,17 +372,17 @@ mod tests {
     fn second_request_for_same_protection_space_joins() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
         {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => panic!("expected New for first request"),
         };
-        match reserve_or_join("id-a", "https://a", "realm", false, "req-2".into(), "block-2".into()) {
+        match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-2".into(), "block-2".into()) {
             Reservation::Joined => {}
             Reservation::New { .. } => panic!("expected Joined for coalescing second request"),
         }
         let resolved = take(&approval_id).expect("entry should exist");
-        assert_eq!(resolved.auth_request_ids.len(), 2);
+        assert_eq!(resolved.auth_requests.len(), 2);
         drain();
     }
 
@@ -346,8 +390,8 @@ mod tests {
     fn different_protection_spaces_do_not_coalesce() {
         let _guard = TEST_LOCK.lock();
         drain();
-        reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into());
-        match reserve_or_join("id-a", "https://b", "realm", false, "req-2".into(), "block-2".into()) {
+        reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into());
+        match reserve_or_join("id-a", "https://b", "host-a", 443, "realm", false, "req-2".into(), "block-2".into()) {
             Reservation::New { .. } => {}
             Reservation::Joined => panic!("different origins must not coalesce"),
         }
@@ -358,8 +402,8 @@ mod tests {
     fn different_identities_do_not_coalesce_even_for_same_origin() {
         let _guard = TEST_LOCK.lock();
         drain();
-        reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into());
-        match reserve_or_join("id-b", "https://a", "realm", false, "req-2".into(), "block-2".into()) {
+        reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into());
+        match reserve_or_join("id-b", "https://a", "host-a", 443, "realm", false, "req-2".into(), "block-2".into()) {
             Reservation::New { .. } => {}
             Reservation::Joined => panic!("different identities must not coalesce"),
         }
@@ -370,7 +414,7 @@ mod tests {
     fn take_removes_entry_and_returns_window_id() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
         {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
@@ -386,7 +430,7 @@ mod tests {
     fn cancel_for_window_finds_entry_by_window_id_not_approval_id() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
         {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
@@ -402,16 +446,19 @@ mod tests {
     fn cancel_for_block_unjoins_without_disturbing_sibling() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
         {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };
-        reserve_or_join("id-a", "https://a", "realm", false, "req-2".into(), "block-2".into());
+        reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-2".into(), "block-2".into());
         let closed_window = cancel_for_block("block-1");
         assert!(closed_window.is_empty(), "sibling still pending — window must not close");
         let resolved = take(&approval_id).expect("entry should still exist for block-2's request");
-        assert_eq!(resolved.auth_request_ids, vec!["req-2".to_string()]);
+        assert_eq!(
+            resolved.auth_requests.iter().map(|r| r.request_id.as_str()).collect::<Vec<_>>(),
+            vec!["req-2"],
+        );
         drain();
     }
 
@@ -419,7 +466,7 @@ mod tests {
     fn cancel_for_block_closes_window_when_last_request_leaves() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
         {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
@@ -435,14 +482,76 @@ mod tests {
     fn abandon_removes_entry_and_returns_request_ids() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
         {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };
-        let ids = abandon(&approval_id);
-        assert_eq!(ids, vec!["req-1".to_string()]);
+        let parked = abandon(&approval_id);
+        assert_eq!(
+            parked.iter().map(|p| p.request_id.as_str()).collect::<Vec<_>>(),
+            vec!["req-1"],
+        );
         assert!(take(&approval_id).is_none());
+        drain();
+    }
+
+    /// codex P2 / reagent P2 on PR #2824: `abandon` must hand back EVERY
+    /// request riding the reservation, each with its own `block_id` — the
+    /// window-creation-failure path falls them all through to the manual
+    /// prompt, and coalesced challenges can come from different panes. The
+    /// old signature returned bare request ids, so the caller had no way to
+    /// address a joined request's prompt to the right pane even if it had
+    /// used the return value (it discarded it, prompting only its own).
+    #[test]
+    fn abandon_returns_every_coalesced_request_with_its_own_block_id() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id =
+            match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into())
+            {
+                Reservation::New { approval_id } => approval_id,
+                Reservation::Joined => unreachable!(),
+            };
+        // A second pane hits the same protection space while the window is
+        // still being created.
+        match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-2".into(), "block-2".into()) {
+            Reservation::Joined => {}
+            Reservation::New { .. } => unreachable!("same protection space must join"),
+        }
+
+        let parked = abandon(&approval_id);
+        let pairs: Vec<(&str, &str)> =
+            parked.iter().map(|p| (p.request_id.as_str(), p.block_id.as_str())).collect();
+        assert_eq!(pairs, vec![("req-1", "block-1"), ("req-2", "block-2")]);
+        assert!(take(&approval_id).is_none());
+        drain();
+    }
+
+    /// The post-approval `Fill`-failure path re-emits the full
+    /// `browser-pane-auth-required` payload, which needs `host`/`port` —
+    /// by then the original challenge's locals are gone, so the entry has
+    /// to have carried them (reagent P1 on PR #2824).
+    #[test]
+    fn take_carries_host_port_and_per_request_block_ids() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id =
+            match reserve_or_join("id-a", "https://a", "host-a", 8443, "realm", false, "req-1".into(), "block-1".into())
+            {
+                Reservation::New { approval_id } => approval_id,
+                Reservation::Joined => unreachable!(),
+            };
+        reserve_or_join("id-a", "https://a", "host-a", 8443, "realm", false, "req-2".into(), "block-2".into());
+
+        let resolved = take(&approval_id).expect("approval still pending");
+        assert_eq!(resolved.host, "host-a");
+        assert_eq!(resolved.port, 8443);
+        assert_eq!(resolved.origin, "https://a");
+        assert_eq!(
+            resolved.auth_requests.iter().map(|r| r.block_id.as_str()).collect::<Vec<_>>(),
+            vec!["block-1", "block-2"],
+        );
         drain();
     }
 
@@ -457,14 +566,14 @@ mod tests {
         let _guard = TEST_LOCK.lock();
         drain();
 
-        let origin_approval = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+        let origin_approval = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into()) {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!("first request for this space"),
         };
         assert!(finalize_window(&origin_approval, "win-origin".into()));
 
         // Same block, DIFFERENT protection space (is_proxy) — a separate entry.
-        let proxy_approval = match reserve_or_join("id-a", "https://a", "realm", true, "req-2".into(), "block-1".into()) {
+        let proxy_approval = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", true, "req-2".into(), "block-1".into()) {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!("different protection space must not coalesce"),
         };
@@ -492,7 +601,7 @@ mod tests {
         let _guard = TEST_LOCK.lock();
         drain();
 
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into()) {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };
@@ -513,7 +622,7 @@ mod tests {
     fn finalize_window_reports_success_for_a_live_reservation() {
         let _guard = TEST_LOCK.lock();
         drain();
-        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+        let approval_id = match reserve_or_join("id-a", "https://a", "host-a", 443, "realm", false, "req-1".into(), "block-1".into()) {
             Reservation::New { approval_id } => approval_id,
             Reservation::Joined => unreachable!(),
         };

--- a/agentmux-cef/src/credential_broker/approval.rs
+++ b/agentmux-cef/src/credential_broker/approval.rs
@@ -1,0 +1,417 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parked credential-approval registry.
+//!
+//! Mirrors [`crate::browser_pane::auth`]'s TTL/epoch/HashMap shape, but is
+//! a distinct registry, not a shared one — the two have different
+//! cleanup triggers (this one's entries die with the *approval subwindow*;
+//! `browser_pane::auth`'s entries die with the *pane*), and a
+//! forced-generic registry covering both would be worse than two small
+//! ones. See `docs/status/majestic-painting-minsky` plan, "Why this
+//! shape."
+//!
+//! One entry here represents one *decision* pending human input — not one
+//! CEF auth challenge. Multiple simultaneous challenges for the same
+//! `(identity_id, origin, realm, is_proxy)` protection space coalesce
+//! into a single entry (and a single approval subwindow): see
+//! [`reserve_or_join`].
+//!
+//! The actual parked CEF `AuthCallback`s stay in `browser_pane::auth`,
+//! keyed by the `request_id`s this module only stores by string — this
+//! module never touches a CEF type directly, so it has no IO-thread
+//! affinity concerns of its own.
+
+use cef::ImplAuthCallback;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// One `browser_pane::auth` request riding this approval — its
+/// `request_id` (to resolve/cancel the parked `AuthCallback` later) and
+/// the `block_id` of the pane that raised it (so a pane closing
+/// independently of the approval window can be un-joined without
+/// disturbing siblings still waiting on the same approval).
+struct AuthRequest {
+    request_id: String,
+    block_id: String,
+}
+
+struct Entry {
+    identity_id: String,
+    origin: String,
+    realm: String,
+    is_proxy: bool,
+    /// `None` until the approval subwindow has actually been created —
+    /// see [`reserve_or_join`]'s doc comment for why reservation and
+    /// window-creation are two separate steps.
+    window_id: Option<String>,
+    auth_requests: Vec<AuthRequest>,
+    epoch: u64,
+}
+
+fn pending() -> &'static Mutex<HashMap<String, Entry>> {
+    static CELL: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+static NEXT_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+/// A single click, not manual multi-field entry — shorter than
+/// `browser_pane::auth`'s 5-minute TTL, but still generous for a human to
+/// actually notice and act on an approval prompt.
+const PARKED_TTL: Duration = Duration::from_secs(60);
+
+pub enum Reservation {
+    /// Joined an already-pending approval for the same protection space —
+    /// caller must NOT open a second approval subwindow. When the existing
+    /// approval resolves, this request resolves with it.
+    Joined,
+    /// No existing approval for this protection space; caller now owns
+    /// creating the subwindow and must call [`finalize_window`] with the
+    /// resulting `window_id` once it exists (or [`abandon`] if window
+    /// creation fails, so this one request can fall through to the normal
+    /// prompt instead of hanging until TTL).
+    New { approval_id: String },
+}
+
+/// Reserve (or join) a pending approval for `(identity_id, origin, realm,
+/// is_proxy)`. Reservation happens BEFORE the subwindow actually exists —
+/// opening a CEF window is itself async, and if a second challenge for the
+/// same protection space arrived in that gap, it would otherwise miss the
+/// yet-to-be-registered entry and open a redundant second window. Callers
+/// must always resolve a `New` reservation via `finalize_window` or
+/// `abandon`.
+pub fn reserve_or_join(
+    identity_id: &str,
+    origin: &str,
+    realm: &str,
+    is_proxy: bool,
+    request_id: String,
+    block_id: String,
+) -> Reservation {
+    let mut g = pending().lock();
+    if let Some(entry) = g.values_mut().find(|e| {
+        e.identity_id == identity_id && e.origin == origin && e.realm == realm && e.is_proxy == is_proxy
+    }) {
+        entry.auth_requests.push(AuthRequest { request_id, block_id });
+        return Reservation::Joined;
+    }
+
+    let approval_id = uuid::Uuid::new_v4().to_string();
+    let epoch = NEXT_EPOCH.fetch_add(1, Ordering::Relaxed);
+    g.insert(
+        approval_id.clone(),
+        Entry {
+            identity_id: identity_id.to_string(),
+            origin: origin.to_string(),
+            realm: realm.to_string(),
+            is_proxy,
+            window_id: None,
+            auth_requests: vec![AuthRequest { request_id, block_id }],
+            epoch,
+        },
+    );
+    arm_ttl(approval_id.clone(), epoch);
+    Reservation::New { approval_id }
+}
+
+/// Record the approval subwindow's `window_id` once it has actually been
+/// created, so `cancel_for_window` can later find this entry when the
+/// window (or its parent, cascading down) closes.
+pub fn finalize_window(approval_id: &str, window_id: String) {
+    let mut g = pending().lock();
+    if let Some(e) = g.get_mut(approval_id) {
+        e.window_id = Some(window_id);
+    } else {
+        tracing::warn!(
+            "[credential-broker] finalize_window: approval {} no longer pending \
+             (already resolved or timed out) — the just-opened subwindow is now \
+             orphaned and should be closed by the caller",
+            approval_id
+        );
+    }
+}
+
+/// A resolved approval — every parked auth request that was riding it,
+/// the window that should now be closed (its job is done), and the
+/// protection-space fields the caller needs to make the `credential.Fill`
+/// call on approve (this registry never holds the password itself — only
+/// enough to ask srv for it once a human has said yes).
+pub struct ResolvedApproval {
+    pub identity_id: String,
+    pub origin: String,
+    pub realm: String,
+    pub is_proxy: bool,
+    pub auth_request_ids: Vec<String>,
+    pub window_id: Option<String>,
+}
+
+/// Take (remove) a pending approval, e.g. after the human clicks
+/// Approve/Deny in the subwindow. `None` if it was already resolved or
+/// timed out — the IPC handler treats that as "nothing to do, just close
+/// the window."
+pub fn take(approval_id: &str) -> Option<ResolvedApproval> {
+    pending().lock().remove(approval_id).map(|e| ResolvedApproval {
+        identity_id: e.identity_id,
+        origin: e.origin,
+        realm: e.realm,
+        is_proxy: e.is_proxy,
+        auth_request_ids: e.auth_requests.into_iter().map(|r| r.request_id).collect(),
+        window_id: e.window_id,
+    })
+}
+
+/// Abandon a `New` reservation whose window creation failed — removes the
+/// entry outright (there's no window to ever finalize) and returns the
+/// request ids so the caller can fall each through to the normal prompt.
+pub fn abandon(approval_id: &str) -> Vec<String> {
+    pending()
+        .lock()
+        .remove(approval_id)
+        .map(|e| e.auth_requests.into_iter().map(|r| r.request_id).collect())
+        .unwrap_or_default()
+}
+
+/// Cancel whichever pending approval owns `window_id` — called when the
+/// approval subwindow itself closes (directly, or cascaded from its
+/// parent closing) before the human decided. Returns the auth request ids
+/// so the caller can cancel each parked `browser_pane::auth` callback
+/// (page falls back to its normal 401 body, same as clicking Cancel on
+/// the manual prompt today).
+pub fn cancel_for_window(window_id: &str) -> Vec<String> {
+    let mut g = pending().lock();
+    let approval_id = g
+        .iter()
+        .find(|(_, e)| e.window_id.as_deref() == Some(window_id))
+        .map(|(k, _)| k.clone());
+    match approval_id {
+        Some(id) => g
+            .remove(&id)
+            .map(|e| e.auth_requests.into_iter().map(|r| r.request_id).collect())
+            .unwrap_or_default(),
+        None => Vec::new(),
+    }
+}
+
+/// Un-join `block_id`'s auth request(s) from whichever pending approval(s)
+/// they're riding — called when a pane closes independently of the
+/// approval window (e.g. one of two coalesced panes closes while the
+/// human hasn't decided yet). If removing them empties an entry
+/// entirely, that whole approval is cancelled too (nothing left to
+/// resolve) and its `window_id` (if the subwindow already exists) is
+/// returned so the caller can close it.
+pub fn cancel_for_block(block_id: &str) -> Option<String> {
+    let mut g = pending().lock();
+    let mut emptied_id: Option<String> = None;
+    for (id, entry) in g.iter_mut() {
+        let before = entry.auth_requests.len();
+        entry.auth_requests.retain(|r| r.block_id != block_id);
+        if entry.auth_requests.len() != before && entry.auth_requests.is_empty() {
+            emptied_id = Some(id.clone());
+            break;
+        }
+    }
+    emptied_id.and_then(|id| g.remove(&id)).and_then(|e| e.window_id)
+}
+
+/// Same rationale as `browser_pane::auth`'s own TTL timer — this can be
+/// armed from CEF's IO thread (via `on_auth_credentials`'s spawned
+/// orchestration task, which itself needed a handle to spawn from in the
+/// first place), so a bare `tokio::spawn` is not guaranteed safe here
+/// either. Shares the single runtime handle installed by
+/// `super::set_runtime_handle` rather than keeping a second copy.
+fn arm_ttl(approval_id: String, epoch: u64) {
+    match super::runtime_handle() {
+        Some(handle) => {
+            handle.spawn(async move {
+                tokio::time::sleep(PARKED_TTL).await;
+                let expired: Option<Entry> = {
+                    let mut g = pending().lock();
+                    match g.get(&approval_id) {
+                        Some(e) if e.epoch == epoch => g.remove(&approval_id),
+                        _ => None,
+                    }
+                };
+                if let Some(entry) = expired {
+                    tracing::warn!(
+                        "[credential-broker] approval {} timed out after {:?} — \
+                         cancelling {} parked auth request(s)",
+                        approval_id,
+                        PARKED_TTL,
+                        entry.auth_requests.len(),
+                    );
+                    for req in entry.auth_requests {
+                        if let Some(cb) = crate::browser_pane::auth::take(&req.request_id) {
+                            cb.cancel();
+                        }
+                    }
+                    // The subwindow (if it exists) is left for the IPC
+                    // decide-handler to close on the next interaction, or
+                    // for its own parent-close cascade — this module has
+                    // no direct window-management handle, only `window_id`
+                    // strings, by design (keeps this registry free of a
+                    // dependency on `commands::window`).
+                }
+            });
+        }
+        None => {
+            tracing::error!(
+                "[credential-broker] tokio handle not installed; TTL timer skipped for \
+                 approval {} — entry will leak if never resolved. Did main.rs call \
+                 credential_broker::approval::set_runtime_handle?",
+                approval_id
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // All tests mutate the same process-wide static registry — cargo runs
+    // tests in a binary concurrently by default, so without serializing
+    // them here two tests could interleave against the same HashMap and
+    // produce flaky failures unrelated to the logic under test.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn drain() {
+        pending().lock().clear();
+    }
+
+    #[test]
+    fn reserve_creates_new_entry_for_first_request() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into()) {
+            Reservation::New { approval_id } => assert!(!approval_id.is_empty()),
+            Reservation::Joined => panic!("expected New for first request"),
+        }
+        drain();
+    }
+
+    #[test]
+    fn second_request_for_same_protection_space_joins() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => panic!("expected New for first request"),
+        };
+        match reserve_or_join("id-a", "https://a", "realm", false, "req-2".into(), "block-2".into()) {
+            Reservation::Joined => {}
+            Reservation::New { .. } => panic!("expected Joined for coalescing second request"),
+        }
+        let resolved = take(&approval_id).expect("entry should exist");
+        assert_eq!(resolved.auth_request_ids.len(), 2);
+        drain();
+    }
+
+    #[test]
+    fn different_protection_spaces_do_not_coalesce() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into());
+        match reserve_or_join("id-a", "https://b", "realm", false, "req-2".into(), "block-2".into()) {
+            Reservation::New { .. } => {}
+            Reservation::Joined => panic!("different origins must not coalesce"),
+        }
+        drain();
+    }
+
+    #[test]
+    fn different_identities_do_not_coalesce_even_for_same_origin() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into());
+        match reserve_or_join("id-b", "https://a", "realm", false, "req-2".into(), "block-2".into()) {
+            Reservation::New { .. } => {}
+            Reservation::Joined => panic!("different identities must not coalesce"),
+        }
+        drain();
+    }
+
+    #[test]
+    fn take_removes_entry_and_returns_window_id() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        finalize_window(&approval_id, "win-1".into());
+        let resolved = take(&approval_id).expect("entry should exist");
+        assert_eq!(resolved.window_id.as_deref(), Some("win-1"));
+        assert!(take(&approval_id).is_none(), "take must remove the entry");
+        drain();
+    }
+
+    #[test]
+    fn cancel_for_window_finds_entry_by_window_id_not_approval_id() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        finalize_window(&approval_id, "win-1".into());
+        let ids = cancel_for_window("win-1");
+        assert_eq!(ids, vec!["req-1".to_string()]);
+        assert!(take(&approval_id).is_none());
+        drain();
+    }
+
+    #[test]
+    fn cancel_for_block_unjoins_without_disturbing_sibling() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        reserve_or_join("id-a", "https://a", "realm", false, "req-2".into(), "block-2".into());
+        let closed_window = cancel_for_block("block-1");
+        assert!(closed_window.is_none(), "sibling still pending — window must not close");
+        let resolved = take(&approval_id).expect("entry should still exist for block-2's request");
+        assert_eq!(resolved.auth_request_ids, vec!["req-2".to_string()]);
+        drain();
+    }
+
+    #[test]
+    fn cancel_for_block_closes_window_when_last_request_leaves() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        finalize_window(&approval_id, "win-1".into());
+        let closed_window = cancel_for_block("block-1");
+        assert_eq!(closed_window.as_deref(), Some("win-1"));
+        assert!(take(&approval_id).is_none());
+        drain();
+    }
+
+    #[test]
+    fn abandon_removes_entry_and_returns_request_ids() {
+        let _guard = TEST_LOCK.lock();
+        drain();
+        let approval_id = match reserve_or_join("id-a", "https://a", "realm", false, "req-1".into(), "block-1".into())
+        {
+            Reservation::New { approval_id } => approval_id,
+            Reservation::Joined => unreachable!(),
+        };
+        let ids = abandon(&approval_id);
+        assert_eq!(ids, vec!["req-1".to_string()]);
+        assert!(take(&approval_id).is_none());
+        drain();
+    }
+}

--- a/agentmux-cef/src/credential_broker/mod.rs
+++ b/agentmux-cef/src/credential_broker/mod.rs
@@ -108,7 +108,7 @@ pub fn on_auth_challenge(
                  credential_broker::set_runtime_handle?",
                 request_id
             );
-            fall_through(&state, &block_id, &request_id, &origin, &host, port, &realm, is_proxy);
+            fall_through_to(&state, &block_id, &request_id, &origin, &host, port, &realm, is_proxy);
         }
     }
 }
@@ -123,7 +123,7 @@ async fn run_challenge(
     realm: String,
     is_proxy: bool,
 ) {
-    let fall_through = || fall_through(&state, &block_id, &request_id, &origin, &host, port, &realm, is_proxy);
+    let fall_through = || fall_through_to(&state, &block_id, &request_id, &origin, &host, port, &realm, is_proxy);
 
     let identity_id = match call_credential_service(
         &state,
@@ -201,7 +201,16 @@ async fn run_challenge(
         .unwrap_or("")
         .to_string();
 
-    match approval::reserve_or_join(&identity_id, &origin, &realm, is_proxy, request_id.clone(), block_id.clone()) {
+    match approval::reserve_or_join(
+        &identity_id,
+        &origin,
+        &host,
+        port,
+        &realm,
+        is_proxy,
+        request_id.clone(),
+        block_id.clone(),
+    ) {
         approval::Reservation::Joined => {
             tracing::info!(
                 "[credential-broker] request_id {} joined an already-pending approval for \
@@ -230,13 +239,34 @@ async fn run_challenge(
                     }
                 }
                 Err(e) => {
+                    // Fall through EVERY request riding this reservation, not
+                    // just our own. Another same-protection-space challenge can
+                    // join on a different Tokio worker while
+                    // `open_approval_window` runs (no lock is held across it),
+                    // and it may belong to a different pane — so each needs a
+                    // prompt addressed to its own `block_id`. Discarding
+                    // `abandon`'s return value left those joined requests
+                    // parked with no prompt until `browser_pane::auth`'s TTL
+                    // fired (codex P2 / reagent P2 on PR #2824).
                     tracing::warn!(
                         "[credential-broker] failed to open approval window for origin={}: {e} \
                          — falling through",
                         origin,
                     );
-                    approval::abandon(&approval_id);
-                    fall_through();
+                    let mut parked = approval::abandon(&approval_id);
+                    // `abandon` returns nothing if the entry was already gone
+                    // (pane closed / TTL) during the window-creation gap. Our
+                    // own request still needs its prompt either way, and must
+                    // not be prompted twice if it is in the list.
+                    if !parked.iter().any(|p| p.request_id == request_id) {
+                        parked.push(approval::ParkedRequest {
+                            request_id: request_id.clone(),
+                            block_id: block_id.clone(),
+                        });
+                    }
+                    for p in &parked {
+                        fall_through_to(&state, &p.block_id, &p.request_id, &origin, &host, port, &realm, is_proxy);
+                    }
                 }
             }
         }
@@ -246,7 +276,7 @@ async fn run_challenge(
 /// Emit the same `browser-pane-auth-required` event `on_auth_credentials`
 /// emitted unconditionally before this feature existed — the unmodified
 /// baseline path, reached from every early-return above.
-fn fall_through(
+pub(crate) fn fall_through_to(
     state: &Arc<AppState>,
     block_id: &str,
     request_id: &str,

--- a/agentmux-cef/src/credential_broker/mod.rs
+++ b/agentmux-cef/src/credential_broker/mod.rs
@@ -346,12 +346,23 @@ fn http_client() -> &'static reqwest::Client {
     CLIENT.get_or_init(reqwest::Client::new)
 }
 
-/// POST `{"service": "credential", "method": ..., "args": [args0]}` to
-/// `/agentmux/service`, same endpoint + `X-AuthKey` auth
+/// POST `{"service": "credential", "method": ..., "args": [args0, secret]}`
+/// to `/agentmux/service`, same endpoint + `X-AuthKey` auth
 /// `client::helpers::backend_close_window` already uses for this
 /// direction — async via `reqwest` here rather than that raw-TCP style,
 /// since this call site is already fully async (unlike
 /// `backend_close_window`'s non-async caller).
+///
+/// `args[1]` is `AGENTMUX_HOST_REG_SECRET` — srv rejects every method on
+/// this service without it. `X-AuthKey` alone is NOT sufficient and must
+/// never be treated as such here: it's injected into every agent's own
+/// environment, so gating on it alone let any agent `curl` the plaintext
+/// password straight out of `credential.Fill` (reagent P0 on PR #2824).
+/// See `agentmux-srv/src/server/service/credential.rs`'s module doc.
+///
+/// Sent as a positional arg rather than a header to match
+/// `host_ipc.Register`'s existing shape (`args[2]` there), keeping both
+/// host→srv host-proving calls in one idiom.
 async fn call_credential_service(
     state: &Arc<AppState>,
     method: &str,
@@ -362,11 +373,22 @@ async fn call_credential_service(
         return Err("backend web_endpoint not yet configured".to_string());
     }
     let auth_key = state.auth_key.lock().clone();
+    let host_reg_secret = state.host_reg_secret.lock().clone();
+    if host_reg_secret.is_empty() {
+        // Every caller of this function already falls through to the manual
+        // prompt on Err, so failing here degrades to "no auto-fill" rather
+        // than breaking auth — the same posture as every other failure mode
+        // in this feature.
+        return Err(format!(
+            "credential.{method}: host has no AGENTMUX_HOST_REG_SECRET — cannot prove \
+             host identity to srv, falling through to the manual prompt"
+        ));
+    }
     let url = format!("{}/agentmux/service", web_endpoint.trim_end_matches('/'));
     let body = serde_json::json!({
         "service": "credential",
         "method": method,
-        "args": [args0],
+        "args": [args0, host_reg_secret],
         "uicontext": serde_json::Value::Null,
     });
 

--- a/agentmux-cef/src/credential_broker/mod.rs
+++ b/agentmux-cef/src/credential_broker/mod.rs
@@ -1,0 +1,458 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Credential-isolated browser-pane auto-fill.
+//!
+//! Orchestrates `on_auth_credentials` (`client::crash_recovery`) against
+//! the srv-side `credential` service (identity resolve → keychain lookup)
+//! and, when a stored credential exists, a human-approval subwindow
+//! (never a `<Modal>` — see [`approval`]'s doc comment and the plan's
+//! "Why this shape" for why a `<Modal>` would leak the Approve control to
+//! any agent's `UIQuery`/`UIClick`, not just the one whose credential is
+//! being approved). See `docs/status/majestic-painting-minsky` plan.
+//!
+//! Every failure mode here — srv unreachable, keychain error, no stored
+//! credential, window-creation failure — falls through to the existing,
+//! unmodified `browser-pane-auth-required` prompt. This module can only
+//! ever make auth *more* automatic, never break the baseline flow.
+
+pub mod approval;
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serde::Deserialize;
+use tokio::runtime::Handle;
+
+use crate::state::AppState;
+
+/// Installed once from `main.rs`, alongside `browser_pane::auth`'s own
+/// handle — CEF invokes `on_auth_credentials` on its IO thread, which has
+/// no `Handle::current()`, so a bare `tokio::spawn` there would panic.
+/// [`approval`]'s TTL timer shares this same handle via [`runtime_handle`]
+/// rather than keeping a second copy.
+static TOKIO_HANDLE: OnceLock<Handle> = OnceLock::new();
+
+pub fn set_runtime_handle(h: Handle) {
+    let _ = TOKIO_HANDLE.set(h);
+}
+
+pub(crate) fn runtime_handle() -> Option<Handle> {
+    TOKIO_HANDLE.get().cloned()
+}
+
+/// srv is on the same machine (`127.0.0.1`) — a slow/unreachable srv must
+/// never add a long stall to auth challenges that have no stored
+/// credential at all (the overwhelming common case, now sitting in this
+/// module's critical path for every challenge, not just ones this feature
+/// actually helps). 3s comfortably covers a legitimately slow keychain
+/// prompt (e.g. an OS consent dialog) without making a genuinely dead srv
+/// feel like a hang.
+const SRV_CALL_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Entry point called from `on_auth_credentials` right after it parks the
+/// CEF `AuthCallback` in `browser_pane::auth` (unchanged). Spawns the
+/// async identity-resolve → keychain-lookup → (approval-window | fall
+/// through) sequence; `on_auth_credentials` itself still returns
+/// synchronously to CEF regardless of what this decides.
+pub fn on_auth_challenge(
+    state: Arc<AppState>,
+    request_id: String,
+    block_id: String,
+    origin: String,
+    host: String,
+    port: i32,
+    realm: String,
+    is_proxy: bool,
+) {
+    match runtime_handle() {
+        Some(handle) => {
+            handle.spawn(run_challenge(state, request_id, block_id, origin, host, port, realm, is_proxy));
+        }
+        None => {
+            tracing::error!(
+                "[credential-broker] tokio handle not installed — falling through to the \
+                 manual prompt for request_id {}. Did main.rs call \
+                 credential_broker::set_runtime_handle?",
+                request_id
+            );
+            fall_through(&state, &block_id, &request_id, &origin, &host, port, &realm, is_proxy);
+        }
+    }
+}
+
+async fn run_challenge(
+    state: Arc<AppState>,
+    request_id: String,
+    block_id: String,
+    origin: String,
+    host: String,
+    port: i32,
+    realm: String,
+    is_proxy: bool,
+) {
+    let fall_through = || fall_through(&state, &block_id, &request_id, &origin, &host, port, &realm, is_proxy);
+
+    let identity_id = match call_credential_service(
+        &state,
+        "ResolveIdentity",
+        serde_json::json!({ "block_id": block_id }),
+    )
+    .await
+    {
+        Ok(data) => data
+            .get("identity_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        Err(e) => {
+            tracing::warn!("[credential-broker] ResolveIdentity failed: {e} — falling through");
+            fall_through();
+            return;
+        }
+    };
+    if identity_id.is_empty() {
+        // No identity bound to this pane's instance — nothing to look up.
+        fall_through();
+        return;
+    }
+
+    // A re-challenge for the exact same protection space shortly after we
+    // auto-filled it means the stored credential was wrong (CEF gives no
+    // "auth succeeded" signal to hook — this is the only observable
+    // proxy). Delete it and fall through rather than looping the same bad
+    // credential forever.
+    let recent_key = recent_fill::key(&identity_id, &origin, &realm, is_proxy);
+    if recent_fill::take_if_recent(&recent_key) {
+        tracing::info!(
+            "[credential-broker] re-challenge within {:?} of an auto-fill for origin={} — \
+             treating the stored credential as wrong; deleting and falling through",
+            recent_fill::WINDOW,
+            origin,
+        );
+        let _ = call_credential_service(
+            &state,
+            "Delete",
+            serde_json::json!({
+                "identity_id": identity_id, "origin": origin, "realm": realm, "is_proxy": is_proxy,
+            }),
+        )
+        .await;
+        fall_through();
+        return;
+    }
+
+    let lookup = match call_credential_service(
+        &state,
+        "Lookup",
+        serde_json::json!({
+            "identity_id": identity_id, "origin": origin, "realm": realm, "is_proxy": is_proxy,
+        }),
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(e) => {
+            tracing::warn!("[credential-broker] Lookup failed: {e} — falling through");
+            fall_through();
+            return;
+        }
+    };
+    let found = lookup.get("found").and_then(|v| v.as_bool()).unwrap_or(false);
+    if !found {
+        fall_through();
+        return;
+    }
+    let masked_username = lookup
+        .get("username")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    match approval::reserve_or_join(&identity_id, &origin, &realm, is_proxy, request_id.clone(), block_id.clone()) {
+        approval::Reservation::Joined => {
+            tracing::info!(
+                "[credential-broker] request_id {} joined an already-pending approval for \
+                 origin={}",
+                request_id,
+                origin,
+            );
+        }
+        approval::Reservation::New { approval_id } => {
+            match open_approval_window(&state, &block_id, &approval_id, &origin, &realm, is_proxy, &masked_username)
+            {
+                Ok(window_id) => approval::finalize_window(&approval_id, window_id),
+                Err(e) => {
+                    tracing::warn!(
+                        "[credential-broker] failed to open approval window for origin={}: {e} \
+                         — falling through",
+                        origin,
+                    );
+                    approval::abandon(&approval_id);
+                    fall_through();
+                }
+            }
+        }
+    }
+}
+
+/// Emit the same `browser-pane-auth-required` event `on_auth_credentials`
+/// emitted unconditionally before this feature existed — the unmodified
+/// baseline path, reached from every early-return above.
+fn fall_through(
+    state: &Arc<AppState>,
+    block_id: &str,
+    request_id: &str,
+    origin: &str,
+    host: &str,
+    port: i32,
+    realm: &str,
+    is_proxy: bool,
+) {
+    crate::events::emit_event_to_top_level_windows(
+        state,
+        "browser-pane-auth-required",
+        &serde_json::json!({
+            "block_id": block_id,
+            "request_id": request_id,
+            "origin": origin,
+            "host": host,
+            "port": port,
+            "realm": realm,
+            "is_proxy": is_proxy,
+        }),
+    );
+}
+
+/// Open the credential-approval subwindow, a genuinely separate top-level
+/// CEF window/DOM (never a `<Modal>`) — see this module's own doc comment
+/// for why. Parented to whichever top-level window currently owns
+/// `block_id`, so it closes along with that window
+/// (`client::lifecycle::on_before_close` → `approval::cancel_for_window`,
+/// wired in a follow-up commit) if the human never decides.
+fn open_approval_window(
+    state: &Arc<AppState>,
+    block_id: &str,
+    approval_id: &str,
+    origin: &str,
+    realm: &str,
+    is_proxy: bool,
+    masked_username: &str,
+) -> Result<String, String> {
+    let parent_label = state
+        .browser_pane_window_label(block_id)
+        .ok_or_else(|| format!("no owning window found for block {block_id}"))?;
+
+    let meta = serde_json::json!({
+        "approval_id": approval_id,
+        "origin": origin,
+        "realm": realm,
+        "is_proxy": is_proxy,
+        "masked_username": masked_username,
+    })
+    .to_string();
+
+    let result = crate::commands::window::open_subwindow(
+        state,
+        parent_label,
+        Some("credential-approval"),
+        Some(&meta),
+    )?;
+    result
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| "open_subwindow returned a non-string window label".to_string())
+}
+
+/// Called once a human approves in the subwindow, right before `cb.cont()`
+/// — the ONE place a plaintext password crosses into this process. Marks
+/// the protection space as "recently filled" so a fast re-challenge (a
+/// wrong saved credential) is recognized by [`run_challenge`] above.
+pub async fn fill_credential(
+    state: &Arc<AppState>,
+    identity_id: &str,
+    origin: &str,
+    realm: &str,
+    is_proxy: bool,
+) -> Result<(String, String), String> {
+    let data = call_credential_service(
+        state,
+        "Fill",
+        serde_json::json!({
+            "identity_id": identity_id, "origin": origin, "realm": realm, "is_proxy": is_proxy,
+        }),
+    )
+    .await?;
+    let username = data
+        .get("username")
+        .and_then(|v| v.as_str())
+        .ok_or("credential.Fill: response missing username")?
+        .to_string();
+    let password = data
+        .get("password")
+        .and_then(|v| v.as_str())
+        .ok_or("credential.Fill: response missing password")?
+        .to_string();
+    recent_fill::mark(recent_fill::key(identity_id, origin, realm, is_proxy));
+    Ok((username, password))
+}
+
+/// Called from the `browser_pane_auth_save` IPC handler after a human
+/// manually submits credentials with the "save this credential" checkbox
+/// checked (`frontend/app/view/browser/use-browser-auth.ts`). Resolves
+/// `block_id` → `identity_id` itself rather than requiring the caller to
+/// — the renderer never learns `identity_id`, only `block_id`.
+pub async fn save_credential(
+    state: &Arc<AppState>,
+    block_id: &str,
+    origin: &str,
+    realm: &str,
+    is_proxy: bool,
+    username: &str,
+    password: &str,
+) -> Result<(), String> {
+    let identity_id = call_credential_service(state, "ResolveIdentity", serde_json::json!({ "block_id": block_id }))
+        .await?
+        .get("identity_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if identity_id.is_empty() {
+        return Err("no identity bound to this pane — nothing to save the credential under".to_string());
+    }
+    call_credential_service(
+        state,
+        "Save",
+        serde_json::json!({
+            "identity_id": identity_id, "origin": origin, "realm": realm, "is_proxy": is_proxy,
+            "username": username, "password": password,
+        }),
+    )
+    .await?;
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct WebReturn {
+    success: bool,
+    error: Option<String>,
+    data: Option<serde_json::Value>,
+}
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// POST `{"service": "credential", "method": ..., "args": [args0]}` to
+/// `/agentmux/service`, same endpoint + `X-AuthKey` auth
+/// `client::helpers::backend_close_window` already uses for this
+/// direction — async via `reqwest` here rather than that raw-TCP style,
+/// since this call site is already fully async (unlike
+/// `backend_close_window`'s non-async caller).
+async fn call_credential_service(
+    state: &Arc<AppState>,
+    method: &str,
+    args0: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+    if web_endpoint.is_empty() {
+        return Err("backend web_endpoint not yet configured".to_string());
+    }
+    let auth_key = state.auth_key.lock().clone();
+    let url = format!("{}/agentmux/service", web_endpoint.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "service": "credential",
+        "method": method,
+        "args": [args0],
+        "uicontext": serde_json::Value::Null,
+    });
+
+    let resp = http_client()
+        .post(&url)
+        .header("X-AuthKey", auth_key)
+        .json(&body)
+        .timeout(SRV_CALL_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| format!("credential.{method}: request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("credential.{method}: HTTP {}", resp.status()));
+    }
+
+    let parsed: WebReturn = resp
+        .json()
+        .await
+        .map_err(|e| format!("credential.{method}: bad response body: {e}"))?;
+    if !parsed.success {
+        return Err(parsed.error.unwrap_or_else(|| format!("credential.{method}: unknown error")));
+    }
+    Ok(parsed.data.unwrap_or(serde_json::Value::Null))
+}
+
+/// Short-TTL "this protection space was just auto-filled" marker, used
+/// only to detect a wrong stored credential (see [`run_challenge`]'s use
+/// of `take_if_recent`). Deliberately separate from [`approval`]'s
+/// registry — different lifetime (survives past the approval itself,
+/// which is already resolved and gone by the time this matters) and
+/// different key shape (no request/window association at all, just a
+/// timestamp per protection space).
+mod recent_fill {
+    use super::*;
+
+    pub const WINDOW: Duration = Duration::from_secs(15);
+
+    fn marks() -> &'static Mutex<HashMap<String, Instant>> {
+        static CELL: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+        CELL.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Not a cryptographic key — just a namespaced join of fields already
+    /// scoped by identity_id (unlike `browser_credential_store::account_key`,
+    /// this key never leaves the process, so delimiter-collision hardening
+    /// isn't worth the extra complexity here; a false-positive collision
+    /// only ever causes an extra fall-through prompt, never a credential
+    /// leak).
+    pub fn key(identity_id: &str, origin: &str, realm: &str, is_proxy: bool) -> String {
+        format!("{identity_id}\u{0}{origin}\u{0}{realm}\u{0}{is_proxy}")
+    }
+
+    pub fn mark(key: String) {
+        marks().lock().insert(key, Instant::now());
+    }
+
+    /// If `key` was marked within the last [`WINDOW`], consume the mark
+    /// (so a THIRD challenge doesn't also read as "recent") and return
+    /// true. Also opportunistically drops any other stale entries so this
+    /// map can't grow unbounded across a long session.
+    pub fn take_if_recent(key: &str) -> bool {
+        let mut g = marks().lock();
+        let now = Instant::now();
+        g.retain(|_, t| now.duration_since(*t) < WINDOW);
+        g.remove(key).is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recent_fill;
+
+    #[test]
+    fn recent_fill_marks_and_consumes_once() {
+        let key = recent_fill::key("id", "https://a", "realm", false);
+        assert!(!recent_fill::take_if_recent(&key), "unmarked key must not read as recent");
+        recent_fill::mark(key.clone());
+        assert!(recent_fill::take_if_recent(&key), "marked key must read as recent");
+        assert!(!recent_fill::take_if_recent(&key), "take_if_recent must consume the mark");
+    }
+
+    #[test]
+    fn recent_fill_key_distinguishes_protection_spaces() {
+        let a = recent_fill::key("id", "https://a", "realm", false);
+        let b = recent_fill::key("id", "https://b", "realm", false);
+        assert_ne!(a, b);
+    }
+}

--- a/agentmux-cef/src/credential_broker/mod.rs
+++ b/agentmux-cef/src/credential_broker/mod.rs
@@ -43,6 +43,36 @@ pub(crate) fn runtime_handle() -> Option<Handle> {
     TOKIO_HANDLE.get().cloned()
 }
 
+/// Closes an approval subwindow by label. Installed once from `lib.rs`
+/// alongside [`set_runtime_handle`], for the same reason a handle is: the
+/// paths that need to close a window (notably [`approval`]'s TTL timer)
+/// run on tasks that hold neither `AppState` nor a window handle.
+///
+/// A hook rather than a direct `commands::window` call from [`approval`] so
+/// that module keeps its stated design property — it holds `window_id`
+/// strings and nothing else, with no dependency on window management.
+type WindowCloser = Box<dyn Fn(&str) + Send + Sync + 'static>;
+static WINDOW_CLOSER: OnceLock<WindowCloser> = OnceLock::new();
+
+pub fn set_window_closer(f: impl Fn(&str) + Send + Sync + 'static) {
+    let _ = WINDOW_CLOSER.set(Box::new(f));
+}
+
+/// Best-effort — a failure (or a closer that was never installed) leaves a
+/// dead window for the human to close, which is strictly better than the
+/// previous behaviour of always leaving it. Never propagates: every caller
+/// is on a cleanup path where there is nothing useful to do with an error.
+pub(crate) fn close_approval_window(window_id: &str) {
+    match WINDOW_CLOSER.get() {
+        Some(f) => f(window_id),
+        None => tracing::error!(
+            "[credential-broker] no window closer installed; approval subwindow {} will \
+             be left open. Did lib.rs call credential_broker::set_window_closer?",
+            window_id
+        ),
+    }
+}
+
 /// srv is on the same machine (`127.0.0.1`) — a slow/unreachable srv must
 /// never add a long stall to auth challenges that have no stored
 /// credential at all (the overwhelming common case, now sitting in this
@@ -183,7 +213,22 @@ async fn run_challenge(
         approval::Reservation::New { approval_id } => {
             match open_approval_window(&state, &block_id, &approval_id, &origin, &realm, is_proxy, &masked_username)
             {
-                Ok(window_id) => approval::finalize_window(&approval_id, window_id),
+                Ok(window_id) => {
+                    // The reservation can be cancelled (pane closed) or time
+                    // out during `open_approval_window`'s synchronous gap —
+                    // no lock is held across it. If that happened, the window
+                    // now belongs to nothing: `cancel_for_window` can't match
+                    // it, the decide-handler's `take` returns `None`, and the
+                    // TTL entry is already gone — so nothing else will ever
+                    // close it (reagent P1 on PR #2824). Close it here, and
+                    // fall this request through to the manual prompt rather
+                    // than leaving it parked for a decision that can no
+                    // longer be made.
+                    if !approval::finalize_window(&approval_id, window_id.clone()) {
+                        close_approval_window(&window_id);
+                        fall_through();
+                    }
+                }
                 Err(e) => {
                     tracing::warn!(
                         "[credential-broker] failed to open approval window for origin={}: {e} \

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -692,31 +692,54 @@ async fn route_command(
                         use cef::ImplAuthCallback;
                         let u = cef::CefString::from(username.as_str());
                         let p = cef::CefString::from(password.as_str());
-                        for request_id in &resolved.auth_request_ids {
-                            if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                        for parked in &resolved.auth_requests {
+                            if let Some(cb) = crate::browser_pane::auth::take(&parked.request_id) {
                                 cb.cont(Some(&u), Some(&p));
                             }
                         }
                     }
                     Err(e) => {
+                        // The human already said yes; the secret just could not
+                        // be read (credential deleted between approval and
+                        // Fill, transient keychain/backend failure, srv
+                        // restart). Cancelling here would render the bare 401
+                        // with no way to type credentials — strictly worse than
+                        // pre-feature behaviour, and a direct violation of this
+                        // feature's "can only make auth more automatic, never
+                        // break the baseline" guarantee (codex P2 → reagent P1
+                        // on PR #2824).
+                        //
+                        // So leave every callback PARKED in
+                        // `browser_pane::auth` and emit the ordinary
+                        // `browser-pane-auth-required` prompt for each, one per
+                        // originating pane — coalesced requests can come from
+                        // different panes. The manual prompt then resolves the
+                        // very same parked callbacks, exactly as it does when
+                        // no stored credential exists at all.
                         tracing::warn!(
                             "[credential-broker] Fill failed for approval_id {}: {e} — \
-                             cancelling {} parked auth request(s)",
+                             falling {} parked auth request(s) through to the manual prompt",
                             approval_id,
-                            resolved.auth_request_ids.len(),
+                            resolved.auth_requests.len(),
                         );
-                        use cef::ImplAuthCallback;
-                        for request_id in &resolved.auth_request_ids {
-                            if let Some(cb) = crate::browser_pane::auth::take(request_id) {
-                                cb.cancel();
-                            }
+                        for parked in &resolved.auth_requests {
+                            crate::credential_broker::fall_through_to(
+                                state,
+                                &parked.block_id,
+                                &parked.request_id,
+                                &resolved.origin,
+                                &resolved.host,
+                                resolved.port,
+                                &resolved.realm,
+                                resolved.is_proxy,
+                            );
                         }
                     }
                 }
             } else {
                 use cef::ImplAuthCallback;
-                for request_id in &resolved.auth_request_ids {
-                    if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                for parked in &resolved.auth_requests {
+                    if let Some(cb) = crate::browser_pane::auth::take(&parked.request_id) {
                         cb.cancel();
                     }
                 }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -234,7 +234,9 @@ async fn route_command(
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| "open_subwindow: parent_instance_id required".to_string())?
                 .to_string();
-            commands::window::open_subwindow(state, parent)
+            let initial_view = args.get("initial_view").and_then(|v| v.as_str());
+            let initial_meta = args.get("initial_meta").and_then(|v| v.as_str());
+            commands::window::open_subwindow(state, parent, initial_view, initial_meta)
         }
         "open_floating_pane_window" => {
             // Floating-pane tear-off — a chromeless window showing just the
@@ -512,6 +514,19 @@ async fn route_command(
             // pane mid-auth-prompt leaks the CEF AuthCallback refcount
             // until the 5-minute TTL fires.
             crate::browser_pane::auth::cancel_for_block(block_id);
+            // Un-join this pane's request from any pending credential
+            // approval it was riding (possibly shared with a sibling pane
+            // hitting the same protection space — see
+            // `credential_broker::approval`'s coalescing). If this was the
+            // last request on that approval, close its now-pointless
+            // subwindow too.
+            if let Some(window_id) = crate::credential_broker::approval::cancel_for_block(block_id) {
+                if let Err(e) =
+                    commands::window::close_window_by_label(state, &serde_json::json!({ "label": window_id }))
+                {
+                    tracing::warn!("[credential-broker] failed to close orphaned approval window: {e}");
+                }
+            }
             state.browser_panes.close(block_id, state);
             Ok(serde_json::json!(true))
         }
@@ -607,6 +622,114 @@ async fn route_command(
             } else {
                 Ok(serde_json::json!(false))
             }
+        }
+        "browser_pane_auth_save" => {
+            // Opt-in save after a manual credential submit — a wholly new
+            // command rather than a flag on browser_pane_auth_submit, so
+            // that IPC's contract stays byte-for-byte unchanged.
+            // `frontend/app/view/browser/use-browser-auth.ts` fires this
+            // right after `browser_pane_auth_submit` when the user checked
+            // "save this credential." A failure here never affects the
+            // page load — auth already succeeded via the untouched submit
+            // path — so this only ever surfaces as a non-blocking toast on
+            // the renderer side.
+            let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            let origin = args.get("origin").and_then(|v| v.as_str()).unwrap_or("");
+            let realm = args.get("realm").and_then(|v| v.as_str()).unwrap_or("");
+            let is_proxy = args.get("is_proxy").and_then(|v| v.as_bool()).unwrap_or(false);
+            let username = args.get("username").and_then(|v| v.as_str()).unwrap_or("");
+            let password = args.get("password").and_then(|v| v.as_str()).unwrap_or("");
+            match crate::credential_broker::save_credential(
+                state, block_id, origin, realm, is_proxy, username, password,
+            )
+            .await
+            {
+                Ok(()) => Ok(serde_json::json!(true)),
+                Err(e) => {
+                    tracing::warn!("[credential-broker] browser_pane_auth_save failed: {e}");
+                    Err(e)
+                }
+            }
+        }
+        "credential_approval_decide" => {
+            // The human resolved the credential-approval subwindow —
+            // approve (Fill + cont() every coalesced parked callback) or
+            // deny (cancel() each). See `credential_broker::approval` for
+            // the coalescing rationale (multiple panes hitting the same
+            // protection space near-simultaneously share one approval).
+            let approval_id = args.get("approval_id").and_then(|v| v.as_str()).unwrap_or("");
+            let approve = args.get("approve").and_then(|v| v.as_bool()).unwrap_or(false);
+            tracing::info!(
+                "[credential-broker] approval_decide approval_id={} approve={}",
+                approval_id,
+                approve,
+            );
+            let Some(resolved) = crate::credential_broker::approval::take(approval_id) else {
+                tracing::warn!(
+                    "[credential-broker] decide for unknown/expired approval_id {} — already \
+                     resolved or timed out",
+                    approval_id,
+                );
+                return Ok(serde_json::json!(false));
+            };
+
+            if approve {
+                match crate::credential_broker::fill_credential(
+                    state,
+                    &resolved.identity_id,
+                    &resolved.origin,
+                    &resolved.realm,
+                    resolved.is_proxy,
+                )
+                .await
+                {
+                    Ok((username, password)) => {
+                        use cef::ImplAuthCallback;
+                        let u = cef::CefString::from(username.as_str());
+                        let p = cef::CefString::from(password.as_str());
+                        for request_id in &resolved.auth_request_ids {
+                            if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                                cb.cont(Some(&u), Some(&p));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[credential-broker] Fill failed for approval_id {}: {e} — \
+                             cancelling {} parked auth request(s)",
+                            approval_id,
+                            resolved.auth_request_ids.len(),
+                        );
+                        use cef::ImplAuthCallback;
+                        for request_id in &resolved.auth_request_ids {
+                            if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                                cb.cancel();
+                            }
+                        }
+                    }
+                }
+            } else {
+                use cef::ImplAuthCallback;
+                for request_id in &resolved.auth_request_ids {
+                    if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                        cb.cancel();
+                    }
+                }
+            }
+
+            // The approval subwindow's job is done — close it regardless
+            // of approve/deny. Best-effort: a failure here just leaves a
+            // dead window the human closes manually, never blocks the
+            // decision that already took effect above.
+            if let Some(window_id) = resolved.window_id {
+                if let Err(e) =
+                    commands::window::close_window_by_label(state, &serde_json::json!({ "label": window_id }))
+                {
+                    tracing::warn!("[credential-broker] failed to close approval window: {e}");
+                }
+            }
+
+            Ok(serde_json::json!(true))
         }
         "browser_panes_set_overlay_clip" => {
             // Apply a clip region to every pane HWND that excludes the given

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -520,7 +520,12 @@ async fn route_command(
             // `credential_broker::approval`'s coalescing). If this was the
             // last request on that approval, close its now-pointless
             // subwindow too.
-            if let Some(window_id) = crate::credential_broker::approval::cancel_for_block(block_id) {
+            // Plural: one pane can ride several approvals at once (a
+            // proxy-auth and an origin-auth challenge from the same page),
+            // and closing it can empty more than one of them. The earlier
+            // singular form dropped every emptied approval past the first
+            // (reagent P2 on PR #2824).
+            for window_id in crate::credential_broker::approval::cancel_for_block(block_id) {
                 if let Err(e) =
                     commands::window::close_window_by_label(state, &serde_json::json!({ "label": window_id }))
                 {

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -34,6 +34,7 @@ mod srv_ipc;
 mod memory_heartbeat;
 mod memory_pressure;
 mod browser_pane;
+mod credential_broker;
 #[cfg(target_os = "windows")]
 mod floating_pane;
 mod reducer;
@@ -645,6 +646,11 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     // `tokio::spawn` there would panic with "there is no reactor
     // running" because that thread has no `Handle::current()`.
     browser_pane::auth::set_runtime_handle(runtime.handle().clone());
+
+    // Same rationale, for the credential broker's async orchestration
+    // (and the approval registry's TTL timer, which shares this handle) —
+    // see `credential_broker::set_runtime_handle`'s doc comment.
+    credential_broker::set_runtime_handle(runtime.handle().clone());
 
     // Start the IPC HTTP server and get the assigned port.
     let ipc_port = runtime.block_on(ipc::start_ipc_server(app_state.clone()));

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -652,6 +652,23 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     // see `credential_broker::set_runtime_handle`'s doc comment.
     credential_broker::set_runtime_handle(runtime.handle().clone());
 
+    // Lets the approval registry's TTL timer close an expired approval's
+    // subwindow. It holds `window_id` strings and nothing else by design, and
+    // its timer task has neither `AppState` nor a window handle — without
+    // this, a timed-out approval left a dead, unresponsive window open until
+    // the human closed it by hand (reagent P2 on PR #2824).
+    {
+        let closer_state = app_state.clone();
+        credential_broker::set_window_closer(move |window_id: &str| {
+            if let Err(e) = commands::window::close_window_by_label(
+                &closer_state,
+                &serde_json::json!({ "label": window_id }),
+            ) {
+                tracing::warn!("[credential-broker] failed to close approval window {window_id}: {e}");
+            }
+        });
+    }
+
     // Start the IPC HTTP server and get the assigned port.
     let ipc_port = runtime.block_on(ipc::start_ipc_server(app_state.clone()));
     *app_state.ipc_port.lock() = ipc_port;

--- a/agentmux-srv/src/identity/browser_credential_store.rs
+++ b/agentmux-srv/src/identity/browser_credential_store.rs
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OS-keychain-backed storage for browser-pane HTTP Basic-Auth credentials,
+//! scoped per identity so one agent's saved site credential is never
+//! reachable through another identity's browsing session.
+//!
+//! Reuses [`crate::identity::secret_store`]'s existing `keyring`-crate
+//! wrapper (already backing `SecretRef::Keychain` for Armory API keys) —
+//! this module only builds the right account-key string and JSON-encodes
+//! the `{username, password}` pair; no new keychain code, no filesystem
+//! path involved (so `agentmux_common::data_paths::sanitize_path_segment`
+//! genuinely doesn't apply here — nothing is written to disk).
+//!
+//! See docs/status/majestic-painting-minsky plan (credential-isolated
+//! browser-pane auto-fill) and
+//! docs/specs/SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md (the v1 spec
+//! that named "Persisted credential store (OS keyring)" as deferred future
+//! work — this module is that follow-up).
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroize;
+
+use crate::identity::secret_store;
+
+/// A saved browser credential. `Zeroize`s on drop so a decoded value
+/// doesn't linger in memory longer than the caller actually needs it —
+/// mirrors `secret_store::get`'s own `Zeroizing<String>` discipline for
+/// the raw keychain read.
+#[derive(Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
+pub struct BrowserCredential {
+    pub username: String,
+    pub password: String,
+}
+
+/// Build the keychain account string for one (identity, protection-space)
+/// pair. Deliberately NOT naive `:`-concatenation of the raw fields —
+/// `origin` itself contains `:` (`https://host:8443`) and `realm` is
+/// server-supplied, effectively attacker-influenced, free text, so two
+/// different (origin, realm) pairs could otherwise concatenate to the same
+/// string (e.g. `origin="https://a:1"` + `realm="b"` vs
+/// `origin="https://a"` + `realm="1:b"`). Hashing a NUL-separated tuple
+/// removes any field-boundary ambiguity — NUL can't appear in either field
+/// in practice, but even if it could, the hash input's own delimiter
+/// collision risk is the same NUL-in-a-field edge case for both operands,
+/// which cancels out (unlike `:`, which is valid content in `origin`).
+///
+/// `identity_id` is kept as a literal prefix (not folded into the hash)
+/// so a corrupted/missing hash can't accidentally resolve under a
+/// different identity, and so the account string stays legible in
+/// diagnostic contexts (e.g. `keyring`-crate error messages) without
+/// revealing the origin/realm themselves — only which identity owns the
+/// entry.
+fn account_key(identity_id: &str, origin: &str, realm: &str, is_proxy: bool) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(origin.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(realm.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(if is_proxy { b"1" } else { b"0" });
+    let digest_hex = hex::encode(hasher.finalize());
+    format!("browser-auth:{identity_id}:{digest_hex}")
+}
+
+/// Store (or overwrite) `username`/`password` for this identity +
+/// protection-space. Unbounded (no timeout) — see `secret_store`'s doc
+/// comment for why a write must not race a timed-out-but-later-completing
+/// keychain call.
+pub fn save(
+    identity_id: &str,
+    origin: &str,
+    realm: &str,
+    is_proxy: bool,
+    username: &str,
+    password: &str,
+) -> Result<(), String> {
+    let key = account_key(identity_id, origin, realm, is_proxy);
+    let cred = BrowserCredential {
+        username: username.to_string(),
+        password: password.to_string(),
+    };
+    let json = serde_json::to_string(&cred).map_err(|e| format!("encode credential: {e}"))?;
+    secret_store::put(&key, &json)
+}
+
+/// Look up a stored credential. `Ok(None)` means "nothing saved for this
+/// identity + protection-space" (not an error) — same contract as
+/// `secret_store::get_optional`, which this wraps directly so a transient
+/// keychain failure (locked keychain, no Secret Service daemon, permission
+/// denied) is distinguishable from "genuinely never saved" at the call
+/// site, the same distinction `secret_store`'s own doc comment argues for.
+pub fn load(
+    identity_id: &str,
+    origin: &str,
+    realm: &str,
+    is_proxy: bool,
+) -> Result<Option<BrowserCredential>, String> {
+    let key = account_key(identity_id, origin, realm, is_proxy);
+    let Some(json) = secret_store::get_optional(&key)? else {
+        return Ok(None);
+    };
+    let cred: BrowserCredential =
+        serde_json::from_str(&json).map_err(|e| format!("decode credential: {e}"))?;
+    Ok(Some(cred))
+}
+
+/// Delete the stored credential for this identity + protection-space.
+/// Idempotent (a missing entry is success) — same contract as
+/// `secret_store::delete`. Called when a stored credential turns out to be
+/// wrong (a re-challenge shortly after an auto-fill — see the
+/// credential_broker orchestration in agentmux-cef).
+pub fn delete(identity_id: &str, origin: &str, realm: &str, is_proxy: bool) -> Result<(), String> {
+    let key = account_key(identity_id, origin, realm, is_proxy);
+    secret_store::delete(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_key_is_namespaced_by_identity() {
+        let a = account_key("identity-a", "https://example.com", "realm", false);
+        let b = account_key("identity-b", "https://example.com", "realm", false);
+        assert_ne!(a, b, "different identities must never share an account key");
+        assert!(a.starts_with("browser-auth:identity-a:"));
+        assert!(b.starts_with("browser-auth:identity-b:"));
+    }
+
+    #[test]
+    fn account_key_is_stable_for_identical_inputs() {
+        let a = account_key("id", "https://example.com", "realm", true);
+        let b = account_key("id", "https://example.com", "realm", true);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn account_key_distinguishes_is_proxy() {
+        let a = account_key("id", "https://example.com", "realm", true);
+        let b = account_key("id", "https://example.com", "realm", false);
+        assert_ne!(a, b, "proxy-auth and origin-server-auth caches must not collide");
+    }
+
+    /// The exact bug naive `format!("{origin}:{realm}")` concatenation
+    /// would have: `origin` itself contains `:` (`https://host:port`), so
+    /// two different (origin, realm) pairs can produce the same
+    /// concatenated string. The NUL-separated-then-hashed scheme must not
+    /// have this problem.
+    #[test]
+    fn account_key_does_not_collide_across_delimiter_boundaries() {
+        let a = account_key("id", "https://a:1", "b", false);
+        let b = account_key("id", "https://a", "1:b", false);
+        assert_ne!(
+            a, b,
+            "origin/realm field-boundary shift must not collide (naive ':' concat would fail this)"
+        );
+    }
+
+    #[test]
+    fn account_key_distinguishes_origin() {
+        let a = account_key("id", "https://example.com", "realm", false);
+        let b = account_key("id", "https://other.com", "realm", false);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn account_key_distinguishes_realm() {
+        let a = account_key("id", "https://example.com", "realm-a", false);
+        let b = account_key("id", "https://example.com", "realm-b", false);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn browser_credential_json_round_trips() {
+        let cred = BrowserCredential {
+            username: "user".to_string(),
+            password: "pass".to_string(),
+        };
+        let json = serde_json::to_string(&cred).unwrap();
+        let decoded: BrowserCredential = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.username, "user");
+        assert_eq!(decoded.password, "pass");
+    }
+}

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -32,6 +32,7 @@
 pub mod auth_diag;
 pub mod auth_patterns;
 pub mod auth_session;
+pub mod browser_credential_store;
 pub mod cleanup;
 pub mod key_validator;
 pub mod oauth_client;

--- a/agentmux-srv/src/server/service/credential.rs
+++ b/agentmux-srv/src/server/service/credential.rs
@@ -19,13 +19,46 @@
 //! is just the `/agentmux/service` RPC surface over it, following the same
 //! shape as [`super::host_ipc`] (the other host→srv service module).
 //!
-//! Auth: same instance-wide `X-AuthKey` every `/agentmux/service` caller
-//! already proves (this route has no per-service auth layer beyond that —
-//! see `super::host_ipc`'s own doc comment for why `host_ipc.Register`
-//! specifically needed a stronger, second secret; that reasoning doesn't
-//! apply here, since every method on this service only ever reads/writes
-//! data scoped to a caller-supplied `identity_id`, not a global
-//! session-hijack-shaped credential like `host_ipc`'s port+token).
+//! ## Auth: host-only, NOT the shared `X-AuthKey`
+//!
+//! **Every method on this service requires `args[1]` to be this srv
+//! instance's `AGENTMUX_HOST_REG_SECRET`**, the same host-only credential
+//! `host_ipc.Register` proves (see that module's doc comment and
+//! `Config::host_reg_secret`).
+//!
+//! An earlier cut of this module gated on the instance-wide `X-AuthKey`
+//! alone, reasoning that — unlike `host_ipc.Register`'s
+//! "session-hijack-shaped" port+token — every method here only touches data
+//! scoped to a caller-supplied `identity_id`. **That reasoning was wrong,
+//! and it defeated this feature's entire stated security goal** (reagent P0
+//! on PR #2824). `X-AuthKey` is deliberately re-injected into every spawned
+//! agent's own environment as `AGENTMUX_AUTH_KEY`
+//! (`server/agent_handlers/input.rs`), and `AGENTMUX_BLOCKID` is injected
+//! alongside it. So any agent could, with a plain `curl` from its own Shell
+//! tool:
+//!
+//!   1. `credential.ResolveIdentity` with its own known `block_id` →
+//!      `identity_id`
+//!   2. `credential.Fill` with that `identity_id` plus the origin/realm it
+//!      already knows (it is, after all, the thing browsing that site) →
+//!      **the plaintext password**
+//!
+//! …with no human approval window anywhere in the path. `Fill` uniquely
+//! returns a raw password, which is exactly the class of secret that needed
+//! `host_ipc.Register`'s treatment, not a weaker one.
+//!
+//! The gate is applied to the whole service rather than to `Fill` alone:
+//! `ResolveIdentity` leaks identity_ids, `Lookup` confirms which sites have
+//! saved credentials, and `Save`/`Delete` let an agent plant or destroy
+//! them. None of those are things an agent should reach either, and a
+//! uniform gate cannot be defeated by finding the one method someone forgot
+//! to cover.
+//!
+//! Note this proves *caller is the host*, not *a human approved this exact
+//! use*. That is the boundary the threat model needs — the host is the
+//! process that runs the approval window, so a capability token it mints
+//! for itself would add no defence against the attacker in question (an
+//! agent), only an internal consistency check within the host.
 
 use serde::Deserialize;
 
@@ -33,8 +66,12 @@ use crate::backend::service::{get_arg, WebCallType, WebReturnType};
 use crate::identity::browser_credential_store;
 
 use super::super::AppState;
+use super::host_ipc::secret_matches;
 
 pub(super) async fn handle_credential_service(state: &AppState, call: &WebCallType) -> WebReturnType {
+    if let Some(rejection) = reject_unless_host_caller(state, call) {
+        return rejection;
+    }
     match call.method.as_str() {
         "ResolveIdentity" => handle_resolve_identity(state, call),
         "Lookup" => handle_lookup(call),
@@ -42,6 +79,70 @@ pub(super) async fn handle_credential_service(state: &AppState, call: &WebCallTy
         "Delete" => handle_delete(call),
         "Fill" => handle_fill(call),
         _ => WebReturnType::error(format!("unknown credential method: {}", call.method)),
+    }
+}
+
+/// `Some(error)` when the caller failed to prove it's the paired host —
+/// checked for EVERY method before dispatch, so a new method added later is
+/// gated by construction rather than by remembering to gate it.
+///
+/// Fails closed when srv has no secret configured: with nothing to verify
+/// against, "allow" would silently restore the exact bypass this exists to
+/// close. Mirrors `host_ipc::handle_register`'s `None` arm.
+/// The whole security decision, as a pure function of the two secrets —
+/// extracted so it can be tested directly (constructing an `AppState` in a
+/// unit test isn't practical, and this gate is far too load-bearing to
+/// leave to integration coverage alone).
+///
+/// `known == None` → always `false`: fail closed. See the caller.
+///
+/// An EMPTY configured secret is treated the same as an absent one. Without
+/// that, `secret_matches("", "")` compares equal and a caller supplying
+/// nothing — precisely what an agent without the secret sends — would be
+/// admitted, turning the misconfiguration into a skeleton key. `Config`
+/// already `.filter(|s| !s.is_empty())`s this value (`config.rs:130`), so
+/// today the case is unreachable; the check is here so the gate stays
+/// correct on its own terms rather than depending on a filter two modules
+/// away that a future refactor could drop.
+fn host_caller_allowed(known: Option<&str>, supplied: &str) -> bool {
+    match known {
+        None => false,
+        Some(known) if known.is_empty() => false,
+        Some(known) => secret_matches(known, supplied),
+    }
+}
+
+fn reject_unless_host_caller(state: &AppState, call: &WebCallType) -> Option<WebReturnType> {
+    let supplied = call.args.get(1).and_then(|v| v.as_str()).unwrap_or("");
+    if host_caller_allowed(state.host_reg_secret.as_deref(), supplied) {
+        return None;
+    }
+    match state.host_reg_secret.as_deref() {
+        None => {
+            tracing::error!(
+                "[credential] REJECTED a {} call — this srv instance has no \
+                 AGENTMUX_HOST_REG_SECRET configured, so it cannot verify the caller is \
+                 really the paired host. Refusing rather than falling back to the shared \
+                 X-AuthKey, which every agent can read from its own environment.",
+                call.method
+            );
+            Some(WebReturnType::error(
+                "credential: srv has no host-registration secret configured — refusing",
+            ))
+        }
+        Some(_) => {
+            tracing::error!(
+                "[credential] REJECTED a {} call — args[1] did not match this srv \
+                 instance's AGENTMUX_HOST_REG_SECRET. Either a caller without that \
+                 credential (an agent riding the shared X-AuthKey never has it) is \
+                 attempting to read stored browser passwords, or a genuine host is out \
+                 of sync with srv's current secret (e.g. after a srv recycle).",
+                call.method
+            );
+            Some(WebReturnType::error(
+                "credential: args[1] does not match this srv instance's host-registration secret",
+            ))
+        }
     }
 }
 
@@ -207,5 +308,54 @@ mod tests {
     #[test]
     fn mask_username_handles_empty() {
         assert_eq!(mask_username(""), "*");
+    }
+
+    // ── Host-caller gate (reagent P0 on PR #2824) ────────────────────────
+    //
+    // The attack these close: an agent reads AGENTMUX_AUTH_KEY and
+    // AGENTMUX_BLOCKID from its own environment (both injected at spawn) and
+    // curls credential.Fill to get a stored plaintext password with no human
+    // approval anywhere in the path. The only thing standing between an agent
+    // and that password is this gate, so it gets tested directly.
+
+    const KNOWN: &str = "host-registration-secret-value";
+
+    #[test]
+    fn the_real_host_secret_is_accepted() {
+        assert!(host_caller_allowed(Some(KNOWN), KNOWN));
+    }
+
+    /// The exact shape of the bypass: an agent has `X-AuthKey` (which got it
+    /// this far) but cannot produce `AGENTMUX_HOST_REG_SECRET`, so it sends
+    /// nothing for `args[1]` and `unwrap_or("")` yields an empty string.
+    #[test]
+    fn an_absent_secret_is_rejected() {
+        assert!(!host_caller_allowed(Some(KNOWN), ""));
+    }
+
+    #[test]
+    fn a_wrong_secret_is_rejected() {
+        assert!(!host_caller_allowed(Some(KNOWN), "not-the-secret"));
+        assert!(!host_caller_allowed(Some(KNOWN), "host-registration-secret-valu"));
+        assert!(!host_caller_allowed(Some(KNOWN), "host-registration-secret-value-extra"));
+    }
+
+    /// Fails CLOSED. If srv has no secret configured there is nothing to
+    /// verify against, and treating that as "allow" would silently restore
+    /// the full bypass on exactly the misconfiguration least likely to be
+    /// noticed. Mirrors `host_ipc::handle_register`'s `None` arm.
+    #[test]
+    fn no_configured_secret_rejects_everything_rather_than_allowing_it() {
+        assert!(!host_caller_allowed(None, ""));
+        assert!(!host_caller_allowed(None, KNOWN));
+        assert!(!host_caller_allowed(None, "anything at all"));
+    }
+
+    /// An empty configured secret must not become a skeleton key for callers
+    /// that also send nothing — `Some("")` is a misconfiguration, not a
+    /// credential, and the empty-vs-empty comparison would otherwise pass.
+    #[test]
+    fn an_empty_configured_secret_does_not_admit_an_empty_supplied_secret() {
+        assert!(!host_caller_allowed(Some(""), ""));
     }
 }

--- a/agentmux-srv/src/server/service/credential.rs
+++ b/agentmux-srv/src/server/service/credential.rs
@@ -1,0 +1,211 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `credential` service — the paired CEF host's browser-pane Basic-Auth
+//! credential broker calls this, host→srv, to resolve an identity for a
+//! pane and to look up / save / delete / fill a stored site credential.
+//!
+//! **`Fill` is the only method here that ever returns a plaintext
+//! password**, and it's called exactly once per approved use, at the
+//! moment the host is about to hand the credential to CEF's
+//! `AuthCallback::cont()`. `Lookup` deliberately returns only a masked
+//! username — the credential-approval window (agentmux-cef,
+//! `open_subwindow`-based, see `credential_broker` there) uses `Lookup`
+//! to decide what to *display*, and must never receive the real password
+//! even transiently.
+//!
+//! Storage itself lives in [`agentmux_srv::identity::browser_credential_store`]
+//! (OS keychain via the existing `secret_store.rs` wrapper) — this module
+//! is just the `/agentmux/service` RPC surface over it, following the same
+//! shape as [`super::host_ipc`] (the other host→srv service module).
+//!
+//! Auth: same instance-wide `X-AuthKey` every `/agentmux/service` caller
+//! already proves (this route has no per-service auth layer beyond that —
+//! see `super::host_ipc`'s own doc comment for why `host_ipc.Register`
+//! specifically needed a stronger, second secret; that reasoning doesn't
+//! apply here, since every method on this service only ever reads/writes
+//! data scoped to a caller-supplied `identity_id`, not a global
+//! session-hijack-shaped credential like `host_ipc`'s port+token).
+
+use serde::Deserialize;
+
+use crate::backend::service::{get_arg, WebCallType, WebReturnType};
+use crate::identity::browser_credential_store;
+
+use super::super::AppState;
+
+pub(super) async fn handle_credential_service(state: &AppState, call: &WebCallType) -> WebReturnType {
+    match call.method.as_str() {
+        "ResolveIdentity" => handle_resolve_identity(state, call),
+        "Lookup" => handle_lookup(call),
+        "Save" => handle_save(call),
+        "Delete" => handle_delete(call),
+        "Fill" => handle_fill(call),
+        _ => WebReturnType::error(format!("unknown credential method: {}", call.method)),
+    }
+}
+
+#[derive(Deserialize)]
+struct ResolveIdentityArgs {
+    block_id: String,
+}
+
+/// `block_id` → `identity_id`, via the same instance-lookup the identity
+/// resolver already uses for OAuth env-var injection at spawn time
+/// (`identity::resolver::inject::…`) — reusing
+/// `Store::instance_get_active_for_block` here keeps "which identity owns
+/// this pane" resolved in exactly one place in the codebase.
+///
+/// Returns `identity_id: ""` (not an error) when the block has no active
+/// instance or the instance has no identity bound — the caller (the CEF
+/// host's credential broker) treats an empty identity_id the same as "no
+/// stored credential" and falls through to the normal prompt, matching
+/// how identity injection itself already treats an unbound instance as a
+/// no-op rather than a hard failure.
+fn handle_resolve_identity(state: &AppState, call: &WebCallType) -> WebReturnType {
+    let args: ResolveIdentityArgs = match get_arg(&call.args, 0) {
+        Ok(a) => a,
+        Err(e) => return WebReturnType::error(format!("credential.ResolveIdentity: {e}")),
+    };
+    let identity_id = state
+        .wstore
+        .instance_get_active_for_block(&args.block_id)
+        .ok()
+        .flatten()
+        .map(|inst| inst.identity_id)
+        .unwrap_or_default();
+    WebReturnType::success(serde_json::json!({ "identity_id": identity_id }))
+}
+
+#[derive(Deserialize)]
+struct ProtectionSpaceArgs {
+    identity_id: String,
+    origin: String,
+    realm: String,
+    is_proxy: bool,
+}
+
+fn handle_lookup(call: &WebCallType) -> WebReturnType {
+    let args: ProtectionSpaceArgs = match get_arg(&call.args, 0) {
+        Ok(a) => a,
+        Err(e) => return WebReturnType::error(format!("credential.Lookup: {e}")),
+    };
+    match browser_credential_store::load(&args.identity_id, &args.origin, &args.realm, args.is_proxy) {
+        Ok(Some(cred)) => WebReturnType::success(serde_json::json!({
+            "found": true,
+            "username": mask_username(&cred.username),
+        })),
+        Ok(None) => WebReturnType::success(serde_json::json!({ "found": false })),
+        Err(e) => {
+            // Never surface the raw keychain error to the caller beyond a
+            // generic message — the exact failure mode (locked keychain,
+            // no Secret Service daemon, permission denied) is diagnostic
+            // detail for the host's own logs, not something to round-trip
+            // back over HTTP. The host's credential_broker treats any
+            // error here identically to "not found" (fall through to the
+            // normal prompt), so the distinction wouldn't be actionable
+            // on that side anyway.
+            tracing::warn!("[credential] Lookup failed: {e}");
+            WebReturnType::error("lookup failed")
+        }
+    }
+}
+
+/// `us***@example.com` / `ab***` style masking for the approval window's
+/// display — enough for a human to recognize which saved login is being
+/// offered, not enough to be useful if somehow logged or screenshotted
+/// wrong. Keeps at most the first 2 characters before any masking.
+fn mask_username(username: &str) -> String {
+    let visible: String = username.chars().take(2).collect();
+    if username.chars().count() <= 2 {
+        return "*".repeat(username.chars().count().max(1));
+    }
+    format!("{visible}***")
+}
+
+#[derive(Deserialize)]
+struct SaveArgs {
+    identity_id: String,
+    origin: String,
+    realm: String,
+    is_proxy: bool,
+    username: String,
+    password: String,
+}
+
+fn handle_save(call: &WebCallType) -> WebReturnType {
+    let args: SaveArgs = match get_arg(&call.args, 0) {
+        Ok(a) => a,
+        Err(e) => return WebReturnType::error(format!("credential.Save: {e}")),
+    };
+    match browser_credential_store::save(
+        &args.identity_id,
+        &args.origin,
+        &args.realm,
+        args.is_proxy,
+        &args.username,
+        &args.password,
+    ) {
+        Ok(()) => WebReturnType::success_empty(),
+        Err(e) => {
+            tracing::warn!("[credential] Save failed: {e}");
+            WebReturnType::error("save failed")
+        }
+    }
+}
+
+fn handle_delete(call: &WebCallType) -> WebReturnType {
+    let args: ProtectionSpaceArgs = match get_arg(&call.args, 0) {
+        Ok(a) => a,
+        Err(e) => return WebReturnType::error(format!("credential.Delete: {e}")),
+    };
+    match browser_credential_store::delete(&args.identity_id, &args.origin, &args.realm, args.is_proxy) {
+        Ok(()) => WebReturnType::success_empty(),
+        Err(e) => {
+            tracing::warn!("[credential] Delete failed: {e}");
+            WebReturnType::error("delete failed")
+        }
+    }
+}
+
+/// The one method that returns a real, unmasked password. Called exactly
+/// once per approved credential use — see this module's own doc comment.
+fn handle_fill(call: &WebCallType) -> WebReturnType {
+    let args: ProtectionSpaceArgs = match get_arg(&call.args, 0) {
+        Ok(a) => a,
+        Err(e) => return WebReturnType::error(format!("credential.Fill: {e}")),
+    };
+    match browser_credential_store::load(&args.identity_id, &args.origin, &args.realm, args.is_proxy) {
+        Ok(Some(cred)) => WebReturnType::success(serde_json::json!({
+            "username": cred.username,
+            "password": cred.password,
+        })),
+        Ok(None) => WebReturnType::error("no stored credential for this identity/origin/realm"),
+        Err(e) => {
+            tracing::warn!("[credential] Fill failed: {e}");
+            WebReturnType::error("fill failed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_username_keeps_at_most_two_leading_chars() {
+        assert_eq!(mask_username("alice"), "al***");
+        assert_eq!(mask_username("bob"), "bo***");
+    }
+
+    #[test]
+    fn mask_username_handles_very_short_names() {
+        assert_eq!(mask_username("a"), "*");
+        assert_eq!(mask_username("ab"), "**");
+    }
+
+    #[test]
+    fn mask_username_handles_empty() {
+        assert_eq!(mask_username(""), "*");
+    }
+}

--- a/agentmux-srv/src/server/service/host_ipc.rs
+++ b/agentmux-srv/src/server/service/host_ipc.rs
@@ -39,7 +39,14 @@ pub(super) async fn handle_host_ipc_service(state: &AppState, call: &WebCallType
 /// matched. Not signing anything meaningful — both sides already hold the
 /// same static secret out-of-band (spawn-time env), so this is just a
 /// constant-time equality check dressed as a one-shot MAC.
-fn secret_matches(known: &str, supplied: &str) -> bool {
+/// `pub(super)` so the `credential` service can reuse this exact check
+/// rather than growing a second constant-time comparison — it gates on the
+/// same `AGENTMUX_HOST_REG_SECRET` for the same reason (proving the caller
+/// is the paired host, not an agent riding the shared `X-AuthKey`). The
+/// NONCE below names host_ipc only because that was the first caller; it's
+/// a locally-computed comparison salt on both sides of a single `==`, never
+/// a wire format, so sharing it across callers is safe.
+pub(super) fn secret_matches(known: &str, supplied: &str) -> bool {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
 

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -16,6 +16,7 @@
 //! (`crate::server::service::…`, `super::service::…`) unchanged.
 
 mod client;
+mod credential;
 mod host_ipc;
 mod introspect;
 pub(crate) mod layout_helpers;
@@ -116,6 +117,7 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
     match call.service.as_str() {
         "object" => object::handle_object_service(state, call).await,
         "client" => client::handle_client_service(state, call).await,
+        "credential" => credential::handle_credential_service(state, call).await,
         "window" => window::handle_window_service(state, call).await,
         "workspace" => workspace::handle_workspace_service(state, call).await,
         "host_ipc" => host_ipc::handle_host_ipc_service(state, call).await,

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -677,7 +677,15 @@ async function initAppInner() {
                     await initHostNewWindow();
                     const coldSearchParams = new URL(window.location.href).searchParams;
                     const coldInitialView = coldSearchParams.get("initialView");
-                    if (coldInitialView) {
+                    // "credential-approval" is not a real pane view — it's
+                    // rendered by app.tsx as this window's ENTIRE content,
+                    // bypassing the normal Workspace/pane tree on purpose
+                    // (see CredentialApprovalWindow's own doc comment for
+                    // why: a pane opened via pane.open gets a
+                    // [data-blockid] wrapper, which would make its Approve
+                    // button reachable by any agent's UIQuery/UIClick).
+                    // Opening it as a real pane here would defeat that.
+                    if (coldInitialView && coldInitialView !== "credential-approval") {
                         const coldMetaRaw = coldSearchParams.get("initialMeta");
                         let coldMeta: Record<string, unknown> | undefined;
                         try { coldMeta = coldMetaRaw ? JSON.parse(coldMetaRaw) : undefined; } catch { /* ignore */ }

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -33,6 +33,7 @@ import { checkSeparatorParity, setupDprTracking } from "./init/dpr";
 import { NotificationBubbles } from "./notification/notificationbubbles";
 import { MemoryPressureBanner } from "./notification/memory-pressure-banner";
 import { BrowserPaneOutsideClickBridge } from "./window/browser-pane-outside-click-bridge";
+import { CredentialApprovalWindow } from "./view/credential-approval/CredentialApprovalWindow";
 
 import "./app.scss";
 
@@ -312,10 +313,24 @@ const AppInner = () => {
     // Cold path (open_floating_pane_window) opens the window with floatingPaneId
     // in the URL from the start, so both paths are correct here.
     const IS_FLOATING_PANE = new URLSearchParams(window.location.search).has("floatingPaneId");
+    // The credential-approval subwindow (`open_subwindow` with
+    // `initial_view=credential-approval` — see `credential_broker` in
+    // agentmux-cef) is a cold-path-only window: unlike floatingPaneId,
+    // there's no pool-promote path that could inject this param after
+    // module load, so reading it once here (rather than at mount time) is
+    // safe. Checked BEFORE the client/windowData gate below — this window
+    // never opens a workspace/backend window object at all (see
+    // app-init.ts's guard against firing `pane.open` for this view), so it
+    // must never wait on atoms that will never populate.
+    const IS_CREDENTIAL_APPROVAL = new URLSearchParams(window.location.search).get("initialView") === "credential-approval";
     const prefersReducedMotion = atoms.prefersReducedMotionAtom;
     const client = atoms.client;
     const windowData = atoms.waveWindow;
     const isFullScreen = atoms.isFullScreen;
+
+    if (IS_CREDENTIAL_APPROVAL) {
+        return <CredentialApprovalWindow />;
+    }
 
     return (
         <Show

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -267,8 +267,8 @@ export function renderRequest(
                             req.onCancel();
                             api.close();
                         }}
-                        onSubmit={(username, password) => {
-                            req.onSubmit(username, password);
+                        onSubmit={(username, password, save) => {
+                            req.onSubmit(username, password, save);
                             api.close();
                         }}
                     />

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -263,8 +263,11 @@ export interface BrowserAuthRequest {
      *  v1 surfaces both with the same UI; future spec may diverge. */
     isProxy: boolean;
     /** User submitted credentials. The layer routes them to the host
-     *  via `browser_pane_auth_submit`. */
-    onSubmit: (username: string, password: string) => void;
+     *  via `browser_pane_auth_submit`, and — when `save` is true (the
+     *  panel's opt-in "save this credential" checkbox) — also fires
+     *  `browser_pane_auth_save` so the host stores it in the OS keychain
+     *  for future auto-fill. */
+    onSubmit: (username: string, password: string, save: boolean) => void;
     /** User cancelled. The layer routes to `browser_pane_auth_cancel`,
      *  which calls `AuthCallback.cancel()` so CEF aborts the request
      *  and renders the 401 response body. */

--- a/frontend/app/view/browser/components/BrowserAuthModal.scss
+++ b/frontend/app/view/browser/components/BrowserAuthModal.scss
@@ -42,3 +42,15 @@
         box-shadow: 0 0 0 1px var(--accent-color);
     }
 }
+
+.browser-auth-modal-save-field {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-1-5);
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    cursor: pointer;
+
+    span { user-select: none; }
+}

--- a/frontend/app/view/browser/components/BrowserAuthModal.tsx
+++ b/frontend/app/view/browser/components/BrowserAuthModal.tsx
@@ -19,12 +19,15 @@ interface BrowserAuthModalPanelProps {
     realm: string;
     isProxy: boolean;
     onCancel: () => void;
-    onSubmit: (username: string, password: string) => void;
+    onSubmit: (username: string, password: string, save: boolean) => void;
 }
 
 export const BrowserAuthModalPanel = (props: BrowserAuthModalPanelProps): JSX.Element => {
     const [username, setUsername] = createSignal("");
     const [password, setPassword] = createSignal("");
+    // Unchecked by default — saving a credential to the OS keychain is an
+    // opt-in action, not the default outcome of a one-off manual sign-in.
+    const [saveCredential, setSaveCredential] = createSignal(false);
     // True once either footer button fired its handler. onCleanup
     // uses this to detect "modal was unmounted via ESC / backdrop
     // click / pane close / replace" and fire onCancel exactly once
@@ -34,7 +37,7 @@ export const BrowserAuthModalPanel = (props: BrowserAuthModalPanelProps): JSX.El
 
     const submit = () => {
         resolved = true;
-        props.onSubmit(username(), password());
+        props.onSubmit(username(), password(), saveCredential());
     };
     const cancel = () => {
         resolved = true;
@@ -89,6 +92,14 @@ export const BrowserAuthModalPanel = (props: BrowserAuthModalPanelProps): JSX.El
                         onInput={(e) => setPassword(e.currentTarget.value)}
                         onKeyDown={onKeyDown}
                     />
+                </label>
+                <label class="browser-auth-modal-save-field">
+                    <input
+                        type="checkbox"
+                        checked={saveCredential()}
+                        onChange={(e) => setSaveCredential(e.currentTarget.checked)}
+                    />
+                    <span>Save this credential</span>
                 </label>
             </div>
             <footer class="modal-panel-footer">

--- a/frontend/app/view/browser/use-browser-auth.ts
+++ b/frontend/app/view/browser/use-browser-auth.ts
@@ -55,14 +55,29 @@ export function useBrowserAuth(params: {
             origin: c.origin || `${c.host}:${c.port}`,
             realm: c.realm,
             isProxy: c.is_proxy,
-            onSubmit: (username, password) => {
+            onSubmit: (username, password, save) => {
                 pendingAuthIds.delete(c.request_id);
-                diag(`auth-submit request_id=${c.request_id}`);
+                diag(`auth-submit request_id=${c.request_id} save=${save}`);
                 void invokeCommand("browser_pane_auth_submit", {
                     request_id: c.request_id,
                     username,
                     password,
                 }).catch((e) => diag(`auth-submit-failed err=${String(e)}`));
+                // Opt-in save — a wholly separate IPC call (not a flag on
+                // browser_pane_auth_submit) so that command's contract
+                // stays byte-for-byte unchanged. A save failure never
+                // affects the page load: auth already succeeded via the
+                // call above regardless of what happens here.
+                if (save) {
+                    void invokeCommand("browser_pane_auth_save", {
+                        block_id: model.blockId,
+                        origin: c.origin,
+                        realm: c.realm,
+                        is_proxy: c.is_proxy,
+                        username,
+                        password,
+                    }).catch((e) => diag(`auth-save-failed err=${String(e)}`));
+                }
                 authActive = false;
                 drainAuthQueue();
             },

--- a/frontend/app/view/credential-approval/CredentialApprovalWindow.tsx
+++ b/frontend/app/view/credential-approval/CredentialApprovalWindow.tsx
@@ -1,0 +1,142 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CredentialApprovalWindow — the entire content of the credential-
+ * approval subwindow opened by `credential_broker::open_approval_window`
+ * (host, agentmux-cef) via `open_subwindow(initial_view="credential-approval")`.
+ *
+ * Deliberately NOT a `<Modal>` / `<ModalLayer>` panel like
+ * `BrowserAuthModalPanel` — this is the sole content of a genuinely
+ * separate top-level CEF window/DOM. That's load-bearing, not cosmetic:
+ * AgentMux's `UIQuery`/`UIClick` MCP tools resolve reachable elements via
+ * `__amq_allowed_for()` (agentmux-cef's browser_api/scripts/query.js),
+ * which treats anything outside a `[data-blockid]` pane subtree as
+ * "shared chrome" reachable by ANY agent. A `<Modal>` rendered in the
+ * main window would put the Approve button in that shared-chrome bucket
+ * — clickable by an agent other than the one whose credential is being
+ * approved, not just the intended human. This component must never
+ * render inside the normal pane/block tree and must never stamp a
+ * `data-blockid` attribute anywhere in its own DOM.
+ *
+ * See docs/status/majestic-painting-minsky plan, "Why this shape."
+ */
+
+import { createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import { invokeCommand } from "@/app/platform/ipc";
+import { Button } from "@/element/button";
+
+import "./credential-approval-window.scss";
+
+type ApprovalMeta = {
+    approvalId: string;
+    origin: string;
+    realm: string;
+    isProxy: boolean;
+    maskedUsername: string;
+};
+
+function parseMeta(): ApprovalMeta | null {
+    const raw = new URLSearchParams(window.location.search).get("initialMeta");
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw);
+        if (typeof parsed?.approval_id !== "string" || !parsed.approval_id) return null;
+        return {
+            approvalId: parsed.approval_id,
+            origin: typeof parsed.origin === "string" ? parsed.origin : "",
+            realm: typeof parsed.realm === "string" ? parsed.realm : "",
+            isProxy: Boolean(parsed.is_proxy),
+            maskedUsername: typeof parsed.masked_username === "string" ? parsed.masked_username : "",
+        };
+    } catch {
+        return null;
+    }
+}
+
+export const CredentialApprovalWindow = (): JSX.Element => {
+    const meta = parseMeta();
+    const [busy, setBusy] = createSignal(false);
+    const [decided, setDecided] = createSignal(false);
+
+    const decide = (approve: boolean) => {
+        if (!meta || busy() || decided()) return;
+        setBusy(true);
+        void invokeCommand("credential_approval_decide", {
+            approval_id: meta.approvalId,
+            approve,
+        })
+            .catch(() => { /* host-side failure already falls through to the normal prompt */ })
+            .finally(() => {
+                // The host closes this window itself once the decision
+                // resolves (approve or deny) — see the
+                // `credential_approval_decide` IPC handler in agentmux-cef.
+                // Disabling the buttons here just prevents a double-decide
+                // in the brief window before that close arrives.
+                setDecided(true);
+                setBusy(false);
+            });
+    };
+
+    onMount(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                decide(false);
+            } else if (e.key === "Enter") {
+                e.preventDefault();
+                decide(true);
+            }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        onCleanup(() => window.removeEventListener("keydown", onKeyDown));
+    });
+
+    if (!meta) {
+        // Malformed/missing initialMeta — shouldn't happen (the host only
+        // ever opens this window with a well-formed payload), but a saved
+        // human can't act on nothing. No approval_id means no way to
+        // decide anything; the CEF AuthCallback(s) waiting on this window
+        // will resolve via TTL fall-through instead.
+        return (
+            <div class="credential-approval-window credential-approval-window-error">
+                <p>
+                    This approval window is missing its request details and can't be used.
+                    Close it and try signing in again.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div class="credential-approval-window">
+            <header class="credential-approval-header">
+                <h2>{meta.isProxy ? "Use saved proxy credential?" : "Use saved sign-in?"}</h2>
+                <p class="credential-approval-origin">
+                    <strong>{meta.origin || "This site"}</strong>
+                </p>
+                {meta.realm ? (
+                    <p class="credential-approval-realm">
+                        says: <em>{meta.realm}</em>
+                    </p>
+                ) : null}
+            </header>
+            <div class="credential-approval-body">
+                <p>
+                    AgentMux has a saved credential for <strong>{meta.maskedUsername || "this account"}</strong>.
+                    Approve to sign in without exposing the password to the agent controlling this pane.
+                </p>
+            </div>
+            <footer class="credential-approval-footer">
+                <Button onClick={() => decide(false)} disabled={busy() || decided()}>
+                    Deny
+                </Button>
+                <Button onClick={() => decide(true)} className="green solid" disabled={busy() || decided()}>
+                    Approve
+                </Button>
+            </footer>
+        </div>
+    );
+};
+
+CredentialApprovalWindow.displayName = "CredentialApprovalWindow";

--- a/frontend/app/view/credential-approval/credential-approval-window.scss
+++ b/frontend/app/view/credential-approval/credential-approval-window.scss
@@ -1,0 +1,64 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// CredentialApprovalWindow is the sole content of its own top-level
+// window (not a `<ModalLayer>` panel), so — unlike BrowserAuthModal.scss
+// — this owns its full chrome rather than layering onto modal.scss.
+
+.credential-approval-window {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    width: 100%;
+    height: 100%;
+    padding: var(--space-5);
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    box-sizing: border-box;
+    user-select: none;
+    -webkit-app-region: no-drag;
+}
+
+.credential-approval-window-error {
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    color: var(--secondary-text-color);
+}
+
+.credential-approval-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+
+    h2 {
+        margin: 0;
+        font-size: var(--text-lg);
+        font-weight: 600;
+    }
+}
+
+.credential-approval-origin {
+    margin: 0;
+    font-size: var(--text-md);
+    word-break: break-all;
+}
+
+.credential-approval-realm {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+}
+
+.credential-approval-body {
+    flex: 1;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: 1.5;
+}
+
+.credential-approval-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+}


### PR DESCRIPTION
## Summary

Adds credential-isolated auto-fill for browser-pane HTTP Basic/Digest auth — inspired by Codex's credential-isolated browsing feature (see `docs/research/RESEARCH_CODEX_CREDENTIAL_ISOLATED_BROWSING_2026_08_26.md`). On a repeat auth challenge with a saved credential, a human approves via a genuinely separate top-level window before the password ever reaches CEF — the agent controlling the pane never sees it.

- **srv**: OS-keychain-backed credential store (identity-scoped, `agentmux-srv/src/identity/browser_credential_store.rs`) + a new `credential` RPC service (`ResolveIdentity`/`Lookup`/`Save`/`Delete`/`Fill` — `Fill` is the only method that ever returns a plaintext password, called exactly once per approved use).
- **agentmux-cef**: `credential_broker` orchestrates the `on_auth_credentials` flow (identity resolve → keychain lookup → approval window or fall-through) and owns a parked-approval registry that coalesces simultaneous challenges for the same protection space into one approval window. A 15s "recently auto-filled" marker auto-invalidates a wrong stored credential instead of looping it.
- **frontend**: `CredentialApprovalWindow` renders as the *entire content* of a dedicated subwindow (`open_subwindow`, never a `<Modal>`) — this is the key security property: AgentMux's `UIQuery`/`UIClick` treat anything outside a pane's own `[data-blockid]` subtree as reachable shared chrome, so a `<Modal>`-based approval UI would let *any* agent click Approve, not just the one whose pane raised the challenge. `BrowserAuthModal` gains an opt-in "Save this credential" checkbox.
- Every failure mode (no bound identity, no stored credential, srv unreachable, keychain error, window-creation failure) falls through to the existing, unmodified manual-entry prompt — this can only make auth *more* automatic, never break the baseline.

## Test plan

- [x] `cargo test -p agentmux-srv` — 2823 passed (incl. 7 new `browser_credential_store` tests + 3 new `credential::tests`)
- [x] `cargo test -p agentmux-cef` — 278 passed (incl. 11 new `credential_broker`/`approval` tests: coalescing, TTL, window/block cleanup)
- [x] `npx tsc --noEmit` — clean
- [x] `npx stylelint` on touched SCSS — clean
- [x] Live `task dev` verification: manual save → close/reopen pane → approval subwindow appears (not the old modal) → Approve loads the page; Deny shows the normal 401 body
- [x] Adversarial check: an agent's own `UIQuery`/`UIClick` cannot reach the approval window's Approve button
- [x] Coalescing: two simultaneous challenges to the same origin produce exactly one approval window

<!-- agentmux:agent_id=loap #2 -->