### PR TITLE
chore: release v0.55.27

### DIFF
--- a/.changesets/1787811411-chore-agent-pane-upgrade-claude-code-cli-pin-to-2-1-247-rela-syjq.md
+++ b/.changesets/1787811411-chore-agent-pane-upgrade-claude-code-cli-pin-to-2-1-247-rela-syjq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(agent-pane): upgrade Claude Code CLI pin to 2.1.247, relabel Opus 5

--- a/.changesets/1787814801-fix-tab-optimistic-tab-removal-on-close-close-flash-structur-ocnk.md
+++ b/.changesets/1787814801-fix-tab-optimistic-tab-removal-on-close-close-flash-structur-ocnk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tab): optimistic tab removal on close — close flash structurally impossible

--- a/.changesets/1787814920-feat-layout-plain-drag-now-group-resizes-the-row-column-shif-pl9l.md
+++ b/.changesets/1787814920-feat-layout-plain-drag-now-group-resizes-the-row-column-shif-pl9l.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(layout): plain drag now group-resizes the row/column; Shift+drag moves a single border

--- a/.changesets/1787815686-feat-layout-shift-window-edge-resize-feeds-only-the-edge-pan-p6co.md
+++ b/.changesets/1787815686-feat-layout-shift-window-edge-resize-feeds-only-the-edge-pan-p6co.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(layout): Shift+window-edge resize feeds only the edge panes (Windows)

--- a/.changesets/1787862551-fix-agent-remove-false-positive-prone-agent-unresponsive-det-jec5.md
+++ b/.changesets/1787862551-fix-agent-remove-false-positive-prone-agent-unresponsive-det-jec5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove false-positive-prone 'agent unresponsive' detection, keep turn-active tracking

--- a/.changesets/1787864262-fix-agent-pane-consolidate-reconnecting-compacting-status-in-z97j.md
+++ b/.changesets/1787864262-fix-agent-pane-consolidate-reconnecting-compacting-status-in-z97j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): consolidate Reconnecting…/Compacting… status into the Working row

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.26"
+version = "0.55.27"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.26"
+version = "0.55.27"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.26"
+version = "0.55.27"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.26"
+version = "0.55.27"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.26"
+version = "0.55.27"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.26"
+version = "0.55.27"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.26"
+version = "0.55.27"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,15 @@
 # AgentMux Version History
 
+## 0.55.27 — 2026-08-27
+
+- chore(agent-pane): upgrade Claude Code CLI pin to 2.1.247, relabel Opus 5
+- fix(tab): optimistic tab removal on close — close flash structurally impossible
+- feat(layout): plain drag now group-resizes the row/column; Shift+drag moves a single border
+- feat(layout): Shift+window-edge resize feeds only the edge panes (Windows)
+- fix(agent): remove false-positive-prone 'agent unresponsive' detection, keep turn-active tracking
+- fix(agent-pane): consolidate Reconnecting…/Compacting… status into the Working row
+
+
 ## 0.55.26 — 2026-08-26
 
 - fix(agent): suppress Activity Dock refresh during backfill bursts and reconcile registry-known background tasks into dock rows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.26",
+  "version": "0.55.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.26",
+      "version": "0.55.27",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.26",
+  "version": "0.55.27",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming the 6 pending changesets, with a **forced patch bump** (`task release -- --as patch`).

`0.55.26` → `0.55.27`

## Bump override

The pending changesets computed to `minor` (two `feat(layout)` entries). A patch was forced deliberately, so those layout features ship under a patch version. `scripts/release.sh` printed the expected loud warning for the lower-than-requested bump.

## Changes included

- chore(agent-pane): upgrade Claude Code CLI pin to 2.1.247, relabel Opus 5
- fix(tab): optimistic tab removal on close — close flash structurally impossible
- feat(layout): plain drag now group-resizes the row/column; Shift+drag moves a single border
- feat(layout): Shift+window-edge resize feeds only the edge panes (Windows)
- fix(agent): remove false-positive-prone 'agent unresponsive' detection, keep turn-active tracking
- fix(agent-pane): consolidate Reconnecting…/Compacting… status into the Working row

## Release consistency invariant

All five version locations verified at `0.55.27` (by `scripts/release.sh` and independently):

| Location | Version |
|---|---|
| `VERSION_HISTORY.md` head | 0.55.27 |
| `package.json` | 0.55.27 |
| `package-lock.json` | 0.55.27 |
| `Cargo.toml` `[workspace.package]` | 0.55.27 |
| `Cargo.lock` (`agentmux-cef`) | 0.55.27 |

No code changes — version files, `VERSION_HISTORY.md`, and consumed changesets only.

<!-- agentmux:agent_id=agent3 -->