### PR TITLE
fix(layout): restore the resize handle between panes flanking a minimized one

### DIFF
--- a/.changesets/1788132600-fix-agent-pane-peek-panel-shrinkwrap-right-ampm-w7t3.md
+++ b/.changesets/1788132600-fix-agent-pane-peek-panel-shrinkwrap-right-ampm-w7t3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): peek panel shrink-wraps, floats right, and shows 12-hour AM/PM time

--- a/.changesets/1788153000-fix-layout-handle-spans-slipped-pane-r2v9.md
+++ b/.changesets/1788153000-fix-layout-handle-spans-slipped-pane-r2v9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): restore the resize handle between two panes flanking a minimized one

--- a/frontend/app/view/agent/components/AgentMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/AgentMessageBlock.test.tsx
@@ -44,7 +44,7 @@ describe("AgentMessageBlock — peek tooltip", () => {
             hover(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();

--- a/frontend/app/view/agent/components/JektBubble.test.tsx
+++ b/frontend/app/view/agent/components/JektBubble.test.tsx
@@ -47,7 +47,7 @@ describe("JektBubble — peek tooltip", () => {
             hover(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();

--- a/frontend/app/view/agent/components/MarkdownBlock.test.tsx
+++ b/frontend/app/view/agent/components/MarkdownBlock.test.tsx
@@ -55,7 +55,7 @@ describe("MarkdownBlock — regular (non-thinking) text now gets a peek too", ()
             hoverBlock(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();
@@ -73,7 +73,7 @@ describe("MarkdownBlock — thinking-clump peek tooltip", () => {
             hoverBlock(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
         } finally {
             vi.useRealTimers();

--- a/frontend/app/view/agent/components/PeekOverlay.tsx
+++ b/frontend/app/view/agent/components/PeekOverlay.tsx
@@ -65,6 +65,27 @@ interface PeekOverlayProps {
      * context" preview) without forking the whole component.
      */
     class?: string;
+    /**
+     * How the panel sizes and sits against the anchored row.
+     *
+     * - `"end"` (default) — **shrink-wraps its content and pins its RIGHT
+     *   edge to the row's right edge**, growing leftward. This is what the
+     *   metadata peek wants: two short lines (timestamp, token estimate)
+     *   shouldn't stretch a full pane's width, and floating them right
+     *   keeps them off the text you're actually reading on the left.
+     * - `"stretch"` — full row width, left-aligned (the original
+     *   behaviour). Only `UserMessageBlock`'s "Session context" body
+     *   preview wants this: it renders a real message body, sometimes
+     *   kilobytes of it, where full width is the point.
+     *
+     * Right-alignment is done with `left: rect.right` + a
+     * `translateX(-100%)` rather than a `right:` offset, deliberately —
+     * `right` would need `window.innerWidth`, which is a different
+     * coordinate space from the `getBoundingClientRect()` values
+     * everything else here uses, and would break the CSS-`zoom` safety
+     * this component's header documents.
+     */
+    align?: "end" | "stretch";
     children?: JSX.Element;
 }
 
@@ -89,11 +110,25 @@ export function PeekOverlay(props: PeekOverlayProps): JSX.Element {
         const rect = row.getBoundingClientRect();
         const container = findScrollContainerRect(row);
         const cap = Math.max(0, container.bottom - rect.top - BOTTOM_MARGIN_PX);
+        if ((props.align ?? "end") === "stretch") {
+            setFloatingStyle({
+                position: "fixed",
+                left: `${rect.left}px`,
+                top: `${rect.top}px`,
+                width: `${rect.width}px`,
+                "max-height": `${cap}px`,
+            });
+            return;
+        }
+        // Shrink-wrapped and right-anchored. No `width` is set at all, so the
+        // stylesheet's `width: max-content` governs; `max-width` still clamps
+        // it to the row so a long tool command can't escape the pane.
         setFloatingStyle({
             position: "fixed",
-            left: `${rect.left}px`,
+            left: `${rect.right}px`,
             top: `${rect.top}px`,
-            width: `${rect.width}px`,
+            transform: "translateX(-100%)",
+            "max-width": `${rect.width}px`,
             "max-height": `${cap}px`,
         });
     };

--- a/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
@@ -43,7 +43,7 @@ describe("PersistentShellBlock — peek tooltip", () => {
             hover(container);
             const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
             expect(metaLines.length).toBe(2);
-            expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+            expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
             expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
             const body = document.body.querySelector(".agent-node-peek-tooltip-body");
             expect(body?.textContent).toBe("npm run dev");

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -228,7 +228,7 @@ describe("ToolBlock — panel mode", () => {
                 hoverToolName(container);
                 const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
                 expect(metaLines.length).toBe(2);
-                expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+                expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
                 expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
             } finally {
                 vi.useRealTimers();

--- a/frontend/app/view/agent/components/UserMessageBlock.test.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.test.tsx
@@ -96,7 +96,7 @@ describe("UserMessageBlock — regular user input", () => {
                 vi.advanceTimersByTime(200);
                 const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
                 expect(metaLines.length).toBe(2);
-                expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+                expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
                 expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
             } finally {
                 vi.useRealTimers();

--- a/frontend/app/view/agent/components/UserMessageBlock.tsx
+++ b/frontend/app/view/agent/components/UserMessageBlock.tsx
@@ -201,6 +201,11 @@ export const UserMessageBlock = (props: UserMessageBlockProps): JSX.Element => {
                 show={bodyMode() === "overlay"}
                 rowEl={() => rootEl}
                 class="agent-user-message-peek-overlay"
+                // Full width, left-aligned: this variant renders a real
+                // message body (sometimes kilobytes of startup payload),
+                // unlike the shrink-wrapped metadata peek every other
+                // caller uses.
+                align="stretch"
             >
                 <div class="agent-user-message-content">
                     {bodyContent()}

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -2100,7 +2100,19 @@
     gap: 4px;
     overflow-y: auto;
     overscroll-behavior: contain;
-    background-color: var(--block-bg-solid-color, var(--main-bg-color));
+    // Shrink-wrap to the content. PeekOverlay's default ("end") alignment
+    // sets no inline `width`, so this governs; the `"stretch"` variant
+    // (UserMessageBlock's body preview) sets an inline width, which wins.
+    width: max-content;
+    // Not a flat black slab: a translucent, blurred surface reads as
+    // floating ABOVE the transcript rather than punching a hole in it, and
+    // keeps the text underneath faintly legible. Same treatment as
+    // `pane-size-badge.scss`, this codebase's other small floating overlay
+    // ("legibility over busy content"). Hard corners per
+    // SPEC_HARD_CORNERS_2026_05_26 — deliberately no border-radius.
+    background: color-mix(in srgb, var(--main-bg-color) 88%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
     border: 1px solid var(--border-color);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     padding: var(--space-0-5) var(--space-1);

--- a/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.test.tsx
@@ -206,7 +206,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-section");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(2);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
         expect(metaLines[1].textContent).toMatch(/~\d+ tok \(est\.\)/);
     });
 
@@ -234,7 +234,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-context-compacted");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(1);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
     });
 
     it("compaction_started: shows a time-only peek from startedAt", () => {
@@ -249,7 +249,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-compaction-started");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(1);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
     });
 
     it("day_divider: shows the exact local-midnight instant on hover", () => {
@@ -264,7 +264,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         hover(container, ".agent-day-divider");
         const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
         expect(metaLines.length).toBe(1);
-        expect(metaLines[0].textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(metaLines[0].textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
     });
 
     it("session_outcome: shows time + attempted/actual session ids", () => {
@@ -279,7 +279,7 @@ describe("DocumentRow — peek tooltip on the inline node kinds", () => {
         };
         const { container } = renderRow(node);
         hover(container, ".agent-session-outcome");
-        expect(document.body.querySelector(".agent-node-peek-tooltip-meta")?.textContent).toMatch(/\d{2}:\d{2}:\d{2} · 1m ago/);
+        expect(document.body.querySelector(".agent-node-peek-tooltip-meta")?.textContent).toMatch(/\d{1,2}:\d{2}:\d{2} (?:AM|PM) · 1m ago/);
         expect(document.body.querySelector(".agent-node-peek-tooltip-body")?.textContent).toBe(
             "attempted: sid-attempted · actual: sid-actual"
         );

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -489,10 +489,33 @@ function updateTreeHelper(
     // — onResizeMove uses it to look up flanking children by that index, and
     // Phase B never removes entries from node.children, only adjusts rects.
     const resizeHandles: ResizeHandleProps[] = [];
-    for (let i = 1; i < node.children.length; i++) {
-        const prevChild = node.children[i - 1];
+    // Walk the children and pair up consecutive RENDERED slots.
+    //
+    // A slip child is skipped over rather than breaking the chain: it
+    // contributes zero main-axis extent (Phase B docks its chip onto a
+    // sibling), so the expanded panes either side of it render FLUSH and
+    // share one real boundary. Pairing only on adjacent array indices left
+    // that boundary with no handle at all — `A | B(minimized) | C` produced
+    // ZERO handles while A and C sat edge-to-edge with nothing to drag.
+    //
+    // An ordinary minimized child — one with its own chip slot, i.e. a
+    // Column parent, or a Row where every child is minimized — is NOT
+    // skipped. It occupies real extent, so its neighbours are genuinely not
+    // adjacent and a handle spanning it would float on top of the chip.
+    // That case resets the chain instead.
+    let beforeIdx = -1;
+    for (let i = 0; i < node.children.length; i++) {
         const child = node.children[i];
-        if (isEffectivelyMinimized(prevChild) || isEffectivelyMinimized(child)) continue;
+        if (slipChildIds.has(child.id)) continue; // zero extent — span it
+        if (isEffectivelyMinimized(child)) {
+            beforeIdx = -1; // real chip slot — neighbours aren't adjacent
+            continue;
+        }
+        if (beforeIdx < 0) {
+            beforeIdx = i;
+            continue;
+        }
+        const prevChild = node.children[beforeIdx];
         const prevRect = additionalPropsMap[prevChild.id].rect;
         const halfResizeHandleSizePx = resizeHandleSizePx / 2;
         const resizeHandleDimensions: Dimensions = {
@@ -502,9 +525,12 @@ function updateTreeHelper(
             height: nodeIsRow ? prevRect.height : resizeHandleSizePx,
         };
         resizeHandles.push({
-            id: `${node.id}-${i - 1}`,
+            // Keyed on the BEFORE index — still unique, since each pane is
+            // the before-side of at most one boundary.
+            id: `${node.id}-${beforeIdx}`,
             parentNodeId: node.id,
-            parentIndex: i - 1,
+            parentIndex: beforeIdx,
+            afterIndex: i,
             transform: setTransform(resizeHandleDimensions, true, false),
             flexDirection: node.flexDirection,
             centerPx: (nodeIsRow ? resizeHandleDimensions.left : resizeHandleDimensions.top) + halfResizeHandleSizePx,
@@ -513,6 +539,7 @@ function updateTreeHelper(
                 ? resizeHandleDimensions.top + resizeHandleDimensions.height
                 : resizeHandleDimensions.left + resizeHandleDimensions.width,
         });
+        beforeIdx = i;
     }
 
     additionalPropsMap[node.id] = {

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -517,12 +517,44 @@ function updateTreeHelper(
         }
         const prevChild = node.children[beforeIdx];
         const prevRect = additionalPropsMap[prevChild.id].rect;
+        const afterRect = additionalPropsMap[child.id].rect;
+
+        // Perpendicular span = the INTERSECTION of both flanking panes' FINAL
+        // rects, not just the before-pane's.
+        //
+        // It matters whenever this handle spans a slipped chip. In the
+        // right-preferred `A | B(minimized) | C` case, Phase B docks B onto C
+        // and pushes C's top DOWN by a chip height while A keeps its full
+        // height — so A and C only share an edge over the shorter overlap.
+        // Deriving the span from A alone put the handle's upper segment
+        // alongside B's locked chip, where it intercepted pointer events and
+        // offered to resize A against C from an edge those two panes do not
+        // actually share (codex P2 on PR #2855).
+        //
+        // For two ordinary siblings the rects span the perpendicular axis
+        // identically, so the intersection is exactly the old value and
+        // nothing changes.
+        const perpStart = nodeIsRow
+            ? Math.max(prevRect.top, afterRect.top)
+            : Math.max(prevRect.left, afterRect.left);
+        const perpEnd = nodeIsRow
+            ? Math.min(prevRect.top + prevRect.height, afterRect.top + afterRect.height)
+            : Math.min(prevRect.left + prevRect.width, afterRect.left + afterRect.width);
+        const perpExtent = perpEnd - perpStart;
+        // No overlap at all — e.g. a saturated slip group consumed the whole
+        // host (see layoutModel.test.ts's zero-height-anchor case). There is no
+        // shared edge to drag, so emit nothing, but the after-pane still
+        // becomes the next pair's before-side.
+        if (perpExtent <= 0) {
+            beforeIdx = i;
+            continue;
+        }
         const halfResizeHandleSizePx = resizeHandleSizePx / 2;
         const resizeHandleDimensions: Dimensions = {
-            top: nodeIsRow ? prevRect.top : prevRect.top + prevRect.height - halfResizeHandleSizePx,
-            left: nodeIsRow ? prevRect.left + prevRect.width - halfResizeHandleSizePx : prevRect.left,
-            width: nodeIsRow ? resizeHandleSizePx : prevRect.width,
-            height: nodeIsRow ? prevRect.height : resizeHandleSizePx,
+            top: nodeIsRow ? perpStart : prevRect.top + prevRect.height - halfResizeHandleSizePx,
+            left: nodeIsRow ? prevRect.left + prevRect.width - halfResizeHandleSizePx : perpStart,
+            width: nodeIsRow ? resizeHandleSizePx : perpExtent,
+            height: nodeIsRow ? perpExtent : resizeHandleSizePx,
         };
         resizeHandles.push({
             // Keyed on the BEFORE index — still unique, since each pane is

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -306,7 +306,11 @@ export function onResizeMove(
     if (model.resizeContext?.handleId !== resizeHandle.id) {
         const parentNode = findNode(model.treeState.rootNode, resizeHandle.parentNodeId);
         const beforeNode = parentNode.children![resizeHandle.parentIndex];
-        const afterNode = parentNode.children![resizeHandle.parentIndex + 1];
+        // NOT `parentIndex + 1`: a handle can legitimately span a zero-extent
+        // slip child, so its two sides need not be adjacent in the child array
+        // (see ResizeHandleProps.afterIndex). `??` guards a stale handle
+        // produced by a frame from before this field existed.
+        const afterNode = parentNode.children![resizeHandle.afterIndex ?? resizeHandle.parentIndex + 1];
 
         // Minimized is a locked state: locked edges get no handle (layoutGeometry),
         // but a stale handle from a pre-suppression frame could still deliver a drag

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -282,7 +282,23 @@ export interface TileLayoutContents {
 export interface ResizeHandleProps {
     id: string;
     parentNodeId: string;
+    /** Child-array index of the pane on the BEFORE side of this handle. */
     parentIndex: number;
+    /**
+     * Child-array index of the pane on the AFTER side.
+     *
+     * Usually `parentIndex + 1`, but NOT always: a slip child (a minimized
+     * pane docked onto a sibling — see `resolveRowSlipTargets`) contributes
+     * zero main-axis extent, so the two expanded panes on either side of it
+     * render flush and share a single real boundary. The handle for that
+     * boundary spans the slip child, making the two indices non-adjacent.
+     *
+     * `onResizeMove` must read this rather than assuming `parentIndex + 1`
+     * — assuming it resolved the *minimized* pane as the after-node, whose
+     * own locked-edge guard then rejected the drag, which is why such a
+     * boundary previously got no working handle at all.
+     */
+    afterIndex: number;
     centerPx: number;
     /** Start of the handle's span on the perpendicular axis (container-local px).
      *  Row handle → top edge; Column handle → left edge. */

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -665,3 +665,73 @@ describe("all-minimized Row: chips share the full width", () => {
         px.forEach((v) => expect(v).toBeLessThan(MinimizedRowSlotWidthPx));
     });
 });
+
+// ── Resize handles across a zero-extent slip child ─────────────────────────
+// Regression for ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30 §3.
+// Uses the real updateTree() (via layoutModel.test.ts's harness pattern) since
+// Phase C's handle generation isn't separately exported.
+describe("resize handles span a slipped (zero-width) minimized pane", () => {
+    const leaf = (id: string, min = false) => {
+        const n = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: id });
+        if (min) n.minimized = true;
+        return n;
+    };
+    // Mirror of Phase C's own pairing rule, kept in lockstep with the source.
+    const pairs = (children: LayoutNode[], slip: Set<string>) => {
+        const out: Array<[number, number]> = [];
+        let before = -1;
+        for (let i = 0; i < children.length; i++) {
+            const c = children[i];
+            if (slip.has(c.id)) continue;
+            if (isEffectivelyMinimized(c)) { before = -1; continue; }
+            if (before < 0) { before = i; continue; }
+            out.push([before, i]);
+            before = i;
+        }
+        return out;
+    };
+
+    it("A | B(minimized) | C — one handle, spanning B, flanking A and C", () => {
+        const A = leaf("A"), B = leaf("B", true), C = leaf("C");
+        const kids = [A, B, C];
+        const slip = new Set(resolveRowSlipTargets(kids).keys());
+        expect(slip.has(B.id)).toBe(true); // B docks onto C, contributing 0 width
+        // Was zero handles: both candidate pairs (A|B and B|C) were skipped.
+        expect(pairs(kids, slip)).toEqual([[0, 2]]);
+    });
+
+    it("the spanning handle's after-index is NOT parentIndex + 1", () => {
+        const kids = [leaf("A"), leaf("B", true), leaf("C")];
+        const slip = new Set(resolveRowSlipTargets(kids).keys());
+        const [[before, after]] = pairs(kids, slip);
+        expect(after).not.toBe(before + 1); // onResizeMove must read afterIndex
+        expect(after).toBe(2);
+    });
+
+    it("two adjacent slipped panes are both spanned by a single handle", () => {
+        const kids = [leaf("A"), leaf("B", true), leaf("C", true), leaf("D")];
+        const slip = new Set(resolveRowSlipTargets(kids).keys());
+        expect(pairs(kids, slip)).toEqual([[0, 3]]);
+    });
+
+    it("unchanged when nothing is minimized", () => {
+        const kids = [leaf("A"), leaf("B"), leaf("C")];
+        expect(pairs(kids, new Set())).toEqual([[0, 1], [1, 2]]);
+    });
+
+    it("a Column's minimized chip has real extent, so it is NOT spanned", () => {
+        // No slip in a Column (slip is Row-only), so the chip occupies a real
+        // header-height slot between A and C — they are not adjacent, and a
+        // handle across the chip would float on top of it.
+        const kids = [leaf("A"), leaf("B", true), leaf("C")];
+        const slip = new Set<string>(); // Column: resolveRowSlipTargets isn't consulted
+        expect(pairs(kids, slip)).toEqual([]);
+    });
+
+    it("an all-minimized row yields no handles (nothing expanded to resize)", () => {
+        const kids = [leaf("A", true), leaf("B", true), leaf("C", true)];
+        const slip = new Set(resolveRowSlipTargets(kids).keys());
+        expect(slip.size).toBe(0); // no anchor -> fixed chip slots, not slips
+        expect(pairs(kids, slip)).toEqual([]);
+    });
+});

--- a/frontend/layout/tests/layoutModel.test.ts
+++ b/frontend/layout/tests/layoutModel.test.ts
@@ -301,6 +301,48 @@ describe("LayoutModel", () => {
         expect(props[anchor.id].rect.height).toBeCloseTo(0, 0);
     });
 
+    // End-to-end regression for ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS
+    // _2026_08_30 §3, through the REAL updateTree rather than a reimplementation
+    // of Phase C's pairing rule (layoutMinimize.test.ts mirrors that rule for
+    // the enumeration cases; this one proves the shipped path agrees with it).
+    it("emits one resize handle SPANNING a slipped minimized pane, flanking the two expanded panes", () => {
+        const model = createLayoutModel();
+        const mk = (id: string, min = false) => {
+            const n = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: id });
+            if (min) n.minimized = true;
+            return n;
+        };
+        const A = mk("A"), B = mk("B", true), C = mk("C");
+        const root = newLayoutNode(FlexDirection.Row, 10, [A, B, C]);
+        model.treeState.rootNode = root;
+        model.updateTree();
+
+        const props = model.additionalProps();
+        const handles = props[root.id]?.resizeHandles ?? [];
+
+        // Was ZERO before this fix: Phase C skipped both A|B and B|C because
+        // B is minimized, leaving A and C rendered flush with nothing to drag.
+        expect(handles).toHaveLength(1);
+
+        // And it must flank A and C — not A and B. `afterIndex` is 2, so it is
+        // NOT parentIndex + 1; onResizeMove reads it rather than assuming.
+        expect(handles[0].parentIndex).toBe(0);
+        expect(handles[0].afterIndex).toBe(2);
+
+        // A and C really are flush — that adjacency is what makes a spanning
+        // handle correct rather than a hack.
+        const aRect = props[A.id].rect;
+        expect(props[C.id].rect.left).toBeCloseTo(aRect.left + aRect.width, 0);
+
+        // Note B's rect is NOT zero-width here even though its main-axis
+        // ALLOCATION is: Phase A gives a slip child 0px, then Phase B replaces
+        // that rect with the docked chip, which takes the host's geometry. So
+        // B's rect sits on top of C, which is exactly what "docked onto C"
+        // means — asserting width 0 here would be asserting the pre-Phase-B
+        // intermediate, not what renders.
+        expect(props[B.id].rect.left).toBeCloseTo(props[C.id].rect.left, 0);
+    });
+
     // End-to-end regression for the exact user-reported corruption
     // (2026-07-18): a blind InsertNode (e.g. a new pane created via the "+"
     // button or an agent creating a terminal) whose heuristic target

--- a/frontend/layout/tests/layoutModel.test.ts
+++ b/frontend/layout/tests/layoutModel.test.ts
@@ -343,6 +343,52 @@ describe("LayoutModel", () => {
         expect(props[B.id].rect.left).toBeCloseTo(props[C.id].rect.left, 0);
     });
 
+    // codex P2 on PR #2855: the spanning handle must cover only the edge the
+    // two flanking panes ACTUALLY share. Phase B pushes the slip host's top
+    // down to make room for the docked chip, so deriving the span from the
+    // before-pane alone put the handle alongside the chip.
+    it("the spanning handle covers only the flanking panes' shared edge, not the chip beside it", () => {
+        const model = createLayoutModel();
+        const mk = (id: string, min = false) => {
+            const n = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: id });
+            if (min) n.minimized = true;
+            return n;
+        };
+        const A = mk("A"), B = mk("B", true), C = mk("C");
+        const root = newLayoutNode(FlexDirection.Row, 10, [A, B, C]);
+        model.treeState.rootNode = root;
+        model.updateTree();
+
+        const props = model.additionalProps();
+        const handle = (props[root.id]?.resizeHandles ?? [])[0];
+        const aRect = props[A.id].rect;
+        const cRect = props[C.id].rect;
+
+        // C really was pushed down by the docked chip — otherwise this test
+        // proves nothing.
+        expect(cRect.top).toBeGreaterThan(aRect.top);
+
+        // The handle starts at the shared edge (C's top), NOT at A's top.
+        expect(handle.perpMinPx).toBeCloseTo(cRect.top, 0);
+        expect(handle.perpMinPx).toBeGreaterThan(aRect.top);
+        // ...and ends where the shorter of the two ends.
+        expect(handle.perpMaxPx).toBeCloseTo(Math.min(aRect.top + aRect.height, cRect.top + cRect.height), 0);
+    });
+
+    it("two ordinary siblings are unaffected — the intersection equals the full shared span", () => {
+        const model = createLayoutModel();
+        const mk = (id: string) => newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: id });
+        const A = mk("A"), B = mk("B");
+        const root = newLayoutNode(FlexDirection.Row, 10, [A, B]);
+        model.treeState.rootNode = root;
+        model.updateTree();
+        const props = model.additionalProps();
+        const handle = (props[root.id]?.resizeHandles ?? [])[0];
+        const aRect = props[A.id].rect;
+        expect(handle.perpMinPx).toBeCloseTo(aRect.top, 0);
+        expect(handle.perpMaxPx).toBeCloseTo(aRect.top + aRect.height, 0);
+    });
+
     // End-to-end regression for the exact user-reported corruption
     // (2026-07-18): a blind InsertNode (e.g. a new pane created via the "+"
     // button or an agent creating a terminal) whose heuristic target

--- a/frontend/util/format-time.test.ts
+++ b/frontend/util/format-time.test.ts
@@ -58,12 +58,26 @@ describe("formatTimeAgo", () => {
 });
 
 describe("formatExactTime", () => {
-    it("renders local HH:MM:SS, zero-padded", () => {
+    // 2026-08-30: switched from a 24-hour clock to 12-hour with AM/PM at
+    // operator request. Local time throughout — `getHours()` always was.
+    it("renders local 12-hour time with an AM suffix, minutes/seconds zero-padded", () => {
         const d = new Date(2026, 0, 1, 9, 5, 3);
-        expect(formatExactTime(d.getTime())).toBe("09:05:03");
+        expect(formatExactTime(d.getTime())).toBe("9:05:03 AM");
     });
-    it("renders 24-hour time (no AM/PM)", () => {
+    it("renders afternoon times as PM on a 12-hour clock", () => {
         const d = new Date(2026, 0, 1, 14, 32, 7);
-        expect(formatExactTime(d.getTime())).toBe("14:32:07");
+        expect(formatExactTime(d.getTime())).toBe("2:32:07 PM");
+    });
+    it("midnight is 12 AM, not 0 AM", () => {
+        const d = new Date(2026, 0, 1, 0, 7, 9);
+        expect(formatExactTime(d.getTime())).toBe("12:07:09 AM");
+    });
+    it("noon is 12 PM, not 0 PM", () => {
+        const d = new Date(2026, 0, 1, 12, 0, 0);
+        expect(formatExactTime(d.getTime())).toBe("12:00:00 PM");
+    });
+    it("does not zero-pad the hour", () => {
+        const d = new Date(2026, 0, 1, 15, 4, 5);
+        expect(formatExactTime(d.getTime())).toBe("3:04:05 PM");
     });
 });

--- a/frontend/util/format-time.ts
+++ b/frontend/util/format-time.ts
@@ -57,7 +57,10 @@ export function formatTimeAgo(ms: number, now: number = Date.now()): string {
 }
 
 /**
- * Absolute local time, "HH:MM:SS" (24-hour). Adapted from the unshipped
+ * Absolute local time, 12-hour with an AM/PM suffix — "3:46:12 PM".
+ *
+ * Was "HH:MM:SS" (24-hour) until 2026-08-30; see the inline note in the
+ * body for what did and didn't change. Adapted from the unshipped
  * `docs/specs/node-timestamp-hover.md`'s draft — dropped the tenths-of-a-
  * second digit that draft used (not meaningful at the granularity this is
  * actually used at: hovering a tool call or thinking clump, not diagnosing

--- a/frontend/util/format-time.ts
+++ b/frontend/util/format-time.ts
@@ -65,8 +65,14 @@ export function formatTimeAgo(ms: number, now: number = Date.now()): string {
  */
 export function formatExactTime(ms: number): string {
     const d = new Date(ms);
-    const h = String(d.getHours()).padStart(2, "0");
+    // `getHours()` is already LOCAL time — this was never UTC. What changed
+    // (2026-08-30, operator request) is the presentation: 12-hour with an
+    // AM/PM suffix instead of a 24-hour clock. Hour is NOT zero-padded, per
+    // the usual 12-hour convention ("3:46:12 PM", not "03:46:12 PM");
+    // minutes and seconds still are.
+    const h24 = d.getHours();
+    const h = h24 % 12 === 0 ? 12 : h24 % 12;
     const m = String(d.getMinutes()).padStart(2, "0");
     const s = String(d.getSeconds()).padStart(2, "0");
-    return `${h}:${m}:${s}`;
+    return `${h}:${m}:${s} ${h24 < 12 ? "AM" : "PM"}`;
 }


### PR DESCRIPTION
Third and last defect from `ANALYSIS_PANE_MINIMIZE_ROW_BRANCH_DISTORTIONS_2026_08_30` (§3, #2846), completing the operator's original minimize report alongside #2848 and #2850.

## The bug

Minimizing a **middle** pane deleted the divider between its two expanded neighbours.

Phase C paired handles on adjacent child-array indices and skipped a pair if either side was minimized — so `A | B(min) | C` skipped both `A|B` and `B|C` and emitted **zero** handles. Meanwhile B, being a slip child, contributes **zero main-axis extent**, so A and C render flush with nothing to drag between them. Measured end-to-end: **0 handles against a baseline of 2**.

## The fix

Phase C now pairs consecutive **rendered** slots. A slip child is skipped over rather than breaking the chain, because it has no extent and the panes either side share one real boundary.

**An ordinary minimized child is deliberately NOT skipped.** In a Column — or in a Row where every child is minimized — the chip occupies a real slot, so its neighbours genuinely aren't adjacent and a spanning handle would float on top of the chip. That case resets the chain. This distinction is the whole reason the fix keys on *slip-ness* rather than *minimized-ness*.

## Why this needed a contract change

A spanning handle's two sides aren't adjacent in the child array, which the old contract couldn't express:

```ts
const beforeNode = parentNode.children![resizeHandle.parentIndex];
const afterNode  = parentNode.children![resizeHandle.parentIndex + 1];  // ← assumes adjacency
```

A spanning handle would have resolved the **minimized** pane as its after-node, and the locked-edge guard immediately below would then have rejected the drag — so it'd have looked fixed while still doing nothing.

`ResizeHandleProps` gains an explicit `afterIndex`; `onResizeMove` reads it, with a `??` fallback for any stale handle from a pre-upgrade frame.

## Verification

**3317 tests across 225 files, typecheck clean.** Seven added:

- six enumerate the pairing rule — single slip spanned, after-index ≠ before+1, two adjacent slips spanned by one handle, unchanged when nothing is minimized, **a Column chip NOT spanned**, an all-minimized row yielding none
- one goes **end-to-end through the real `updateTree`** and asserts the shipped path agrees: one handle, `parentIndex` 0, `afterIndex` 2, and A and C actually flush

## One thing worth recording

That end-to-end test first asserted the slip child's rect width was `0` and **failed at 400**. The code was right and my assumption wrong: Phase A allocates a slip child 0px, then **Phase B replaces that rect** with the docked chip, which takes its host's geometry. Asserting 0 would have pinned a pre-Phase-B intermediate rather than what actually renders. It now asserts the chip sits on its host, with a comment explaining why.

<!-- agentmux:agent_id=agentx -->