### PR TITLE
Manoz@Area54: feat(armory): merge Global Memory + Personal Memory into one Memory tab

### DIFF
--- a/.changesets/1788075082-feat-armory-merge-global-memory-personal-memory-into-one-mem-sf7u.md
+++ b/.changesets/1788075082-feat-armory-merge-global-memory-personal-memory-into-one-mem-sf7u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(armory): merge Global Memory + Personal Memory into one Memory tab

--- a/docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md
+++ b/docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md
@@ -1,0 +1,128 @@
+# Spec: Armory rail — merge "Global Memory" + "Personal Memory" into one "Memory" tab
+
+**Date:** 2026-08-30
+**Status:** Proposed
+**Motivated by:** direct request — collapse the two adjacent memory-scoped
+rail tabs into a single "Memory" tab, with Global and Personal as sections
+inside it, using the brain icon for the combined tab.
+
+## Background
+
+`docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md` split
+one "Memory" concept into two adjacent rail tabs — "Global Memory" (`memory`
+id, `GlobalBrainManager`) and "Personal Memory" (`native_memory` id,
+`NativeMemoryManager`) — to make each tab's scope legible at a glance. That
+spec explicitly kept them as two separate rail entries; this spec undoes
+that specific choice (one tab, not two) while keeping everything else from
+08-22 intact: the two backing systems stay separate under the hood, and
+`ABF` is unaffected.
+
+Current rail (`frontend/app/view/armory/armory-view.tsx` `RAIL`):
+
+```
+Accounts, Global Memory, Personal Memory, Skills, MCP Servers, ABF
+```
+
+## Design
+
+### Rail
+
+Collapse the two memory entries into one:
+
+```
+Accounts, Memory, Skills, MCP Servers, ABF
+```
+
+- New single rail entry: `{ id: "memory", label: "Memory", icon: "brain" }`
+  — reuses the `memory` id and the `brain` icon `Global Memory` already
+  has today, so no icon or id churn for the common case.
+- `native_memory` is removed as a **rail** entry (no separate button in
+  either `.bundle-manager-tab-bar` or `.bundle-manager-rail`).
+
+### Inside the Memory pane
+
+The Memory pane content gets its own small sub-nav — two segments, "Global"
+and "Personal" — rendered above the existing manager component, same
+pattern as the outer rail but scoped to this one pane:
+
+```
+┌─ Memory ──────────────────────────────┐
+│  [ Global ] [ Personal ]              │  ← new sub-nav, this pane only
+│  ────────────────────────────────────  │
+│  <GlobalBrainManager /> or             │
+│  <NativeMemoryManager />               │
+└────────────────────────────────────────┘
+```
+
+Both `GlobalBrainManager` and `NativeMemoryManager` are reused as-is —
+this is a wrapping/nesting change, not a rewrite of either component.
+
+### Persistence
+
+- Outer tab selection stays on `block.meta["armory:section"]`, same key,
+  now with `native_memory` no longer a selectable value going forward.
+- New key `block.meta["armory:memory:subsection"]`, values `"global" |
+  "personal"`, default `"global"` — same `useBlockAtom` +
+  `RpcApi.SetMetaCommand` pattern `sectionAtom`/`zoomAtom` already use in
+  `armory-model.ts`, so the sub-tab also survives a block remount.
+
+### Backward compatibility for existing persisted meta
+
+Users with `armory:section: "native_memory"` already saved (from before
+this change) must not silently land on `"accounts"` the way an unrecognized
+value does today (`isArmorySection` in `armory-model.ts`) — that would read
+as the tab vanishing. Instead, normalize at read time:
+
+- `armory:section === "native_memory"` → treated as `"memory"` **and**
+  seeds `armory:memory:subsection` to `"personal"` (so a user who had
+  Personal Memory open lands on Memory → Personal, not Memory → Global).
+- This normalization is read-only / in-memory (derived in `sectionAtom`'s
+  `createMemo`, same place the existing fallback-to-`"accounts"` logic
+  lives) — it does not need to rewrite the stored meta value.
+- `ArmorySection`'s type keeps `"native_memory"` as a recognized-but-
+  non-rail value purely so `isArmorySection` still accepts old persisted
+  data instead of rejecting it into the `"accounts"` fallback; `RAIL` and
+  `ARMORY_SECTION_LABELS`'s user-facing entries drop it.
+
+### Labels
+
+`ARMORY_SECTION_LABELS` (`armory-model.ts`):
+
+- `memory: "Global Memory"` → `memory: "Memory"`
+- `native_memory: "Personal Memory"` entry removed from the *rail-facing*
+  label map (kept only internally for the normalization above, not
+  rendered anywhere).
+
+`viewName` (pane title) shows `"Memory"` regardless of which sub-tab is
+active — same level of granularity `ABF` already gets (no sub-scope in the
+pane title), keeping this consistent rather than introducing a new
+"Memory — Personal" pattern nowhere else in Armory uses.
+
+## Files to change
+
+- `frontend/app/view/armory/armory-model.ts` — `ArmorySection` type,
+  `ARMORY_SECTION_LABELS`, `isArmorySection`/`sectionAtom` normalization
+  for legacy `native_memory` meta, new `memorySubsectionAtom`.
+- `frontend/app/view/armory/armory-view.tsx` — `RAIL` array (one entry
+  instead of two), Memory pane now renders a sub-nav + conditionally
+  `GlobalBrainManager`/`NativeMemoryManager` instead of each having its own
+  top-level `.bundle-manager-pane`.
+- `frontend/app/view/armory/armory-view.scss` — small sub-nav style (can
+  likely reuse `.bundle-manager-tab-bar`/`-rail` button styles rather than
+  inventing new ones).
+- `frontend/app/view/armory/armory-view.test.tsx` — update rail-order and
+  label assertions (08-22's tests asserted exactly the two-tab shape this
+  spec removes); add coverage for the sub-nav and the legacy
+  `native_memory` → Memory/Personal normalization.
+
+## Non-goals
+
+- **No data-model change.** `GlobalBrainManager` (`is_global` Memory
+  bundles) and `NativeMemoryManager` (native memory files) remain two
+  separate backing systems — same non-goal 08-22 already established.
+  This spec only changes how they're grouped in the rail.
+- No change to `ABF`.
+- No change to either manager component's internals beyond being mounted
+  under the new sub-nav instead of directly under the outer rail.
+- No change to write access (both sub-sections stay writable by human and
+  agent, as 08-22 confirmed).

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -9,16 +9,24 @@ import { createMemo, type Accessor } from "solid-js";
 // Section ids are internal and stay stable across renames (they're
 // persisted in block.meta["armory:section"] — changing an id would strand
 // a user's previously-selected tab back to "accounts"). "memory" is the
-// global-brain tab (label "Global Memory" below); "native_memory" is the
-// per-agent tab (label "Personal Memory" below) — both distinct from a
-// bundle's own "bundles" section (label "ABF"; its backing component,
-// MemoryManager, is itself a naming leftover — see
+// combined Memory tab (label "Memory" below), covering both the global
+// brain (GlobalBrainManager, is_global Memory bundles) and the per-agent
+// native memory history (NativeMemoryManager) as sections inside one pane
+// — see docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md. Distinct
+// from a bundle's own "bundles" section (label "ABF"; its backing
+// component, MemoryManager, is itself a naming leftover — see
 // docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3).
-// "Global Memory"/"Personal Memory" abstract away, for the user, that these
-// are two structurally different backing systems (is_global Memory bundles
-// vs. the harness's own native memory files) — see
-// docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md.
-export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles" | "native_memory";
+//
+// "native_memory" is a legacy rail-section id: prior to the 08-30 merge it
+// was its own rail tab ("Personal Memory") — see
+// docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md. It is
+// no longer written, but a block saved before the merge may still carry it
+// in block.meta["armory:section"]; sectionAtom below normalizes it to
+// "memory" (and memorySubsectionAtom seeds "personal") so those users land
+// on the equivalent spot in the merged tab instead of falling back to
+// "accounts".
+export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles";
+type LegacyArmorySection = ArmorySection | "native_memory";
 
 // Label text only (not icon/tooltip, which stay armory-view.tsx's own
 // presentation detail) — hoisted here so viewName can read it without
@@ -27,15 +35,22 @@ export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles"
 // too, so the two can never drift out of sync.
 export const ARMORY_SECTION_LABELS: Record<ArmorySection, string> = {
     accounts: "Accounts",
-    memory: "Global Memory",
+    memory: "Memory",
     skills: "Skills",
     mcp: "MCP Servers",
     bundles: "ABF",
-    native_memory: "Personal Memory",
 };
 
 function isArmorySection(v: unknown): v is ArmorySection {
     return typeof v === "string" && Object.prototype.hasOwnProperty.call(ARMORY_SECTION_LABELS, v);
+}
+
+// Sub-tab inside the merged Memory pane — see armory-view.tsx's memory
+// sub-nav and SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md.
+export type MemorySubsection = "global" | "personal";
+
+function isMemorySubsection(v: unknown): v is MemorySubsection {
+    return v === "global" || v === "personal";
 }
 
 export class ArmoryViewModel implements ViewModel {
@@ -53,6 +68,10 @@ export class ArmoryViewModel implements ViewModel {
     // (below) can react to it, and as a side effect the selected tab now
     // survives a block remount instead of always resetting to "accounts".
     sectionAtom: Accessor<ArmorySection>;
+    // Sub-tab (Global vs Personal) inside the merged Memory pane — same
+    // meta-backed pattern as sectionAtom. See
+    // SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md.
+    memorySubsectionAtom: Accessor<MemorySubsection>;
 
     viewIcon = () => "vault";
     // wired in armory.tsx to avoid circular import
@@ -72,8 +91,20 @@ export class ArmoryViewModel implements ViewModel {
         );
         this.sectionAtom = useBlockAtom(blockId, "armory-section", () =>
             createMemo<ArmorySection>(() => {
-                const s = this.blockAtom()?.meta?.["armory:section"];
+                const s = this.blockAtom()?.meta?.["armory:section"] as LegacyArmorySection | undefined;
+                if (s === "native_memory") return "memory";
                 return isArmorySection(s) ? s : "accounts";
+            }),
+        );
+        this.memorySubsectionAtom = useBlockAtom(blockId, "armory-memory-subsection", () =>
+            createMemo<MemorySubsection>(() => {
+                const sub = this.blockAtom()?.meta?.["armory:memory:subsection"];
+                if (isMemorySubsection(sub)) return sub;
+                // Legacy: a pre-merge armory:section of "native_memory" meant
+                // the user had Personal Memory open — seed Personal instead
+                // of defaulting to Global. See sectionAtom above.
+                const legacySection = this.blockAtom()?.meta?.["armory:section"];
+                return legacySection === "native_memory" ? "personal" : "global";
             }),
         );
         this.viewName = useBlockAtom(blockId, "armory-view-name", () =>

--- a/frontend/app/view/armory/armory-view.scss
+++ b/frontend/app/view/armory/armory-view.scss
@@ -151,6 +151,55 @@
     }
 }
 
+// ── Merged Memory pane — Global/Personal sub-nav ─────────────────────────────
+// See SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md. .memory-subnav-content
+// establishes the containing block the nested .bundle-manager-pane rules
+// (position: absolute; inset: 0) already expect.
+
+.memory-pane {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.memory-subnav {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    padding: 8px;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--panel-bg-color, var(--main-bg-color));
+
+    button {
+        padding: 6px 14px;
+        border: none;
+        border-radius: 4px;
+        background: transparent;
+        color: var(--main-text-color);
+        font-size: 12px;
+        cursor: default;
+        opacity: 0.7;
+
+        &:hover:not(.is-active) {
+            opacity: 1;
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+        }
+
+        &.is-active {
+            opacity: 1;
+            background: var(--accent-color);
+            color: var(--accent-text-color, #fff);
+        }
+    }
+}
+
+.memory-subnav-content {
+    position: relative;
+    flex: 1 1 auto;
+    overflow: hidden;
+}
+
 // ── Responsive container queries ─────────────────────────────────────────────
 
 // sm: compress outer rail to icon-only (48px)

--- a/frontend/app/view/armory/armory-view.test.tsx
+++ b/frontend/app/view/armory/armory-view.test.tsx
@@ -13,13 +13,15 @@
  *
  * docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md renamed
  * "Memories" to "Global Memory" and "Native Memory" to "Personal Memory",
- * and moved Personal Memory up to sit right below Global Memory (both now
- * adjacent, just below Accounts) — one user-facing "Memory" concept split
- * by scope, abstracting away the two structurally different backing
- * systems. Current rail order: Accounts, Global Memory, Personal Memory,
- * Skills, MCP Servers, ABF. These tests guard the rail contents directly;
- * `ArmorySection`'s type-level rejection of `"identities"` is checked at
- * compile time below (no runtime assertion needed for that part).
+ * as two adjacent rail tabs.
+ *
+ * docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md then merged those
+ * two rail tabs into a single "Memory" tab (brain icon), with Global and
+ * Personal as a sub-nav inside that one pane instead of two rail entries.
+ * Current rail order: Accounts, Memory, Skills, MCP Servers, ABF. These
+ * tests guard the rail contents directly; `ArmorySection`'s type-level
+ * rejection of `"identities"` is checked at compile time below (no runtime
+ * assertion needed for that part).
  */
 
 import { createSignal } from "solid-js";
@@ -31,6 +33,9 @@ vi.mock("@/app/view/accounts/accounts-manager", () => ({
 }));
 vi.mock("@/app/view/brain/global-brain-manager", () => ({
     GlobalBrainManager: () => <div data-testid="brain-manager" />,
+}));
+vi.mock("@/app/view/native-memory/native-memory-manager", () => ({
+    NativeMemoryManager: () => <div data-testid="native-memory-manager" />,
 }));
 vi.mock("@/app/view/memory/memory-manager", () => ({
     MemoryManager: () => <div data-testid="memory-manager" />,
@@ -108,24 +113,73 @@ describe("ArmoryView rail", () => {
         expect(container.querySelector(".bundle-manager-pane--identity")).not.toBeInTheDocument();
     });
 
-    it("labels the brain tab 'Global Memory' (renamed from 'Memories')", () => {
+    it("labels the combined tab 'Memory' with a brain icon (merged from 'Global Memory' + 'Personal Memory')", () => {
         renderArmory();
-        expect(screen.getAllByText("Global Memory").length).toBeGreaterThan(0);
+        const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
+        expect(screen.getAllByText("Memory").length).toBeGreaterThan(0);
+        expect(screen.queryByText("Global Memory")).not.toBeInTheDocument();
+        expect(screen.queryByText("Personal Memory")).not.toBeInTheDocument();
         expect(screen.queryByText("Memories")).not.toBeInTheDocument();
-        expect(screen.queryByText("Memory")).not.toBeInTheDocument();
+        expect(rail.querySelector(".bundle-manager-rail-item .fa-brain")).toBeInTheDocument();
     });
 
-    it("labels the native-memory tab 'Personal Memory' (renamed from 'Native Memory')", () => {
-        renderArmory();
-        expect(screen.getAllByText("Personal Memory").length).toBeGreaterThan(0);
-        expect(screen.queryByText("Native Memory")).not.toBeInTheDocument();
-    });
-
-    it("orders the rail as Accounts, Global Memory, Personal Memory, Skills, MCP Servers, ABF", () => {
+    it("orders the rail as Accounts, Memory, Skills, MCP Servers, ABF", () => {
         renderArmory();
         const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
         const labels = Array.from(rail.querySelectorAll("button span")).map((el) => el.textContent);
-        expect(labels).toEqual(["Accounts", "Global Memory", "Personal Memory", "Skills", "MCP Servers", "ABF"]);
+        expect(labels).toEqual(["Accounts", "Memory", "Skills", "MCP Servers", "ABF"]);
+    });
+});
+
+describe("ArmoryView Memory sub-nav", () => {
+    afterEach(() => {
+        cleanup();
+        setMetaMock.mockClear();
+        setBlockMeta({});
+    });
+
+    function renderArmory() {
+        const model = new ArmoryViewModel("test-block", null as any);
+        return render(() => (
+            <ArmoryView
+                blockId="test-block"
+                model={model}
+                blockRef={{ current: null }}
+                contentRef={{ current: null }}
+            />
+        ));
+    }
+
+    it("defaults to the Global section showing GlobalBrainManager", () => {
+        setBlockMeta({ "armory:section": "memory" });
+        renderArmory();
+        const globalPane = screen.getByTestId("brain-manager").closest(".bundle-manager-pane");
+        const personalPane = screen.getByTestId("native-memory-manager").closest(".bundle-manager-pane");
+        expect(globalPane?.classList.contains("is-hidden")).toBe(false);
+        expect(personalPane?.classList.contains("is-hidden")).toBe(true);
+    });
+
+    it("clicking Personal writes armory:memory:subsection and swaps the visible pane", () => {
+        setBlockMeta({ "armory:section": "memory" });
+        renderArmory();
+        const subnav = screen.getByLabelText("Memory scope");
+        const personalButton = Array.from(subnav.querySelectorAll("button")).find(
+            (b) => b.textContent === "Personal",
+        ) as HTMLButtonElement;
+        personalButton.click();
+        expect(setMetaMock).toHaveBeenCalledWith(
+            undefined,
+            { oref: "block:test-block", meta: { "armory:memory:subsection": "personal" } },
+        );
+        const personalPane = screen.getByTestId("native-memory-manager").closest(".bundle-manager-pane");
+        expect(personalPane?.classList.contains("is-hidden")).toBe(false);
+    });
+
+    it("normalizes a legacy armory:section='native_memory' value to Memory + Personal", () => {
+        setBlockMeta({ "armory:section": "native_memory" });
+        const model = new ArmoryViewModel("test-block", null as any);
+        expect(model.viewName()).toBe("Memory");
+        expect(model.memorySubsectionAtom()).toBe("personal");
     });
 });
 

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -12,21 +12,27 @@ import { GlobalBrainManager } from "@/app/view/brain/global-brain-manager";
 import { McpManager } from "@/app/view/mcp/mcp-manager";
 import { SkillManager } from "@/app/view/skill/skill-manager";
 import { NativeMemoryManager } from "@/app/view/native-memory/native-memory-manager";
-import { ARMORY_SECTION_LABELS, type ArmorySection, type ArmoryViewModel } from "./armory-model";
+import { ARMORY_SECTION_LABELS, type ArmorySection, type ArmoryViewModel, type MemorySubsection } from "./armory-model";
 import "./armory-view.scss";
 
-// Global Memory + Personal Memory sit together right below Accounts,
-// deliberately adjacent — the user-facing framing is one "Memory" concept
-// split in two by scope (workspace-wide vs. per-agent), not two unrelated
-// features that happen to share a rail. See
-// docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md.
+// Memory sits right below Accounts — a single tab covering both Global
+// (workspace-wide, composes into every agent's CLAUDE.md) and Personal
+// (per-agent version history) scopes, presented as sections inside the one
+// pane rather than two adjacent rail tabs. See
+// docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md (supersedes the
+// two-tab split from
+// docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md).
 const RAIL: { id: ArmorySection; label: string; tooltip?: string; icon: string }[] = [
     { id: "accounts", label: ARMORY_SECTION_LABELS.accounts, icon: "key" },
-    { id: "memory",   label: ARMORY_SECTION_LABELS.memory,   tooltip: "Workspace-wide — composes into every agent's CLAUDE.md", icon: "brain" },
-    { id: "native_memory", label: ARMORY_SECTION_LABELS.native_memory, tooltip: "Per-agent — version history, diff and revert", icon: "clock-rotate-left" },
+    { id: "memory",   label: ARMORY_SECTION_LABELS.memory,   tooltip: "Global (workspace-wide) and Personal (per-agent) memory", icon: "brain" },
     { id: "skills",   label: ARMORY_SECTION_LABELS.skills,   icon: "wand-magic-sparkles" },
     { id: "mcp",      label: ARMORY_SECTION_LABELS.mcp,      icon: "plug" },
     { id: "bundles",  label: ARMORY_SECTION_LABELS.bundles,  tooltip: "Armory Bundle Format (ABF)", icon: "layer-group" },
+];
+
+const MEMORY_SUBNAV: { id: MemorySubsection; label: string }[] = [
+    { id: "global", label: "Global" },
+    { id: "personal", label: "Personal" },
 ];
 
 export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Element {
@@ -39,6 +45,12 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
         void RpcApi.SetMetaCommand(TabRpcClient, {
             oref: `block:${model.blockId}`,
             meta: { "armory:section": id },
+        });
+    const subsection = model.memorySubsectionAtom;
+    const setSubsection = (id: MemorySubsection) =>
+        void RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: `block:${model.blockId}`,
+            meta: { "armory:memory:subsection": id },
         });
     let viewRef: HTMLDivElement | undefined;
 
@@ -118,14 +130,37 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                 </nav>
                 <div class="bundle-manager-section">
                     {/*
-                     * All six managers stay mounted — toggling is instant and
+                     * All five managers stay mounted — toggling is instant and
                      * never re-fetches. All stay consistent via WPS *:changed events.
                      */}
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "accounts" }}>
                         <AccountsManager />
                     </div>
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "memory" }}>
-                        <GlobalBrainManager />
+                        <div class="memory-pane">
+                            <nav class="memory-subnav" aria-label="Memory scope">
+                                <For each={MEMORY_SUBNAV}>
+                                    {(item) => (
+                                        <button
+                                            type="button"
+                                            classList={{ "is-active": subsection() === item.id }}
+                                            aria-pressed={subsection() === item.id}
+                                            onClick={() => setSubsection(item.id)}
+                                        >
+                                            {item.label}
+                                        </button>
+                                    )}
+                                </For>
+                            </nav>
+                            <div class="memory-subnav-content">
+                                <div class="bundle-manager-pane" classList={{ "is-hidden": subsection() !== "global" }}>
+                                    <GlobalBrainManager />
+                                </div>
+                                <div class="bundle-manager-pane" classList={{ "is-hidden": subsection() !== "personal" }}>
+                                    <NativeMemoryManager />
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "skills" }}>
                         <SkillManager />
@@ -135,9 +170,6 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                     </div>
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "bundles" }}>
                         <MemoryManager />
-                    </div>
-                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "native_memory" }}>
-                        <NativeMemoryManager />
                     </div>
                 </div>
             </div>

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -130,7 +130,9 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                 </nav>
                 <div class="bundle-manager-section">
                     {/*
-                     * All five managers stay mounted — toggling is instant and
+                     * All six manager components stay mounted (AccountsManager,
+                     * GlobalBrainManager, NativeMemoryManager, SkillManager,
+                     * McpManager, MemoryManager) — toggling is instant and
                      * never re-fetches. All stay consistent via WPS *:changed events.
                      */}
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "accounts" }}>

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1577,7 +1577,13 @@ declare global {
         "subagent:session"?: string;
         // Selected rail section, meta-backed so it survives a block remount
         // and the view model can react to it (armory-model.ts/warden-model.ts).
+        // "native_memory" is a legacy value (pre SPEC_ARMORY_MEMORY_TAB_MERGE_
+        // 2026_08_30.md) — no longer written, but still accepted on read and
+        // normalized to "memory" by armory-model.ts's sectionAtom.
         "armory:section"?: "accounts" | "memory" | "skills" | "mcp" | "bundles" | "native_memory";
+        // Sub-tab inside the merged Memory pane (Global vs Personal) — see
+        // SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md.
+        "armory:memory:subsection"?: "global" | "personal";
         "warden:section"?: "host" | "lan" | "internet" | "audit" | "supervisor";
         // Set once by quick-fork.ts right after a fork lands on a provider
         // with no --fork-session equivalent and a parent session existed to


### PR DESCRIPTION
## Summary
- Collapses the Armory rail's two adjacent memory tabs ("Global Memory", "Personal Memory") into a single "Memory" tab (brain icon), with Global/Personal as a sub-nav inside one pane instead of two rail entries.
- Underlying backends stay separate (`GlobalBrainManager`'s `is_global` Memory bundles vs. `NativeMemoryManager`'s native memory files) — UI-only change.
- Legacy persisted `armory:section="native_memory"` meta normalizes to Memory + Personal instead of stranding users on Accounts.

See `docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md` for the full design (supersedes `docs/specs/SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md`'s two-tab split).

## Test plan
- [x] `npx vitest run frontend/app/view/armory/armory-view.test.tsx` — 19/19 passing, including new sub-nav toggle test and legacy-normalization test
- [x] `npx tsc --noEmit` — clean
- [x] Verified via `task dev` — Memory tab shows brain icon, sub-nav toggles Global/Personal panes correctly

<!-- agentmux:agent_id=manoz -->