### PR TITLE
Camper@claudius: chore: release v0.55.28

### DIFF
--- a/.changesets/1787881995-fix-agent-disclose-a-fresh-start-when-a-pane-spawns-with-no--8wep.md
+++ b/.changesets/1787881995-fix-agent-disclose-a-fresh-start-when-a-pane-spawns-with-no--8wep.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): disclose a fresh start when a pane spawns with no --resume but prior history exists

--- a/.changesets/1787897455-feat-agent-tell-the-pane-at-open-whether-its-conversation-wi-oct6.md
+++ b/.changesets/1787897455-feat-agent-tell-the-pane-at-open-whether-its-conversation-wi-oct6.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): tell the pane at open whether its conversation will resume or start new

--- a/.changesets/1787939804-fix-swarm-bounded-backfill-naming-backlog-pass-for-historica-27qm.md
+++ b/.changesets/1787939804-fix-swarm-bounded-backfill-naming-backlog-pass-for-historica-27qm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): bounded backfill-naming backlog pass for historical subagents/dispatches

--- a/.changesets/1787986039-fix-statusbar-report-backend-uptime-from-a-monotonic-clock-s-7mig.md
+++ b/.changesets/1787986039-fix-statusbar-report-backend-uptime-from-a-monotonic-clock-s-7mig.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): report backend uptime from a monotonic clock so a system clock step can't make it negative

--- a/.changesets/1788004345-fix-sysinfo-keep-the-chart-correct-across-a-backwards-system-6oga.md
+++ b/.changesets/1788004345-fix-sysinfo-keep-the-chart-correct-across-a-backwards-system-6oga.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sysinfo): keep the chart correct across a backwards system-clock step

--- a/.changesets/1788031768-feat-browser-pane-credential-isolated-http-auth-auto-fill-hato.md
+++ b/.changesets/1788031768-feat-browser-pane-credential-isolated-http-auth-auto-fill-hato.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser-pane): credential-isolated HTTP auth auto-fill

--- a/.changesets/1788034240-fix-agent-pane-force-stick-to-bottom-on-a-pane-s-first-overf-h92j.md
+++ b/.changesets/1788034240-fix-agent-pane-force-stick-to-bottom-on-a-pane-s-first-overf-h92j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): force stick-to-bottom on a pane's first overflow

--- a/.changesets/1788055801-fix-subagent-watcher-replayed-subagents-are-born-abandoned-w-q9py.md
+++ b/.changesets/1788055801-fix-subagent-watcher-replayed-subagents-are-born-abandoned-w-q9py.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(subagent-watcher): replayed subagents are born Abandoned when the parent turn is confirmed idle

--- a/.changesets/1788056049-fix-blockfile-stop-a-30s-line-count-poll-forcing-a-full-outp-6ogw.md
+++ b/.changesets/1788056049-fix-blockfile-stop-a-30s-line-count-poll-forcing-a-full-outp-6ogw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(blockfile): stop a 30s line-count poll forcing a full output.idx rebuild

--- a/.changesets/1788056148-fix-agent-pane-anchor-the-model-selector-and-shell-to-the-co-yn23.md
+++ b/.changesets/1788056148-fix-agent-pane-anchor-the-model-selector-and-shell-to-the-co-yn23.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): anchor the model selector and Shell to the composer strip's bottom row

--- a/.changesets/1788056792-fix-agent-pane-clamp-the-tool-elapsed-ticker-so-a-backwards--6h6a.md
+++ b/.changesets/1788056792-fix-agent-pane-clamp-the-tool-elapsed-ticker-so-a-backwards--6h6a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): clamp the tool elapsed ticker so a backwards clock step can't render a negative

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.27"
+version = "0.55.28"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.27"
+version = "0.55.28"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.27"
+version = "0.55.28"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.27"
+version = "0.55.28"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.27"
+version = "0.55.28"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.27"
+version = "0.55.28"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.27"
+version = "0.55.28"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.55.28 — 2026-08-29
+
+- fix(agent): disclose a fresh start when a pane spawns with no --resume but prior history exists
+- feat(agent): tell the pane at open whether its conversation will resume or start new
+- fix(swarm): bounded backfill-naming backlog pass for historical subagents/dispatches
+- fix(statusbar): report backend uptime from a monotonic clock so a system clock step can't make it negative
+- fix(sysinfo): keep the chart correct across a backwards system-clock step
+- feat(browser-pane): credential-isolated HTTP auth auto-fill
+- fix(agent-pane): force stick-to-bottom on a pane's first overflow
+- fix(subagent-watcher): replayed subagents are born Abandoned when the parent turn is confirmed idle
+- fix(blockfile): stop a 30s line-count poll forcing a full output.idx rebuild
+- fix(agent-pane): anchor the model selector and Shell to the composer strip's bottom row
+- fix(agent-pane): clamp the tool elapsed ticker so a backwards clock step can't render a negative
+
+
 ## 0.55.27 — 2026-08-27
 
 - chore(agent-pane): upgrade Claude Code CLI pin to 2.1.247, relabel Opus 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.27",
+  "version": "0.55.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.27",
+      "version": "0.55.28",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.27",
+  "version": "0.55.28",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR: **0.55.27 → 0.55.28**, produced by `task release -- --as patch`.

## ⚠️ Deliberate patch override

The computed bump from the pending changesets was **`minor`** — two of the 11 are `feat`-level:

- `feat(agent): tell the pane at open whether its conversation will resume or start new`
- `feat(browser-pane): credential-isolated HTTP auth auto-fill`

`--as patch` was used to force a patch anyway, so those ship under a patch version. The release script's own loud `WARNING: forcing a LOWER bump than the changesets request` fired and was accepted — flagging it here too so it's visible in review rather than buried in build output.

## Release consistency invariant

All 5 locations verified in agreement at `0.55.28` before commit (the reagent gate in `CLAUDE.md`):

| Location | Value |
|---|---|
| `package.json.version` | 0.55.28 |
| `Cargo.toml [workspace.package].version` | 0.55.28 |
| `Cargo.lock` workspace members (`agentmux-cef`) | 0.55.28 |
| `package-lock.json` root | 0.55.28 |
| `VERSION_HISTORY.md` head | `## 0.55.28 — 2026-08-29` |

## Contents (11 changesets consumed)

- fix(agent): disclose a fresh start when a pane spawns with no `--resume` but prior history exists
- feat(agent): tell the pane at open whether its conversation will resume or start new
- fix(swarm): bounded backfill-naming backlog pass for historical subagents/dispatches
- fix(statusbar): report backend uptime from a monotonic clock so a system clock step can't make it negative
- fix(sysinfo): keep the chart correct across a backwards system-clock step
- feat(browser-pane): credential-isolated HTTP auth auto-fill
- fix(agent-pane): force stick-to-bottom on a pane's first overflow
- fix(subagent-watcher): replayed subagents are born Abandoned when the parent turn is confirmed idle
- fix(blockfile): stop a 30s line-count poll forcing a full `output.idx` rebuild
- fix(agent-pane): anchor the model selector and Shell to the composer strip's bottom row
- fix(agent-pane): clamp the tool elapsed ticker so a backwards clock step can't render a negative

<!-- agentmux:agent_id=camper -->