### PR TITLE
Manoz@Area54: feat(statusbar): break out token usage panel by agent, with cost + turn count

### DIFF
--- a/.changesets/1788129105-feat-statusbar-break-out-token-usage-panel-by-agent-with-cos-1rcn.md
+++ b/.changesets/1788129105-feat-statusbar-break-out-token-usage-panel-by-agent-with-cos-1rcn.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(statusbar): break out token usage panel by agent, with cost + turn count

--- a/docs/specs/SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md
+++ b/docs/specs/SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md
@@ -1,0 +1,202 @@
+# Spec: Token stats panel — break out by agent + value-add details
+
+**Date:** 2026-08-30
+**Status:** Proposed
+**Motivated by:** direct request — the status bar's token breakdown popover
+currently groups by provider/service only; break it out by agent instead,
+and identify what else is worth adding while touching this panel.
+
+## Background
+
+The status bar's `TokenUsageIndicator` (`frontend/app/statusbar/`) shows a
+running `↑X ↓Y` total for the whole AgentMux session and opens
+`TokenBreakdownPopover` on click. The popover is driven by
+`frontend/app/store/token-usage.ts`, a session-local store keyed by
+**provider id** (`"claude"`, `"codex"`, `"gemini"`, …) — see
+`SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md`. `InstancePanel.tsx`'s own doc
+comment already flagged this as a known gap: *"Per-window token totals
+deferred until token-usage is per-window."* This spec is that follow-up.
+
+Two things make "by agent" more than a regroup:
+
+1. **`recordTurn(provider, tokens)` has no agent identity at all today.**
+   Its real call site, `useTurnLifecycle.ts:110`, has `opts.blockId` and
+   `opts.model` (`AgentPaneModel`) in scope but doesn't pass either through
+   — grouping by agent requires resolving and threading agent identity
+   into the store for the first time, not just re-reading existing data.
+2. **`provider` is already overloaded with non-agent pseudo-ids.**
+   `ActivityDock.tsx`, `useNextPromptSuggestion.ts`,
+   `useAgentActivitySummary.ts`, and `swarm-view.tsx` all call `recordTurn`
+   with ids like `"ambient:next_prompt_suggestion"`,
+   `"ambient:activity_summary"`, `"ambient:subagent_name"` — real token
+   spend from AgentMux's own background features, not a user's agent. The
+   current breakdown lists these as peer rows next to `"claude"` with no
+   visual distinction, which is confusing and gets worse once real agent
+   rows are also broken out individually.
+
+Separately, `SessionStats` (`frontend/app/view/agent/types.ts:545`) already
+carries `cost_usd`, `duration_ms`, and `num_turns` **per pane**, accumulated
+cumulatively in `AgentPaneState.sessionTotals`
+(`SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md`) — and none of it reaches
+the status bar today. `AgentFooter.tsx:281` already has the display
+convention (`` `$${cost_usd.toFixed(3)}` ``) to reuse.
+
+## What's worth adding, beyond "group by agent"
+
+Ranked by value vs. cost, given what's already tracked somewhere in the
+codebase (cheap to surface) vs. what needs new plumbing:
+
+1. **Cost in USD, per agent and total.** `cost_usd` already exists per pane
+   and is never shown outside that one pane's own composer strip. This is
+   the single highest-value addition — token counts alone don't answer
+   "what is this session costing me," which is the question a user
+   opening this popover is most likely asking. Reuse the `$X.XXX` format
+   from `AgentFooter.tsx`.
+2. **Turn count per agent.** `num_turns` is already tracked alongside
+   `cost_usd` in the same `SessionStats` — free once cost is threaded
+   through. Read together with tokens it gives a cheap tokens/turn signal
+   (an agent burning 50k tokens over 3 turns reads very differently from
+   50k over 30).
+3. **Separate "Agents" from "AgentMux internal."** The ambient pseudo-ids
+   above are real spend but not a user's agent — collapse them into one
+   "AgentMux internal" row (background suggestions, activity summaries,
+   subagent naming) instead of interleaving with per-agent rows. Directly
+   fixes the confusion described above, and costs nothing new to compute —
+   it's a matter of not losing the `ambient:` prefix that already exists in
+   every one of these ids, which the current per-service view discards by
+   treating it as just another service name.
+4. **Click a row to focus that agent's pane.** The by-agent grouping
+   naturally carries a `blockId` per row (Instance Panel's window list
+   already does exactly this — focus-on-click for a `blockId`, see
+   `InstancePanel.tsx`). Low incremental cost once rows are keyed by agent,
+   turns a read-only breakdown into a navigation aid ("which agent is
+   burning tokens" → click → look at it).
+5. **Per-agent cache hit rate.** `getCacheHitRate()` already exists
+   globally (`token-usage.ts:133`); the same computation applies per-agent
+   once usage is bucketed that way. Surfaces which agents are cache-
+   efficient (stable, append-only context) vs. not (context that churns
+   every turn, e.g. frequent file-content injection) — useful for a user
+   trying to reduce spend. Lower priority than 1–3: a secondary metric, not
+   the first thing someone opening this panel wants.
+6. **Active vs. idle/retired grouping.** AgentMux's swarm view already
+   distinguishes active from retired agents. Splitting the panel the same
+   way (currently-running agents first, finished ones collapsed below)
+   keeps a long swarm session's breakdown scannable instead of a flat list
+   growing forever. Worth doing once agent count in a session is
+   realistically > 5–6; lower priority for the initial cut.
+7. **Session burn rate (cost or tokens per minute).** Cheap to derive
+   (`total / (now - sessionStartAt)`) but of debatable value — a single
+   number that's noisy early in a session and mostly redundant with the
+   total once you can already see elapsed time via "since HH:MM" in the
+   header. Listed for completeness; **not recommended for v1** (see
+   Non-goals).
+
+## Design
+
+### Store: `frontend/app/store/token-usage.ts`
+
+Add agent-keyed aggregation alongside the existing service-keyed one
+(kept, not replaced — some ambient/ancillary callers have no agent
+identity to attach, and per-service is still meaningful inside an agent
+row when a pane forks across providers).
+
+```ts
+export interface AgentUsage {
+    agentName: string;       // display name, from block.meta.agentName
+    blockId: string | null;  // null only for the "AgentMux internal" bucket
+    isAmbient: boolean;      // true for the internal bucket
+    input: number;
+    output: number;
+    costUsd: number;         // 0 if provider never reports cost_usd
+    numTurns: number;
+    freshInput?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
+    byService: Record<string, ServiceUsage>; // existing per-service shape, nested
+}
+```
+
+- New `byAgent: Record<string, AgentUsage>` field on `TokenUsageState`,
+  keyed by `blockId` for real agents and by a fixed sentinel key (e.g.
+  `"__ambient__"`) for the internal bucket.
+- `recordTurn` gains an optional third parameter:
+  ```ts
+  export function recordTurn(
+      provider: string,
+      tokens: ServiceUsage | null | undefined,
+      agent?: { blockId: string; agentName: string; costUsd?: number },
+  ): void
+  ```
+  Omitting `agent` (all four existing ambient call sites) files the turn
+  under the `"__ambient__"` bucket, tagged `isAmbient: true` — no call-site
+  change required at those four sites beyond leaving the third arg off,
+  so the "Agents vs. internal" split (item 3) falls out of the *existing*
+  `ambient:`-prefixed provider ids for free, just read at the right level
+  instead of discarded.
+- `getAgentBreakdown()`: sibling to `getBreakdown()`, returns `AgentUsage[]`
+  sorted by `costUsd` descending (falls back to token total when
+  `costUsd` is 0/unknown for every row — some providers may never report
+  cost), real agents before the ambient bucket regardless of its size.
+- `getAgentCacheHitRate(row: AgentUsage)`: same formula as the existing
+  global `getCacheHitRate()`, applied to one `AgentUsage` row.
+
+### Call-site change: `frontend/app/view/agent/hooks/useTurnLifecycle.ts`
+
+The only call site with genuine per-agent turn data. At the existing
+`recordTurn(opts.provider, tokens)` call (line 110):
+
+- Resolve `agentName` from `block.meta.agentName` via
+  `WOS.getWaveObjectAtom<Block>(makeORef("block", opts.blockId))()` — same
+  pattern `armory-model.ts` already uses to read block meta reactively;
+  here it's a one-shot read at turn-finalize time, not a reactive memo.
+  Fall back to the raw `blockId` (truncated, matching the existing
+  `blockId.slice(0, 7)` convention already used for log lines in this same
+  file) if `agentName` is unset.
+- Pass `stats?.cost_usd` through as `costUsd` (the `stats` merge already
+  in scope for `statsTokens` above).
+- The other three call sites (`ActivityDock.tsx`, `useNextPromptSuggestion.ts`,
+  `useAgentActivitySummary.ts`) and `swarm-view.tsx`'s `"ambient:subagent_name"`
+  call stay unchanged — they have no pane-level `SessionStats` to draw
+  `agentName`/`costUsd` from, and per the design above that's fine: they
+  fall into the ambient bucket automatically.
+
+### UI: `TokenBreakdownPopover.tsx`
+
+- Rows become per-agent instead of per-service: agent name, `↑`/`↓`
+  tokens, turn count, `$cost` (value-adds 1–2). Omit the `$` segment
+  entirely for a row whose `costUsd` is 0 across every turn (provider
+  never reported cost) rather than showing a misleading `$0.000`.
+- Clicking a real-agent row (not the ambient one) focuses that pane —
+  reuse whatever pane-focus action `InstancePanel.tsx`'s window list
+  already calls for a `blockId` (item 4).
+- "AgentMux internal" renders as a single collapsed row at the bottom,
+  expandable to the existing per-service view for just that bucket (item
+  3) — collapsed by default so it doesn't compete visually with real
+  agent rows.
+- Per-agent cache hit rate (item 5) as a small inline `%` next to a row,
+  same `title=` tooltip-on-hover treatment the existing global cache-rate
+  line uses — not a v1 requirement, can land after the base regroup.
+- Grand total row and "Reset counter" footer stay as-is (still a global
+  reset — resetting per-agent is a non-goal, see below).
+
+## Non-goals
+
+- **No cross-restart persistence.** Store stays session-local, same as
+  today (`token-usage.ts`'s own doc comment already flags this as a
+  separate stretch goal in the original spec) — out of scope here.
+- **No per-turn history/timeline graph.** This spec only extends the
+  existing cumulative-since-session-start model to a new grouping axis; a
+  time-series view is a materially bigger feature.
+- **No session burn-rate metric (item 7)** in the initial cut — low value
+  relative to the other items, revisit only if requested after the
+  by-agent regroup ships.
+- **No per-agent reset.** "Reset counter" stays a single global action;
+  scoping it to one agent row adds UI complexity (confirm-per-row) for a
+  use case not raised in the motivating request.
+- **No backend changes.** Every field this spec adds (`cost_usd`,
+  `blockId`, `agentName`) is already available frontend-side today —
+  this is purely a frontend aggregation + display change, same framing as
+  `SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md`'s own non-goals.
+- **Active/idle grouping (item 6)** deferred to a follow-up once real
+  usage shows sessions commonly running enough concurrent agents to need
+  it — noted here so it isn't lost, not built in v1.

--- a/frontend/app/statusbar/TokenBreakdownPopover.test.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.test.tsx
@@ -1,0 +1,108 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TokenBreakdownPopover — by-agent regroup.
+ * SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md.
+ *
+ * Store-level aggregation (sorting, ambient collapse, cost/cache math)
+ * already has thorough coverage in token-usage.test.ts — these tests
+ * cover only what that can't: does the popover actually render agent
+ * rows, keep the ambient bucket collapsed by default, and wire a click
+ * through to focusBlock.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { autoUpdate } from "@floating-ui/dom";
+import { recordTurn, resetSession } from "@/store/token-usage";
+
+vi.mock("@floating-ui/dom", () => ({
+    autoUpdate: vi.fn(() => vi.fn()),
+}));
+vi.mock("@/app/platform/pane-overlay", () => ({
+    usePaneOverlay: vi.fn(),
+}));
+vi.mock("@/app/util/menu-position", () => ({
+    computeMenuPosition: vi.fn(async () => ({
+        style: { position: "fixed", left: "0px", top: "0px" },
+    })),
+}));
+const focusBlockMock = vi.fn(async (_blockId: string) => {});
+vi.mock("@/app/util/focus-block", () => ({
+    focusBlock: (blockId: string) => focusBlockMock(blockId),
+}));
+
+import { TokenBreakdownPopover } from "./TokenBreakdownPopover";
+
+describe("TokenBreakdownPopover — by-agent regroup", () => {
+    beforeEach(() => {
+        resetSession();
+        focusBlockMock.mockClear();
+        vi.mocked(autoUpdate).mockClear();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    function renderPopover() {
+        return render(() => (
+            <TokenBreakdownPopover anchorRect={null} onClose={() => {}} />
+        ));
+    }
+
+    it("shows the empty state when no turns have completed", () => {
+        renderPopover();
+        expect(screen.getByText("No turns completed yet this session.")).toBeInTheDocument();
+    });
+
+    it("renders one row per real agent, with turn count and cost, and no ambient row when nothing ambient ran", () => {
+        recordTurn("claude", { input: 1000, output: 50 }, { blockId: "block-1", agentName: "Manoz", costUsd: 0.12 });
+        recordTurn("claude", { input: 500, output: 20 }, { blockId: "block-1", agentName: "Manoz", costUsd: 0.05 });
+        recordTurn("codex", { input: 300, output: 10 }, { blockId: "block-2", agentName: "Codex Agent" });
+        renderPopover();
+
+        expect(screen.getByText("Manoz")).toBeInTheDocument();
+        expect(screen.getByText("Codex Agent")).toBeInTheDocument();
+        expect(screen.getByText(/2 turns/)).toBeInTheDocument();
+        expect(screen.getByText(/\$0\.170/)).toBeInTheDocument();
+        expect(screen.queryByText("AgentMux internal")).not.toBeInTheDocument();
+    });
+
+    it("collapses ambient usage into a single toggleable row, expanding to per-service detail on click", () => {
+        recordTurn("claude", { input: 1000, output: 50 }, { blockId: "block-1", agentName: "Manoz" });
+        recordTurn("ambient:next_prompt_suggestion", { input: 100, output: 5 });
+        recordTurn("ambient:activity_summary", { input: 40, output: 2 });
+        renderPopover();
+
+        expect(screen.getByText(/AgentMux internal/)).toBeInTheDocument();
+        // Collapsed by default — per-service ambient rows not yet in the DOM.
+        expect(screen.queryByText("Next Prompt Suggestion")).not.toBeInTheDocument();
+
+        const toggle = screen.getByText(/AgentMux internal/).closest("button") as HTMLButtonElement;
+        fireEvent.click(toggle);
+
+        // Expanded: the ambient bucket's own service breakdown appears.
+        expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("clicking a real agent row calls focusBlock with that agent's blockId", () => {
+        recordTurn("claude", { input: 1000, output: 50 }, { blockId: "block-1", agentName: "Manoz" });
+        renderPopover();
+
+        const row = screen.getByText("Manoz").closest("button") as HTMLButtonElement;
+        fireEvent.click(row);
+
+        expect(focusBlockMock).toHaveBeenCalledWith("block-1");
+    });
+
+    it("does not throw when clicking the ambient row (no blockId to focus)", () => {
+        recordTurn("ambient:next_prompt_suggestion", { input: 100, output: 5 });
+        renderPopover();
+
+        const row = screen.getByText(/AgentMux internal/).closest("button") as HTMLButtonElement;
+        expect(() => fireEvent.click(row)).not.toThrow();
+        expect(focusBlockMock).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/statusbar/TokenBreakdownPopover.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.tsx
@@ -3,12 +3,15 @@
 
 /**
  * TokenBreakdownPopover — click-opened popover anchored under the
- * TokenUsageIndicator. Lists per-service input/output totals, a
+ * TokenUsageIndicator. Lists per-agent totals (tokens, turns, cost), a
+ * collapsed "AgentMux internal" row for ambient/background usage, a
  * grand total row, and a destructive-gated "Reset counter" action.
+ * Clicking a real agent row focuses that agent's pane.
  *
  * Calls `usePaneOverlay` so the popover renders cleanly over any
  * browser pane HWND (same airspace pattern as MoreDropdown and the
- * canonical `<Modal>`). Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §4.2.
+ * canonical `<Modal>`). Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §4.2,
+ * SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md.
  */
 
 import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
@@ -18,13 +21,16 @@ import { computeMenuPosition } from "@/app/util/menu-position";
 import { ConfirmModal } from "@/element/modal";
 import { getCliCatalogEntry } from "@/app/view/agent/defaults/cli-catalog";
 import { formatCompactNumber } from "@/util/format-count";
+import { focusBlock } from "@/app/util/focus-block";
 import {
-    getBreakdown,
+    getAgentBreakdown,
+    getAgentCacheHitRate,
     getCacheHitRate,
     getSessionStartAt,
     getTotal,
     resetSession,
     tokenUsageState,
+    type AgentUsage,
     type ServiceRow,
 } from "@/store/token-usage";
 
@@ -38,6 +44,27 @@ function serviceDisplayName(id: string): string {
     if (entry) return entry.displayName;
     // Titlecase fallback for unknowns.
     return id.slice(0, 1).toUpperCase() + id.slice(1);
+}
+
+/** `AgentUsage.byService` as a sorted ServiceRow[] — same shape/order
+ *  getBreakdown() produces globally, scoped to one agent row. Used by
+ *  the "AgentMux internal" bucket's expanded per-service detail. */
+function serviceRowsOf(row: AgentUsage): ServiceRow[] {
+    const rows: ServiceRow[] = Object.entries(row.byService).map(([id, u]) => ({
+        id,
+        input: u.input,
+        output: u.output,
+        freshInput: u.freshInput,
+        cacheCreation: u.cacheCreation,
+        cacheRead: u.cacheRead,
+    }));
+    rows.sort((a, b) => {
+        const aTotal = a.input + a.output;
+        const bTotal = b.input + b.output;
+        if (bTotal !== aTotal) return bTotal - aTotal;
+        return a.id.localeCompare(b.id);
+    });
+    return rows;
 }
 
 interface TokenBreakdownPopoverProps {
@@ -55,13 +82,16 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
     usePaneOverlay(() => rootRef);
 
     const [confirmingReset, setConfirmingReset] = createSignal(false);
+    const [ambientExpanded, setAmbientExpanded] = createSignal(false);
 
     // Trigger reactivity on the store so breakdown re-renders when
     // a new turn lands while the popover is open.
-    const rows = createMemo((): ServiceRow[] => {
-        void tokenUsageState.byService;
-        return getBreakdown();
+    const agentRows = createMemo((): AgentUsage[] => {
+        void tokenUsageState.byAgent;
+        return getAgentBreakdown();
     });
+    const realAgentRows = createMemo(() => agentRows().filter((r) => !r.isAmbient));
+    const ambientRow = createMemo(() => agentRows().find((r) => r.isAmbient) ?? null);
     const total = createMemo(() => {
         void tokenUsageState.byService;
         return getTotal();
@@ -125,6 +155,12 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
         props.onClose();
     };
 
+    const handleAgentClick = (row: AgentUsage) => {
+        if (!row.blockId) return;
+        void focusBlock(row.blockId);
+        props.onClose();
+    };
+
     return (
         <>
             <div
@@ -142,7 +178,7 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
                     </span>
                 </div>
                 <Show
-                    when={rows().length > 0}
+                    when={agentRows().length > 0}
                     fallback={
                         <div class="token-usage-breakdown-empty">
                             No turns completed yet this session.
@@ -150,22 +186,87 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
                     }
                 >
                     <div class="token-usage-breakdown-rows">
-                        <For each={rows()}>
+                        <For each={realAgentRows()}>
+                            {(row) => {
+                                const agentCacheRate = createMemo(() => getAgentCacheHitRate(row));
+                                return (
+                                    <button
+                                        type="button"
+                                        class="token-usage-breakdown-row token-usage-breakdown-agent-row"
+                                        onClick={() => handleAgentClick(row)}
+                                        title={`Click to focus ${row.agentName}'s pane`}
+                                    >
+                                        <span class="token-usage-breakdown-row-name">
+                                            {row.agentName}
+                                            <Show when={agentCacheRate() != null}>
+                                                <span
+                                                    class="token-usage-breakdown-row-cache"
+                                                    title={`${Math.round((agentCacheRate() as number) * 100)}% of input served from cache`}
+                                                >
+                                                    {Math.round((agentCacheRate() as number) * 100)}%
+                                                </span>
+                                            </Show>
+                                        </span>
+                                        <span class="token-usage-breakdown-row-meta">
+                                            {row.numTurns} {row.numTurns === 1 ? "turn" : "turns"}
+                                            <Show when={row.costUsd > 0}>
+                                                {" "}·{" "}${row.costUsd.toFixed(3)}
+                                            </Show>
+                                        </span>
+                                        <span class="token-usage-breakdown-row-counts">
+                                            <span class="token-usage-indicator-arrow">↑</span>
+                                            {formatCompactNumber(row.input)}
+                                            {" "}
+                                            <span class="token-usage-indicator-arrow">↓</span>
+                                            {formatCompactNumber(row.output)}
+                                        </span>
+                                    </button>
+                                );
+                            }}
+                        </For>
+                        <Show when={ambientRow()}>
                             {(row) => (
-                                <div class="token-usage-breakdown-row">
-                                    <span class="token-usage-breakdown-row-name">
-                                        {serviceDisplayName(row.id)}
-                                    </span>
-                                    <span class="token-usage-breakdown-row-counts">
-                                        <span class="token-usage-indicator-arrow">↑</span>
-                                        {formatCompactNumber(row.input)}
-                                        {" "}
-                                        <span class="token-usage-indicator-arrow">↓</span>
-                                        {formatCompactNumber(row.output)}
-                                    </span>
+                                <div class="token-usage-breakdown-ambient">
+                                    <button
+                                        type="button"
+                                        class="token-usage-breakdown-row token-usage-breakdown-ambient-toggle"
+                                        onClick={() => setAmbientExpanded(!ambientExpanded())}
+                                        aria-expanded={ambientExpanded()}
+                                    >
+                                        <span class="token-usage-breakdown-row-name">
+                                            {ambientExpanded() ? "▾" : "▸"} {row().agentName}
+                                        </span>
+                                        <span class="token-usage-breakdown-row-counts">
+                                            <span class="token-usage-indicator-arrow">↑</span>
+                                            {formatCompactNumber(row().input)}
+                                            {" "}
+                                            <span class="token-usage-indicator-arrow">↓</span>
+                                            {formatCompactNumber(row().output)}
+                                        </span>
+                                    </button>
+                                    <Show when={ambientExpanded()}>
+                                        <div class="token-usage-breakdown-ambient-detail">
+                                            <For each={serviceRowsOf(row())}>
+                                                {(svc) => (
+                                                    <div class="token-usage-breakdown-row token-usage-breakdown-ambient-row">
+                                                        <span class="token-usage-breakdown-row-name">
+                                                            {serviceDisplayName(svc.id)}
+                                                        </span>
+                                                        <span class="token-usage-breakdown-row-counts">
+                                                            <span class="token-usage-indicator-arrow">↑</span>
+                                                            {formatCompactNumber(svc.input)}
+                                                            {" "}
+                                                            <span class="token-usage-indicator-arrow">↓</span>
+                                                            {formatCompactNumber(svc.output)}
+                                                        </span>
+                                                    </div>
+                                                )}
+                                            </For>
+                                        </div>
+                                    </Show>
                                 </div>
                             )}
-                        </For>
+                        </Show>
                         <div class="token-usage-breakdown-row token-usage-breakdown-total">
                             <span class="token-usage-breakdown-row-name">Total</span>
                             <span class="token-usage-breakdown-row-counts">
@@ -191,7 +292,7 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
                         type="button"
                         class="token-usage-breakdown-reset"
                         onClick={handleResetClick}
-                        disabled={rows().length === 0}
+                        disabled={agentRows().length === 0}
                     >
                         Reset counter
                     </button>

--- a/frontend/app/statusbar/_token-usage.scss
+++ b/frontend/app/statusbar/_token-usage.scss
@@ -108,6 +108,16 @@
         justify-content: space-between;
         padding: var(--space-0-5) var(--space-3);
         font-size: 12px;
+        width: 100%;
+        // Rows that are <button>s (agent rows, the ambient toggle) need
+        // to shed native button chrome to read identically to the
+        // plain-<div> total/service rows around them.
+        background: transparent;
+        border: none;
+        color: inherit;
+        font-family: inherit;
+        text-align: left;
+        cursor: default;
 
         &.token-usage-breakdown-total {
             margin-top: var(--space-1);
@@ -117,8 +127,43 @@
         }
     }
 
+    // Real-agent rows are clickable (focus that agent's pane) — give
+    // them a hover affordance the plain total/service rows don't have.
+    .token-usage-breakdown-agent-row,
+    .token-usage-breakdown-ambient-toggle {
+        &:hover {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+        }
+    }
+
+    .token-usage-breakdown-agent-row {
+        flex-wrap: wrap;
+        row-gap: 1px;
+    }
+
     .token-usage-breakdown-row-name {
         color: var(--main-text-color);
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+    }
+
+    .token-usage-breakdown-row-cache {
+        font-size: 9px;
+        font-weight: 400;
+        color: var(--secondary-text-color);
+        opacity: 0.8;
+    }
+
+    // Turn count + cost — sits between the agent name and the token
+    // counts on its own implicit line when the row wraps (agent names
+    // can run long).
+    .token-usage-breakdown-row-meta {
+        flex: 1 1 100%;
+        order: 3;
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        opacity: 0.85;
     }
 
     .token-usage-breakdown-row-counts {
@@ -129,6 +174,22 @@
             opacity: 0.55;
             margin-right: 1px;
         }
+    }
+
+    .token-usage-breakdown-ambient {
+        margin-top: var(--space-1);
+        border-top: 1px dashed var(--border-color);
+    }
+
+    .token-usage-breakdown-ambient-detail {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .token-usage-breakdown-ambient-row {
+        padding-left: calc(var(--space-3) + var(--space-2));
+        opacity: 0.8;
+        font-size: 11px;
     }
 
     .token-usage-breakdown-total .token-usage-breakdown-row-counts {

--- a/frontend/app/statusbar/_token-usage.scss
+++ b/frontend/app/statusbar/_token-usage.scss
@@ -128,9 +128,14 @@
     }
 
     // Real-agent rows are clickable (focus that agent's pane) — give
-    // them a hover affordance the plain total/service rows don't have.
+    // them a hover affordance the plain total/service rows don't have,
+    // plus an explicit pointer cursor (ReAgent P2 on PR #2849 — hover
+    // background alone under-signals interactivity for these two new
+    // row types specifically).
     .token-usage-breakdown-agent-row,
     .token-usage-breakdown-ambient-toggle {
+        cursor: pointer;
+
         &:hover {
             background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
         }

--- a/frontend/app/store/token-usage.test.ts
+++ b/frontend/app/store/token-usage.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { getCacheHitRate, getTotal, recordTurn, resetSession } from "./token-usage";
+import { getAgentBreakdown, getAgentCacheHitRate, getCacheHitRate, getTotal, recordTurn, resetSession } from "./token-usage";
 
 describe("token-usage store — cache-hit-rate normalization", () => {
     beforeEach(() => {
@@ -48,5 +48,86 @@ describe("token-usage store — cache-hit-rate normalization", () => {
         const total = getTotal();
         expect(total.input).toBe(1050);
         expect(total.output).toBe(55);
+    });
+});
+
+describe("token-usage store — by-agent breakdown (SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md)", () => {
+    beforeEach(() => {
+        resetSession();
+    });
+
+    it("keys a real agent turn by blockId and carries its agentName/costUsd/turn count", () => {
+        recordTurn("claude", { input: 1000, output: 50 }, { blockId: "block-1", agentName: "Manoz", costUsd: 0.12 });
+        recordTurn("claude", { input: 500, output: 20 }, { blockId: "block-1", agentName: "Manoz", costUsd: 0.05 });
+        const rows = getAgentBreakdown();
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            blockId: "block-1",
+            agentName: "Manoz",
+            isAmbient: false,
+            input: 1500,
+            output: 70,
+            numTurns: 2,
+        });
+        expect(rows[0].costUsd).toBeCloseTo(0.17, 5);
+    });
+
+    it("collapses turns with no agent context into a single ambient bucket", () => {
+        recordTurn("ambient:next_prompt_suggestion", { input: 100, output: 5 });
+        recordTurn("ambient:activity_summary", { input: 40, output: 2 });
+        const rows = getAgentBreakdown();
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            blockId: null,
+            isAmbient: true,
+            agentName: "AgentMux internal",
+            input: 140,
+            output: 7,
+            numTurns: 2,
+        });
+    });
+
+    it("sorts real agents before the ambient bucket regardless of size", () => {
+        recordTurn("ambient:next_prompt_suggestion", { input: 100_000, output: 5_000 });
+        recordTurn("claude", { input: 10, output: 1 }, { blockId: "block-1", agentName: "Manoz", costUsd: 0.01 });
+        const rows = getAgentBreakdown();
+        expect(rows.map((r) => r.isAmbient)).toEqual([false, true]);
+    });
+
+    it("sorts real agents by cost descending when any row has a nonzero cost", () => {
+        recordTurn("claude", { input: 100, output: 10 }, { blockId: "block-cheap", agentName: "Cheap", costUsd: 0.01 });
+        recordTurn("claude", { input: 100, output: 10 }, { blockId: "block-pricey", agentName: "Pricey", costUsd: 0.5 });
+        const rows = getAgentBreakdown();
+        expect(rows.map((r) => r.agentName)).toEqual(["Pricey", "Cheap"]);
+    });
+
+    it("falls back to token total ordering when no agent has reported a cost", () => {
+        recordTurn("codex", { input: 100, output: 10 }, { blockId: "block-small", agentName: "Small" });
+        recordTurn("codex", { input: 900, output: 90 }, { blockId: "block-big", agentName: "Big" });
+        const rows = getAgentBreakdown();
+        expect(rows.map((r) => r.agentName)).toEqual(["Big", "Small"]);
+    });
+
+    it("re-asserts agentName on later turns so an early unresolved name doesn't strand the fallback", () => {
+        recordTurn("claude", { input: 10, output: 1 }, { blockId: "block-1", agentName: "block-1" });
+        recordTurn("claude", { input: 10, output: 1 }, { blockId: "block-1", agentName: "Manoz" });
+        const rows = getAgentBreakdown();
+        expect(rows[0].agentName).toBe("Manoz");
+    });
+
+    it("computes a per-agent cache hit rate independent of other agents' breakdowns", () => {
+        recordTurn("claude", { input: 1000, output: 50, freshInput: 100, cacheCreation: 0, cacheRead: 900 }, { blockId: "block-1", agentName: "Manoz" });
+        recordTurn("codex", { input: 500, output: 20 }, { blockId: "block-2", agentName: "Other" });
+        const rows = getAgentBreakdown();
+        const manoz = rows.find((r) => r.blockId === "block-1")!;
+        const other = rows.find((r) => r.blockId === "block-2")!;
+        expect(getAgentCacheHitRate(manoz)).toBeCloseTo(0.9, 5);
+        expect(getAgentCacheHitRate(other)).toBeNull();
+    });
+
+    it("resetSession clears byAgent alongside byService", () => {
+        recordTurn("claude", { input: 10, output: 1 }, { blockId: "block-1", agentName: "Manoz" });
+        resetSession();
+        expect(getAgentBreakdown()).toHaveLength(0);
     });
 });

--- a/frontend/app/store/token-usage.test.ts
+++ b/frontend/app/store/token-usage.test.ts
@@ -130,4 +130,31 @@ describe("token-usage store — by-agent breakdown (SPEC_STATUSBAR_TOKEN_PANEL_B
         resetSession();
         expect(getAgentBreakdown()).toHaveLength(0);
     });
+
+    // Codex P2 on PR #2849: a stats-only session_end (cost_usd/num_turns
+    // reported, no token usage at all) used to be dropped entirely
+    // because recordTurn required truthy tokens.
+    it("still records cost and turn count when tokens is null (stats-only session_end)", () => {
+        recordTurn("claude", null, { blockId: "block-1", agentName: "Manoz", costUsd: 0.08, numTurns: 1 });
+        const rows = getAgentBreakdown();
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ blockId: "block-1", input: 0, output: 0, numTurns: 1 });
+        expect(rows[0].costUsd).toBeCloseTo(0.08, 5);
+    });
+
+    it("still no-ops for a genuinely empty ambient call (no tokens, no agent context)", () => {
+        recordTurn("ambient:next_prompt_suggestion", { input: 0, output: 0 });
+        expect(getAgentBreakdown()).toHaveLength(0);
+    });
+
+    // Codex P2 on PR #2849: recordTurn always added exactly 1 to
+    // numTurns regardless of what the provider itself reported for that
+    // finalized turn, understating the total relative to the pane's own
+    // sessionTotals accumulator (agent-pane-state/reducer.ts).
+    it("adds the provider-reported num_turns instead of always incrementing by 1", () => {
+        recordTurn("claude", { input: 100, output: 10 }, { blockId: "block-1", agentName: "Manoz", numTurns: 3 });
+        recordTurn("claude", { input: 50, output: 5 }, { blockId: "block-1", agentName: "Manoz" }); // no numTurns → falls back to 1
+        const rows = getAgentBreakdown();
+        expect(rows[0].numTurns).toBe(4);
+    });
 });

--- a/frontend/app/store/token-usage.ts
+++ b/frontend/app/store/token-usage.ts
@@ -10,10 +10,19 @@
  * status-bar indicator reads the total; the breakdown popover reads
  * per-service detail. Resets to zero on user action.
  *
+ * Also aggregates the same turns keyed by agent (`byAgent`, added by
+ * SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md) — real agent turns
+ * (the only call site with pane identity, useTurnLifecycle.ts) are keyed
+ * by blockId; the four ambient/internal call sites (background
+ * suggestions, activity summaries, subagent naming — all pass no `agent`
+ * argument) collapse into a single "__ambient__" bucket instead of
+ * appearing as peer rows next to real agents.
+ *
  * Session-local only — no persistence across AgentMux restarts.
  * Stretch goal noted in SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §7.
  *
- * Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §5.1.
+ * Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §5.1,
+ * SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md.
  */
 
 import { createStore } from "solid-js/store";
@@ -37,35 +46,98 @@ export interface ServiceUsage {
     cacheRead?: number;
 }
 
+/**
+ * One agent's (or the ambient bucket's) running totals — see the
+ * module doc comment above. `byService` mirrors the top-level shape,
+ * nested, to cover a pane that forks across providers mid-session
+ * (rare, but real agent turns still carry a `provider`, so it's free to
+ * keep).
+ */
+export interface AgentUsage {
+    agentName: string;
+    blockId: string | null;
+    isAmbient: boolean;
+    input: number;
+    output: number;
+    costUsd: number;
+    numTurns: number;
+    freshInput?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
+    byService: Record<string, ServiceUsage>;
+}
+
+/** Context describing which agent a real (non-ambient) turn belongs to. */
+export interface AgentTurnContext {
+    blockId: string;
+    agentName: string;
+    costUsd?: number;
+}
+
+const AMBIENT_KEY = "__ambient__";
+
 interface TokenUsageState {
     sessionStartAt: number;
     byService: Record<string, ServiceUsage>;
+    byAgent: Record<string, AgentUsage>;
 }
 
 const [state, setState] = createStore<TokenUsageState>({
     sessionStartAt: Date.now(),
     byService: {},
+    byAgent: {},
 });
 
+function accumulateServiceUsage(current: ServiceUsage, tokens: ServiceUsage): ServiceUsage {
+    const input = tokens.input ?? 0;
+    const output = tokens.output ?? 0;
+    const hasBreakdown =
+        tokens.freshInput != null || tokens.cacheCreation != null || tokens.cacheRead != null;
+    // Same normalization recordTurn already applies below (two incompatible
+    // wire shapes reach this under the same field names) — see recordTurn's
+    // own doc comment for the full rationale; kept in sync here since both
+    // the service-keyed and agent-keyed aggregates need it identically.
+    const freshContribution =
+        tokens.freshInput
+        ?? ((tokens.cacheCreation != null || tokens.cacheRead != null) ? input : undefined);
+    return {
+        input: current.input + input,
+        output: current.output + output,
+        freshInput: hasBreakdown
+            ? (current.freshInput ?? 0) + (freshContribution ?? 0)
+            : current.freshInput,
+        cacheCreation: hasBreakdown
+            ? (current.cacheCreation ?? 0) + (tokens.cacheCreation ?? 0)
+            : current.cacheCreation,
+        cacheRead: hasBreakdown
+            ? (current.cacheRead ?? 0) + (tokens.cacheRead ?? 0)
+            : current.cacheRead,
+    };
+}
+
 /**
- * Record a completed turn's tokens under `provider`. No-op if the
- * tokens are missing or both counts are zero (nothing to aggregate).
+ * Record a completed turn's tokens under `provider`, and — for real
+ * agent turns — under the agent identified by `agent`. Omitting `agent`
+ * (the four ambient/internal call sites) files the turn under the
+ * shared ambient bucket instead. No-op if the tokens are missing or both
+ * counts are zero (nothing to aggregate).
  */
-export function recordTurn(provider: string, tokens: ServiceUsage | null | undefined): void {
+export function recordTurn(
+    provider: string,
+    tokens: ServiceUsage | null | undefined,
+    agent?: AgentTurnContext,
+): void {
     if (!provider || !tokens) return;
     const input = tokens.input ?? 0;
     const output = tokens.output ?? 0;
     if (input === 0 && output === 0) return;
     const id = provider.toLowerCase();
-    const current = state.byService[id] ?? { input: 0, output: 0 };
-    // Breakdown fields accumulate only when provided — `?? 0` on the
-    // current side (not the incoming side) so a provider that has never
-    // reported a breakdown keeps reading as `undefined` (unknown) rather
-    // than silently becoming `0` (known-zero) the moment ANY turn for it
-    // omits the fields. Once any turn does supply the fields for this
-    // service, the running total is exact from that point on.
-    const hasBreakdown =
-        tokens.freshInput != null || tokens.cacheCreation != null || tokens.cacheRead != null;
+    // Breakdown fields accumulate only when provided by THIS turn — see
+    // accumulateServiceUsage's use of `hasBreakdown` — so a provider that
+    // has never reported a breakdown keeps reading as `undefined`
+    // (unknown) rather than silently becoming `0` (known-zero) the moment
+    // any turn for it omits the fields.
+    //
     // reagentx/codex P2 on PR #2658: two incompatible wire shapes reach
     // this function under the same field names. claude-translator.ts /
     // useAgentStream.ts (via useTurnLifecycle.ts) pass `input` as the
@@ -83,23 +155,72 @@ export function recordTurn(provider: string, tokens: ServiceUsage | null | undef
     // sets cacheCreation/cacheRead (see useAgentStream.ts/reducer.ts — all
     // three are sourced together or not at all), so "cache fields present,
     // freshInput absent" unambiguously means the TokenCounts shape, where
-    // `input` IS the fresh count.
-    const freshContribution =
-        tokens.freshInput
-        ?? ((tokens.cacheCreation != null || tokens.cacheRead != null) ? input : undefined);
-    setState("byService", id, {
-        input: current.input + input,
-        output: current.output + output,
-        freshInput: hasBreakdown
-            ? (current.freshInput ?? 0) + (freshContribution ?? 0)
-            : current.freshInput,
-        cacheCreation: hasBreakdown
-            ? (current.cacheCreation ?? 0) + (tokens.cacheCreation ?? 0)
-            : current.cacheCreation,
-        cacheRead: hasBreakdown
-            ? (current.cacheRead ?? 0) + (tokens.cacheRead ?? 0)
-            : current.cacheRead,
+    // `input` IS the fresh count. accumulateServiceUsage applies this same
+    // normalization to both the byService and byAgent aggregates below.
+    setState("byService", id, (current) => accumulateServiceUsage(current ?? { input: 0, output: 0 }, tokens));
+
+    const agentKey = agent?.blockId ?? AMBIENT_KEY;
+    setState("byAgent", agentKey, (current) => {
+        const base: AgentUsage = current ?? {
+            agentName: agent?.agentName ?? "AgentMux internal",
+            blockId: agent?.blockId ?? null,
+            isAmbient: agent == null,
+            input: 0,
+            output: 0,
+            costUsd: 0,
+            numTurns: 0,
+            byService: {},
+        };
+        const serviceCurrent = base.byService[id] ?? { input: 0, output: 0 };
+        const serviceNext = accumulateServiceUsage(serviceCurrent, tokens);
+        const byServiceNext = { ...base.byService, [id]: serviceNext };
+        // Summed across every service this agent has used (usually one —
+        // a mid-session provider fork is the only way it's more than
+        // one), not just the service this particular turn belongs to.
+        const breakdown = sumBreakdown(byServiceNext);
+        return {
+            ...base,
+            // A pane's agentName can't change turn-to-turn (one block, one
+            // launch), but re-assert it anyway so a first turn recorded
+            // before block.meta finished resolving doesn't strand the
+            // fallback name for the rest of the session.
+            agentName: agent?.agentName ?? base.agentName,
+            input: base.input + input,
+            output: base.output + output,
+            costUsd: base.costUsd + (agent?.costUsd ?? 0),
+            numTurns: base.numTurns + 1,
+            freshInput: breakdown.freshInput,
+            cacheCreation: breakdown.cacheCreation,
+            cacheRead: breakdown.cacheRead,
+            byService: byServiceNext,
+        };
     });
+}
+
+/** Sum the cache breakdown fields across a services map — shared by the
+ *  per-agent aggregation in recordTurn and getAgentCacheHitRate below.
+ *  Fields stay `undefined` (unknown) rather than `0` when no service in
+ *  the map has ever reported a breakdown, same "unknown vs. known-zero"
+ *  distinction ServiceUsage's own doc comment establishes. */
+function sumBreakdown(services: Record<string, ServiceUsage>): {
+    freshInput?: number;
+    cacheCreation?: number;
+    cacheRead?: number;
+} {
+    let freshInput = 0;
+    let cacheCreation = 0;
+    let cacheRead = 0;
+    let hasBreakdown = false;
+    for (const id in services) {
+        const u = services[id];
+        if (u.freshInput == null && u.cacheCreation == null && u.cacheRead == null) continue;
+        hasBreakdown = true;
+        freshInput += u.freshInput ?? 0;
+        cacheCreation += u.cacheCreation ?? 0;
+        cacheRead += u.cacheRead ?? 0;
+    }
+    if (!hasBreakdown) return {};
+    return { freshInput, cacheCreation, cacheRead };
 }
 
 /**
@@ -131,7 +252,16 @@ export function getTotal(): ServiceUsage {
  * See docs/reports/REPORT_TOKEN_ACCOUNTING_AND_COMPACTION_CONTROL_2026_08_18.md §5.3.
  */
 export function getCacheHitRate(): number | null {
-    const services = state.byService;
+    return cacheHitRateOf(state.byService);
+}
+
+/** Same computation as getCacheHitRate, scoped to one agent row's own
+ *  service breakdown instead of the whole session. */
+export function getAgentCacheHitRate(row: AgentUsage): number | null {
+    return cacheHitRateOf(row.byService);
+}
+
+function cacheHitRateOf(services: Record<string, ServiceUsage>): number | null {
     let promptTotal = 0;
     let cacheRead = 0;
     let hasBreakdown = false;
@@ -177,6 +307,27 @@ export function getBreakdown(): ServiceRow[] {
     return rows;
 }
 
+/**
+ * Per-agent breakdown, sorted by cost descending (falls back to token
+ * total when cost is 0/unknown for every row — some providers never
+ * report `cost_usd`). Real agents always sort before the ambient
+ * ("AgentMux internal") bucket, regardless of its size, since it isn't a
+ * peer of a user's agents. See SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md.
+ */
+export function getAgentBreakdown(): AgentUsage[] {
+    const rows = Object.values(state.byAgent);
+    const anyCost = rows.some((r) => r.costUsd > 0);
+    rows.sort((a, b) => {
+        if (a.isAmbient !== b.isAmbient) return a.isAmbient ? 1 : -1;
+        if (anyCost && a.costUsd !== b.costUsd) return b.costUsd - a.costUsd;
+        const aTotal = a.input + a.output;
+        const bTotal = b.input + b.output;
+        if (bTotal !== aTotal) return bTotal - aTotal;
+        return a.agentName.localeCompare(b.agentName);
+    });
+    return rows;
+}
+
 export function getSessionStartAt(): number {
     return state.sessionStartAt;
 }
@@ -190,6 +341,7 @@ export function resetSession(): void {
     setState({
         sessionStartAt: Date.now(),
         byService: {},
+        byAgent: {},
     });
 }
 

--- a/frontend/app/store/token-usage.ts
+++ b/frontend/app/store/token-usage.ts
@@ -72,6 +72,12 @@ export interface AgentTurnContext {
     blockId: string;
     agentName: string;
     costUsd?: number;
+    /** The provider's own reported turn count for this one finalized
+     *  turn (SessionStats.num_turns) — a single finalizeTurn call can
+     *  bundle more than one provider-side turn. Falls back to 1 when
+     *  absent, matching accumulateStats' own fallback in
+     *  agent-pane-state/reducer.ts so the two accumulators agree. */
+    numTurns?: number;
 }
 
 const AMBIENT_KEY = "__ambient__";
@@ -119,18 +125,27 @@ function accumulateServiceUsage(current: ServiceUsage, tokens: ServiceUsage): Se
  * Record a completed turn's tokens under `provider`, and — for real
  * agent turns — under the agent identified by `agent`. Omitting `agent`
  * (the four ambient/internal call sites) files the turn under the
- * shared ambient bucket instead. No-op if the tokens are missing or both
- * counts are zero (nothing to aggregate).
+ * shared ambient bucket instead.
+ *
+ * No-op if there is genuinely nothing to record: both token counts are
+ * zero/missing AND `agent` carries no cost/turn-count signal either. A
+ * stats-only `session_end` (cost_usd/num_turns reported, no token usage
+ * at all — the Claude translator can emit exactly this shape) still
+ * needs to land even with `tokens` null/zero, or the popover would
+ * silently discard real cost/turn-count data just because token usage
+ * happened to be unavailable for that turn. Codex P2 on PR #2849.
  */
 export function recordTurn(
     provider: string,
     tokens: ServiceUsage | null | undefined,
     agent?: AgentTurnContext,
 ): void {
-    if (!provider || !tokens) return;
-    const input = tokens.input ?? 0;
-    const output = tokens.output ?? 0;
-    if (input === 0 && output === 0) return;
+    if (!provider) return;
+    const input = tokens?.input ?? 0;
+    const output = tokens?.output ?? 0;
+    const hasTokens = input !== 0 || output !== 0;
+    const hasAgentSignal = agent != null && (agent.costUsd != null || agent.numTurns != null);
+    if (!hasTokens && !hasAgentSignal) return;
     const id = provider.toLowerCase();
     // Breakdown fields accumulate only when provided by THIS turn — see
     // accumulateServiceUsage's use of `hasBreakdown` — so a provider that
@@ -157,7 +172,14 @@ export function recordTurn(
     // freshInput absent" unambiguously means the TokenCounts shape, where
     // `input` IS the fresh count. accumulateServiceUsage applies this same
     // normalization to both the byService and byAgent aggregates below.
-    setState("byService", id, (current) => accumulateServiceUsage(current ?? { input: 0, output: 0 }, tokens));
+    //
+    // Skip the service-map mutation entirely for a zero-token,
+    // signal-only turn (stats-only session_end) — accumulateServiceUsage
+    // would add nothing anyway, and skipping avoids inserting a
+    // zero-valued phantom row into the per-service breakdown.
+    if (hasTokens) {
+        setState("byService", id, (current) => accumulateServiceUsage(current ?? { input: 0, output: 0 }, tokens!));
+    }
 
     const agentKey = agent?.blockId ?? AMBIENT_KEY;
     setState("byAgent", agentKey, (current) => {
@@ -172,8 +194,8 @@ export function recordTurn(
             byService: {},
         };
         const serviceCurrent = base.byService[id] ?? { input: 0, output: 0 };
-        const serviceNext = accumulateServiceUsage(serviceCurrent, tokens);
-        const byServiceNext = { ...base.byService, [id]: serviceNext };
+        const serviceNext = hasTokens ? accumulateServiceUsage(serviceCurrent, tokens!) : serviceCurrent;
+        const byServiceNext = hasTokens ? { ...base.byService, [id]: serviceNext } : base.byService;
         // Summed across every service this agent has used (usually one —
         // a mid-session provider fork is the only way it's more than
         // one), not just the service this particular turn belongs to.
@@ -188,7 +210,13 @@ export function recordTurn(
             input: base.input + input,
             output: base.output + output,
             costUsd: base.costUsd + (agent?.costUsd ?? 0),
-            numTurns: base.numTurns + 1,
+            // The provider's own reported count for this one finalized
+            // turn — can be > 1 (a single finalizeTurn bundling several
+            // provider-side turns). Falls back to 1 when absent, same as
+            // accumulateStats in agent-pane-state/reducer.ts. Codex P2 on
+            // PR #2849 — this used to always add exactly 1, understating
+            // the total relative to the pane's own accumulator.
+            numTurns: base.numTurns + (agent?.numTurns ?? 1),
             freshInput: breakdown.freshInput,
             cacheCreation: breakdown.cacheCreation,
             cacheRead: breakdown.cacheRead,

--- a/frontend/app/util/focus-block.ts
+++ b/frontend/app/util/focus-block.ts
@@ -1,0 +1,64 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Navigate to the pane for a given block ID, switching tabs and windows as
+ * needed. Tries the current window first (fast path), then searches all
+ * other workspaces and brings the containing window to focus.
+ *
+ * Extracted from swarm-view.tsx (its original, still-only-real
+ * implementation) so other status-bar/breakdown-style views — e.g.
+ * TokenBreakdownPopover's per-agent rows, see
+ * SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md — can jump to an
+ * agent's pane the same way swarm's own rows already do, without
+ * duplicating the cross-window search.
+ */
+
+import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { WorkspaceService } from "@/app/store/services";
+import { WOS, workspace, setActiveTab, getApi } from "@/app/store/global";
+
+export async function focusBlock(blockId: string): Promise<void> {
+    // Fast path: search the current window's workspace.
+    const ws = workspace();
+    if (ws) {
+        const allTabIds = [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])];
+        for (const tabId of allTabIds) {
+            const layoutModel = getLayoutModelForTabById(tabId);
+            const node = layoutModel?.getNodeByBlockId(blockId);
+            if (node?.id != null) {
+                await setActiveTab(tabId);
+                layoutModel.focusNode(node.id);
+                return;
+            }
+        }
+    }
+    // Slow path: agent is in a different window — query all workspaces.
+    // We need Tab.blockids to find which tab holds the block. Layout models for
+    // other-window tabs are not available from this renderer. We fetch each Tab
+    // from the server (cache hit is instant; miss triggers one server round-trip).
+    // focusNode is intentionally omitted: a layout model in another renderer
+    // process cannot be driven from this side.
+    const allWorkspaces = await RpcApi.WorkspaceListCommand(TabRpcClient);
+    for (const wsInfo of allWorkspaces) {
+        if (wsInfo.workspacedata.oid === ws?.oid) continue;
+        const wsData = wsInfo.workspacedata;
+        const allTabIds = [...(wsData.pinnedtabids ?? []), ...(wsData.tabids ?? [])];
+        for (const tabId of allTabIds) {
+            const oref = WOS.makeORef("tab", tabId);
+            // Use cached value when available; reloadWaveObject on cache miss.
+            const cached = WOS.getObjectValue<Tab>(oref);
+            const tab = cached ?? (await WOS.reloadWaveObject<Tab>(oref));
+            if (!tab?.blockids?.includes(blockId)) continue;
+            await WorkspaceService.SetActiveTab(wsData.oid, tabId);
+            const instances = await getApi().listWindowInstances();
+            const instance = instances.find((i) => i.windowId === wsInfo.windowid);
+            if (instance?.label) {
+                await getApi().focusWindow(instance.label);
+            }
+            return;
+        }
+    }
+}

--- a/frontend/app/view/agent/hooks/useTurnLifecycle.ts
+++ b/frontend/app/view/agent/hooks/useTurnLifecycle.ts
@@ -113,7 +113,14 @@ export function useTurnLifecycle(opts: UseTurnLifecycleOptions): UseTurnLifecycl
         // one-shot (non-reactive) block-meta read is enough here: we
         // only need the name at this exact instant, not a live
         // subscription. See SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md.
-        if (opts.provider && tokens) {
+        //
+        // Called even when `tokens` is null — a stats-only session_end
+        // (cost_usd/num_turns reported, no token usage at all) is a real
+        // shape the Claude translator emits; recordTurn's own no-op
+        // check handles the case where there's truly nothing to record.
+        // Codex P2 on PR #2849 — this used to be gated on `tokens` being
+        // truthy, silently dropping that cost/turn-count data.
+        if (opts.provider) {
             const agentName =
                 WOS.getObjectValue<Block>(WOS.makeORef("block", opts.blockId))?.meta?.agentName
                 ?? opts.blockId.slice(0, 7);
@@ -121,6 +128,7 @@ export function useTurnLifecycle(opts: UseTurnLifecycleOptions): UseTurnLifecycl
                 blockId: opts.blockId,
                 agentName,
                 costUsd: stats?.cost_usd,
+                numTurns: stats?.num_turns,
             });
         }
         // Detect user-initiated stop via the reducer's turn phase.

--- a/frontend/app/view/agent/hooks/useTurnLifecycle.ts
+++ b/frontend/app/view/agent/hooks/useTurnLifecycle.ts
@@ -106,8 +106,22 @@ export function useTurnLifecycle(opts: UseTurnLifecycleOptions): UseTurnLifecycl
         // indicator + breakdown popover stay up to date. Guarded
         // against double-counting by recordTurn's own no-op-on-zero
         // check — see SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §5.1.
+        //
+        // This is the only recordTurn call site with real pane/agent
+        // identity in scope — pass it through so the status bar's
+        // breakdown can group by agent instead of just by provider. A
+        // one-shot (non-reactive) block-meta read is enough here: we
+        // only need the name at this exact instant, not a live
+        // subscription. See SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md.
         if (opts.provider && tokens) {
-            recordTurn(opts.provider, tokens);
+            const agentName =
+                WOS.getObjectValue<Block>(WOS.makeORef("block", opts.blockId))?.meta?.agentName
+                ?? opts.blockId.slice(0, 7);
+            recordTurn(opts.provider, tokens, {
+                blockId: opts.blockId,
+                agentName,
+                costUsd: stats?.cost_usd,
+            });
         }
         // Detect user-initiated stop via the reducer's turn phase.
         // PR G: replaces the legacy `stoppingAtom` getter — the

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -9,64 +9,18 @@ import AnsiLine from "@/element/ansiline";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { WOS, workspace, setActiveTab, atoms, getApi } from "@/app/store/global";
+import { WOS, atoms } from "@/app/store/global";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
 import { getBlockTurnPhase } from "@/app/store/agentActivity";
-import { WorkspaceService } from "@/app/store/services";
 import { recordTurn } from "@/app/store/token-usage";
 import { useTick } from "@/app/hook/useTick";
 import { formatCompactNumber } from "@/util/format-count";
 import { formatElapsedClock } from "@/util/format-time";
+import { focusBlock } from "@/app/util/focus-block";
 import { FleetToolbar, FleetResultPanel } from "./swarm-fleet-toolbar";
 import "./swarm-view.scss";
-
-// Navigate to the pane for a given block ID, switching tabs and windows as needed.
-// Tries the current window first (fast path), then searches all other workspaces
-// and brings the containing window to focus.
-async function focusBlock(blockId: string): Promise<void> {
-    // Fast path: search the current window's workspace.
-    const ws = workspace();
-    if (ws) {
-        const allTabIds = [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])];
-        for (const tabId of allTabIds) {
-            const layoutModel = getLayoutModelForTabById(tabId);
-            const node = layoutModel?.getNodeByBlockId(blockId);
-            if (node?.id != null) {
-                await setActiveTab(tabId);
-                layoutModel.focusNode(node.id);
-                return;
-            }
-        }
-    }
-    // Slow path: agent is in a different window — query all workspaces.
-    // We need Tab.blockids to find which tab holds the block. Layout models for
-    // other-window tabs are not available from this renderer. We fetch each Tab
-    // from the server (cache hit is instant; miss triggers one server round-trip).
-    // focusNode is intentionally omitted: a layout model in another renderer
-    // process cannot be driven from this side.
-    const allWorkspaces = await RpcApi.WorkspaceListCommand(TabRpcClient);
-    for (const wsInfo of allWorkspaces) {
-        if (wsInfo.workspacedata.oid === ws?.oid) continue;
-        const wsData = wsInfo.workspacedata;
-        const allTabIds = [...(wsData.pinnedtabids ?? []), ...(wsData.tabids ?? [])];
-        for (const tabId of allTabIds) {
-            const oref = WOS.makeORef("tab", tabId);
-            // Use cached value when available; reloadWaveObject on cache miss.
-            const cached = WOS.getObjectValue<Tab>(oref);
-            const tab = cached ?? (await WOS.reloadWaveObject<Tab>(oref));
-            if (!tab?.blockids?.includes(blockId)) continue;
-            await WorkspaceService.SetActiveTab(wsData.oid, tabId);
-            const instances = await getApi().listWindowInstances();
-            const instance = instances.find((i) => i.windowId === wsInfo.windowid);
-            if (instance?.label) {
-                await getApi().focusWindow(instance.label);
-            }
-            return;
-        }
-    }
-}
 
 export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Element {
     const model = props.model;


### PR DESCRIPTION
## Summary
- Regroups the status bar's token breakdown popover from per-provider to per-agent: each row now shows tokens, turn count, and cost ($, from `SessionStats.cost_usd` — already tracked per-pane but never surfaced in the status bar until now).
- Background/ambient usage (next-prompt-suggestion, activity summaries, subagent naming) collapses into a single collapsible "AgentMux internal" row instead of appearing as confusing peer rows next to real agents.
- Per-agent cache hit rate shown inline (same computation as the existing global rate, scoped to one agent).
- Clicking a real agent row focuses that agent's pane — extracted swarm-view's `focusBlock` into `frontend/app/util/focus-block.ts` so both call sites share it instead of duplicating the cross-window search.
- No backend changes — `cost_usd`/`blockId`/`agentName` were all already available frontend-side; this is aggregation + display only.

See `docs/specs/SPEC_STATUSBAR_TOKEN_PANEL_BY_AGENT_2026_08_30.md` for the full design, including the value-add ideas considered and why (cost, turn count, ambient split, click-to-focus) vs. deferred (active/idle grouping, burn rate).

## Test plan
- [x] `npx vitest run frontend/app/store/token-usage.test.ts` — 13/13 passing, including new by-agent aggregation/sort/reset coverage
- [x] `npx vitest run frontend/app/statusbar/TokenBreakdownPopover.test.tsx` — 5/5 passing (new), covers empty state, per-agent rows, ambient collapse/expand, focus-on-click
- [x] `npx vitest run frontend/app/view/swarm` — 93/93 passing (regression check on the `focusBlock` extraction)
- [x] Full suite: `npx vitest run` — 226 files / 3325 tests passing, 2 files/3 tests skipped (unrelated e2e, gated by `AGENTMUX_E2E_BUILD_DIR`)
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=manoz -->