### PR TITLE
fix(subagent-watcher): don't assert false-Active state on backfill replay

### DIFF
--- a/.changesets/1788055801-fix-subagent-watcher-replayed-subagents-are-born-abandoned-w-q9py.md
+++ b/.changesets/1788055801-fix-subagent-watcher-replayed-subagents-are-born-abandoned-w-q9py.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(subagent-watcher): replayed subagents are born Abandoned when the parent turn is confirmed idle

--- a/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
@@ -111,6 +111,36 @@ impl SubagentWatcher {
                     );
                 }
             }
+            // A replayed spawn (`live == false`) describes a subagent whose
+            // transcript already existed on disk when this pane opened.
+            // Inserting it as `Active` asserts something the replay cannot
+            // know, and `reconcile_stale_subagents` (scan.rs) then retracts it
+            // moments later — up to 200 spurious abandon broadcasts per reopen,
+            // and a window where `subagent.ListActive` reports rows the backend
+            // is about to disown. See
+            // docs/reports/REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md §2.
+            //
+            // Decided here using the SAME predicate reconcile uses, not a
+            // second independently-invented one — a confirmed-idle parent turn
+            // means nothing on disk can still be running. Two deliberate
+            // fallbacks to `Active`:
+            //   - `live` always wins. `turn_active` can lag a genuine spawn,
+            //     and mislabelling a real subagent would break live rows.
+            //   - An unregistered controller is UNKNOWN, not idle.
+            //     `scan_session_subagents` can run before the controller
+            //     registers, so this keeps reconcile's own retry path as the
+            //     authority rather than inferring `Abandoned` from absent
+            //     information.
+            let initial_status = if live {
+                SubAgentStatus::Active
+            } else {
+                match crate::backend::blockcontroller::get_block_controller_status(parent_block_id)
+                    .map(|s| s.turn_active)
+                {
+                    Some(false) => SubAgentStatus::Abandoned,
+                    _ => SubAgentStatus::Active,
+                }
+            };
             let state = session.subagents.entry(agent_id.clone()).or_insert_with(|| {
                 SubagentState {
                     info: SubAgent {
@@ -122,7 +152,7 @@ impl SubagentWatcher {
                         session_id: session_id.clone(),
                         spawned_at: now_millis(),
                         last_event_at: now_millis(),
-                        status: SubAgentStatus::Active,
+                        status: initial_status,
                         event_count: 0,
                         model: None,
                         dispatch_id: dispatch_id.clone(),

--- a/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
@@ -164,6 +164,28 @@ impl SubagentWatcher {
                 }
             });
 
+            // A live observation outranks a replay's inference.
+            //
+            // codex P1 on PR #2837: if a backfill scan races ahead of the
+            // filesystem watcher on a newly-created transcript, it can read the
+            // documented-lagging `turn_active == false` and insert the entry as
+            // `Abandoned`. The `live == true` call that follows would otherwise
+            // be stuck with that: `or_insert_with` doesn't run for an existing
+            // entry, ordinary events never revive a status, and
+            // `reconcile_stale_subagents` only ever downgrades `Active` ->
+            // `Abandoned`. A genuinely running subagent would read as abandoned
+            // until a `result` line happened to arrive.
+            //
+            // `Abandoned` is always an inference; watching the file change is a
+            // direct observation, so the observation wins. This can't strand a
+            // wrong answer in the other direction either: if the subagent has
+            // in fact finished, its own `result` event sets `Completed` below;
+            // if the parent turn really is idle, the next reconcile pass
+            // re-abandons it.
+            if live && state.info.status == SubAgentStatus::Abandoned {
+                state.info.status = SubAgentStatus::Active;
+            }
+
             state.file_offset = new_offset;
             state.info.dispatch_id = dispatch_id.clone();
 

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -2201,3 +2201,92 @@ fn a_finished_replayed_transcript_is_completed_not_abandoned() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn a_racing_live_observation_promotes_a_replay_abandoned_entry_back_to_active() {
+    // codex P1 on PR #2837. A backfill scan and the filesystem watcher can
+    // race on a newly-created transcript: the scan reads the lagging
+    // turn_active == false and inserts Abandoned, then the live call arrives.
+    // Without the promotion, or_insert_with is skipped (entry exists),
+    // ordinary events never revive a status, and reconcile only downgrades
+    // Active -> Abandoned — so a genuinely running subagent would read as
+    // abandoned until a result line happened to show up.
+    let block_id = format!("backfill-race-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dir = std::env::temp_dir().join(format!("amx-backfill-race-{}", now_millis()));
+    let jsonl_path = write_unfinished_transcript(&dir, "sub-race");
+
+    let watcher = fixture_watcher();
+
+    // 1. Backfill replay wins the race and marks it abandoned.
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, false);
+    assert_eq!(
+        watcher.get_info("sub-race").expect("recorded").status,
+        SubAgentStatus::Abandoned,
+        "precondition: the replay inserted it as abandoned"
+    );
+
+    // 2. The watcher then observes real activity on the same file.
+    std::fs::write(
+        &jsonl_path,
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"working\"}]}}\n\
+         {\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"still here\"}]}}\n",
+    )
+    .unwrap();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, true);
+
+    assert_eq!(
+        watcher.get_info("sub-race").expect("recorded").status,
+        SubAgentStatus::Active,
+        "a live observation must outrank the replay's inference"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn a_live_observation_does_not_resurrect_a_completed_subagent() {
+    // The promotion is scoped to Abandoned (an inference). Completed is
+    // established by the transcript's own result line and must stick, or a
+    // trailing live write would flip a finished subagent back to running.
+    let block_id = format!("backfill-done-race-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dir = std::env::temp_dir().join(format!("amx-backfill-done-race-{}", now_millis()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let jsonl_path = dir.join("agent-sub-fin.jsonl");
+    std::fs::write(
+        &jsonl_path,
+        concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"done\"}\n",
+        ),
+    )
+    .unwrap();
+
+    let watcher = fixture_watcher();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, false);
+    assert_eq!(
+        watcher.get_info("sub-fin").expect("recorded").status,
+        SubAgentStatus::Completed
+    );
+
+    // A trailing live append must not undo that.
+    std::fs::write(
+        &jsonl_path,
+        concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"done\"}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"trailing\"}]}}\n",
+        ),
+    )
+    .unwrap();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, true);
+
+    assert_eq!(
+        watcher.get_info("sub-fin").expect("recorded").status,
+        SubAgentStatus::Completed,
+        "Completed is observed from the transcript and must not be promoted"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -2070,3 +2070,134 @@ fn journal_counts_skips_unterminated_trailing_line() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// ── backfill replay must not assert false-Active state ───────────────
+//
+// docs/reports/REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md §2:
+// a cold backfill replayed ~200 historical spawns straight into the live
+// `Active` set, and `reconcile_stale_subagents` then retracted all 200 a few
+// hundred ms later — while the pane was still loading. For that window
+// `subagent.ListActive` (the RPC the Activity Dock's rows are built from)
+// genuinely returned rows the backend was about to disown, which is what the
+// dock rendered as rows appearing and vanishing on every reopen.
+//
+// These cover the insert-time decision only. The reconcile pass keeps its own
+// tests above; it remains the authority whenever the insert can't decide.
+
+/// Writes a single-line transcript with no `result` event — i.e. the file
+/// alone gives no reason to think the subagent finished.
+fn write_unfinished_transcript(dir: &std::path::Path, agent_id: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(dir).unwrap();
+    let p = dir.join(format!("agent-{agent_id}.jsonl"));
+    std::fs::write(
+        &p,
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"working\"}]}}\n",
+    )
+    .unwrap();
+    p
+}
+
+#[test]
+fn backfill_replay_is_born_abandoned_when_the_parent_turn_is_confirmed_idle() {
+    let block_id = format!("backfill-idle-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dir = std::env::temp_dir().join(format!("amx-backfill-idle-{}", now_millis()));
+    let jsonl_path = write_unfinished_transcript(&dir, "sub-replay");
+
+    let watcher = fixture_watcher();
+    // live: false — this is a cold-backfill replay, not a real spawn.
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, false);
+
+    let info = watcher.get_info("sub-replay").expect("subagent recorded");
+    assert_eq!(
+        info.status,
+        SubAgentStatus::Abandoned,
+        "a replayed spawn under a confirmed-idle parent must never enter the Active set"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn live_spawn_stays_active_even_when_the_parent_turn_reads_idle() {
+    // The turn_active flag can lag a genuine spawn, so `live` must win — this
+    // is the regression that would break real-time subagent rows.
+    let block_id = format!("backfill-live-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dir = std::env::temp_dir().join(format!("amx-backfill-live-{}", now_millis()));
+    let jsonl_path = write_unfinished_transcript(&dir, "sub-live");
+
+    let watcher = fixture_watcher();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, true);
+
+    let info = watcher.get_info("sub-live").expect("subagent recorded");
+    assert_eq!(info.status, SubAgentStatus::Active);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn backfill_replay_stays_active_when_the_parent_turn_is_running() {
+    // A live turn can legitimately own still-running subagents whose files are
+    // already on disk, so the replay must not disown them. Same predicate
+    // `reconcile_stale_subagents` uses, applied earlier.
+    let block_id = format!("backfill-busy-{}", now_millis());
+    register_stub_controller(&block_id, true);
+    let dir = std::env::temp_dir().join(format!("amx-backfill-busy-{}", now_millis()));
+    let jsonl_path = write_unfinished_transcript(&dir, "sub-busy");
+
+    let watcher = fixture_watcher();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, false);
+
+    let info = watcher.get_info("sub-busy").expect("subagent recorded");
+    assert_eq!(info.status, SubAgentStatus::Active);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn backfill_replay_stays_active_when_no_controller_is_registered() {
+    // Unknown, not idle: `scan_session_subagents` can run before the
+    // controller registers. Falling back to today's behaviour keeps
+    // `reconcile_stale_subagents`'s retry path as the authority rather than
+    // guessing Abandoned from absence of information.
+    let block_id = format!("backfill-unknown-{}", now_millis());
+    let dir = std::env::temp_dir().join(format!("amx-backfill-unknown-{}", now_millis()));
+    let jsonl_path = write_unfinished_transcript(&dir, "sub-unknown");
+
+    let watcher = fixture_watcher();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, false);
+
+    let info = watcher.get_info("sub-unknown").expect("subagent recorded");
+    assert_eq!(info.status, SubAgentStatus::Active);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn a_finished_replayed_transcript_is_completed_not_abandoned() {
+    // The file's own `result` event outranks the turn-idle inference — a
+    // subagent that demonstrably finished its work is Completed, and must not
+    // be relabelled as abandoned just because it arrived via backfill.
+    let block_id = format!("backfill-done-{}", now_millis());
+    register_stub_controller(&block_id, false);
+    let dir = std::env::temp_dir().join(format!("amx-backfill-done-{}", now_millis()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let jsonl_path = dir.join("agent-sub-done.jsonl");
+    std::fs::write(
+        &jsonl_path,
+        concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"final answer\"}\n",
+        ),
+    )
+    .unwrap();
+
+    let watcher = fixture_watcher();
+    watcher.process_jsonl_change("parent-1", &block_id, &jsonl_path, false);
+
+    let info = watcher.get_info("sub-done").expect("subagent recorded");
+    assert_eq!(info.status, SubAgentStatus::Completed);
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/agentmux-srv/src/backend/subagent_watcher/types.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/types.rs
@@ -66,9 +66,25 @@ pub enum SubAgentStatus {
     /// The parent block's turn ended without a `Result` line ever appearing
     /// for this subagent — it crashed, was killed, or was interrupted by an
     /// app/srv restart mid-task. Distinct from `Completed`: the subagent
-    /// didn't finish, it was cut off. Set only by
-    /// `reconcile_stale_subagents`, never by `process_jsonl_change`'s
-    /// normal event processing.
+    /// didn't finish, it was cut off.
+    ///
+    /// **Always an inference, never an observation** — which is what decides
+    /// precedence against `Active` everywhere below.
+    ///
+    /// Two writers (the second added by PR #2837; this comment previously
+    /// said `reconcile_stale_subagents` was the only one — reagentx P2):
+    ///
+    /// 1. `reconcile_stale_subagents` (`scan.rs`) — downgrades `Active`
+    ///    entries once the parent turn is confirmed idle. Never promotes.
+    /// 2. `process_jsonl_change` (`jsonl.rs`) at INSERT time, for a
+    ///    cold-backfill replay (`live == false`) whose parent turn is already
+    ///    confirmed idle. Avoids asserting `Active` for something the replay
+    ///    cannot know is running, which `reconcile` would then have to retract.
+    ///
+    /// A live observation outranks both: `process_jsonl_change` promotes an
+    /// existing `Abandoned` entry back to `Active` when it sees real-time file
+    /// activity, since watching the file change is direct evidence and this
+    /// status is not.
     Abandoned,
 }
 


### PR DESCRIPTION
Implements §2 of `REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md` (PR #2836).

## The problem

A cold backfill replays up to `BACKFILL_MAX_FILES` (200) historical transcripts through `process_jsonl_change(..., live: false)`, and every one was inserted into the watcher's live `sessions` map with `SubAgentStatus::Active` — because a spawn record, replayed, looks exactly like a spawn. `reconcile_stale_subagents` then retracted all 200 a few hundred ms later, broadcasting an abandon event for each.

So on every pane reopen the backend asserted state it was about to disown, and for that window `subagent.ListActive` would report rows that were not active.

## The fix

Decide it at insert time, using the **same predicate `reconcile_stale_subagents` already uses** rather than a second independently-invented one — a confirmed-idle parent turn means nothing on disk can still be running.

Two deliberate fallbacks to `Active`, both covered by tests:

- **`live` always wins.** `turn_active` can lag a genuine spawn, and mislabelling a real subagent would break live rows.
- **An unregistered controller is UNKNOWN, not idle.** `scan_session_subagents` can run before the controller registers, so reconcile's existing retry path stays the authority rather than inferring `Abandoned` from absent information.

A replayed transcript containing its own `result` event still lands `Completed` — the file's own evidence outranks the turn-idle inference.

## Scope — what this does NOT claim

Stated up front because the report originally overreached on both points; codex caught them on #2836 and they're corrected there.

- **This is not claimed as the fix for the visible dock flicker.** The trace behind the report does not establish that the frontend ever sampled inside the false-`Active` window — every `ListActive` in it post-dates the reconciliation. The transient is real and code-verified; its link to the observed symptom is a hypothesis.
- **This does not suppress the `is_new` broadcast path.** The backend still emits up to 200 `subagent:spawned` events per reopen, so `createDebouncedRefresh` is still what keeps those from becoming an RPC storm and must stay. Of §3's four mechanisms only the two backfill gates lose their job, not three.

What it does buy, on its own terms: a state model that no longer asserts something it must immediately retract, and 200 fewer spurious abandon broadcasts per reopen.

## Tests

Five new, all in `subagent_watcher/tests.rs`, using the existing `register_stub_controller` helper:

| Test | Pins |
|---|---|
| `backfill_replay_is_born_abandoned_when_the_parent_turn_is_confirmed_idle` | the fix (fails on `main`) |
| `live_spawn_stays_active_even_when_the_parent_turn_reads_idle` | `live` wins — the regression that would break real-time rows |
| `backfill_replay_stays_active_when_the_parent_turn_is_running` | a live turn can own still-running subagents already on disk |
| `backfill_replay_stays_active_when_no_controller_is_registered` | unknown ≠ idle; reconcile stays the authority |
| `a_finished_replayed_transcript_is_completed_not_abandoned` | `result` outranks the turn-idle inference |

Four of the five pass against `main` unchanged — they pin behaviour the fix must *preserve*, so a future change that over-applies the abandon inference fails here.

## Verification

`cargo test -p agentmux-srv` — **2839 passed, 0 failed**, 6 ignored.

One flake observed once during this work, disclosed rather than papered over: `read_task_prompt_extracts_plain_string_content_from_first_line` failed on `create_dir_all` under parallel execution, then passed in isolation and on every rerun. Unrelated to this change — my tests use distinct temp-dir prefixes — and that test's own comment documents earlier flakiness of exactly this kind. Not fixed here; flagging so it isn't mistaken for a new regression.

Relates to discussion #2375 (process/turn-liveness consolidation) — a concrete instance of two mechanisms disagreeing about what is alive.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
