### PR TITLE
fix(layout): an all-minimized row's chips share the full width

### DIFF
--- a/.changesets/1788130400-fix-layout-minimized-row-fill-width-q4m8.md
+++ b/.changesets/1788130400-fix-layout-minimized-row-fill-width-q4m8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): an all-minimized row of panes fills the width instead of leaving dead space to the right

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -140,9 +140,31 @@ export function computeMainAxisAllocation(
         isSlip(c) ? 0 : isEffectivelyMinimized(c) ? minimizedFixedPx(c, nodeIsRow, gapPx) : 0
     );
     const fixedTotal = fixed.reduce((a, b) => a + b, 0);
-    const scale = fixedTotal > nodePixels && fixedTotal > 0 ? nodePixels / fixedTotal : 1;
-    const remainingPx = Math.max(nodePixels - fixedTotal * scale, 0);
     const flexTotal = children.reduce((s, c, i) => (fixed[i] || isSlip(c) ? s : s + getSize(c)), 0);
+
+    // When every child of a Row is a chip, the chips ARE the row's occupants —
+    // share the full width among them rather than each taking a fixed
+    // `MinimizedRowSlotWidthPx` and leaving dead space to the right. This is
+    // reachable only when no sibling is expanded (an expanded sibling would
+    // have absorbed them via `resolveRowSlipTargets` instead), so there is no
+    // flex child whose space this could steal.
+    //
+    // Distributed proportionally to each child's own collapsed extent, not
+    // strictly equally: an all-leaf row divides evenly (the common case), while
+    // a nested fully-minimized Row branch — which genuinely needs N chip-widths
+    // for its N side-by-side chips — keeps its larger share.
+    //
+    // Row-only, deliberately. The Column equivalent is already correct and must
+    // not stretch: a fully-minimized Column is handed exactly its collapsed
+    // extent by its parent (see `collapsedExtentPx`), so there is nothing left
+    // over, and stretching would render chips TALLER than a header.
+    const chipsOwnTheRow = nodeIsRow && flexTotal === 0 && fixedTotal > 0;
+    const scale = chipsOwnTheRow
+        ? nodePixels / fixedTotal
+        : fixedTotal > nodePixels && fixedTotal > 0
+          ? nodePixels / fixedTotal
+          : 1;
+    const remainingPx = Math.max(nodePixels - fixedTotal * scale, 0);
     const pixelToSizeRatio =
         flexTotal > 0 && remainingPx > 0
             ? flexTotal / remainingPx

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -604,3 +604,64 @@ describe("collapsedExtentPx — cross-split (perpendicular nested branch)", () =
         expect(collapsedExtentPx(outer, true, gap)).toBe(2 * chipH);
     });
 });
+
+// ── All-minimized Row: chips fill the width instead of leaving dead space ───
+// Operator report (2026-08-30): after the cross-split height fix, "the space
+// above the 2 collapsed panes is gone, but there is still blank space to the
+// right. The collapsed panes should equally fill up the empty space."
+describe("all-minimized Row: chips share the full width", () => {
+    const gap = 3;
+    const size = (n: LayoutNode) => n.size;
+    const minLeaf = (id: string) => {
+        const n = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: id });
+        n.minimized = true;
+        return n;
+    };
+
+    it("two minimized leaves split the row evenly, no leftover", () => {
+        const kids = [minLeaf("a"), minLeaf("b")];
+        const { px } = computeMainAxisAllocation(kids, true, 1200, size, gap);
+        expect(px[0]).toBeCloseTo(600);
+        expect(px[1]).toBeCloseTo(600);
+        expect(px[0] + px[1]).toBeCloseTo(1200); // was 2 * (180+3) = 366
+    });
+
+    it("three minimized leaves split evenly", () => {
+        const kids = [minLeaf("a"), minLeaf("b"), minLeaf("c")];
+        const { px } = computeMainAxisAllocation(kids, true, 1200, size, gap);
+        px.forEach((v) => expect(v).toBeCloseTo(400));
+        expect(px.reduce((a, b) => a + b, 0)).toBeCloseTo(1200);
+    });
+
+    it("a nested fully-minimized Row branch keeps its larger share (proportional, not strictly equal)", () => {
+        // [ leaf, Row[leaf, leaf] ] — the branch needs two chip-widths to the
+        // leaf's one, so it takes 2/3 of the row, not 1/2.
+        const solo = minLeaf("solo");
+        const pair = newLayoutNode(FlexDirection.Row, 10, [minLeaf("a"), minLeaf("b")]);
+        const { px } = computeMainAxisAllocation([solo, pair], true, 900, size, gap);
+        expect(px[0]).toBeCloseTo(300);
+        expect(px[1]).toBeCloseTo(600);
+        expect(px[0] + px[1]).toBeCloseTo(900);
+    });
+
+    it("does NOT stretch when an expanded sibling is present — that one still slips", () => {
+        const a = minLeaf("a");
+        const b = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "b" });
+        const { px } = computeMainAxisAllocation([a, b], true, 1200, size, gap);
+        expect(px[0]).toBe(MinimizedRowSlotWidthPx + gap); // unchanged fixed chip
+        expect(px[1]).toBeCloseTo(1200 - (MinimizedRowSlotWidthPx + gap));
+    });
+
+    it("does NOT stretch a Column — chips must stay header-height", () => {
+        const kids = [minLeaf("a"), minLeaf("b")];
+        const { px } = computeMainAxisAllocation(kids, false, 1200, size, gap);
+        px.forEach((v) => expect(v).toBe(HeaderHeightPx + gap));
+    });
+
+    it("still shrinks to fit when the row is narrower than the chips need", () => {
+        const kids = [minLeaf("a"), minLeaf("b"), minLeaf("c"), minLeaf("d"), minLeaf("e"), minLeaf("f")];
+        const { px } = computeMainAxisAllocation(kids, true, 300, size, gap);
+        expect(px.reduce((a, b) => a + b, 0)).toBeCloseTo(300);
+        px.forEach((v) => expect(v).toBeLessThan(MinimizedRowSlotWidthPx));
+    });
+});


### PR DESCRIPTION
Follow-up to #2848, straight from the operator's own check of it:

> the space above the 2 collapsed panes is gone, but there is still blank space to the right. The collapsed panes should equally fill up the empty space.

## The remaining half

#2848 fixed the row's **height**. Its **width** was still wrong: every minimized child of a Row took a flat `MinimizedRowSlotWidthPx` (180px + gap), so two chips occupied ~366px of a full-width row and left the rest empty.

That fixed width is correct when a chip sits beside an expanded pane. But this path is **only reachable when no sibling is expanded** — an expanded one would have absorbed the chips via `resolveRowSlipTargets` instead. With no flex child in the row, the chips are its only occupants, and there is nobody else the leftover space could belong to.

## The change

When a Row has fixed children and **no** flex children, the chips scale to fill `nodePixels`.

Distributed **proportionally to each child's own collapsed extent**, not strictly equally — an all-leaf row divides evenly (the reported case), while a nested fully-minimized Row branch keeps the larger share it genuinely needs for its N side-by-side chips.

**Row-only, deliberately.** A fully-minimized Column is already handed exactly its collapsed extent by its parent (#2848), so it has no leftover to fill, and stretching it would render chips *taller than a header*. There's a test pinning that.

Existing shrink-to-fit is untouched and still covered: six chips in a 300px row still scale below one chip-width and sum to the container.

## Tests

**193/193**, six added:

| | |
|---|---|
| two / three minimized leaves | split evenly, sum to the full width (was 366 of 1200) |
| nested fully-minimized Row branch | proportional — 300 / 600 of 900, not 450 / 450 |
| expanded sibling present | **no** stretch — still the fixed chip width (the slip path) |
| Column parent | **no** stretch — chips stay header-height |
| narrow row | still shrinks below one chip-width, sums to container |

Every pre-existing test pinning `MinimizedRowSlotWidthPx` has an expanded sibling, so none of them exercise this path — I checked that before changing it.

## Not verified visually

The live `task dev` panes had been restored to expanded by the time I captured, so the fill state wasn't on screen. The unit coverage is exact (600/600 in a 1200px row), but the visual check is still worth doing — the fix is hot-loaded in that instance if you re-minimize them.

<!-- agentmux:agent_id=agentx -->