### PR TITLE
feat(agent-pane): dock a bare sleep immediately with a live countdown

### DIFF
--- a/.changesets/1788130657-feat-agent-pane-dock-a-bare-sleep-immediately-with-a-live-co-gl5d.md
+++ b/.changesets/1788130657-feat-agent-pane-dock-a-bare-sleep-immediately-with-a-live-co-gl5d.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent-pane): dock a bare sleep immediately with a live countdown

--- a/docs/specs/REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md
+++ b/docs/specs/REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md
@@ -1,6 +1,39 @@
 # Report: auto-detecting long-running tool calls (sleep and beyond) and docking them — status refresh, 2026-07-26
 
-**Status:** Report — audit + design synthesis, all open questions resolved (§4), not yet implemented. This is **not** a from-scratch analysis: it verifies and consolidates two existing same-topic reports against `main` as of today, and updates them with what has (and hasn't) shipped in the 10 days since.
+**Status:** Report — audit + design synthesis, all open questions resolved (§4). **Largely implemented since; see the status table below (refreshed 2026-08-30).** This is **not** a from-scratch analysis: it verifies and consolidates two existing same-topic reports against `main` as of today, and updates them with what has (and hasn't) shipped in the 10 days since.
+
+### §3 implementation status (verified against `main`, 2026-08-30)
+
+| Step | State | Where |
+|---|---|---|
+| 1. Duration-threshold promotion | **shipped** | `activity/tool-adapter.ts`, `TOOL_PROMOTION_MS = 30_000` |
+| 1a. `sleep <N>` → immediate dock + "~Ns left" | **shipped 2026-08-30** | `activity/sleep-detect.ts` — see the note below |
+| 2. `run_in_background` end-to-end | **shipped** | issues #2490, #2518, #2491, #2492 |
+| 3. Two-axis pane status | **shipped** | `activity/attached-task.ts`, `SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md` |
+| 4. Feed the signal to Swarm | **partial** | `shellRows`/`cronRows` exist; dock-promoted Bash calls are still absent |
+| 5. Generalize beyond Bash | **not started** | `isBashToolNode` still gates on `tool === "Bash"` |
+
+**On 1a (§4.2's "cheap UX polish"), with the measurement §4.2 called for.**
+That section asked for "real-transcript validation, not just Agent1's one
+heartbeat example, before it ships." Done — 7,761 foreground Bash calls across
+12 production transcripts:
+
+- The **naive** rule §4.2 rejected ("command starts with `sleep`") matches 270
+  calls, of which **204 (76%) are not waits** — `sleep 90; tail -30 <log>`,
+  `sleep 60; ls <dir>`. The rejection was correct.
+- Restricting to commands that are a wait **and nothing else** matches 66, every
+  one genuine, median 61s. No false-positive surface: there is no second clause
+  to be wrong about. 18 of the 66 finish under 30s, i.e. the duration rule
+  misses them entirely.
+- All 204 compound sleeps ran 28–100s, so duration already catches every one —
+  ignoring them here costs nothing.
+
+Shipped as exactly what §4.2 specifies: an optimization layered on top of
+duration promotion, never the classifier. Also measured, and **rejected**:
+lowering `TOOL_PROMOTION_MS` to 10s. Median foreground Bash is 7.5s, so 10s
+lands on the steepest part of the distribution — 3.5× the dock rows, 21% of all
+calls newly promoted, and identical commands flipping across the line depending
+on cache state.
 **Author:** Agent3
 **Verified against:** `main` @ `45155f864` (pulled 2026-07-26).
 **Supersedes/updates:**

--- a/frontend/app/view/agent/activity/attached-task.test.ts
+++ b/frontend/app/view/agent/activity/attached-task.test.ts
@@ -26,7 +26,9 @@ function mkBash(overrides: Partial<ToolNode> = {}): ToolNode {
         id: "tool-1",
         tool: "Bash",
         status: "running",
-        params: { command: "sleep 300" },
+        // Not a sleep — see the same note in tool-adapter.test.ts's mkBash:
+        // a whole-command sleep skips the threshold entirely.
+        params: { command: "cargo test -p agentmux-srv" },
         collapsed: false,
         summary: "",
         timestamp: 0,

--- a/frontend/app/view/agent/activity/sleep-detect.test.ts
+++ b/frontend/app/view/agent/activity/sleep-detect.test.ts
@@ -32,10 +32,6 @@ describe("wholeCommandSleepMs — matches", () => {
         expect(wholeCommandSleepMs("timeout 60 sleep 60")).toBe(60_000);
         expect(wholeCommandSleepMs("timeout 90s sleep 60")).toBe(60_000);
     });
-
-    it("is case-insensitive", () => {
-        expect(wholeCommandSleepMs("SLEEP 60")).toBe(60_000);
-    });
 });
 
 describe("wholeCommandSleepMs — refuses anything with a second clause", () => {
@@ -91,5 +87,55 @@ describe("wholeCommandSleepMs — the micro-delay floor", () => {
 
     it("accepts exactly at the floor", () => {
         expect(wholeCommandSleepMs("sleep 5")).toBe(SLEEP_IMMEDIATE_MIN_MS);
+    });
+});
+
+describe("wholeCommandSleepMs — timeout wrapper decides the real wait (codex P2, PR #2851)", () => {
+    /** `timeout N sleep M` ends at whichever comes first. Counting down from
+     *  the sleep's own argument would say "~300s left" about a process that
+     *  dies in 5 — the confidently-wrong reading this module exists to avoid. */
+    it("uses the timeout when it is shorter than the sleep", () => {
+        expect(wholeCommandSleepMs("timeout 5 sleep 300")).toBe(5_000);
+        expect(wholeCommandSleepMs("timeout 30s sleep 600")).toBe(30_000);
+        expect(wholeCommandSleepMs("timeout 1m sleep 3600")).toBe(60_000);
+    });
+
+    it("uses the sleep when the timeout is longer (it never fires)", () => {
+        expect(wholeCommandSleepMs("timeout 600 sleep 30")).toBe(30_000);
+    });
+
+    /** `timeout --help`: "A duration of 0 disables the associated timeout." */
+    it("treats a zero timeout as no timeout at all", () => {
+        expect(wholeCommandSleepMs("timeout 0 sleep 300")).toBe(300_000);
+    });
+
+    it("applies the micro-delay floor to the EFFECTIVE wait, not the sleep argument", () => {
+        // Dies after 2s despite the `sleep 300` — below the floor, so no row.
+        expect(wholeCommandSleepMs("timeout 2 sleep 300")).toBeNull();
+    });
+});
+
+describe("wholeCommandSleepMs — case sensitivity matches the shell (codex P2, PR #2851)", () => {
+    /** Verified against coreutils: `sleep 5M` -> "invalid time interval '5M'".
+     *  Matching it would promote a call that fails instantly — phantom dock
+     *  row, suppressed working row, bogus attached-task exemption. */
+    it("refuses uppercase unit suffixes, which coreutils rejects", () => {
+        expect(wholeCommandSleepMs("sleep 5M")).toBeNull();
+        expect(wholeCommandSleepMs("sleep 30S")).toBeNull();
+        expect(wholeCommandSleepMs("sleep 1H")).toBeNull();
+    });
+
+    it("refuses an uppercase command name, which is not a command on a case-sensitive fs", () => {
+        expect(wholeCommandSleepMs("SLEEP 60")).toBeNull();
+        expect(wholeCommandSleepMs("Sleep 60")).toBeNull();
+    });
+
+    it("refuses an uppercase timeout wrapper", () => {
+        expect(wholeCommandSleepMs("TIMEOUT 60 sleep 60")).toBeNull();
+    });
+
+    it("still accepts the ordinary lowercase forms", () => {
+        expect(wholeCommandSleepMs("sleep 5m")).toBe(300_000);
+        expect(wholeCommandSleepMs("sleep 30s")).toBe(30_000);
     });
 });

--- a/frontend/app/view/agent/activity/sleep-detect.test.ts
+++ b/frontend/app/view/agent/activity/sleep-detect.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { wholeCommandSleepMs, SLEEP_IMMEDIATE_MIN_MS } from "./sleep-detect";
+
+describe("wholeCommandSleepMs — matches", () => {
+    it("a bare sleep in seconds", () => {
+        expect(wholeCommandSleepMs("sleep 300")).toBe(300_000);
+        expect(wholeCommandSleepMs("sleep 60")).toBe(60_000);
+    });
+
+    it("tolerates surrounding whitespace and a trailing semicolon", () => {
+        expect(wholeCommandSleepMs("  sleep 300  ")).toBe(300_000);
+        expect(wholeCommandSleepMs("sleep 300;")).toBe(300_000);
+        expect(wholeCommandSleepMs("sleep 300 ; ")).toBe(300_000);
+    });
+
+    it("understands unit suffixes", () => {
+        expect(wholeCommandSleepMs("sleep 30s")).toBe(30_000);
+        expect(wholeCommandSleepMs("sleep 5m")).toBe(300_000);
+        expect(wholeCommandSleepMs("sleep 1h")).toBe(3_600_000);
+    });
+
+    it("understands fractional seconds", () => {
+        expect(wholeCommandSleepMs("sleep 7.5")).toBe(7_500);
+    });
+
+    /** `timeout N sleep N` is a real idiom for a bounded wait and is still
+     *  purely a wait — nothing runs after it. */
+    it("accepts a timeout-wrapped sleep", () => {
+        expect(wholeCommandSleepMs("timeout 60 sleep 60")).toBe(60_000);
+        expect(wholeCommandSleepMs("timeout 90s sleep 60")).toBe(60_000);
+    });
+
+    it("is case-insensitive", () => {
+        expect(wholeCommandSleepMs("SLEEP 60")).toBe(60_000);
+    });
+});
+
+describe("wholeCommandSleepMs — refuses anything with a second clause", () => {
+    // These are the 204-of-270 real-transcript cases that made the naive
+    // "starts with sleep" rule wrong 76% of the time. Every one is
+    // wait-then-do-something, not a pure wait, and every one runs long enough
+    // that ordinary duration promotion already catches it.
+    it.each([
+        "sleep 90; tail -30 /tmp/build.log",
+        "sleep 60; ls ~/Documents/out",
+        "sleep 30; cat /tmp/task.output",
+        "sleep 20 && tail -30 /tmp/x.log",
+        "sleep 2 && rm -rf /tmp/staging",
+        "sleep 45 cd /repo && npm test",
+        "sleep 10 | tee /tmp/log",
+        "sleep 10\necho done",
+    ])("refuses %j", (cmd) => {
+        expect(wholeCommandSleepMs(cmd)).toBeNull();
+    });
+
+    it("refuses a loop that merely contains a sleep", () => {
+        // The Agent1 heartbeat shape. Genuinely long-running, but duration
+        // promotion is what catches it — a text rule can't read intent here,
+        // and `sleep 25` inside the loop is not this command's total wait.
+        expect(wholeCommandSleepMs('while true; do sleep 25; echo "[hb]"; done')).toBeNull();
+    });
+});
+
+describe("wholeCommandSleepMs — refuses non-sleeps and malformed input", () => {
+    it.each([
+        ["a bare sleep with no argument", "sleep"],
+        ["a non-numeric argument", "sleep forever"],
+        ["GNU multi-arg sleep (summing it isn't worth the surface)", "sleep 1 2"],
+        ["a different command entirely", "npm test"],
+        ["a command merely mentioning sleep", "grep -r sleep src/"],
+        ["a command ending in sleep", "npm run sleep"],
+    ])("refuses %s", (_label, cmd) => {
+        expect(wholeCommandSleepMs(cmd)).toBeNull();
+    });
+
+    it("handles empty/undefined without throwing", () => {
+        expect(wholeCommandSleepMs("")).toBeNull();
+        expect(wholeCommandSleepMs(undefined)).toBeNull();
+    });
+});
+
+describe("wholeCommandSleepMs — the micro-delay floor", () => {
+    it("refuses a sleep below the floor, so a micro-delay never takes a dock row", () => {
+        expect(wholeCommandSleepMs("sleep 1")).toBeNull();
+        expect(wholeCommandSleepMs("sleep 2")).toBeNull();
+        expect(wholeCommandSleepMs("sleep 4.9")).toBeNull();
+    });
+
+    it("accepts exactly at the floor", () => {
+        expect(wholeCommandSleepMs("sleep 5")).toBe(SLEEP_IMMEDIATE_MIN_MS);
+    });
+});

--- a/frontend/app/view/agent/activity/sleep-detect.ts
+++ b/frontend/app/view/agent/activity/sleep-detect.ts
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Recognizes a Bash command that is *nothing but* a wait, so the dock can
+ * promote it immediately (instead of after `TOOL_PROMOTION_MS`) and show a
+ * real countdown instead of a blind elapsed timer.
+ *
+ * ## Why this is deliberately narrow
+ *
+ * `REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md` §4.2 rejected
+ * text matching as the *classifier* — correctly. Measured against 7,761
+ * foreground Bash calls from real transcripts, the obvious rule ("command
+ * starts with `sleep`") matches 270 calls of which **204 (76%) are not waits
+ * at all** — they're `sleep 90; tail -30 <log>`, `sleep 60; ls <dir>`,
+ * `sleep 30; cat <file>`: poll-then-inspect. Promoting on that basis would be
+ * wrong three times out of four.
+ *
+ * What that rejection over-shot is the case where the command is a wait and
+ * **nothing else**. `sleep 300` has no second clause to be wrong about, so
+ * matching it has no false-positive surface *by construction* — the risk the
+ * report identified lives entirely in the part after the `&&`/`;`, and this
+ * matcher refuses anything that has one. Same 7,761 calls: 66 match, every
+ * one a genuine wait, median 61s.
+ *
+ * Duration-based promotion remains the classifier for everything else,
+ * exactly as that report specifies. This is the report's own "phase 1a, cheap
+ * UX polish" — layered on top of the duration rule, never replacing it. The
+ * 204 compound sleeps this ignores all ran 28-100s, so the duration rule
+ * already catches every one of them; skipping them here costs nothing.
+ */
+
+/**
+ * Below this, a bare sleep is a micro-delay, not something worth a dock row —
+ * `sleep 1` between two commands would otherwise occupy the dock for its own
+ * duration plus the full `RETENTION_MS.done` window, which is strictly more
+ * noise than signal. Such commands keep the ordinary duration behaviour (i.e.
+ * they never promote, because they finish long before the threshold).
+ */
+export const SLEEP_IMMEDIATE_MIN_MS = 5_000;
+
+/**
+ * The whole command, and only a wait:
+ *   `sleep 300` · `sleep 300;` · `sleep 0.5` · `sleep 5m` · `timeout 60 sleep 60`
+ *
+ * Anything with a second clause (`&&`, `;` followed by work, `|`, a newline)
+ * fails to match and falls through to duration promotion. So does a bare
+ * `sleep` with no argument, and GNU's multi-arg `sleep 1 2` form (rare, and
+ * summing it is not worth the surface).
+ */
+const WHOLE_COMMAND_SLEEP = /^\s*(?:timeout\s+\d+(?:\.\d+)?[smhd]?\s+)?sleep\s+(\d+(?:\.\d+)?)([smhd]?)\s*;?\s*$/i;
+
+const UNIT_MS: Record<string, number> = { "": 1_000, s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+
+/**
+ * Milliseconds this command will sleep for, or `null` when it isn't a
+ * whole-command sleep (the overwhelmingly common case — 99.15% of real Bash
+ * calls). Callers treat `null` as "no special handling, use the duration
+ * rule".
+ *
+ * Returns `null` below [`SLEEP_IMMEDIATE_MIN_MS`] too, so a single check
+ * answers both "is this a pure wait" and "is it worth showing" — no caller
+ * has to remember to apply the floor itself.
+ */
+export function wholeCommandSleepMs(command: string | undefined): number | null {
+    if (!command) return null;
+    const m = WHOLE_COMMAND_SLEEP.exec(command);
+    if (!m) return null;
+    const value = Number.parseFloat(m[1]);
+    if (!Number.isFinite(value)) return null;
+    const ms = value * (UNIT_MS[m[2].toLowerCase()] ?? 1_000);
+    return ms >= SLEEP_IMMEDIATE_MIN_MS ? ms : null;
+}

--- a/frontend/app/view/agent/activity/sleep-detect.ts
+++ b/frontend/app/view/agent/activity/sleep-detect.ts
@@ -47,10 +47,28 @@ export const SLEEP_IMMEDIATE_MIN_MS = 5_000;
  * fails to match and falls through to duration promotion. So does a bare
  * `sleep` with no argument, and GNU's multi-arg `sleep 1 2` form (rare, and
  * summing it is not worth the surface).
+ *
+ * **Case-sensitive, and lowercase suffixes only** (codex P2 on PR #2851).
+ * `sleep 5M` is not a slow sleep — coreutils rejects it outright (*"invalid
+ * time interval '5M'"*, verified), and `SLEEP 60` is not a command at all on
+ * any case-sensitive filesystem. Matching either would promote a call that is
+ * about to die instantly: a phantom dock row, a suppressed working row, and a
+ * bogus attached-task exemption, all for a command that never waited. A false
+ * negative here is free — it just falls through to duration promotion.
+ *
+ * Groups: 1/2 = the `timeout` wrapper's duration + unit (absent when
+ * unwrapped), 3/4 = the sleep's own.
  */
-const WHOLE_COMMAND_SLEEP = /^\s*(?:timeout\s+\d+(?:\.\d+)?[smhd]?\s+)?sleep\s+(\d+(?:\.\d+)?)([smhd]?)\s*;?\s*$/i;
+const WHOLE_COMMAND_SLEEP =
+    /^\s*(?:timeout\s+(\d+(?:\.\d+)?)([smhd]?)\s+)?sleep\s+(\d+(?:\.\d+)?)([smhd]?)\s*;?\s*$/;
 
 const UNIT_MS: Record<string, number> = { "": 1_000, s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+
+function toMs(value: string, unit: string): number | null {
+    const n = Number.parseFloat(value);
+    if (!Number.isFinite(n)) return null;
+    return n * (UNIT_MS[unit] ?? 1_000);
+}
 
 /**
  * Milliseconds this command will sleep for, or `null` when it isn't a
@@ -66,8 +84,18 @@ export function wholeCommandSleepMs(command: string | undefined): number | null 
     if (!command) return null;
     const m = WHOLE_COMMAND_SLEEP.exec(command);
     if (!m) return null;
-    const value = Number.parseFloat(m[1]);
-    if (!Number.isFinite(value)) return null;
-    const ms = value * (UNIT_MS[m[2].toLowerCase()] ?? 1_000);
-    return ms >= SLEEP_IMMEDIATE_MIN_MS ? ms : null;
+
+    const sleepMs = toMs(m[3], m[4]);
+    if (sleepMs == null) return null;
+
+    // `timeout N sleep M` waits for whichever comes first — the countdown must
+    // follow the process, not the sleep's own argument (codex P2 on PR #2851).
+    // `timeout 5 sleep 300` dies at 5s; counting down from 5 minutes would be
+    // exactly the confidently-wrong reading this module exists to avoid.
+    // Per `timeout --help`: "A duration of 0 disables the associated timeout",
+    // so a zero wrapper means the sleep runs in full.
+    const timeoutMs = m[1] != null ? toMs(m[1], m[2]) : null;
+    const effectiveMs = timeoutMs != null && timeoutMs > 0 ? Math.min(timeoutMs, sleepMs) : sleepMs;
+
+    return effectiveMs >= SLEEP_IMMEDIATE_MIN_MS ? effectiveMs : null;
 }

--- a/frontend/app/view/agent/activity/tool-adapter.test.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.test.ts
@@ -11,7 +11,12 @@ function mkBash(overrides: Partial<ToolNode> = {}): ToolNode {
         id: "tool-1",
         tool: "Bash",
         status: "running",
-        params: { command: "sleep 300" },
+        // NOT a sleep, deliberately. `sleep-detect.ts` promotes a
+        // whole-command sleep immediately, bypassing TOOL_PROMOTION_MS — so a
+        // `sleep` fixture here would make every threshold assertion below
+        // vacuously pass. This must stay a command that only the duration rule
+        // can catch.
+        params: { command: "cargo test -p agentmux-srv" },
         collapsed: false,
         summary: "",
         timestamp: 0,
@@ -21,7 +26,7 @@ function mkBash(overrides: Partial<ToolNode> = {}): ToolNode {
 
 describe("toolToActivity", () => {
     it("maps a running Bash node to a running, non-stoppable activity", () => {
-        const n = mkBash({ id: "t1", timestamp: 1000, params: { command: "sleep 300" } });
+        const n = mkBash({ id: "t1", timestamp: 1000, params: { command: "cargo test -p agentmux-srv" } });
         const a = toolToActivity(n);
         expect(a.id).toBe("t1");
         expect(a.kind).toBe("tool");
@@ -29,7 +34,7 @@ describe("toolToActivity", () => {
         expect(a.startedAt).toBe(1000);
         expect(a.endedAt).toBeUndefined();
         expect(a.canStop).toBe(false);
-        expect(a.title).toBe("sleep 300");
+        expect(a.title).toBe("cargo test -p agentmux-srv");
         expect(a.tool).toBe(n);
     });
 
@@ -272,5 +277,63 @@ describe("toolActivities — backgrounded calls", () => {
         expect(acts).toHaveLength(1);
         expect(acts[0].id).toBe("fg");
         expect(acts[0].status).toBe("running");
+    });
+});
+
+describe("whole-command sleeps promote immediately (sleep-detect.ts)", () => {
+    const sleepNode = (over: Partial<ToolNode> = {}) =>
+        mkBash({ id: "s1", timestamp: 1000, params: { command: "sleep 300" }, ...over });
+
+    /** The point of the feature: a self-declared wait needs no detection
+     *  window. Measured median for these in real transcripts is 61s, so the
+     *  old behaviour spent the first 30s of every one saying "Working…". */
+    it("docks a bare sleep at t=0, without waiting for TOOL_PROMOTION_MS", () => {
+        const nodes: DocumentNode[] = [sleepNode()];
+        expect(toolActivities(nodes, 1000).map((a) => a.id)).toEqual(["s1"]);
+        expect(toolActivities(nodes, 1001).map((a) => a.id)).toEqual(["s1"]);
+    });
+
+    it("carries sleepMs so the row can render a real countdown", () => {
+        expect(toolActivities([sleepNode()], 1000)[0].sleepMs).toBe(300_000);
+    });
+
+    it("suppresses the working row's tool text immediately too", () => {
+        // Otherwise the dock would show the sleep while AgentWorkingRow went on
+        // repeating it for another 30s.
+        expect(hasRunningPromotedTool([sleepNode()], 1000)).toBe(true);
+    });
+
+    it("schedules no promotion timer — it is already promoted", () => {
+        expect(nextToolPromotionAt([sleepNode()], 1000)).toBeNull();
+    });
+
+    /** It was docked from t=0, so it must RESOLVE in place (done, then normal
+     *  retention) rather than vanish the instant it ends — which is what the
+     *  duration rule alone would do for anything under the threshold. */
+    it("keeps a short sleep's row after it finishes, instead of dropping it", () => {
+        const finished = sleepNode({ params: { command: "sleep 12" }, status: "success", duration: 12 });
+        const acts = toolActivities([finished], 1000 + 12_000 + 1_000);
+        expect(acts).toHaveLength(1);
+        expect(acts[0].status).toBe("done");
+        expect(acts[0].endedAt).toBe(1000 + 12_000);
+    });
+
+    /** The 76%-wrong case from the real-transcript measurement. A compound
+     *  sleep must follow the ordinary duration rule — it is not a pure wait,
+     *  and its total runtime is unknowable from the text. */
+    it("does NOT fast-path a compound sleep, and gives it no countdown", () => {
+        const compound = mkBash({ id: "c1", timestamp: 1000, params: { command: "sleep 90; tail -30 /tmp/b.log" } });
+        expect(toolActivities([compound], 1000)).toEqual([]);
+        expect(nextToolPromotionAt([compound], 1000)).toBe(1000 + TOOL_PROMOTION_MS);
+        const promoted = toolActivities([compound], 1000 + TOOL_PROMOTION_MS);
+        expect(promoted.map((a) => a.id)).toEqual(["c1"]);
+        expect(promoted[0].sleepMs).toBeUndefined();
+    });
+
+    /** A micro-delay is below sleep-detect's floor, so it stays on the ordinary
+     *  path and never takes a dock row at all. */
+    it("ignores a micro-delay sleep entirely", () => {
+        const micro = mkBash({ id: "m1", timestamp: 1000, params: { command: "sleep 2" }, status: "success", duration: 2 });
+        expect(toolActivities([micro], 1000 + 60_000)).toEqual([]);
     });
 });

--- a/frontend/app/view/agent/activity/tool-adapter.ts
+++ b/frontend/app/view/agent/activity/tool-adapter.ts
@@ -30,9 +30,26 @@
 
 import { extractToolDetail } from "../stream-parser";
 import type { BashParams, BashResult, DocumentNode, ToolNode } from "../types";
+import { wholeCommandSleepMs } from "./sleep-detect";
 import type { ActivityStatus, PinnedActivity } from "./types";
 
 export const TOOL_PROMOTION_MS = 30_000;
+
+/**
+ * Milliseconds a call will spend sleeping, when the command is *nothing but*
+ * a wait — see `sleep-detect.ts` for why that narrowness is the whole point.
+ * `null` for 99%+ of calls, which then follow the ordinary duration rule.
+ *
+ * Such a call is promoted IMMEDIATELY rather than after `TOOL_PROMOTION_MS`:
+ * the threshold exists to *detect* undeclared long work, and a bare `sleep
+ * 300` has already declared itself — waiting 30s to show it is 30s of
+ * "Working…" for a pane that is, provably, doing nothing. Measured median for
+ * these in real transcripts is 61s, so the old behaviour spent half the wait
+ * saying the wrong thing.
+ */
+function pureSleepMs(n: ToolNode): number | null {
+    return wholeCommandSleepMs((n.params as BashParams | undefined)?.command);
+}
 
 /** The harness's literal acceptance-message prefix for a genuinely detached
  *  launch (see BashParams.run_in_background's doc comment). Exported so any
@@ -148,7 +165,10 @@ function backgroundCompletions(nodes: ReadonlyArray<DocumentNode>): Map<string, 
  *  already finished (that case is handled entirely by its retained,
  *  terminal-status dock row, not by anything time-gated). */
 function isRunningPastThreshold(n: ToolNode, now: number): boolean {
-    return n.status === "running" && now - n.timestamp! >= TOOL_PROMOTION_MS;
+    if (n.status !== "running") return false;
+    // A self-declared pure wait needs no detection window (`pureSleepMs`).
+    if (pureSleepMs(n) != null) return true;
+    return now - n.timestamp! >= TOOL_PROMOTION_MS;
 }
 
 /** True once `n` is known to have run for at least `TOOL_PROMOTION_MS`,
@@ -157,6 +177,11 @@ function isRunningPastThreshold(n: ToolNode, now: number): boolean {
  *  is the "did this call ever deserve a dock row" gate for `toolActivities`. */
 function everCrossedThreshold(n: ToolNode, now: number): boolean {
     if (n.status === "running") return isRunningPastThreshold(n, now);
+    // A finished pure sleep keeps its row through the ordinary retention
+    // window. It was docked from the moment it started, so dropping it the
+    // instant it ends (which the duration rule would do for anything under
+    // TOOL_PROMOTION_MS) would make the row vanish rather than resolve.
+    if (pureSleepMs(n) != null) return true;
     if (n.duration != null) return n.duration * 1000 >= TOOL_PROMOTION_MS;
     return false;
 }
@@ -175,10 +200,15 @@ function toolActivityStatus(status: ToolNode["status"]): ActivityStatus {
 
 export function toolToActivity(n: ToolNode): PinnedActivity {
     const detail = extractToolDetail(n.tool, (n.params as Record<string, any>) ?? {});
+    const sleepMs = pureSleepMs(n);
     return {
         id: n.id,
         kind: "tool",
         title: detail || n.toolName || n.tool,
+        // Only set for a whole-command sleep, which is the only case where the
+        // remaining time is actually KNOWN rather than guessed — the row shows
+        // a countdown instead of a blind elapsed timer.
+        ...(sleepMs != null ? { sleepMs } : {}),
         status: toolActivityStatus(n.status),
         startedAt: n.timestamp!,
         endedAt: n.status !== "running" && n.duration != null ? n.timestamp! + n.duration * 1000 : undefined,
@@ -247,6 +277,10 @@ export function nextToolPromotionAt(nodes: ReadonlyArray<DocumentNode>, now: num
     let next: number | null = null;
     for (const n of nodes) {
         if (!isBashToolNode(n) || n.status !== "running") continue;
+        // Pure sleeps promoted the instant they started — there is no future
+        // moment to schedule a timer for, and treating one as pending would
+        // wake the pane for a promotion that already happened.
+        if (pureSleepMs(n) != null) continue;
         const promotesAt = n.timestamp! + TOOL_PROMOTION_MS;
         if (promotesAt <= now) continue;
         if (next == null || promotesAt < next) next = promotesAt;

--- a/frontend/app/view/agent/activity/types.ts
+++ b/frontend/app/view/agent/activity/types.ts
@@ -53,6 +53,13 @@ export interface PinnedActivity {
     /** Present when `kind === "tool"` — an ordinary Bash tool call promoted
      *  after running past `TOOL_PROMOTION_MS` (tool-adapter.ts). */
     tool?: ToolNode;
+    /** Present only when the command is a whole-command sleep
+     *  (`activity/sleep-detect.ts`): how long it will wait, in ms. The one
+     *  case where remaining time is genuinely KNOWN rather than estimated, so
+     *  the row renders a countdown instead of a blind elapsed timer. Absent
+     *  for every other activity — `sleep 90; tail log` deliberately does NOT
+     *  get one, since the trailing work makes the total unknowable. */
+    sleepMs?: number;
 }
 
 /** Per-kind sigil; colored by status in CSS. */

--- a/frontend/app/view/agent/components/ActivityRow.countdown.test.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.countdown.test.tsx
@@ -1,0 +1,122 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The "~Ns left" countdown actually reaching the DOM.
+ *
+ * The rest of this feature is covered by pure-function tests
+ * (`sleep-detect.test.ts`, `tool-adapter.test.ts`), which prove the number is
+ * computed correctly — but not that anything renders it. This file closes
+ * that gap deterministically, which is a better artifact than eyeballing a
+ * screenshot once: the rendered output is a function of the activity's props,
+ * so it can be asserted rather than observed.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ActivityRow } from "./ActivityRow";
+import type { ActivityStatus, PinnedActivity } from "../activity/types";
+
+afterEach(cleanup);
+
+const START = 1_000_000;
+
+function sleepActivity(over: Partial<PinnedActivity> = {}): PinnedActivity {
+    return {
+        id: "s1",
+        kind: "tool",
+        title: "sleep 300",
+        status: "running",
+        startedAt: START,
+        canStop: false,
+        sleepMs: 300_000,
+        ...over,
+    };
+}
+
+function renderRow(activity: PinnedActivity) {
+    const [a] = createSignal<PinnedActivity | undefined>(activity);
+    const [expanded] = createSignal(false);
+    const [leaving] = createSignal(false);
+    return render(() => (
+        <ActivityRow
+            activity={a}
+            expanded={expanded}
+            leaving={leaving}
+            onToggle={() => {}}
+            onStop={() => {}}
+            onDismiss={() => {}}
+        />
+    ));
+}
+
+const countdownText = (c: HTMLElement) => c.querySelector(".agent-activity-remaining")?.textContent ?? null;
+
+describe("ActivityRow — sleep countdown", () => {
+    it("renders the remaining time for a running whole-command sleep", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(START + 40_000); // 40s into a 300s sleep
+        const { container } = renderRow(sleepActivity());
+        expect(countdownText(container)).toBe("~260s left");
+        vi.useRealTimers();
+    });
+
+    it("counts down as time passes", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(START);
+        const { container } = renderRow(sleepActivity());
+        expect(countdownText(container)).toBe("~300s left");
+        // useTick(1000) drives the recompute. advanceTimersByTime moves the
+        // mocked clock as well as firing timers, so it alone is the elapsed
+        // time — adding a setSystemTime on top would double-count it.
+        vi.advanceTimersByTime(5_000);
+        expect(countdownText(container)).toBe("~295s left");
+        vi.useRealTimers();
+    });
+
+    /** The process is reaped slightly after its own deadline, so the last tick
+     *  before ToolEnd must not render a negative number. */
+    it("clamps at zero rather than going negative past the deadline", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(START + 305_000); // 5s past a 300s sleep
+        const { container } = renderRow(sleepActivity());
+        expect(countdownText(container)).toBe("~0s left");
+        vi.useRealTimers();
+    });
+
+    it.each<ActivityStatus>(["done", "error", "stopped"])(
+        "shows no countdown once terminal (%s) — the final elapsed is the reading",
+        (status) => {
+            vi.useFakeTimers();
+            vi.setSystemTime(START + 40_000);
+            const { container } = renderRow(sleepActivity({ status, endedAt: START + 30_000 }));
+            expect(countdownText(container)).toBeNull();
+            vi.useRealTimers();
+        },
+    );
+
+    /** Every other activity kind — and every compound sleep — has no knowable
+     *  remaining time, so the element must be absent entirely rather than
+     *  rendering an empty or guessed value. */
+    it("shows no countdown for an activity with no sleepMs", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(START + 40_000);
+        const { container } = renderRow(sleepActivity({ sleepMs: undefined, title: "cargo test" }));
+        expect(countdownText(container)).toBeNull();
+        // …while the ordinary elapsed clock still renders, so this asserts the
+        // countdown's absence, not the whole row failing to mount.
+        expect(container.querySelector(".agent-activity-elapsed")).not.toBeNull();
+        vi.useRealTimers();
+    });
+
+    it("renders the countdown alongside the elapsed clock, not instead of it", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(START + 40_000);
+        const { container } = renderRow(sleepActivity());
+        expect(container.querySelector(".agent-activity-elapsed")?.textContent).toBe("[0:40]");
+        expect(countdownText(container)).toBe("~260s left");
+        vi.useRealTimers();
+    });
+});

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -83,6 +83,25 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
         onCleanup(() => clearTimeout(timer));
     });
 
+    /**
+     * "~Ns left" for a whole-command sleep, while it's still running — the one
+     * activity whose remaining time is actually known (`sleepMs`, set only by
+     * `sleep-detect.ts`'s narrow matcher). Everything else shows elapsed only,
+     * because a guess here would be worse than nothing.
+     *
+     * Clamped at 0: the process is reaped slightly after its own deadline, so
+     * the last tick before `ToolEnd` would otherwise render a negative number.
+     * Empty once terminal — a finished row shows its final elapsed, not a
+     * countdown to a moment that has passed.
+     */
+    const remaining = createMemo(() => {
+        const a = props.activity();
+        if (!a || a.sleepMs == null || a.status !== "running") return "";
+        tick();
+        const leftMs = Math.max(0, a.startedAt + a.sleepMs - Date.now());
+        return `~${Math.ceil(leftMs / 1000)}s left`;
+    });
+
     const elapsed = createMemo(() => {
         const a = props.activity();
         if (!a) return "";
@@ -197,6 +216,9 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
                         <span class="agent-activity-sigil">{sigil()}</span>
                         <span class="agent-activity-title">{a().title}</span>
                         <span class="agent-activity-elapsed">[{elapsed()}]</span>
+                        <Show when={remaining()}>
+                            <span class="agent-activity-remaining">{remaining()}</span>
+                        </Show>
                         <Show when={tail()}>
                             <span class="agent-activity-tail">↳ {tail()}</span>
                         </Show>

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -268,6 +268,17 @@
     white-space: nowrap;
 }
 
+// "~Ns left" countdown — only ever rendered for a whole-command sleep, the one
+// activity whose remaining time is known (ActivityRow's `remaining` memo).
+// Dimmer than the elapsed clock beside it: supplementary detail, not the row's
+// primary reading.
+.agent-activity-remaining {
+    flex: 0 0 auto;
+    font-size: 11px;
+    color: var(--secondary-text-color, rgba(255, 255, 255, 0.55));
+    white-space: nowrap;
+}
+
 .agent-activity-tail {
     flex: 1 1 0;
     min-width: 0;


### PR DESCRIPTION
## Summary

A `sleep 300` sat in "Working…" for 30s before the dock showed anything — promotion is duration-based and can't tell a wait from a build. Median for these in real transcripts is **61s**, so the old behaviour spent half of every wait saying the wrong thing.

`sleep-detect.ts` recognizes a command that is a wait **and nothing else**. Such a call promotes at `t=0` — it has already declared itself, and the threshold exists to *detect undeclared* work — and carries `sleepMs`, so the row renders **"~Ns left"** instead of a blind elapsed timer.

This is `REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md` §4.2's "phase 1a, cheap UX polish" — layered on duration promotion, never replacing it.

## The measurement §4.2 asked for

That section rejected text matching as the classifier and required *"real-transcript validation, not just Agent1's one heartbeat example, before it ships."* Done — 7,761 foreground Bash calls across 12 production transcripts:

| Rule | Matches | Verdict |
|---|---|---|
| Naive: "command starts with `sleep`" | 270 | **204 (76%) are not waits** — `sleep 90; tail -30 <log>`, `sleep 60; ls <dir>` |
| Narrow: whole command **is** a sleep | 66 | all genuine, median 61s, **zero false positives** |

§4.2's rejection was correct — the naive rule is wrong three times in four. What it over-shot is the case with no second clause to be wrong about. Two facts make the narrow rule free:

- All 204 compound sleeps ran **28–100s**, so duration promotion already catches every one. Ignoring them here costs nothing.
- **18 of the 66** finish under 30s — invisible in the dock today.

Validated the shipped matcher against the 299 distinct real sleep-containing commands: 15 matched (all bare `sleep N`, 5–400s), 284 rejected (all compound).

## Also measured — and rejected

Lowering `TOOL_PROMOTION_MS` to 10s. **Median foreground Bash is 7.5s**, so 10s lands on the steepest part of the distribution:

```
  5-10s : 3,372  43.4%   <-- largest bucket
 10-30s : 1,636  21.1%   <-- would be newly promoted
promote @30s :   647 ( 8.3%)
promote @10s : 2,283 (29.4%)   3.5x the dock rows
```

It converts the dock from "something unusual is happening" into a command log, and makes the same command dock or not depending on cache state. **30s stays.**

## Details

- `SLEEP_IMMEDIATE_MIN_MS = 5s` floor keeps micro-delays out — `sleep 1` between two commands would otherwise hold a row for its own duration plus the full retention window.
- A finished pure sleep **resolves in place** (done → retention) rather than vanishing, since it was docked from `t=0`.
- `nextToolPromotionAt` skips pure sleeps — no timer for a promotion that already happened.
- Countdown clamps at 0 (the process is reaped just after its deadline) and disappears once terminal.

**Fixture change worth a look:** `tool-adapter.test.ts` and `attached-task.test.ts` both used `sleep 300` as their generic long-running command, which now takes the fast path and made every threshold assertion vacuously pass. Their defaults are now a non-sleep command, with a comment saying why it must stay that way.

## Testing

- 24 matcher tests, including the eight real compound-sleep shapes it must refuse
- 7 adapter tests for immediate promotion, countdown data, retention, and the compound-sleep fallthrough
- `npx vitest run frontend/app/view/agent` — **1554 passed** (up from 1523)
- `npx tsc --noEmit` clean; new SCSS block stylelint-clean (the 8 `color-no-hex` errors in that file are pre-existing and identical on `main`)

**Not verified in a live pane** — the matcher is validated against production command text and the adapter against unit tests, but the rendered countdown is code-verified only.

Also refreshes that report's §3 status table: steps 1–3 shipped, step 4 partial (Swarm has `shellRows`/`cronRows` but not dock-promoted Bash calls), step 5 not started.

<!-- agentmux:agent_id=agent2 -->