### PR TITLE
feat(muxspect): `layout` — inspect the persisted pane tree, run the doctor

### DIFF
--- a/.changesets/1788154400-feat-muxspect-layout-command-k8p4.md
+++ b/.changesets/1788154400-feat-muxspect-layout-command-k8p4.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxspect): `layout` command — inspect the persisted pane tree and run the layout doctor

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -515,7 +515,16 @@ function renderDock(data) {
  *
  * Exported (pure, no I/O) for muxspect.test.mjs.
  */
-function renderLayout(data) {
+export function renderLayout(data) {
+    // A whole-request failure (the store couldn't be read at all) comes back
+    // as 200 + {error} with NO `layouts` key — see handle_muxspect_layout for
+    // why it isn't a 4xx. Without this branch it fell through to "no layouts
+    // found" and exit 0, reporting success for exactly the on-disk failure
+    // this command exists to surface (reagent P1 on PR #2856).
+    if (data.error) {
+        console.error(`layout: ${data.error}`);
+        return;
+    }
     const layouts = data.layouts ?? [];
     if (!layouts.length) {
         console.log("no layouts found");
@@ -658,8 +667,12 @@ async function main() {
         if (json) console.log(JSON.stringify(data, null, 2));
         else renderLayout(data);
         // A tree with violations is a real finding — exit non-zero so a
-        // scripted caller notices without parsing stdout.
-        if ((data.layouts ?? []).some((l) => l.violations?.length || l.error)) process.exitCode = 1;
+        // scripted caller notices without parsing stdout. `data.error` is the
+        // whole-request failure (no `layouts` key at all); without it the
+        // command exited 0 on a store-read failure.
+        if (data.error || (data.layouts ?? []).some((l) => l.violations?.length || l.error)) {
+            process.exitCode = 1;
+        }
         return;
     }
 

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -80,6 +80,17 @@ Usage:
                                   (SPEC_MUXSPECT_VERIFY_SENDER_2026_08_21.md).
                                   Exits non-zero unless the verdict is
                                   'found'.
+  muxspect layout [tab_id] [--json]
+                                  the PERSISTED layout tree for every tab (or
+                                  one), as an indented outline: direction,
+                                  size, minimized/magnified flags, block ids —
+                                  plus the layout doctor's verdict on each
+                                  tree. Answers "what does the layout actually
+                                  look like right now" without reading
+                                  db_layout out of SQLite by hand. Note it
+                                  reports what is PERSISTED, which can lag
+                                  what the frontend is currently rendering.
+                                  Exits non-zero if any tree has violations.
   muxspect help                   this message
 
 Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY in the environment.
@@ -504,6 +515,42 @@ function renderDock(data) {
  *
  * Exported (pure, no I/O) for muxspect.test.mjs.
  */
+function renderLayout(data) {
+    const layouts = data.layouts ?? [];
+    if (!layouts.length) {
+        console.log("no layouts found");
+        return;
+    }
+    for (const l of layouts) {
+        if (l.error) {
+            console.log(`tab ${l.tab_name ?? l.tab_id}  \u2716 ${l.error}`);
+            continue;
+        }
+        const verdict = l.healthy ? "healthy" : `${l.violations.length} violation(s)`;
+        console.log(
+            `tab ${l.tab_name ?? l.tab_id}  (${l.leaf_count} pane(s), ` +
+                `${l.minimized_leaf_count} minimized)  ${verdict}`
+        );
+        for (const v of l.violations ?? []) console.log(`  ! ${v}`);
+        for (const n of l.nodes ?? []) {
+            const indent = "  ".repeat(n.depth + 1);
+            const flags = [];
+            if (n.locked) flags.push("minimized");
+            // Only meaningful on a branch — a leaf's own locked flag already
+            // says it, and repeating it there would be noise.
+            if (n.kind === "branch" && n.effectively_minimized) flags.push("all-minimized");
+            if (n.id === l.magnified_node_id) flags.push("magnified");
+            const tail = flags.length ? `  [${flags.join(", ")}]` : "";
+            const label =
+                n.kind === "leaf"
+                    ? `leaf ${n.block_id ? n.block_id.slice(0, 8) : "(no block)"}`
+                    : `${n.flex_direction} (${n.child_count})`;
+            console.log(`${indent}${label}  size=${n.size}${tail}`);
+        }
+        console.log("");
+    }
+}
+
 export function parseArgs(argv) {
     const json = argv.includes("--json");
     const help = argv.includes("--help") || argv.includes("-h");
@@ -600,6 +647,19 @@ async function main() {
         const data = await apiGet(url, authKey, `/api/v1/muxspect/dock?block_id=${encodeURIComponent(blockId)}`);
         if (json) console.log(JSON.stringify(data, null, 2));
         else renderDock(data);
+        return;
+    }
+
+    if (cmd === "layout") {
+        // `blockId` is muxspect's generic first positional; for this command
+        // it is an optional tab id.
+        const qs = blockId ? `?tab_id=${encodeURIComponent(blockId)}` : "";
+        const data = await apiGet(url, authKey, `/api/v1/muxspect/layout${qs}`);
+        if (json) console.log(JSON.stringify(data, null, 2));
+        else renderLayout(data);
+        // A tree with violations is a real finding — exit non-zero so a
+        // scripted caller notices without parsing stdout.
+        if ((data.layouts ?? []).some((l) => l.violations?.length || l.error)) process.exitCode = 1;
         return;
     }
 

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -497,23 +497,11 @@ function renderDock(data) {
 }
 
 /**
- * Split argv into `{ cmd, sub, blockId, nodeId, json, help }`,
- * flags-and-positionals separated regardless of ordering. Flags can
- * legally appear before OR after the positional args (both 'muxspect
- * describe --json <id>' and 'muxspect --json describe <id>' are natural to
- * type) — filtering them out first, then reading command/args
- * positionally, is what makes both orders work; indexing into the raw,
- * flag-interspersed argv (the original implementation) silently ran
- * 'list' instead of 'describe' — or picked up a flag string as the
- * block_id — depending on where the flag landed (reagent P2 on PR #2380).
+ * Render `muxspect layout` — the persisted pane tree per tab as an indented
+ * outline, plus the layout doctor's verdict.
  *
- * `dock clear <block_id> <node_id>` doesn't fit the flat `{cmd, blockId}`
- * shape the other subcommands use (three positionals after the flag
- * filter, not two) — `sub` disambiguates `dock <block_id>` (read) from
- * `dock clear <block_id> <node_id>` (write) so `main()` doesn't have to
- * re-parse positional[1] itself.
- *
- * Exported (pure, no I/O) for muxspect.test.mjs.
+ * Exported (pure apart from console output) for muxspect.test.mjs, so the
+ * failure paths are testable rather than asserted.
  */
 export function renderLayout(data) {
     // A whole-request failure (the store couldn't be read at all) comes back
@@ -560,6 +548,25 @@ export function renderLayout(data) {
     }
 }
 
+/**
+ * Split argv into `{ cmd, sub, blockId, nodeId, json, help }`,
+ * flags-and-positionals separated regardless of ordering. Flags can
+ * legally appear before OR after the positional args (both 'muxspect
+ * describe --json <id>' and 'muxspect --json describe <id>' are natural to
+ * type) — filtering them out first, then reading command/args
+ * positionally, is what makes both orders work; indexing into the raw,
+ * flag-interspersed argv (the original implementation) silently ran
+ * 'list' instead of 'describe' — or picked up a flag string as the
+ * block_id — depending on where the flag landed (reagent P2 on PR #2380).
+ *
+ * `dock clear <block_id> <node_id>` doesn't fit the flat `{cmd, blockId}`
+ * shape the other subcommands use (three positionals after the flag
+ * filter, not two) — `sub` disambiguates `dock <block_id>` (read) from
+ * `dock clear <block_id> <node_id>` (write) so `main()` doesn't have to
+ * re-parse positional[1] itself.
+ *
+ * Exported (pure, no I/O) for muxspect.test.mjs.
+ */
 export function parseArgs(argv) {
     const json = argv.includes("--json");
     const help = argv.includes("--help") || argv.includes("-h");

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -13,7 +13,7 @@
 // parser silently misbehaved depending on which side they landed on.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { checkSpawnerTier, logSrvVersion, parseArgs } from "./muxspect.mjs";
+import { checkSpawnerTier, logSrvVersion, parseArgs, renderLayout } from "./muxspect.mjs";
 
 describe("muxspect parseArgs", () => {
     it("'layout' with no tab id parses as a bare command", () => {
@@ -246,5 +246,54 @@ describe("muxspect logSrvVersion", () => {
     it("returns undefined/falsy and logs nothing when the header is absent (older srv build)", () => {
         expect(logSrvVersion(fakeResponse(null))).toBeFalsy();
         expect(errSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("muxspect renderLayout - whole-request failure", () => {
+    let errSpy;
+    let logSpy;
+    beforeEach(() => {
+        errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+    afterEach(() => {
+        errSpy.mockRestore();
+        logSpy.mockRestore();
+    });
+
+    // reagent P1 on PR #2856: a store-read failure returns 200 + {error} with
+    // NO `layouts` key. Falling through to `data.layouts ?? []` printed
+    // "no layouts found" and exited 0, reporting success for exactly the
+    // on-disk failure this command exists to surface.
+    it("prints the error to stderr instead of 'no layouts found'", () => {
+        renderLayout({ error: "failed to list tabs: db locked" });
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("failed to list tabs"));
+        expect(logSpy).not.toHaveBeenCalledWith("no layouts found");
+    });
+
+    it("still says 'no layouts found' for a genuinely empty but SUCCESSFUL response", () => {
+        renderLayout({ layouts: [] });
+        expect(logSpy).toHaveBeenCalledWith("no layouts found");
+        expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it("renders a per-tab error without swallowing the rest of the tabs", () => {
+        renderLayout({
+            layouts: [
+                { tab_id: "t1", tab_name: "broken", error: "layoutstate unreadable" },
+                {
+                    tab_id: "t2",
+                    tab_name: "ok",
+                    healthy: true,
+                    violations: [],
+                    leaf_count: 1,
+                    minimized_leaf_count: 0,
+                    nodes: [],
+                },
+            ],
+        });
+        const printed = logSpy.mock.calls.map((c) => c.join(" ")).join(" | ");
+        expect(printed).toContain("layoutstate unreadable");
+        expect(printed).toContain("healthy");
     });
 });

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -16,6 +16,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { checkSpawnerTier, logSrvVersion, parseArgs } from "./muxspect.mjs";
 
 describe("muxspect parseArgs", () => {
+    it("'layout' with no tab id parses as a bare command", () => {
+        expect(parseArgs(["layout"])).toEqual({ cmd: "layout", blockId: undefined, json: false, help: false });
+    });
+
+    it("'layout <tab_id>' puts the tab id in the generic positional", () => {
+        // `layout` reuses muxspect's single positional slot for an optional
+        // tab id rather than adding a parser special case.
+        expect(parseArgs(["layout", "tab-1"])).toEqual({
+            cmd: "layout",
+            blockId: "tab-1",
+            json: false,
+            help: false,
+        });
+    });
+
+    it("'layout --json' works with the flag on either side of the positional", () => {
+        expect(parseArgs(["layout", "tab-1", "--json"]).json).toBe(true);
+        expect(parseArgs(["--json", "layout", "tab-1"]).json).toBe(true);
+        expect(parseArgs(["--json", "layout", "tab-1"]).blockId).toBe("tab-1");
+    });
+
     it("no args defaults to 'list'", () => {
         expect(parseArgs([])).toEqual({ cmd: "list", blockId: undefined, json: false, help: false });
     });

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -463,6 +463,7 @@ pub fn build_router(state: AppState) -> Router {
         // reaches every other /api/v1/* route (X-AuthKey from the caller's
         // own environment, no new IPC).
         .route("/api/v1/muxspect/list", get(muxspect_handlers::handle_muxspect_list))
+        .route("/api/v1/muxspect/layout", get(muxspect_handlers::handle_muxspect_layout))
         .route("/api/v1/muxspect/describe", get(muxspect_handlers::handle_muxspect_describe))
         // Cross-instance lookup — Ext 4 of
         // docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md.

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -1253,6 +1253,21 @@ pub async fn handle_muxspect_layout(
         }));
     }
 
+    // An explicit tab_id that matched nothing is a FAILED LOOKUP, not an
+    // empty result. Returning `{"layouts": []}` made a stale or mistyped id
+    // indistinguishable from a successful run over a tab with no panes --
+    // the CLI printed "no layouts found" and exited 0, which is exactly the
+    // wrong answer for a targeted diagnostic in a script (codex P2 on
+    // PR #2856). Same 200-with-`error` shape as the store-read failure above,
+    // for the same reason: a non-2xx would be reported by muxspect.mjs's
+    // apiGet() as "srv is unreachable".
+    if let Some(want) = q.tab_id.as_deref() {
+        if layouts.is_empty() {
+            return Json(json!({ "error": format!("no tab with id '{want}' in this instance") }))
+                .into_response();
+        }
+    }
+
     Json(json!({ "layouts": layouts })).into_response()
 }
 

--- a/agentmux-srv/src/server/muxspect_handlers.rs
+++ b/agentmux-srv/src/server/muxspect_handlers.rs
@@ -1126,6 +1126,142 @@ pub async fn handle_muxspect_conversations(State(state): State<AppState>) -> imp
     Json(json!({ "agents": agents })).into_response()
 }
 
+/// Flatten one layout tree into a compact, renderable node list.
+///
+/// Deliberately a FLAT list carrying a `depth`, not nested JSON: the CLI
+/// renders an indented outline, and a flat list keeps both the wire shape and
+/// the renderer trivial.
+fn flatten_layout_nodes(
+    node: &agentmux_common::LayoutNode,
+    depth: usize,
+    index_path: &str,
+    out: &mut Vec<serde_json::Value>,
+) {
+    let is_branch = !node.children.is_empty();
+    out.push(json!({
+        "id": node.id,
+        "depth": depth,
+        "path": index_path,
+        "kind": if is_branch { "branch" } else { "leaf" },
+        "flex_direction": match node.flex_direction {
+            agentmux_common::FlexDirection::Row => "row",
+            agentmux_common::FlexDirection::Column => "column",
+        },
+        "size": node.size,
+        // `minimized` round-trips through the untyped `extra` catch-all on
+        // this side, not as a typed field — same access the reducer's own
+        // `is_node_locked` uses. Reported as "locked" rather than raw
+        // `minimized` because legacy pre-display-mode markers
+        // (`minimizedSize`/`slipMinimize`/`columnDissolve`) count too, and an
+        // unmigrated tree on disk is exactly the case this route should show.
+        "locked": crate::backend::layout::is_node_locked(node),
+        // A branch is "effectively minimized" when every leaf under it is —
+        // the state that drives chip geometry. Surfaced explicitly because it
+        // is NOT visible from the `minimized` flag alone on a branch.
+        "effectively_minimized": crate::backend::layout::is_effectively_minimized(node),
+        "block_id": node.data.as_ref().map(|d| d.block_id.clone()),
+        "child_count": node.children.len(),
+    }));
+    for (i, child) in node.children.iter().enumerate() {
+        let child_path = if index_path.is_empty() {
+            i.to_string()
+        } else {
+            format!("{index_path}.{i}")
+        };
+        flatten_layout_nodes(child, depth + 1, &child_path, out);
+    }
+}
+
+/// `GET /api/v1/muxspect/layout[?tab_id=X]` — the persisted layout tree for
+/// every tab (or one), plus the layout doctor's verdict on each.
+///
+/// Why this exists: layout state was previously only inspectable by reading
+/// `db_layout` out of SQLite by hand and walking the JSON, which is what
+/// diagnosing the cross-split minimize bugs (#2848, #2850, #2855) actually
+/// required. This applies `muxspect`'s existing "what is this instance doing
+/// right now" contract to layout.
+///
+/// It reports the PERSISTED tree, a genuinely different question from what
+/// the frontend currently renders: `validate_layout_invariants` normally runs
+/// at reducer write-time, so running it on demand here also catches
+/// corruption already sitting on disk, including trees written by older
+/// versions that never ran the check.
+///
+/// Read-only, like every route in this module except `dock clear`.
+pub async fn handle_muxspect_layout(
+    State(state): State<AppState>,
+    Query(q): Query<MuxspectLayoutQuery>,
+) -> impl IntoResponse {
+    let tabs = match state.wstore.get_all::<crate::backend::obj::Tab>() {
+        Ok(t) => t,
+        Err(e) => {
+            // 200 with an `error` field, not a 4xx/5xx — muxspect.mjs's
+            // apiGet() treats a non-2xx as a transport failure and prints a
+            // connection error, which would misattribute a store-read problem
+            // as "srv is unreachable".
+            return Json(json!({ "error": format!("failed to list tabs: {e}") })).into_response();
+        }
+    };
+
+    let mut layouts = Vec::new();
+    for tab in tabs {
+        if let Some(want) = q.tab_id.as_deref() {
+            if tab.oid != want {
+                continue;
+            }
+        }
+        let ls = match state
+            .wstore
+            .must_get::<crate::backend::obj::LayoutState>(&tab.layoutstate)
+        {
+            Ok(ls) => ls,
+            Err(e) => {
+                // A tab pointing at a missing layoutstate is itself a finding
+                // worth surfacing rather than skipping silently.
+                layouts.push(json!({
+                    "tab_id": tab.oid,
+                    "tab_name": tab.name,
+                    "layoutstate_oid": tab.layoutstate,
+                    "error": format!("layoutstate unreadable: {e}"),
+                }));
+                continue;
+            }
+        };
+
+        let violations = crate::backend::layout::validate_layout_invariants(&ls.rootnode);
+        let mut nodes = Vec::new();
+        if let Some(root) = ls.rootnode.as_ref() {
+            flatten_layout_nodes(root, 0, "", &mut nodes);
+        }
+        let leaf_count = nodes.iter().filter(|n| n["kind"] == "leaf").count();
+        let minimized_leaves = nodes
+            .iter()
+            .filter(|n| n["kind"] == "leaf" && n["locked"] == true)
+            .count();
+
+        layouts.push(json!({
+            "tab_id": tab.oid,
+            "tab_name": tab.name,
+            "layoutstate_oid": ls.oid,
+            "magnified_node_id": ls.magnifiednodeid,
+            "node_count": nodes.len(),
+            "leaf_count": leaf_count,
+            "minimized_leaf_count": minimized_leaves,
+            "violations": violations,
+            "healthy": violations.is_empty(),
+            "nodes": nodes,
+        }));
+    }
+
+    Json(json!({ "layouts": layouts })).into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub struct MuxspectLayoutQuery {
+    /// Restrict to one tab. Omitted = every tab in this instance.
+    pub tab_id: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1794,6 +1930,83 @@ mod tests {
         let (preview, activity_ms) = last_line_preview_and_activity(&wstore, &filestore, "no-such-block");
         assert_eq!(preview, None);
         assert_eq!(activity_ms, None);
+    }
+
+    /// `flatten_layout_nodes` is what `muxspect layout` renders from, so its
+    /// shape is the contract. Covers the cross-split arrangement the layout
+    /// fixes (#2848/#2850/#2855) came from: a Row nested inside a Column.
+    #[test]
+    fn flatten_layout_nodes_reports_depth_path_and_effective_minimize() {
+        use agentmux_common::{FlexDirection, LayoutNode, LayoutNodeData};
+
+        fn leaf(id: &str, block: &str, minimized: bool) -> LayoutNode {
+            let mut n = LayoutNode {
+                id: id.to_string(),
+                flex_direction: FlexDirection::Row,
+                size: 10.0,
+                children: Vec::new(),
+                data: Some(LayoutNodeData {
+                    block_id: block.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            if minimized {
+                // Round-trips through `extra`, not a typed field — same as
+                // the frontend writes it.
+                n.extra.insert("minimized".to_string(), json!(true));
+            }
+            n
+        }
+
+        // Column[ top, Row[ A(min), B(min) ], bottom ]
+        let inner = LayoutNode {
+            id: "inner".into(),
+            flex_direction: FlexDirection::Row,
+            size: 10.0,
+            children: vec![leaf("a", "blk-a", true), leaf("b", "blk-b", true)],
+            data: None,
+            ..Default::default()
+        };
+        let root = LayoutNode {
+            id: "root".into(),
+            flex_direction: FlexDirection::Column,
+            size: 10.0,
+            children: vec![leaf("top", "blk-top", false), inner, leaf("bot", "blk-bot", false)],
+            data: None,
+            ..Default::default()
+        };
+
+        let mut out = Vec::new();
+        flatten_layout_nodes(&root, 0, "", &mut out);
+
+        // Flat, pre-order, one entry per node.
+        assert_eq!(out.len(), 6);
+        assert_eq!(out[0]["id"], "root");
+        assert_eq!(out[0]["depth"], 0);
+        assert_eq!(out[0]["kind"], "branch");
+        assert_eq!(out[0]["flex_direction"], "column");
+
+        // Index path is positional, so a reader can locate a node in the tree.
+        assert_eq!(out[1]["path"], "0");
+        assert_eq!(out[2]["path"], "1");
+        assert_eq!(out[3]["path"], "1.0");
+        assert_eq!(out[3]["depth"], 2);
+
+        // The inner Row is a BRANCH with no minimized flag of its own, but is
+        // effectively minimized because every leaf under it is — the state
+        // that drives chip geometry, and invisible from `locked` alone. This
+        // is the distinction the cross-split bugs turned on.
+        assert_eq!(out[2]["id"], "inner");
+        assert_eq!(out[2]["locked"], false);
+        assert_eq!(out[2]["effectively_minimized"], true);
+        assert_eq!(out[2]["child_count"], 2);
+
+        // Leaves carry their block id; the minimized ones report locked.
+        assert_eq!(out[3]["block_id"], "blk-a");
+        assert_eq!(out[3]["locked"], true);
+        assert_eq!(out[1]["locked"], false);
+        assert_eq!(out[1]["effectively_minimized"], false);
     }
 
     #[test]

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -118,6 +118,49 @@ known channel" — not an error. Same LAN/WAN boundary as `conversations`
 above (host + cross-channel only). See
 `docs/specs/SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md`.
 
+## Inspecting the pane layout (`layout`)
+
+```bash
+node ~/.agentmux/shell/muxspect.mjs layout            # every tab
+node ~/.agentmux/shell/muxspect.mjs layout <tab_id>   # one tab
+node ~/.agentmux/shell/muxspect.mjs layout --json     # machine-readable
+```
+
+Prints the layout tree as an indented outline — each node's direction, flex
+size, block id, and whether it is minimized or magnified — followed by the
+layout doctor's verdict.
+
+```
+tab tab1  (4 pane(s), 2 minimized)  healthy
+  column (3)  size=10
+    leaf dbe65c4c  size=10
+    row (2)  size=10  [all-minimized]
+      leaf 44807f01  size=10  [minimized]
+      leaf 04cc1750  size=10  [minimized]
+    leaf dd598cf3  size=10
+```
+
+**`[all-minimized]` on a branch is the one non-obvious flag.** A branch never
+carries a `minimized` marker of its own; it is *effectively* minimized when
+every leaf beneath it is, and that derived state — not the raw flag — is what
+drives chip geometry. It was the distinction behind three pane-minimize bugs
+(#2848, #2850, #2855), and it is invisible if you only read the stored flags.
+
+Exits non-zero when any tree has invariant violations, so it can gate a script.
+
+### Two caveats worth knowing
+
+**It reports what is PERSISTED, not what is on screen.** The frontend derives
+minimize geometry fresh on every render pass and only writes structural
+changes back, so a tree here can lag what you are looking at. For "why does
+this pane look wrong right now", this tells you the structure; it does not
+tell you the rendered rects.
+
+**The doctor runs against the tree on disk.** `validate_layout_invariants`
+normally runs at reducer write-time, so violations here mean corruption that
+is already persisted — including in trees written by older builds that never
+ran the check. That is the case this command catches which nothing else does.
+
 ## What it can and can't see
 
 `muxspect` is a thin, read-only client over the same `ProcessBroker`


### PR DESCRIPTION
Adds `GET /api/v1/muxspect/layout[?tab_id=X]` and the `muxspect layout` command.

```
tab tab1  (4 pane(s), 2 minimized)  healthy
  column (3)  size=10
    leaf dbe65c4c  size=10
    row (2)  size=10  [all-minimized]
      leaf 44807f01  size=10  [minimized]
      leaf 04cc1750  size=10  [minimized]
    leaf dd598cf3  size=10
```

## Why

Layout state was previously only inspectable by copying `db_layout` out of SQLite and hand-walking the JSON — which is what diagnosing the cross-split minimize bugs (#2848, #2850, #2855) actually took, twice in one session. This applies muxspect's existing *"what is this instance doing right now"* contract to layout.

## Scope note — stated plainly, because it changed mid-flight

The original pitch for this was **detecting the cross-split extent mismatch**. Those fixes landed first, so that detection would now find nothing, and this is deliberately **not** built around it.

What it's actually for:
1. **Inspectability** — the outline above, instead of hand-rolled SQLite walking.
2. **Running the doctor against the tree ON DISK.** `validate_layout_invariants` normally only runs at reducer write-time, so on-demand checking catches corruption *already persisted* — including by older builds that never ran it. That's the case nothing else covers.

## Two things the implementation had to get right rather than assume

**`minimized` isn't a typed field** on the Rust `LayoutNode` — it round-trips through the untyped `extra` catch-all. Reported as `locked` via the reducer's own `is_node_locked`, which also recognises the legacy pre-display-mode markers (`minimizedSize`/`slipMinimize`/`columnDissolve`). An unmigrated tree on disk is exactly what this route should surface; reading the raw flag would have missed it.

**`effectively_minimized` is surfaced per node** because a *branch* never carries a minimized marker of its own — it's derived from every leaf beneath it, and that derived state is what drives chip geometry. It's the distinction all three minimize bugs turned on, and it's invisible from the stored flags.

## Error handling

Store errors return **200 with an `error` field**, not a 4xx: `apiGet()` in `muxspect.mjs` treats non-2xx as transport failure and would report a store-read problem as *"srv is unreachable."* A tab pointing at a missing `layoutstate` is likewise reported as a per-tab finding rather than skipped — that's itself worth seeing.

Exits non-zero when any tree has violations, so it can gate a script.

## Tests

- **agentmux-srv: 2846 passed.** The Rust test covers `flatten_layout_nodes` over the cross-split shape itself — a Row nested in a Column — asserting depth, index path, and that the inner Row reports `locked=false` but `effectively_minimized=true`.
- **muxspect.mjs: 31 passed** (28 existing + 3 new), covering the command's arg parsing with flags on either side of the positional.

## Docs

`docs/MUXSPECT.md` gains a section including the two caveats a reader needs: it reports **persisted** state, which can lag the screen; and the doctor's findings here mean **already-on-disk** corruption.

<!-- agentmux:agent_id=agentx -->