### PR TITLE
Camper@claudius: fix(agent-pane): anchor the model selector and Shell to the composer strip's bottom row

### DIFF
--- a/.changesets/1788056148-fix-agent-pane-anchor-the-model-selector-and-shell-to-the-co-yn23.md
+++ b/.changesets/1788056148-fix-agent-pane-anchor-the-model-selector-and-shell-to-the-co-yn23.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): anchor the model selector and Shell to the composer strip's bottom row

--- a/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
@@ -512,10 +512,15 @@ describe("computeComposerRows — anchored model selector + Shell (Rev 8)", () =
         expect(oneSided.length).toBeLessThanOrEqual(1);
     });
 
-    it("anchors that cannot share a line degrade to two ADJACENT one-sided rows, still bottom-most", () => {
+    it("keeps the anchors on ONE row even when they cannot fit side by side (reagent P1, PR #2839)", () => {
         // runtime(120) + hostShell(120) + gap(5) = 245 > availableWidth
-        // 200 — the physical-capacity exception (spec §1). They must not
-        // be forced onto one overflowing row, but must still not travel.
+        // 200. An earlier revision split these into two adjacent one-sided
+        // rows via the generic physical-capacity exception — but only the
+        // LAST row is hoisted out of the render's <For>, so that put
+        // `runtime` back inside it and destroyed AgentRuntimeDropup on any
+        // resize across the split boundary. The row's own flex-wrap
+        // renders the same two visual lines without moving either anchor
+        // between DOM subtrees, so the row must stay singular here.
         const slots = [
             { key: "runtime", width: 120 },
             { key: "w1", width: 100 },
@@ -523,10 +528,31 @@ describe("computeComposerRows — anchored model selector + Shell (Rev 8)", () =
             { key: "hostShell", width: 120 },
         ];
         const rows = computeComposerRows(slots, "hostShell", 200, 5, "runtime");
-        expect(rows.slice(-2)).toEqual([
-            { left: ["runtime"], right: [] },
-            { left: [], right: ["hostShell"] },
-        ]);
+        expect(rows[rows.length - 1]).toEqual({ left: ["runtime"], right: ["hostShell"] });
+    });
+
+    it("the anchors share exactly one row at EVERY width, so neither can change rows on resize", () => {
+        // The property the P1 above is really about: sweep a wide range of
+        // available widths and assert the anchors are always together on
+        // the final row. If that holds everywhere, no resize can ever move
+        // them between the hoisted element and a <For> index.
+        const slots = [
+            { key: "runtime", width: 120 },
+            { key: "w1", width: 100 },
+            { key: "w2", width: 90 },
+            { key: "auth", width: 40 },
+            { key: "hostShell", width: 120 },
+        ];
+        for (const availableWidth of [1000, 700, 500, 400, 300, 240, 200, 150, 100, 50]) {
+            const rows = computeComposerRows(slots, "hostShell", availableWidth, 5, "runtime");
+            const last = rows[rows.length - 1];
+            expect(last.left).toContain("runtime");
+            expect(last.right).toContain("hostShell");
+            for (const r of rows.slice(0, -1)) {
+                expect([...r.left, ...r.right]).not.toContain("runtime");
+                expect([...r.left, ...r.right]).not.toContain("hostShell");
+            }
+        }
     });
 
     it("falls back to the pre-anchor behavior when the model selector is absent (controls hidden)", () => {

--- a/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
@@ -16,6 +16,7 @@ import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ComposerRow } from "./AgentComposerStrip";
 import { AgentComposerStrip, computeBalancedLeftKeys, computeComposerRows, computeStatsInline, orderKeysForEdgePriority } from "./AgentComposerStrip";
 
 // AgentRuntimeDropup (rendered via showControls()) imports this — same mock
@@ -414,6 +415,153 @@ describe("computeComposerRows", () => {
         const oneSidedCount = rows.filter((r) => r.left.length === 0 || r.right.length === 0).length;
         const maxAllowed = slots.length % 2 === 1 ? 1 : 0;
         expect(oneSidedCount).toBeLessThanOrEqual(maxAllowed);
+    });
+});
+
+/**
+ * Rev 8 (2026-08-29, user-directed): the model selector (`runtime`) and
+ * the Shell toggle (`hostShell`) must never travel as the pane resizes.
+ * Both anchor to the BOTTOM row — nearest the composer input — with the
+ * model selector on its left and Shell on its right. In the single-row
+ * case there is no "bottom," so the constraint degrades to its positional
+ * meaning: outermost-left and outermost-right of the one row.
+ *
+ * This deliberately reverses the "the model selector moving sides is
+ * acceptable" call recorded in
+ * docs/retro/retro-composer-strip-one-sided-lines-misdiagnosis-2026-08-26.md
+ * step 3, which dismissed it once as cosmetic.
+ */
+describe("computeComposerRows — anchored model selector + Shell (Rev 8)", () => {
+    const lastRow = (rows: ComposerRow[]) => rows[rows.length - 1];
+
+    it("single row: the model selector is the outermost LEFT occupant, Shell the outermost RIGHT", () => {
+        const slots = [
+            { key: "runtime", width: 60 },
+            { key: "auth", width: 40 },
+            { key: "ctx", width: 40 },
+            { key: "hostShell", width: 50 },
+        ];
+        const rows = computeComposerRows(slots, "hostShell", 500, 5, "runtime");
+        expect(rows).toHaveLength(1);
+        expect(rows[0].left[0]).toBe("runtime");
+        expect(rows[0].right[rows[0].right.length - 1]).toBe("hostShell");
+    });
+
+    it("single row: the model selector stays LEFT even when pure width-balance would move it right", () => {
+        // Widths chosen so the UNANCHORED balancer genuinely prefers
+        // runtime on the right: one wide passive slot alone on the left
+        // (100) balances runtime+hostShell (10+10) better than any split
+        // that keeps runtime left. That's exactly the "model selector
+        // travelled sides" regression the retro dismissed as cosmetic and
+        // this constraint now forbids.
+        const slots = [
+            { key: "runtime", width: 10 },
+            { key: "wide", width: 100 },
+            { key: "hostShell", width: 10 },
+        ];
+        const unanchored = computeComposerRows(slots, "hostShell", 500, 5);
+        expect(unanchored[0].left).not.toContain("runtime");
+        expect(unanchored[0].right).toContain("runtime");
+
+        const anchored = computeComposerRows(slots, "hostShell", 500, 5, "runtime");
+        expect(anchored[0].left[0]).toBe("runtime");
+        expect(anchored[0].right.at(-1)).toBe("hostShell");
+    });
+
+    it("multi-row: the anchors are reserved as the LAST row, model selector left / Shell right", () => {
+        const slots = [
+            { key: "runtime", width: 60 },
+            { key: "w1", width: 100 },
+            { key: "w2", width: 80 },
+            { key: "w3", width: 40 },
+            { key: "hostShell", width: 50 },
+        ];
+        const rows = computeComposerRows(slots, "hostShell", 200, 5, "runtime");
+        expect(lastRow(rows)).toEqual({ left: ["runtime"], right: ["hostShell"] });
+    });
+
+    it("multi-row: neither anchor ever appears in any row but the last", () => {
+        const slots = [
+            { key: "runtime", width: 60 },
+            { key: "w1", width: 100 },
+            { key: "w2", width: 80 },
+            { key: "w3", width: 40 },
+            { key: "hostShell", width: 50 },
+        ];
+        const rows = computeComposerRows(slots, "hostShell", 200, 5, "runtime");
+        for (const row of rows.slice(0, -1)) {
+            expect([...row.left, ...row.right]).not.toContain("runtime");
+            expect([...row.left, ...row.right]).not.toContain("hostShell");
+        }
+    });
+
+    it("reserving exactly two anchors preserves parity — the singleton budget is unchanged", () => {
+        // 5 slots (odd) → still at most ONE one-sided row, even though 2
+        // of them are now reserved out of the pairing pool. Reserving a
+        // PAIR can't flip the remainder's parity; that's why the anchor
+        // constraint doesn't weaken spec §1.
+        const slots = [
+            { key: "runtime", width: 60 },
+            { key: "w1", width: 100 },
+            { key: "w2", width: 80 },
+            { key: "w3", width: 40 },
+            { key: "hostShell", width: 50 },
+        ];
+        const rows = computeComposerRows(slots, "hostShell", 200, 5, "runtime");
+        const oneSided = rows.filter((r) => r.left.length === 0 || r.right.length === 0);
+        expect(oneSided.length).toBeLessThanOrEqual(1);
+    });
+
+    it("anchors that cannot share a line degrade to two ADJACENT one-sided rows, still bottom-most", () => {
+        // runtime(120) + hostShell(120) + gap(5) = 245 > availableWidth
+        // 200 — the physical-capacity exception (spec §1). They must not
+        // be forced onto one overflowing row, but must still not travel.
+        const slots = [
+            { key: "runtime", width: 120 },
+            { key: "w1", width: 100 },
+            { key: "w2", width: 90 },
+            { key: "hostShell", width: 120 },
+        ];
+        const rows = computeComposerRows(slots, "hostShell", 200, 5, "runtime");
+        expect(rows.slice(-2)).toEqual([
+            { left: ["runtime"], right: [] },
+            { left: [], right: ["hostShell"] },
+        ]);
+    });
+
+    it("falls back to the pre-anchor behavior when the model selector is absent (controls hidden)", () => {
+        const slots = [
+            { key: "w1", width: 100 },
+            { key: "w2", width: 80 },
+            { key: "w3", width: 60 },
+            { key: "hostShell", width: 50 },
+        ];
+        // Same pool, same widths, with and without an anchorLeftKey that
+        // matches nothing — identical output, so hiding the runtime slot
+        // can never change how the remaining slots lay out.
+        expect(computeComposerRows(slots, "hostShell", 200, 5, "runtime")).toEqual(
+            computeComposerRows(slots, "hostShell", 200, 5),
+        );
+    });
+
+    it("keeps Shell rightmost on the last row across a wide→narrow→wide round-trip", () => {
+        // Round-trip, not a one-way sweep — the exact verification shape
+        // PR #2814's one-way-trap regression proved is necessary here.
+        const slots = [
+            { key: "runtime", width: 60 },
+            { key: "w1", width: 100 },
+            { key: "w2", width: 80 },
+            { key: "hostShell", width: 50 },
+        ];
+        const wide = computeComposerRows(slots, "hostShell", 500, 5, "runtime");
+        const narrow = computeComposerRows(slots, "hostShell", 200, 5, "runtime");
+        const wideAgain = computeComposerRows(slots, "hostShell", 500, 5, "runtime");
+
+        expect(wide).toEqual(wideAgain);
+        expect(lastRow(wide).right.at(-1)).toBe("hostShell");
+        expect(lastRow(narrow).right.at(-1)).toBe("hostShell");
+        expect(lastRow(wide).left[0]).toBe("runtime");
+        expect(lastRow(narrow).left[0]).toBe("runtime");
     });
 });
 

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -1240,7 +1240,25 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     // change how many rows exist. Iterating `rows()` objects directly
     // would repeat the exact reagent-P1 identity bug the slot-level fix
     // above already fixed, one level up.
-    const rowIndices = createMemo(() => rows().map((_, i) => i));
+    //
+    // The LAST row is deliberately NOT part of this list — it renders from
+    // its own fixed element below (Codex P2, PR #2839). `<For>` over
+    // indices only preserves a subtree while the row COUNT is unchanged:
+    // crossing 1 row -> 2 rows makes index 1 a brand-new subtree, so any
+    // slot moving into it is destroyed and rebuilt. That is exactly what
+    // the Rev 8 anchor constraint forces on `runtime`/`hostShell` (they're
+    // in the sole row at index 0 when single-row, the last row at index
+    // N-1 when multi-row), and `AgentRuntimeDropup` keeps its open/
+    // selectedOptIndex state in component-local signals — so resizing a
+    // pane across that boundary with the model menu open silently closed
+    // it and lost keyboard selection. Verified live over CDP: pre-change
+    // the trigger node survived the crossing, with the anchor constraint
+    // it did not. Hoisting the anchors' row out of the `<For>` gives them
+    // one stable home for every row count, which is the DOM expression of
+    // the same "these two never travel" requirement the constraint states
+    // at the layout level.
+    const precedingRowIndices = createMemo(() => rows().slice(0, -1).map((_, i) => i));
+    const lastRowIndex = createMemo(() => rows().length - 1);
 
     const renderSlot = (key: string, rowSide: "left" | "right") => {
         // untrack: see `slotByKey`'s own doc comment above — without
@@ -1323,19 +1341,39 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
             <Show when={!statsInline()}>{statsZone("multi")}</Show>
 
             <div class="agent-composer-strip-rows" ref={rowsRef}>
-                <For each={rowIndices()}>
+                <For each={precedingRowIndices()}>
                     {(rowIndex) => (
                         <div class="agent-composer-strip-row">
                             <span class="agent-composer-strip-row-left">
                                 <For each={rows()[rowIndex]?.left ?? []}>{(key) => renderSlot(key, "left")}</For>
                             </span>
-                            <Show when={statsInline()}>{statsZone("single")}</Show>
                             <span class="agent-composer-strip-row-right">
                                 <For each={rows()[rowIndex]?.right ?? []}>{(key) => renderSlot(key, "right")}</For>
                             </span>
                         </div>
                     )}
                 </For>
+                {/* The anchors' row, rendered from its own fixed element
+                    rather than as the `<For>`'s last entry — see
+                    `precedingRowIndices`'s doc comment (Codex P2, PR
+                    #2839). This is the row `runtime`/`hostShell` always
+                    occupy (the sole row when single-row, the bottom row
+                    when multi-row), so keeping it one stable subtree is
+                    what preserves `AgentRuntimeDropup`'s open state across
+                    a resize that changes the row count. The inline stats
+                    zone lives here too: `statsInline()` is only ever true
+                    at one row, and at one row this IS that row. */}
+                <Show when={rows().length > 0}>
+                    <div class="agent-composer-strip-row">
+                        <span class="agent-composer-strip-row-left">
+                            <For each={rows()[lastRowIndex()]?.left ?? []}>{(key) => renderSlot(key, "left")}</For>
+                        </span>
+                        <Show when={statsInline()}>{statsZone("single")}</Show>
+                        <span class="agent-composer-strip-row-right">
+                            <For each={rows()[lastRowIndex()]?.right ?? []}>{(key) => renderSlot(key, "right")}</For>
+                        </span>
+                    </div>
+                </Show>
             </div>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -157,6 +157,7 @@ import { RuntimeBadge } from "./RuntimeBadge";
 export function computeBalancedLeftKeys(
     movable: { key: string; width: number }[],
     fixedRightWidth: number,
+    fixedLeftWidth = 0,
 ): Set<string> {
     const n = movable.length;
     const totalMovable = movable.reduce((sum, m) => sum + m.width, 0);
@@ -176,9 +177,17 @@ export function computeBalancedLeftKeys(
         // applied by the caller (zones() below) as a uniform override
         // regardless of which path (measured or fallback) produced the
         // split, so it's deliberately not special-cased again here.
-        if (leftKeys.size === 0) continue;
+        //
+        // `fixedLeftWidth > 0` (the anchored model selector — see
+        // `computeComposerRows`'s `anchorLeftKey`) means the left side is
+        // already occupied by something this search can't move, so an
+        // empty movable-left is a legitimate, genuinely-balanced answer
+        // rather than a dead zone. Without this carve-out the anchor
+        // would drag an arbitrary extra slot leftward purely to satisfy a
+        // rule that exists to prevent emptiness the anchor already prevents.
+        if (leftKeys.size === 0 && fixedLeftWidth === 0) continue;
         const rightWidth = fixedRightWidth + (totalMovable - leftWidth);
-        const diff = Math.abs(leftWidth - rightWidth);
+        const diff = Math.abs(fixedLeftWidth + leftWidth - rightWidth);
         if (diff < bestDiff) {
             bestDiff = diff;
             best = leftKeys;
@@ -220,6 +229,28 @@ export interface ComposerRow {
  *     END of the row list — "Shell always outermost" (Rev 4/5/6),
  *     expressed here as "always the last row's right occupant."
  *
+ * ANCHORED ELEMENTS (2026-08-29, user-directed — Rev 8). Two slots must
+ * never travel as the pane resizes: the model selector (`anchorLeftKey`,
+ * the `runtime` dropup) and the Shell toggle (`hostShellKey`). Both are
+ * pinned to the BOTTOM — nearest the composer input:
+ *
+ *   - Multi-row: they are reserved OUT of the pairing pool and emitted as
+ *     the final row, `{left: [anchor], right: [hostShell]}`. Reserving
+ *     exactly two slots preserves the remainder's parity, so §1's "at most
+ *     one singleton row" is unaffected.
+ *   - Single row: there is no "bottom" to speak of, so the constraint
+ *     degrades to its positional meaning — the anchor is the outermost
+ *     LEFT occupant, hostShell the outermost RIGHT one, on the one row
+ *     that exists.
+ *   - If the two anchors cannot physically share a line, the same
+ *     physical-capacity exception that governs any other pair applies:
+ *     two adjacent one-sided rows, still bottom-most, rather than an
+ *     overflowing row that `flex-wrap` would split anyway.
+ *
+ * This deliberately reverses the earlier "the model selector moving sides
+ * is acceptable" call recorded in the retro's step 3 — it was dismissed
+ * once as cosmetic and has now been made a hard constraint.
+ *
  * Deliberately a sort + two-pointer walk, not a search — the smallest
  * mechanism that can satisfy the invariant, matching this file's own
  * repeated lesson (SPEC_COMPOSER_STRIP_DYNAMIC_BALANCE_2026_08_24.md's
@@ -259,24 +290,47 @@ export function computeComposerRows(
     hostShellKey: string,
     availableWidth: number,
     gapPx: number,
+    anchorLeftKey?: string,
 ): ComposerRow[] {
     if (slots.length === 0) return [];
 
+    const anchorLeft = anchorLeftKey ? slots.find((s) => s.key === anchorLeftKey) : undefined;
+    const hostShell = slots.find((s) => s.key === hostShellKey);
+
     const totalWidth = slots.reduce((sum, s) => sum + s.width, 0) + Math.max(0, slots.length - 1) * gapPx;
     if (totalWidth <= availableWidth) {
-        const movable = slots.filter((s) => s.key !== hostShellKey);
-        const hostShellWidth = slots.find((s) => s.key === hostShellKey)?.width ?? 0;
-        const leftKeys = computeBalancedLeftKeys(movable, hostShellWidth);
+        // Single row: the anchors are the OUTERMOST occupant of their own
+        // side rather than a whole reserved row (there is only one row —
+        // "forget the top, it's just left and right respectively").
+        const movable = slots.filter((s) => s.key !== hostShellKey && s.key !== anchorLeft?.key);
+        const leftKeys = computeBalancedLeftKeys(movable, hostShell?.width ?? 0, anchorLeft?.width ?? 0);
         return [
             {
-                left: slots.filter((s) => leftKeys.has(s.key)).map((s) => s.key),
-                right: slots.filter((s) => !leftKeys.has(s.key)).map((s) => s.key),
+                left: [
+                    ...(anchorLeft ? [anchorLeft.key] : []),
+                    ...movable.filter((s) => leftKeys.has(s.key)).map((s) => s.key),
+                ],
+                right: [
+                    ...movable.filter((s) => !leftKeys.has(s.key)).map((s) => s.key),
+                    ...(hostShell ? [hostShell.key] : []),
+                ],
             },
         ];
     }
 
-    const sorted = [...slots].sort((a, b) => b.width - a.width);
-    const pairs: [string, string | undefined][] = [];
+    // Multi-row. When BOTH anchors exist they are reserved out of the
+    // pairing pool entirely and emitted as the final row, so neither one
+    // travels between rows as the pane resizes (the whole point of the
+    // constraint). Reserving exactly TWO slots preserves the parity of
+    // what's left, so spec §1's "at most one singleton row" still holds
+    // unchanged — pairing 2 fewer slots can't turn an even remainder odd.
+    const anchorsReserved = Boolean(anchorLeft && hostShell);
+    const pool = anchorsReserved
+        ? slots.filter((s) => s.key !== anchorLeft!.key && s.key !== hostShellKey)
+        : slots;
+
+    const sorted = [...pool].sort((a, b) => b.width - a.width);
+    const pairs: [string | undefined, string | undefined][] = [];
     let i = 0;
     let j = sorted.length - 1;
     while (i < j) {
@@ -293,18 +347,36 @@ export function computeComposerRows(
         pairs.push([sorted[i].key, undefined]);
     }
 
-    // hostShellKey is always present in `slots` by construction (the
-    // component always includes it in the pool passed here) — reorient
-    // whichever pair it landed in so it's the RIGHT occupant, then move
-    // that pair to the end.
-    const hostPairIdx = pairs.findIndex(([a, b]) => a === hostShellKey || b === hostShellKey);
-    if (hostPairIdx !== -1) {
-        let [a, b] = pairs[hostPairIdx];
-        if (a === hostShellKey) {
-            [a, b] = [b, a];
+    if (anchorsReserved) {
+        // The constraint row. If the two anchors genuinely cannot share a
+        // line at this width, the physical-capacity exception (spec §1)
+        // applies exactly as it does to any other pair — emit them as two
+        // adjacent one-sided rows rather than forcing an overflow that the
+        // row's own `flex-wrap` would silently split anyway (which is the
+        // one-sided-lines bug this file exists to prevent, reintroduced by
+        // a different route). They stay bottom-most and adjacent either
+        // way, so neither anchor travels; only their sharing of one line
+        // degrades.
+        if (anchorLeft!.width + hostShell!.width + gapPx <= availableWidth) {
+            pairs.push([anchorLeft!.key, hostShell!.key]);
+        } else {
+            pairs.push([anchorLeft!.key, undefined]);
+            pairs.push([undefined, hostShell!.key]);
         }
-        pairs.splice(hostPairIdx, 1);
-        pairs.push([a, b]);
+    } else {
+        // No anchor pair to reserve (e.g. the runtime slot is absent
+        // because controls are hidden) — fall back to the pre-anchor
+        // behavior: reorient whichever pair `hostShell` landed in so it's
+        // the RIGHT occupant, then move that pair to the end.
+        const hostPairIdx = pairs.findIndex(([a, b]) => a === hostShellKey || b === hostShellKey);
+        if (hostPairIdx !== -1) {
+            let [a, b] = pairs[hostPairIdx];
+            if (a === hostShellKey) {
+                [a, b] = [b, a];
+            }
+            pairs.splice(hostPairIdx, 1);
+            pairs.push([a, b]);
+        }
     }
 
     return pairs.map(([left, right]) => ({
@@ -1133,6 +1205,7 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
             "hostShell",
             width,
             gapPx,
+            "runtime",
         );
 
         // Stats share the single row's line only when slots PLUS stats

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -242,10 +242,12 @@ export interface ComposerRow {
  *     degrades to its positional meaning — the anchor is the outermost
  *     LEFT occupant, hostShell the outermost RIGHT one, on the one row
  *     that exists.
- *   - If the two anchors cannot physically share a line, the same
- *     physical-capacity exception that governs any other pair applies:
- *     two adjacent one-sided rows, still bottom-most, rather than an
- *     overflowing row that `flex-wrap` would split anyway.
+ *   - The anchor row is NEVER split, even when the two can't fit side by
+ *     side — the row's own `flex-wrap` breaks them onto two visual lines
+ *     instead, which renders identically without moving either anchor
+ *     between DOM subtrees (reagent P1, PR #2839). See the inline comment
+ *     at the `anchorsReserved` branch for why this pair is exempt from
+ *     the generic physical-capacity exception.
  *
  * This deliberately reverses the earlier "the model selector moving sides
  * is acceptable" call recorded in the retro's step 3 — it was dismissed
@@ -348,21 +350,27 @@ export function computeComposerRows(
     }
 
     if (anchorsReserved) {
-        // The constraint row. If the two anchors genuinely cannot share a
-        // line at this width, the physical-capacity exception (spec §1)
-        // applies exactly as it does to any other pair — emit them as two
-        // adjacent one-sided rows rather than forcing an overflow that the
-        // row's own `flex-wrap` would silently split anyway (which is the
-        // one-sided-lines bug this file exists to prevent, reintroduced by
-        // a different route). They stay bottom-most and adjacent either
-        // way, so neither anchor travels; only their sharing of one line
-        // degrades.
-        if (anchorLeft!.width + hostShell!.width + gapPx <= availableWidth) {
-            pairs.push([anchorLeft!.key, hostShell!.key]);
-        } else {
-            pairs.push([anchorLeft!.key, undefined]);
-            pairs.push([undefined, hostShell!.key]);
-        }
+        // The constraint row — ALWAYS exactly one row, never split, even
+        // when the two anchors can't fit side by side at this width
+        // (reagent P1, PR #2839). An earlier revision emitted them as two
+        // adjacent one-sided rows in that case, borrowing the generic
+        // physical-capacity exception (spec §1). That was wrong here for a
+        // reason specific to the anchors: only the LAST row is hoisted out
+        // of the render's `<For>` (see `precedingRowIndices`), so a split
+        // put `runtime` in the second-to-last row — back inside the `<For>`
+        // — and resizing across the split boundary destroyed and rebuilt
+        // `AgentRuntimeDropup`, reintroducing the very open-state loss the
+        // hoist exists to prevent, just at a different width.
+        //
+        // Keeping them one row is safe precisely because this pair is
+        // degenerate: two items, one per side, nothing else competing. The
+        // row's own `flex-wrap` (SCSS, the long-standing reagent-P1 #2393
+        // safety net) then breaks them onto two VISUAL lines at narrow
+        // widths — the identical rendering the split produced, reached
+        // without ever moving either anchor between DOM subtrees. The
+        // generic exception still applies to every other pair above, where
+        // the wrap outcome genuinely is unpredictable.
+        pairs.push([anchorLeft!.key, hostShell!.key]);
     } else {
         // No anchor pair to reserve (e.g. the runtime slot is absent
         // because controls are hidden) — fall back to the pre-anchor


### PR DESCRIPTION
## Summary

User-directed constraint (Rev 8): two composer-strip slots must **never travel** as the pane resizes — the **model selector** (`runtime`) and the **Shell toggle** (`hostShell`). Both anchor to the **bottom**, nearest the composer input: model selector on its left, Shell on its right.

Confirmed the problem live on the release build (CDP, v0.55.27) **before** changing anything — at 722px the strip really rendered `left: [ctx, auth]` / `right: [model selector, HOST+Shell]`, i.e. the selector had travelled to the right edge. This deliberately reverses the *"the model selector moving sides is acceptable"* call recorded in `docs/retro/retro-composer-strip-one-sided-lines-misdiagnosis-2026-08-26.md` step 3.

## Design

- **Multi-row:** both anchors are reserved **out** of the widest-with-narrowest pairing pool and emitted as the final row. Reserving exactly **two** slots preserves the remainder's parity, so spec §1's *"at most one singleton row"* invariant is untouched.
- **Single row:** no "bottom" exists, so the constraint degrades to its positional meaning — selector outermost-**left**, Shell outermost-**right**.
- **Anchors that can't share a line** fall to the same physical-capacity exception (spec §1) as any other pair: two adjacent one-sided rows, still bottom-most.
- `computeBalancedLeftKeys` gains an optional `fixedLeftWidth` (defaults to `0`, so every existing caller/test is byte-identical).
- **No anchor present** (controls hidden) falls back to the exact pre-anchor behavior, asserted by a test comparing both call shapes.
- **Anchors' row is rendered outside the `<For>`** (Codex P2) — see below.

## Live verification ✅

Built a dev instance off this branch, brought up a real agent pane, and drove it over CDP.

**Width sweep — wide → narrow → wide round-trip** (a one-way sweep structurally cannot catch the "stuck multi-row" class of bug that PR #2814 hit):

| width | rows | layout |
|---|---|---|
| 1071 / 700 / 520 / 420 | 1 | `selector ··· auth, hostShell` |
| 320 | 2 | `auth ··· –` / **`selector ··· hostShell`** |
| 240 | 3 | `auth ··· –` / `selector ··· –` / `– ··· hostShell` (capacity exception firing for real) |
| 1071 (return) | 1 | identical to start — no stuck multi-row |

Selector is the first element of the last row's left at every width; `hostShell` the last of its right; neither ever appears in a non-last row.

**Component identity (Codex P2), A/B on a real pane** — open the model menu, resize across the 1→2 row boundary:

| build | menu stayed open | trigger DOM node survived |
|---|---|---|
| `origin/main` | ✅ | ✅ |
| anchor constraint alone | ❌ | ❌ |
| + fix (`3bca64e9a`) | ✅ | ✅ |

The constraint forced `runtime` into a brand-new `<For>` subtree on every 1→2 crossing, destroying `AgentRuntimeDropup` and its local open/selection state. Fixed by rendering the anchors' row from its own fixed element. Layout after the restructure is byte-identical to before it (sweep re-run).

## Test plan

- [x] 8 new pure-function tests, incl. one pinning the actual regression (my first attempt at it was a false positive — the widths I picked didn't exercise it, so I re-picked) and a wide→narrow→wide round-trip.
- [x] 49/49 in `AgentComposerStrip.test.tsx` (41 pre-existing unmodified + 8 new).
- [x] 1522/1522 in `frontend/app/view/agent/`. (One `tool-renderers/registry.test.ts` failure on the first run passes in isolation both with and without this change and on a clean re-run — parallel-load flake.)
- [x] `npx tsc --noEmit` clean.
- [x] Live multi-width + round-trip + component-identity verification (above).

## ⚠️ Cleanup note for the repo owner

Live verification needed a real agent pane, so I created a throwaway agent named **`ZZ-Camper-Layout-Probe`** (named to sort last and be obviously disposable). Agent definitions are **global**, so it will show in your agent list. I closed its pane and stopped the dev instance, but couldn't find a delete path from the picker UI — **please delete it when convenient.** No other state was touched; agent count was otherwise unchanged.

<!-- agentmux:agent_id=camper -->