### PR TITLE
Camper@claudius: chore: release v0.55.29

### DIFF
--- a/.changesets/1788075082-feat-armory-merge-global-memory-personal-memory-into-one-mem-sf7u.md
+++ b/.changesets/1788075082-feat-armory-merge-global-memory-personal-memory-into-one-mem-sf7u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): merge Global Memory + Personal Memory into one Memory tab

--- a/.changesets/1788076062-feat-mcp-capture-tier-model-agents-can-screenshot-any-window-jys4.md
+++ b/.changesets/1788076062-feat-mcp-capture-tier-model-agents-can-screenshot-any-window-jys4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): capture-tier model — agents can screenshot any window except another OS user's

--- a/.changesets/1788101900-fix-layout-cross-split-minimize-extent-x9k2.md
+++ b/.changesets/1788101900-fix-layout-cross-split-minimize-extent-x9k2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): derive a minimized branch's extent from its own direction, not its leaf count

--- a/.changesets/1788127480-fix-layout-drag-ghost-matches-the-dragged-pane-s-aspect-rati-gvbp.md
+++ b/.changesets/1788127480-fix-layout-drag-ghost-matches-the-dragged-pane-s-aspect-rati-gvbp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): drag ghost matches the dragged pane's aspect ratio instead of a fixed square

--- a/.changesets/1788129105-feat-statusbar-break-out-token-usage-panel-by-agent-with-cos-1rcn.md
+++ b/.changesets/1788129105-feat-statusbar-break-out-token-usage-panel-by-agent-with-cos-1rcn.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(statusbar): break out token usage panel by agent, with cost + turn count

--- a/.changesets/1788130400-fix-layout-minimized-row-fill-width-q4m8.md
+++ b/.changesets/1788130400-fix-layout-minimized-row-fill-width-q4m8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): an all-minimized row of panes fills the width instead of leaving dead space to the right

--- a/.changesets/1788130657-feat-agent-pane-dock-a-bare-sleep-immediately-with-a-live-co-gl5d.md
+++ b/.changesets/1788130657-feat-agent-pane-dock-a-bare-sleep-immediately-with-a-live-co-gl5d.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): dock a bare sleep immediately with a live countdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.28"
+version = "0.55.29"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.28"
+version = "0.55.29"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.28"
+version = "0.55.29"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.28"
+version = "0.55.29"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.28"
+version = "0.55.29"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.28"
+version = "0.55.29"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.28"
+version = "0.55.29"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,16 @@
 # AgentMux Version History
 
+## 0.55.29 — 2026-08-30
+
+- feat(armory): merge Global Memory + Personal Memory into one Memory tab
+- feat(mcp): capture-tier model — agents can screenshot any window except another OS user's
+- fix(layout): derive a minimized branch's extent from its own direction, not its leaf count
+- fix(layout): drag ghost matches the dragged pane's aspect ratio instead of a fixed square
+- feat(statusbar): break out token usage panel by agent, with cost + turn count
+- fix(layout): an all-minimized row of panes fills the width instead of leaving dead space to the right
+- feat(agent-pane): dock a bare sleep immediately with a live countdown
+
+
 ## 0.55.28 — 2026-08-29
 
 - fix(agent): disclose a fresh start when a pane spawns with no --resume but prior history exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.28",
+  "version": "0.55.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.28",
+      "version": "0.55.29",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.28",
+  "version": "0.55.29",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR: **0.55.28 → 0.55.29**, produced by `task release -- --as patch`.

## ⚠️ Deliberate patch override

The computed bump from the pending changesets was **`minor`** — 4 of the 7 are `feat`-level:

- `feat(armory)`: merge Global Memory + Personal Memory into one Memory tab
- `feat(mcp)`: capture-tier model — agents can screenshot any window except another OS user's
- `feat(statusbar)`: break out token usage panel by agent, with cost + turn count
- `feat(agent-pane)`: dock a bare `sleep` immediately with a live countdown

`--as patch` forces a patch anyway, so those ship under a patch version. The release script's own `WARNING: forcing a LOWER bump than the changesets request` fired and was accepted — surfacing it here so it's visible in review rather than buried in build output.

## Release consistency invariant

All 5 locations verified in agreement at `0.55.29` before commit (the reagent gate in `CLAUDE.md`):

| Location | Value |
|---|---|
| `package.json.version` | 0.55.29 |
| `Cargo.toml [workspace.package].version` | 0.55.29 |
| `Cargo.lock` workspace members (`agentmux-cef`) | 0.55.29 |
| `package-lock.json` root | 0.55.29 |
| `VERSION_HISTORY.md` head | `## 0.55.29 — 2026-08-30` |

## Contents (7 changesets consumed)

- feat(armory): merge Global Memory + Personal Memory into one Memory tab
- feat(mcp): capture-tier model — agents can screenshot any window except another OS user's
- fix(layout): derive a minimized branch's extent from its own direction, not its leaf count
- fix(layout): drag ghost matches the dragged pane's aspect ratio instead of a fixed square
- feat(statusbar): break out token usage panel by agent, with cost + turn count
- fix(layout): an all-minimized row of panes fills the width instead of leaving dead space to the right
- feat(agent-pane): dock a bare sleep immediately with a live countdown

<!-- agentmux:agent_id=camper -->