### PR TITLE
fix(layout): derive a minimized branch's extent from its own direction, not its leaf count

### DIFF
--- a/.changesets/1788101900-fix-layout-cross-split-minimize-extent-x9k2.md
+++ b/.changesets/1788101900-fix-layout-cross-split-minimize-extent-x9k2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): derive a minimized branch's extent from its own direction, not its leaf count

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -28,16 +28,58 @@ export interface MainAxisAllocation {
     pixelToSizeRatio: number;
 }
 
-/** Leaf count of a subtree — one header chip per leaf when fully minimized. */
-function countLeafPanes(node: LayoutNode): number {
-    if (!node.children?.length) return 1;
-    return node.children.reduce((s, c) => s + countLeafPanes(c), 0);
+/**
+ * Extent (in px) a FULLY-MINIMIZED subtree needs along one axis, once every
+ * leaf in it has become a header chip.
+ *
+ * This must recurse on each branch's own `flexDirection`, not just count
+ * leaves: chips only accumulate along the axis their container lays out on,
+ * and span (max) across the perpendicular one.
+ *
+ * - leaf → one chip: a header-height along the vertical axis, a fixed
+ *   compact width along the horizontal one.
+ * - branch laid out ALONG the measured axis → **sum** of its children
+ *   (a stack: N chips take N chip-extents).
+ * - branch laid out ACROSS it → **max** of its children
+ *   (a strip: N chips side by side still occupy one chip-extent deep).
+ *
+ * The previous implementation was `countLeafPanes(node) * (Header + gap)` —
+ * i.e. sum-always, which silently assumes every branch on the path stacks
+ * along the axis being measured. That holds for an all-Column subtree and
+ * breaks for any **cross-split** (a branch nested perpendicular to its
+ * parent: a Row inside a Column, or the mirror). A fully-minimized Row of
+ * 3 panes inside a Column parent was asked for 3 header-heights of height
+ * and rendered a single 1-header-high strip of chips, leaving 2
+ * header-heights of dead space below it — visible as an empty band between
+ * the chip strip and the pane underneath, and reproduced end-to-end in
+ * `docs/analysis/ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30.md`
+ * §2. The mirrored case UNDER-allocated for the same reason: a
+ * fully-minimized Row branch inside a Row parent got one chip's width for
+ * N side-by-side chips.
+ *
+ * Pure; exported for unit tests.
+ */
+export function collapsedExtentPx(node: LayoutNode, axisIsVertical: boolean, gapPx: number): number {
+    const kids = node.children;
+    if (!kids?.length) {
+        return axisIsVertical ? HeaderHeightPx + gapPx : MinimizedRowSlotWidthPx + gapPx;
+    }
+    const extents = kids.map((c) => collapsedExtentPx(c, axisIsVertical, gapPx));
+    // A Column lays its children out vertically; a Row, horizontally.
+    const laidOutAlongThisAxis = (node.flexDirection === FlexDirection.Column) === axisIsVertical;
+    return laidOutAlongThisAxis
+        ? extents.reduce((a, b) => a + b, 0)
+        : extents.reduce((a, b) => Math.max(a, b), 0);
 }
 
 /**
  * Fixed main-axis pixels for a minimized child: a header-height strip per
  * stacked chip in a Column parent, a compact fixed-width chip in a Row parent.
  * Derived fresh every pass — minimize never writes sizes (see layoutMinimize).
+ *
+ * Delegates to [`collapsedExtentPx`] so a minimized BRANCH is measured by its
+ * own internal direction rather than by leaf count — see that function for
+ * the cross-split bug this fixes.
  *
  * Gap compensation: each tile's rendered box is inset by `gapSizePx`
  * downstream (`innerRect` computes `calc(size - gapSizePx)` in
@@ -46,24 +88,29 @@ function countLeafPanes(node: LayoutNode): number {
  * box to come out exactly header-sized instead of clipping.
  */
 function minimizedFixedPx(node: LayoutNode, parentIsRow: boolean, gapPx: number): number {
-    if (parentIsRow) return MinimizedRowSlotWidthPx + gapPx;
-    return countLeafPanes(node) * (HeaderHeightPx + gapPx);
+    // A Row parent allocates along the horizontal axis; a Column, vertical.
+    return collapsedExtentPx(node, !parentIsRow, gapPx);
 }
 
 /**
- * Cross-axis (height) a minimized child needs when its parent is a Row: one
- * header height per leaf in its subtree, stacked. A single minimized leaf
- * needs one header height; a fully-minimized BRANCH holding N leaves needs
- * N header-heights, because its own recursive Column layout will stack N
- * chips inside whatever cross-axis space its parent gives it here — giving
- * it less produces overlapping/clipped chips, giving it more produces dead
- * space below them (the bug this function exists to prevent). Same formula
- * as `minimizedFixedPx`'s Column-parent branch — a stack's required extent
- * doesn't depend on which axis it's being measured for. Pure; exported for
- * unit tests.
+ * Cross-axis (height) a minimized child needs when its parent is a Row.
+ *
+ * A single minimized leaf needs one header height. A fully-minimized BRANCH
+ * needs however deep its own chip arrangement actually is: a **Column**
+ * branch holding N leaves stacks N chips and needs N header-heights, while a
+ * **Row** branch holding N leaves lays them side by side and needs only ONE
+ * — giving it less produces overlapping/clipped chips, giving it more
+ * produces dead space below them (the bug this function exists to prevent,
+ * in both directions).
+ *
+ * An earlier version of this comment claimed "a stack's required extent
+ * doesn't depend on which axis it's being measured for." That is true of a
+ * stack and false of a strip, and it is exactly why the Row-inside-Column
+ * case over-allocated — see [`collapsedExtentPx`]. Pure; exported for unit
+ * tests.
  */
 export function minimizedCrossAxisPx(child: LayoutNode, gapPx: number): number {
-    return minimizedFixedPx(child, false, gapPx);
+    return collapsedExtentPx(child, true, gapPx);
 }
 
 /**

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -12,7 +12,12 @@ import {
     HeaderHeightPx,
     MinimizedRowSlotWidthPx,
 } from "../lib/layoutMinimize";
-import { computeMainAxisAllocation, minimizedCrossAxisPx, resolveRowSlipTargets } from "../lib/layoutGeometry";
+import {
+    computeMainAxisAllocation,
+    minimizedCrossAxisPx,
+    resolveRowSlipTargets,
+    collapsedExtentPx,
+} from "../lib/layoutGeometry";
 import { resizeNode, splitVertical } from "../lib/layoutTree";
 import { FlexDirection, type LayoutNode } from "../lib/types";
 
@@ -517,5 +522,85 @@ describe("computeMainAxisAllocation with slipChildIds", () => {
         const { px } = computeMainAxisAllocation([a, b], true, 1000, size, 3);
         expect(px[1]).toBe(MinimizedRowSlotWidthPx + 3);
         expect(px[0]).toBeCloseTo(1000 - (MinimizedRowSlotWidthPx + 3));
+    });
+});
+
+// ── Cross-split: a branch nested PERPENDICULAR to its parent ────────────────
+// Regression for ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30 §2.
+// The suite's prior branch-level minimize coverage was all Column-inside-
+// Column, which is the one shape the old countLeafPanes formula got right.
+describe("collapsedExtentPx — cross-split (perpendicular nested branch)", () => {
+    const gap = 3;
+    const chipH = HeaderHeightPx + gap;
+    const chipW = MinimizedRowSlotWidthPx + gap;
+    const minLeaf = (id: string) => {
+        const n = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: id });
+        n.minimized = true;
+        return n;
+    };
+
+    it("a minimized leaf is one chip on either axis", () => {
+        const leaf = minLeaf("a");
+        expect(collapsedExtentPx(leaf, true, gap)).toBe(chipH);
+        expect(collapsedExtentPx(leaf, false, gap)).toBe(chipW);
+    });
+
+    it("a COLUMN branch stacks: N chips deep vertically, one chip wide", () => {
+        const col = newLayoutNode(FlexDirection.Column, 5, [minLeaf("a"), minLeaf("b"), minLeaf("c")]);
+        expect(collapsedExtentPx(col, true, gap)).toBe(3 * chipH);
+        expect(collapsedExtentPx(col, false, gap)).toBe(chipW);
+    });
+
+    it("a ROW branch is a strip: ONE chip deep vertically, N chips wide", () => {
+        const row = newLayoutNode(FlexDirection.Row, 5, [minLeaf("a"), minLeaf("b"), minLeaf("c")]);
+        // The bug: this used to return 3 * chipH via countLeafPanes, so the
+        // parent Column handed the row 3 header-heights for a 1-header-high
+        // strip of chips -> 2 header-heights of dead space beneath it.
+        expect(collapsedExtentPx(row, true, gap)).toBe(chipH);
+        expect(collapsedExtentPx(row, false, gap)).toBe(3 * chipW);
+    });
+
+    it("minimizedCrossAxisPx: a fully-minimized ROW branch needs one header height, not N", () => {
+        const row = newLayoutNode(FlexDirection.Row, 5, [minLeaf("a"), minLeaf("b"), minLeaf("c")]);
+        expect(minimizedCrossAxisPx(row, gap)).toBe(chipH);
+    });
+
+    it("no dead space: the reported layout — Column[top, Row[A,B,C], bottom]", () => {
+        const size = (n: LayoutNode) => n.size;
+        const row = newLayoutNode(FlexDirection.Row, 10, [minLeaf("A"), minLeaf("B"), minLeaf("C")]);
+        const top = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "top" });
+        const bottom = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "bottom" });
+
+        // What the parent Column allocates to the row on its main (vertical) axis.
+        const outer = computeMainAxisAllocation([top, row, bottom], false, 900, size, gap);
+        const allocatedToRow = outer.px[1];
+
+        // What the row actually fills: its chips laid out side by side are one
+        // chip-height deep, whatever the container gives them.
+        const consumed = minimizedCrossAxisPx(row, gap);
+
+        expect(allocatedToRow).toBe(chipH);
+        expect(consumed).toBe(chipH);
+        expect(allocatedToRow - consumed).toBe(0); // <- was 2 * chipH of dead space
+    });
+
+    it("mirror case: a fully-minimized ROW branch inside a ROW parent gets N chip-widths, not one", () => {
+        const size = (n: LayoutNode) => n.size;
+        const row = newLayoutNode(FlexDirection.Row, 10, [minLeaf("A"), minLeaf("B")]);
+        const expanded = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "keep" });
+        const alloc = computeMainAxisAllocation([row, expanded], true, 1200, size, gap);
+        // Previously minimizedFixedPx returned a flat MinimizedRowSlotWidthPx
+        // for ANY minimized child of a Row parent, so this branch was given
+        // one chip's width for two side-by-side chips (under-allocation).
+        expect(alloc.px[0]).toBe(2 * chipW);
+    });
+
+    it("deep nesting resolves per level, not by leaf count", () => {
+        // Column[ Row[a,b], c ] fully minimized, measured vertically:
+        //   Row[a,b] is a strip -> 1 chip deep; plus leaf c -> 1 chip.
+        //   Total 2 chip-heights, NOT the 3 that leaf-counting would give.
+        const inner = newLayoutNode(FlexDirection.Row, 5, [minLeaf("a"), minLeaf("b")]);
+        const outer = newLayoutNode(FlexDirection.Column, 5, [inner, minLeaf("c")]);
+        expect(collapsedExtentPx(outer, true, gap)).toBe(2 * chipH);
     });
 });


### PR DESCRIPTION
Fixes the pane-minimize distortion reported for a **cross-split** layout — a block above, a block below, several side by side in the middle. Analysis: `docs/analysis/ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30.md` §2 (#2846).

## The bug

A fully-minimized subtree's extent was `countLeafPanes(node) * (HeaderHeightPx + gap)` — **sum-always**. That assumes every branch on the path stacks along the axis being measured, which holds only for an all-Column subtree.

In `root(Column)[top, Row[A,B,C], bottom]`, minimizing all the middle panes makes the Row *effectively minimized*, so the parent Column allocates it `3 × (header+gap)` of **height**. But a Row lays its chips out **side by side** — it renders one header-high strip and leaves **2 header-heights of dead space** beneath it. A visible empty band between the chips and the pane below.

The mirror case **under**-allocated for the same reason: `minimizedFixedPx` returned a flat `MinimizedRowSlotWidthPx` for *any* minimized child of a Row parent, so a fully-minimized Row branch got one chip's width for N side-by-side chips.

## The fix

`collapsedExtentPx(node, axisIsVertical, gap)` recurses on each branch's **own** `flexDirection`:

| | |
|---|---|
| leaf | one chip on the measured axis |
| branch laid out **along** that axis | **sum** of children — a stack |
| branch laid out **across** it | **max** of children — a strip |

`countLeafPanes` was the sum-always special case, correct only when direction and axis happened to agree. Both `minimizedFixedPx` and `minimizedCrossAxisPx` delegate to it, so the main-axis allocation and Phase A's cross-axis clamp stay consistent by construction.

Also corrects the doc comment that *asserted* the bug: *"a stack's required extent doesn't depend on which axis it's being measured for."* True of a stack, false of a strip — which is exactly the case that broke.

## Verification

**Unit:** 174/174 in `frontend/layout`. Seven added for the cross-split shape — both axes for leaf/Column/Row, the reported `Column[top, Row, bottom]` layout asserting **zero** dead space, the Row-in-Row mirror, and two-level nesting that resolves per level rather than by leaf count.

**End-to-end:** measured through the real `LayoutModel.updateTree()` before the fix — the Row's rect ran to y=354 while its chip strip ended at y=282, with the bottom pane starting at y=354. **72px dead band.**

**Live:** reproduced in a running `task dev` instance in the reported broken state (`Column[top, Row[min,min], bottom]`), confirmed visually, then confirmed again after Vite hot-reloaded the fix — the band closes and the freed space returns to the flex children.

## Why it survived

The suite's prior branch-level minimize coverage was **all Column-inside-Column** — the one arrangement the old formula got right.

## Not included

The second defect from the analysis (§3 — minimizing a *middle* pane deletes the resize handle between its two expanded neighbours, leaving them flush with nothing to drag) is untouched here. It needs care around `parentIndex` and `onResizeMove`'s flanking lookup, so it's better as its own change.

<!-- agentmux:agent_id=agentx -->