### PR TITLE
fix(agent-pane): clamp the tool elapsed ticker across a backwards clock step

### DIFF
--- a/.changesets/1788056792-fix-agent-pane-clamp-the-tool-elapsed-ticker-so-a-backwards--6h6a.md
+++ b/.changesets/1788056792-fix-agent-pane-clamp-the-tool-elapsed-ticker-so-a-backwards--6h6a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): clamp the tool elapsed ticker so a backwards clock step can't render a negative

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -81,7 +81,19 @@ function fadeInOnMount(el: HTMLElement): void {
 
 function ToolElapsedTicker(props: { startMs: number }): JSX.Element {
     const tick = useTick(1000);
-    const elapsed = createMemo(() => (tick(), Math.floor((Date.now() - props.startMs) / 1000)));
+    // `startMs` is wall-clock, so a backwards system-clock step (NTP
+    // correction, manual set, VM resume) mid-tool-call makes this negative —
+    // and this ticker exists specifically for calls long-running enough to
+    // need one, which is exactly when a step has time to land. Rendered raw it
+    // would print e.g. "-1717984694s…" in the transcript and Activity Dock,
+    // the same class of bug as PR #2831 (status-bar uptime) and #2832 (sysinfo
+    // chart), both traced to one real clock step on this machine.
+    //
+    // `formatElapsedCompact`/`formatElapsedClock` in `util/format-time` already
+    // clamp for the same reason; this call site simply never routed through
+    // them. Clamping rather than hiding: a stalled-looking "0s…" is honest
+    // about having lost the reference point, where a negative is just wrong.
+    const elapsed = createMemo(() => (tick(), Math.max(0, Math.floor((Date.now() - props.startMs) / 1000))));
     return <>{elapsed()}s…</>;
 }
 


### PR DESCRIPTION
Last member of the clock-step bug class, found by sweeping for the rest of it after #2831 and #2832 merged rather than waiting for a third report.

## The bug

`ToolElapsedTicker` (`ToolBlock.tsx`) rendered its value raw:

```tsx
const elapsed = createMemo(() => (tick(), Math.floor((Date.now() - props.startMs) / 1000)));
return <>{elapsed()}s…</>;
```

`startMs` is wall-clock, so a backwards system-clock step — NTP correction, manual set, VM resume — mid-call makes this negative. It would print e.g. `-1717984694s…` in the transcript and the Activity Dock.

The exposure is not theoretical for this particular call site: the ticker only appears for tool calls long-running enough to need one, which is exactly the window in which a clock step has time to land.

Same root cause as #2831 (status-bar uptime) and #2832 (sysinfo chart), both traced to one real clock step on this machine — it booted with the RTC reading **2081-02-05** and was corrected back to 2026 nearly three hours later.

## The sweep

Worth recording what *didn't* need fixing, since it's most of it. `frontend/util/format-time.ts`'s `formatElapsedCompact` / `formatElapsedClock` already clamp with `Math.max(0, …)`, so these are safe:

- Swarm shell uptime
- `ActivityRow`
- `PersistentShellBlock`
- `AgentFooter` (turn / reconnecting / compacting elapsed)
- `AgentComposerStrip`

And two degrade gracefully rather than showing garbage: `AgentDisconnectedBanner` (a negative age falls into the `< 1_000` → "just now" branch) and the terminal spawn-age badge (`elapsedHours < 1` → returns null, so the badge just doesn't render).

`ToolElapsedTicker` was the one call site that never routed through those helpers.

## The choice

Clamp rather than hide the row. A stalled-looking `0s…` is honest about having lost the reference point; a negative is simply wrong. This matches what `format-time` already does for every other elapsed display, so the behaviour is now consistent across the pane.

## Verification

`npx tsc --noEmit` — clean.

No new test: this is a one-expression clamp on a component-local memo with no exported pure function to target, and the identical `Math.max(0, …)` guard is already covered where it lives in `format-time`. Extracting a helper purely to have something to assert on would be more indirection than the fix. Flagging the choice rather than leaving it unstated.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
