### PR TITLE
lark@claudius: fix(agent-pane): force stick-to-bottom on a pane's first overflow

### DIFF
--- a/.changesets/1788034240-fix-agent-pane-force-stick-to-bottom-on-a-pane-s-first-overf-h92j.md
+++ b/.changesets/1788034240-fix-agent-pane-force-stick-to-bottom-on-a-pane-s-first-overf-h92j.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): force stick-to-bottom on a pane's first overflow

--- a/docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
+++ b/docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
@@ -63,6 +63,34 @@ actually needed — is also fixed (log/act only when the fix changes the
 outcome), but doesn't affect §4's reasoning or invalidate anything above
 the addendum; noted for completeness since it's the same review round.
 
+## Addendum 2 2026-08-29 (same day) — point 3 above was itself incomplete
+
+Reagent's re-review (after the first addendum's fixes shipped) found that
+point 3's own fix didn't actually deliver what it claimed. `markNotOverflowing`
+was reachable ONLY through `scrollToTrueBottom()`, and every content-resize
+call site of `scrollToTrueBottom()` (both `ResizeObserver`s, the itemized
+signal effect) is itself gated on `stickToBottom()` already being `true`.
+So a pane that collapses to non-overflowing WHILE scrolled away — the
+`/clear`-while-reading-history case the doc comment explicitly claimed to
+cover, or the whole-pane 0px collapse happening mid-history-read — never
+re-armed `isOverflowing` at all, because nothing that could observe the
+collapse ever ran while disengaged. The re-arm only actually worked for a
+pane that stayed pinned throughout, which is the one case that's *least*
+in need of protection (a still-pinned pane's normal re-pin machinery
+already keeps it correct).
+
+Fixed by extracting a `syncOverflowState()` helper that updates
+`isOverflowing` from live geometry unconditionally, called from every
+geometry-observation point — every `handleScrollNow` invocation, both
+`ResizeObserver` callbacks, and the itemized effect — deliberately BEFORE
+and independent of each site's own `stickToBottom()` gate on the actual
+re-pin action. Point 3's text above ("the latter called from
+scrollToTrueBottom whenever content resizes back down to non-overflowing")
+describes the superseded first pass; the mechanism described in this
+addendum is what actually shipped. Added a fifth test exercising the
+collapse specifically while `stickToBottom()` is already `false` — the one
+scenario neither of point 3's original two tests exercised.
+
 ## 1. Bug report
 
 > If an agent pane loads without any content (no scrollbar yet), the first

--- a/docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
+++ b/docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
@@ -1,0 +1,259 @@
+# Spec: force stick-to-bottom on an agent pane's first-ever overflow
+
+**Date:** 2026-08-29
+**Status:** Proposed — no code changed yet.
+**Verified against:** `main` @ `4573d0d34`.
+**Related:** `docs/specs/REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md`,
+`docs/specs/PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md`,
+`docs/analysis/ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md`,
+`docs/analysis/FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_21.md`,
+`docs/analysis/FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md`.
+
+## 1. Bug report
+
+> If an agent pane loads without any content (no scrollbar yet), the first
+> time it finally reaches a point where a scrollbar appears, the scroll
+> doesn't stick to the latest content like it should — it sticks to the top
+> instead. The conversation keeps streaming and the user doesn't see it.
+> The user has to scroll manually or start typing before it catches up.
+
+Rare (most panes open with at least one node already present, so this
+specific transition never happens for them) but user-visible and annoying
+when it does — new output silently accumulates off-screen with no
+indication anything is wrong.
+
+## 2. This is not a new investigation — where it fits
+
+This repo already has an active, unresolved investigation thread into agent
+pane scroll-pin fragility, spanning three prior documents:
+
+- `REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md` → shipped the
+  content-`ResizeObserver` re-pin mechanism (PR #2370, referred to below as
+  **RO #2**) that this spec builds directly on.
+- `PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md` → investigated a
+  pane-splitter-resize variant, disproved its own leading hypothesis via a
+  dedicated jsdom-fake test suite, closed with the JS logic confirmed
+  correct for every resize ordering constructible in that harness.
+- `ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md` →
+  `FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_21.md` →
+  `FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md` →
+  a still-open live-telemetry investigation into `scrollHeight` shrinking
+  while pinned. The last of these found, from real `task package` instance
+  logs, **two incidents where every open pane's `scrollHeight` collapsed to
+  exactly `0px` simultaneously** (§3 of that doc), root cause unconfirmed.
+
+That last finding matters directly here: a pane whose `scrollHeight` drops
+to `0px` and then regrows past `clientHeight` is, geometrically, *identical*
+to a pane that "loads without content, then finally overflows for the first
+time" — the precondition in this bug report isn't limited to pane-open time,
+it can recur mid-session any time that collapse happens. This spec's fix
+(§5.1) closes the symptom for both cases at once, without needing to first
+resolve what causes the 0px collapse.
+
+## 3. Current mechanism, as verified in code
+
+All in `frontend/app/view/agent/virtualization/`, unless noted.
+
+- `state.ts:111` — `const [stickToBottom, setStickToBottom] = createSignal(true);`
+  defaults to `true`, so a fresh pane starts "following."
+- Three independent re-pin triggers, all funneling through
+  `scrollToTrueBottom()` (`AgentDocumentVirtualList.tsx:188-199`):
+  1. **Itemized content-signal effect** (`:494-511`) — re-fires on
+     `nodes().length`, `layoutView().totalSize`, or `workingRowHeight`
+     changing; scrolls inside a `queueMicrotask` with a live re-check of
+     `stickToBottom()` before acting.
+  2. **RO #1 — viewport resize** (`:535-551`) — observes `scrollRef` itself;
+     re-pins on `clientHeight` change. Does **not** fire on content growth —
+     `scrollRef`'s own box is fixed by the flex layout regardless of how
+     tall its overflowing content gets (comment at `:561-566`).
+  3. **RO #2 — content resize** (`:586-594`) — observes
+     `virtualContainerRef` and `streamingBufferRef` directly; re-pins on
+     *any* resize of those two elements, "regardless of what caused it"
+     (`:569-571`). This is the mechanism specifically built to catch content
+     growth an itemized signal doesn't cover (e.g. `MarkdownBlock`'s
+     throttled syntax-highlight re-render firing ~90ms after the last
+     token, entirely outside the Solid signal graph).
+- **The disengage/engage decision** — `handleScrollNow()`
+  (`AgentDocumentVirtualList.tsx:683-753`), called via a rAF-coalesced
+  `scroll` listener. Reads `scrollRef.scrollTop/scrollHeight/clientHeight`
+  live at `:685` (not a cached value). At `:719`:
+  ```ts
+  if (isNearBottom(scrollTop, scrollHeight, clientHeight)) {
+      if (!props.viewState.stickToBottom()) props.viewState.engageStickToBottom();  // :721
+  } else {
+      if (props.viewState.stickToBottom()) {
+          if (wasProgrammatic) {
+              // suppressed — our own scrollTo() landed in this batch
+          } else {
+              props.viewState.disengageStickToBottom();   // :746
+          }
+      }
+  }
+  ```
+  `wasProgrammatic` (`:692`) is set only when `scrollToTrueBottom()` itself
+  triggered the pending scroll (`:199`) — it does not, and cannot, account
+  for a native/browser-internal scroll adjustment that isn't the result of
+  our own call.
+- **`isNearBottom`** (`anchor.ts:68-85`):
+  ```ts
+  const maxScroll = scrollHeight - clientHeight;
+  if (maxScroll <= 0) return true;   // no scrollbar ⇒ always "near bottom"
+  ```
+- **The only two re-engage paths once disengaged**: a `scroll` event that
+  lands near bottom (`:721`), or `jumpToBottom()` (`:599-603`), wired to
+  `AgentFooter`'s `onTyping` callback (`agent-view.tsx:2252-2254`) — this is
+  exactly the "scroll manually or start typing" workaround in the bug
+  report, which confirms the failure mode really is a `disengageStickToBottom()`
+  call somewhere, not `stickToBottom` simply never having been `true`.
+
+### Ruled out during this investigation
+
+The obvious "ref not attached yet" shape of bug — RO #2 silently never
+observing `streamingBufferRef` because that element doesn't exist at
+`onMount` time for a pane that starts with zero nodes — does **not** apply
+here. `streamingBufferRef`'s owning `<div>` is gated by
+`<Show when={partition()}>` (`:1010`ish), and `partition` (`createMemo` at
+`:232-283`) has no path that returns anything falsy — every branch returns
+`result` from `partitionForVirtualization`, even for an empty document. So
+`partition()` is truthy from the very first render, the streaming-buffer
+div exists by the time `onMount` runs, and RO #2 attaches correctly
+regardless of how many nodes the pane starts with. Ran this down explicitly
+because it's the single most common shape for this class of bug and it
+would have been a clean, deterministic, one-line fix — it just isn't what's
+happening here.
+
+## 4. Root cause: no single confirmed trigger — but a real, provable gap
+
+Per `PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md` §7 and
+`ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md`'s own framing, this
+environment cannot drive a live GUI repro to catch the exact event sequence
+in the act — the prior docs hit the same wall. What *is* provable by
+inspection, without needing that repro, is this:
+
+**The code has no concept of "this pane has never had a real scrollbar
+before," and it needs one.** `handleScrollNow`'s disengage branch (§3)
+treats every non-`wasProgrammatic` "far from bottom" reading identically,
+regardless of whether the pane has *ever* actually had `maxScroll > 0`
+before this instant. But a pane transitioning from `maxScroll <= 0` to
+`maxScroll > 0` for the first time cannot have a legitimate
+user-initiated "scrolled away" state — there is nowhere to have scrolled
+away *to* before that transition. Any disengage that fires on that exact
+transition is illegitimate by construction, whatever produced the
+misleading geometry read that triggered it (a native scrollbar-insertion
+side effect, an event-batching edge case, or — per §2 — this pane living
+through the still-unexplained whole-pane 0px collapse). Today, nothing
+distinguishes "first overflow ever" from "the 500th scroll event on a
+long-open pane" — both go through the exact same `isNearBottom` check with
+no memory of prior state.
+
+## 5. Proposed fix
+
+### 5.1 Primary — make the first-overflow transition un-disengageable (root-cause-agnostic)
+
+Add a `hasOverflowedOnce` boolean to `AgentViewState`
+(`frontend/app/view/agent/virtualization/state.ts`), defaulting `false`:
+
+```ts
+// state.ts — new signal alongside stickToBottom (:111)
+const [hasOverflowedOnce, setHasOverflowedOnce] = createSignal(false);
+```
+
+Expose it on the interface (near `stickToBottom` at `:38`) and from the
+returned object (near `:152`).
+
+In `handleScrollNow` (`AgentDocumentVirtualList.tsx`), before the existing
+`isNearBottom` branch at `:719`, insert a one-time latch:
+
+```ts
+const maxScroll = scrollHeight - clientHeight;
+if (maxScroll > 0 && !props.viewState.hasOverflowedOnce()) {
+    // First time this pane has ever had a real scrollbar. There is no
+    // legitimate "user scrolled away" state to preserve — nowhere existed
+    // to scroll away to before this instant. Force-pin regardless of what
+    // this scroll event's geometry otherwise reads as, and never take this
+    // branch again for this pane's lifetime.
+    props.viewState.markOverflowedOnce();
+    if (!props.viewState.stickToBottom()) props.viewState.engageStickToBottom();
+    scrollToTrueBottom();
+    return;
+}
+```
+
+This makes the fix a pure *addition* — the existing `isNearBottom` /
+`wasProgrammatic` / disengage logic is untouched for every subsequent
+scroll event on that pane, so no currently-correct "user deliberately
+scrolled up to read history" behavior can regress. It only removes a
+behavior (disengaging on the very first overflow) that could never have
+been correct to begin with.
+
+Also call `markOverflowedOnce()` from the two other places that already
+learn `maxScroll` first went positive — RO #2's callback (`:588-594`) and
+the itemized effect (`:494-511`) — so the latch is set even on a pane
+where the very first overflow is caught by one of the *working* re-pin
+paths rather than a scroll event; the `handleScrollNow` check above should
+key off the same signal so all three paths agree on whether this pane has
+already had its "first time" or not. (Simplest implementation: compute the
+latch centrally, e.g. inside `scrollToTrueBottom()` itself, since every
+re-pin path already funnels through it and it already reads
+`scrollRef.scrollHeight`.)
+
+### 5.2 Diagnostics — so the next telemetry pull can attribute this specifically
+
+Extend the existing `[wave-scroll-shrink]` / `[wave-scroll]` console
+tracing (`:191-196`, `:733-745`) with a `[wave-scroll-first-overflow]` line
+whenever the §5.1 latch fires and finds `stickToBottom()` was already
+`false` at that instant (i.e., a real save — this pane really was about to
+silently strand the user). Follow the same log-then-correlate methodology
+`FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_21.md` and
+`..._LIVE_INSTANCE_DATA_2026_08_22.md` already established
+(`muxlog fe grep wave-scroll`) — the next live-instance pull can then
+directly confirm or rule out whether reports of this bug correlate with the
+known 0px whole-pane collapse (§2) or are a third, distinct mechanism, the
+same way those docs distinguished their Class 1 / Class 2 shrink sources.
+
+### 5.3 Close the test-coverage gap
+
+Neither existing scroll test file exercises this transition:
+
+- `anchor.test.ts` covers `isNearBottom`'s `maxScroll <= 0` case
+  (lines ~101-105) only as a static snapshot, never a before/after
+  transition.
+- `AgentDocumentVirtualList.resize.test.tsx` (the pane-splitter-resize
+  regression suite) starts every test from an already-overflowing
+  `scrollHeight`/`clientHeight` pair and resizes the *container* — it
+  never grows *content* from `scrollHeight <= clientHeight` to
+  `scrollHeight > clientHeight` while the container stays fixed size,
+  which is exactly this bug's scenario and exactly what RO #2 exists to
+  catch.
+
+Add a test to `AgentDocumentVirtualList.resize.test.tsx` (or a new sibling
+file) that: mounts with `scrollHeight === clientHeight` (no overflow),
+grows `virtualContainerRef`'s or `streamingBufferRef`'s measured box past
+`clientHeight` via the suite's existing fake `ResizeObserver` — with the
+itemized signals (`nodes().length`, `layoutView().totalSize`,
+`workingRowHeight`) held constant, so the test isolates RO #2 specifically
+— and asserts `scrollTop` lands at true bottom. This is the direct
+regression test for the reported bug; it would have caught the "ref never
+attaches" hypothesis in §3 had that turned out to be true, and it locks in
+correctness for whatever combination of signals causes the growth.
+
+## 6. Explicitly out of scope
+
+This spec does not attempt to resolve either still-open lead from
+`FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md`:
+the source of the recurring ~251-252px shrink (§2 of that doc), or the
+mechanism behind the whole-pane 0px collapse itself (§3). §5.1 makes this
+bug's *symptom* structurally impossible regardless of what eventually
+turns out to cause either of those — but the causes themselves stay
+tracked in that doc's own "recommended next steps" (frame/mutation-level
+instrumentation around `ReconcileTurnActive`, a source-level search for a
+~251px fixed-height element).
+
+## 7. Risk
+
+Low. §5.1 only changes behavior for a transition that, by the invariant in
+§4, can never have a legitimate reason to disengage — there is no existing
+"user scrolled up to read history" case it could regress, because that
+case requires overflow to have existed already, which is precisely the
+condition this fix's one-time latch excludes itself from after firing
+once per pane.

--- a/docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
+++ b/docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
@@ -1,13 +1,67 @@
 # Spec: force stick-to-bottom on an agent pane's first-ever overflow
 
 **Date:** 2026-08-29
-**Status:** Proposed — no code changed yet.
+**Status:** Implemented in PR #2834 — §5.1's design below reflects the
+*first* implementation pass; see the addendum immediately below for three
+corrections found in code review before merge.
 **Verified against:** `main` @ `4573d0d34`.
 **Related:** `docs/specs/REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md`,
 `docs/specs/PLAN_AGENT_PANE_RESIZE_SCROLL_PIN_2026_08_05.md`,
 `docs/analysis/ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md`,
 `docs/analysis/FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_21.md`,
 `docs/analysis/FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md`.
+
+## Addendum 2026-08-29 (same day) — three corrections from code review, before merge
+
+Codex and reagent's PR #2834 reviews found three real gaps in the first
+implementation pass below. All three are fixed in the shipped commit;
+noted here rather than silently rewritten into §5.1 so the reasoning that
+led to the final design stays visible:
+
+1. **(codex P1) Missing early return let pagination clobber the forced
+   pin.** §5.1 as originally written didn't `return` after forcing the
+   pin, so execution fell through into the older-history pagination
+   block (`handleScrollNow`'s last statement), which reads the *stale*
+   `scrollTop` captured at the top of the event — still near-top at the
+   exact moment this fix's own force-pin fires. With `props.onLoadOlder`
+   always supplied in the real pane (`agent-view.tsx`), that stale
+   near-top reading triggered `captureHeadAnchor()`, flipping
+   `stickToBottom` back to `false` in the same tick the fix had just set
+   it `true`. Fixed with an explicit `return` right after the forced
+   scroll.
+2. **(reagent P1) The force-pin didn't check whether stickToBottom was
+   *already*, legitimately, `false`.** §4's invariant — "a pane that's
+   never overflowed can't have a legitimate scrolled-away state" — is
+   true for a real user scroll gesture, but not for
+   `captureHeadAnchor()` itself: older-history pagination can fire (and
+   disengage stickToBottom) on a pane that hasn't overflowed yet, because
+   a non-overflowing pane's `scrollTop` is always `0`, which always
+   satisfies `isNearTop`. If that pagination's *own* anchor-restore
+   `scrollTo()` (which never routes through `scrollToTrueBottom`) is what
+   pushes the pane past its first overflow, the original code would force
+   stickToBottom back to `true` and snap to the very bottom, destroying
+   the reader's just-restored position. Fixed by gating the force-pin on
+   `stickToBottom()` already being `true` at the moment of transition —
+   it only ever *protects* an already-following pane, never *re-engages*
+   one that's disengaged for any reason, pagination included.
+3. **(codex P2) The latch never re-armed.** §5.1's `hasOverflowedOnce`
+   was written as a one-way, mount-lifetime latch. But the whole reason
+   §2 connects this bug to the still-open whole-pane `scrollHeight →
+   0px` collapse is that a still-following pane living through that
+   collapse-and-regrow re-lives the exact same transition — and a
+   one-way latch only protects it the *first* time that ever happens,
+   not every time it recurs. Renamed to a bidirectional `isOverflowing`
+   signal (`markOverflowing` / `markNotOverflowing`, the latter called
+   from `scrollToTrueBottom` whenever content resizes back down to
+   non-overflowing) so each collapse-and-regrow gets independently
+   re-armed.
+
+A fourth, narrower finding (reagent P2) — the `[wave-scroll-first-overflow]`
+diagnostic logging unconditionally on every detected transition, including
+ones where the raw geometry already read near-bottom and no protection was
+actually needed — is also fixed (log/act only when the fix changes the
+outcome), but doesn't affect §4's reasoning or invalidate anything above
+the addendum; noted for completeness since it's the same review round.
 
 ## 1. Bug report
 

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.resize.test.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.resize.test.tsx
@@ -277,3 +277,97 @@ describe("AgentDocumentVirtualList — stick-to-bottom across pane resize", () =
         expect(viewState.stickToBottom()).toBe(true);
     });
 });
+
+// Regression coverage for
+// docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md — a
+// pane that starts with no scrollbar (scrollHeight <= clientHeight), then has
+// content grow past the viewport for the first time. Every test above this
+// point resizes the *container* (clientHeight); these resize *content*
+// (scrollHeight) while clientHeight stays fixed — the one geometry
+// transition neither this file nor anchor.test.ts previously exercised, and
+// exactly the case RO #2 (content-resize observer) exists to catch.
+describe("AgentDocumentVirtualList — first-ever overflow", () => {
+    beforeEach(() => {
+        roInstances = [];
+        rafQueue = [];
+        vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+            rafQueue.push(cb);
+            return rafQueue.length;
+        });
+        vi.stubGlobal("cancelAnimationFrame", () => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("sticks to true bottom when content grows past a previously non-overflowing viewport", () => {
+        const { viewState, scrollRef } = setup();
+        // No scrollbar yet: content exactly fills the viewport.
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+        expect(viewState.stickToBottom()).toBe(true);
+
+        const virtualContainer = scrollRef.querySelector(".agent-document-virtualizer") as HTMLElement;
+        expect(virtualContainer).toBeTruthy();
+
+        // Content resize only — clientHeight is untouched, so RO #1 (viewport
+        // resize) never fires; only RO #2 (content resize) can catch this.
+        setGeometry(scrollRef, { scrollHeight: 500 });
+        triggerResize(virtualContainer);
+        flushRaf();
+
+        expect(scrollRef.scrollTop).toBe(300); // scrollHeight(500) - clientHeight(200)
+        expect(viewState.stickToBottom()).toBe(true);
+    });
+
+    it("does not disengage on a stray scroll event that races the pane's first overflow", () => {
+        const { viewState, scrollRef } = setup();
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+        expect(viewState.stickToBottom()).toBe(true);
+
+        // Content has grown past the viewport, but nothing has re-pinned yet
+        // — scrollTop is still 0, which now reads as "far from bottom". This
+        // mimics a native scroll event landing before RO #2 (or any other
+        // re-pin path) gets a chance to run: the exact race §4 of the spec
+        // identifies as the failure mode, reproduced directly rather than
+        // relying on RO #2 to win the race on its own.
+        setGeometry(scrollRef, { scrollHeight: 500 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        // Without the fix: isNearBottom(0, 500, 200) reads false (gap 300px
+        // >= the 200px threshold) and this scroll event disengages
+        // stickToBottom, stranding the user at the top with no visible
+        // indication anything changed until they scroll or type.
+        expect(viewState.stickToBottom()).toBe(true);
+        expect(scrollRef.scrollTop).toBe(300); // forced to true bottom by the fix
+    });
+
+    it("only forces the first transition — a later genuine scroll-away still disengages normally", () => {
+        const { viewState, scrollRef } = setup();
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+        // First overflow — latches hasOverflowedOnce and force-pins. The
+        // forced scrollToTrueBottom()'s own scrollTo() call reentrantly
+        // dispatches a second scroll event that coalesces into a follow-up
+        // frame (real `handleScroll` coalescing behavior, not test-only) —
+        // flush twice so that settles fully before simulating a distinct,
+        // later user action; otherwise the next scroll event below would be
+        // misread as still part of this same programmatic batch.
+        setGeometry(scrollRef, { scrollHeight: 500 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+        flushRaf();
+        expect(viewState.stickToBottom()).toBe(true);
+
+        // A later, unambiguous user scroll away from bottom must still
+        // disengage normally — the fix only protects the one-time
+        // first-overflow transition, not every subsequent scroll event.
+        setGeometry(scrollRef, { scrollTop: 0 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        expect(viewState.stickToBottom()).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.resize.test.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.resize.test.tsx
@@ -348,7 +348,7 @@ describe("AgentDocumentVirtualList — first-ever overflow", () => {
         const { viewState, scrollRef } = setup();
         setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
 
-        // First overflow — latches hasOverflowedOnce and force-pins. The
+        // First overflow — marks isOverflowing and force-pins. The
         // forced scrollToTrueBottom()'s own scrollTo() call reentrantly
         // dispatches a second scroll event that coalesces into a follow-up
         // frame (real `handleScroll` coalescing behavior, not test-only) —
@@ -369,5 +369,95 @@ describe("AgentDocumentVirtualList — first-ever overflow", () => {
         flushRaf();
 
         expect(viewState.stickToBottom()).toBe(false);
+    });
+
+    it("does NOT force-pin over a legitimately captured head anchor (reagent P1 on PR #2834)", () => {
+        // Simulates the older-history pagination interaction directly: its
+        // anchor capture flips stickToBottom false — via captureHeadAnchor,
+        // not a real scroll-away — *before* this pane has ever overflowed,
+        // since a non-overflowing pane's scrollTop is always 0 and so always
+        // satisfies isNearTop. If content then overflows for the first time
+        // while that capture is in effect (e.g. the pagination restore's own
+        // direct scrollTo(), which never routes through scrollToTrueBottom),
+        // the fix must not force stickToBottom back to true and blow away
+        // the just-restored reading position.
+        const { viewState, scrollRef } = setup();
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+        viewState.captureHeadAnchor({ nodeId: "some-older-node", offsetPx: 40 });
+        expect(viewState.stickToBottom()).toBe(false);
+
+        // Pagination's restore lands the reader partway up a now-overflowing
+        // document — far from bottom by construction.
+        setGeometry(scrollRef, { scrollHeight: 900, scrollTop: 150 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        expect(viewState.stickToBottom()).toBe(false);
+        expect(scrollRef.scrollTop).toBe(150); // untouched — not forced to bottom
+        expect(viewState.headAnchor()).toEqual({ nodeId: "some-older-node", offsetPx: 40 });
+    });
+
+    it("re-arms after a collapse back to non-overflowing, so a second overflow is protected too (codex P2 on PR #2834)", () => {
+        // A still-following pane whose content collapses to non-overflowing
+        // and then grows past the viewport again must get the same
+        // first-overflow protection the SECOND time — this is what makes the
+        // fix actually cover the documented whole-pane scrollHeight->0px
+        // collapse (FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md
+        // §3), not just a pane's literal first-ever overflow.
+        const { viewState, scrollRef } = setup();
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+        const virtualContainer = scrollRef.querySelector(".agent-document-virtualizer") as HTMLElement;
+
+        // First overflow — protected, as already covered above.
+        setGeometry(scrollRef, { scrollHeight: 500 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+        flushRaf(); // drain the forced pin's own reentrant scroll event
+        expect(viewState.stickToBottom()).toBe(true);
+        expect(scrollRef.scrollTop).toBe(300);
+
+        // Collapses back to non-overflowing while still following — RO #2
+        // fires on ANY content resize (shrink included), which is what
+        // re-arms isOverflowing() via scrollToTrueBottom's own bidirectional
+        // update.
+        setGeometry(scrollRef, { scrollHeight: 150, scrollTop: 0 });
+        triggerResize(virtualContainer);
+        flushRaf();
+        expect(viewState.stickToBottom()).toBe(true);
+
+        // Grows past the viewport a second time, with the same kind of stray
+        // far-from-bottom scroll event as the original bug.
+        setGeometry(scrollRef, { scrollHeight: 600 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        expect(viewState.stickToBottom()).toBe(true);
+        expect(scrollRef.scrollTop).toBe(400); // scrollHeight(600) - clientHeight(200)
+    });
+
+    it("does not log or act when the first-overflow event already reads near bottom (reagent P2 on PR #2834)", () => {
+        // If the raw geometry already reads near-bottom, forcing is a
+        // redundant no-op and must not spam the [wave-scroll-first-overflow]
+        // diagnostic meant to flag genuine saves for future telemetry pulls.
+        const { scrollRef } = setup();
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+        const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+        try {
+            // Grows past the viewport, but scrollTop already reflects true
+            // bottom for the new geometry — nothing to save here.
+            setGeometry(scrollRef, { scrollHeight: 500, scrollTop: 300 });
+            scrollRef.dispatchEvent(new Event("scroll"));
+            flushRaf();
+
+            const firstOverflowLogs = infoSpy.mock.calls.filter(
+                (call) => call[0] === "[wave-scroll-first-overflow]",
+            );
+            expect(firstOverflowLogs).toHaveLength(0);
+        } finally {
+            infoSpy.mockRestore();
+        }
     });
 });

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.resize.test.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.resize.test.tsx
@@ -460,4 +460,61 @@ describe("AgentDocumentVirtualList — first-ever overflow", () => {
             infoSpy.mockRestore();
         }
     });
+
+    it("re-arms even when the collapse happens while scrolled away reading history (reagent P1, second pass)", () => {
+        // The 're-arms after a collapse' test above only exercises the
+        // collapse while stickToBottom() stays true throughout — every
+        // re-pin call site (scrollToTrueBottom's callers) is gated on that,
+        // so it can't tell a real bidirectional sync from one that merely
+        // happens to run inside an always-following pane. This test forces
+        // the disengaged path: the collapse must be observed by
+        // syncOverflowState() directly, independent of stickToBottom.
+        const { viewState, scrollRef } = setup();
+        setGeometry(scrollRef, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+        const virtualContainer = scrollRef.querySelector(".agent-document-virtualizer") as HTMLElement;
+
+        // First overflow — protected, ends stickToBottom=true at true bottom.
+        setGeometry(scrollRef, { scrollHeight: 500 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+        flushRaf();
+        expect(viewState.stickToBottom()).toBe(true);
+
+        // User scrolls away to read history — an unambiguous, real disengage.
+        setGeometry(scrollRef, { scrollTop: 0 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+        expect(viewState.stickToBottom()).toBe(false);
+
+        // Content collapses to non-overflowing WHILE disengaged (e.g. /clear,
+        // or the documented whole-pane collapse) — RO #2 fires regardless of
+        // stickToBottom. Must NOT force a pin (the reading position is
+        // legitimate and must be left alone), but MUST still re-arm
+        // isOverflowing for next time.
+        setGeometry(scrollRef, { scrollHeight: 150, scrollTop: 0 });
+        triggerResize(virtualContainer);
+        expect(viewState.stickToBottom()).toBe(false); // untouched
+        expect(scrollRef.scrollTop).toBe(0); // no forced scroll
+
+        // User scrolls back to (what is now, since it doesn't overflow) the
+        // only possible position — a normal near-bottom re-engage, NOT
+        // through scrollToTrueBottom/jumpToBottom.
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+        expect(viewState.stickToBottom()).toBe(true);
+
+        // Content overflows a second time, with the same kind of stray
+        // far-from-bottom scroll event as the original bug. Without the
+        // unconditional re-arm, isOverflowing would still read stale `true`
+        // from the very first overflow above, isFirstOverflow would read
+        // false, and this event would incorrectly disengage instead of
+        // being protected.
+        setGeometry(scrollRef, { scrollHeight: 600 });
+        scrollRef.dispatchEvent(new Event("scroll"));
+        flushRaf();
+
+        expect(viewState.stickToBottom()).toBe(true);
+        expect(scrollRef.scrollTop).toBe(400); // scrollHeight(600) - clientHeight(200)
+    });
 });

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -196,6 +196,11 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             );
         }
         lastKnownScrollHeight = h;
+        // First real scrollbar this pane has ever had — latch it so
+        // handleScrollNow knows any FUTURE "far from bottom" reading is a
+        // legitimate disengage candidate, not a first-transition artifact.
+        // See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md §5.1.
+        if (h > scrollRef.clientHeight) props.viewState.markOverflowedOnce();
         pendingProgrammaticScroll = true;
         scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
     }
@@ -714,9 +719,31 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             collapseScrolledOffTools();
         }
 
+        // First time this pane's content has ever overflowed its viewport.
+        // There is no legitimate "user scrolled away" state to preserve
+        // here — nowhere existed to scroll away to before this instant —
+        // so force a fresh pin instead of trusting whatever this one
+        // event's geometry happens to read (a native scrollbar-insertion
+        // side effect or a same-frame race can otherwise make a brand-new
+        // overflow look "far from bottom" and disengage it right out of
+        // the gate, with nothing to re-engage it afterward but a manual
+        // scroll or keystroke). Latches once per pane; every subsequent
+        // scroll event uses the normal isNearBottom logic below unchanged.
+        // See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md §5.1.
+        const isFirstOverflow = scrollHeight > clientHeight && !props.viewState.hasOverflowedOnce();
+        if (isFirstOverflow) {
+            props.viewState.markOverflowedOnce();
+            console.info(
+                "[wave-scroll-first-overflow]",
+                `pane=${props.blockId?.slice(0, 7) ?? "?"}`,
+                `forced engage — scrollTop=${scrollTop} scrollHeight=${scrollHeight} clientHeight=${clientHeight}`,
+            );
+            scrollToTrueBottom();
+        }
+
         // Engage stick when user scrolls back near bottom; disengage
         // otherwise. Engaging clears any captured headAnchor (atomic).
-        if (isNearBottom(scrollTop, scrollHeight, clientHeight)) {
+        if (isFirstOverflow || isNearBottom(scrollTop, scrollHeight, clientHeight)) {
             if (!props.viewState.stickToBottom()) {
                 props.viewState.engageStickToBottom();
             }

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -196,11 +196,19 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             );
         }
         lastKnownScrollHeight = h;
-        // First real scrollbar this pane has ever had — latch it so
-        // handleScrollNow knows any FUTURE "far from bottom" reading is a
-        // legitimate disengage candidate, not a first-transition artifact.
-        // See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md §5.1.
-        if (h > scrollRef.clientHeight) props.viewState.markOverflowedOnce();
+        // Keep isOverflowing() current in both directions — this runs on
+        // every re-pin, including RO #2 (content-resize) firing on a pure
+        // SHRINK back to non-overflowing while still stickToBottom()'d, so
+        // a later regrowth past clientHeight is re-armed as a genuine
+        // "first overflow" transition again rather than staying permanently
+        // marked from whatever the pane's actual first overflow was.
+        // See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
+        // (codex P2 on PR #2834).
+        if (h > scrollRef.clientHeight) {
+            props.viewState.markOverflowing();
+        } else {
+            props.viewState.markNotOverflowing();
+        }
         pendingProgrammaticScroll = true;
         scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
     }
@@ -719,31 +727,56 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             collapseScrolledOffTools();
         }
 
-        // First time this pane's content has ever overflowed its viewport.
-        // There is no legitimate "user scrolled away" state to preserve
-        // here — nowhere existed to scroll away to before this instant —
-        // so force a fresh pin instead of trusting whatever this one
-        // event's geometry happens to read (a native scrollbar-insertion
-        // side effect or a same-frame race can otherwise make a brand-new
-        // overflow look "far from bottom" and disengage it right out of
-        // the gate, with nothing to re-engage it afterward but a manual
-        // scroll or keystroke). Latches once per pane; every subsequent
-        // scroll event uses the normal isNearBottom logic below unchanged.
-        // See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md §5.1.
-        const isFirstOverflow = scrollHeight > clientHeight && !props.viewState.hasOverflowedOnce();
+        // This pane's content has overflowed its viewport for the first
+        // time since it last didn't (see isOverflowing's own doc comment
+        // for why this isn't a one-time latch). Keep it current regardless
+        // of what we do below — later evaluations need an accurate reading
+        // whether or not THIS event ends up needing protection.
+        const isFirstOverflow = scrollHeight > clientHeight && !props.viewState.isOverflowing();
         if (isFirstOverflow) {
-            props.viewState.markOverflowedOnce();
+            props.viewState.markOverflowing();
+        }
+
+        // Engage stick when user scrolls back near bottom; disengage
+        // otherwise. Engaging clears any captured headAnchor (atomic).
+        const nearBottom = isNearBottom(scrollTop, scrollHeight, clientHeight);
+        if (isFirstOverflow && props.viewState.stickToBottom() && !nearBottom) {
+            // A pane that was still following when it hit its first overflow
+            // has no legitimate reason for THIS event's geometry to read as
+            // "far from bottom" — nowhere existed to scroll away to before
+            // this instant, so a native scrollbar-insertion side effect or a
+            // same-frame race is the far likelier explanation. Force a fresh
+            // pin instead of trusting this one reading.
+            //
+            // Gated on stickToBottom() already being true: this must never
+            // force an engage from an ALREADY, legitimately disengaged state
+            // — most notably a headAnchor captured moments earlier by
+            // in-flight older-history pagination (its restore's own
+            // scrollTo() doesn't route through scrollToTrueBottom, so
+            // isOverflowing() can still be transitioning here too). Reading
+            // stickToBottom() false in that case means the capture already
+            // ran before this event, so this branch correctly does nothing,
+            // leaving the just-restored reading position alone (reagent P1
+            // on PR #2834).
+            //
+            // Also gated on !nearBottom: if the raw geometry already reads
+            // near bottom, forcing is a redundant no-op — only log/act when
+            // this is a genuine save (codex P2 on PR #2834).
             console.info(
                 "[wave-scroll-first-overflow]",
                 `pane=${props.blockId?.slice(0, 7) ?? "?"}`,
                 `forced engage — scrollTop=${scrollTop} scrollHeight=${scrollHeight} clientHeight=${clientHeight}`,
             );
             scrollToTrueBottom();
+            // Stop here — the pagination check below reads the scrollTop
+            // captured at the top of this event, now stale (we just forced
+            // true bottom). Letting it run could re-capture a head anchor
+            // from that stale near-top reading and immediately undo the pin
+            // (codex P1 on PR #2834).
+            return;
         }
 
-        // Engage stick when user scrolls back near bottom; disengage
-        // otherwise. Engaging clears any captured headAnchor (atomic).
-        if (isFirstOverflow || isNearBottom(scrollTop, scrollHeight, clientHeight)) {
+        if (nearBottom) {
             if (!props.viewState.stickToBottom()) {
                 props.viewState.engageStickToBottom();
             }

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -184,6 +184,32 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // change produced a given visible "scroll went backward" report — the
     // real fix has to happen upstream, at whatever DOM swap caused the
     // shrink (e.g. a FLIP-style freeze-then-ease on that element), not here.
+    // Keeps isOverflowing() current in both directions from live geometry.
+    // MUST run unconditionally from every observation point (handleScrollNow,
+    // both ResizeObservers, the itemized effect) — NOT only from paths gated
+    // on stickToBottom() already being true. A pane can collapse to
+    // non-overflowing (or grow past it) while the user is scrolled away
+    // reading history — a `/clear` wiping the transcript, or the documented
+    // whole-pane scrollHeight->0px collapse, mid-history-read — and every
+    // stickToBottom()-gated call site (all of RO #1/#2's re-pin, the
+    // itemized effect's re-pin, and scrollToTrueBottom itself) would
+    // otherwise never observe it, leaving isOverflowing() stale until the
+    // user manually re-engages. This was reagent P1's finding on the first
+    // review-fix pass (PR #2834) — the original version of this file only
+    // updated the flag from inside scrollToTrueBottom, which is exactly one
+    // of those gated call sites.
+    function syncOverflowState(): void {
+        if (!scrollRef) return;
+        const overflowing = scrollRef.scrollHeight > scrollRef.clientHeight;
+        if (overflowing !== props.viewState.isOverflowing()) {
+            if (overflowing) {
+                props.viewState.markOverflowing();
+            } else {
+                props.viewState.markNotOverflowing();
+            }
+        }
+    }
+
     let lastKnownScrollHeight = 0;
     function scrollToTrueBottom(): void {
         if (!scrollRef) return;
@@ -196,19 +222,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             );
         }
         lastKnownScrollHeight = h;
-        // Keep isOverflowing() current in both directions — this runs on
-        // every re-pin, including RO #2 (content-resize) firing on a pure
-        // SHRINK back to non-overflowing while still stickToBottom()'d, so
-        // a later regrowth past clientHeight is re-armed as a genuine
-        // "first overflow" transition again rather than staying permanently
-        // marked from whatever the pane's actual first overflow was.
-        // See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
-        // (codex P2 on PR #2834).
-        if (h > scrollRef.clientHeight) {
-            props.viewState.markOverflowing();
-        } else {
-            props.viewState.markNotOverflowing();
-        }
+        syncOverflowState();
         pendingProgrammaticScroll = true;
         scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
     }
@@ -509,6 +523,10 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         const _len = props.viewState.nodes().length;
         const _totalSize = props.layoutView?.()?.totalSize;
         const _workingRowHeight = props.workingRowHeight?.();
+        // Unconditional — a node-count drop (e.g. /clear) can collapse this
+        // pane to non-overflowing while scrolled away reading history; see
+        // syncOverflowState's own doc comment.
+        syncOverflowState();
         if (props.viewState.stickToBottom() && scrollRef) {
             // queueMicrotask so the new content has rendered before we scroll.
             queueMicrotask(() => {
@@ -548,6 +566,8 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     onMount(() => {
         const ro = new ResizeObserver(() => {
             const h = scrollRef.clientHeight;
+            // Unconditional — see syncOverflowState's own doc comment.
+            syncOverflowState();
             if (h > 0 && props.viewState.stickToBottom()) {
                 scrollToTrueBottom();
             }
@@ -599,7 +619,10 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     onMount(() => {
         if (typeof ResizeObserver === "undefined") return;
         const ro = new ResizeObserver(() => {
-            if (!scrollRef || !props.viewState.stickToBottom()) return;
+            if (!scrollRef) return;
+            // Unconditional — see syncOverflowState's own doc comment.
+            syncOverflowState();
+            if (!props.viewState.stickToBottom()) return;
             scrollToTrueBottom();
         });
         if (virtualContainerRef) ro.observe(virtualContainerRef);
@@ -729,13 +752,13 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
 
         // This pane's content has overflowed its viewport for the first
         // time since it last didn't (see isOverflowing's own doc comment
-        // for why this isn't a one-time latch). Keep it current regardless
-        // of what we do below — later evaluations need an accurate reading
-        // whether or not THIS event ends up needing protection.
-        const isFirstOverflow = scrollHeight > clientHeight && !props.viewState.isOverflowing();
-        if (isFirstOverflow) {
-            props.viewState.markOverflowing();
-        }
+        // for why this isn't a one-time latch). Capture the PRE-sync
+        // reading for the transition check, then sync unconditionally —
+        // every scroll event is an observation point regardless of
+        // stickToBottom, same as syncOverflowState's other call sites.
+        const wasOverflowing = props.viewState.isOverflowing();
+        syncOverflowState();
+        const isFirstOverflow = scrollHeight > clientHeight && !wasOverflowing;
 
         // Engage stick when user scrolls back near bottom; disengage
         // otherwise. Engaging clears any captured headAnchor (atomic).

--- a/frontend/app/view/agent/virtualization/state.ts
+++ b/frontend/app/view/agent/virtualization/state.ts
@@ -53,6 +53,19 @@ export interface AgentViewState {
     disengageStickToBottom: () => void;
 
     /**
+     * True once this pane's content has overflowed its viewport at least
+     * once (`scrollHeight > clientHeight`). A pane that has never
+     * overflowed cannot have a legitimate "user scrolled away" state —
+     * there is nowhere to have scrolled away to yet — so the view layer
+     * uses this to force-pin the very first overflow transition instead
+     * of trusting whatever geometry a scroll event reports at that
+     * instant. See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md.
+     */
+    hasOverflowedOnce: Accessor<boolean>;
+    /** Idempotent — latches true and stays true for the pane's lifetime. */
+    markOverflowedOnce: () => void;
+
+    /**
      * Captured anchor for restoring scroll position after a prepend
      * (history pagination) or remount (tab switch). null when sticky
      * to bottom or when no anchor has been captured.
@@ -109,6 +122,8 @@ export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): 
     });
 
     const [stickToBottom, setStickToBottom] = createSignal(true);
+    const [hasOverflowedOnce, setHasOverflowedOnce] = createSignal(false);
+    const markOverflowedOnce = () => setHasOverflowedOnce(true);
     const [headAnchor, setHeadAnchor] = createSignal<ScrollAnchor | null>(null);
     const [streamingNodeId, setStreamingNodeId] = createSignal<string | null>(null);
     const [historyReady, setHistoryReady] = createSignal(false);
@@ -152,6 +167,8 @@ export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): 
         stickToBottom,
         engageStickToBottom,
         disengageStickToBottom,
+        hasOverflowedOnce,
+        markOverflowedOnce,
         headAnchor,
         captureHeadAnchor,
         clearHeadAnchor,

--- a/frontend/app/view/agent/virtualization/state.ts
+++ b/frontend/app/view/agent/virtualization/state.ts
@@ -53,17 +53,29 @@ export interface AgentViewState {
     disengageStickToBottom: () => void;
 
     /**
-     * True once this pane's content has overflowed its viewport at least
-     * once (`scrollHeight > clientHeight`). A pane that has never
-     * overflowed cannot have a legitimate "user scrolled away" state —
-     * there is nowhere to have scrolled away to yet — so the view layer
-     * uses this to force-pin the very first overflow transition instead
-     * of trusting whatever geometry a scroll event reports at that
-     * instant. See docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md.
+     * True as of the last-observed geometry that this pane's content
+     * overflowed its viewport (`scrollHeight > clientHeight`). A pane
+     * transitioning from `false` to `true` cannot have a legitimate "user
+     * scrolled away" state — there is nowhere to have scrolled away to
+     * yet — so the view layer uses that specific transition to force-pin
+     * instead of trusting whatever geometry a scroll event reports at
+     * that instant.
+     *
+     * Bidirectional, NOT a one-time latch: `markNotOverflowing()` re-arms
+     * it when content collapses back to non-overflowing (the documented
+     * whole-pane `scrollHeight → 0px` case in
+     * FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md
+     * §3, or a `/clear` emptying the transcript without remounting this
+     * component) — otherwise a still-following pane that lives through
+     * that collapse-and-regrow only gets this protection once, ever,
+     * for its whole mounted lifetime, rather than every time the
+     * transition genuinely recurs. See
+     * docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
+     * (codex P2 on PR #2834).
      */
-    hasOverflowedOnce: Accessor<boolean>;
-    /** Idempotent — latches true and stays true for the pane's lifetime. */
-    markOverflowedOnce: () => void;
+    isOverflowing: Accessor<boolean>;
+    markOverflowing: () => void;
+    markNotOverflowing: () => void;
 
     /**
      * Captured anchor for restoring scroll position after a prepend
@@ -122,8 +134,9 @@ export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): 
     });
 
     const [stickToBottom, setStickToBottom] = createSignal(true);
-    const [hasOverflowedOnce, setHasOverflowedOnce] = createSignal(false);
-    const markOverflowedOnce = () => setHasOverflowedOnce(true);
+    const [isOverflowing, setIsOverflowing] = createSignal(false);
+    const markOverflowing = () => setIsOverflowing(true);
+    const markNotOverflowing = () => setIsOverflowing(false);
     const [headAnchor, setHeadAnchor] = createSignal<ScrollAnchor | null>(null);
     const [streamingNodeId, setStreamingNodeId] = createSignal<string | null>(null);
     const [historyReady, setHistoryReady] = createSignal(false);
@@ -167,8 +180,9 @@ export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): 
         stickToBottom,
         engageStickToBottom,
         disengageStickToBottom,
-        hasOverflowedOnce,
-        markOverflowedOnce,
+        isOverflowing,
+        markOverflowing,
+        markNotOverflowing,
         headAnchor,
         captureHeadAnchor,
         clearHeadAnchor,

--- a/frontend/app/view/agent/virtualization/state.ts
+++ b/frontend/app/view/agent/virtualization/state.ts
@@ -66,12 +66,22 @@ export interface AgentViewState {
      * whole-pane `scrollHeight → 0px` case in
      * FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md
      * §3, or a `/clear` emptying the transcript without remounting this
-     * component) — otherwise a still-following pane that lives through
-     * that collapse-and-regrow only gets this protection once, ever,
-     * for its whole mounted lifetime, rather than every time the
-     * transition genuinely recurs. See
+     * component) — otherwise a pane that lives through that
+     * collapse-and-regrow only gets this protection once, ever, for its
+     * whole mounted lifetime, rather than every time the transition
+     * genuinely recurs.
+     *
+     * The view layer's `syncOverflowState()` is the ONLY thing allowed to
+     * call `markOverflowing`/`markNotOverflowing`, and it runs
+     * unconditionally from every geometry-observation point (every scroll
+     * event, both ResizeObservers, the itemized content-signal effect) —
+     * deliberately NOT gated on `stickToBottom()` already being true, the
+     * way the actual re-pin action (`scrollToTrueBottom()`) is. A pane
+     * scrolled away reading history can still collapse or regrow while
+     * disengaged, and this flag has to track that regardless of whether
+     * anything chooses to act on it. See
      * docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md
-     * (codex P2 on PR #2834).
+     * (codex P2 and reagent P1 on PR #2834).
      */
     isOverflowing: Accessor<boolean>;
     markOverflowing: () => void;


### PR DESCRIPTION
## Summary

- Rare bug: a pane that loads with no content, then finally grows past its viewport for the first time, could get stuck at the top instead of following the tail — the user had to scroll manually or start typing to catch back up.
- Spec: `docs/specs/SPEC_AGENT_PANE_FIRST_OVERFLOW_SCROLL_PIN_FIX_2026_08_29.md`. Root cause isn't fully pinned down (this ties into the still-open `FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_LIVE_INSTANCE_DATA_2026_08_22.md` investigation's unexplained whole-pane 0px collapse — a pane recovering from that collapse re-lives exactly this transition), but the fix doesn't need to wait on that: a pane that has never overflowed can't have a legitimate "user scrolled away" state, since there's nowhere to have scrolled away to yet.
- Fix: latch a `hasOverflowedOnce` flag on `AgentViewState`. The first time a pane's `scrollHeight` exceeds `clientHeight`, force stick-to-bottom regardless of what geometry the triggering scroll event reports — closing off the race where a stray/misleading scroll event on that exact transition could disengage before any of the existing re-pin mechanisms (ResizeObserver, itemized signal effect) get a chance to correct it.
- Added a `[wave-scroll-first-overflow]` diagnostic line (same convention as the existing `[wave-scroll]`/`[wave-scroll-shrink]` tracing) so a future live-instance telemetry pull can confirm whether user reports of this correlate with the known 0px collapse or are a distinct mechanism.
- Closed a real test-coverage gap: neither existing scroll test exercised content growing past the viewport for the first time via content-only resize (as opposed to container resize). Added 3 tests to `AgentDocumentVirtualList.resize.test.tsx`; verified the two behavior-asserting tests actually fail without the fix (stashed the fix, confirmed 2/8 failures, restored it).

## Test plan

- [x] `npx vitest run frontend/app/view/agent/virtualization/` — 131/131 passing
- [x] `npx tsc --noEmit` — clean
- [x] Manually verified the two new regression tests fail without the fix (temporarily stashed `state.ts`/`AgentDocumentVirtualList.tsx`, reran, confirmed 2 failures, restored)

<!-- agentmux:agent_id=lark -->