### PR TITLE
docs(analysis): pane-minimize distortions for a Row branch between two panes

### DIFF
--- a/docs/analysis/ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30.md
+++ b/docs/analysis/ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30.md
@@ -1,19 +1,32 @@
 # Analysis: pane-minimize distortions when a Row of panes sits between a top and a bottom pane
 
 **Date:** 2026-08-30
-**Status:** Analysis only — **no code changed**. Four distortions identified and
-reproduced against the real geometry functions; fix directions proposed but not
-implemented or tested.
+**Status:** Analysis only — **no code changed**. Two defects (§2, §3) reproduced
+end-to-end through the real `LayoutModel.updateTree()`; one seam flagged for a
+product decision (§4); one item investigated and **withdrawn as a defect** — it
+turned out to be intentional, regression-locked behaviour (§5).
 **Area:** `frontend/layout/lib/layoutGeometry.ts`, `frontend/layout/lib/layoutMinimize.ts`
 **Trigger:** operator report — "multiple panes open side-by-side with 1 pane atop
 and 1 below; if I start minimizing the middle panes, we get distorted behavior."
 
-**Confidence, stated up front:** every number below was produced by calling the
-actual exported functions (`computeMainAxisAllocation`, `resolveRowSlipTargets`,
-`minimizedCrossAxisPx`) in a scratch vitest file, not by reading the code and
-reasoning. What I have **not** done is run the app and watch it happen. So these
-are demonstrated defects in the geometry layer; which one(s) produced the visual
-the operator actually saw is not established — see §6.
+**Confidence, per finding — these are not all the same strength:**
+
+| § | Finding | How it was measured |
+|---|---|---|
+| §2 | Dead space under a minimized Row branch | **End-to-end**: built the tree, called `model.updateTree()`, read `model.additionalProps()` |
+| §3 | Resize handles vanish | **End-to-end**: same, read `resizeHandles` off the parent's props |
+| §4 | Discontinuous chip reflow | Exported pure functions (`resolveRowSlipTargets`, `computeMainAxisAllocation`) |
+| §5 | Zero-height host | **Not a defect** — existing intended behaviour, see §5 |
+
+An earlier revision of this document claimed all findings came from calling
+exported functions. That was wrong for two of them, which were measured by
+copying non-exported snippets (the Phase C handle predicate, the Phase B host
+arithmetic) into a scratch test — and it contradicted this document's own §7.
+Codex caught it on the PR. §2 and §3 have since been genuinely re-measured
+through `updateTree`; the numbers did not change.
+
+What I still have **not** done is run the app and watch it happen. Which finding
+produced the visual the operator actually saw is not established — see §6.
 
 ---
 
@@ -45,13 +58,18 @@ Constants used throughout: `HeaderHeightPx = 33`, `gap = 3`,
 
 ## 2. Finding A — 72px of dead space once all three middle panes are minimized (root cause)
 
-**Measured:**
+**Measured end-to-end** — tree built, `model.updateTree()` called, rects read
+back from `model.additionalProps()` (800×600 container, gap 3):
 
 | | |
 |---|---|
-| Vertical space the root Column allocates to MIDDLE | **108px** |
-| Vertical space MIDDLE actually fills | **36px** |
-| **Dead space** | **72px** |
+| MIDDLE's rect | top 246, height **108px** |
+| Chip heights (A, B, C) | 36, 36, 36 |
+| Chip widths (A, B, C) | 183, 183, 183 |
+| Bottom of the chip strip | y = **282** |
+| Bottom of MIDDLE's rect | y = **354** |
+| **Dead space** | **72px** (y 282 → 354) |
+| BOTTOM pane starts at | y = 354 |
 
 Same subtree declared as a Column branch instead: allocated 108, consumed 108 —
 exact. The defect is direction-specific.
@@ -109,13 +127,15 @@ passes and this doesn't.
 
 ## 3. Finding B — minimizing a middle pane deletes the resize handle between its two expanded neighbours
 
-**Measured**, for `A | B(minimized) | C`:
+**Measured end-to-end** for `A | B(minimized) | C` via `model.updateTree()`,
+reading `resizeHandles` off the parent's own props (800px-wide container):
 
 | | |
 |---|---|
 | Resize handles generated | **0** |
-| Child widths A, B, C | **600, 0, 600** |
-| Baseline (nothing minimized) | 2 handles (`0|1`, `1|2`) |
+| Baseline, nothing minimized | **2** |
+| Rendered rects (left, width) | A (0, 400), C (400, 400) — **flush at x=400** |
+| B's chip | (400, 400) — docked on top of C |
 
 B contributes zero main-axis width (it slips onto C), so **A and C are rendered
 flush against each other** — and there is no divider between them anywhere in
@@ -169,41 +189,46 @@ seam.
 
 ---
 
-## 5. Finding D — enough docked chips crush their host pane to zero height
+## 5. WITHDRAWN — "docked chips crush their host to zero height" is intended behaviour
 
-**Measured**, 6 panes in a 120px-tall row, 5 minimized onto the survivor:
+**An earlier revision of this document listed this as a fourth defect and
+proposed adding a minimum host height. That was wrong, and the proposed fix
+would have reverted a regression test.**
 
-| | |
-|---|---|
-| Combined chip height | 180px |
-| Row height | 120px |
-| `clampedSlipHeight` | 120px |
-| **Host pane's resulting height** | **0px** |
-
-The row's only expanded pane renders at zero height and disappears.
-
-**Root cause.** Phase B scales the *chips* down to fit
-(`scale = clampedSlipHeight / totalSlipHeight`, added for an earlier reagent P1)
-but computes the host's rect independently:
+The behaviour is real — with enough minimized panes docking onto one short row,
+Phase B's arithmetic yields a host height of exactly 0:
 
 ```ts
 const clampedSlipHeight = Math.min(totalSlipHeight, targetProps.rect.height);
 const shrunkRect = { ...targetProps.rect,
-    top: originalTop + clampedSlipHeight,
-    height: targetProps.rect.height - clampedSlipHeight };
+    height: targetProps.rect.height - clampedSlipHeight };   // → 0 when saturated
 ```
 
-When `totalSlipHeight ≥ rect.height`, `clampedSlipHeight` equals the full height
-and the subtraction yields exactly 0. The chips are made to fit; the pane they
-docked onto is not given a floor.
+But it is **deliberate and locked in by a test**.
+`frontend/layout/tests/layoutModel.test.ts` (the "scales down chip heights
+proportionally when a slip group's total height exceeds the target's space" case,
+added for a reagent P1 on **PR #2211**) sets up exactly this saturated slip group
+and asserts:
 
-**Fix direction.** Reserve a minimum host height and scale the chip stack against
-`rect.height − minHostPx` instead of `rect.height`. Requires a product call on
-what the floor is — one header height, or something content-bearing.
+```ts
+// The anchor's own content area is fully consumed (0 height left) —
+// the whole container is chips when they overflow this badly.
+expect(props[anchor.id].rect.height).toBeCloseTo(0, 0);
+```
 
-**Reachability.** Needs ~5 minimized panes docking onto one short row, so it is
-less likely than A–C in the reported 3-pane scenario. Included because it is the
-same class of defect and cheap to fix alongside.
+So "the whole row becomes chips" is the specified outcome when the stack
+saturates, not an accident. Reserving a host-height floor would break that test
+by design.
+
+**What remains, reframed as a product question rather than a bug:** *is
+"saturate to all-chips" the behaviour we want when a slip group overflows, or
+should the host keep a minimum visible height?* There is a defensible argument
+either way — the current rule is at least predictable and has no dead space. Any
+change here is a deliberate reversal of #2211's decision and needs to be made as
+one, with that test updated intentionally rather than "fixed".
+
+Recorded here rather than deleted, so the next person who notices the
+zero-height host finds the reasoning instead of re-opening it.
 
 ---
 
@@ -226,25 +251,37 @@ same class of defect and cheap to fix alongside.
 
 ## 7. Reproducing the measurements
 
-Findings A–D were produced by a scratch vitest file (since deleted) calling the
-exported pure functions directly. To regenerate: build the tree shapes described
-in each section with `newLayoutNode` from `frontend/layout/lib/layoutNode`, then
-call `computeMainAxisAllocation` / `resolveRowSlipTargets` /
-`minimizedCrossAxisPx` from `frontend/layout/lib/layoutGeometry`, using
-`HeaderHeightPx = 33`, `gap = 3`. The Phase C handle predicate in §3 and the
-Phase B host-height arithmetic in §5 are copied verbatim from
-`updateTreeHelper`, since neither is separately exported.
+All measurements came from scratch vitest files, since deleted.
+
+**§2 and §3 (end-to-end).** Copy the preamble of
+`frontend/layout/tests/layoutModel.test.ts` (lines 1–99: its imports, the
+`@/app/store/global` `vi.mock`, and `createLayoutModel()`), then build the tree
+shape with `newLayoutNode`, set `n.minimized = true` on the intended leaves,
+assign `model.treeState.rootNode`, call `model.updateTree()`, and read
+`model.additionalProps()`. §2 reads each node's `rect`; §3 reads
+`props[rootNode.id].resizeHandles`. This exercises the real
+`updateTreeHelper` — Phases A, B and C — not a reimplementation of it.
+
+**§4 (pure functions).** `resolveRowSlipTargets` and
+`computeMainAxisAllocation`, both exported from
+`frontend/layout/lib/layoutGeometry.ts`, called directly.
+
+Constants: `HeaderHeightPx = 33`, gap 3, container 800×600 unless stated.
+`createLayoutModel()`'s default bounding rect is 800×600, which is where §2's
+absolute y-coordinates come from.
 
 ## 8. Suggested order of work
 
-1. **Finding A** — replace `countLeafPanes` with the direction-aware
-   `collapsedExtent`. Root cause of the visible dead space, self-contained, and
-   the existing test suite's blind spot is easy to close (add the Row-branch
-   mirror of the current Column-branch test).
-2. **Finding D** — host-height floor in Phase B. Small, adjacent to A.
-3. **Finding B** — rendered-slot-adjacency handles. Needs care around
-   `parentIndex` and `onResizeMove`'s lookup.
-4. **Finding C** — product decision first, then implementation if wanted.
+1. **§2 (dead space)** — replace `countLeafPanes` with the direction-aware
+   `collapsedExtent`. Root cause of the visible band, self-contained, and the
+   suite's blind spot is easy to close: add the Row-branch mirror of the
+   existing Column-branch test.
+2. **§3 (missing handles)** — handles between adjacent *rendered* slots rather
+   than adjacent array indices. Needs care around `parentIndex` and
+   `onResizeMove`'s lookup, so it is not a one-line predicate change.
+3. **§4 (discontinuous reflow)** — product decision first, implementation only
+   if wanted.
+4. **§5** — nothing to do unless we deliberately reverse PR #2211.
 
 ## References
 

--- a/docs/analysis/ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30.md
+++ b/docs/analysis/ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30.md
@@ -1,0 +1,260 @@
+# Analysis: pane-minimize distortions when a Row of panes sits between a top and a bottom pane
+
+**Date:** 2026-08-30
+**Status:** Analysis only — **no code changed**. Four distortions identified and
+reproduced against the real geometry functions; fix directions proposed but not
+implemented or tested.
+**Area:** `frontend/layout/lib/layoutGeometry.ts`, `frontend/layout/lib/layoutMinimize.ts`
+**Trigger:** operator report — "multiple panes open side-by-side with 1 pane atop
+and 1 below; if I start minimizing the middle panes, we get distorted behavior."
+
+**Confidence, stated up front:** every number below was produced by calling the
+actual exported functions (`computeMainAxisAllocation`, `resolveRowSlipTargets`,
+`minimizedCrossAxisPx`) in a scratch vitest file, not by reading the code and
+reasoning. What I have **not** done is run the app and watch it happen. So these
+are demonstrated defects in the geometry layer; which one(s) produced the visual
+the operator actually saw is not established — see §6.
+
+---
+
+## 1. The layout under test
+
+```
+┌─────────────────────────────────┐
+│              TOP                │   leaf
+├─────────┬─────────┬─────────────┤
+│    A    │    B    │      C      │   ← "the middle panes"
+├─────────┴─────────┴─────────────┤
+│             BOTTOM              │   leaf
+└─────────────────────────────────┘
+```
+
+Tree: `root(Column) → [ TOP, MIDDLE(Row) → [A, B, C], BOTTOM ]`
+
+The important structural fact: **MIDDLE is a Row branch nested inside a Column
+parent.** Every finding below traces to that, and the existing test suite has no
+case of this shape — its only branch-level minimize regression test uses a
+*Column* branch (`layoutMinimize.test.ts`, "minimizedCrossAxisPx: one
+header-height for a minimized leaf, N for an N-leaf minimized branch", where
+`rightCol = newLayoutNode(FlexDirection.Column, …)`).
+
+Constants used throughout: `HeaderHeightPx = 33`, `gap = 3`,
+`MinimizedRowSlotWidthPx = 180`.
+
+---
+
+## 2. Finding A — 72px of dead space once all three middle panes are minimized (root cause)
+
+**Measured:**
+
+| | |
+|---|---|
+| Vertical space the root Column allocates to MIDDLE | **108px** |
+| Vertical space MIDDLE actually fills | **36px** |
+| **Dead space** | **72px** |
+
+Same subtree declared as a Column branch instead: allocated 108, consumed 108 —
+exact. The defect is direction-specific.
+
+**Root cause.** `minimizedFixedPx` (`layoutGeometry.ts`) computes a
+fully-minimized child's extent as:
+
+```ts
+if (parentIsRow) return MinimizedRowSlotWidthPx + gapPx;
+return countLeafPanes(node) * (HeaderHeightPx + gapPx);
+```
+
+`countLeafPanes` is a plain recursive leaf count. It encodes the assumption that
+a collapsed subtree's chips **stack along the measured axis** — one header-height
+per leaf. That is true only when the subtree's own `flexDirection` matches the
+axis being measured.
+
+MIDDLE is a **Row**. Its three minimized children lay out *side by side*, each
+one header tall. Its true vertical extent is `1 × (33+3) = 36px`. The formula
+returns `3 × (33+3) = 108px`.
+
+The function's own doc comment states the assumption explicitly, and is wrong in
+exactly this case:
+
+> "Same formula as `minimizedFixedPx`'s Column-parent branch — a stack's
+> required extent doesn't depend on which axis it's being measured for."
+
+A stack's extent doesn't, but **this isn't always a stack.** A Row branch is a
+*strip*, and a strip's extent very much depends on the axis.
+
+**Where it shows up.** Both call sites are affected, because
+`minimizedCrossAxisPx` just delegates to `minimizedFixedPx(child, false, gap)`:
+
+- Root Column's main-axis allocation → MIDDLE gets 108px of height instead of 36px.
+- Phase A's cross-axis clamp → chips inside MIDDLE are 36px tall in a 108px rect.
+
+Net user-visible effect: **an empty horizontal band roughly two header-heights
+tall between the chip strip and BOTTOM**, appearing only after the *last* middle
+pane is minimized.
+
+**Correct formula.** Extent must recurse on direction, not count leaves:
+
+```
+collapsedExtent(node, axis):
+  leaf                       → axis === vertical ? Header+gap : MinimizedRowSlotWidth+gap
+  branch, flexDirection == axis   → Σ children collapsedExtent(child, axis)
+  branch, flexDirection ⟂ axis    → max children collapsedExtent(child, axis)
+```
+
+`countLeafPanes` is the `Σ`-always special case — correct only when every branch
+on the path is aligned with the measured axis, which is why the all-Column test
+passes and this doesn't.
+
+---
+
+## 3. Finding B — minimizing a middle pane deletes the resize handle between its two expanded neighbours
+
+**Measured**, for `A | B(minimized) | C`:
+
+| | |
+|---|---|
+| Resize handles generated | **0** |
+| Child widths A, B, C | **600, 0, 600** |
+| Baseline (nothing minimized) | 2 handles (`0|1`, `1|2`) |
+
+B contributes zero main-axis width (it slips onto C), so **A and C are rendered
+flush against each other** — and there is no divider between them anywhere in
+the row. The user can no longer resize A against C at all.
+
+**Root cause.** Phase C skips a handle whenever *either* flanking child is
+effectively minimized:
+
+```ts
+if (isEffectivelyMinimized(prevChild) || isEffectivelyMinimized(child)) continue;
+```
+
+With the minimized pane in the *middle*, that predicate kills both candidate
+handles — `A|B` (because B is minimized) and `B|C` (because B is minimized) —
+leaving the row with none. The rule is right for the chip's own edges; it just
+doesn't account for a zero-width slip child collapsing two real edges into one.
+
+**Fix direction.** Generate handles between consecutive *rendered* slots rather
+than consecutive array indices: skip over zero-width slip children when choosing
+the flanking pair, so `A|C` yields one handle whose `parentIndex` still refers to
+A. Note `onResizeMove` looks up flanking children by `parentIndex`, so the pair
+it resolves must be the pair actually being resized — this needs care, not just a
+predicate tweak.
+
+---
+
+## 4. Finding C — the row's chip layout flips discontinuously on the last minimize
+
+**Measured**, same row, widths `[A, B, C]` in a 1200px row:
+
+| State | A | B | C | How chips render |
+|---|---|---|---|---|
+| A, B minimized; C expanded | 0 | 0 | **1200** | chips **full-width**, stacked above C |
+| A, B, C all minimized | **183** | **183** | **183** | chips **narrow**, side by side |
+
+One toggle takes A's chip from **1200px wide to 183px wide** and moves it from a
+vertical stack into a horizontal strip.
+
+**Root cause.** Not a defect in either branch — it's the seam between two
+deliberately different mechanisms. `resolveRowSlipTargets` returns a target only
+when *some* sibling is still expanded; when the last one collapses it returns an
+empty map (documented behaviour), and every child falls back to
+`computeMainAxisAllocation`'s fixed-chip path. The two paths produce
+qualitatively different geometry and nothing interpolates between them.
+
+**Assessment.** This is the finding I'm least sure is a *bug* — the all-minimized
+strip may well be the intended presentation. But it is a large, abrupt, unanimated
+reflow triggered by one click, and "distorted" is a fair description of how it
+reads. Worth an explicit product decision rather than leaving it as an emergent
+seam.
+
+---
+
+## 5. Finding D — enough docked chips crush their host pane to zero height
+
+**Measured**, 6 panes in a 120px-tall row, 5 minimized onto the survivor:
+
+| | |
+|---|---|
+| Combined chip height | 180px |
+| Row height | 120px |
+| `clampedSlipHeight` | 120px |
+| **Host pane's resulting height** | **0px** |
+
+The row's only expanded pane renders at zero height and disappears.
+
+**Root cause.** Phase B scales the *chips* down to fit
+(`scale = clampedSlipHeight / totalSlipHeight`, added for an earlier reagent P1)
+but computes the host's rect independently:
+
+```ts
+const clampedSlipHeight = Math.min(totalSlipHeight, targetProps.rect.height);
+const shrunkRect = { ...targetProps.rect,
+    top: originalTop + clampedSlipHeight,
+    height: targetProps.rect.height - clampedSlipHeight };
+```
+
+When `totalSlipHeight ≥ rect.height`, `clampedSlipHeight` equals the full height
+and the subtraction yields exactly 0. The chips are made to fit; the pane they
+docked onto is not given a floor.
+
+**Fix direction.** Reserve a minimum host height and scale the chip stack against
+`rect.height − minHostPx` instead of `rect.height`. Requires a product call on
+what the floor is — one header height, or something content-bearing.
+
+**Reachability.** Needs ~5 minimized panes docking onto one short row, so it is
+less likely than A–C in the reported 3-pane scenario. Included because it is the
+same class of defect and cheap to fix alongside.
+
+---
+
+## 6. What is NOT established
+
+- **Which finding the operator actually saw.** A is the best match for "distorted"
+  in the described 3-pane scenario (a visible empty band), and B is the best match
+  for something feeling subtly broken without being obviously wrong. I did not
+  reproduce the report visually and am not claiming to have.
+- **Whether any of this reproduces in the running app.** All measurements are at
+  the pure-function level. The functions are the ones `updateTreeHelper` calls
+  with these exact arguments, but a live check is the honest next step —
+  especially since the FLIP/render layer downstream could mask or compound the
+  geometry.
+- **Whether Finding C is a defect at all** (see §4).
+- **Any Column-direction equivalents.** I only tested Row branches under Column
+  parents, the reported shape. The mirrored case — a Column branch under a Row
+  parent, fully minimized — is presumably affected by the same `countLeafPanes`
+  assumption in the other direction, but I did not test it.
+
+## 7. Reproducing the measurements
+
+Findings A–D were produced by a scratch vitest file (since deleted) calling the
+exported pure functions directly. To regenerate: build the tree shapes described
+in each section with `newLayoutNode` from `frontend/layout/lib/layoutNode`, then
+call `computeMainAxisAllocation` / `resolveRowSlipTargets` /
+`minimizedCrossAxisPx` from `frontend/layout/lib/layoutGeometry`, using
+`HeaderHeightPx = 33`, `gap = 3`. The Phase C handle predicate in §3 and the
+Phase B host-height arithmetic in §5 are copied verbatim from
+`updateTreeHelper`, since neither is separately exported.
+
+## 8. Suggested order of work
+
+1. **Finding A** — replace `countLeafPanes` with the direction-aware
+   `collapsedExtent`. Root cause of the visible dead space, self-contained, and
+   the existing test suite's blind spot is easy to close (add the Row-branch
+   mirror of the current Column-branch test).
+2. **Finding D** — host-height floor in Phase B. Small, adjacent to A.
+3. **Finding B** — rendered-slot-adjacency handles. Needs care around
+   `parentIndex` and `onResizeMove`'s lookup.
+4. **Finding C** — product decision first, then implementation if wanted.
+
+## References
+
+- `frontend/layout/lib/layoutGeometry.ts` — `minimizedFixedPx`,
+  `minimizedCrossAxisPx`, `computeMainAxisAllocation`, `resolveRowSlipTargets`,
+  `updateTreeHelper` Phases A/B/C
+- `frontend/layout/lib/layoutMinimize.ts` — the display-mode model
+- `frontend/layout/tests/layoutMinimize.test.ts` — existing coverage; note its
+  branch-level cases are all Column
+- `docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md`
+- `docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md`
+- `docs/specs/SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md`,
+  `SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md` — the slip/dissolve requirement


### PR DESCRIPTION
## Summary

Analysis only — **no code changed**. Investigates the reported distortion when minimizing the middle panes of:

```
root(Column) → [ TOP, MIDDLE(Row) → [A, B, C], BOTTOM ]
```

**Four defects, all measured against the real exported geometry functions** (`computeMainAxisAllocation`, `resolveRowSlipTargets`, `minimizedCrossAxisPx`) in a scratch vitest file — not inferred from reading the code.

## A — 72px dead space (root cause)

`minimizedFixedPx` computes a fully-minimized subtree's extent as `countLeafPanes × (header+gap)` — "one header height per leaf, stacked." **That holds only when the subtree's own `flexDirection` matches the axis being measured.** A fully-minimized **Row** branch lays its chips out *side by side*, so its true vertical extent is one header height, not N.

| | |
|---|---|
| Root Column allocates to MIDDLE | **108px** |
| MIDDLE actually fills | **36px** |
| **Dead space** | **72px** |
| Same subtree as a *Column* branch | 108 / 108 — exact |

The function's own doc comment asserts the axis-independence that's wrong here: *"a stack's required extent doesn't depend on which axis it's being measured for."* A stack's doesn't — but a Row branch is a **strip**, not a stack.

Correct formula recurses on direction (Σ along the matching axis, `max` across the perpendicular one); `countLeafPanes` is the Σ-always special case.

## B — minimizing a *middle* pane deletes the divider between its two expanded neighbours

Phase C skips a handle when *either* flanking child is minimized, so a minimized B kills both `A|B` and `B|C` — leaving the row with **zero** handles. Meanwhile B contributes zero width, so A and C render flush with no divider and can't be resized against each other.

Measured: **0 handles, widths 600 / 0 / 600**, against a 2-handle baseline.

## D — enough docked chips crush their host to zero height

Phase B scales the *chips* to fit but computes the host's height independently as `rect.height − clampedSlipHeight`, which is exactly 0 when the stack fills the row. Measured: 5 chips onto one survivor in a 120px row → **host height 0**, the row's only expanded pane disappears.

## C — chip layout flips discontinuously on the last minimize

One toggle takes a chip from **1200px wide (stacked)** to **183px wide (side-by-side)**, because slip resolution returns empty once no sibling is expanded and everything falls back to the fixed-chip path. Flagged as needing a **product decision** rather than asserted as a bug — the all-minimized strip may be intended.

## Why this survived

The existing suite's only branch-level minimize regression test uses a **Column** branch (`layoutMinimize.test.ts` — `rightCol = newLayoutNode(FlexDirection.Column, …)`). There is no Row-branch case, and the bug is direction-specific.

## Explicitly not established

Recorded in §6 of the doc rather than glossed:

- **Which finding produced the visual the operator actually saw.** A is the best match for a visible empty band; B for something feeling subtly broken. I did not reproduce it visually.
- **Whether any of it reproduces in the running app** — all measurements are pure-function level. A live check is the honest next step.
- Whether C is a defect at all.
- The mirrored Column-under-Row case, which I did not test.

## Suggested order

1. **A** — direction-aware extent (root cause, self-contained, easy test to add)
2. **D** — host-height floor (small, adjacent to A)
3. **B** — rendered-slot adjacency; needs care around `parentIndex` / `onResizeMove`
4. **C** — product call first

<!-- agentmux:agent_id=agentx -->