### PR TITLE
feat(agent): know at pane open whether a conversation will resume or start new

### DIFF
--- a/.changesets/1787881995-fix-agent-disclose-a-fresh-start-when-a-pane-spawns-with-no--8wep.md
+++ b/.changesets/1787881995-fix-agent-disclose-a-fresh-start-when-a-pane-spawns-with-no--8wep.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): disclose a fresh start when a pane spawns with no --resume but prior history exists

--- a/.changesets/1787897455-feat-agent-tell-the-pane-at-open-whether-its-conversation-wi-oct6.md
+++ b/.changesets/1787897455-feat-agent-tell-the-pane-at-open-whether-its-conversation-wi-oct6.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(agent): tell the pane at open whether its conversation will resume or start new

--- a/.changesets/1787897455-feat-agent-tell-the-pane-at-open-whether-its-conversation-wi-oct6.md
+++ b/.changesets/1787897455-feat-agent-tell-the-pane-at-open-whether-its-conversation-wi-oct6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): tell the pane at open whether its conversation will resume or start new

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -83,6 +83,77 @@ fn session_outcome_line(
     )
 }
 
+/// Should a spawn that attached NO `--resume` disclose itself as a fresh
+/// start (subject to the caller also confirming prior history actually
+/// exists — see `has_prior_transcript`)?
+///
+/// SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md §2.1 deliberately left
+/// this case unreported, reasoning that a spawn with no session id has
+/// "nothing to lose". That's true for a brand-new agent and false for the
+/// case `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
+/// recorded: a long-lived named agent opened in a fresh channel whose shared
+/// registry pointer is empty gets no `--resume` at all, so the CLI never
+/// errors, `persistent_resume` never tracks anything, and no outcome is ever
+/// emitted — while the pane renders the entire prior conversation through
+/// `blockfile.rs`'s cross-channel read fallback. That is exactly the silent
+/// disagreement between "what the pane shows" and "what the model has" that
+/// `EmitSessionOutcome` exists to prevent.
+///
+/// `generation == 1` restricts this to a controller's FIRST spawn. Later
+/// generations also spawn without `--resume`, but each already has its own
+/// disclosure or deliberately has none: `retry_after_resume_failure`'s
+/// no-recovery-candidate path emits `Fresh` itself, and
+/// `respawn_once_for_leftover_queue` restarts a session whose fresh-vs-resumed
+/// status was decided on an earlier generation. Only a first spawn can be the
+/// "pane just opened onto history this process never had" case.
+///
+/// Kept a pure free function (the FileStore lookup stays at the call site) so
+/// the gate is unit-testable without a controller or a spawned process.
+fn fresh_start_needs_disclosure(attempted_resume_sid: Option<&str>, generation: u64) -> bool {
+    attempted_resume_sid.is_none() && generation == 1
+}
+
+#[cfg(test)]
+mod fresh_start_disclosure_tests {
+    use super::fresh_start_needs_disclosure;
+
+    /// The case STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md
+    /// recorded: a pane's first spawn, no registry pointer to resume, prior
+    /// history on disk. Nothing else in the resume machinery reports this.
+    #[test]
+    fn a_first_spawn_with_no_resume_is_disclosed() {
+        assert!(fresh_start_needs_disclosure(None, 1));
+    }
+
+    /// A resume WAS attempted — `persistent_resume`'s own tracking owns the
+    /// outcome from here (Resumed, or Fresh via the retry/recovery cascade).
+    /// Disclosing here too would double-report and could contradict it.
+    #[test]
+    fn a_spawn_that_attempted_a_resume_is_never_disclosed_here() {
+        assert!(!fresh_start_needs_disclosure(Some("some-sid"), 1));
+        assert!(!fresh_start_needs_disclosure(Some("some-sid"), 4));
+    }
+
+    /// Later generations spawn without `--resume` too, but each already has
+    /// its own disclosure or deliberately has none —
+    /// `retry_after_resume_failure` emits `Fresh` itself when no recovery
+    /// candidate exists, and `respawn_once_for_leftover_queue` restarts a
+    /// session already decided on an earlier generation. Re-disclosing would
+    /// stack a second divider onto an unchanged conversation.
+    #[test]
+    fn a_later_generation_respawn_is_not_re_disclosed() {
+        assert!(!fresh_start_needs_disclosure(None, 2));
+        assert!(!fresh_start_needs_disclosure(None, 17));
+    }
+
+    /// Generation 0 never reaches a spawn (`spawn_process` bumps before use),
+    /// but the gate must not treat the sentinel as a first spawn.
+    #[test]
+    fn generation_zero_is_not_treated_as_a_first_spawn() {
+        assert!(!fresh_start_needs_disclosure(None, 0));
+    }
+}
+
 /// Publish a `wps::EVENT_AGENT_RESUME_RETRY` status ping — a free function
 /// (not a method) for the same reason `session_outcome_line` above is one:
 /// callable from the stdout-reader/process-waiter match arms, which only
@@ -1592,6 +1663,53 @@ impl PersistentSubprocessController {
         );
     }
 
+    /// Does a transcript already exist for this pane — either in this
+    /// channel's own blockfile, or in the agent's GLOBAL transcript zone?
+    ///
+    /// The second half is the one that matters for
+    /// [`fresh_start_needs_disclosure`]: on a cross-channel or cross-version
+    /// open this channel's blockfile is empty, but the pane still renders the
+    /// full prior conversation through `app_api::global_output_source`'s read
+    /// fallback. Mirrors that function's checks (agent-anchored, not archived,
+    /// non-empty `output`) so "the pane will show history" and "we disclose a
+    /// fresh start" can't disagree.
+    ///
+    /// Two `stat` calls at most, on the spawn path only — cheap enough to run
+    /// unconditionally behind the caller's own generation gate.
+    fn has_prior_transcript(&self) -> bool {
+        if let Some(ref fs) = self.filestore {
+            if matches!(fs.stat(&self.block_id, PERSISTENT_OUTPUT_SUBJECT), Ok(Some(ref f)) if f.size > 0)
+            {
+                return true;
+            }
+        }
+        let Some(ref store) = self.wstore else {
+            return false;
+        };
+        let Ok(block) = store.must_get::<crate::backend::obj::Block>(&self.block_id) else {
+            return false;
+        };
+        let archived = block
+            .meta
+            .get(crate::backend::session_archive::META_SESSION_ARCHIVED_AT)
+            .and_then(|v| v.as_i64())
+            .map(|v| v > 0)
+            .unwrap_or(false);
+        if archived {
+            return false;
+        }
+        let Some(zone) = crate::backend::agent_session::agent_zone_for_block_meta(&block.meta) else {
+            return false;
+        };
+        let Some(gfs) = crate::backend::agent_session::global_transcript_store() else {
+            return false;
+        };
+        matches!(
+            gfs.stat(&zone, crate::backend::agent_session::OUTPUT_FILE),
+            Ok(Some(ref f)) if f.size > 0
+        )
+    }
+
     /// After a confirmed-stale `--resume` failure, try to recover a REAL
     /// session instead of giving up and starting blank
     /// (`docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`).
@@ -2343,6 +2461,28 @@ impl PersistentSubprocessController {
             }
         }
 
+        // This process starts with none of the conversation the pane is about
+        // to display — say so, in the transcript, before any of its own output
+        // lands. See `fresh_start_needs_disclosure` for why
+        // `persistent_resume`'s `SpawnedFresh` can't decide this itself.
+        //
+        // `attempted_sid` is empty: there was no id to attempt, which is the
+        // whole point. The frontend renders that as "—" rather than a blank
+        // (`DocumentRow.tsx`'s session-outcome body).
+        if fresh_start_needs_disclosure(attempted_resume_sid.as_deref(), my_generation)
+            && self.has_prior_transcript()
+        {
+            tracing::info!(
+                block_id = %self.block_id,
+                "spawned with no --resume while prior history exists — disclosing a fresh start"
+            );
+            self.emit_session_outcome_now(
+                persistent_resume::SessionOutcome::Fresh,
+                String::new(),
+                None,
+            );
+        }
+
         let pid = child.id().unwrap_or(0);
 
         // Notify the turn-activity tracker that a turn is starting.
@@ -2747,6 +2887,22 @@ impl PersistentSubprocessController {
                                         // publish (still fine) when this outcome came from a
                                         // plain first-time resume that was never retried.
                                         publish_resume_retry_status(&broker_read, &block_id_read, "resolved");
+                                        // A recovery scan can turn an
+                                        // already-disclosed resume failure
+                                        // into a genuine resume — retract the
+                                        // banner so it can't contradict the
+                                        // `resumed` divider appended just
+                                        // below. See
+                                        // `session_recovery::clear_resume_failed`.
+                                        if matches!(outcome, persistent_resume::SessionOutcome::Resumed) {
+                                            if let Some(ref store) = wstore_read {
+                                                super::session_recovery::clear_resume_failed(
+                                                    store,
+                                                    &event_bus_read,
+                                                    &block_id_read,
+                                                );
+                                            }
+                                        }
                                         if let Some(ref broker) = broker_read {
                                             let line = session_outcome_line(outcome, attempted_sid, actual_sid);
                                             super::shell::handle_append_block_file(
@@ -3267,6 +3423,20 @@ impl PersistentSubprocessController {
                                 actual_sid,
                             } => {
                                 publish_resume_retry_status(&broker_wait, &block_id_wait, "resolved");
+                                // Same retraction as the stdout-reader site
+                                // above — this arm reaches `Fresh` today, but
+                                // the clear is keyed on the outcome rather
+                                // than on which arm produced it, so it stays
+                                // correct if that ever changes.
+                                if matches!(outcome, persistent_resume::SessionOutcome::Resumed) {
+                                    if let Some(ref store) = wstore_wait {
+                                        super::session_recovery::clear_resume_failed(
+                                            store,
+                                            &event_bus_wait,
+                                            &block_id_wait,
+                                        );
+                                    }
+                                }
                                 if let Some(ref broker) = broker_wait {
                                     let line = session_outcome_line(outcome, attempted_sid, actual_sid);
                                     super::shell::handle_append_block_file(
@@ -3896,6 +4066,17 @@ mod send_input_tests {
     /// (issue #2365 — retry batches carry identity, not just text).
     fn qentry(seq: u64, json: &str) -> persistent_resume::QueuedRetryEntry {
         persistent_resume::QueuedRetryEntry { seq, json: json.to_string() }
+    }
+
+    /// `has_prior_transcript` gates the fresh-start disclosure, so a false
+    /// positive would stamp "New session started" onto a brand-new agent's
+    /// very first turn — and, worse, clamp its scrollback against a boundary
+    /// that has nothing before it. With no filestore and no store there is
+    /// provably no history, and it must say so rather than defaulting to
+    /// "assume there might be".
+    #[test]
+    fn has_prior_transcript_is_false_without_any_backing_store() {
+        assert!(!controller().has_prior_transcript());
     }
 
     /// codex P1 on PR #2500 (second round): the fresh-start clear must

--- a/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
+++ b/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
@@ -31,6 +31,12 @@
 //! different trigger (a resume rejection mid-session, not a stale PID found
 //! at boot) — kept in this file rather than a new module since it's the
 //! established home for "frontend-only session-state signal flags."
+//!
+//! Unlike `was_interrupted`, `resume_failed` is cleared by the backend as well
+//! as by the user: `clear_resume_failed` retracts it when the recovery scan
+//! that follows a rejection succeeds, so the banner can't claim the
+//! conversation was lost while the transcript's own session-outcome divider
+//! says it was resumed.
 
 use std::sync::Arc;
 
@@ -85,6 +91,75 @@ pub fn mark_resume_failed(wstore: &Arc<Store>, event_bus: &Option<Arc<EventBus>>
     let Some(ref bus) = event_bus else {
         return;
     };
+    if let Ok(updated_block) = wstore.must_get::<Block>(block_id) {
+        let update_data = serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
+            updatetype: "update".into(),
+            otype: "block".into(),
+            oid: block_id.to_string(),
+            obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
+        })
+        .ok();
+        bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+            eventtype: "waveobj:update".to_string(),
+            oref: oref_str,
+            data: update_data,
+        });
+    }
+}
+
+/// Clear `session:resume_failed` — the counterpart to [`mark_resume_failed`],
+/// called when a resume attempt ultimately resolves as `Resumed`.
+///
+/// [`mark_resume_failed`] fires from the stderr reader the instant the CLI
+/// says "No conversation found", which is *before*
+/// `persistent.rs`'s `retry_after_resume_failure` runs its recovery scan. In
+/// the common case that scan finds the real, live on-disk session and resumes
+/// it (live-confirmed in
+/// `docs/status/STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md` §2),
+/// the conversation was NOT lost — but nothing cleared the flag, so the pane
+/// kept showing "Couldn't resume the previous conversation — started a new
+/// one" while the `agentmux_session_outcome` divider in the same transcript
+/// said `resumed`. Two disclosure surfaces contradicting each other is worse
+/// than either alone, so the flag now tracks the *resolved* outcome.
+///
+/// Skips both the write and the broadcast when the flag isn't currently set —
+/// a `Resumed` outcome is the overwhelmingly common case and almost never
+/// follows a failure, so the no-op path must not spam `waveobj:update` on
+/// every ordinary resume.
+pub fn clear_resume_failed(wstore: &Arc<Store>, event_bus: &Option<Arc<EventBus>>, block_id: &str) {
+    match wstore.get::<Block>(block_id) {
+        Ok(Some(block)) => {
+            let set = block
+                .meta
+                .get(META_SESSION_RESUME_FAILED)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !set {
+                return;
+            }
+        }
+        // Block missing or unreadable — nothing to clear, and the write
+        // below would fail anyway.
+        _ => return,
+    }
+
+    let mut meta = MetaMapType::new();
+    meta.insert(META_SESSION_RESUME_FAILED.to_string(), serde_json::Value::Null);
+    let oref_str = format!("block:{}", block_id);
+    if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
+        tracing::warn!(block_id = %block_id, error = %e, "session_recovery: failed to clear resume_failed");
+        return;
+    }
+    tracing::info!(
+        block_id = %block_id,
+        "session_recovery: resume recovered — cleared the resume_failed disclosure"
+    );
+    let Some(ref bus) = event_bus else {
+        return;
+    };
+    // Same live-delivery requirement as `mark_resume_failed`: the user may be
+    // staring at the banner right now, so the clear must reach an already-open
+    // `blockAtom`, not only the pane's next reload.
     if let Ok(updated_block) = wstore.must_get::<Block>(block_id) {
         let update_data = serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
             updatetype: "update".into(),
@@ -400,6 +475,114 @@ mod tests {
                 .and_then(|v| v.as_bool()),
             Some(true),
             "broadcast payload must carry the flag, not just trigger a generic refetch",
+        );
+    }
+
+    fn agent_block(block_id: &str) -> Block {
+        Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m
+            },
+            subblockids: None,
+        }
+    }
+
+    /// The recovery scan that follows a rejected `--resume` usually succeeds
+    /// (live-confirmed in STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23
+    /// §2). When it does, the banner `mark_resume_failed` already raised must
+    /// come back down — otherwise the pane claims the conversation was lost
+    /// while the transcript's own outcome divider says `resumed`.
+    #[test]
+    fn test_clear_resume_failed_retracts_the_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+
+        let block_id = "55555555-5555-5555-5555-555555555555";
+        let mut block = agent_block(block_id);
+        wstore.insert(&mut block).unwrap();
+
+        mark_resume_failed(&wstore, &None, block_id);
+        clear_resume_failed(&wstore, &None, block_id);
+
+        let after: Block = wstore.get(block_id).unwrap().unwrap();
+        assert_eq!(
+            after.meta.get(META_SESSION_RESUME_FAILED).and_then(|v| v.as_bool()),
+            None,
+            "a recovered resume must leave no resume_failed flag behind",
+        );
+    }
+
+    /// A `Resumed` outcome is the overwhelmingly common case and almost never
+    /// follows a failure, so the clear must not broadcast `waveobj:update` on
+    /// every ordinary resume just to write a null over an absent key.
+    #[tokio::test]
+    async fn test_clear_resume_failed_is_silent_when_the_flag_was_never_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+        let event_bus = Arc::new(EventBus::new());
+
+        let block_id = "66666666-6666-6666-6666-666666666666";
+        let mut block = agent_block(block_id);
+        wstore.insert(&mut block).unwrap();
+        let version_before = wstore.get::<Block>(block_id).unwrap().unwrap().version;
+
+        let mut receivers = event_bus.register_ws("test-conn", "test-tab");
+
+        clear_resume_failed(&wstore, &Some(event_bus.clone()), block_id);
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                receivers.priority.recv(),
+            )
+            .await
+            .is_err(),
+            "no broadcast may fire when there was no flag to retract",
+        );
+        assert_eq!(
+            wstore.get::<Block>(block_id).unwrap().unwrap().version,
+            version_before,
+            "the block must not be rewritten when there was nothing to clear",
+        );
+    }
+
+    /// The retraction has the same live-delivery requirement as the flag
+    /// itself: the user may be looking at the banner right now, so an
+    /// already-open `blockAtom` must see it go away without a pane reload.
+    #[tokio::test]
+    async fn test_clear_resume_failed_broadcasts_waveobj_update() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+        let event_bus = Arc::new(EventBus::new());
+
+        let block_id = "88888888-8888-8888-8888-888888888888";
+        let mut block = agent_block(block_id);
+        wstore.insert(&mut block).unwrap();
+        mark_resume_failed(&wstore, &None, block_id);
+
+        let mut receivers = event_bus.register_ws("test-conn", "test-tab");
+
+        clear_resume_failed(&wstore, &Some(event_bus.clone()), block_id);
+
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(2), receivers.priority.recv())
+            .await
+            .expect("timed out waiting for waveobj:update broadcast")
+            .expect("priority channel closed");
+        assert_eq!(msg.get("eventtype").and_then(|v| v.as_str()), Some("waveobj:update"));
+        let obj = msg.get("data").and_then(|d| d.get("obj")).expect("data.obj present");
+        assert_eq!(
+            obj.get("meta")
+                .and_then(|m| m.get(META_SESSION_RESUME_FAILED))
+                .and_then(|v| v.as_bool()),
+            None,
+            "the broadcast payload must show the flag gone, not still set",
         );
     }
 }

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -36,6 +36,7 @@ pub mod messagebus;
 pub mod oref;
 pub mod process_tracker;
 pub mod reactive;
+pub mod resume_preflight;
 pub mod rpc;
 pub mod rpc_types;
 pub mod schema;

--- a/agentmux-srv/src/backend/resume_preflight.rs
+++ b/agentmux-srv/src/backend/resume_preflight.rs
@@ -1,0 +1,360 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Answer "will this pane resume its conversation, or start a new one?" at
+//! **pane-open time**, before anything is spawned.
+//!
+//! ## Why this exists
+//!
+//! The persistent controller spawns lazily, on the first message — so every
+//! signal that reports what actually happened to a resume
+//! (`agentmux_session_outcome`, `session:resume_failed`,
+//! SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md Part A) can only speak
+//! *after* the user has already typed. The lived experience that produces is
+//! the one this module exists to remove: the pane opens showing a long prior
+//! conversation, the user types into it, and only then does the transcript
+//! clear and announce a new session. The information was knowable the whole
+//! time; nothing asked for it.
+//!
+//! ## Why it can be known in advance
+//!
+//! `--resume <sid>` fails for exactly one reason in practice: the session's
+//! `.jsonl` isn't under the `CLAUDE_CONFIG_DIR` the CLI is about to run with.
+//! That is a file-existence question, and
+//! `session_backfill::session_is_reachable` answers it using the same path
+//! scheme and the same home-dir expansion the spawn path itself uses. So the
+//! preflight is not a heuristic or a guess about CLI behaviour — it evaluates
+//! the same condition the CLI will, just earlier.
+//!
+//! ## Faithfulness to the real spawn path
+//!
+//! [`preflight`] deliberately mirrors `persistent.rs`'s decision sequence
+//! rather than modelling an idealized one, so its verdict and the eventual
+//! outcome can't disagree:
+//!
+//! | Pane state | Spawn does | Verdict |
+//! |---|---|---|
+//! | sid held, transcript present | `--resume <sid>` succeeds | [`Verdict::Resume`] |
+//! | sid held, transcript missing, another session on disk | rejected → `retry_after_resume_failure` → `find_recovery_session_id` resumes that one | [`Verdict::Recover`] |
+//! | sid held, transcript missing, nothing else on disk | rejected → retry finds nothing → blank | [`Verdict::Fresh`] |
+//! | no sid at all | spawns with no `--resume`; **no recovery scan runs on this path** | [`Verdict::Fresh`] |
+//! | provider has no resume flag | resume isn't a concept here | [`Verdict::Unknown`] |
+//!
+//! The fourth row is the one worth stating explicitly, because it's the case
+//! `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
+//! recorded and the one this whole module is aimed at: a spawn with no sid
+//! does **not** consult the on-disk transcripts. A session may well be sitting
+//! right there — [`Preflight::recoverable_session_id`] reports it when so —
+//! but nothing in the current spawn path will reach for it, so the honest
+//! verdict is `Fresh`. Reporting `Recover` here would describe a rehydrate
+//! step that doesn't exist yet (that spec's Part B).
+
+use std::time::Instant;
+
+use crate::backend::session_backfill;
+
+/// What will happen to this pane's conversation on its next spawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// The exact session this pane would resume is present and reachable.
+    Resume,
+    /// The held session id is unreachable, but a real session for this working
+    /// dir is on disk and the recovery path will pick it up — continuity
+    /// survives, after a visible "Reconnecting…" pause.
+    Recover,
+    /// The next spawn starts a conversation with none of the prior turns.
+    Fresh,
+    /// Not determinable — the provider has no simple-flag resume, or the pane
+    /// carries no working dir / config dir to check against. Callers should
+    /// stay silent rather than guess.
+    Unknown,
+}
+
+impl Verdict {
+    /// Wire form, matching the TS union in `gotypes.d.ts`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Resume => "resume",
+            Verdict::Recover => "recover",
+            Verdict::Fresh => "fresh",
+            Verdict::Unknown => "unknown",
+        }
+    }
+}
+
+/// One line in the pane's progress list while the preflight runs. Mirrors the
+/// launcher splash's `StageRow` shape (`agentmux-launcher/src/splash.rs`) so
+/// the two read as the same idea in two places.
+#[derive(Debug, Clone)]
+pub struct Step {
+    pub id: &'static str,
+    pub label: String,
+    /// Did this step find what it was looking for? A `false` here is normal
+    /// (it's how the sequence narrows), not an error.
+    pub ok: bool,
+    pub detail: String,
+    pub duration_ms: u64,
+}
+
+/// The full answer, including the trail of how it was reached.
+#[derive(Debug, Clone)]
+pub struct Preflight {
+    pub verdict: Verdict,
+    /// The session that would actually end up loaded — the held id for
+    /// [`Verdict::Resume`], the recovered one for [`Verdict::Recover`], `None`
+    /// otherwise.
+    pub session_id: Option<String>,
+    /// A real session found on disk that the next spawn will NOT reach for.
+    /// Only ever `Some` alongside [`Verdict::Fresh`], where it's the evidence
+    /// that this pane's history is recoverable in principle even though
+    /// nothing will recover it today (see the module doc's fourth row).
+    pub recoverable_session_id: Option<String>,
+    pub steps: Vec<Step>,
+    pub duration_ms: u64,
+}
+
+/// Everything [`preflight`] needs, lifted out of block meta by the caller so
+/// this stays a pure-ish function over plain values (one `is_file` and at most
+/// one `read_dir` of a single directory — no store, no block, no RPC types).
+#[derive(Debug, Clone, Default)]
+pub struct PreflightInput {
+    /// `agent:resume_flag` — empty means this provider has no `--resume`.
+    pub resume_flag: String,
+    /// `agent:sessionid` — the id the next spawn would attempt, if any.
+    pub session_id: String,
+    /// `cmd:cwd` — unexpanded is fine; expansion matches the spawn path.
+    pub working_dir: String,
+    /// `CLAUDE_CONFIG_DIR` out of `cmd:env`.
+    pub config_dir: String,
+}
+
+fn step(id: &'static str, label: &str, ok: bool, detail: impl Into<String>, started: Instant) -> Step {
+    Step {
+        id,
+        label: label.to_string(),
+        ok,
+        detail: detail.into(),
+        duration_ms: started.elapsed().as_millis() as u64,
+    }
+}
+
+/// Decide, without spawning anything, what the next spawn will do to this
+/// pane's conversation. See the module doc for the mapping this mirrors.
+pub fn preflight(input: &PreflightInput) -> Preflight {
+    let overall = Instant::now();
+    let mut steps: Vec<Step> = Vec::new();
+
+    let finish = |verdict: Verdict,
+                  session_id: Option<String>,
+                  recoverable_session_id: Option<String>,
+                  steps: Vec<Step>| Preflight {
+        verdict,
+        session_id,
+        recoverable_session_id,
+        steps,
+        duration_ms: overall.elapsed().as_millis() as u64,
+    };
+
+    // 1. Can this provider resume at all?
+    let t = Instant::now();
+    if input.resume_flag.is_empty() {
+        steps.push(step("provider", "Checking provider", false, "no resume flag", t));
+        return finish(Verdict::Unknown, None, None, steps);
+    }
+    if input.config_dir.is_empty() {
+        // Without a config dir there's nowhere to look; guessing "fresh" here
+        // would warn on panes we know nothing about.
+        steps.push(step("provider", "Checking provider", false, "no config dir", t));
+        return finish(Verdict::Unknown, None, None, steps);
+    }
+    steps.push(step("provider", "Checking provider", true, input.resume_flag.clone(), t));
+
+    // 2. Is there a session id to resume in the first place?
+    let t = Instant::now();
+    if input.session_id.is_empty() {
+        steps.push(step("session-id", "Resolving session id", false, "none recorded", t));
+        // Report what's on disk, but don't let it change the verdict — the
+        // no-sid spawn path never looks (module doc, fourth row).
+        let t = Instant::now();
+        let on_disk = session_backfill::find_largest_session_for_working_dir(
+            &input.config_dir,
+            &input.working_dir,
+        );
+        match &on_disk {
+            Some(sid) => steps.push(step(
+                "scan",
+                "Scanning for recoverable sessions",
+                false,
+                format!("found {sid}, but a no-resume spawn won't load it"),
+                t,
+            )),
+            None => steps.push(step("scan", "Scanning for recoverable sessions", false, "none on disk", t)),
+        }
+        return finish(Verdict::Fresh, None, on_disk, steps);
+    }
+    steps.push(step("session-id", "Resolving session id", true, input.session_id.clone(), t));
+
+    // 3. Would `--resume <sid>` actually find it? Same check the CLI makes.
+    let t = Instant::now();
+    if session_backfill::session_is_reachable(&input.config_dir, &input.working_dir, &input.session_id) {
+        steps.push(step("transcript", "Locating transcript", true, "reachable", t));
+        return finish(Verdict::Resume, Some(input.session_id.clone()), None, steps);
+    }
+    steps.push(step("transcript", "Locating transcript", false, "not under this config dir", t));
+
+    // 4. It's unreachable — the spawn will be rejected and recovery will run.
+    //    Mirror `find_recovery_session_id`, including its refusal to "recover"
+    //    the very id that just failed.
+    let t = Instant::now();
+    let recovered = session_backfill::find_largest_session_for_working_dir(
+        &input.config_dir,
+        &input.working_dir,
+    )
+    .filter(|sid| sid != &input.session_id);
+    match recovered {
+        Some(sid) => {
+            steps.push(step("recovery", "Checking recovery", true, sid.clone(), t));
+            finish(Verdict::Recover, Some(sid), None, steps)
+        }
+        None => {
+            steps.push(step("recovery", "Checking recovery", false, "nothing to recover", t));
+            finish(Verdict::Fresh, None, None, steps)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    /// Build a config dir containing `projects/<slug>/<sid>.jsonl` files of the
+    /// given sizes, mirroring Claude Code's own on-disk layout.
+    fn config_dir_with(working_dir: &str, sessions: &[(&str, usize)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let slug = session_backfill::encode_project_slug(working_dir);
+        let dir = tmp.path().join("projects").join(slug);
+        fs::create_dir_all(&dir).unwrap();
+        for (sid, size) in sessions {
+            fs::write(dir.join(format!("{sid}.jsonl")), "x".repeat(*size)).unwrap();
+        }
+        tmp
+    }
+
+    fn input(config_dir: &Path, working_dir: &str, session_id: &str) -> PreflightInput {
+        PreflightInput {
+            resume_flag: "--resume".to_string(),
+            session_id: session_id.to_string(),
+            working_dir: working_dir.to_string(),
+            config_dir: config_dir.to_string_lossy().to_string(),
+        }
+    }
+
+    const WORK_DIR: &str = "/home/dev/agents/agentx";
+
+    #[test]
+    fn a_reachable_session_resumes() {
+        let cfg = config_dir_with(WORK_DIR, &[("sid-live", 4096)]);
+        let out = preflight(&input(cfg.path(), WORK_DIR, "sid-live"));
+        assert_eq!(out.verdict, Verdict::Resume);
+        assert_eq!(out.session_id.as_deref(), Some("sid-live"));
+        assert_eq!(out.recoverable_session_id, None);
+    }
+
+    /// The STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23 §2 shape: the
+    /// held pointer is a real but superseded session that no longer exists
+    /// here, while the genuinely-live one sits on disk. Continuity survives via
+    /// the recovery path, so the pane must NOT be warned that it's losing the
+    /// conversation.
+    #[test]
+    fn an_unreachable_session_with_another_on_disk_recovers() {
+        let cfg = config_dir_with(WORK_DIR, &[("sid-real", 900_000)]);
+        let out = preflight(&input(cfg.path(), WORK_DIR, "sid-superseded"));
+        assert_eq!(out.verdict, Verdict::Recover);
+        assert_eq!(out.session_id.as_deref(), Some("sid-real"));
+    }
+
+    /// `find_recovery_session_id` refuses to "recover" the id that just failed;
+    /// the preflight must refuse it too, or it would promise a resume that the
+    /// real path is specifically coded to reject.
+    #[test]
+    fn the_failed_id_is_never_offered_back_as_a_recovery() {
+        let cfg = config_dir_with(WORK_DIR, &[]);
+        // The dir exists but holds nothing — the only "candidate" would be the
+        // attempted id itself if the scan somehow returned it.
+        let out = preflight(&input(cfg.path(), WORK_DIR, "sid-gone"));
+        assert_eq!(out.verdict, Verdict::Fresh);
+        assert_eq!(out.session_id, None);
+    }
+
+    #[test]
+    fn an_unreachable_session_with_nothing_on_disk_is_fresh() {
+        let cfg = tempfile::tempdir().unwrap();
+        let out = preflight(&input(cfg.path(), WORK_DIR, "sid-gone"));
+        assert_eq!(out.verdict, Verdict::Fresh);
+        assert_eq!(out.session_id, None);
+        assert_eq!(out.recoverable_session_id, None);
+    }
+
+    /// The cross-channel open this module exists for: no pointer at all, but
+    /// the real conversation is right there on disk. The verdict is still
+    /// `Fresh` — the no-resume spawn path never scans — and the reachable
+    /// session is reported separately as evidence, not as a promise.
+    #[test]
+    fn no_session_id_is_fresh_even_when_a_session_exists_on_disk() {
+        let cfg = config_dir_with(WORK_DIR, &[("sid-orphaned", 2_000_000)]);
+        let out = preflight(&input(cfg.path(), WORK_DIR, ""));
+        assert_eq!(out.verdict, Verdict::Fresh);
+        assert_eq!(out.session_id, None);
+        assert_eq!(
+            out.recoverable_session_id.as_deref(),
+            Some("sid-orphaned"),
+            "the orphaned session must be reported so the UI can say history exists",
+        );
+    }
+
+    #[test]
+    fn no_session_id_and_no_transcripts_is_plainly_fresh() {
+        let cfg = tempfile::tempdir().unwrap();
+        let out = preflight(&input(cfg.path(), WORK_DIR, ""));
+        assert_eq!(out.verdict, Verdict::Fresh);
+        assert_eq!(out.recoverable_session_id, None);
+    }
+
+    /// Staying silent matters as much as warning: a provider with no resume
+    /// flag, or a pane with no config dir, must not be told it's about to lose
+    /// a conversation we never had any way to check.
+    #[test]
+    fn an_unknowable_pane_reports_unknown_rather_than_guessing() {
+        let cfg = tempfile::tempdir().unwrap();
+
+        let mut no_flag = input(cfg.path(), WORK_DIR, "sid");
+        no_flag.resume_flag = String::new();
+        assert_eq!(preflight(&no_flag).verdict, Verdict::Unknown);
+
+        let mut no_config = input(cfg.path(), WORK_DIR, "sid");
+        no_config.config_dir = String::new();
+        assert_eq!(preflight(&no_config).verdict, Verdict::Unknown);
+    }
+
+    /// The steps are the pane's progress list, so every path must produce a
+    /// non-empty, labelled trail — including the early returns.
+    #[test]
+    fn every_path_reports_labelled_steps() {
+        let cfg = config_dir_with(WORK_DIR, &[("sid-live", 10)]);
+        for inp in [
+            input(cfg.path(), WORK_DIR, "sid-live"),
+            input(cfg.path(), WORK_DIR, "sid-missing"),
+            input(cfg.path(), WORK_DIR, ""),
+            PreflightInput::default(),
+        ] {
+            let out = preflight(&inp);
+            assert!(!out.steps.is_empty(), "every verdict must show its work");
+            assert!(
+                out.steps.iter().all(|s| !s.label.is_empty() && !s.id.is_empty()),
+                "every step needs an id and a human label",
+            );
+        }
+    }
+}

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -537,6 +537,10 @@ pub const COMMAND_MCP_CATALOG_LIST_FOR_BUNDLE: &str = "mcp.catalog.list_for_bund
 // See the identical comment on COMMAND_SKILL_CATALOG_UPSERT_FOR_BUNDLE above.
 pub const COMMAND_MCP_CATALOG_UPSERT_FOR_BUNDLE: &str = "mcp.catalog.upsert_for_bundle";
 
+// Pane-open resume preflight — "will this conversation resume, or start new?"
+// answered before anything is spawned. See crate::backend::resume_preflight.
+pub const COMMAND_SESSION_RESUME_PREFLIGHT: &str = "session:resume_preflight";
+
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";
 pub const COMMAND_SESSION_RESTORE: &str = "session:restore";

--- a/agentmux-srv/src/backend/rpc_types/session.rs
+++ b/agentmux-srv/src/backend/rpc_types/session.rs
@@ -76,6 +76,48 @@ pub struct NextPromptSuggestionResult {
     pub tokens: Option<TokenCounts>,
 }
 
+// ---- Resume preflight types ----
+
+/// Request for session:resume_preflight — asks, before any spawn, whether this
+/// pane's next turn will continue its conversation or start a new one.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandSessionResumePreflightData {
+    pub block_id: String,
+}
+
+/// One row of the pane's progress list while the preflight runs — same shape as
+/// the launcher splash's stage rows.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ResumePreflightStep {
+    pub id: String,
+    pub label: String,
+    /// `false` is normal — it's how the sequence narrows, not an error.
+    pub ok: bool,
+    pub detail: String,
+    pub duration_ms: u64,
+}
+
+/// Response from session:resume_preflight.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionResumePreflightResult {
+    pub block_id: String,
+    /// `"resume" | "recover" | "fresh" | "unknown"`.
+    pub verdict: String,
+    /// The session that would actually load, when one would.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// A real session on disk that the next spawn will NOT reach for — set
+    /// only alongside `"fresh"`, as evidence that history exists even though
+    /// nothing will load it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recoverable_session_id: Option<String>,
+    pub steps: Vec<ResumePreflightStep>,
+    pub duration_ms: u64,
+}
+
 // ---- Session archival types ----
 
 /// Request for session:archive — compress and archive a session's FileStore output.

--- a/agentmux-srv/src/backend/session_backfill.rs
+++ b/agentmux-srv/src/backend/session_backfill.rs
@@ -106,6 +106,40 @@ pub fn find_largest_session_for_working_dir(config_dir: &str, working_dir: &str)
     largest_session_id(&[projects_dir], &slug)
 }
 
+/// Absolute path of the transcript file `--resume <sid>` would need to find:
+/// `<config_dir>/projects/<slug(working_dir)>/<sid>.jsonl`.
+///
+/// Shares [`find_largest_session_for_working_dir`]'s expansion rules exactly —
+/// `expand_home_dir_safe` for the config dir, `core::expand_home_dir` for the
+/// working dir — because the two answer the same question from opposite ends
+/// ("which session is there?" vs "is THIS session there?"), and a preflight
+/// that expanded paths differently from the recovery scan would contradict it.
+/// `None` when `config_dir` or `sid` is empty (nothing to look for).
+pub fn session_file_path(config_dir: &str, working_dir: &str, sid: &str) -> Option<PathBuf> {
+    if config_dir.is_empty() || sid.is_empty() {
+        return None;
+    }
+    let expanded = crate::backend::base::expand_home_dir_safe(config_dir);
+    let expanded_working_dir = crate::backend::blockcontroller::core::expand_home_dir(working_dir);
+    let slug = encode_project_slug(&expanded_working_dir);
+    Some(
+        expanded
+            .join("projects")
+            .join(slug)
+            .join(format!("{sid}.jsonl")),
+    )
+}
+
+/// Would `--resume <sid>` find its conversation under this exact
+/// `CLAUDE_CONFIG_DIR`? This is the whole of what the CLI checks before
+/// answering "No conversation found with session ID" — so asking it up front
+/// predicts a resume's success without spawning anything.
+pub fn session_is_reachable(config_dir: &str, working_dir: &str, sid: &str) -> bool {
+    session_file_path(config_dir, working_dir, sid)
+        .map(|p| p.is_file())
+        .unwrap_or(false)
+}
+
 /// Populate `session_id` for registry records that lack one, from the agent's
 /// largest provider session. Idempotent (skips records that already carry a
 /// non-empty id). Returns the number populated. Best-effort per record — a

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -3,9 +3,91 @@ use super::*;
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_session_activity_summary(engine, state);
     register_session_next_prompt_suggestion(engine, state);
+    register_session_resume_preflight_handler(engine, state);
     register_session_archive_handler(engine, state);
     register_session_restore_handler(engine, state);
     register_session_export_handler(engine, state);
+}
+
+/// `session:resume_preflight` — read-only, mutates nothing, spawns nothing.
+///
+/// The pane calls this on mount so it can say whether the conversation it's
+/// displaying will actually be continued, instead of the user finding out by
+/// typing and watching the transcript clear
+/// (`crate::backend::resume_preflight`'s module doc).
+fn register_session_resume_preflight_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_SESSION_RESUME_PREFLIGHT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandSessionResumePreflightData = serde_json::from_value(data)
+                    .map_err(|e| format!("session:resume_preflight: {e}"))?;
+
+                let block = wstore
+                    .must_get::<Block>(&cmd.block_id)
+                    .map_err(|e| format!("session:resume_preflight: {e}"))?;
+
+                // `CLAUDE_CONFIG_DIR` lives inside the block's own `cmd:env`
+                // map — the same map `apply_working_dir` hands to the child, so
+                // the preflight checks the exact config dir the CLI will use.
+                let config_dir = block
+                    .meta
+                    .get(crate::backend::blockcontroller::META_KEY_CMD_ENV)
+                    .and_then(|v| v.as_object())
+                    .and_then(|env| env.get("CLAUDE_CONFIG_DIR"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let input = crate::backend::resume_preflight::PreflightInput {
+                    resume_flag: obj::meta_get_string(&block.meta, "agent:resume_flag", ""),
+                    session_id: obj::meta_get_string(&block.meta, "agent:sessionid", ""),
+                    working_dir: obj::meta_get_string(&block.meta, "cmd:cwd", ""),
+                    config_dir,
+                };
+
+                // Blocking file I/O (one `is_file`, at most one `read_dir` of a
+                // single directory) off the async runtime's worker threads —
+                // small, but a pane open shouldn't be able to stall the
+                // reactor on a cold or network-backed home directory.
+                let result = tokio::task::spawn_blocking(move || crate::backend::resume_preflight::preflight(&input))
+                    .await
+                    .map_err(|e| format!("session:resume_preflight: {e}"))?;
+
+                tracing::info!(
+                    block_id = %cmd.block_id,
+                    verdict = %result.verdict.as_str(),
+                    duration_ms = result.duration_ms,
+                    "session:resume_preflight"
+                );
+
+                Ok(Some(
+                    serde_json::to_value(&SessionResumePreflightResult {
+                        block_id: cmd.block_id,
+                        verdict: result.verdict.as_str().to_string(),
+                        session_id: result.session_id,
+                        recoverable_session_id: result.recoverable_session_id,
+                        steps: result
+                            .steps
+                            .into_iter()
+                            .map(|s| ResumePreflightStep {
+                                id: s.id.to_string(),
+                                label: s.label,
+                                ok: s.ok,
+                                detail: s.detail,
+                                duration_ms: s.duration_ms,
+                            })
+                            .collect(),
+                        duration_ms: result.duration_ms,
+                    })
+                    .unwrap(),
+                ))
+            })
+        }),
+    );
 }
 
 fn register_session_archive_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -17,11 +17,17 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// (`crate::backend::resume_preflight`'s module doc).
 fn register_session_resume_preflight_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    // Needed to resolve an identity-bound pane's REAL config dir — see
+    // `preflight_input_from_meta`.
+    let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
 
     engine.register_handler(
         COMMAND_SESSION_RESUME_PREFLIGHT,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 let cmd: CommandSessionResumePreflightData = serde_json::from_value(data)
                     .map_err(|e| format!("session:resume_preflight: {e}"))?;
@@ -30,7 +36,13 @@ fn register_session_resume_preflight_handler(engine: &Arc<WshRpcEngine>, state: 
                     .must_get::<Block>(&cmd.block_id)
                     .map_err(|e| format!("session:resume_preflight: {e}"))?;
 
-                let input = preflight_input_from_meta(&block.meta);
+                let bound_config_dir = crate::identity::resolver::resolve_bound_oauth_config_dir(
+                    &wstore,
+                    &id_store,
+                    &identity_store,
+                    &cmd.block_id,
+                );
+                let input = preflight_input_from_meta(&block.meta, bound_config_dir);
 
                 // Blocking file I/O (one `is_file`, at most one `read_dir` of a
                 // single directory) off the async runtime's worker threads —
@@ -90,19 +102,41 @@ fn register_session_resume_preflight_handler(engine: &Arc<WshRpcEngine>, state: 
 /// at all: the spawn still attaches `--resume`, but the preflight was
 /// reporting `Unknown` and silently suppressing the notice for exactly the
 /// long-lived panes this feature exists for.
+/// `bound_config_dir` is `identity::resolver::resolve_bound_oauth_config_dir`'s
+/// answer for this block, and **takes precedence over `cmd:env`** whenever
+/// it's `Some` (reagent P1, second pass on PR #2833).
+///
+/// For an agent bound to an Armory OAuth identity, the `cmd:env` snapshot is
+/// simply not where the CLI will look: the real spawn resolves the isolated
+/// dir dynamically through `inject_identity_env_async`
+/// (`agent_handlers/input.rs:224`, `app_api/agent_io.rs:184`), and
+/// `reactive.rs` already documents that "identity-bound agents' real
+/// `CLAUDE_CONFIG_DIR` is never the stale `cmd:env` snapshot"
+/// (`SPEC_SUBAGENT_WATCHER_IDENTITY_BOUND_CONFIG_DIR_2026_08_22.md`).
+/// Checking reachability against the wrong directory is worse than not
+/// checking: it can warn "fresh" at a pane that will resume perfectly well,
+/// or stay quiet at one that's about to lose its conversation.
+///
+/// `None` — not identity-bound, or a non-OAuth provider — keeps the
+/// `cmd:env` read, which is correct for those. Same helper and same
+/// precedence order `subagent_watcher` already uses for this exact
+/// pre-spawn question.
 fn preflight_input_from_meta(
     meta: &crate::backend::obj::MetaMapType,
+    bound_config_dir: Option<std::path::PathBuf>,
 ) -> crate::backend::resume_preflight::PreflightInput {
-    // `CLAUDE_CONFIG_DIR` lives inside the block's own `cmd:env` map — the
-    // same map `apply_working_dir` hands to the child, so the preflight
-    // checks the exact config dir the CLI will use.
-    let config_dir = meta
-        .get(crate::backend::blockcontroller::META_KEY_CMD_ENV)
-        .and_then(|v| v.as_object())
-        .and_then(|env| env.get("CLAUDE_CONFIG_DIR"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
+    // `CLAUDE_CONFIG_DIR` from the block's own `cmd:env` map — the fallback
+    // when this pane isn't identity-bound.
+    let config_dir = match bound_config_dir {
+        Some(dir) => dir.to_string_lossy().to_string(),
+        None => meta
+            .get(crate::backend::blockcontroller::META_KEY_CMD_ENV)
+            .and_then(|v| v.as_object())
+            .and_then(|env| env.get("CLAUDE_CONFIG_DIR"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+    };
 
     crate::backend::resume_preflight::PreflightInput {
         resume_flag: obj::meta_get_string(meta, "agent:resume_flag", "--resume"),
@@ -1519,7 +1553,7 @@ mod preflight_input_tests {
     /// silent.
     #[test]
     fn absent_resume_flag_defaults_to_the_same_value_the_spawn_path_uses() {
-        let input = preflight_input_from_meta(&meta_of(&[]));
+        let input = preflight_input_from_meta(&meta_of(&[]), None);
         assert_eq!(
             input.resume_flag, "--resume",
             "must match agent_handlers/input.rs:400's default, or the preflight              reports Unknown for panes whose spawn really will --resume",
@@ -1531,13 +1565,13 @@ mod preflight_input_tests {
     /// the default, or the preflight would claim resume support that isn't there.
     #[test]
     fn an_explicitly_empty_resume_flag_is_preserved_not_defaulted() {
-        let input = preflight_input_from_meta(&meta_of(&[("agent:resume_flag", serde_json::json!(""))]));
+        let input = preflight_input_from_meta(&meta_of(&[("agent:resume_flag", serde_json::json!(""))]), None);
         assert_eq!(input.resume_flag, "");
     }
 
     #[test]
     fn an_explicit_resume_flag_is_read_verbatim() {
-        let input = preflight_input_from_meta(&meta_of(&[("agent:resume_flag", serde_json::json!("-r"))]));
+        let input = preflight_input_from_meta(&meta_of(&[("agent:resume_flag", serde_json::json!("-r"))]), None);
         assert_eq!(input.resume_flag, "-r");
     }
 
@@ -1546,7 +1580,7 @@ mod preflight_input_tests {
         let input = preflight_input_from_meta(&meta_of(&[(
             "cmd:env",
             serde_json::json!({ "CLAUDE_CONFIG_DIR": "/home/dev/.claude", "OTHER": "x" }),
-        )]));
+        )]), None);
         assert_eq!(input.config_dir, "/home/dev/.claude");
     }
 
@@ -1555,29 +1589,67 @@ mod preflight_input_tests {
     /// silent, which is the correct posture when there's nowhere to look.
     #[test]
     fn a_missing_config_dir_is_empty_rather_than_a_guess() {
-        assert_eq!(preflight_input_from_meta(&meta_of(&[])).config_dir, "");
+        assert_eq!(preflight_input_from_meta(&meta_of(&[]), None).config_dir, "");
         assert_eq!(
-            preflight_input_from_meta(&meta_of(&[("cmd:env", serde_json::json!({ "PATH": "/usr/bin" }))]))
+            preflight_input_from_meta(&meta_of(&[("cmd:env", serde_json::json!({ "PATH": "/usr/bin" }))]), None)
                 .config_dir,
             ""
         );
         assert_eq!(
-            preflight_input_from_meta(&meta_of(&[("cmd:env", serde_json::json!("not-an-object"))])).config_dir,
+            preflight_input_from_meta(&meta_of(&[("cmd:env", serde_json::json!("not-an-object"))]), None).config_dir,
             ""
         );
     }
 
     #[test]
     fn session_id_and_working_dir_default_to_empty() {
-        let input = preflight_input_from_meta(&meta_of(&[]));
+        let input = preflight_input_from_meta(&meta_of(&[]), None);
         assert_eq!(input.session_id, "");
         assert_eq!(input.working_dir, "");
 
         let input = preflight_input_from_meta(&meta_of(&[
             ("agent:sessionid", serde_json::json!("sid-1")),
             ("cmd:cwd", serde_json::json!("/work/dir")),
-        ]));
+        ]), None);
         assert_eq!(input.session_id, "sid-1");
         assert_eq!(input.working_dir, "/work/dir");
+    }
+
+    /// reagent P1 (second pass): an identity-bound pane's real config dir
+    /// comes from the identity resolver, never the `cmd:env` snapshot, so a
+    /// resolved dir must win outright — including when `cmd:env` disagrees.
+    #[test]
+    fn a_bound_identity_config_dir_overrides_the_cmd_env_snapshot() {
+        let meta = meta_of(&[(
+            "cmd:env",
+            serde_json::json!({ "CLAUDE_CONFIG_DIR": "/stale/from/spawn/snapshot" }),
+        )]);
+        let input = preflight_input_from_meta(
+            &meta,
+            Some(std::path::PathBuf::from("/identities/acct-7/claude")),
+        );
+        assert_eq!(
+            input.config_dir, "/identities/acct-7/claude",
+            "the identity-resolved dir is where the CLI will actually look",
+        );
+    }
+
+    /// …and a resolved dir must still win when there's no `cmd:env` at all.
+    #[test]
+    fn a_bound_identity_config_dir_is_used_with_no_cmd_env_present() {
+        let input = preflight_input_from_meta(
+            &meta_of(&[]),
+            Some(std::path::PathBuf::from("/identities/acct-9/claude")),
+        );
+        assert_eq!(input.config_dir, "/identities/acct-9/claude");
+    }
+
+    /// `None` means "not identity-bound, or not an OAuth provider" — for
+    /// those the `cmd:env` snapshot IS what the spawn uses, so it must still
+    /// be read rather than dropped.
+    #[test]
+    fn an_unbound_pane_still_falls_back_to_cmd_env() {
+        let meta = meta_of(&[("cmd:env", serde_json::json!({ "CLAUDE_CONFIG_DIR": "/home/dev/.claude" }))]);
+        assert_eq!(preflight_input_from_meta(&meta, None).config_dir, "/home/dev/.claude");
     }
 }

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -30,24 +30,7 @@ fn register_session_resume_preflight_handler(engine: &Arc<WshRpcEngine>, state: 
                     .must_get::<Block>(&cmd.block_id)
                     .map_err(|e| format!("session:resume_preflight: {e}"))?;
 
-                // `CLAUDE_CONFIG_DIR` lives inside the block's own `cmd:env`
-                // map — the same map `apply_working_dir` hands to the child, so
-                // the preflight checks the exact config dir the CLI will use.
-                let config_dir = block
-                    .meta
-                    .get(crate::backend::blockcontroller::META_KEY_CMD_ENV)
-                    .and_then(|v| v.as_object())
-                    .and_then(|env| env.get("CLAUDE_CONFIG_DIR"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                let input = crate::backend::resume_preflight::PreflightInput {
-                    resume_flag: obj::meta_get_string(&block.meta, "agent:resume_flag", ""),
-                    session_id: obj::meta_get_string(&block.meta, "agent:sessionid", ""),
-                    working_dir: obj::meta_get_string(&block.meta, "cmd:cwd", ""),
-                    config_dir,
-                };
+                let input = preflight_input_from_meta(&block.meta);
 
                 // Blocking file I/O (one `is_file`, at most one `read_dir` of a
                 // single directory) off the async runtime's worker threads —
@@ -88,6 +71,45 @@ fn register_session_resume_preflight_handler(engine: &Arc<WshRpcEngine>, state: 
             })
         }),
     );
+}
+
+/// Lift a block's meta into a [`resume_preflight::PreflightInput`].
+///
+/// **Every default here must match what the real spawn path uses for the
+/// same key**, or the preflight predicts something the spawn won't do —
+/// which is worse than not predicting at all, since the pane then states a
+/// falsehood confidently.
+///
+/// `agent:resume_flag` defaulting to `"--resume"` is that rule doing real
+/// work (reagent P1 on PR #2833): it was `""` here while all four real
+/// spawn-path readers default to `"--resume"`
+/// (`agent_handlers/input.rs:400,422`, `app_api/agent_io.rs:265,287` — the
+/// first of those is the exact line that builds `PersistentSpawnConfig`).
+/// `agent_open.rs` only started writing the key recently, so any Claude pane
+/// created before that and not respawned since has no `agent:resume_flag`
+/// at all: the spawn still attaches `--resume`, but the preflight was
+/// reporting `Unknown` and silently suppressing the notice for exactly the
+/// long-lived panes this feature exists for.
+fn preflight_input_from_meta(
+    meta: &crate::backend::obj::MetaMapType,
+) -> crate::backend::resume_preflight::PreflightInput {
+    // `CLAUDE_CONFIG_DIR` lives inside the block's own `cmd:env` map — the
+    // same map `apply_working_dir` hands to the child, so the preflight
+    // checks the exact config dir the CLI will use.
+    let config_dir = meta
+        .get(crate::backend::blockcontroller::META_KEY_CMD_ENV)
+        .and_then(|v| v.as_object())
+        .and_then(|env| env.get("CLAUDE_CONFIG_DIR"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    crate::backend::resume_preflight::PreflightInput {
+        resume_flag: obj::meta_get_string(meta, "agent:resume_flag", "--resume"),
+        session_id: obj::meta_get_string(meta, "agent:sessionid", ""),
+        working_dir: obj::meta_get_string(meta, "cmd:cwd", ""),
+        config_dir,
+    }
 }
 
 fn register_session_archive_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -1468,5 +1490,94 @@ mod sanitize_ambient_text_tests {
         // string while failing to match.
         let s = "\u{0130} think we should refactor this";
         assert_eq!(sanitize_ambient_text(s), s);
+    }
+}
+
+#[cfg(test)]
+mod preflight_input_tests {
+    use super::preflight_input_from_meta;
+
+    // ── resume-preflight meta extraction (reagent P1 on PR #2833) ────────
+    //
+    // The divergence these guard: the preflight must read every meta key with
+    // the SAME default the real spawn path uses, or it predicts a spawn that
+    // won't happen. Unit-testing `preflight` itself (as the rest of the suite
+    // does) can't catch that — it takes an explicit `PreflightInput`, so the
+    // extraction defaults are exactly the part those tests skip.
+
+    fn meta_of(pairs: &[(&str, serde_json::Value)]) -> crate::backend::obj::MetaMapType {
+        let mut m = crate::backend::obj::MetaMapType::new();
+        for (k, v) in pairs {
+            m.insert(k.to_string(), v.clone());
+        }
+        m
+    }
+
+    /// The regression itself: a Claude pane predating `agent_open.rs` writing
+    /// `agent:resume_flag`. The spawn attaches `--resume` via its own default,
+    /// so the preflight must not read this as "provider can't resume" and go
+    /// silent.
+    #[test]
+    fn absent_resume_flag_defaults_to_the_same_value_the_spawn_path_uses() {
+        let input = preflight_input_from_meta(&meta_of(&[]));
+        assert_eq!(
+            input.resume_flag, "--resume",
+            "must match agent_handlers/input.rs:400's default, or the preflight              reports Unknown for panes whose spawn really will --resume",
+        );
+    }
+
+    /// A provider that genuinely has no resume flag writes an explicit empty
+    /// string; that must survive as empty rather than being back-filled with
+    /// the default, or the preflight would claim resume support that isn't there.
+    #[test]
+    fn an_explicitly_empty_resume_flag_is_preserved_not_defaulted() {
+        let input = preflight_input_from_meta(&meta_of(&[("agent:resume_flag", serde_json::json!(""))]));
+        assert_eq!(input.resume_flag, "");
+    }
+
+    #[test]
+    fn an_explicit_resume_flag_is_read_verbatim() {
+        let input = preflight_input_from_meta(&meta_of(&[("agent:resume_flag", serde_json::json!("-r"))]));
+        assert_eq!(input.resume_flag, "-r");
+    }
+
+    #[test]
+    fn config_dir_is_read_out_of_the_cmd_env_map() {
+        let input = preflight_input_from_meta(&meta_of(&[(
+            "cmd:env",
+            serde_json::json!({ "CLAUDE_CONFIG_DIR": "/home/dev/.claude", "OTHER": "x" }),
+        )]));
+        assert_eq!(input.config_dir, "/home/dev/.claude");
+    }
+
+    /// No `cmd:env` at all, or no `CLAUDE_CONFIG_DIR` within it, must yield an
+    /// empty config dir — `preflight` turns that into `Unknown` and stays
+    /// silent, which is the correct posture when there's nowhere to look.
+    #[test]
+    fn a_missing_config_dir_is_empty_rather_than_a_guess() {
+        assert_eq!(preflight_input_from_meta(&meta_of(&[])).config_dir, "");
+        assert_eq!(
+            preflight_input_from_meta(&meta_of(&[("cmd:env", serde_json::json!({ "PATH": "/usr/bin" }))]))
+                .config_dir,
+            ""
+        );
+        assert_eq!(
+            preflight_input_from_meta(&meta_of(&[("cmd:env", serde_json::json!("not-an-object"))])).config_dir,
+            ""
+        );
+    }
+
+    #[test]
+    fn session_id_and_working_dir_default_to_empty() {
+        let input = preflight_input_from_meta(&meta_of(&[]));
+        assert_eq!(input.session_id, "");
+        assert_eq!(input.working_dir, "");
+
+        let input = preflight_input_from_meta(&meta_of(&[
+            ("agent:sessionid", serde_json::json!("sid-1")),
+            ("cmd:cwd", serde_json::json!("/work/dir")),
+        ]));
+        assert_eq!(input.session_id, "sid-1");
+        assert_eq!(input.working_dir, "/work/dir");
     }
 }

--- a/docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
+++ b/docs/specs/SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md
@@ -1,7 +1,7 @@
 # SPEC: Align pane scrollback with actual model context, and make cross-instance opens honest
 
 **Date:** 2026-08-05
-**Status:** active — Part A (session-outcome transcript event) shipped in PR #2426; Parts B (rehydrate-before-resume) and C (session_id backfill) not started. Verified 2026-08-10. See also SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md, which builds on Part A.
+**Status:** active — Part A (session-outcome transcript event) shipped in PR #2426, and extended 2026-08-27 to cover the no-`--resume`-attempted case (§2.1's superseded callout). Parts B (rehydrate-before-resume) and C (session_id backfill) still not started — `rehydrate_claude_session` exists only in `scripts/import-agents.sh`, not in `agentmux-srv`. Verified against `main` 2026-08-27. See also SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md, which builds on Part A.
 **Severity:** Medium — no data loss, but a real correctness gap: the pane can
 imply the agent remembers a conversation it does not, with no visible signal
 that anything went wrong.
@@ -158,8 +158,9 @@ fn emit_session_outcome_line(&self, outcome: SessionOutcome, attempted_sid: Stri
 exactly — a frame shape the provider CLI itself would never emit (no collision
 risk) that both consumers already know how to special-case.
 
-**Deliberately not touched:** the `SpawnedFresh` transition (spawn-time
-classification of "no resume attempted this generation"). As documented in
+**Deliberately not touched (in the original PR — superseded 2026-08-27, see
+below):** the `SpawnedFresh` transition (spawn-time classification of "no
+resume attempted this generation"). As documented in
 `persistent.rs:1918-1932`, that classification also fires for a truly-first-ever
 turn (no session existed to lose) and for internal respawns with no immediate
 message — neither is a "the model lost its memory" event, and disambiguating
@@ -167,6 +168,28 @@ them correctly from inside `spawn_process` would touch code with a long history
 of subtle races (issue #2368, PR #2373 rounds 4/5/7/9). Out of scope for this
 PR; not needed for the two outcome points above, which already cover every case
 where AgentMux *positively knows* what happened to a resume attempt.
+
+> **Superseded (2026-08-27).** The "no session existed to lose" reasoning has
+> one real exception, which
+> `docs/status/STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md`
+> then observed live: a long-lived named agent opened in a **fresh channel**
+> whose shared-registry pointer is empty gets no `--resume` at all, so the CLI
+> never errors and no outcome is ever emitted — while the pane renders the
+> entire prior conversation through `blockfile.rs`'s cross-channel read
+> fallback from the global transcript zone. There *is* something to lose in
+> that case, and it was the one case with no signal of any kind.
+>
+> `spawn_process` now emits `Fresh` (with an empty `attempted_sid` — there was
+> no id to attempt) when all three hold: no `--resume` was attached, this is
+> the controller's **first** generation, and a transcript already exists
+> locally or in the agent's global zone. The generation gate is what keeps the
+> races above out of scope — later generations that spawn without `--resume`
+> either emit their own outcome (`retry_after_resume_failure`) or are
+> respawns of an already-classified session. `persistent_resume::update`'s
+> `SpawnedFresh` arm is still effect-free and its regression guards (§8) still
+> hold; the decision lives in `persistent.rs`'s `fresh_start_needs_disclosure`
+> because "does prior history exist" is a FileStore question the pure state
+> machine can't answer.
 
 ### 2.2 Frontend: render it as a distinct divider, not silently
 
@@ -333,9 +356,17 @@ doc §6) and copy it into the isolated home before spawning — reusing the
 `rehydrate_claude_session` shape already prototyped for the import path
 (`import-agents.sh:107-120`, cited in the analysis doc). If no transcript can
 be found anywhere (genuinely nothing to rehydrate), spawn without `--resume` —
-this is the "load empty if the memory is empty" half of the ask, and with Part
-A already landed, that fresh-start is now an honest, visibly-labeled event
-instead of an unexplained blank pane.
+this is the "load empty if the memory is empty" half of the ask.
+
+**Correction (2026-08-27):** this paragraph originally continued "...and with
+Part A already landed, that fresh-start is now an honest, visibly-labeled event
+instead of an unexplained blank pane." That was **not** true of Part A as
+shipped — §2.1 explicitly exempted the no-`--resume`-attempted spawn, and
+`persistent_resume.rs`'s own regression guard
+(`spawned_fresh_and_never_confirmed_paths_never_emit_a_session_outcome`) pinned
+the opposite. It became true on 2026-08-27 via §2.1's superseded callout, which
+labels exactly this case. Part B still has to hold up its own end: the label is
+honest, but it only *describes* a lost conversation — it doesn't recover one.
 
 ### 6.3 Part C — backfill the session_id-less migrated agents
 

--- a/frontend/app/store/rpc-api/session.ts
+++ b/frontend/app/store/rpc-api/session.ts
@@ -38,6 +38,13 @@ export const SessionApi = {
         return client.rpcCall("session:next_prompt_suggestion", data, opts);
     },
 
+    // Will this pane's next turn continue its conversation, or start a new
+    // one? Read-only; spawns nothing. Called on pane mount so the answer is
+    // known before the user types.
+    SessionResumePreflightCommand(client: RpcClient, data: CommandSessionResumePreflightData, opts?: RpcOpts): Promise<SessionResumePreflightResult> {
+        return client.rpcCall("session:resume_preflight", data, opts);
+    },
+
     SessionArchiveCommand(client: RpcClient, data: CommandSessionArchiveData, opts?: RpcOpts): Promise<SessionArchiveResult> {
         return client.rpcCall("session:archive", data, opts);
     },

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -104,6 +104,8 @@ import { computeTermSizeFromEl, usePtyWidth } from "./hooks/usePtyWidth";
 import { useScrollToNode } from "./hooks/useScrollToNode";
 import { useSnapshotPersistence } from "./hooks/useSnapshotPersistence";
 import { injectHistoryLink } from "./inject-history-link";
+import { buildResumePreflightNode, injectResumePreflight } from "./inject-resume-preflight";
+import { useResumePreflight } from "./hooks/useResumePreflight";
 import { HISTORY_TAB_FOR_META_KEY, openOrFocusHistoryTab } from "./open-history-tab";
 import { getProvider } from "./providers";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
@@ -1005,6 +1007,12 @@ const AgentPresentationView = ({
         log,
     });
 
+    // Will the next spawn continue the conversation this pane is displaying, or
+    // start a new one? Asked once on mount, before the user can type — the
+    // whole point is to beat the first send, since every other continuity
+    // signal is retrospective. See `hooks/useResumePreflight.ts`.
+    const resumePreflight = useResumePreflight(model.blockId);
+
     // True when content older than the working session exists out of view:
     // set by the restore/pagination clamp paths (scopeClamped) OR derived
     // from a live clamp — after the reducer's StreamFlush trim, the fresh
@@ -1024,7 +1032,15 @@ const AgentPresentationView = ({
     // setter, so pairing a derived read with the real write side is safe
     // (nothing writes through this pair, so there's nothing to desync).
     const displayDocumentAtom: SignalPair<DocumentNode[]> = [
-        () => injectHistoryLink(agentAtoms().documentAtom[0](), earlierHistoryAvailable()),
+        () =>
+            injectResumePreflight(
+                injectHistoryLink(agentAtoms().documentAtom[0](), earlierHistoryAvailable()),
+                buildResumePreflightNode(
+                    agentAtoms().documentAtom[0](),
+                    resumePreflight.result(),
+                    resumePreflight.showSteps(),
+                ),
+            ),
         agentAtoms().documentAtom[1],
     ];
 

--- a/frontend/app/view/agent/hooks/useResumePreflight.ts
+++ b/frontend/app/view/agent/hooks/useResumePreflight.ts
@@ -1,0 +1,81 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useResumePreflight — ask, at pane mount, whether this agent's next turn will
+ * continue the conversation on screen or start a new one.
+ *
+ * Every other continuity signal in the pane is retrospective: the
+ * `agentmux_session_outcome` divider, the `session:resume_failed` banner and
+ * the "Reconnecting…" readout all describe a resume that has already been
+ * attempted, which can only happen once the user has sent something. That
+ * produces the experience this hook exists to remove — the pane opens showing
+ * a long prior conversation, the user types, and only then does the transcript
+ * clear and announce a new session.
+ *
+ * The backend can answer this without spawning anything (a `--resume` fails
+ * exactly when the session file isn't under the CLI's config dir), so this is
+ * one read-only RPC on mount. See `agentmux-srv/src/backend/resume_preflight.rs`.
+ *
+ * Deliberately fire-and-forget: no retry, no polling, no refetch on
+ * `agent:sessionid` changes. Once the pane has spawned, the retrospective
+ * signals above are authoritative and strictly better informed than this
+ * prediction — a preflight that kept re-running would eventually contradict
+ * them. The verdict describes the pane as the user found it, and that's all.
+ */
+
+import { createSignal, onCleanup } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+/**
+ * How long to let the preflight run before showing its progress list. The
+ * common case is one or two `stat`s and resolves far inside this, so the list
+ * never appears; a cold or network-backed home directory is what it's for.
+ */
+const STEPS_VISIBLE_AFTER_MS = 200;
+
+export interface UseResumePreflightResult {
+    /** `null` until the RPC resolves, and on any failure. */
+    result: () => SessionResumePreflightResult | null;
+    /** True once the preflight has been running longer than the reveal delay. */
+    showSteps: () => boolean;
+    /** True from mount until the RPC settles either way. */
+    pending: () => boolean;
+}
+
+export function useResumePreflight(blockId: string): UseResumePreflightResult {
+    const [result, setResult] = createSignal<SessionResumePreflightResult | null>(null);
+    const [showSteps, setShowSteps] = createSignal(false);
+    const [pending, setPending] = createSignal(true);
+
+    const revealTimer = setTimeout(() => {
+        if (pending()) setShowSteps(true);
+    }, STEPS_VISIBLE_AFTER_MS);
+
+    let disposed = false;
+    onCleanup(() => {
+        disposed = true;
+        clearTimeout(revealTimer);
+    });
+
+    RpcApi.SessionResumePreflightCommand(TabRpcClient, { block_id: blockId })
+        .then((r) => {
+            if (disposed) return;
+            setResult(r);
+        })
+        .catch((e) => {
+            // A failed preflight must be indistinguishable from "we don't
+            // know" — never a warning of its own. Predicting continuity is a
+            // convenience; being wrong about it is worse than being silent.
+            console.warn("resume preflight failed:", e);
+        })
+        .finally(() => {
+            if (disposed) return;
+            setPending(false);
+            setShowSteps(false);
+            clearTimeout(revealTimer);
+        });
+
+    return { result, showSteps, pending };
+}

--- a/frontend/app/view/agent/inject-resume-preflight.test.ts
+++ b/frontend/app/view/agent/inject-resume-preflight.test.ts
@@ -1,0 +1,100 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { buildResumePreflightNode, injectResumePreflight } from "./inject-resume-preflight";
+import type { DocumentNode } from "./types";
+
+const md = (id: string): DocumentNode => ({ type: "markdown", id, content: "hi" } as DocumentNode);
+
+const outcome = (): DocumentNode =>
+    ({
+        type: "session_outcome",
+        id: "so-1",
+        outcome: "fresh",
+        attemptedSid: "",
+        actualSid: null,
+        timestamp: 0,
+    } as DocumentNode);
+
+const result = (
+    verdict: SessionResumePreflightResult["verdict"],
+    extra: Partial<SessionResumePreflightResult> = {},
+): SessionResumePreflightResult => ({
+    block_id: "b",
+    verdict,
+    steps: [],
+    duration_ms: 3,
+    ...extra,
+});
+
+describe("buildResumePreflightNode", () => {
+    it("warns when the next spawn will start a new conversation", () => {
+        const node = buildResumePreflightNode([md("a")], result("fresh"), false);
+        expect(node).toMatchObject({ type: "resume_preflight", verdict: "fresh", pending: false });
+    });
+
+    it("carries the recoverable session id through as evidence history exists", () => {
+        const node = buildResumePreflightNode(
+            [md("a")],
+            result("fresh", { recoverable_session_id: "sid-orphaned" }),
+            false,
+        );
+        expect(node?.recoverableSessionId).toBe("sid-orphaned");
+    });
+
+    it("reports a recover verdict distinctly — continuity survives, it just pauses", () => {
+        const node = buildResumePreflightNode([md("a")], result("recover"), false);
+        expect(node?.verdict).toBe("recover");
+    });
+
+    it("says nothing when the conversation will simply resume", () => {
+        expect(buildResumePreflightNode([md("a")], result("resume"), false)).toBeNull();
+    });
+
+    it("says nothing when the verdict is unknowable", () => {
+        expect(buildResumePreflightNode([md("a")], result("unknown"), false)).toBeNull();
+    });
+
+    // A brand-new agent has no "conversation below" to lose — warning there
+    // would put a scary row on every first open.
+    it("says nothing on an empty document, even for a fresh verdict", () => {
+        expect(buildResumePreflightNode([], result("fresh"), false)).toBeNull();
+    });
+
+    // The prediction must never sit next to the retrospective fact: once a real
+    // session_outcome exists the spawn has happened and reported for itself.
+    it("stands down once a real session_outcome divider is present", () => {
+        expect(buildResumePreflightNode([outcome(), md("a")], result("fresh"), false)).toBeNull();
+    });
+
+    it("shows a pending row while the check is still running", () => {
+        const node = buildResumePreflightNode([md("a")], null, true);
+        expect(node).toMatchObject({ pending: true });
+        expect(node?.verdict).toBeUndefined();
+    });
+
+    it("shows nothing while the check is fast — pending false, no result yet", () => {
+        expect(buildResumePreflightNode([md("a")], null, false)).toBeNull();
+    });
+
+    // Even mid-check, a document that already reported its own outcome must not
+    // sprout a spinner about a question that's already answered.
+    it("suppresses the pending row too when a session_outcome is present", () => {
+        expect(buildResumePreflightNode([outcome()], null, true)).toBeNull();
+    });
+});
+
+describe("injectResumePreflight", () => {
+    it("prepends the notice ahead of everything it describes", () => {
+        const nodes = [md("a"), md("b")];
+        const node = buildResumePreflightNode(nodes, result("fresh"), false);
+        const out = injectResumePreflight(nodes, node);
+        expect(out.map((n) => n.type)).toEqual(["resume_preflight", "markdown", "markdown"]);
+    });
+
+    it("returns the document untouched when there's nothing to say", () => {
+        const nodes = [md("a")];
+        expect(injectResumePreflight(nodes, null)).toBe(nodes);
+    });
+});

--- a/frontend/app/view/agent/inject-resume-preflight.ts
+++ b/frontend/app/view/agent/inject-resume-preflight.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pane-open continuity notice injection for the LIVE working document — a
+ * render-time synthetic (never persisted, never dispatched into the reducer
+ * store), the same shape as `inject-history-link.ts`.
+ *
+ * Answers, at the top of the transcript, the question the pane could never
+ * answer before the user typed: is the conversation below actually going to be
+ * continued? See `hooks/useResumePreflight.ts`.
+ */
+
+import type { DocumentNode, ResumePreflightNode } from "./types";
+
+/**
+ * Build the notice node, or `null` when there's nothing worth saying.
+ *
+ * Silent by design in three cases, because a notice nobody needs is a notice
+ * that trains people to ignore the ones they do:
+ *   - `resume` / `unknown` verdicts — nothing is being lost, or we can't tell.
+ *   - an empty document — there is no "conversation below" to warn about, so a
+ *     brand-new agent's first open stays clean.
+ *   - a document that already carries a real `session_outcome` divider — the
+ *     spawn has happened and reported for itself; a *prediction* must never sit
+ *     alongside the retrospective fact and risk contradicting it.
+ */
+export function buildResumePreflightNode(
+    nodes: ReadonlyArray<DocumentNode>,
+    preflight: SessionResumePreflightResult | null,
+    pending: boolean,
+): ResumePreflightNode | null {
+    // Cheap rejections first. This runs on every document change, i.e. every
+    // stream flush, and the `session_outcome` scan below is the only part that
+    // walks the node list — so it must not run for the vast majority of panes,
+    // which resolve to `resume` and have nothing to say from then on.
+    const verdict =
+        preflight?.verdict === "fresh" || preflight?.verdict === "recover"
+            ? preflight.verdict
+            : null;
+    if (!pending && verdict == null) return null;
+    if (nodes.length === 0) return null;
+    if (nodes.some((n) => n.type === "session_outcome")) return null;
+
+    if (pending) {
+        return { type: "resume_preflight", id: "resume-preflight", pending: true, steps: [] };
+    }
+    if (!preflight || verdict == null) return null;
+
+    return {
+        type: "resume_preflight",
+        id: "resume-preflight",
+        verdict,
+        recoverableSessionId: preflight.recoverable_session_id,
+        pending: false,
+        steps: preflight.steps ?? [],
+    };
+}
+
+/**
+ * Prepend the notice to the document. Front of the list on purpose: it's about
+ * everything below it, and `injectHistoryLink` runs after this so the history
+ * link keeps its own position relative to a `session_outcome` boundary.
+ * Returns `nodes` unchanged when there's nothing to say.
+ */
+export function injectResumePreflight(
+    nodes: ReadonlyArray<DocumentNode>,
+    node: ResumePreflightNode | null,
+): DocumentNode[] {
+    if (!node) return nodes as DocumentNode[];
+    return [node, ...nodes];
+}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -2174,3 +2174,67 @@
         }
     }
 }
+
+// ── Pane-open continuity notice ──────────────────────────────────────────────
+// Injected at the very top of the live document by `injectResumePreflight` when
+// the next spawn won't continue the conversation on screen. Shares
+// `.agent-history-link-row`'s dashed-outline vocabulary — both are render-time
+// synthetics about the conversation rather than part of it — but carries a
+// warning tint, since this one is telling you something is about to be lost.
+.agent-resume-preflight {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    padding: 8px var(--space-2);
+    margin: 0 var(--space-1-5);
+    border: 1px dashed var(--border-color, rgba(255, 255, 255, 0.12));
+    border-radius: 4px;
+    user-select: none;
+
+    .agent-resume-preflight-sigil {
+        flex-shrink: 0;
+        opacity: 0.8;
+    }
+
+    .agent-resume-preflight-label {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 11px;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.55));
+    }
+
+    .agent-resume-preflight-cta {
+        flex-shrink: 0;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--accent-color);
+        cursor: var(--cursor-interactive, pointer);
+
+        &:hover,
+        &:focus-visible {
+            text-decoration: underline;
+        }
+
+        &:focus-visible {
+            outline: none;
+        }
+    }
+}
+
+.agent-resume-preflight-fresh {
+    border-color: color-mix(in srgb, var(--warning-color, #d89a3a) 45%, transparent);
+
+    .agent-resume-preflight-sigil {
+        color: var(--warning-color, #d89a3a);
+    }
+}
+
+// Continuity survives here — this is a "brace for a pause", not a warning, so
+// it stays in the neutral vocabulary rather than borrowing the warning tint.
+.agent-resume-preflight-recover .agent-resume-preflight-sigil,
+.agent-resume-preflight-pending .agent-resume-preflight-sigil {
+    color: var(--tertiary-text-color, rgba(255, 255, 255, 0.35));
+}

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -53,7 +53,7 @@ export type InitState = {
 /**
  * Document node types that make up the agent's markdown document
  */
-export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | ShellNode | AgentErrorNode | ContextCompactedNode | CompactionStartedNode | JektMessageNode | SessionOutcomeNode | DayDividerNode | HistoryLinkNode;
+export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | ShellNode | AgentErrorNode | ContextCompactedNode | CompactionStartedNode | JektMessageNode | SessionOutcomeNode | DayDividerNode | HistoryLinkNode | ResumePreflightNode;
 
 /**
  * Raw markdown text block
@@ -508,6 +508,35 @@ export interface DayDividerNode {
 export interface HistoryLinkNode {
     type: "history_link";
     id: "history-link";
+}
+
+/**
+ * Pane-open continuity notice — "the conversation below won't be continued",
+ * known before anything is spawned (`useResumePreflight`, backed by
+ * `agentmux-srv/src/backend/resume_preflight.rs`).
+ *
+ * A render-time synthetic like `HistoryLinkNode`: injected by
+ * `injectResumePreflight`, never persisted, never in the reducer store. It has
+ * to be a document node rather than a banner because the pane's other banner
+ * host (`AgentControlBar`) renders only while the details panel is open, and
+ * this notice is worthless if it can be missed.
+ *
+ * Distinct from `SessionOutcomeNode`, which reports what a resume attempt
+ * *did*. This reports what the next one *will* do, and disappears once the
+ * real outcome is known — the two never claim to describe the same event.
+ *
+ * `pending` is the progress-list state: the preflight is still running and has
+ * been for long enough to be worth showing (`STEPS_VISIBLE_AFTER_MS`).
+ */
+export interface ResumePreflightNode {
+    type: "resume_preflight";
+    id: "resume-preflight";
+    /** Omitted while `pending` — there's no verdict yet. */
+    verdict?: "fresh" | "recover";
+    /** A real session on disk that the next spawn won't reach for. */
+    recoverableSessionId?: string;
+    pending: boolean;
+    steps: ResumePreflightStep[];
 }
 
 /**

--- a/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
@@ -285,6 +285,27 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         );
     });
 
+    it("session_outcome: an empty attemptedSid reads as '—', not a blank", () => {
+        vi.useFakeTimers();
+        // srv emits `attempted_sid: ""` when the spawn had no session id to
+        // resume at all (the cross-channel-open case its
+        // `fresh_start_needs_disclosure` gate covers) — distinct from having
+        // attempted an id that was rejected.
+        const node: SessionOutcomeNode = {
+            type: "session_outcome",
+            id: "so-2",
+            outcome: "fresh",
+            attemptedSid: "",
+            actualSid: null,
+            timestamp: Date.now() - 65_000,
+        };
+        const { container } = renderRow(node);
+        hover(container, ".agent-session-outcome");
+        expect(document.body.querySelector(".agent-node-peek-tooltip-body")?.textContent).toBe(
+            "attempted: — · actual: —"
+        );
+    });
+
     it("history_link: no peek anchor at all — nothing to show", () => {
         vi.useFakeTimers();
         const node: HistoryLinkNode = { type: "history_link", id: "history-link" };

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -457,6 +457,63 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     <span class="agent-history-link-cta">Open Agent History →</span>
                 </div>
             </Show>
+            {/* resume_preflight — like history_link, a render-time synthetic
+                with a fixed id, no timestamp and no hidden content, so it has
+                no peek either (same deliberate exception). */}
+            <Show when={props.node() && props.node().type === "resume_preflight"}>
+                {(() => {
+                    const n = props.node() as Extract<DocumentNode, { type: "resume_preflight" }>;
+                    return (
+                        <Show
+                            when={!n.pending}
+                            fallback={
+                                // Only ever rendered when the check has already
+                                // run longer than its reveal delay — see
+                                // `useResumePreflight`'s STEPS_VISIBLE_AFTER_MS.
+                                <div class="agent-resume-preflight agent-resume-preflight-pending">
+                                    <span class="agent-resume-preflight-sigil">⟳</span>
+                                    <span class="agent-resume-preflight-label">
+                                        Checking whether this conversation can resume…
+                                    </span>
+                                </div>
+                            }
+                        >
+                            <div
+                                class={
+                                    n.verdict === "recover"
+                                        ? "agent-resume-preflight agent-resume-preflight-recover"
+                                        : "agent-resume-preflight agent-resume-preflight-fresh"
+                                }
+                            >
+                                <span class="agent-resume-preflight-sigil">
+                                    {n.verdict === "recover" ? "⟲" : "⚠"}
+                                </span>
+                                <span class="agent-resume-preflight-label">
+                                    {n.verdict === "recover"
+                                        ? "This agent will reconnect to its conversation — it may pause briefly on your first message."
+                                        : "This agent will start a new conversation — the history below isn't available to it."}
+                                </span>
+                                <Show when={n.verdict === "fresh" && props.onOpenHistory}>
+                                    <span
+                                        class="agent-resume-preflight-cta"
+                                        role="button"
+                                        tabindex="0"
+                                        onClick={() => props.onOpenHistory?.()}
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter" || e.key === " ") {
+                                                e.preventDefault();
+                                                props.onOpenHistory?.();
+                                            }
+                                        }}
+                                    >
+                                        Open Agent History →
+                                    </span>
+                                </Show>
+                            </div>
+                        </Show>
+                    );
+                })()}
+            </Show>
             <Show when={props.node() && props.node().type === "session_outcome"}>
                 {(() => {
                     const n = props.node() as Extract<DocumentNode, { type: "session_outcome" }>;

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -474,7 +474,12 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                         peekTick();
                         return `${formatExactTime(n.timestamp)} · ${formatTimeAgo(n.timestamp)}`;
                     });
-                    const bodyText = `attempted: ${n.attemptedSid} · actual: ${n.actualSid ?? "—"}`;
+                    // An empty `attemptedSid` is meaningful, not missing: the
+                    // spawn had no session id to resume at all (srv's
+                    // `fresh_start_needs_disclosure` path), as opposed to
+                    // having attempted one that was rejected. Render it as "—"
+                    // so the peek body doesn't read as a truncated id.
+                    const bodyText = `attempted: ${n.attemptedSid || "—"} · actual: ${n.actualSid ?? "—"}`;
                     return (
                         <div
                             ref={setPeekRowEl}

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -125,5 +125,9 @@ export function currentExpansion(
         case "history_link":
             // Fixed-height link row — never collapsible.
             return OPEN_DEFAULT;
+
+        case "resume_preflight":
+            // Fixed-height continuity notice — never collapsible.
+            return OPEN_DEFAULT;
     }
 }

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -157,6 +157,9 @@ export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     day_divider: false,
     // Render-time synthetic link row (live view) — static.
     history_link: false,
+    // Render-time synthetic continuity notice (live view) — static. Its
+    // pending/resolved swap replaces the node wholesale, never streams.
+    resume_preflight: false,
 };
 
 /**
@@ -179,6 +182,7 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "session_outcome":   return 48;
         case "day_divider":       return 32;
         case "history_link":      return 40;
+        case "resume_preflight":  return 56;
     }
 }
 
@@ -222,6 +226,7 @@ export function estimateNodeForState(
             case "session_outcome":   return 48;
             case "day_divider":       return 32;
         case "history_link":      return 40;
+        case "resume_preflight":  return 56;
         }
     }
     // expanded
@@ -239,5 +244,6 @@ export function estimateNodeForState(
         case "session_outcome":   return 48;
         case "day_divider":       return 32;
         case "history_link":      return 40;
+        case "resume_preflight":  return 56;
     }
 }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2651,6 +2651,39 @@ declare global {
         tokens?: TokenCounts;
     };
 
+    // wshrpc.CommandSessionResumePreflightData
+    type CommandSessionResumePreflightData = {
+        block_id: string;
+    };
+
+    // wshrpc.ResumePreflightStep — one row of the pane's progress list.
+    // `ok: false` is normal (it's how the sequence narrows), not an error.
+    type ResumePreflightStep = {
+        id: string;
+        label: string;
+        ok: boolean;
+        detail: string;
+        duration_ms: number;
+    };
+
+    // wshrpc.SessionResumePreflightResult — what the next spawn will do to this
+    // pane's conversation, decided before anything is spawned.
+    //   resume  — the exact session is present; it will be continued
+    //   recover — the held id is dead but a real session on disk will be
+    //             picked up by the retry path (continuity survives a pause)
+    //   fresh   — the next turn starts with none of the prior conversation
+    //   unknown — not determinable (no resume flag / no config dir); say nothing
+    type SessionResumePreflightResult = {
+        block_id: string;
+        verdict: "resume" | "recover" | "fresh" | "unknown";
+        session_id?: string;
+        // A real session on disk the next spawn will NOT reach for — set only
+        // alongside "fresh", as evidence history exists though nothing loads it.
+        recoverable_session_id?: string;
+        steps: ResumePreflightStep[];
+        duration_ms: number;
+    };
+
     // wshrpc.CommandSessionArchiveData
     type CommandSessionArchiveData = {
         block_id: string;


### PR DESCRIPTION
## Summary

Every continuity signal in the agent pane was **retrospective**. The
`agentmux_session_outcome` divider, the `session:resume_failed` banner and the
"Reconnecting…" readout all describe a resume that has *already been attempted* —
and the persistent controller spawns lazily, on the first message. So the only way
to learn a conversation was gone was to type into it and watch the transcript clear.

Two commits: close the detection gap, then move the answer to pane-open time.

## 1. `fix(agent)` — detect when the agent has no access to the prior conversation

`SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md` §2.1 exempted the
"no `--resume` attempted at all" spawn, reasoning it has *"nothing to lose"*. True
for a brand-new agent; false for the case
`STATUS_CROSS_CHANNEL_RESUME_STALE_SESSION_ID_2026_08_20.md` recorded — a
long-lived named agent opened in a fresh channel whose registry pointer is empty
gets no `--resume`, so the CLI never errors and no outcome is ever emitted, while
`blockfile.rs`'s cross-channel fallback renders the whole prior conversation.

`spawn_process` now emits `Fresh` when no `--resume` was attached, it's the
controller's first generation, and a transcript already exists locally or in the
agent's global zone. `persistent_resume::update`'s `SpawnedFresh` arm stays
effect-free and its regression guards still hold — "does prior history exist" is a
FileStore question the pure state machine can't answer, so the gate lives in
`persistent.rs`.

Also retracts `session:resume_failed` when a recovery scan succeeds.
`mark_resume_failed` fires from the stderr reader *before* recovery runs, so a
successful recovery left the banner claiming the conversation was lost while the
transcript's own divider said `resumed`.

## 2. `feat(agent)` — pane-open resume pre-flight

`--resume` fails for exactly one reason in practice: the session's `.jsonl` isn't
under the `CLAUDE_CONFIG_DIR` the CLI will use. That's a file-existence question, so
`backend/resume_preflight.rs` evaluates the same condition the CLI will, just
earlier — reusing `session_backfill`'s path scheme and home-dir expansion so the two
can't drift. It mirrors `persistent.rs`'s real decision sequence, including
`find_recovery_session_id`'s refusal to recover the id that just failed:

| Verdict | Meaning |
|---|---|
| `resume` | exact session present — silent |
| `recover` | held id dead, retry path will reach a real one → "will reconnect, may pause" |
| `fresh` | next turn starts with none of the prior conversation → warns + Open Agent History |
| `unknown` | no resume flag / no config dir — stays silent rather than guessing |

The no-session-id case is deliberately `fresh` even when a session sits on disk,
because that spawn path never scans for one; the orphaned id rides along as
`recoverable_session_id` — evidence, not a promise. Calling it `recover` would
describe the rehydrate step Part B hasn't built.

Surfaced as a render-time synthetic document node, the shape
`inject-history-link.ts` established. It can't be an `AgentControlBar` banner —
that region only renders while the details panel is open, and a notice you can miss
is worthless. The node stands down the moment a real `session_outcome` exists (a
prediction must never sit beside the retrospective fact) and says nothing on an
empty document, so a new agent's first open stays clean. The progress list only
appears if the check outruns 200ms.

## Spec corrections

§2.1's exemption is marked superseded, and §6.2's claim that Part A already made
this fresh start *"an honest, visibly-labeled event"* is corrected — it did not, and
`spawned_fresh_and_never_confirmed_paths_never_emit_a_session_outcome` pinned the
opposite.

## Testing

- `cargo test -p agentmux-srv` — 2802 passed, 0 failed
- `npx vitest run frontend/app/view/agent` — 118 files, 1507 passed
- `npx tsc --noEmit` — clean

New coverage: 8 tests over the pre-flight verdict table (real tempdir transcript
layouts), 12 over the injection/suppression rules, 4 over the disclosure gate, 3
over the `resume_failed` retraction.

**Not verified in a live pane.** The verdict logic is unit-tested against real
on-disk layouts, but the RPC round-trip and node rendering are code-verified only —
worth a `task dev` pass against an agent known to have lost its pointer.

<!-- agentmux:agent_id=agent2 -->