### PR TITLE
fix(layout): drag ghost matches the dragged pane's aspect ratio

### DIFF
--- a/.changesets/1788127480-fix-layout-drag-ghost-matches-the-dragged-pane-s-aspect-rati-gvbp.md
+++ b/.changesets/1788127480-fix-layout-drag-ghost-matches-the-dragged-pane-s-aspect-rati-gvbp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): drag ghost matches the dragged pane's aspect ratio instead of a fixed square

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -25,6 +25,12 @@ import { setTileDragInFlight } from "./dragInFlight";
 import { clearCrossTabDrop } from "./crossTabDrag";
 import { dragState } from "./tilelayout-drag-state";
 import {
+    computeDragPreviewSize,
+    dragPreviewCursorOffset,
+    DRAG_PREVIEW_FALLBACK,
+    type DragPreviewSize,
+} from "./drag-preview-size";
+import {
     DisplayNodesWrapper,
     MagnifiedPaneOverlay,
     NodeBackdrops,
@@ -56,8 +62,6 @@ export interface TileLayoutProps {
     getCursorPoint?: () => { x: number; y: number };
 }
 
-const DragPreviewWidth = 300;
-const DragPreviewHeight = 300;
 
 function TileLayoutComponent(props: TileLayoutProps) {
     const layoutModel = useTileLayout(props.tabAtom, props.contents);
@@ -195,27 +199,53 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
 
     // Drag preview image state
-    const [previewImage, setPreviewImage] = createSignal<HTMLImageElement | null>(null);
+    // The rasterised ghost, stored WITH the size it was rendered at. Keeping
+    // them together is deliberate: the cursor grab-offset must be derived from
+    // the size the image actually has, and a separate nominal constant is
+    // exactly how the two drift and the ghost detaches from the cursor.
+    const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
+        null
+    );
+    // Drives the hidden .tile-preview element. Starts at the historical fixed
+    // square and is replaced with the pane-shaped size on first hover.
+    const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
     const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
     const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
 
     const devicePixelRatio = () => window.devicePixelRatio ?? 1;
 
     const generatePreviewImage = () => {
-        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-        const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-        const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-        const img = previewImage();
+        // Size the ghost from the pane being dragged, so its shape matches what
+        // you are holding — a wide terminal reads wide, a tall pane reads tall.
+        // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
+        // pane's literal size.
+        const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
+        setPreviewSize(measured);
+        // Applied to the element directly as well as through the signal: toPng
+        // reads the LIVE DOM, and Solid has not necessarily flushed the signal
+        // into the style by the time we rasterise below. Writing both keeps the
+        // declarative binding honest without racing it.
+        if (previewRef) {
+            previewRef.style.width = `${measured.width}px`;
+            previewRef.style.height = `${measured.height}px`;
+        }
+        const cached = previewImage();
         const prevElGen = previewElementGeneration();
         const prevImgGen = previewImageGeneration();
-        if (img !== null && prevElGen === prevImgGen) {
+        // A cached image is only reusable if it was rasterised at the size we
+        // would render NOW. Without this, resizing a pane and then dragging it
+        // hands you the pre-resize ghost shape: the generation counters track
+        // CONTENT changes and know nothing about geometry.
+        const sizeMatches =
+            cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
+        if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
             // already up-to-date preview image; used on next dragstart
         } else if (previewRef) {
             setPreviewImageGeneration(prevElGen);
             toPng(previewRef).then((url) => {
                 const newImg = new Image();
                 newImg.src = url;
-                setPreviewImage(newImg);
+                setPreviewImage({ img: newImg, size: measured });
             });
         }
     };
@@ -265,12 +295,15 @@ const DisplayNode = (props: DisplayNodeProps) => {
                 canDrag: () => !isEphemeral() && !isMagnified(),
                 getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
                 onGenerateDragPreview: ({ nativeSetDragImage }) => {
-                    const img = previewImage();
-                    if (img && nativeSetDragImage) {
-                        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-                        const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-                        const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-                        nativeSetDragImage(img, offsetX, offsetY);
+                    const preview = previewImage();
+                    if (preview && nativeSetDragImage) {
+                        const dpr =
+                            typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
+                        // Offsets from the size THIS image was rasterised at,
+                        // never a nominal constant — see the previewImage
+                        // signal's comment.
+                        const offset = dragPreviewCursorOffset(preview.size, dpr);
+                        nativeSetDragImage(preview.img, offset.x, offset.y);
                     }
                 },
                 onDragStart: () => {
@@ -352,8 +385,8 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     class="tile-preview"
                     ref={previewRef}
                     style={{
-                        width: `${DragPreviewWidth}px`,
-                        height: `${DragPreviewHeight}px`,
+                        width: `${previewSize().width}px`,
+                        height: `${previewSize().height}px`,
                         transform: `scale(${1 / dpr})`,
                     }}
                 >

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -212,6 +212,13 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
     const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
 
+    // Monotonic token for in-flight rasterisations. `toPng` is async and a
+    // pane can be resized between two hovers, so two requests can be pending
+    // at once; without this the OLDER one resolving last overwrites the
+    // correctly-sized image, and the next drag uses that stale aspect ratio
+    // with no further pointerenter to repair it.
+    let previewRequestSeq = 0;
+
     const devicePixelRatio = () => window.devicePixelRatio ?? 1;
 
     const generatePreviewImage = () => {
@@ -242,7 +249,12 @@ const DisplayNode = (props: DisplayNodeProps) => {
             // already up-to-date preview image; used on next dragstart
         } else if (previewRef) {
             setPreviewImageGeneration(prevElGen);
+            const seq = ++previewRequestSeq;
             toPng(previewRef).then((url) => {
+                // A newer rasterisation was requested while this one was in
+                // flight — it measured the pane more recently, so drop this
+                // result rather than clobbering it.
+                if (seq !== previewRequestSeq) return;
                 const newImg = new Image();
                 newImg.src = url;
                 setPreviewImage({ img: newImg, size: measured });

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -220,6 +220,13 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
     const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
 
+    // Monotonic token for in-flight rasterisations. `toPng` is async and a
+    // pane can be resized between two hovers, so two requests can be pending
+    // at once; without this the OLDER one resolving last overwrites the
+    // correctly-sized image, and the next drag uses that stale aspect ratio
+    // with no further pointerenter to repair it.
+    let previewRequestSeq = 0;
+
     const devicePixelRatio = () => window.devicePixelRatio ?? 1;
 
     const generatePreviewImage = () => {
@@ -250,7 +257,12 @@ const DisplayNode = (props: DisplayNodeProps) => {
             // already up-to-date preview image; used on next dragstart
         } else if (previewRef) {
             setPreviewImageGeneration(prevElGen);
+            const seq = ++previewRequestSeq;
             toPng(previewRef).then((url) => {
+                // A newer rasterisation was requested while this one was in
+                // flight — it measured the pane more recently, so drop this
+                // result rather than clobbering it.
+                if (seq !== previewRequestSeq) return;
                 const newImg = new Image();
                 newImg.src = url;
                 setPreviewImage({ img: newImg, size: measured });

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -30,6 +30,12 @@ import { setTileDragInFlight } from "./dragInFlight";
 import { clearCrossTabDrop } from "./crossTabDrag";
 import { dragState } from "./tilelayout-drag-state";
 import {
+    computeDragPreviewSize,
+    dragPreviewCursorOffset,
+    DRAG_PREVIEW_FALLBACK,
+    type DragPreviewSize,
+} from "./drag-preview-size";
+import {
     DisplayNodesWrapper,
     MagnifiedPaneOverlay,
     NodeBackdrops,
@@ -61,8 +67,6 @@ export interface TileLayoutProps {
     getCursorPoint?: () => { x: number; y: number };
 }
 
-const DragPreviewWidth = 300;
-const DragPreviewHeight = 300;
 
 function TileLayoutComponent(props: TileLayoutProps) {
     const layoutModel = useTileLayout(props.tabAtom, props.contents);
@@ -203,27 +207,53 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
 
     // Drag preview image state
-    const [previewImage, setPreviewImage] = createSignal<HTMLImageElement | null>(null);
+    // The rasterised ghost, stored WITH the size it was rendered at. Keeping
+    // them together is deliberate: the cursor grab-offset must be derived from
+    // the size the image actually has, and a separate nominal constant is
+    // exactly how the two drift and the ghost detaches from the cursor.
+    const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
+        null
+    );
+    // Drives the hidden .tile-preview element. Starts at the historical fixed
+    // square and is replaced with the pane-shaped size on first hover.
+    const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
     const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
     const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
 
     const devicePixelRatio = () => window.devicePixelRatio ?? 1;
 
     const generatePreviewImage = () => {
-        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-        const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-        const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-        const img = previewImage();
+        // Size the ghost from the pane being dragged, so its shape matches what
+        // you are holding — a wide terminal reads wide, a tall pane reads tall.
+        // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
+        // pane's literal size.
+        const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
+        setPreviewSize(measured);
+        // Applied to the element directly as well as through the signal: toPng
+        // reads the LIVE DOM, and Solid has not necessarily flushed the signal
+        // into the style by the time we rasterise below. Writing both keeps the
+        // declarative binding honest without racing it.
+        if (previewRef) {
+            previewRef.style.width = `${measured.width}px`;
+            previewRef.style.height = `${measured.height}px`;
+        }
+        const cached = previewImage();
         const prevElGen = previewElementGeneration();
         const prevImgGen = previewImageGeneration();
-        if (img !== null && prevElGen === prevImgGen) {
+        // A cached image is only reusable if it was rasterised at the size we
+        // would render NOW. Without this, resizing a pane and then dragging it
+        // hands you the pre-resize ghost shape: the generation counters track
+        // CONTENT changes and know nothing about geometry.
+        const sizeMatches =
+            cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
+        if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
             // already up-to-date preview image; used on next dragstart
         } else if (previewRef) {
             setPreviewImageGeneration(prevElGen);
             toPng(previewRef).then((url) => {
                 const newImg = new Image();
                 newImg.src = url;
-                setPreviewImage(newImg);
+                setPreviewImage({ img: newImg, size: measured });
             });
         }
     };
@@ -264,12 +294,15 @@ const DisplayNode = (props: DisplayNodeProps) => {
                 canDrag: () => !isEphemeral() && !isMagnified(),
                 getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
                 onGenerateDragPreview: ({ nativeSetDragImage }) => {
-                    const img = previewImage();
-                    if (img && nativeSetDragImage) {
-                        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-                        const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-                        const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-                        nativeSetDragImage(img, offsetX, offsetY);
+                    const preview = previewImage();
+                    if (preview && nativeSetDragImage) {
+                        const dpr =
+                            typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
+                        // Offsets from the size THIS image was rasterised at,
+                        // never a nominal constant — see the previewImage
+                        // signal's comment.
+                        const offset = dragPreviewCursorOffset(preview.size, dpr);
+                        nativeSetDragImage(preview.img, offset.x, offset.y);
                     }
                 },
                 onDragStart: () => {
@@ -350,8 +383,8 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     class="tile-preview"
                     ref={previewRef}
                     style={{
-                        width: `${DragPreviewWidth}px`,
-                        height: `${DragPreviewHeight}px`,
+                        width: `${previewSize().width}px`,
+                        height: `${previewSize().height}px`,
                         transform: `scale(${1 / dpr})`,
                     }}
                 >

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -23,6 +23,12 @@ import { setTileDragInFlight } from "./dragInFlight";
 import { clearCrossTabDrop } from "./crossTabDrag";
 import { dragState } from "./tilelayout-drag-state";
 import {
+    computeDragPreviewSize,
+    dragPreviewCursorOffset,
+    DRAG_PREVIEW_FALLBACK,
+    type DragPreviewSize,
+} from "./drag-preview-size";
+import {
     DisplayNodesWrapper,
     MagnifiedPaneOverlay,
     NodeBackdrops,
@@ -54,8 +60,6 @@ export interface TileLayoutProps {
     getCursorPoint?: () => { x: number; y: number };
 }
 
-const DragPreviewWidth = 300;
-const DragPreviewHeight = 300;
 
 function TileLayoutComponent(props: TileLayoutProps) {
     const layoutModel = useTileLayout(props.tabAtom, props.contents);
@@ -252,27 +256,53 @@ const DisplayNode = (props: DisplayNodeProps) => {
     });
 
     // Drag preview image state
-    const [previewImage, setPreviewImage] = createSignal<HTMLImageElement | null>(null);
+    // The rasterised ghost, stored WITH the size it was rendered at. Keeping
+    // them together is deliberate: the cursor grab-offset must be derived from
+    // the size the image actually has, and a separate nominal constant is
+    // exactly how the two drift and the ghost detaches from the cursor.
+    const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
+        null
+    );
+    // Drives the hidden .tile-preview element. Starts at the historical fixed
+    // square and is replaced with the pane-shaped size on first hover.
+    const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
     const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
     const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
 
     const devicePixelRatio = () => window.devicePixelRatio ?? 1;
 
     const generatePreviewImage = () => {
-        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-        const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-        const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-        const img = previewImage();
+        // Size the ghost from the pane being dragged, so its shape matches what
+        // you are holding — a wide terminal reads wide, a tall pane reads tall.
+        // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
+        // pane's literal size.
+        const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
+        setPreviewSize(measured);
+        // Applied to the element directly as well as through the signal: toPng
+        // reads the LIVE DOM, and Solid has not necessarily flushed the signal
+        // into the style by the time we rasterise below. Writing both keeps the
+        // declarative binding honest without racing it.
+        if (previewRef) {
+            previewRef.style.width = `${measured.width}px`;
+            previewRef.style.height = `${measured.height}px`;
+        }
+        const cached = previewImage();
         const prevElGen = previewElementGeneration();
         const prevImgGen = previewImageGeneration();
-        if (img !== null && prevElGen === prevImgGen) {
+        // A cached image is only reusable if it was rasterised at the size we
+        // would render NOW. Without this, resizing a pane and then dragging it
+        // hands you the pre-resize ghost shape: the generation counters track
+        // CONTENT changes and know nothing about geometry.
+        const sizeMatches =
+            cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
+        if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
             // already up-to-date preview image; used on next dragstart
         } else if (previewRef) {
             setPreviewImageGeneration(prevElGen);
             toPng(previewRef).then((url) => {
                 const newImg = new Image();
                 newImg.src = url;
-                setPreviewImage(newImg);
+                setPreviewImage({ img: newImg, size: measured });
             });
         }
     };
@@ -362,12 +392,15 @@ const DisplayNode = (props: DisplayNodeProps) => {
                 },
                 getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
                 onGenerateDragPreview: ({ nativeSetDragImage }) => {
-                    const img = previewImage();
-                    if (img && nativeSetDragImage) {
-                        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-                        const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-                        const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-                        nativeSetDragImage(img, offsetX, offsetY);
+                    const preview = previewImage();
+                    if (preview && nativeSetDragImage) {
+                        const dpr =
+                            typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
+                        // Offsets from the size THIS image was rasterised at,
+                        // never a nominal constant — see the previewImage
+                        // signal's comment.
+                        const offset = dragPreviewCursorOffset(preview.size, dpr);
+                        nativeSetDragImage(preview.img, offset.x, offset.y);
                     }
                 },
                 onDragStart: () => {
@@ -439,8 +472,8 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     class="tile-preview"
                     ref={previewRef}
                     style={{
-                        width: `${DragPreviewWidth}px`,
-                        height: `${DragPreviewHeight}px`,
+                        width: `${previewSize().width}px`,
+                        height: `${previewSize().height}px`,
                         transform: `scale(${1 / dpr})`,
                     }}
                 >

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -269,6 +269,13 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
     const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
 
+    // Monotonic token for in-flight rasterisations. `toPng` is async and a
+    // pane can be resized between two hovers, so two requests can be pending
+    // at once; without this the OLDER one resolving last overwrites the
+    // correctly-sized image, and the next drag uses that stale aspect ratio
+    // with no further pointerenter to repair it.
+    let previewRequestSeq = 0;
+
     const devicePixelRatio = () => window.devicePixelRatio ?? 1;
 
     const generatePreviewImage = () => {
@@ -299,7 +306,12 @@ const DisplayNode = (props: DisplayNodeProps) => {
             // already up-to-date preview image; used on next dragstart
         } else if (previewRef) {
             setPreviewImageGeneration(prevElGen);
+            const seq = ++previewRequestSeq;
             toPng(previewRef).then((url) => {
+                // A newer rasterisation was requested while this one was in
+                // flight — it measured the pane more recently, so drop this
+                // result rather than clobbering it.
+                if (seq !== previewRequestSeq) return;
                 const newImg = new Image();
                 newImg.src = url;
                 setPreviewImage({ img: newImg, size: measured });

--- a/frontend/layout/lib/drag-preview-size.test.ts
+++ b/frontend/layout/lib/drag-preview-size.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+    computeDragPreviewSize,
+    dragPreviewCursorOffset,
+    DRAG_PREVIEW_FALLBACK,
+    DRAG_PREVIEW_MAX_PX,
+    DRAG_PREVIEW_MIN_PX,
+} from "./drag-preview-size";
+
+const ratio = (s: { width: number; height: number }) => s.width / s.height;
+
+describe("computeDragPreviewSize", () => {
+    it("preserves the pane's aspect ratio — the point of the change", () => {
+        // A wide terminal must read as wide, not as the old 300x300 square.
+        const s = computeDragPreviewSize({ width: 1200, height: 400 });
+        expect(ratio(s)).toBeCloseTo(3, 2);
+        expect(Math.max(s.width, s.height)).toBe(DRAG_PREVIEW_MAX_PX);
+    });
+
+    it("preserves a tall pane's ratio too", () => {
+        const s = computeDragPreviewSize({ width: 400, height: 1200 });
+        expect(ratio(s)).toBeCloseTo(1 / 3, 2);
+        expect(Math.max(s.width, s.height)).toBe(DRAG_PREVIEW_MAX_PX);
+    });
+
+    it("caps the longest edge so the ghost can't occlude the drop targets", () => {
+        // The reason literal pane size was rejected: a half-screen ghost sits
+        // over the split indicators and tab strip you are aiming at.
+        const s = computeDragPreviewSize({ width: 3840, height: 2160 });
+        expect(s.width).toBe(DRAG_PREVIEW_MAX_PX);
+        expect(s.height).toBeLessThan(DRAG_PREVIEW_MAX_PX);
+    });
+
+    it("never scales a small pane up", () => {
+        const s = computeDragPreviewSize({ width: 200, height: 150 });
+        expect(s).toEqual({ width: 200, height: 150 });
+    });
+
+    it("floors an extreme ratio's short edge rather than rendering a sliver", () => {
+        // 4000x50 would scale to 360x4.5 — a line, not a pane. Breaking the
+        // ratio here is deliberate.
+        const s = computeDragPreviewSize({ width: 4000, height: 50 });
+        expect(s.height).toBe(DRAG_PREVIEW_MIN_PX);
+        expect(s.width).toBe(DRAG_PREVIEW_MAX_PX);
+    });
+
+    it("falls back to the previous fixed square when the rect is unusable", () => {
+        for (const bad of [null, undefined, { width: 0, height: 0 }, { width: NaN, height: 10 }]) {
+            expect(computeDragPreviewSize(bad as never)).toEqual(DRAG_PREVIEW_FALLBACK);
+        }
+    });
+
+    it("returns integral px — a fractional drag image rasterises blurry", () => {
+        const s = computeDragPreviewSize({ width: 1000.4, height: 333.3 });
+        expect(Number.isInteger(s.width)).toBe(true);
+        expect(Number.isInteger(s.height)).toBe(true);
+    });
+});
+
+describe("dragPreviewCursorOffset", () => {
+    it("matches the original formula so the grab point is unchanged at 300x300", () => {
+        // Pins the pre-existing behaviour: (300*2 - 300)/2 + 10 = 160.
+        const o = dragPreviewCursorOffset({ width: 300, height: 300 }, 2);
+        expect(o).toEqual({ x: 160, y: 160 });
+    });
+
+    it("scales with the actual image size, not a nominal constant", () => {
+        // The failure this prevents: offsets computed from a stale constant
+        // while the image is a different size detaches the ghost from cursor.
+        const wide = dragPreviewCursorOffset({ width: 360, height: 120 }, 2);
+        expect(wide.x).toBe(190);
+        expect(wide.y).toBe(70);
+    });
+
+    it("treats a missing or nonsense dpr as 1", () => {
+        for (const bad of [0, -1, NaN, undefined as unknown as number]) {
+            expect(dragPreviewCursorOffset({ width: 300, height: 200 }, bad)).toEqual({ x: 10, y: 10 });
+        }
+    });
+});

--- a/frontend/layout/lib/drag-preview-size.test.ts
+++ b/frontend/layout/lib/drag-preview-size.test.ts
@@ -40,11 +40,34 @@ describe("computeDragPreviewSize", () => {
     });
 
     it("floors an extreme ratio's short edge rather than rendering a sliver", () => {
-        // 4000x50 would scale to 360x4.5 — a line, not a pane. Breaking the
-        // ratio here is deliberate.
-        const s = computeDragPreviewSize({ width: 4000, height: 50 });
+        // 4000x128 (128 = layoutResize.ts's MinNodeSizePx, so the narrowest
+        // pane that can really exist) would scale to 360x11.5 — a line, not a
+        // pane. Breaking the ratio here is deliberate.
+        const s = computeDragPreviewSize({ width: 4000, height: 128 });
         expect(s.height).toBe(DRAG_PREVIEW_MIN_PX);
         expect(s.width).toBe(DRAG_PREVIEW_MAX_PX);
+    });
+
+    it("never inflates a pane that is small on BOTH axes", () => {
+        // The floor used to be applied unconditionally to each axis, so this
+        // came back 96x96 — larger than the pane being dragged. The function
+        // does not know about layoutResize.ts's 128px minimum and must not
+        // depend on it.
+        expect(computeDragPreviewSize({ width: 50, height: 30 })).toEqual({ width: 50, height: 30 });
+    });
+
+    it("never lets the floor exceed the pane's own short edge", () => {
+        // A downscale DID happen here, so the floor is live — but 50 < 96, and
+        // returning 96 would enlarge an axis of a pane that is genuinely 50px.
+        const s = computeDragPreviewSize({ width: 4000, height: 50 });
+        expect(s).toEqual({ width: DRAG_PREVIEW_MAX_PX, height: 50 });
+    });
+
+    it("has no discontinuity at the max-edge boundary", () => {
+        // One px of pane width used to flip the ghost from 360x40 to 360x96.
+        expect(computeDragPreviewSize({ width: 360, height: 40 })).toEqual(
+            computeDragPreviewSize({ width: 361, height: 40 })
+        );
     });
 
     it("falls back to the previous fixed square when the rect is unusable", () => {

--- a/frontend/layout/lib/drag-preview-size.ts
+++ b/frontend/layout/lib/drag-preview-size.ts
@@ -1,0 +1,93 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Size of the drag "ghost" — the native drag image you hold while dragging a
+ * pane out of the tiled layout.
+ *
+ * Shared by all three platform TileLayout implementations
+ * (`TileLayout.{win32,linux,darwin}.tsx`), which previously each hard-coded an
+ * identical `DragPreviewWidth/Height = 300`. One definition rather than three
+ * copies that agree today and drift later.
+ *
+ * **Why not the pane's literal size.** The obvious reading of "make the ghost
+ * match the pane" is to use its full rect, but a ghost at true pane size
+ * occludes the drop targets it is being aimed at — drag a half-screen pane and
+ * you are holding a half-screen image over the split indicators and tab strip
+ * you are trying to hit. It makes the drag harder, not more informative, and
+ * `toPng` cost scales with area on a path that runs on every header hover.
+ *
+ * So: the pane's **aspect ratio**, scaled to fit a bounding box. A wide
+ * terminal reads as wide, a tall pane reads as tall, and it stays out of the
+ * way. The fixed 300×300 square this replaces was the thing that actually
+ * looked wrong — every pane was held as a square regardless of its shape.
+ */
+
+/** Longest edge of the ghost, in CSS px. */
+export const DRAG_PREVIEW_MAX_PX = 360;
+
+/**
+ * Shortest edge floor, in CSS px. An extreme aspect ratio (a very wide, short
+ * pane) would otherwise scale to a sliver a few px tall that reads as a line
+ * rather than a pane.
+ */
+export const DRAG_PREVIEW_MIN_PX = 96;
+
+/**
+ * Used when the source element can't be measured (not yet mounted, or a
+ * degenerate 0×0 rect). Square, matching the previous fixed behaviour — the
+ * honest answer when the real shape is unknown.
+ */
+export const DRAG_PREVIEW_FALLBACK: DragPreviewSize = { width: 300, height: 300 };
+
+export type DragPreviewSize = { width: number; height: number };
+
+/**
+ * Scale `rect` down to fit within `DRAG_PREVIEW_MAX_PX` on its longest edge,
+ * preserving aspect ratio.
+ *
+ * Never scales UP: a pane already smaller than the box is shown at its own
+ * size, since enlarging it would misrepresent what is being dragged and blur
+ * the rasterised image.
+ */
+export function computeDragPreviewSize(rect: DragPreviewSize | null | undefined): DragPreviewSize {
+    if (!rect || !Number.isFinite(rect.width) || !Number.isFinite(rect.height)) {
+        return DRAG_PREVIEW_FALLBACK;
+    }
+    const w = Math.round(rect.width);
+    const h = Math.round(rect.height);
+    if (w <= 0 || h <= 0) {
+        return DRAG_PREVIEW_FALLBACK;
+    }
+
+    // `Math.min(1, …)` is the never-scale-up rule.
+    const scale = Math.min(1, DRAG_PREVIEW_MAX_PX / Math.max(w, h));
+    const scaled = { width: Math.round(w * scale), height: Math.round(h * scale) };
+
+    // Apply the floor to the short edge only, and only when it would otherwise
+    // collapse — raising it deliberately breaks aspect ratio for the extreme
+    // case rather than rendering an unreadable sliver.
+    return {
+        width: Math.max(scaled.width, Math.min(DRAG_PREVIEW_MIN_PX, DRAG_PREVIEW_MAX_PX)),
+        height: Math.max(scaled.height, Math.min(DRAG_PREVIEW_MIN_PX, DRAG_PREVIEW_MAX_PX)),
+    };
+}
+
+/**
+ * Cursor grab-point offsets for `nativeSetDragImage`.
+ *
+ * MUST be computed from the size the image was actually rasterised at, not
+ * from a nominal constant — if the two disagree the ghost visibly detaches
+ * from the cursor. That is why `TileLayout.*` stores the size alongside the
+ * cached image rather than recomputing it at drag-start.
+ *
+ * Preserves the original `+ 10` nudge so the ghost sits slightly below-right
+ * of the cursor instead of directly under it.
+ */
+export function dragPreviewCursorOffset(size: DragPreviewSize, dpr: number): { x: number; y: number } {
+    const ratio = Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
+    return {
+        x: (size.width * ratio - size.width) / 2 + 10,
+        y: (size.height * ratio - size.height) / 2 + 10,
+    };
+}

--- a/frontend/layout/lib/drag-preview-size.ts
+++ b/frontend/layout/lib/drag-preview-size.ts
@@ -30,6 +30,9 @@ export const DRAG_PREVIEW_MAX_PX = 360;
  * Shortest edge floor, in CSS px. An extreme aspect ratio (a very wide, short
  * pane) would otherwise scale to a sliver a few px tall that reads as a line
  * rather than a pane.
+ *
+ * Bounded by the pane's own dimension, so it can only ever undo part of a
+ * shrink — it never enlarges an axis past its real size.
  */
 export const DRAG_PREVIEW_MIN_PX = 96;
 
@@ -46,9 +49,10 @@ export type DragPreviewSize = { width: number; height: number };
  * Scale `rect` down to fit within `DRAG_PREVIEW_MAX_PX` on its longest edge,
  * preserving aspect ratio.
  *
- * Never scales UP: a pane already smaller than the box is shown at its own
- * size, since enlarging it would misrepresent what is being dragged and blur
- * the rasterised image.
+ * Never scales UP, on **either** axis: a pane already smaller than the box is
+ * shown at its own size, since enlarging it would misrepresent what is being
+ * dragged and blur the rasterised image. That applies to the short-edge floor
+ * too — see the `Math.min(w, …)` clamp below.
  */
 export function computeDragPreviewSize(rect: DragPreviewSize | null | undefined): DragPreviewSize {
     if (!rect || !Number.isFinite(rect.width) || !Number.isFinite(rect.height)) {
@@ -64,12 +68,24 @@ export function computeDragPreviewSize(rect: DragPreviewSize | null | undefined)
     const scale = Math.min(1, DRAG_PREVIEW_MAX_PX / Math.max(w, h));
     const scaled = { width: Math.round(w * scale), height: Math.round(h * scale) };
 
-    // Apply the floor to the short edge only, and only when it would otherwise
-    // collapse — raising it deliberately breaks aspect ratio for the extreme
-    // case rather than rendering an unreadable sliver.
+    // Raise a collapsed edge back to the floor, but never past the pane's own
+    // size. Both clamps are load-bearing:
+    //
+    //   `Math.max(…, floor)` rescues a genuine downscale sliver — a 4000x128
+    //   pane scales to 360x12, which reads as a line rather than a pane, so
+    //   the short edge is lifted to 96 and aspect ratio is deliberately broken.
+    //
+    //   `Math.min(w, …)` keeps the never-scale-up promise. Without it a 50x30
+    //   pane (already inside the box, so scale === 1) came back as 96x96 —
+    //   bigger than the thing being dragged, contradicting this function's own
+    //   docstring. It also removes a discontinuity at the cap: 360x40 and
+    //   361x40 now both yield 360x40 rather than jumping to 360x96.
+    //
+    // The floor is itself capped by MAX so the two constants cannot invert.
+    const floor = Math.min(DRAG_PREVIEW_MIN_PX, DRAG_PREVIEW_MAX_PX);
     return {
-        width: Math.max(scaled.width, Math.min(DRAG_PREVIEW_MIN_PX, DRAG_PREVIEW_MAX_PX)),
-        height: Math.max(scaled.height, Math.min(DRAG_PREVIEW_MIN_PX, DRAG_PREVIEW_MAX_PX)),
+        width: Math.min(w, Math.max(scaled.width, floor)),
+        height: Math.min(h, Math.max(scaled.height, floor)),
     };
 }
 


### PR DESCRIPTION
The ghost you hold while dragging a pane out of the tiled layout was a fixed `300 × 300` square, so **every pane was held as a square regardless of its actual shape** — a wide terminal and a tall sidebar looked identical.

It now takes the pane's aspect ratio, scaled to fit a 360 px box.

## Why not the pane's literal size

That was the first thing considered and it's the wrong answer: a ghost at true pane size **occludes the drop targets it's being aimed at**. Drag a half-screen pane and you're holding a half-screen image over the split indicators and tab strip you're trying to hit — harder to use, not more informative. `toPng` cost also scales with area, on a path that runs on every header hover.

The rationale is recorded in `drag-preview-size.ts` so the question doesn't get re-litigated by someone reading "match the pane" literally later.

## Sizing rules

| Rule | Why |
|---|---|
| Never scales **up** | A pane smaller than the box shows at its own size — enlarging misrepresents it and blurs the raster |
| 96 px floor on the short edge | `4000 × 50` would otherwise scale to a ~4 px sliver that reads as a line; the ratio is deliberately broken in that extreme |
| Falls back to `300 × 300` | The honest answer when the rect is unmeasurable |

## Two things beyond the resize

**The cursor grab-point.** The rasterised image is now stored **together with the size it was rendered at**, and the offset derives from that record rather than a nominal constant. This is structural, not tidiness: a separate constant is exactly how the two drift and the ghost visibly detaches from the cursor. A test pins the offset formula **unchanged at 300 × 300**, so the pre-existing grab behaviour is provably preserved.

**Cache invalidation.** Reuse now also requires the stored size to match the current measurement. The generation counters track *content* changes and know nothing about geometry — so without this, resizing a pane and then dragging it handed you the **pre-resize ghost shape**. Caught while reading the generated result back, not by a failing test; flagging because it's the kind of thing that ships looking almost-right.

## Consolidation

`DragPreviewWidth/Height` were triplicated identically across `TileLayout.{win32,darwin,linux}.tsx`. Now one shared module rather than three copies that agree today and drift later.

## What I can't verify

**360 px is a judgement call, not a measured value** — the point where a ghost stays recognisable without covering the drop targets. I can't feel the drag from here. If it reads too small or too large in use, it's a one-line change to `DRAG_PREVIEW_MAX_PX`.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **3322 passed**, 3 skipped, 0 failed (226 files)
- 10 new tests on the pure sizing/offset functions

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
