### PR TITLE
fix(statusbar): backend uptime from a monotonic clock, not two wall-clock stamps

### DIFF
--- a/.changesets/1787986039-fix-statusbar-report-backend-uptime-from-a-monotonic-clock-s-7mig.md
+++ b/.changesets/1787986039-fix-statusbar-report-backend-uptime-from-a-monotonic-clock-s-7mig.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): report backend uptime from a monotonic clock so a system clock step can't make it negative

--- a/agentmux-srv/src/backend/rpc_types/misc.rs
+++ b/agentmux-srv/src/backend/rpc_types/misc.rs
@@ -254,6 +254,18 @@ pub struct CommandVarResponseData {
 pub struct TimeSeriesData {
     pub ts: i64,
     pub values: HashMap<String, f64>,
+    /// Backend uptime in seconds, from a MONOTONIC clock (`sysinfo::uptime_secs`)
+    /// — NOT `ts` minus some earlier wall-clock stamp. Only the top-level
+    /// sysinfo tick carries it; per-block stats and the CPU-stream RPCs leave
+    /// it `None`, hence `skip_serializing_if` so their payload shape is
+    /// byte-for-byte unchanged.
+    ///
+    /// Exists because the frontend previously derived uptime by subtracting
+    /// the host's wall-clock `backend_started_at` from this struct's own
+    /// wall-clock `ts`, which goes permanently negative after any backwards
+    /// clock step. See `frontend/app/statusbar/backend-uptime.ts`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uptime_secs: Option<u64>,
 }
 
 /// Matches Go's `RemoteInfo`

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -37,32 +37,74 @@ const MAX_INTERVAL_SECS: f64 = 2.0;
 // name-guessing), and "other" (everything else, top-N by commit kept for
 // visibility — Chrome, VS Code, Docker, Windows itself, ...).
 
-/// Monotonic reference point for this backend process's uptime, set once at
-/// startup by `mark_process_start` (`bootstrap.rs`).
+/// Milliseconds from a SUSPEND-AWARE monotonic clock — one that keeps counting
+/// while the machine is asleep, and can never move backwards.
 ///
-/// `Instant` and NOT `SystemTime`/`chrono::Utc::now()` deliberately: uptime
-/// must survive a system clock step. The previous scheme subtracted two
-/// independent wall-clock reads taken at opposite ends of the backend's life
-/// (the host's `backend_started_at` stamp vs. each sysinfo tick's `ts`), so an
-/// NTP correction, a manual clock set, or a VM resume made the difference
-/// negative for the rest of that backend's life. Observed live on 0.55.26: the
-/// app started while the machine's clock read 2081-02-05, the clock was later
-/// corrected to 2026-08-29 with no restart, and the status bar rendered
-/// `-59:0-14`. An `Instant` cannot move backwards, so no clock event can
-/// reproduce that.
-static PROCESS_START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+/// Uptime needs both properties, and no single obvious clock has them:
+///
+/// - Wall clock (`SystemTime`/`chrono::Utc::now()`) counts suspend but moves
+///   backwards on an NTP correction, a manual set, or a VM resume. That was
+///   the original bug: on 0.55.26 the app started while the machine's clock
+///   read 2081-02-05, the clock was later corrected to 2026-08-29 with no
+///   restart, and the status bar rendered `-59:0-14`.
+/// - `std::time::Instant` can't move backwards, but it STOPS while the machine
+///   is suspended (`CLOCK_MONOTONIC` on Linux, `mach_absolute_time` on macOS,
+///   QPC on Windows). Using it would silently under-report by the whole
+///   suspend interval on every laptop lid-close — a regression against the
+///   wall-clock behaviour it replaced (codex P2 on PR #2831).
+///
+/// So each platform's suspend-aware counter is used directly:
+///
+/// | Platform | Source | Counts suspend |
+/// |---|---|---|
+/// | Linux/Android | `CLOCK_BOOTTIME` | yes (`CLOCK_MONOTONIC` does not) |
+/// | macOS/BSD | `CLOCK_MONOTONIC` | yes — Darwin's continues across sleep, unlike `CLOCK_UPTIME_RAW` and unlike the `mach_absolute_time` behind `Instant` |
+/// | Windows | `GetTickCount64` | yes (`QueryUnbiasedInterruptTime` does not) |
+///
+/// All three count from system boot, not process start, so `mark_process_start`
+/// takes a baseline and `uptime_secs` subtracts it.
+#[cfg(windows)]
+fn suspend_aware_now_ms() -> u64 {
+    // SAFETY: no arguments, no pointers, always succeeds.
+    unsafe { windows_sys::Win32::System::SystemInformation::GetTickCount64() }
+}
+
+#[cfg(not(windows))]
+fn suspend_aware_now_ms() -> u64 {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    const CLOCK: libc::clockid_t = libc::CLOCK_BOOTTIME;
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    const CLOCK: libc::clockid_t = libc::CLOCK_MONOTONIC;
+
+    let mut ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+    // SAFETY: `ts` is a valid, initialized, exclusively-borrowed timespec.
+    if unsafe { libc::clock_gettime(CLOCK, &mut ts) } != 0 {
+        // Reporting 0 makes uptime read 0 — visibly wrong but harmless and
+        // never negative. Preferable to substituting a clock with different
+        // properties partway through the process's life.
+        return 0;
+    }
+    (ts.tv_sec as u64) * 1_000 + (ts.tv_nsec as u64) / 1_000_000
+}
+
+/// Baseline reading of `suspend_aware_now_ms` captured at process start by
+/// `mark_process_start` (`main.rs`).
+static PROCESS_START_MS: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
 
 /// Record this process's start for uptime reporting. Idempotent; the first
 /// call wins, so a stray second call can't restart the clock.
 pub fn mark_process_start() {
-    let _ = PROCESS_START.set(Instant::now());
+    let _ = PROCESS_START_MS.set(suspend_aware_now_ms());
 }
 
 /// Seconds since `mark_process_start`. Falls back to initializing on first
 /// read, so a caller that never marked startup reports a truthful (if
-/// late-based) 0 rather than a wrong number or a panic.
+/// late-based) 0 rather than a wrong number or a panic. `saturating_sub`
+/// makes a decrease structurally impossible even if a platform counter ever
+/// misbehaved.
 pub fn uptime_secs() -> u64 {
-    PROCESS_START.get_or_init(Instant::now).elapsed().as_secs()
+    let start = *PROCESS_START_MS.get_or_init(suspend_aware_now_ms);
+    suspend_aware_now_ms().saturating_sub(start) / 1_000
 }
 
 /// How often to log a full attribution snapshot in the steady state.
@@ -1159,12 +1201,13 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
 mod uptime_tests {
     use super::*;
 
-    /// The real property this fix guarantees — that uptime is immune to a
-    /// system clock step — can't be asserted without a mockable clock, since
-    /// `Instant` is deliberately unsettable. What IS assertable: the marker is
-    /// idempotent (a stray second call can't restart the clock) and the value
-    /// never runs backwards. The type being `u64` is itself part of the fix:
-    /// the old wall-clock subtraction was signed and went to about -1.7e9.
+    /// Neither property this fix depends on — immunity to a clock step, and
+    /// counting across suspend — can be asserted in a unit test: the platform
+    /// counters are deliberately unsettable, and suspending the machine isn't
+    /// something a test can do. What IS assertable: the marker is idempotent
+    /// (a stray second call can't restart the clock) and the value never runs
+    /// backwards. The `u64` return type is itself part of the fix — the old
+    /// wall-clock subtraction was signed and reached about -1.7e9.
     #[test]
     fn uptime_is_monotonic_and_the_start_marker_is_idempotent() {
         mark_process_start();
@@ -1172,6 +1215,20 @@ mod uptime_tests {
         mark_process_start();
         let second = uptime_secs();
         assert!(second >= first, "uptime went backwards: {second} < {first}");
+    }
+
+    /// The suspend-aware counter must be a sane, forward-running millisecond
+    /// source on whatever platform this is built for — a `clock_gettime`
+    /// failure returning 0, or a units mix-up, would show up here.
+    #[test]
+    fn suspend_aware_clock_is_nonzero_and_never_decreases() {
+        let a = suspend_aware_now_ms();
+        let b = suspend_aware_now_ms();
+        assert!(a > 0, "suspend-aware clock returned 0 — clock_gettime failed?");
+        assert!(b >= a, "suspend-aware clock went backwards: {b} < {a}");
+        // Sanity on units: a machine that booted more than ~10 years ago is a
+        // units error (ns or µs mistaken for ms), not a real uptime.
+        assert!(a < 10 * 365 * 24 * 60 * 60 * 1_000, "implausible ms reading: {a}");
     }
 
     /// The frontend's fallback path keys off this field's ABSENCE, and the

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -37,6 +37,34 @@ const MAX_INTERVAL_SECS: f64 = 2.0;
 // name-guessing), and "other" (everything else, top-N by commit kept for
 // visibility — Chrome, VS Code, Docker, Windows itself, ...).
 
+/// Monotonic reference point for this backend process's uptime, set once at
+/// startup by `mark_process_start` (`bootstrap.rs`).
+///
+/// `Instant` and NOT `SystemTime`/`chrono::Utc::now()` deliberately: uptime
+/// must survive a system clock step. The previous scheme subtracted two
+/// independent wall-clock reads taken at opposite ends of the backend's life
+/// (the host's `backend_started_at` stamp vs. each sysinfo tick's `ts`), so an
+/// NTP correction, a manual clock set, or a VM resume made the difference
+/// negative for the rest of that backend's life. Observed live on 0.55.26: the
+/// app started while the machine's clock read 2081-02-05, the clock was later
+/// corrected to 2026-08-29 with no restart, and the status bar rendered
+/// `-59:0-14`. An `Instant` cannot move backwards, so no clock event can
+/// reproduce that.
+static PROCESS_START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+
+/// Record this process's start for uptime reporting. Idempotent; the first
+/// call wins, so a stray second call can't restart the clock.
+pub fn mark_process_start() {
+    let _ = PROCESS_START.set(Instant::now());
+}
+
+/// Seconds since `mark_process_start`. Falls back to initializing on first
+/// read, so a caller that never marked startup reports a truthful (if
+/// late-based) 0 rather than a wrong number or a panic.
+pub fn uptime_secs() -> u64 {
+    PROCESS_START.get_or_init(Instant::now).elapsed().as_secs()
+}
+
 /// How often to log a full attribution snapshot in the steady state.
 #[cfg(target_os = "windows")]
 const ATTRIBUTION_INTERVAL: Duration = Duration::from_secs(30);
@@ -1009,7 +1037,7 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
             .unwrap_or_default()
             .as_millis() as i64;
 
-        let ts_data = TimeSeriesData { ts: now, values };
+        let ts_data = TimeSeriesData { ts: now, values, uptime_secs: Some(uptime_secs()) };
 
         let event = WaveEvent {
             event: EVENT_SYS_INFO.to_string(),
@@ -1103,6 +1131,8 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
                 let block_ts = TimeSeriesData {
                     ts: now,
                     values: block_values,
+                    // Per-block process stats, not the backend's own uptime.
+                    uptime_secs: None,
                 };
                 let block_event = WaveEvent {
                     event: EVENT_BLOCK_STATS.to_string(),
@@ -1122,5 +1152,52 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod uptime_tests {
+    use super::*;
+
+    /// The real property this fix guarantees — that uptime is immune to a
+    /// system clock step — can't be asserted without a mockable clock, since
+    /// `Instant` is deliberately unsettable. What IS assertable: the marker is
+    /// idempotent (a stray second call can't restart the clock) and the value
+    /// never runs backwards. The type being `u64` is itself part of the fix:
+    /// the old wall-clock subtraction was signed and went to about -1.7e9.
+    #[test]
+    fn uptime_is_monotonic_and_the_start_marker_is_idempotent() {
+        mark_process_start();
+        let first = uptime_secs();
+        mark_process_start();
+        let second = uptime_secs();
+        assert!(second >= first, "uptime went backwards: {second} < {first}");
+    }
+
+    /// The frontend's fallback path keys off this field's ABSENCE, and the
+    /// per-block stats / CPU-stream payloads must keep their exact prior
+    /// shape — so `skip_serializing_if` is a wire contract, not a style choice.
+    #[test]
+    fn uptime_secs_is_emitted_when_present_and_omitted_when_absent() {
+        let with = TimeSeriesData { ts: 5, values: HashMap::new(), uptime_secs: Some(42) };
+        let v = serde_json::to_value(&with).expect("serialize");
+        assert_eq!(v["uptime_secs"], serde_json::json!(42));
+
+        let without = TimeSeriesData { ts: 5, values: HashMap::new(), uptime_secs: None };
+        let v = serde_json::to_value(&without).expect("serialize");
+        assert!(
+            v.get("uptime_secs").is_none(),
+            "block-stats/CPU-stream payload shape must be byte-for-byte unchanged"
+        );
+    }
+
+    /// A payload produced before this field existed (e.g. replayed from the
+    /// sysinfo persist ring across an upgrade) must still deserialize.
+    #[test]
+    fn payload_without_uptime_still_deserializes() {
+        let json = serde_json::json!({ "ts": 7, "values": { "cpu": 1.5 } });
+        let parsed: TimeSeriesData = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed.ts, 7);
+        assert_eq!(parsed.uptime_secs, None);
     }
 }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -47,6 +47,11 @@ async fn main() {
     #[cfg(windows)]
     let _crash_guard = bootstrap::install_crash_guard();
 
+    // 0c. Anchor the monotonic uptime clock before anything else can take time.
+    //     Must NOT be derived from wall-clock stamps — see the doc comment on
+    //     `PROCESS_START` for the clock-step bug that motivated it.
+    backend::sysinfo::mark_process_start();
+
     // 1. Init tracing (stderr + rolling file)
     let _log_guard = bootstrap::init_logging();
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -47,9 +47,10 @@ async fn main() {
     #[cfg(windows)]
     let _crash_guard = bootstrap::install_crash_guard();
 
-    // 0c. Anchor the monotonic uptime clock before anything else can take time.
-    //     Must NOT be derived from wall-clock stamps — see the doc comment on
-    //     `PROCESS_START` for the clock-step bug that motivated it.
+    // 0c. Anchor the uptime clock before anything else can take time. Must be
+    //     neither a wall-clock stamp (moves backwards on a clock step) nor an
+    //     `Instant` (stops while suspended) — see `suspend_aware_now_ms` in
+    //     `backend::sysinfo` for both bugs and the per-platform sources.
     backend::sysinfo::mark_process_start();
 
     // 1. Init tracing (stderr + rolling file)

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -11,20 +11,7 @@ import { Portal } from "solid-js/web";
 import { autoUpdate } from "@floating-ui/dom";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { computeMenuPosition } from "@/app/util/menu-position";
-
-function pad2(n: number): string {
-    return n < 10 ? `0${n}` : `${n}`;
-}
-
-function formatUptime(secs: number): string {
-    const s = secs % 60;
-    const m = Math.floor(secs / 60) % 60;
-    const h = Math.floor(secs / 3600) % 24;
-    const d = Math.floor(secs / 86400);
-    if (d > 0) return `${d}:${pad2(h)}:${pad2(m)}:${pad2(s)}`;
-    if (h > 0) return `${h}:${pad2(m)}:${pad2(s)}`;
-    return `${m}:${pad2(s)}`;
-}
+import { formatUptime, resolveUptimeSecs } from "./backend-uptime";
 
 function gpuColor(c: ReturnType<typeof getGpuInfo>["classification"]): string {
     switch (c) {
@@ -311,18 +298,27 @@ const BackendStatus = (): JSX.Element => {
         }
     });
 
-    // Drive uptime from sysinfo event timestamp so all windows update in sync.
-    // The backend broadcasts sysinfo with a server-side ts (ms epoch); all windows
-    // receive the same ts and compute the same integer, eliminating phase drift.
+    // Drive uptime from the sysinfo event so all windows update in sync — every
+    // window receives the same tick and shows the same integer, eliminating
+    // phase drift.
+    //
+    // The value itself comes from srv's MONOTONIC `uptime_secs`, not from
+    // subtracting the event's wall-clock `ts` from the host's `started_at`
+    // stamp. Those are two independent wall-clock reads spanning the backend's
+    // whole lifetime, so any backwards clock step (NTP correction, manual set,
+    // VM resume) made the difference negative and left it that way until the
+    // next restart. See `backend-uptime.ts` for the live 2081 -> 2026 case this
+    // fixes. `ts` is still passed as a clamped fallback for a payload that
+    // predates the field.
     onMount(() => {
         const unsub = waveEventSubscribe({
             eventType: WpsEvent.SysInfo,
             scope: "local",
             handler: (event) => {
-                const ts: number | undefined = (event as WaveEvent)?.data?.ts;
-                const start = startedAt();
-                if (ts != null && start != null) {
-                    setUptimeSecs(Math.floor((ts - start) / 1000));
+                const data = (event as WaveEvent)?.data;
+                const next = resolveUptimeSecs(data?.uptime_secs, data?.ts, startedAt());
+                if (next != null) {
+                    setUptimeSecs(next);
                 }
             },
         });

--- a/frontend/app/statusbar/backend-uptime.test.ts
+++ b/frontend/app/statusbar/backend-uptime.test.ts
@@ -1,0 +1,85 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { formatUptime, resolveUptimeSecs } from "./backend-uptime";
+
+describe("formatUptime", () => {
+    it("formats sub-hour uptimes as m:ss", () => {
+        expect(formatUptime(0)).toBe("0:00");
+        expect(formatUptime(9)).toBe("0:09");
+        expect(formatUptime(75)).toBe("1:15");
+        expect(formatUptime(3599)).toBe("59:59");
+    });
+
+    it("formats sub-day uptimes as h:mm:ss", () => {
+        expect(formatUptime(3600)).toBe("1:00:00");
+        expect(formatUptime(45296)).toBe("12:34:56");
+    });
+
+    it("formats multi-day uptimes as d:hh:mm:ss", () => {
+        expect(formatUptime(86400)).toBe("1:00:00:00");
+        expect(formatUptime(90061)).toBe("1:01:01:01");
+    });
+
+    // Regression: a backwards system-clock step (NTP correction, manual set,
+    // VM resume) used to drive uptimeSecs negative, and neither formatUptime
+    // nor its pad2 helper guarded the sign — `secs % 60` stayed negative and
+    // pad2's `n < 10 ? "0" + n` prepended a zero to the MINUS SIGN, rendering
+    // e.g. "-59:0-14" in the status bar. Worse, it read as a countdown: as ts
+    // advanced the seconds field went "0-14" -> "0-13" -> "0-12".
+    it("clamps negative uptimes to zero rather than rendering a padded minus sign", () => {
+        expect(formatUptime(-14)).toBe("0:00");
+        expect(formatUptime(-1717984694)).toBe("0:00");
+    });
+
+    it("clamps non-finite input to zero", () => {
+        expect(formatUptime(NaN)).toBe("0:00");
+        expect(formatUptime(Infinity)).toBe("0:00");
+    });
+
+    it("truncates fractional seconds", () => {
+        expect(formatUptime(75.9)).toBe("1:15");
+    });
+});
+
+describe("resolveUptimeSecs", () => {
+    it("prefers the backend's monotonic uptime when present", () => {
+        expect(resolveUptimeSecs(1234, 1_000_000, 999_000)).toBe(1234);
+    });
+
+    it("uses the backend value even when the wall clock disagrees wildly", () => {
+        // The exact live failure: srv started when the clock read 2081, the
+        // clock was corrected back to 2026, so the wall-clock difference is
+        // about -1.7e9. The monotonic value is the truth.
+        const start = new Date("2081-02-05T08:31:08.693Z").getTime();
+        const ts = new Date("2026-08-29T06:32:55.280Z").getTime();
+        expect(resolveUptimeSecs(60, ts, start)).toBe(60);
+    });
+
+    it("falls back to the wall-clock difference when the backend omits uptime", () => {
+        expect(resolveUptimeSecs(undefined, 1_000_000, 940_000)).toBe(60);
+        expect(resolveUptimeSecs(null, 1_000_000, 940_000)).toBe(60);
+    });
+
+    it("clamps the wall-clock fallback at zero instead of going negative", () => {
+        const start = new Date("2081-02-05T08:31:08.693Z").getTime();
+        const ts = new Date("2026-08-29T06:32:55.280Z").getTime();
+        expect(resolveUptimeSecs(undefined, ts, start)).toBe(0);
+    });
+
+    it("rejects a negative or non-finite backend value and falls back", () => {
+        expect(resolveUptimeSecs(-5, 1_000_000, 940_000)).toBe(60);
+        expect(resolveUptimeSecs(NaN, 1_000_000, 940_000)).toBe(60);
+        expect(resolveUptimeSecs("120", 1_000_000, 940_000)).toBe(60);
+    });
+
+    it("returns null when neither source is usable, so the caller keeps its last value", () => {
+        expect(resolveUptimeSecs(undefined, undefined, 940_000)).toBeNull();
+        expect(resolveUptimeSecs(undefined, 1_000_000, null)).toBeNull();
+    });
+
+    it("truncates a fractional backend value", () => {
+        expect(resolveUptimeSecs(12.9, 1_000_000, 940_000)).toBe(12);
+    });
+});

--- a/frontend/app/statusbar/backend-uptime.ts
+++ b/frontend/app/statusbar/backend-uptime.ts
@@ -1,0 +1,79 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Backend uptime: which clock to trust, and how to render it.
+ *
+ * Extracted from `BackendStatus.tsx` as pure functions for direct unit
+ * coverage, same rationale as `disk-volumes.ts` in this directory.
+ *
+ * Why this exists as its own module: uptime used to be derived entirely
+ * from two independent WALL-CLOCK stamps —
+ * `backend_started_at` (`chrono::Utc::now()`, stamped once by the host in
+ * `agentmux-cef/src/sidecar.rs` when it spawns the sidecar, never
+ * re-stamped) and the sysinfo event's `ts` (`SystemTime::now()` on every
+ * tick in `agentmux-srv/src/backend/sysinfo.rs`). Subtracting them is only
+ * correct while the system clock is monotonic across the backend's whole
+ * lifetime, which it is not: an NTP correction, a manual clock set, or a VM
+ * resume steps it, and any BACKWARDS step makes the difference negative for
+ * the rest of that backend's life.
+ *
+ * Observed live on 0.55.26: the app started while the machine's clock read
+ * 2081-02-05 and the clock was later corrected to 2026-08-29, with no
+ * restart in between (one `agentmuxsrv starting` line spanning both eras in
+ * the same log file). uptimeSecs sat at about -1.7e9 and the status bar
+ * rendered `-59:0-14`, ticking `0-14` -> `0-13` -> `0-12` — a padded minus
+ * sign that read as a countdown.
+ *
+ * The fix is to stop subtracting wall-clock stamps at all: srv now reports
+ * `uptime_secs` measured from a monotonic `Instant` captured at its own
+ * start, which no clock step can perturb. The wall-clock path is kept only
+ * as a clamped fallback for a sysinfo payload that predates that field
+ * (e.g. one replayed from the persist ring across an upgrade).
+ */
+
+function pad2(n: number): string {
+    return n < 10 ? `0${n}` : `${n}`;
+}
+
+/**
+ * Render a duration in seconds as `m:ss` / `h:mm:ss` / `d:hh:mm:ss`.
+ *
+ * Negative and non-finite input clamps to zero. That guard is deliberately
+ * here rather than only at the call site: this is also the formatter for the
+ * crash popover's `backendDeathInfo.uptime_secs`, which arrives from the
+ * host's own wall-clock arithmetic and is exposed to the exact same class of
+ * clock step.
+ */
+export function formatUptime(secs: number): string {
+    const safe = Number.isFinite(secs) && secs > 0 ? Math.floor(secs) : 0;
+    const s = safe % 60;
+    const m = Math.floor(safe / 60) % 60;
+    const h = Math.floor(safe / 3600) % 24;
+    const d = Math.floor(safe / 86400);
+    if (d > 0) return `${d}:${pad2(h)}:${pad2(m)}:${pad2(s)}`;
+    if (h > 0) return `${h}:${pad2(m)}:${pad2(s)}`;
+    return `${m}:${pad2(s)}`;
+}
+
+/**
+ * Decide the uptime to display from one sysinfo tick.
+ *
+ * Prefers `reported` — srv's monotonic `uptime_secs`. Falls back to the
+ * legacy wall-clock difference (clamped at zero) when that field is absent,
+ * and returns `null` when neither source is usable so the caller leaves its
+ * previous value alone rather than flashing a zero.
+ */
+export function resolveUptimeSecs(
+    reported: unknown,
+    sysinfoTsMs: unknown,
+    startedAtMs: number | null,
+): number | null {
+    if (typeof reported === "number" && Number.isFinite(reported) && reported >= 0) {
+        return Math.floor(reported);
+    }
+    if (typeof sysinfoTsMs === "number" && Number.isFinite(sysinfoTsMs) && startedAtMs != null) {
+        return Math.max(0, Math.floor((sysinfoTsMs - startedAtMs) / 1000));
+    }
+    return null;
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1965,6 +1965,11 @@ declare global {
     type TimeSeriesData = {
         ts: number;
         values: {[key: string]: number};
+        // Backend uptime in seconds, from srv's monotonic clock. Present only
+        // on the top-level sysinfo tick, absent on per-block stats and the
+        // CPU-stream RPCs. Never derive uptime from `ts` — see
+        // frontend/app/statusbar/backend-uptime.ts.
+        uptime_secs?: number;
     };
 
     // uctypes.UIChat


### PR DESCRIPTION
## The bug

The status bar's backend uptime renders as a padded negative that appears to count down — e.g. `-59:0-14`, ticking `0-14` → `0-13` → `0-12`.

Reproduced live on the released `0.55.26`, not synthetically: this machine's clock read **2081-02-05** when the app started and was later corrected to **2026-08-29**, with no restart in between — a single `agentmuxsrv starting` line spans both eras in one log file (`agentmuxsrv-v0.55.26.log.2081-02-05`, 410 lines stamped 2081 followed by 54 stamped 2026). `uptimeSecs` sat at about `-1.7e9`.

## Root cause

Uptime was never reported by the backend at all. The frontend derived it by subtracting **two independent wall-clock stamps** taken at opposite ends of the backend's life:

- `backend_started_at` — `chrono::Utc::now()`, stamped once by the host in `agentmux-cef/src/sidecar.rs` when it spawns the sidecar, never re-stamped.
- the sysinfo tick's `ts` — `SystemTime::now()`, fresh every tick.

That subtraction is only correct while the system clock stays monotonic for the backend's whole lifetime. Any **backwards** step — NTP correction, manual set, VM resume — makes it negative and leaves it that way until the next restart.

Two unguarded formatters then compounded it. `formatUptime` had no sign guard, so `secs % 60` stayed negative, and `pad2`'s `n < 10 ? "0" + n : n` prepended a zero to the **minus sign** rather than to a digit. The countdown appearance is real: as `ts` advances the seconds field genuinely moves toward zero, but with the minus inside the padded field the visible digits shrink.

Running the real code against the real timestamps:

```
2026-08-29T06:32:55Z -> uptimeSecs = -1717984694 -> "-59:0-14"
2026-08-29T06:32:56Z -> uptimeSecs = -1717984693 -> "-59:0-13"
2026-08-29T06:32:57Z -> uptimeSecs = -1717984692 -> "-59:0-12"
```

## The fix

Stop subtracting wall-clock stamps. `srv` now reports `uptime_secs` from a **suspend-aware monotonic** counter anchored at process start (`sysinfo::mark_process_start`, called from `main.rs` before anything else can take time), and the frontend displays that value directly.

Uptime needs two properties at once and no single obvious clock has both — wall clock counts suspend but moves backwards on a clock step; `std::time::Instant` cannot move backwards but **stops while the machine is asleep**. This PR's first version used `Instant`, which fixed the reported bug but silently under-reported by the whole suspend interval on every lid-close — a regression against the behaviour it replaced. That was codex's P2, fixed in `98023edbf`. Each platform's suspend-aware counter is now used directly:

| Platform | Source | Why not the obvious one |
|---|---|---|
| Linux/Android | `CLOCK_BOOTTIME` | `CLOCK_MONOTONIC` does not count suspend |
| macOS/BSD | `CLOCK_MONOTONIC` | Darwin's continues across sleep, unlike `CLOCK_UPTIME_RAW` and unlike the `mach_absolute_time` behind `Instant` |
| Windows | `GetTickCount64` | `QueryUnbiasedInterruptTime` does not count suspend |

All three count from boot rather than process start, so the baseline is captured once and subtracted. `saturating_sub` makes a decrease structurally impossible even if a platform counter misbehaved. No Cargo.toml change: `libc` is already a dependency and `windows-sys` already enables `Win32_System_SystemInformation`.

Kept deliberately narrow otherwise:

- **Wire compatibility** — `uptime_secs` is `Option<u64>` with `skip_serializing_if`, so per-block stats and the CPU-stream RPCs keep their exact prior payload shape. A payload predating the field still deserializes (`None`).
- **Fallback, not a second source of truth** — the old wall-clock path survives only for a payload without the field (e.g. one replayed from the sysinfo persist ring across an upgrade), and it is now clamped at zero.
- **Defence in depth** — `formatUptime` clamps negative and non-finite input to zero. That guard is in the formatter rather than only at the call site because the crash popover formats a *host*-supplied `backendDeathInfo.uptime_secs` with exactly the same exposure.

Pure logic moved to `frontend/app/statusbar/backend-uptime.ts` for direct unit coverage, following `disk-volumes.ts` next to it.

## What isn't claimed

Neither property that matters — immunity to a clock step, and counting across suspend — can be asserted in a unit test: the platform counters are deliberately unsettable, and a test cannot suspend the machine. The tests cover what is assertable: the start marker is idempotent, the value never runs backwards, the counter is non-zero and in plausible millisecond units (a `clock_gettime` failure or a ns/us mix-up fails there), the serialization contract holds both ways, and the formatter/resolver handle every negative and non-finite case including the exact live `-1717984694`.

The Linux path is compiled and exercised by CI's ubuntu job. **macOS is not in this repo's PR checks**, so that path is written against documented Darwin semantics and is not machine-verified here.

Also unchanged: the uptime display is still gated on `startedAt() != null`, so a failed `getBackendInfo()` hides uptime even though it is now known independently. Pre-existing behaviour, left alone to keep this diff scoped.

## Verification

- `cargo test -p agentmux-srv` — 2790 passed, 0 failed (Windows)
- `npx tsc --noEmit` — clean
- `npx vitest run` — 3260 passed, 3 skipped, 0 failed

New: 13 frontend tests, 4 backend tests.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
