### PR TITLE
fix(agent-pane): consolidate Reconnecting…/Compacting… status into the Working row

### DIFF
--- a/.changesets/1787864262-fix-agent-pane-consolidate-reconnecting-compacting-status-in-z97j.md
+++ b/.changesets/1787864262-fix-agent-pane-consolidate-reconnecting-compacting-status-in-z97j.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): consolidate Reconnecting…/Compacting… status into the Working row

--- a/docs/specs/SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md
+++ b/docs/specs/SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md
@@ -1,11 +1,13 @@
 # SPEC: Agent-pane status cleanup — remove "unresponsive" detection, consolidate Reconnecting/Compacting/Working
 
 **Date:** 2026-08-25
-**Status:** Part 1 (removal) implemented, verified (cargo test + vitest +
-tsc all green), pending PR/merge. Part 2 (status consolidation) scoped with
-an explicit design recommendation, not yet implemented. Two
-separately-implementable pieces in one doc — either can ship as its own PR
-(per repo-owner direction when this spec was extended).
+**Status:** Part 1 (removal) implemented, PR #2825 (includes a fixup commit
+restoring container-exec failure classification that Codex caught in
+review — see that PR for detail). Part 2 (status consolidation) implemented
+per §10's design recommendation, verified (tsc + full vitest green),
+pending PR/merge. Two separately-implementable pieces in one doc — either
+can ship as its own PR (per repo-owner direction when this spec was
+extended).
 **Scope — Part 1:** `agentmux-srv/src/backend/blockcontroller/health.rs`,
 `agentmux-srv/src/backend/blockcontroller/{mod,core,persistent,acp}.rs`,
 `agentmux-srv/src/backend/blockcontroller/subprocess/{mod,host_spawn,container_spawn}.rs`,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2142,7 +2142,26 @@ const AgentPresentationView = ({
                 <Show when={workingRowVisible()}>
                     <div
                         class="agent-working-row-backdrop"
-                        classList={{ "agent-working-row-backdrop--loading": workingRowLoading() }}
+                        classList={{
+                            // Must mirror AgentWorkingRow's OWN loading gate
+                            // (`props.loading || !!props.compacting ||
+                            // !!props.reconnecting`, AgentFooter.tsx), not
+                            // just `workingRowLoading()` — reagent P1 on
+                            // PR #2826: since `workingRowVisible()` above
+                            // already renders this backdrop for
+                            // compacting/reconnecting too, using only
+                            // `workingRowLoading()` here left the backdrop in
+                            // its `--worked` (non-loading) color while the
+                            // row itself rendered its loading/accent-tinted
+                            // variant during those two states — the exact
+                            // backdrop/row color-mismatch
+                            // SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
+                            // fixed for the plain loading case.
+                            "agent-working-row-backdrop--loading":
+                                workingRowLoading() ||
+                                agentAtoms().compactingAtom[0]() != null ||
+                                agentAtoms().reconnectingAtom[0]() != null,
+                        }}
                     />
                 </Show>
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1552,7 +1552,13 @@ const AgentPresentationView = ({
     const workingRowLoading = createMemo(
         () => showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]())
     );
-    const workingRowVisible = createMemo(() => workingRowLoading() || agentAtoms().sessionStatsAtom[0]() != null);
+    const workingRowVisible = createMemo(
+        () =>
+            workingRowLoading() ||
+            agentAtoms().sessionStatsAtom[0]() != null ||
+            agentAtoms().compactingAtom[0]() != null ||
+            agentAtoms().reconnectingAtom[0]() != null,
+    );
 
     // Ref CALLBACK, not a one-shot onMount(): originally fixed a bug where
     // Agent History's now-removed `bodyMode` in-place swap (PR #2509)
@@ -2200,6 +2206,8 @@ const AgentPresentationView = ({
                                 const phase = agentAtoms().turnPhaseAtom[0]();
                                 return phase.kind === "Streaming" ? (phase.retryAfterMs ?? null) : null;
                             })()}
+                            compacting={agentAtoms().compactingAtom[0]()}
+                            reconnecting={agentAtoms().reconnectingAtom[0]()}
                         />
                     </Show>
                 </div>
@@ -2365,7 +2373,6 @@ const AgentPresentationView = ({
                 providerId={provider()?.id ?? ""}
                 agentMode={block()?.meta?.["agentMode"] as string | undefined}
                 compacting={agentAtoms().compactingAtom[0]()}
-                reconnecting={agentAtoms().reconnectingAtom[0]()}
                 // Route through handleSendMessage — same pattern as the
                 // SlashHelpPanel's onInvoke above, and for the same reason:
                 // this needs the same pre-TurnStart wasAlreadyWorking

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -113,7 +113,7 @@
  *     `@container` queries for this decision.
  *
  * Stats zone (center, unaffected by the above): tokens (↑in ↓out) ·
- * elapsed, or the live "Compacting…"/"Reconnecting…" readout.
+ * elapsed.
  *
  * The strip bar itself is not clickable. "Shell" is the sole toggle for
  * the details drawer (the AgentShellSubblock terminal — activity-log lines
@@ -127,7 +127,7 @@
 
 import { useTick } from "@/app/hook/useTick";
 import { compactionThreshold } from "@/app/store/agent-pane-state/context-window";
-import type { CompactionState, ResumeRetryState } from "@/app/store/agent-pane-state/types";
+import type { CompactionState } from "@/app/store/agent-pane-state/types";
 import { formatCompactNumber, formatExactNumber } from "@/util/format-count";
 import { formatElapsedCompact } from "@/util/format-time";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount, untrack, type JSX } from "solid-js";
@@ -456,21 +456,14 @@ interface AgentComposerStripProps {
     agentMode?: string;
     /**
      * Live "compaction in progress" state (reducer-owned, set by the
-     * `PreCompact` hook's `compaction_started` signal). While set, the
-     * center stats zone shows "Compacting…" plus a live elapsed
-     * counter instead of the normal turn/session stats — Tier 1/2 of
-     * docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md.
+     * `PreCompact` hook's `compaction_started` signal). Gates the manual
+     * Compact button (`canCompact()` below) and its tooltip. The
+     * "Compacting…" + live elapsed readout this used to also drive here
+     * moved to `AgentWorkingRow` (2026-08-27, Part 2 of
+     * SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md) — see
+     * `agent-view.tsx`'s `<AgentWorkingRow compacting=.../>` call site.
      */
     compacting?: CompactionState | null;
-    /**
-     * Live "reconnecting after a stale `--resume` session id" state, or
-     * null. While set, the center stats zone shows "Reconnecting…" plus a
-     * live elapsed counter — same treatment as `compacting`, so a stale-
-     * resume recovery (usually seconds, occasionally tens of seconds) never
-     * reads as a silent hang. See
-     * docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md §6.2.
-     */
-    reconnecting?: ResumeRetryState | null;
     /**
      * Manually trigger compaction now, instead of waiting for the CLI's
      * own auto-compact threshold. Only meaningful for Claude — sends the
@@ -511,42 +504,7 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
         return s != null ? (tick(), Date.now() - s) : 0;
     });
 
-    // Live elapsed time since compaction started — a real stopwatch via
-    // Date.now() deltas (ticks every second through the same `useTick`
-    // this strip already uses for the turn-elapsed display). Once the
-    // authoritative `compact_boundary` event lands, `compacting` clears
-    // and the finalized transcript node shows the backend's real
-    // `durationMs` instead — this live reading is only ever the
-    // in-progress approximation. Tier 2 of
-    // docs/specs/SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md.
-    const compactingElapsedMs = createMemo(() => {
-        const c = props.compacting;
-        return c ? (tick(), Date.now() - c.startedAt) : 0;
-    });
-
-    // Live elapsed time since a stale-`--resume` retry began — same
-    // stopwatch pattern as compactingElapsedMs above. Clears the moment
-    // `reconnecting` clears (the retry's outcome — Fresh or Resumed — is
-    // known); there's no separate finalized-duration node to hand off to,
-    // unlike compaction's transcript node.
-    const reconnectingElapsedMs = createMemo(() => {
-        const r = props.reconnecting;
-        return r ? (tick(), Date.now() - r.startedAt) : 0;
-    });
-
     const rightText = createMemo((): string => {
-        // Mutually exclusive with `compacting` by construction (a stale-
-        // resume retry only fires once the underlying process has already
-        // exited, at which point compaction can't still be in progress),
-        // but checked first regardless — a silent-gap recovery is the more
-        // easily mistaken-for-a-hang state, so it takes priority if both
-        // were ever somehow set.
-        if (props.reconnecting) {
-            return `Reconnecting…  ${formatElapsedCompact(reconnectingElapsedMs())}`;
-        }
-        if (props.compacting) {
-            return `Compacting…  ${formatElapsedCompact(compactingElapsedMs())}`;
-        }
         const parts: string[] = [];
         if (props.loading) {
             if (props.turnTokens) parts.push(fmtTokens(props.turnTokens));
@@ -1262,13 +1220,7 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     const statsZone = (variant: "single" | "multi") => (
         <span class="agent-composer-strip-stats-zone" ref={(el) => (statsRefs[variant] = el)}>
             <Show when={rightText()}>
-                <span
-                    class="agent-composer-strip-stats"
-                    classList={{
-                        "agent-composer-strip-stats--compacting": !!props.compacting,
-                        "agent-composer-strip-stats--reconnecting": !!props.reconnecting,
-                    }}
-                >
+                <span class="agent-composer-strip-stats">
                     {rightText()}
                 </span>
             </Show>

--- a/frontend/app/view/agent/components/AgentFooter.test.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.test.tsx
@@ -17,7 +17,7 @@ import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { AgentFooter } from "./AgentFooter";
+import { AgentFooter, AgentWorkingRow } from "./AgentFooter";
 import { ObjectService } from "@/app/store/services";
 import type { AgentViewModel } from "../agent-model";
 
@@ -475,5 +475,54 @@ describe("AgentFooter composer draft persistence (SPEC_AGENT_HISTORY_AS_TAB_AND_
 
         render(() => <AgentFooter agentName="Test" />);
         expect(getComposer().value).toBe("");
+    });
+});
+
+/**
+ * Reconnecting/Compacting sub-states, relocated onto AgentWorkingRow from
+ * AgentComposerStrip's now-removed rightText() display (2026-08-27, Part 2
+ * of docs/specs/SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md §10).
+ * Both states must render the row even with `loading={false}` and no
+ * `sessionStats` — that's the whole point of the relocation (a stale-resume
+ * reconnect fires only after the underlying process has already exited, so
+ * `loading` is typically false while it's in progress).
+ */
+describe("AgentWorkingRow compacting/reconnecting sub-states (SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md Part 2)", () => {
+    it('renders "Reconnecting…" in the left zone and an elapsed counter in the right zone, even with loading=false and no sessionStats', () => {
+        const { container } = render(() => (
+            <AgentWorkingRow loading={false} reconnecting={{ startedAt: Date.now() }} />
+        ));
+
+        expect(container.querySelector(".agent-working-row--loading")).toBeTruthy();
+        expect(container.querySelector(".agent-working-row-left")?.textContent).toBe("Reconnecting…");
+        expect(container.querySelector(".agent-working-row-right")?.textContent).toMatch(/^\d+s$/);
+    });
+
+    it('renders "Compacting…" similarly when compacting is set (and reconnecting is not)', () => {
+        const { container } = render(() => (
+            <AgentWorkingRow loading={false} compacting={{ trigger: "auto", startedAt: Date.now() }} />
+        ));
+
+        expect(container.querySelector(".agent-working-row--loading")).toBeTruthy();
+        expect(container.querySelector(".agent-working-row-left")?.textContent).toBe("Compacting…");
+        expect(container.querySelector(".agent-working-row-right")?.textContent).toMatch(/^\d+s$/);
+    });
+
+    it("reconnecting takes priority over compacting when both are somehow set", () => {
+        const { container } = render(() => (
+            <AgentWorkingRow
+                loading={false}
+                compacting={{ trigger: "auto", startedAt: Date.now() }}
+                reconnecting={{ startedAt: Date.now() }}
+            />
+        ));
+
+        expect(container.querySelector(".agent-working-row-left")?.textContent).toBe("Reconnecting…");
+    });
+
+    it("is not visible (no worked-summary/nothing) when neither loading, compacting, nor reconnecting is set and there's no sessionStats", () => {
+        const { container } = render(() => <AgentWorkingRow loading={false} />);
+
+        expect(container.querySelector(".agent-working-row")).toBeNull();
     });
 });

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -15,6 +15,7 @@ import { formatCompactNumber } from "@/util/format-count";
 import { formatElapsedCompact } from "@/util/format-time";
 import { abbreviateText } from "@/util/format-text";
 import { MicButton } from "@/app/element/MicButton";
+import type { CompactionState, ResumeRetryState } from "@/app/store/agent-pane-state/types";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
@@ -93,6 +94,19 @@ interface AgentWorkingRowProps {
      *  launchPhase to "waiting-for-login-completion" too, so without this the
      *  row rendered a second, redundant Cancel button alongside AuthUrlBox's. */
     hasAuthUrl?: boolean;
+    /** Live "compaction in progress" state, or null — relocated here from
+     *  AgentComposerStrip (2026-08-27, Part 2 of
+     *  SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md) so a user has
+     *  exactly one place to check "is something happening right now." Takes
+     *  priority over the normal Working/tool display. */
+    compacting?: CompactionState | null;
+    /** Live "recovering from a stale --resume session id" state, or null —
+     *  same relocation as `compacting` above. Fires ONLY after the
+     *  underlying process has already crashed/exited, so this can be set
+     *  while `loading` is false — the row must render for this alone. Takes
+     *  priority over `compacting` (mirrors the old composer-strip priority:
+     *  a silent-gap recovery is more easily mistaken for a hang). */
+    reconnecting?: ResumeRetryState | null;
 }
 
 // reagent P2 on PR #2304: "waiting-for-login-link" (tier 1's own up-to-15s
@@ -111,6 +125,8 @@ const CANCELLABLE_LAUNCH_PHASES = new Set([
  *  of the JSX ternary chain so both the type-out reveal effect and the
  *  render itself read the same computed value. */
 function loadingLeftText(props: AgentWorkingRowProps, phrase: string, nowMs: number): string {
+    if (props.reconnecting) return "Reconnecting…";
+    if (props.compacting) return "Compacting…";
     if (props.stopping) return "Stopping…";
     if (props.waitingReason === "rate_limited") {
         return props.retryAfterMs != null
@@ -206,6 +222,19 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
         return s != null ? (tick(), Date.now() - s) : 0;
     });
 
+    // Live elapsed time since compaction/reconnecting-retry started —
+    // relocated from AgentComposerStrip (2026-08-27, Part 2 of
+    // SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md). Same
+    // stopwatch pattern as elapsedMs above.
+    const compactingElapsedMs = createMemo(() => {
+        const c = props.compacting;
+        return c ? (tick(), Date.now() - c.startedAt) : 0;
+    });
+    const reconnectingElapsedMs = createMemo(() => {
+        const r = props.reconnecting;
+        return r ? (tick(), Date.now() - r.startedAt) : 0;
+    });
+
     createEffect(() => {
         if (!props.loading || (props.currentTool && !props.toolPromoted)) return;
         setPhrase(pickThinkingPhrase());
@@ -255,6 +284,12 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     });
 
     const rightText = createMemo((): string => {
+        // reconnecting/compacting show only the elapsed-time readout, no
+        // token counts — matches the old composer-strip behavior these
+        // states were relocated from. `reconnecting` takes priority (see
+        // its prop doc comment above).
+        if (props.reconnecting) return formatElapsedCompact(reconnectingElapsedMs());
+        if (props.compacting) return formatElapsedCompact(compactingElapsedMs());
         const right: string[] = [];
         if (props.turnTokens) right.push(fmtTokens(props.turnTokens));
         right.push(formatElapsedCompact(elapsedMs()));
@@ -276,7 +311,7 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     // reducer axis itself stays, for the watchdog/Swarm consumers).
     return (
         <Show
-            when={props.loading}
+            when={props.loading || !!props.compacting || !!props.reconnecting}
             fallback={
                 <Show when={workedSummary()}>
                     <span class="agent-working-row agent-working-row--worked">


### PR DESCRIPTION
## Summary

Follow-up to #2825 (Part 1 of the same spec, merged). "Reconnecting…" and
"Compacting…" used to render inside `AgentComposerStrip`'s stats zone — a
different DOM region than `AgentWorkingRow`'s "Working…", directly above the
textarea rather than in the conversation area above it. There was no visual
relationship between the two, so a user had no way to know there were two
separate status slots, or why "Reconnecting…" could appear while "Working…"
was simultaneously absent (correctly so — the underlying process had already
crashed and AgentMux was transparently retrying with a fresh `--resume`
session id; nothing was "working" in that moment, but nothing communicated
that distinction).

This moves both states into `AgentWorkingRow` as two additional
mutually-exclusive sub-states alongside `Working`/idle, so there's exactly
**one** place to check "is something happening to this agent right now" —
the same shimmer/type-out treatment `Working` already has applies
automatically. Wording stays distinct per state (`Reconnecting…` vs.
`Compacting…` vs. `Working…`) — this is a **placement** fix, not a wording
simplification. Collapsing to one generic label was considered and rejected
(spec §10, "Alternative considered, not recommended") — these states exist
specifically because a prior generic "is it hanging?" ambiguity was a real,
reported problem; collapsing them back would reintroduce it.

`AgentWorkingRow` now renders whenever `loading`, `compacting`, or
`reconnecting` is set (previously gated on `loading` alone) — `reconnecting`
in particular fires only *after* the underlying process has already exited,
so it's orthogonal to `TurnPhase`/`loading` by design. `AgentComposerStrip`
keeps the `compacting` prop (still gates the manual Compact button + its
tooltip) but loses `reconnecting` entirely and the two rightText() display
branches — it falls back to its plain token/elapsed readout, unchanged
otherwise. `AgentComposerStrip.tsx`'s layout/row-balancing algorithm
(computeBalancedLeftKeys/computeComposerRows/measurement effects) — recently
and heavily revised across several other PRs — was deliberately NOT touched
beyond these two prop/branch removals.

Full design + the rejected alternative: `docs/specs/SPEC_REMOVE_AGENT_UNRESPONSIVE_DETECTION_2026_08_25.md`
§9-§12 (Part 2).

## Test plan

- [x] `tsc --noEmit` — clean.
- [x] `vitest run` (full suite) — 218 test files, 3170 tests, 0 failed.
- [x] New `AgentFooter.test.tsx` cases: Reconnecting renders with
      `loading=false`/no `sessionStats`; Compacting renders similarly;
      Reconnecting takes priority over Compacting when both are set; the row
      stays absent when none of loading/compacting/reconnecting/sessionStats
      are set.
- [ ] Manual: trigger a real compaction and a real stale-resume retry and
      confirm the relocated status reads correctly in the single new
      location, with no flash of the old composer-strip text.

<!-- agentmux:agent_id=agent2 -->