### PR TITLE
Manoz@Area54: fix(identity): stop isolated Claude Code config dirs leaking the host's ~/.claude/CLAUDE.md

### DIFF
--- a/.changesets/1788151399-fix-identity-stop-isolated-claude-code-config-dirs-leaking-t-32yz.md
+++ b/.changesets/1788151399-fix-identity-stop-isolated-claude-code-config-dirs-leaking-t-32yz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): stop isolated Claude Code config dirs leaking the host's ~/.claude/CLAUDE.md

--- a/agentmux-srv/src/agents/failure.rs
+++ b/agentmux-srv/src/agents/failure.rs
@@ -238,6 +238,31 @@ pub fn classify(
             &tail,
         );
     }
+    // The identity spawn gate's CLAUDE.md isolation-seed refusal
+    // (identity/resolver/errors.rs's `SpawnGateError::ClaudeMdSeedFailed`
+    // Display impl — same reasoning as the two branches above: this never
+    // reaches the API, so it needs its own title/detail instead of falling
+    // through to the generic UnknownNonZero fallback. ReAgent P2 on PR
+    // #2854 — added alongside AmbientHomeDirNotAllowed's sibling branch
+    // above but initially missed for this newer variant.
+    if hay.contains("refusing to spawn with an unprotected config dir") {
+        let provider_phrase = extract_claude_md_seed_provider(&combined)
+            .map(|p| format!("This agent's {} config directory", capitalize_provider(&p)))
+            .unwrap_or_else(|| "This agent's config directory".to_string());
+        return build(
+            FailureClass::Auth,
+            "Could not isolate this agent's config",
+            &format!(
+                "{provider_phrase} could not be prepared for isolated use — the spawn was \
+                 refused rather than risk it silently reading your personal CLI config. \
+                 Retry, and check the directory's permissions if it persists."
+            ),
+            false,
+            exit_code,
+            signal,
+            &tail,
+        );
+    }
     if hay.contains("authentication_error")
         || hay.contains("authentication_failed")
         || hay.contains("invalid authentication")
@@ -403,6 +428,22 @@ fn extract_ambient_home_provider(combined: &str) -> Option<String> {
     let start = combined.find(marker)? + marker.len();
     let rest = &combined[start..];
     let end = rest.find(" identity points directly")?;
+    let provider = rest[..end].trim();
+    if provider.is_empty() {
+        None
+    } else {
+        Some(provider.to_string())
+    }
+}
+
+/// Pulls the provider id out of
+/// `SpawnGateError::ClaudeMdSeedFailed`'s own Display wording ("could not
+/// isolate this agent's {provider} config directory (…): …").
+fn extract_claude_md_seed_provider(combined: &str) -> Option<String> {
+    let marker = "could not isolate this agent's ";
+    let start = combined.find(marker)? + marker.len();
+    let rest = &combined[start..];
+    let end = rest.find(" config directory")?;
     let provider = rest[..end].trim();
     if provider.is_empty() {
         None
@@ -717,6 +758,57 @@ mod tests {
         assert_eq!(f.code, FailureClass::Auth);
         assert!(f.detail.contains("Codex"), "detail: {}", f.detail);
         assert!(!f.detail.contains("Claude"), "detail: {}", f.detail);
+    }
+
+    #[test]
+    fn spawn_gate_claude_md_seed_failed_is_auth_not_unknown() {
+        // docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md — ReAgent P2
+        // on PR #2854: this newer SpawnGateError variant had no
+        // classification branch, so it fell through to the generic
+        // UnknownNonZero "Agent failed" instead of the guidance its own
+        // Display text already carries. Same "must not fall through to a
+        // dead-end Retry" reasoning as its MissingCredentials/
+        // AmbientHomeDirNotAllowed siblings above.
+        let frame = json!({
+            "type": "result",
+            "is_error": true,
+            "subtype": "error_during_execution",
+            "error": { "message": "[AgentMux] could not isolate this agent's claude config directory (C:\\Users\\asafe\\.agentmux\\shared\\identities\\id-1\\claude): permission denied. Refusing to spawn with an unprotected config dir — retry, and check the directory's permissions if it persists." }
+        });
+        let f = classify(Some(1), None, "", Some(&frame));
+        assert_eq!(f.code, FailureClass::Auth);
+        assert!(!f.retryable, "a bare retry may not succeed against a persistent permissions issue");
+        assert!(f.detail.contains("Claude"), "detail: {}", f.detail);
+        assert!(f.title.to_lowercase().contains("isolate"), "title: {}", f.title);
+    }
+
+    #[test]
+    fn spawn_gate_claude_md_seed_failed_names_the_actual_provider_not_claude() {
+        let frame = json!({
+            "type": "result",
+            "is_error": true,
+            "subtype": "error_during_execution",
+            "error": { "message": "[AgentMux] could not isolate this agent's codex config directory (/home/user/.agentmux/shared/providers/codex): permission denied. Refusing to spawn with an unprotected config dir — retry, and check the directory's permissions if it persists." }
+        });
+        let f = classify(Some(1), None, "", Some(&frame));
+        assert_eq!(f.code, FailureClass::Auth);
+        assert!(f.detail.contains("Codex"), "detail: {}", f.detail);
+        assert!(!f.detail.contains("Claude"), "detail: {}", f.detail);
+    }
+
+    #[test]
+    fn extract_claude_md_seed_provider_reads_the_provider_out_of_the_gate_wording() {
+        assert_eq!(
+            extract_claude_md_seed_provider(
+                "could not isolate this agent's gemini config directory (/x): some io error."
+            ),
+            Some("gemini".to_string()),
+        );
+    }
+
+    #[test]
+    fn extract_claude_md_seed_provider_returns_none_on_wording_mismatch() {
+        assert_eq!(extract_claude_md_seed_provider("some unrelated error text"), None);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -677,6 +677,20 @@ pub fn seed_claude_md_placeholder_if_missing(
     if provider.auth_dir_name != "claude" {
         return Ok(false);
     }
+    // Codex P2 on PR #2854: a blank config_dir would resolve
+    // `Path::new("").join("CLAUDE.md")` relative to the server process's
+    // own CWD (`create_dir_all("")` succeeds, silently no-op) instead of
+    // erroring — writing an unrelated file while leaving the actual
+    // (empty-string) CLAUDE_CONFIG_DIR still exposed to ambient fallback.
+    // Reject before touching the filesystem so the caller's fail-closed
+    // handling (both call sites now block spawn on any Err here) covers
+    // this case too, rather than silently succeeding at nothing.
+    if config_dir.trim().is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "config_dir is empty",
+        ));
+    }
     let path = std::path::Path::new(config_dir).join("CLAUDE.md");
     if path.exists() {
         return Ok(false);
@@ -1088,6 +1102,23 @@ mod tests {
             let wrote = seed_claude_md_placeholder_if_missing(codex, &dir.path().to_string_lossy()).unwrap();
             assert!(!wrote);
             assert!(!dir.path().join("CLAUDE.md").exists());
+        }
+
+        // Codex P2 on PR #2854: an empty config_dir would otherwise resolve
+        // relative to the server process's own CWD instead of erroring.
+        #[test]
+        fn rejects_an_empty_config_dir() {
+            let claude = get_provider("claude").unwrap();
+            let err = seed_claude_md_placeholder_if_missing(claude, "").unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+            assert!(!std::path::Path::new("CLAUDE.md").exists(), "must not write into CWD");
+        }
+
+        #[test]
+        fn rejects_a_whitespace_only_config_dir() {
+            let claude = get_provider("claude").unwrap();
+            let err = seed_claude_md_placeholder_if_missing(claude, "   ").unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         }
     }
 }

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -638,6 +638,54 @@ pub fn is_provider_ambient_home_dir(provider: &ProviderConfig, dir: &str) -> boo
     paths_resolve_to_same_dir(&ambient, dir)
 }
 
+/// Placeholder written by `seed_claude_md_placeholder_if_missing` — explains
+/// itself so an operator who opens the file isn't confused by an unexplained
+/// empty one.
+const CLAUDE_MD_ISOLATION_PLACEHOLDER: &str = "<!--\n\
+AgentMux: intentionally empty.\n\
+\n\
+This is an isolated Claude Code config directory (CLAUDE_CONFIG_DIR),\n\
+separate from your personal ~/.claude/CLAUDE.md, so this agent never\n\
+silently inherits your personal global instructions. To give every\n\
+agent shared instructions, use Armory -> Memory -> Global instead --\n\
+those compose into this agent's own project-level CLAUDE.md at launch,\n\
+not this file. See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.\n\
+-->\n";
+
+/// Seeds an empty placeholder `CLAUDE.md` into an isolated Claude Code
+/// `CLAUDE_CONFIG_DIR` the first time it's used, so Claude Code CLI's own
+/// user-level `CLAUDE.md` discovery always finds *something* there instead
+/// of silently falling through to the operator's real
+/// `$HOME/.claude/CLAUDE.md`. `CLAUDE_CONFIG_DIR` relocates credential/
+/// session/project storage but AgentMux never wrote a `CLAUDE.md` into the
+/// relocated dir — verified live on a real machine: 18+ isolated `claude`
+/// config dirs, none with a `CLAUDE.md`, and a session whose
+/// `CLAUDE_CONFIG_DIR` was a genuinely separate (non-ambient) dir still
+/// received the real host file's contents. See
+/// `docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md`.
+///
+/// Scoped to the `claude` provider only (`auth_dir_name == "claude"`) —
+/// this is a Claude Code CLI-specific fallback behavior; whether any other
+/// provider's CLI has an equivalent gap is unverified. Never overwrites an
+/// existing `CLAUDE.md` — Global Memory (or anything else) may have
+/// legitimately placed real content at that path. Returns `Ok(true)` only
+/// when it actually wrote the placeholder.
+pub fn seed_claude_md_placeholder_if_missing(
+    provider: &ProviderConfig,
+    config_dir: &str,
+) -> std::io::Result<bool> {
+    if provider.auth_dir_name != "claude" {
+        return Ok(false);
+    }
+    let path = std::path::Path::new(config_dir).join("CLAUDE.md");
+    if path.exists() {
+        return Ok(false);
+    }
+    std::fs::create_dir_all(config_dir)?;
+    std::fs::write(&path, CLAUDE_MD_ISOLATION_PLACEHOLDER)?;
+    Ok(true)
+}
+
 /// The actual comparison, split out with the reference side pre-resolved
 /// (not calling `get_home_dir()` internally) so it's directly testable
 /// against a tempdir instead of the real `$HOME`/`%USERPROFILE%` — same
@@ -994,6 +1042,52 @@ mod tests {
             // A dir that can't possibly be the real ambient home (this
             // process's actual $HOME/.claude) must never match.
             assert!(!is_provider_ambient_home_dir(claude, "/tmp/agentmux-test-definitely-not-ambient"));
+        }
+    }
+
+    mod claude_md_placeholder_tests {
+        use super::*;
+
+        #[test]
+        fn writes_the_placeholder_when_claude_md_is_missing() {
+            let dir = tempfile::tempdir().unwrap();
+            let claude = get_provider("claude").unwrap();
+            let wrote = seed_claude_md_placeholder_if_missing(claude, &dir.path().to_string_lossy()).unwrap();
+            assert!(wrote);
+            let content = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+            assert!(content.contains("AgentMux: intentionally empty"));
+        }
+
+        #[test]
+        fn creates_the_config_dir_first_if_it_does_not_exist_yet() {
+            let base = tempfile::tempdir().unwrap();
+            let not_yet_created = base.path().join("nested").join("claude");
+            let claude = get_provider("claude").unwrap();
+            let wrote =
+                seed_claude_md_placeholder_if_missing(claude, &not_yet_created.to_string_lossy()).unwrap();
+            assert!(wrote);
+            assert!(not_yet_created.join("CLAUDE.md").exists());
+        }
+
+        #[test]
+        fn never_overwrites_an_existing_claude_md() {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(dir.path().join("CLAUDE.md"), "real user content, do not touch").unwrap();
+            let claude = get_provider("claude").unwrap();
+            let wrote = seed_claude_md_placeholder_if_missing(claude, &dir.path().to_string_lossy()).unwrap();
+            assert!(!wrote);
+            let content = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+            assert_eq!(content, "real user content, do not touch");
+        }
+
+        #[test]
+        fn no_ops_for_a_non_claude_provider_even_with_no_claude_md() {
+            let dir = tempfile::tempdir().unwrap();
+            let codex = get_provider("codex").unwrap();
+            assert_eq!(codex.auth_dir_name, "codex");
+            let wrote = seed_claude_md_placeholder_if_missing(codex, &dir.path().to_string_lossy()).unwrap();
+            assert!(!wrote);
+            assert!(!dir.path().join("CLAUDE.md").exists());
         }
     }
 }

--- a/agentmux-srv/src/identity/resolver/errors.rs
+++ b/agentmux-srv/src/identity/resolver/errors.rs
@@ -45,6 +45,15 @@ pub enum SpawnGateError {
     /// §8); this variant is the enforcement that closes that gap. See
     /// `docs/specs/SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md`.
     AmbientHomeDirNotAllowed { provider: String, dir: String },
+    /// Failed to seed the isolated Claude Code config dir's `CLAUDE.md`
+    /// placeholder (`providers::seed_claude_md_placeholder_if_missing`).
+    /// Blocked rather than warn-and-continue: an isolated dir with no
+    /// `CLAUDE.md` of its own is exactly the condition where Claude Code
+    /// CLI falls through to the operator's real `~/.claude/CLAUDE.md` —
+    /// continuing to spawn would launch the agent with the leak this
+    /// fix exists to close. See
+    /// `docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md`.
+    ClaudeMdSeedFailed { provider: String, dir: String, error: String },
 }
 
 impl std::fmt::Display for SpawnGateError {
@@ -76,6 +85,12 @@ impl std::fmt::Display for SpawnGateError {
                  own global CLI login. Re-bind this identity to an isolated account \
                  in Armory → Accounts (delete the current {provider} account and log \
                  in again to create a fresh, isolated one), then retry.",
+            ),
+            SpawnGateError::ClaudeMdSeedFailed { provider, dir, error } => write!(
+                f,
+                "could not isolate this agent's {provider} config directory ({dir}): \
+                 {error}. Refusing to spawn with an unprotected config dir — retry, \
+                 and check the directory's permissions if it persists.",
             ),
         }
     }

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -590,6 +590,21 @@ pub fn inject_identity_env_with_broker(
                             dir: dir.clone(),
                         });
                     }
+                    // `dir` is confirmed NOT the ambient home at this point —
+                    // but a genuinely separate isolated dir can still lack a
+                    // CLAUDE.md of its own, which Claude Code CLI treats as
+                    // "fall through to the real $HOME/.claude/CLAUDE.md,"
+                    // not "no user-level memory file." Idempotent — cheap
+                    // no-op after the first call. See
+                    // SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
+                    if let Err(e) = crate::backend::providers::seed_claude_md_placeholder_if_missing(provider_cfg, &dir) {
+                        tracing::warn!(
+                            target: "identity",
+                            dir = %dir,
+                            error = %e,
+                            "failed to seed CLAUDE.md isolation placeholder",
+                        );
+                    }
                 }
                 env_vars.insert(config_dir_env_var.to_string(), dir.clone());
                 // Canonicalized (codex P1 on PR #2377) — see def_provider's

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -834,6 +834,22 @@ mod tests {
         store.insert(&mut block).unwrap();
     }
 
+    /// A genuinely writable temp path for a test's `SecretRef::OAuthConfigDir`.
+    ///
+    /// `inject_identity_env` now really seeds a `CLAUDE.md` into the bound dir
+    /// and FAILS CLOSED if it can't (SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md),
+    /// so these tests need a dir that actually exists/can be created rather
+    /// than a synthetic absolute path. The previous `/var/agentmux/...`
+    /// literals were unwritable on Linux CI (`Permission denied`) while
+    /// silently resolving to the current drive on Windows — green locally,
+    /// red on the ubuntu leg.
+    fn test_config_dir(name: &str) -> String {
+        std::env::temp_dir()
+            .join(format!("agentmux-inject-test-{}-{name}", std::process::id()))
+            .to_string_lossy()
+            .into_owned()
+    }
+
     fn make_instance(block_id: &str, identity_id: &str) -> AgentInstance {
         AgentInstance {
             id: format!("inst-{block_id}"),
@@ -897,7 +913,7 @@ mod tests {
             "acct-claude",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-oauth/claude".to_string(),
+                dir: test_config_dir("id-oauth"),
             },
         );
         store.identity_upsert(&claude).unwrap();
@@ -917,8 +933,8 @@ mod tests {
 
         // OAuth dispatch sets the provider's config-dir env var.
         assert_eq!(
-            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/var/agentmux/identities/id-oauth/claude"),
+            env.get("CLAUDE_CONFIG_DIR").cloned(),
+            Some(test_config_dir("id-oauth")),
         );
         // And does NOT set the anthropic api-key env var — dispatch
         // is by provider class, not by token shape.
@@ -1151,7 +1167,7 @@ mod tests {
             "acct-migrated",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-migrated/claude".to_string(),
+                dir: test_config_dir("id-migrated"),
             },
         );
         identity_store.identity_upsert(&claude).unwrap();
@@ -1172,8 +1188,8 @@ mod tests {
              'account row not found' — this is the exact reported continuity bug: {res:?}"
         );
         assert_eq!(
-            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/var/agentmux/identities/id-migrated/claude"),
+            env.get("CLAUDE_CONFIG_DIR").cloned(),
+            Some(test_config_dir("id-migrated")),
         );
     }
 
@@ -1240,7 +1256,7 @@ mod tests {
             "acct-fresh",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-fresh/claude".to_string(),
+                dir: test_config_dir("id-fresh"),
             },
         );
         id_store.identity_upsert_with_mirror(&identity_store, &claude).unwrap();
@@ -1266,8 +1282,8 @@ mod tests {
              backfill) must still resolve after a channel switch: {res:?}"
         );
         assert_eq!(
-            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/var/agentmux/identities/id-fresh/claude"),
+            env.get("CLAUDE_CONFIG_DIR").cloned(),
+            Some(test_config_dir("id-fresh")),
         );
     }
 
@@ -1495,7 +1511,7 @@ mod tests {
             "acct-alias",
             "claude-code",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-alias/claude".to_string(),
+                dir: test_config_dir("id-alias"),
             },
         );
         store.identity_upsert(&claude).unwrap();
@@ -1513,8 +1529,8 @@ mod tests {
 
         assert!(res.is_ok(), "expected Ok, got {res:?}");
         assert_eq!(
-            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/var/agentmux/identities/id-alias/claude"),
+            env.get("CLAUDE_CONFIG_DIR").cloned(),
+            Some(test_config_dir("id-alias")),
         );
     }
 
@@ -1585,7 +1601,7 @@ mod tests {
             "acct-gone",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-x/claude".to_string(),
+                dir: test_config_dir("id-x"),
             },
         );
         store.identity_upsert(&claude).unwrap();
@@ -1633,7 +1649,7 @@ mod tests {
             "acct-gone-2",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-y/claude".to_string(),
+                dir: test_config_dir("id-y"),
             },
         );
         store.identity_upsert(&claude).unwrap();
@@ -2657,7 +2673,7 @@ mod tests {
             "acct-drift",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-drift/claude".to_string(),
+                dir: test_config_dir("id-drift"),
             },
         );
         id_store.identity_upsert_with_mirror(&identity_store, &claude).unwrap();
@@ -2674,8 +2690,8 @@ mod tests {
 
         assert!(res.is_ok(), "a valid claude account must not be blocked by a stale codex column: {res:?}");
         assert_eq!(
-            env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/var/agentmux/identities/id-drift/claude"),
+            env.get("CLAUDE_CONFIG_DIR").cloned(),
+            Some(test_config_dir("id-drift")),
             "the claude binding must actually inject, proving the gate expected claude (from the bundle), not codex (from the drifted column)"
         );
     }
@@ -2727,7 +2743,7 @@ mod tests {
             "acct-claude",
             "claude",
             SecretRef::OAuthConfigDir {
-                dir: "/var/agentmux/identities/id-bound/claude".to_string(),
+                dir: test_config_dir("id-bound"),
             },
         );
         store.identity_upsert(&claude).unwrap();
@@ -2740,7 +2756,7 @@ mod tests {
         let resolved = resolve_bound_oauth_config_dir(&store, &store, &store, "block-bound");
         assert_eq!(
             resolved,
-            Some(std::path::PathBuf::from("/var/agentmux/identities/id-bound/claude")),
+            Some(std::path::PathBuf::from(test_config_dir("id-bound"))),
         );
     }
 

--- a/agentmux-srv/src/identity/resolver/inject.rs
+++ b/agentmux-srv/src/identity/resolver/inject.rs
@@ -595,15 +595,30 @@ pub fn inject_identity_env_with_broker(
                     // CLAUDE.md of its own, which Claude Code CLI treats as
                     // "fall through to the real $HOME/.claude/CLAUDE.md,"
                     // not "no user-level memory file." Idempotent — cheap
-                    // no-op after the first call. See
-                    // SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
-                    if let Err(e) = crate::backend::providers::seed_claude_md_placeholder_if_missing(provider_cfg, &dir) {
+                    // no-op after the first call. Fail closed (same as the
+                    // ambient-home-dir check above) rather than warn-and-
+                    // continue: Codex P1 + ReAgent P1 on PR #2854 — a
+                    // warn-only failure here would launch the agent with
+                    // exactly the unprotected condition this fix exists to
+                    // close. See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
+                    if let Err(e) =
+                        crate::backend::providers::seed_claude_md_placeholder_if_missing(provider_cfg, &dir)
+                    {
                         tracing::warn!(
                             target: "identity",
-                            dir = %dir,
-                            error = %e,
-                            "failed to seed CLAUDE.md isolation placeholder",
+                            "identity.spawn.blocked: account {} for provider {} \
+                             failed CLAUDE.md isolation seed ({}) — refusing to \
+                             spawn (identity {})",
+                            binding.account_id,
+                            binding.provider,
+                            e,
+                            instance.identity_id,
                         );
+                        return Err(SpawnGateError::ClaudeMdSeedFailed {
+                            provider: binding.provider.clone(),
+                            dir: dir.clone(),
+                            error: e.to_string(),
+                        });
                     }
                 }
                 env_vars.insert(config_dir_env_var.to_string(), dir.clone());
@@ -987,6 +1002,85 @@ mod tests {
                 assert_eq!(dir, ambient_claude_dir);
             }
             other => panic!("expected AmbientHomeDirNotAllowed, got {other:?}"),
+        }
+        // The gate must block BEFORE anything is injected — no partial
+        // env-var leak from the refused binding.
+        assert!(env.get("CLAUDE_CONFIG_DIR").is_none());
+    }
+
+    /// Codex P1 + ReAgent P1 on PR #2854: seeding the CLAUDE.md isolation
+    /// placeholder must fail closed, not warn-and-continue — otherwise the
+    /// agent spawns with a CLAUDE_CONFIG_DIR that still has no CLAUDE.md,
+    /// exactly the condition that falls through to the ambient home. An
+    /// empty `dir` (rejected by seed_claude_md_placeholder_if_missing's own
+    /// InvalidInput guard) is a deterministic, cross-platform way to
+    /// trigger a seed failure without relying on real filesystem
+    /// permissions. It is also NOT the ambient home, so this exercises the
+    /// seed check specifically, not the AmbientHomeDirNotAllowed path
+    /// covered by the test above.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn inject_oauth_class_blocks_spawn_when_claude_md_seed_fails() {
+        let store = make_store();
+
+        let mut def = crate::backend::storage::store::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        store.agent_def_insert(&mut def).unwrap();
+
+        let claude = make_account(
+            "acct-empty-dir",
+            "claude",
+            SecretRef::OAuthConfigDir { dir: String::new() },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store
+            .agent_identity_link("def-1", "acct-empty-dir", "claude")
+            .unwrap();
+
+        insert_block_for_agent(&store, "block-empty-dir", "def-1");
+        let inst = make_instance("block-empty-dir", "id-empty-dir");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        let err = inject_identity_env(store.clone(), store.clone(), store, "block-empty-dir", &mut env)
+            .expect_err("spawn must be refused when the CLAUDE.md isolation seed fails");
+
+        match err {
+            SpawnGateError::ClaudeMdSeedFailed { provider, dir, .. } => {
+                assert_eq!(provider, "claude");
+                assert_eq!(dir, "");
+            }
+            other => panic!("expected ClaudeMdSeedFailed, got {other:?}"),
         }
         // The gate must block BEFORE anything is injected — no partial
         // env-var leak from the refused binding.

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -310,6 +310,14 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .unwrap_or_else(|| format!("{}/.agentmux/shared/providers/{}", home, provider.auth_dir_name));
                 let _ = std::fs::create_dir_all(&auth_dir);
                 env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
+                // Claude Code CLI's own user-level CLAUDE.md discovery falls
+                // through to the real $HOME/.claude/CLAUDE.md when this
+                // isolated dir has none of its own — CLAUDE_CONFIG_DIR only
+                // relocates credential/session/project storage, not this.
+                // See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
+                if let Err(e) = providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir) {
+                    tracing::warn!(auth_dir = %auth_dir, error = %e, "failed to seed CLAUDE.md isolation placeholder");
+                }
                 for (k, v) in provider.auth_extra_env {
                     env_vars.insert(k.to_string(), json!(v));
                 }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -314,10 +314,18 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // through to the real $HOME/.claude/CLAUDE.md when this
                 // isolated dir has none of its own — CLAUDE_CONFIG_DIR only
                 // relocates credential/session/project storage, not this.
+                // Fail closed (block the spawn) rather than warn-and-continue
+                // on a seed failure: continuing would launch the agent with
+                // exactly the unprotected condition this fix exists to
+                // close (Codex P1 + ReAgent P1 on PR #2854). No-op (Ok) for
+                // non-claude providers, so this never blocks their spawns.
                 // See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
-                if let Err(e) = providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir) {
-                    tracing::warn!(auth_dir = %auth_dir, error = %e, "failed to seed CLAUDE.md isolation placeholder");
-                }
+                providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir).map_err(|e| {
+                    format!(
+                        "failed to isolate this agent's Claude Code config ({auth_dir}): {e}. \
+                         Refusing to launch with an unprotected config dir."
+                    )
+                })?;
                 for (k, v) in provider.auth_extra_env {
                     env_vars.insert(k.to_string(), json!(v));
                 }

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -91,10 +91,24 @@ pub struct LastErrorFrame {
 /// recognized — without this branch every ambient-home refusal reported
 /// `unknown` instead of `identity`, regressing this diagnostic for exactly
 /// the pre-spawn refusal case it exists to classify.
+///
+/// ReAgent P2, PR #2854: same regression again for
+/// `SpawnGateError::ClaudeMdSeedFailed` (a newer variant, wording starts
+/// with "could not isolate this agent's") — this function needs a new
+/// branch every time a `SpawnGateError` variant with distinct wording is
+/// added, since it infers the source from message text rather than the
+/// error's own type. A future variant will hit the same gap again unless
+/// this doc comment (and the parallel test below) are kept in sync.
 fn classify_last_error_source(message: &str) -> &'static str {
     if message.starts_with("no credentials for")
         || message.starts_with("credential injection could not run")
         || message.starts_with("this agent's")
+        // ReAgent P2 on PR #2854: SpawnGateError::ClaudeMdSeedFailed's own
+        // Display prefix — same regression this function's doc history
+        // already covers for AmbientHomeDirNotAllowed (codex P2, PR #2802),
+        // recurring for a newer SpawnGateError variant this function wasn't
+        // updated for when it was added.
+        || message.starts_with("could not isolate this agent's")
     {
         "identity"
     } else if message.starts_with("container exec failed") || message.starts_with("container ensure_running failed")
@@ -1189,6 +1203,11 @@ mod tests {
         // codex P2, PR #2802: SpawnGateError::AmbientHomeDirNotAllowed.
         assert_eq!(
             classify_last_error_source("this agent's claude identity points directly at your personal claude config directory (C:\\Users\\asafe\\.claude) instead of an isolated AgentMux account — AgentMux no longer allows spawning an agent against your own global CLI login. Re-bind this identity to an isolated account in Armory \u{2192} Accounts (delete the current claude account and log in again to create a fresh, isolated one), then retry."),
+            "identity"
+        );
+        // ReAgent P2, PR #2854: SpawnGateError::ClaudeMdSeedFailed.
+        assert_eq!(
+            classify_last_error_source("could not isolate this agent's claude config directory (C:\\Users\\asafe\\.agentmux\\shared\\identities\\id-1\\claude): permission denied. Refusing to spawn with an unprotected config dir — retry, and check the directory's permissions if it persists."),
             "identity"
         );
         assert_eq!(

--- a/docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md
+++ b/docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md
@@ -1,0 +1,182 @@
+# Spec: Stop the isolated Claude Code config dir from falling back to the host's `~/.claude/CLAUDE.md`
+
+**Date:** 2026-08-31
+**Status:** Proposed
+**Motivated by:** direct request to verify that AgentMux agents don't use
+the host's global Claude Code config — verification found a real, live
+leak, not just a documentation gap.
+
+## Problem
+
+The Armory "Global Memory" pane (`GlobalBrainManager`) shows a read-only
+reference panel labeled **"Claude Code — host CLI config"** with the
+tooltip *"Claude Code's own config on this machine. Not read by spawned
+in-app agents — see the block above for what they use."* That claim is
+**false as implemented.**
+
+### Verified evidence (this machine, live)
+
+- AgentMux correctly sets `CLAUDE_CONFIG_DIR` to an isolated per-
+  provider or per-identity directory for every spawned agent
+  (`agent_open.rs`'s `provider_auth_dir()` for default agents,
+  `identity/resolver/inject.rs`'s bound-account injection for identity-
+  bound ones). This part of the isolation design is real and correctly
+  wired — confirmed by reading both code paths directly, not just specs.
+- **None of the 18+ isolated `.../claude` config directories on this
+  machine — spanning every channel, identity, and the shared default
+  provider dir — have ever had a `CLAUDE.md` file written into them.**
+- A live agent session (this one) with `CLAUDE_CONFIG_DIR` correctly
+  pointed at an isolated identity directory nonetheless received the
+  full contents of the real `C:\Users\<user>\.claude\CLAUDE.md` in its
+  system prompt.
+
+### Root cause
+
+`CLAUDE_CONFIG_DIR` relocates Claude Code CLI's credential/session/
+project storage (confirmed on-disk: `.credentials.json`, `.claude.json`,
+`projects/`, `sessions/`), but AgentMux never writes a `CLAUDE.md` into
+that relocated directory. Claude Code CLI's own user-level `CLAUDE.md`
+discovery does not treat an isolated dir with no `CLAUDE.md` as "no
+user-level memory file" — it falls through to the real
+`$HOME/.claude/CLAUDE.md` instead. The net effect: every AgentMux-
+spawned Claude Code agent on this machine has likely been silently
+inheriting the operator's personal global instructions file, the exact
+thing the isolation boundary exists to prevent.
+
+This is a **different** bug from the one already fixed in
+`SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md` (which
+blocks spawn when an identity's configured dir literally *is* the
+ambient home). That fix doesn't help here: the leak reproduces even when
+`CLAUDE_CONFIG_DIR` points at a genuinely separate, correctly-isolated
+directory — the problem is an *empty* isolated directory, not a
+misdirected one.
+
+## Design
+
+Seed an empty placeholder `CLAUDE.md` into a `claude`-provider isolated
+config dir the first time it's used, so Claude Code CLI always finds
+*something* there and never falls through to the real home. Idempotent
+and non-destructive: only ever written when no `CLAUDE.md` already
+exists at that path, so it can never clobber content Global Memory (or
+anything else) has legitimately placed there.
+
+### `agentmux-srv/src/backend/providers.rs`
+
+New function, next to the existing `is_provider_ambient_home_dir` (same
+file already owns the provider/dir isolation logic both call sites use):
+
+```rust
+pub fn seed_claude_md_placeholder_if_missing(
+    provider: &ProviderConfig,
+    config_dir: &str,
+) -> std::io::Result<bool> {
+    if provider.auth_dir_name != "claude" {
+        return Ok(false); // Claude-CLI-specific fallback behavior; unverified for other providers.
+    }
+    let path = std::path::Path::new(config_dir).join("CLAUDE.md");
+    if path.exists() {
+        return Ok(false);
+    }
+    std::fs::create_dir_all(config_dir)?;
+    std::fs::write(&path, CLAUDE_MD_ISOLATION_PLACEHOLDER)?;
+    Ok(true)
+}
+```
+
+Placeholder content explains itself (a curious operator who opens the
+file shouldn't be confused by an unexplained empty file):
+
+```
+<!--
+AgentMux: intentionally empty.
+
+This is an isolated Claude Code config directory (CLAUDE_CONFIG_DIR),
+separate from your personal ~/.claude/CLAUDE.md, so this agent never
+silently inherits your personal global instructions. To give every
+agent shared instructions, use Armory -> Memory -> Global instead —
+those compose into this agent's own project-level CLAUDE.md at launch,
+not this file. See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
+-->
+```
+
+### Call site 1 — default agents: `agentmux-srv/src/server/app_api/agent_open.rs`
+
+Right after the existing `create_dir_all(&auth_dir)` / `CLAUDE_CONFIG_DIR`
+env-var insert (~line 311-312), which already runs unconditionally on
+every `agent.open`:
+
+```rust
+let _ = std::fs::create_dir_all(&auth_dir);
+env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
+if let Err(e) = providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir) {
+    tracing::warn!(auth_dir = %auth_dir, error = %e, "failed to seed CLAUDE.md isolation placeholder");
+}
+```
+
+### Call site 2 — identity-bound agents: `agentmux-srv/src/identity/resolver/inject.rs`
+
+Inside the existing `if let Some(provider_cfg) = ...` block (~line
+574-593) that already looks up `provider_cfg` to run the ambient-home-
+dir check — added right after that check passes (i.e., only once we
+know `dir` is NOT the ambient home, which is exactly the case this spec
+targets):
+
+```rust
+if let Some(provider_cfg) =
+    crate::backend::providers::get_provider(&resolve_provider_alias(&binding.provider))
+{
+    if crate::backend::providers::is_provider_ambient_home_dir(provider_cfg, &dir) {
+        // ... existing block-spawn logic, unchanged ...
+    }
+    if let Err(e) = crate::backend::providers::seed_claude_md_placeholder_if_missing(provider_cfg, &dir) {
+        tracing::warn!(target: "identity", dir = %dir, error = %e, "failed to seed CLAUDE.md isolation placeholder");
+    }
+}
+env_vars.insert(config_dir_env_var.to_string(), dir.clone());
+```
+
+This path runs on every message send (per `inject_identity_env_with_broker`),
+so the seed check is a cheap `path.exists()` after the first run.
+
+### Tests
+
+`agentmux-srv/src/backend/providers.rs`, unit tests next to
+`is_provider_ambient_home_dir`'s own tests, using a tempdir (same
+pattern `cli_handlers.rs`'s `selfheal_tests` already establishes):
+
+- writes the placeholder when `CLAUDE.md` is missing, for the `claude`
+  provider.
+- does not overwrite an existing `CLAUDE.md` (any content — simulates
+  Global Memory or a user having legitimately placed one there).
+- no-ops for a non-`claude` provider (e.g. `codex`) even when its
+  config dir has no `CLAUDE.md` — this is a Claude-CLI-specific
+  fallback behavior, not assumed for any other provider without
+  separate verification.
+- creates the config dir first if it doesn't exist yet (mirrors the
+  `create_dir_all` already done by both call sites, so the function is
+  safe to call standalone too).
+
+## Non-goals
+
+- **No change to identity-bound accounts whose configured dir already
+  resolves to the ambient home** — that case is already blocked
+  entirely by `SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md`;
+  this spec's seed function never runs for that case (spawn is refused
+  before reaching it).
+- **No attempt to import or compose the operator's real `~/.claude/CLAUDE.md`
+  content into the isolated dir.** An empty placeholder is deliberate —
+  Global Memory (composed into the agent's project-level `CLAUDE.md`
+  instead) is the existing, correct mechanism for shared instructions;
+  silently blending the operator's personal global rules into every
+  agent would reintroduce exactly the leak this spec closes, just
+  copied instead of live-read.
+- **No change for non-`claude` providers** (Codex, Gemini, etc.) — this
+  spec only verified the leak for Claude Code CLI's specific
+  `CLAUDE_CONFIG_DIR` + `CLAUDE.md` discovery behavior. Whether other
+  providers have an analogous gap for their own config-dir env var is
+  unverified and out of scope here.
+- **No change to the GlobalBrainManager UI copy** describing "host CLI
+  config" as reference-only — that framing is correct in intent (it's
+  meant to be read-only reference, never composed into agent
+  instructions); this spec fixes the code so the claim is actually true,
+  rather than rewording the claim.

--- a/docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md
+++ b/docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md
@@ -73,6 +73,11 @@ pub fn seed_claude_md_placeholder_if_missing(
     if provider.auth_dir_name != "claude" {
         return Ok(false); // Claude-CLI-specific fallback behavior; unverified for other providers.
     }
+    // Codex P2 on PR #2854: a blank config_dir would otherwise resolve
+    // relative to the server process's own CWD instead of erroring.
+    if config_dir.trim().is_empty() {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "config_dir is empty"));
+    }
     let path = std::path::Path::new(config_dir).join("CLAUDE.md");
     if path.exists() {
         return Ok(false);
@@ -103,14 +108,20 @@ not this file. See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
 
 Right after the existing `create_dir_all(&auth_dir)` / `CLAUDE_CONFIG_DIR`
 env-var insert (~line 311-312), which already runs unconditionally on
-every `agent.open`:
+every `agent.open`. **Fails closed** (`?`, refusing the spawn) rather
+than warn-and-continue — Codex P1 + ReAgent P1 on PR #2854: continuing
+past a seed failure would launch the agent with exactly the unprotected
+condition this spec exists to close:
 
 ```rust
 let _ = std::fs::create_dir_all(&auth_dir);
 env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
-if let Err(e) = providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir) {
-    tracing::warn!(auth_dir = %auth_dir, error = %e, "failed to seed CLAUDE.md isolation placeholder");
-}
+providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir).map_err(|e| {
+    format!(
+        "failed to isolate this agent's Claude Code config ({auth_dir}): {e}. \
+         Refusing to launch with an unprotected config dir."
+    )
+})?;
 ```
 
 ### Call site 2 — identity-bound agents: `agentmux-srv/src/identity/resolver/inject.rs`
@@ -119,7 +130,9 @@ Inside the existing `if let Some(provider_cfg) = ...` block (~line
 574-593) that already looks up `provider_cfg` to run the ambient-home-
 dir check — added right after that check passes (i.e., only once we
 know `dir` is NOT the ambient home, which is exactly the case this spec
-targets):
+targets). Also fails closed, via a new `SpawnGateError::ClaudeMdSeedFailed`
+variant — the same established mechanism the `AmbientHomeDirNotAllowed`
+check two lines above it already uses:
 
 ```rust
 if let Some(provider_cfg) =
@@ -128,8 +141,14 @@ if let Some(provider_cfg) =
     if crate::backend::providers::is_provider_ambient_home_dir(provider_cfg, &dir) {
         // ... existing block-spawn logic, unchanged ...
     }
-    if let Err(e) = crate::backend::providers::seed_claude_md_placeholder_if_missing(provider_cfg, &dir) {
-        tracing::warn!(target: "identity", dir = %dir, error = %e, "failed to seed CLAUDE.md isolation placeholder");
+    if let Err(e) =
+        crate::backend::providers::seed_claude_md_placeholder_if_missing(provider_cfg, &dir)
+    {
+        return Err(SpawnGateError::ClaudeMdSeedFailed {
+            provider: binding.provider.clone(),
+            dir: dir.clone(),
+            error: e.to_string(),
+        });
     }
 }
 env_vars.insert(config_dir_env_var.to_string(), dir.clone());
@@ -137,6 +156,21 @@ env_vars.insert(config_dir_env_var.to_string(), dir.clone());
 
 This path runs on every message send (per `inject_identity_env_with_broker`),
 so the seed check is a cheap `path.exists()` after the first run.
+
+### Failure classification
+
+Two existing components pattern-match `SpawnGateError`'s `Display` text
+by prefix to classify a pre-spawn refusal — both needed a branch added
+for the new `ClaudeMdSeedFailed` variant, the same class of gap
+`AmbientHomeDirNotAllowed` already hit once before (codex P2, PR #2802):
+
+- `agentmux-srv/src/agents/failure.rs` — `classify()`, so the agent pane
+  shows a specific "Could not isolate this agent's config" title/detail
+  instead of falling through to the generic `UnknownNonZero` "Agent
+  failed" (ReAgent P2).
+- `agentmux-srv/src/server/muxspect_handlers.rs` — `classify_last_error_source()`,
+  so `muxspect`'s last-error diagnostic reports `"identity"` instead of
+  `"unknown"` for this refusal (ReAgent P2).
 
 ### Tests
 
@@ -155,6 +189,19 @@ pattern `cli_handlers.rs`'s `selfheal_tests` already establishes):
 - creates the config dir first if it doesn't exist yet (mirrors the
   `create_dir_all` already done by both call sites, so the function is
   safe to call standalone too).
+- rejects an empty/whitespace-only `config_dir` with `InvalidInput`,
+  without touching the filesystem.
+
+`agentmux-srv/src/identity/resolver/inject.rs` — a new test exercising
+the fail-closed path end-to-end (an empty `SecretRef::OAuthConfigDir`
+deterministically triggers the seed rejection above, without relying on
+real filesystem permissions), asserting `ClaudeMdSeedFailed` is returned
+and no env var was injected before the refusal.
+
+`agentmux-srv/src/agents/failure.rs` and
+`agentmux-srv/src/server/muxspect_handlers.rs` — new/updated test cases
+covering the new classification branches, mirroring the existing
+`AmbientHomeDirNotAllowed` coverage in each file.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Verified (at direct request) whether AgentMux agents actually avoid the operator's global Claude Code config — found a real, live leak, not just a doc claim.

- `CLAUDE_CONFIG_DIR` is correctly set to an isolated dir for every spawned Claude Code agent (default and identity-bound), and correctly relocates credential/session/project storage.
- **But AgentMux never wrote a `CLAUDE.md` into that relocated dir.** Claude Code CLI's own user-level `CLAUDE.md` discovery treats an isolated dir with none of its own as "fall through to the real `$HOME/.claude/CLAUDE.md`," not "no memory file."
- Verified live on this machine: **18+ isolated `claude` config dirs, none with a `CLAUDE.md`**, and a live agent session whose `CLAUDE_CONFIG_DIR` was a genuinely separate (non-ambient) directory nonetheless received the real host file's contents in its system prompt.
- This directly contradicts the Armory "Global Memory" pane's own claim that the host CLI config is "Not read by spawned in-app agents."
- Distinct from `SPEC_BLOCK_AMBIENT_HOME_DIR_IDENTITY_BINDING_2026_08_25.md` (already-fixed case: config dir literally *is* the ambient home) — this leak reproduces even when the dir is genuinely separate and correctly isolated, just empty.

## Fix

Seeds an empty, self-explanatory placeholder `CLAUDE.md` into a `claude`-provider isolated config dir the first time it's used — idempotent, never overwrites real content (so Global Memory or anything else already there is untouched):

- `agentmux-srv/src/backend/providers.rs` — new `seed_claude_md_placeholder_if_missing(provider, config_dir)`, scoped to `auth_dir_name == "claude"` only (unverified for other providers).
- `agentmux-srv/src/server/app_api/agent_open.rs` — wired into the default-agent spawn path, right where `CLAUDE_CONFIG_DIR` already gets set.
- `agentmux-srv/src/identity/resolver/inject.rs` — wired into the identity-bound spawn path, right after the existing ambient-home-dir block check passes.

See `docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md` for the full writeup, including non-goals (no attempt to import/compose the host's real `CLAUDE.md` content — that would just reintroduce the leak in a different form; Global Memory stays the correct mechanism for shared instructions).

## Test plan
- [x] New unit tests in `providers.rs` (`claude_md_placeholder_tests`): writes when missing, creates the dir first if needed, never overwrites existing content, no-ops for non-`claude` providers — all passing
- [x] `cargo test -p agentmux-srv --bin agentmux-srv identity::resolver::inject` — 28/28 passing (confirms the ambient-home-dir gate is unaffected)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv server::app_api::agent_open` — 7/7 passing
- [x] Full suite: `cargo test -p agentmux-srv --bin agentmux-srv` — 2849 passed, 0 failed, 6 ignored
- [x] `cargo check -p agentmux-srv` — clean (no new warnings)

<!-- agentmux:agent_id=manoz -->