### PR TITLE
fix(agent-pane): peek panel shrink-wraps, floats right, 12-hour AM/PM time

### DIFF
--- a/.changesets/1788132600-fix-agent-pane-peek-panel-shrinkwrap-right-ampm-w7t3.md
+++ b/.changesets/1788132600-fix-agent-pane-peek-panel-shrinkwrap-right-ampm-w7t3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): peek panel shrink-wraps, floats right, and shows 12-hour AM/PM time

--- a/frontend/app/view/agent/components/AgentMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/AgentMessageBlock.test.tsx
@@ -44,7 +44,7 @@ describe("AgentMessageBlock — peek tooltip", () => {
             hover(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();

--- a/frontend/app/view/agent/components/JektBubble.test.tsx
+++ b/frontend/app/view/agent/components/JektBubble.test.tsx
@@ -47,7 +47,7 @@ describe("JektBubble — peek tooltip", () => {
             hover(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();

--- a/frontend/app/view/agent/components/MarkdownBlock.test.tsx
+++ b/frontend/app/view/agent/components/MarkdownBlock.test.tsx
@@ -55,7 +55,7 @@ describe("MarkdownBlock — regular (non-thinking) text now gets a peek too", ()
             hoverBlock(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();
@@ -73,7 +73,7 @@ describe("MarkdownBlock — thinking-clump peek tooltip", () => {
             hoverBlock(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();

--- a/frontend/app/view/agent/components/PeekOverlay.tsx
+++ b/frontend/app/view/agent/components/PeekOverlay.tsx
@@ -65,6 +65,27 @@ interface PeekOverlayProps {
      * context" preview) without forking the whole component.
      */
     class?: string;
+    /**
+     * How the panel sizes and sits against the anchored row.
+     *
+     * - `"end"` (default) — **shrink-wraps its content and pins its RIGHT
+     *   edge to the row's right edge**, growing leftward. This is what the
+     *   metadata peek wants: two short lines (timestamp, token estimate)
+     *   shouldn't stretch a full pane's width, and floating them right
+     *   keeps them off the text you're actually reading on the left.
+     * - `"stretch"` — full row width, left-aligned (the original
+     *   behaviour). Only `UserMessageBlock`'s "Session context" body
+     *   preview wants this: it renders a real message body, sometimes
+     *   kilobytes of it, where full width is the point.
+     *
+     * Right-alignment is done with `left: rect.right` + a
+     * `translateX(-100%)` rather than a `right:` offset, deliberately —
+     * `right` would need `window.innerWidth`, which is a different
+     * coordinate space from the `getBoundingClientRect()` values
+     * everything else here uses, and would break the CSS-`zoom` safety
+     * this component's header documents.
+     */
+    align?: "end" | "stretch";
     children?: JSX.Element;
 }
 
@@ -89,11 +110,25 @@ export function PeekOverlay(props: PeekOverlayProps): JSX.Element {
         const rect = row.getBoundingClientRect();
         const container = findScrollContainerRect(row);
         const cap = Math.max(0, container.bottom - rect.top - BOTTOM_MARGIN_PX);
+        if ((props.align ?? "end") === "stretch") {
+            setFloatingStyle({
+                position: "fixed",
+                left: `${rect.left}px`,
+                top: `${rect.top}px`,
+                width: `${rect.width}px`,
+                "max-height": `${cap}px`,
+            });
+            return;
+        }
+        // Shrink-wrapped and right-anchored. No `width` is set at all, so the
+        // stylesheet's `width: max-content` governs; `max-width` still clamps
+        // it to the row so a long tool command can't escape the pane.
         setFloatingStyle({
             position: "fixed",
-            left: `${rect.left}px`,
+            left: `${rect.right}px`,
             top: `${rect.top}px`,
-            width: `${rect.width}px`,
+            transform: "translateX(-100%)",
+            "max-width": `${rect.width}px`,
             "max-height": `${cap}px`,
         });
     };

--- a/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
@@ -43,7 +43,7 @@ describe("PersistentShellBlock — peek tooltip", () => {
             hover(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
             const body = document.body.querySelector(".agent-node-peek-tooltip-body");
             expect(body?.textContent).toBe("npm run dev");

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -228,7 +228,7 @@ describe("ToolBlock — panel mode", () => {
                 hoverToolName(container);
                 const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
                 expect(metaLines.length).toBe(2);
-                expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+                expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
                 expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
             } finally {
                 vi.useRealTimers();

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -96,7 +96,7 @@ describe("UserMessageBlock — regular user input", () => {
                 vi.advanceTimersByTime(200);
                 const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
                 expect(metaLines.length).toBe(2);
-                expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+                expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
                 expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
             } finally {
                 vi.useRealTimers();

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -201,6 +201,11 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
                 show={bodyMode() === "overlay"}
                 rowEl={() => rootEl}
                 class="agent-user-message-peek-overlay"
+                // Full width, left-aligned: this variant renders a real
+                // message body (sometimes kilobytes of startup payload),
+                // unlike the shrink-wrapped metadata peek every other
+                // caller uses.
+                align="stretch"
             >
                 <div class="agent-user-message-content">
                     {bodyContent()}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -2100,7 +2100,19 @@
     gap: 4px;
     overflow-y: auto;
     overscroll-behavior: contain;
-    background-color: var(--block-bg-solid-color, var(--main-bg-color));
+    // Shrink-wrap to the content. PeekOverlay's default ("end") alignment
+    // sets no inline `width`, so this governs; the `"stretch"` variant
+    // (UserMessageBlock's body preview) sets an inline width, which wins.
+    width: max-content;
+    // Not a flat black slab: a translucent, blurred surface reads as
+    // floating ABOVE the transcript rather than punching a hole in it, and
+    // keeps the text underneath faintly legible. Same treatment as
+    // `pane-size-badge.scss`, this codebase's other small floating overlay
+    // ("legibility over busy content"). Hard corners per
+    // SPEC_HARD_CORNERS_2026_05_26 — deliberately no border-radius.
+    background: color-mix(in srgb, var(--main-bg-color) 88%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
     border: 1px solid var(--border-color);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     padding: var(--space-0-5) var(--space-1);

--- a/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
@@ -206,7 +206,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-section");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(2);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
         expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
     });
 
@@ -234,7 +234,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-context-compacted");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(1);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
     });
 
     it("compaction_started: shows a time-only peek from startedAt", () => {
@@ -249,7 +249,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-compaction-started");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(1);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
     });
 
     it("day_divider: shows the exact local-midnight instant on hover", () => {
@@ -264,7 +264,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-day-divider");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(1);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
     });
 
     it("session_outcome: shows time + attempted/actual session ids", () => {
@@ -279,7 +279,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         };
         const { container } = renderRow(node);
         hover(container, ".agent-session-outcome");
-        expect(document.body.querySelector(".agent-node-peek-tooltip-meta")?.textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(document.body.querySelector(".agent-node-peek-tooltip-meta")?.textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
         expect(document.body.querySelector(".agent-node-peek-tooltip-body")?.textContent).toBe(
             "attempted: sid-attempted · actual: sid-actual"
         );

--- a/frontend/util/format-time.test.ts
+++ b/frontend/util/format-time.test.ts
@@ -58,12 +58,26 @@ describe("formatTimeAgo", () => {
 });
 
 describe("formatExactTime", () => {
-    it("renders local HH:MM:SS, zero-padded", () => {
+    // 2026-08-30: switched from a 24-hour clock to 12-hour with AM/PM at
+    // operator request. Local time throughout — `getHours()` always was.
+    it("renders local 12-hour time with an AM suffix, minutes/seconds zero-padded", () => {
         const d = new Date(2026, 0, 1, 9, 5, 3);
-        expect(formatExactTime(d.getTime())).toBe("09:05:03");
+        expect(formatExactTime(d.getTime())).toBe("9:05:03 AM");
     });
-    it("renders 24-hour time (no AM/PM)", () => {
+    it("renders afternoon times as PM on a 12-hour clock", () => {
         const d = new Date(2026, 0, 1, 14, 32, 7);
-        expect(formatExactTime(d.getTime())).toBe("14:32:07");
+        expect(formatExactTime(d.getTime())).toBe("2:32:07 PM");
+    });
+    it("midnight is 12 AM, not 0 AM", () => {
+        const d = new Date(2026, 0, 1, 0, 7, 9);
+        expect(formatExactTime(d.getTime())).toBe("12:07:09 AM");
+    });
+    it("noon is 12 PM, not 0 PM", () => {
+        const d = new Date(2026, 0, 1, 12, 0, 0);
+        expect(formatExactTime(d.getTime())).toBe("12:00:00 PM");
+    });
+    it("does not zero-pad the hour", () => {
+        const d = new Date(2026, 0, 1, 15, 4, 5);
+        expect(formatExactTime(d.getTime())).toBe("3:04:05 PM");
     });
 });

--- a/frontend/util/format-time.ts
+++ b/frontend/util/format-time.ts
@@ -57,7 +57,10 @@ export function formatTimeAgo(ms: number, now: number = Date.now()): string {
 }
 
 /**
- * Absolute local time, "HH:MM:SS" (24-hour). Adapted from the unshipped
+ * Absolute local time, 12-hour with an AM/PM suffix — "3:46:12 PM".
+ *
+ * Was "HH:MM:SS" (24-hour) until 2026-08-30; see the inline note in the
+ * body for what did and didn't change. Adapted from the unshipped
  * `docs/specs/node-timestamp-hover.md`'s draft — dropped the tenths-of-a-
  * second digit that draft used (not meaningful at the granularity this is
  * actually used at: hovering a tool call or thinking clump, not diagnosing

--- a/frontend/util/format-time.ts
+++ b/frontend/util/format-time.ts
@@ -65,8 +65,14 @@ export function formatTimeAgo(ms: number, now: number = Date.now()): string {
  */
 export function formatExactTime(ms: number): string {
     const d = new Date(ms);
-    const h = String(d.getHours()).padStart(2, "0");
+    // `getHours()` is already LOCAL time — this was never UTC. What changed
+    // (2026-08-30, operator request) is the presentation: 12-hour with an
+    // AM/PM suffix instead of a 24-hour clock. Hour is NOT zero-padded, per
+    // the usual 12-hour convention ("3:46:12 PM", not "03:46:12 PM");
+    // minutes and seconds still are.
+    const h24 = d.getHours();
+    const h = h24 % 12 === 0 ? 12 : h24 % 12;
     const m = String(d.getMinutes()).padStart(2, "0");
     const s = String(d.getSeconds()).padStart(2, "0");
-    return `${h}:${m}:${s}`;
+    return `${h}:${m}:${s} ${h24 < 12 ? "AM" : "PM"}`;
 }


### PR DESCRIPTION
Three operator-requested refinements to the hover-to-peek panel (`SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25`).

## 1. Shrink-wrap instead of full row width

The panel stretched the **entire width of the hovered row** to hold two short metadata lines — covering the content you're trying to inspect. Now sizes to its content (`width: max-content`), with the inline `max-width` still clamping it to the row so a long tool command can't escape the pane.

## 2. Float right

Pinned to the row's **right edge**, growing leftward, so it sits clear of the text you're reading on the left.

Implemented as `left: rect.right` + `transform: translateX(-100%)`, **not** a `right:` offset — `right` would need `window.innerWidth`, a different coordinate space from the `getBoundingClientRect()` values the rest of the component uses, which would break the CSS-`zoom` safety its header documents.

## 3. Not a flat black slab

Translucent + blurred (`color-mix` 88% + `backdrop-filter`), so it reads as floating *above* the transcript rather than punching a hole in it. Same treatment as `pane-size-badge.scss` — this codebase's other small floating overlay, which uses it for "legibility over busy content". Hard corners kept per `SPEC_HARD_CORNERS_2026_05_26`.

## 4. 12-hour local time with AM/PM

`formatExactTime` was **already local** — `getHours()` always was — so only the presentation changed. Hour is unpadded per the usual convention (`3:46:12 PM`, not `03:46:12 PM`); minutes and seconds still padded.

## On the shared component

Alignment is a new `align` prop defaulting to **`"end"`**, because six of the seven call sites are the metadata peek and want it. `UserMessageBlock`'s "Session context" body preview explicitly opts into `"stretch"` and keeps full width — it renders a real message body, sometimes kilobytes of startup payload, where full width is the point.

Defaulting the other way would have meant editing six call sites and leaving the odd one out silently correct.

## Verification

**1678 tests passed across 129 files** (`frontend/app/view/agent` + `frontend/util`).

Four cases added for the time format, covering the two boundaries 12-hour conversion usually gets wrong — **midnight as 12 AM, not 0 AM**, and **noon as 12 PM** — plus the unpadded hour. Eight peek tests asserted the old two-digit 24-hour pattern and were updated.

`tsc --noEmit` clean. Stylelint on the touched SCSS reports **the same 36 pre-existing errors before and after** — verified by running it against the stashed file, not assumed.

## Not verified

The panel only renders on hover, which I can't drive from here, so this is unverified visually. It's hot-loaded in the running `task dev` instance.

<!-- agentmux:agent_id=agentx -->