### PR TITLE
fix(sysinfo): keep the chart correct across a backwards system-clock step

### DIFF
--- a/.changesets/1788004345-fix-sysinfo-keep-the-chart-correct-across-a-backwards-system-6oga.md
+++ b/.changesets/1788004345-fix-sysinfo-keep-the-chart-correct-across-a-backwards-system-6oga.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(sysinfo): keep the chart correct across a backwards system-clock step

--- a/frontend/app/view/sysinfo/sysinfo-model.test.ts
+++ b/frontend/app/view/sysinfo/sysinfo-model.test.ts
@@ -1,0 +1,154 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { sampleReducer } from "./sysinfo-model";
+import type { DataItem } from "./sysinfo-types";
+
+const INTERVAL = 1;
+const INTERVAL_MS = 1000;
+const NUM_POINTS = 120;
+
+function sample(ts: number, cpu = 10): DataItem {
+    return { ts, cpu };
+}
+
+function append(state: DataItem[], item: DataItem): DataItem[] {
+    return sampleReducer(state, { type: "APPEND", item, intervalSecs: INTERVAL, numPoints: NUM_POINTS });
+}
+
+function reset(items: DataItem[]): DataItem[] {
+    return sampleReducer([], { type: "RESET", items, intervalSecs: INTERVAL, numPoints: NUM_POINTS });
+}
+
+/** The exact live incident: srv ran under a 2081 clock, then the clock was
+ *  corrected back to 2026 with no restart. */
+const PRE_STEP = new Date("2081-02-05T09:58:22.373Z").getTime();
+const POST_STEP = new Date("2026-08-29T06:28:33.964Z").getTime();
+
+describe("sampleReducer — APPEND, ordinary forward time", () => {
+    it("appends a contiguous sample", () => {
+        const state = [sample(1000), sample(2000)];
+        expect(append(state, sample(3000)).map((d) => d.ts)).toEqual([1000, 2000, 3000]);
+    });
+
+    it("trims samples older than the visible window", () => {
+        const old = sample(1000);
+        const recent = sample(1000 + INTERVAL_MS * (NUM_POINTS + 1));
+        const next = sample(recent.ts + INTERVAL_MS);
+        const out = append([old, recent], next);
+        expect(out.map((d) => d.ts)).toEqual([recent.ts, next.ts]);
+    });
+
+    it("zero-order holds across 1-3 missed ticks", () => {
+        const state = [sample(1000, 42)];
+        const out = append(state, sample(4000, 7));
+        expect(out.map((d) => d.ts)).toEqual([1000, 2000, 3000, 4000]);
+        expect(out[1].cpu).toBe(42);
+        expect(out[2].cpu).toBe(42);
+        expect(out[3].cpu).toBe(7);
+    });
+
+    it("inserts a NaN sentinel across a long forward break", () => {
+        const state = [sample(1000)];
+        const out = append(state, sample(20000));
+        expect(out).toHaveLength(3);
+        expect(out[1].blank).toBe(1);
+        expect(Number.isNaN(out[1].cpu as number)).toBe(true);
+    });
+});
+
+// Regression: wall-clock `ts` can step BACKWARDS (NTP correction, manual set,
+// VM resume). Before the fix the reducer had two forward-only assumptions:
+//
+//  1. `cutoffTs = item.ts - intervalMs * (numPoints + 1)` with
+//     `state.filter(d => d.ts >= cutoffTs)` — a pre-step point's ts is LARGER
+//     than any post-step cutoff, so it passed the filter forever and never
+//     aged out.
+//  2. Both gap branches tested `gap > ...`, and a backwards jump makes `gap`
+//     negative, so neither fired and no break was marked — the series went
+//     silently non-monotonic in x.
+describe("sampleReducer — APPEND across a backwards clock step", () => {
+    it("drops points stamped after the new sample instead of retaining them forever", () => {
+        const state = [sample(PRE_STEP - 2000), sample(PRE_STEP - 1000), sample(PRE_STEP)];
+        const out = append(state, sample(POST_STEP));
+        expect(out.map((d) => d.ts)).toEqual([POST_STEP]);
+    });
+
+    it("keeps the buffer bounded and monotonic as samples continue after the step", () => {
+        let state: DataItem[] = [sample(PRE_STEP - 1000), sample(PRE_STEP)];
+        for (let i = 0; i < 10; i++) {
+            state = append(state, sample(POST_STEP + i * INTERVAL_MS));
+        }
+        expect(state).toHaveLength(10);
+        for (let i = 1; i < state.length; i++) {
+            expect(state[i].ts).toBeGreaterThan(state[i - 1].ts);
+        }
+    });
+
+    it("marks a break rather than connecting the line across the seam", () => {
+        // A partial step — small enough that some points survive the trim, so
+        // there is a real seam to mark (the full-step case above has nothing
+        // left to connect from).
+        const base = 10_000_000;
+        const state = [sample(base), sample(base + 8000)];
+        const out = append(state, sample(base + 1000));
+        const blanks = out.filter((d) => d.blank === 1);
+        expect(blanks).toHaveLength(1);
+        expect(out[out.length - 1].ts).toBe(base + 1000);
+        // The far-ahead point is gone; the retained one is genuinely older.
+        expect(out.some((d) => d.ts === base + 8000)).toBe(false);
+    });
+
+    it("tolerates sub-threshold jitter without discarding the buffer", () => {
+        // A ~1s backwards nudge is slew, not a step: keep the history.
+        const base = 10_000_000;
+        const state = [sample(base), sample(base + 1000)];
+        const out = append(state, sample(base + 500));
+        expect(out.map((d) => d.ts)).toEqual([base, base + 1000, base + 500]);
+        expect(out.some((d) => d.blank === 1)).toBe(false);
+    });
+});
+
+describe("sampleReducer — RESET", () => {
+    // RESET pads the start of the window with leading blanks when the oldest
+    // real sample is newer than the cutoff (pre-existing behaviour, so the
+    // x-domain is filled) — assert on the real samples, not the padding.
+    const realSamples = (out: DataItem[]) => out.filter((d) => d.blank !== 1).map((d) => d.ts);
+
+    it("keeps a contiguous history intact", () => {
+        const items = [sample(1000), sample(2000), sample(3000)];
+        expect(realSamples(reset(items))).toEqual([1000, 2000, 3000]);
+    });
+
+    it("inserts sentinels around a forward gap in history", () => {
+        const items = [sample(1000), sample(60000)];
+        const out = reset(items);
+        const blankTs = out.filter((d) => d.blank === 1).map((d) => d.ts);
+        // The pair bracketing the gap itself, distinct from the leading pad.
+        expect(blankTs).toContain(1001);
+        expect(blankTs).toContain(59999);
+        expect(realSamples(out)).toEqual([1000, 60000]);
+    });
+
+    it("drops pre-step points from a history that spans a backwards clock step", () => {
+        // Ring order is insertion order: pre-step samples first, then post-step.
+        const items = [
+            sample(PRE_STEP - 1000),
+            sample(PRE_STEP),
+            sample(POST_STEP),
+            sample(POST_STEP + INTERVAL_MS),
+        ];
+        const out = reset(items);
+        expect(out.every((d) => d.ts <= POST_STEP + INTERVAL_MS)).toBe(true);
+        expect(out.some((d) => d.ts === PRE_STEP)).toBe(false);
+    });
+
+    it("never returns a non-monotonic series", () => {
+        const items = [sample(PRE_STEP), sample(POST_STEP), sample(POST_STEP + INTERVAL_MS)];
+        const out = reset(items);
+        for (let i = 1; i < out.length; i++) {
+            expect(out[i].ts).toBeGreaterThan(out[i - 1].ts);
+        }
+    });
+});

--- a/frontend/app/view/sysinfo/sysinfo-model.test.ts
+++ b/frontend/app/view/sysinfo/sysinfo-model.test.ts
@@ -100,13 +100,46 @@ describe("sampleReducer — APPEND across a backwards clock step", () => {
         expect(out.some((d) => d.ts === base + 8000)).toBe(false);
     });
 
-    it("tolerates sub-threshold jitter without discarding the buffer", () => {
-        // A ~1s backwards nudge is slew, not a step: keep the history.
+    it("tolerates sub-threshold jitter without marking a break", () => {
+        // A sub-tick backwards nudge is slew, not a step: keep the history and
+        // do NOT insert a visible break. The one overtaken point is dropped so
+        // the series still can't go non-monotonic.
         const base = 10_000_000;
         const state = [sample(base), sample(base + 1000)];
         const out = append(state, sample(base + 500));
-        expect(out.map((d) => d.ts)).toEqual([base, base + 1000, base + 500]);
+        expect(out.map((d) => d.ts)).toEqual([base, base + 500]);
         expect(out.some((d) => d.blank === 1)).toBe(false);
+    });
+
+    // reagentx P1 (PR #2832): the first version of this fix used ONE threshold
+    // for two different jobs — deciding a step happened, and deciding which
+    // points may remain. A point sitting between `item.ts` and
+    // `item.ts + gapThreshold` survived the filter but is still AHEAD of the
+    // new sample, so the `clockStepped` branch appended
+    // `[...trimmed, blank(last.ts + 1), item]` with `last.ts + 1 > item.ts` —
+    // reintroducing exactly the non-monotonic series this PR exists to fix.
+    // Only reachable for a PARTIAL step: bigger than the threshold, but not
+    // big enough to clear every buffered point — i.e. an ordinary few-second
+    // NTP correction, which is far more common than a 55-year jump.
+    it("stays monotonic for a partial step that clears only some of the buffer", () => {
+        const out = append([sample(8000), sample(9000), sample(10000)], sample(5000));
+        expect(out.map((d) => d.ts)).toEqual([5000]);
+        for (let i = 1; i < out.length; i++) {
+            expect(out[i].ts).toBeGreaterThan(out[i - 1].ts);
+        }
+    });
+
+    it("stays monotonic across every backwards step magnitude", () => {
+        const base = 10_000_000;
+        const state = [sample(base), sample(base + 1000), sample(base + 2000), sample(base + 3000)];
+        // Sweep well past the gap threshold (3000ms at 1Hz) and back, so both
+        // the partial-step and full-clear regimes are covered.
+        for (const back of [100, 500, 1000, 2500, 3000, 3500, 4000, 5000, 10_000, 60_000]) {
+            const out = append(state, sample(base + 3000 - back));
+            for (let i = 1; i < out.length; i++) {
+                expect(out[i].ts, `regression at back=${back}ms`).toBeGreaterThan(out[i - 1].ts);
+            }
+        }
     });
 });
 
@@ -150,5 +183,44 @@ describe("sampleReducer — RESET", () => {
         for (let i = 1; i < out.length; i++) {
             expect(out[i].ts).toBeGreaterThan(out[i - 1].ts);
         }
+    });
+
+    // codex P2 (PR #2832): a sub-threshold backwards correction in history left
+    // BOTH samples in place, and bracketing the seam with `prev.ts + 1` /
+    // `cur.ts - 1` blanks inherits the same inversion rather than repairing it
+    // — history [10000, 8000] emitted 10000, 10001, 7999, 8000.
+    it("drops the superseded segment on a sub-threshold backwards correction", () => {
+        const out = reset([sample(10000), sample(8000)]);
+        const ts = out.map((d) => d.ts);
+        expect(ts).not.toContain(10000);
+        expect(ts).toContain(8000);
+        for (let i = 1; i < out.length; i++) {
+            expect(out[i].ts).toBeGreaterThan(out[i - 1].ts);
+        }
+    });
+
+    it("repairs arbitrary out-of-order ring content, anchored on the newest sample", () => {
+        // Ring order is insertion order, so any interleaving is possible.
+        const out = reset([sample(5000), sample(9000), sample(6000), sample(7000)]);
+        for (let i = 1; i < out.length; i++) {
+            expect(out[i].ts).toBeGreaterThan(out[i - 1].ts);
+        }
+        // The newest-by-arrival sample is the live one and must survive.
+        expect(out[out.length - 1].ts).toBe(7000);
+    });
+});
+
+describe("sampleReducer — no duplicate x", () => {
+    it("omits the seam sentinel when it would collide with the new sample", () => {
+        // `last.ts + 1 === item.ts`: the sentinel has nowhere to go.
+        const out = append([sample(4999), sample(20000)], sample(5000));
+        expect(out.map((d) => d.ts)).toEqual([4999, 5000]);
+        expect(new Set(out.map((d) => d.ts)).size).toBe(out.length);
+    });
+
+    it("supersedes a buffered sample sharing the new sample's timestamp", () => {
+        const out = append([sample(1000), sample(2000, 11)], sample(2000, 99));
+        expect(out.map((d) => d.ts)).toEqual([1000, 2000]);
+        expect(out[out.length - 1].cpu).toBe(99);
     });
 });

--- a/frontend/app/view/sysinfo/sysinfo-model.ts
+++ b/frontend/app/view/sysinfo/sysinfo-model.ts
@@ -33,8 +33,14 @@ type SampleAction =
     | { type: "APPEND"; item: DataItem; intervalSecs: number; numPoints: number };
 
 /**
- * How far ahead of the newest sample a retained point may sit before it is
- * treated as debris from a BACKWARDS clock step rather than ordinary jitter.
+ * How far ahead of the newest sample a point must sit before the jump counts
+ * as a real BACKWARDS clock step rather than ordinary slew.
+ *
+ * This governs only whether a visible break is drawn. It is NOT a retention
+ * tolerance: which points may remain is decided separately and strictly
+ * (`d.ts <= newest`), because any retained point ahead of the newest sample
+ * leaves the series non-monotonic regardless of how it got there. Sharing one
+ * threshold for both jobs was reagentx's P1 on PR #2832.
  *
  * Sample timestamps are wall-clock (`SystemTime::now()` in
  * `agentmux-srv/src/backend/sysinfo.rs`), so they can jump backwards on an NTP
@@ -50,6 +56,32 @@ function staleAheadCutoff(newestTs: number, intervalSecs: number): number {
     return newestTs + getGapThresholdMs(intervalSecs);
 }
 
+/**
+ * Keep only a strictly increasing run, anchored on the NEWEST sample: walk
+ * backwards from the end and drop any earlier entry that isn't strictly older
+ * than the one after it.
+ *
+ * Needed because persisted history arrives in ring (insertion) order, not
+ * timestamp order — so a clock step leaves earlier slots holding LATER
+ * timestamps. Bracketing such a seam with `prev.ts + 1` / `cur.ts - 1` blanks
+ * cannot repair that (the blanks inherit the same inversion), which was
+ * codex's P2 on PR #2832: history `[10000, 8000]` emitted
+ * `10000, 10001, 7999, 8000`. Dropping the superseded segment is the only
+ * monotonic answer, and anchoring on the newest sample is what makes it the
+ * *right* segment to drop — the post-step samples are the live ones.
+ */
+function keepStrictlyIncreasing(items: DataItem[]): DataItem[] {
+    const kept: DataItem[] = [];
+    let limit = Infinity;
+    for (let i = items.length - 1; i >= 0; i--) {
+        if (items[i].ts < limit) {
+            kept.push(items[i]);
+            limit = items[i].ts;
+        }
+    }
+    return kept.reverse();
+}
+
 export function sampleReducer(state: DataItem[], action: SampleAction): DataItem[] {
     if (action.type === "RESET") {
         const { items, intervalSecs, numPoints } = action;
@@ -61,8 +93,10 @@ export function sampleReducer(state: DataItem[], action: SampleAction): DataItem
         // on it and drop anything stamped implausibly far ahead of it.
         const latestTs = items[items.length - 1].ts;
         const cutoffTs = latestTs - intervalSecs * 1000 * targetLen;
-        const staleAheadTs = staleAheadCutoff(latestTs, intervalSecs);
-        const filtered = items.filter((d) => d.ts >= cutoffTs && d.ts <= staleAheadTs);
+        // Window-trim first, then enforce monotonicity — `keepStrictlyIncreasing`
+        // subsumes "drop anything ahead of the newest sample" (reagentx P1)
+        // and also repairs out-of-order ring content in general (codex P2).
+        const filtered = keepStrictlyIncreasing(items.filter((d) => d.ts >= cutoffTs));
         if (filtered.length === 0) return [];
         const template = filtered[filtered.length - 1];
         const result: DataItem[] = [];
@@ -74,10 +108,10 @@ export function sampleReducer(state: DataItem[], action: SampleAction): DataItem
         for (let i = 1; i < filtered.length; i++) {
             const prev = filtered[i - 1];
             const cur = filtered[i];
-            // `cur.ts < prev.ts` catches a residual backwards seam small
-            // enough to survive the staleAhead filter above — a subtraction
-            // test alone can't, since a negative delta is never `> threshold`.
-            if (cur.ts - prev.ts > gapThreshold || cur.ts < prev.ts) {
+            // A backwards seam can't reach here: `keepStrictlyIncreasing`
+            // above guarantees `cur.ts > prev.ts`, so this only ever sees a
+            // genuine forward gap.
+            if (cur.ts - prev.ts > gapThreshold) {
                 result.push(makeBlankItem(template, prev.ts + 1));
                 result.push(makeBlankItem(template, cur.ts - 1));
             }
@@ -90,15 +124,27 @@ export function sampleReducer(state: DataItem[], action: SampleAction): DataItem
         const { item, intervalSecs, numPoints } = action;
         const intervalMs = intervalSecs * 1000;
 
-        // Drop points stamped implausibly far AHEAD of this sample before the
-        // window trim below. They are debris from a backwards clock step, and
-        // the trim alone can never remove them: their ts is larger than any
-        // cutoff derived from the new (earlier) ts, so `d.ts >= cutoffTs`
-        // stays true forever and they'd pin the series non-monotonic for the
-        // life of the pane. See `staleAheadCutoff`.
-        const staleAheadTs = staleAheadCutoff(item.ts, intervalSecs);
-        const fresh = state.filter((d) => d.ts <= staleAheadTs);
-        const clockStepped = fresh.length !== state.length;
+        // TWO SEPARATE QUESTIONS, deliberately not sharing a threshold
+        // (reagentx P1 on PR #2832 — the first version of this fix used one
+        // for both and reintroduced the very defect it set out to remove):
+        //
+        //   1. WHICH POINTS MAY REMAIN — anything stamped ahead of this sample
+        //      must go, with no tolerance. The window trim below can never
+        //      remove them (their ts exceeds any cutoff derived from the new,
+        //      earlier ts, so `d.ts >= cutoffTs` stays true forever), and
+        //      keeping even one leaves the series non-monotonic. Using the
+        //      step threshold here let a point in `(item.ts, item.ts +
+        //      threshold]` survive and sit AFTER the new sample in x.
+        //      Strict `<`, not `<=`: a buffered point sharing this sample's
+        //      exact ts is superseded by it, and keeping both would put two
+        //      points on the same x.
+        const fresh = state.filter((d) => d.ts < item.ts);
+        //
+        //   2. WAS THIS A STEP, OR JUST SLEW — only a jump past the gap
+        //      threshold is a real discontinuity worth drawing a break for. A
+        //      sub-tick nudge silently drops the one overtaken point (rule 1
+        //      still applies) rather than scarring the chart with a sentinel.
+        const clockStepped = state.some((d) => d.ts > staleAheadCutoff(item.ts, intervalSecs));
 
         const cutoffTs = item.ts - intervalMs * (numPoints + 1);
         const trimmed = fresh.filter((d) => d.ts >= cutoffTs);
@@ -109,7 +155,15 @@ export function sampleReducer(state: DataItem[], action: SampleAction): DataItem
             // the seam. Both gap branches below test `gap > ...`, which a
             // negative gap can never satisfy — that's why this is handled here
             // rather than as another case inside them.
-            return last ? [...trimmed, makeBlankItem(last, last.ts + 1), item] : [item];
+            //
+            // The sentinel is only inserted when it fits strictly between the
+            // two: `last.ts + 1` equals `item.ts` when the surviving point is
+            // adjacent to it, and emitting both would put two samples on the
+            // same x. The seam is invisible at 1ms anyway.
+            if (last && last.ts + 1 < item.ts) {
+                return [...trimmed, makeBlankItem(last, last.ts + 1), item];
+            }
+            return [...trimmed, item];
         }
 
         if (last) {

--- a/frontend/app/view/sysinfo/sysinfo-model.ts
+++ b/frontend/app/view/sysinfo/sysinfo-model.ts
@@ -32,15 +32,37 @@ type SampleAction =
     | { type: "RESET"; items: DataItem[]; intervalSecs: number; numPoints: number }
     | { type: "APPEND"; item: DataItem; intervalSecs: number; numPoints: number };
 
-function sampleReducer(state: DataItem[], action: SampleAction): DataItem[] {
+/**
+ * How far ahead of the newest sample a retained point may sit before it is
+ * treated as debris from a BACKWARDS clock step rather than ordinary jitter.
+ *
+ * Sample timestamps are wall-clock (`SystemTime::now()` in
+ * `agentmux-srv/src/backend/sysinfo.rs`), so they can jump backwards on an NTP
+ * correction, a manual clock set, or a VM resume. Both of this reducer's
+ * original trim/gap rules assumed time only moves forward, which made a
+ * backwards step permanently corrupt the series — see this module's tests and
+ * `frontend/app/statusbar/backend-uptime.ts` for the live 2081 -> 2026 case.
+ *
+ * Reuses the same threshold as a "true break" so slew (a sub-tick nudge) keeps
+ * the history while a real step clears it.
+ */
+function staleAheadCutoff(newestTs: number, intervalSecs: number): number {
+    return newestTs + getGapThresholdMs(intervalSecs);
+}
+
+export function sampleReducer(state: DataItem[], action: SampleAction): DataItem[] {
     if (action.type === "RESET") {
         const { items, intervalSecs, numPoints } = action;
         if (items.length === 0) return [];
         const targetLen = numPoints + 1;
         const gapThreshold = getGapThresholdMs(intervalSecs);
+        // Ring order is insertion order, so the LAST item is the newest by
+        // arrival even when the clock stepped mid-history; anchor both bounds
+        // on it and drop anything stamped implausibly far ahead of it.
         const latestTs = items[items.length - 1].ts;
         const cutoffTs = latestTs - intervalSecs * 1000 * targetLen;
-        const filtered = items.filter((d) => d.ts >= cutoffTs);
+        const staleAheadTs = staleAheadCutoff(latestTs, intervalSecs);
+        const filtered = items.filter((d) => d.ts >= cutoffTs && d.ts <= staleAheadTs);
         if (filtered.length === 0) return [];
         const template = filtered[filtered.length - 1];
         const result: DataItem[] = [];
@@ -52,7 +74,10 @@ function sampleReducer(state: DataItem[], action: SampleAction): DataItem[] {
         for (let i = 1; i < filtered.length; i++) {
             const prev = filtered[i - 1];
             const cur = filtered[i];
-            if (cur.ts - prev.ts > gapThreshold) {
+            // `cur.ts < prev.ts` catches a residual backwards seam small
+            // enough to survive the staleAhead filter above — a subtraction
+            // test alone can't, since a negative delta is never `> threshold`.
+            if (cur.ts - prev.ts > gapThreshold || cur.ts < prev.ts) {
                 result.push(makeBlankItem(template, prev.ts + 1));
                 result.push(makeBlankItem(template, cur.ts - 1));
             }
@@ -64,9 +89,28 @@ function sampleReducer(state: DataItem[], action: SampleAction): DataItem[] {
     if (action.type === "APPEND") {
         const { item, intervalSecs, numPoints } = action;
         const intervalMs = intervalSecs * 1000;
+
+        // Drop points stamped implausibly far AHEAD of this sample before the
+        // window trim below. They are debris from a backwards clock step, and
+        // the trim alone can never remove them: their ts is larger than any
+        // cutoff derived from the new (earlier) ts, so `d.ts >= cutoffTs`
+        // stays true forever and they'd pin the series non-monotonic for the
+        // life of the pane. See `staleAheadCutoff`.
+        const staleAheadTs = staleAheadCutoff(item.ts, intervalSecs);
+        const fresh = state.filter((d) => d.ts <= staleAheadTs);
+        const clockStepped = fresh.length !== state.length;
+
         const cutoffTs = item.ts - intervalMs * (numPoints + 1);
-        const trimmed = state.filter((d) => d.ts >= cutoffTs);
+        const trimmed = fresh.filter((d) => d.ts >= cutoffTs);
         const last = trimmed.length > 0 ? trimmed[trimmed.length - 1] : null;
+
+        if (clockStepped) {
+            // A real discontinuity: mark it so the line doesn't connect across
+            // the seam. Both gap branches below test `gap > ...`, which a
+            // negative gap can never satisfy — that's why this is handled here
+            // rather than as another case inside them.
+            return last ? [...trimmed, makeBlankItem(last, last.ts + 1), item] : [item];
+        }
 
         if (last) {
             const gap = item.ts - last.ts;


### PR DESCRIPTION
Follow-up to #2831 — same root cause (wall-clock timestamps assumed monotonic), different subsystem. Found while tracing that bug: this machine ran under a **2081** clock, then it was corrected back to **2026** with no restart in between.

## The bug

The sysinfo chart is a time series keyed on each sample's wall-clock `ts` (`SystemTime::now()`, `sysinfo.rs`). `sampleReducer` had two forward-only assumptions, and a backwards clock step corrupted the series permanently:

**1. Pre-step points never age out.**

```js
const cutoffTs = item.ts - intervalMs * (numPoints + 1);
const trimmed = state.filter((d) => d.ts >= cutoffTs);
```

The cutoff is derived from the *new*, earlier `ts`. A point stamped before the step carries a timestamp 55 years larger, so it satisfies `>= cutoffTs` and survives every subsequent trim — for the life of the pane.

**2. Gap detection can't see a backwards jump.**

```js
const gap = item.ts - last.ts;                          // negative
if (gap > intervalMs * 1.5 && gap <= intervalMs * 3.5) { ... }
else if (gap > intervalMs * 3.5) { ... }
```

Both guards are `gap >`. A negative gap falls through to a plain append, so no NaN sentinel marks the discontinuity and the line mark connects straight across it.

`RESET` had both holes too, so a history read spanning the step reproduced them.

## The fix

Both paths now drop points stamped implausibly far ahead of the newest sample, and mark the seam so the line doesn't connect across it.

The threshold reuses the existing `getGapThresholdMs` rather than introducing a new constant, which keeps the "don't overreact to jitter" posture the reducer already has: ordinary slew (a sub-tick backwards nudge) keeps the history, while a real step clears it. There's a test for exactly that boundary — a small backwards jitter must not discard the buffer.

## Scope — what was *not* wrong

Worth stating because it's the natural assumption and it's incorrect: **the x-domain was never the problem.** `sysinfo-plot.tsx` anchors it on the newest point with a fixed window width, so the axis stayed a correct ~2-minute window and the stale points were simply off-screen. The chart never "zoomed out to 55 years."

The visible damage was the unmarked seam, plus — for auto-scaled metrics only (memory, network, disk) — `computeAutoMaxY` iterating the whole array and scaling the y-axis to invisible pre-step samples. **CPU was exempt from that second effect** (`maxy: 100`, `autoMaxY` unset).

I did not change `computeAutoMaxY`; it needs no fix once the stale points are gone.

## What I could not verify

I never observed the rendered chart. `UIScreenshot` is scoped to the calling agent's own pane and the Sysinfo widget is a different pane, so the visual symptom is inferred from the code and the confirmed clock step, not seen. The reducer-level defects are directly demonstrated by the tests.

Also worth knowing for anyone reproducing: the sysinfo persist ring holds 1024 events (~17 min at the default 1 Hz), so a pane reopened long enough after a step rebuilds cleanly from history and looks fine — the damage is most visible in a pane that was open *across* the step. That's a property of the ring, not of this fix; the fix makes both paths correct regardless of timing.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 3259 passed, 3 skipped, 0 failed

12 new tests. Four of them cover the *pre-existing* forward-time behaviour (contiguous append, window trim, zero-order hold across 1-3 missed ticks, forward-break sentinel) specifically so this change can't silently alter it — that path had no test coverage at all before.

`sampleReducer` is exported for direct unit coverage, matching the pattern used elsewhere for pure reducer/decision functions.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
