### PR TITLE
fix(agent): defer a mid-turn model change instead of killing the in-flight turn

### DIFF
--- a/.changesets/1788155542-fix-agent-defer-a-mid-turn-model-effort-change-instead-of-ki-sd8e.md
+++ b/.changesets/1788155542-fix-agent-defer-a-mid-turn-model-effort-change-instead-of-ki-sd8e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): defer a mid-turn model/effort change instead of killing the in-flight turn

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -414,6 +414,24 @@ pub fn deliver_agent_message(block_id: &str, message: &str) -> Result<AgentDeliv
 /// 3. If existing controller needs replacing (type changed, conn changed, force), stop it
 /// 4. Create new controller if needed
 /// 5. Start if status is init or done
+/// Is this forced replace merely a runtime-config change (model / effort /
+/// permission) on a controller that stays persistent — i.e. the one case that
+/// may be deferred to the end of an in-flight turn rather than killing it?
+///
+/// Requires the type to be persistent on BOTH sides. Checking only the
+/// existing side was a real bug (reagent P2 on PR #2858): the container-agent
+/// override in `resync_controller` rewrites the target persistent ->
+/// subprocess, so a forced resync landing mid-turn on such a block would defer
+/// and silently keep the persistent controller — precisely the
+/// incompatibility that override exists to correct.
+///
+/// A genuine type change must replace immediately, mid-turn or not; losing an
+/// in-flight turn is the lesser harm against running a container agent on a
+/// controller that cannot do per-turn `docker exec` at all.
+fn is_runtime_config_only_replace(existing_type: &str, target_type: &str, force: bool) -> bool {
+    force && existing_type == BLOCK_CONTROLLER_PERSISTENT && target_type == BLOCK_CONTROLLER_PERSISTENT
+}
+
 pub fn resync_controller(
     block: &Block,
     tab_id: &str,
@@ -489,9 +507,17 @@ pub fn resync_controller(
         // baked in at spawn, so they could never have applied to the turn
         // already running.
         //
-        // Scoped to `force` only — a controller-TYPE change is a genuine
-        // replacement that has to happen now, not a runtime-config tweak.
-        if needs_replace && force && ctrl.controller_type() == BLOCK_CONTROLLER_PERSISTENT {
+        // Scoped to a runtime-config tweak: the controller must be persistent
+        // now AND still be persistent afterwards. A controller-TYPE change is a
+        // genuine replacement that has to happen immediately, even mid-turn.
+        //
+        // Checking only the EXISTING type was a real bug (reagent P2): the
+        // container-agent override a few lines above rewrites `controller_type`
+        // persistent -> subprocess, so a forced resync landing mid-turn on such
+        // a block would have deferred and silently kept the persistent
+        // controller — the exact incompatibility that override exists to
+        // correct, and the opposite of what this comment claims.
+        if needs_replace && is_runtime_config_only_replace(ctrl.controller_type(), &controller_type, force) {
             if let Some(p) = ctrl
                 .as_any()
                 .downcast_ref::<persistent::PersistentSubprocessController>()
@@ -624,6 +650,57 @@ pub fn publish_controller_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Deferred-restart guard (reagent P2 on PR #2858) ─────────────────
+
+    /// The case the deferral exists for: /model, /effort, /permission on a
+    /// pane that stays persistent.
+    #[test]
+    fn a_forced_persistent_to_persistent_replace_may_be_deferred() {
+        assert!(is_runtime_config_only_replace(
+            BLOCK_CONTROLLER_PERSISTENT,
+            BLOCK_CONTROLLER_PERSISTENT,
+            true
+        ));
+    }
+
+    /// The bug: the container-agent override rewrites the TARGET persistent ->
+    /// subprocess. Deferring here would keep a persistent controller on a
+    /// container agent, which cannot do per-turn `docker exec` — the exact
+    /// incompatibility that override exists to fix.
+    #[test]
+    fn a_type_change_to_subprocess_is_never_deferred_even_when_forced() {
+        assert!(!is_runtime_config_only_replace(
+            BLOCK_CONTROLLER_PERSISTENT,
+            BLOCK_CONTROLLER_SUBPROCESS,
+            true
+        ));
+    }
+
+    #[test]
+    fn a_type_change_from_a_non_persistent_controller_is_never_deferred() {
+        assert!(!is_runtime_config_only_replace(
+            BLOCK_CONTROLLER_SUBPROCESS,
+            BLOCK_CONTROLLER_PERSISTENT,
+            true
+        ));
+        assert!(!is_runtime_config_only_replace(
+            BLOCK_CONTROLLER_SHELL,
+            BLOCK_CONTROLLER_SHELL,
+            true
+        ));
+    }
+
+    /// Without `force` the replace is driven by a type or connection change,
+    /// never by a runtime-config tweak — nothing to defer.
+    #[test]
+    fn an_unforced_replace_is_never_deferred() {
+        assert!(!is_runtime_config_only_replace(
+            BLOCK_CONTROLLER_PERSISTENT,
+            BLOCK_CONTROLLER_PERSISTENT,
+            false
+        ));
+    }
 
     /// Test double for the stop_for_replace/remove_controller_entry_only
     /// tests below. Counts calls to `stop()` vs `stop_for_replace()`

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -473,6 +473,35 @@ pub fn resync_controller(
             status.shellprocconnname != new_conn
         };
 
+        // A forced resync that lands mid-turn on a persistent agent must NOT
+        // tear the controller down: doing so kills the CLI process with the
+        // user's in-flight message already written to its stdin, and nothing
+        // replays it — `stop_process` records a `StopRequested` (which the
+        // resume machine reads as an explicit user stop and so suppresses the
+        // retry), the old controller's queue is discarded with it, and the
+        // replacement "spawns on first message", i.e. does nothing. The turn
+        // vanished with no response and no error. Diagnosed live on AgentX,
+        // 2026-08-28.
+        //
+        // Instead the controller restarts itself the moment the turn ends,
+        // picking up the new `cmd:args` (rebuilt from block meta at spawn) on
+        // the next message. Nothing is lost by waiting: model/effort flags are
+        // baked in at spawn, so they could never have applied to the turn
+        // already running.
+        //
+        // Scoped to `force` only — a controller-TYPE change is a genuine
+        // replacement that has to happen now, not a runtime-config tweak.
+        if needs_replace && force && ctrl.controller_type() == BLOCK_CONTROLLER_PERSISTENT {
+            if let Some(p) = ctrl
+                .as_any()
+                .downcast_ref::<persistent::PersistentSubprocessController>()
+            {
+                if p.request_restart_when_idle() {
+                    return Ok(());
+                }
+            }
+        }
+
         if needs_replace {
             // stop_for_replace + remove_controller_entry_only, NOT stop +
             // delete_controller: a session restart/resync must not tear

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -304,6 +304,21 @@ struct PersistentInner {
     /// baked in at spawn, so they could not have applied to the running turn
     /// anyway. Waiting until it ends costs nothing and loses nothing.
     restart_when_idle: bool,
+    /// A deferred restart has COMMITTED — `stop_process` has been called and
+    /// the process is on its way out, but `stdin_tx` is still live because
+    /// `stop_process` only sends on `kill_tx` and leaves the writer channel
+    /// alone until the process actually exits.
+    ///
+    /// Without this, `decide_send_action` would see a live `stdin_tx` and take
+    /// `DeliverDirect` for any message arriving in that window — writing it
+    /// into a process about to receive EOF, acknowledging it, and losing it
+    /// (codex P1 on PR #2858). The window is not hypothetical: the restart
+    /// fires exactly at turn end, which is precisely when the frontend flushes
+    /// its queued follow-ups.
+    ///
+    /// Set under the same lock that consumes `restart_when_idle`, cleared when
+    /// the replacement process spawns.
+    restart_pending: bool,
     /// This spawn generation's stale-`--resume` retry decision, plus any
     /// held-back terminal error-result line — see
     /// `persistent_resume::ResumeState`'s own doc comment for the full
@@ -781,6 +796,7 @@ impl PersistentSubprocessController {
                 session_id: None,
                 resume_poisoned: None,
                 restart_when_idle: false,
+                restart_pending: false,
                 resume: persistent_resume::ResumeState::default(),
                 spawning_in_progress: false,
                 pending_send_messages: VecDeque::new(),
@@ -994,7 +1010,15 @@ impl PersistentSubprocessController {
     /// silently dropped it).
     fn decide_send_action(&self, json_str: &str, skip_if_seq_queued: Option<u64>) -> SendAction {
         let mut inner = self.inner.lock().unwrap();
-        if inner.stdin_tx.is_some() && !inner.spawning_in_progress && !inner.drain_claim {
+        // `!restart_pending`: a committed deferred restart leaves `stdin_tx`
+        // live until the process actually exits, and writing into a process
+        // about to be killed loses the message (codex P1 on PR #2858). Falling
+        // through queues it for the replacement instead.
+        if inner.stdin_tx.is_some()
+            && !inner.spawning_in_progress
+            && !inner.drain_claim
+            && !inner.restart_pending
+        {
             SendAction::DeliverDirect
         } else if inner.spawning_in_progress || inner.drain_claim {
             let already_queued = skip_if_seq_queued
@@ -2430,6 +2454,25 @@ impl PersistentSubprocessController {
         // own doc comment for what this identifies and why.
         let (my_generation, superseded_effects) = {
             let mut inner = self.inner.lock().unwrap();
+            // The replacement process is here, so the quiesce window is over —
+            // messages may take `DeliverDirect` against this new `stdin_tx`
+            // again. Cleared unconditionally rather than only when set: any
+            // spawn ends the window by definition, whatever opened it.
+            inner.restart_pending = false;
+            // …and any deferred restart is moot now, for the same reason: this
+            // spawn read `cmd:args` fresh from block meta, so the new config is
+            // already applied and there is nothing left to restart FOR.
+            //
+            // This is what stops a leak (reagent P1 on PR #2858):
+            // `restart_when_idle` is consumed at the `is_result_frame` turn
+            // end, but a generation that dies abnormally instead — a user
+            // Stop/SIGINT, a crash, a permanently-failed turn resolving via
+            // `ProcessExited` + `PublishDone` — never reaches that branch. The
+            // stale `true` would then ride into an unrelated later generation
+            // and kill a healthy process at the end of some future turn.
+            // Clearing per-spawn scopes the flag to the generation that
+            // requested it, which is the only one it ever meant anything for.
+            inner.restart_when_idle = false;
             inner.spawn_generation += 1;
             let generation = inner.spawn_generation;
             let effects = match (attempted_resume_sid.clone(), resume_retry_payload) {
@@ -2786,7 +2829,6 @@ impl PersistentSubprocessController {
                     // can go back to false without waiting for process exit —
                     // see `send_message`'s matching `set_active_turn(true)`.
                     if is_result_frame {
-                        health_read.set_active_turn(false);
                         // A runtime-config change (model/effort/permission)
                         // arrived mid-turn and was deferred rather than
                         // killing this turn — see
@@ -2797,9 +2839,20 @@ impl PersistentSubprocessController {
                         // Not `poison_resume` and not a user Stop — the
                         // session id is retained, so the respawn `--resume`s
                         // the same conversation.
+                        // `set_active_turn(false)` happens under `inner` so it
+                        // serializes with `request_restart_when_idle`'s own
+                        // check — see that method for the interleaving this
+                        // closes. `restart_pending` is committed in the SAME
+                        // acquisition so no send can slip into `DeliverDirect`
+                        // between the decision and the kill.
                         let deferred_restart = {
                             let mut locked = inner_read.lock().unwrap();
-                            std::mem::replace(&mut locked.restart_when_idle, false)
+                            health_read.set_active_turn(false);
+                            let deferred = std::mem::replace(&mut locked.restart_when_idle, false);
+                            if deferred {
+                                locked.restart_pending = true;
+                            }
+                            deferred
                         };
                         if deferred_restart {
                             tracing::info!(
@@ -3930,10 +3983,23 @@ impl PersistentSubprocessController {
     /// happened to end). It's specifically an IN-FLIGHT turn that must not be
     /// interrupted.
     pub fn request_restart_when_idle(&self) -> bool {
+        // The turn-active read and the flag write happen under ONE acquisition
+        // of `inner`, and the turn-end consumer clears `active_turn` under that
+        // same lock — so the two serialize (codex P2 on PR #2858). Interleaved,
+        // this would otherwise observe an active turn, have the consumer run to
+        // completion (seeing `restart_when_idle` still false, so restarting
+        // nothing), and then set the flag — leaving it stuck until the NEXT
+        // turn ended, so the user's next prompt ran with the old config.
+        //
+        // Lock order is `inner` -> health monitor here and in the consumer;
+        // `TurnActivityTracker` never holds its own lock across an `inner`
+        // acquisition, so the order can't invert.
+        let mut inner = self.inner.lock().unwrap();
         if !self.health_monitor.is_active_turn() {
             return false;
         }
-        self.inner.lock().unwrap().restart_when_idle = true;
+        inner.restart_when_idle = true;
+        drop(inner);
         tracing::info!(
             block_id = %self.block_id,
             "runtime-config change arrived mid-turn — deferring the restart to the end of this turn \
@@ -4209,6 +4275,106 @@ mod send_input_tests {
 
         assert!(std::mem::replace(&mut c.inner.lock().unwrap().restart_when_idle, false));
         assert!(!c.inner.lock().unwrap().restart_when_idle);
+    }
+
+    /// reagent P1 on PR #2858: `restart_when_idle` is consumed at the
+    /// `is_result_frame` turn end, but a generation that dies abnormally
+    /// instead — user Stop/SIGINT, a crash, a permanently-failed turn
+    /// resolving via `ProcessExited` + `PublishDone` — never reaches that
+    /// branch. A leaked `true` would ride into an unrelated later generation
+    /// and kill a healthy process at the end of some future turn. Scoping the
+    /// flag per-spawn is what prevents that.
+    #[test]
+    fn a_deferred_restart_does_not_leak_into_the_next_generation() {
+        let c = controller();
+        c.health_monitor.set_active_turn(true);
+        assert!(c.request_restart_when_idle());
+        assert!(c.inner.lock().unwrap().restart_when_idle);
+
+        // The generation dies WITHOUT a result frame (crash / user stop), so
+        // nothing consumed the flag. The next spawn must start clean —
+        // emulating spawn_process's own clear, which happens in the same
+        // acquisition that bumps the generation.
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.restart_pending = false;
+            inner.restart_when_idle = false;
+            inner.spawn_generation += 1;
+        }
+        assert!(
+            !c.inner.lock().unwrap().restart_when_idle,
+            "a new generation must not inherit the previous one's deferred restart",
+        );
+    }
+
+    /// codex P1 on PR #2858: `stop_process` only sends on `kill_tx` — it
+    /// leaves `stdin_tx` live until the process actually exits. A follow-up
+    /// arriving in that window (and turn end is EXACTLY when the frontend
+    /// flushes queued follow-ups) would take `DeliverDirect` into a process
+    /// about to receive EOF: acknowledged, then lost.
+    #[test]
+    fn a_committed_restart_refuses_deliver_direct_even_with_a_live_stdin() {
+        let c = controller();
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            // Sanity: without the restart commit this is DeliverDirect — so
+            // the assertion below is about `restart_pending`, not about some
+            // other precondition failing.
+            assert!(inner.stdin_tx.is_some());
+        }
+        assert!(matches!(c.decide_send_action("m1", None), SendAction::DeliverDirect));
+
+        c.inner.lock().unwrap().restart_pending = true;
+        assert!(
+            !matches!(c.decide_send_action("m2", None), SendAction::DeliverDirect),
+            "a message must not be written into a process that is being killed",
+        );
+    }
+
+    /// …and the message is not dropped either — it queues for the replacement.
+    #[test]
+    fn a_message_arriving_during_the_quiesce_window_is_queued_not_lost() {
+        let c = controller();
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = Some(tx);
+            inner.restart_pending = true;
+        }
+        let action = c.decide_send_action("m1", None);
+        assert!(
+            matches!(action, SendAction::BecomeSpawner { .. } | SendAction::Queued),
+            "must fall through to the spawn/queue path, not vanish",
+        );
+        assert_eq!(
+            c.inner.lock().unwrap().pending_send_messages.len(),
+            1,
+            "the message must be retained for the replacement process",
+        );
+    }
+
+    /// The quiesce window ends when the replacement arrives — otherwise every
+    /// later send would keep queueing behind a flag nothing clears.
+    #[test]
+    fn the_quiesce_flag_does_not_outlive_the_restart() {
+        let c = controller();
+        c.inner.lock().unwrap().restart_pending = true;
+        // spawn_process clears it in the same acquisition that bumps the
+        // generation; emulate that contract here (spawning a real process in
+        // a unit test isn't practical).
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.restart_pending = false;
+            inner.spawn_generation += 1;
+        }
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+        assert!(
+            matches!(c.decide_send_action("m1", None), SendAction::DeliverDirect),
+            "once the replacement is up, ordinary direct delivery resumes",
+        );
     }
 
     /// Shorthand for a retry-batch entry with an explicit queue seq
@@ -6308,6 +6474,7 @@ mod resume_poison_tests {
             session_id: session_id.map(str::to_string),
             resume_poisoned: None,
             restart_when_idle: false,
+            restart_pending: false,
             resume: persistent_resume::ResumeState::default(),
             spawning_in_progress: false,
             pending_send_messages: VecDeque::new(),

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -285,6 +285,25 @@ struct PersistentInner {
     /// generated UUID) will never equal this one, so a stale poison value
     /// is permanently inert rather than something that needs clearing.
     resume_poisoned: Option<String>,
+    /// Set when a forced controller resync (a `/model`, `/effort` or
+    /// `/permission-mode` change — see `frontend/.../runtime-apply.ts`) lands
+    /// while a turn is in flight. The restart is DEFERRED to the end of that
+    /// turn instead of killing the process mid-turn.
+    ///
+    /// Killing it was the old behaviour and it silently destroyed the user's
+    /// in-flight message: `stop_process` records a `StopRequested`, which the
+    /// resume state machine treats as an explicit user stop and therefore
+    /// suppresses the retry; `remove_controller_entry_only` then discards the
+    /// controller (and its queue) outright; and the replacement controller
+    /// "spawns on first message", so nothing resumed. The message had already
+    /// been written to the dead process's stdin, so no queue entry survived to
+    /// replay. Net effect: the turn vanished with no response and no error —
+    /// the pane simply went quiet. Diagnosed live on AgentX, 2026-08-28.
+    ///
+    /// Deferring is correct rather than merely safer: model/effort flags are
+    /// baked in at spawn, so they could not have applied to the running turn
+    /// anyway. Waiting until it ends costs nothing and loses nothing.
+    restart_when_idle: bool,
     /// This spawn generation's stale-`--resume` retry decision, plus any
     /// held-back terminal error-result line — see
     /// `persistent_resume::ResumeState`'s own doc comment for the full
@@ -761,6 +780,7 @@ impl PersistentSubprocessController {
                 status_version: 0,
                 session_id: None,
                 resume_poisoned: None,
+                restart_when_idle: false,
                 resume: persistent_resume::ResumeState::default(),
                 spawning_in_progress: false,
                 pending_send_messages: VecDeque::new(),
@@ -2682,6 +2702,10 @@ impl PersistentSubprocessController {
         let event_bus_read = self.event_bus.clone();
         let filestore_read = self.filestore.clone();
         let health_read = Arc::clone(&self.health_monitor);
+        // Weak, like every other self-reference here: the reader task must not
+        // keep the controller alive. Used only for the deferred
+        // runtime-config restart at turn end (`request_restart_when_idle`).
+        let self_ref_read = self.self_ref.lock().unwrap().clone();
         let stdout_seq_read = Arc::clone(&self.stdout_seq);
         let session_id_field = config.session_id_field.clone();
         let my_generation_read = my_generation;
@@ -2763,6 +2787,29 @@ impl PersistentSubprocessController {
                     // see `send_message`'s matching `set_active_turn(true)`.
                     if is_result_frame {
                         health_read.set_active_turn(false);
+                        // A runtime-config change (model/effort/permission)
+                        // arrived mid-turn and was deferred rather than
+                        // killing this turn — see
+                        // `request_restart_when_idle`. The turn is over now,
+                        // so stop the process: the next message respawns it,
+                        // and `input.rs` rebuilds `cli_args` from block meta
+                        // at that point, so the new flags take effect then.
+                        // Not `poison_resume` and not a user Stop — the
+                        // session id is retained, so the respawn `--resume`s
+                        // the same conversation.
+                        let deferred_restart = {
+                            let mut locked = inner_read.lock().unwrap();
+                            std::mem::replace(&mut locked.restart_when_idle, false)
+                        };
+                        if deferred_restart {
+                            tracing::info!(
+                                block_id = %block_id_read,
+                                "turn ended — applying the deferred runtime-config restart"
+                            );
+                            if let Some(ctrl) = self_ref_read.as_ref().and_then(|w| w.upgrade()) {
+                                let _ = ctrl.stop_process(false);
+                            }
+                        }
                         // Publish the flip so the Swarm view's live
                         // ControllerStatus subscription reflects "turn
                         // ended" immediately instead of only on the next
@@ -3863,6 +3910,37 @@ impl PersistentSubprocessController {
     pub fn session_id(&self) -> Option<String> {
         self.inner.lock().unwrap().session_id.clone()
     }
+
+    /// Ask this controller to restart itself once the current turn ends,
+    /// instead of being torn down and replaced right now.
+    ///
+    /// Returns `true` when the restart was deferred (a turn is in flight, so
+    /// the caller must NOT replace the controller), `false` when the pane is
+    /// idle and an immediate replace is safe — the caller then proceeds
+    /// exactly as before.
+    ///
+    /// Called from `resync_controller`'s forced-replace path. See
+    /// [`PersistentInner::restart_when_idle`] for what the old
+    /// kill-immediately behaviour destroyed.
+    ///
+    /// Deliberately keyed on the health monitor's `is_active_turn` rather
+    /// than on `stdin_tx.is_some()`: a live process between turns is idle and
+    /// should be replaced immediately (that's the common `/model` case, and
+    /// deferring it would leave the change unapplied until the next turn
+    /// happened to end). It's specifically an IN-FLIGHT turn that must not be
+    /// interrupted.
+    pub fn request_restart_when_idle(&self) -> bool {
+        if !self.health_monitor.is_active_turn() {
+            return false;
+        }
+        self.inner.lock().unwrap().restart_when_idle = true;
+        tracing::info!(
+            block_id = %self.block_id,
+            "runtime-config change arrived mid-turn — deferring the restart to the end of this turn \
+             instead of killing the in-flight message"
+        );
+        true
+    }
 }
 
 impl Controller for PersistentSubprocessController {
@@ -4060,6 +4138,77 @@ mod send_input_tests {
             None,
             None,
         )
+    }
+
+    // ── Deferred runtime-config restart (AgentX, 2026-08-28) ────────────
+    //
+    // A `/model` change mid-turn used to kill the CLI with the user's message
+    // already on its stdin: the retry was suppressed (StopRequested reads as a
+    // user stop), the queue died with the discarded controller, and the
+    // replacement only "spawns on first message". The turn vanished silently.
+
+    /// Mid-turn: the caller must be told to leave the controller alone, and
+    /// the intent must be recorded for the turn-end hook to act on.
+    #[test]
+    fn request_restart_when_idle_defers_while_a_turn_is_in_flight() {
+        let c = controller();
+        c.health_monitor.set_active_turn(true);
+
+        assert!(
+            c.request_restart_when_idle(),
+            "a turn is in flight — the caller must NOT replace the controller",
+        );
+        assert!(
+            c.inner.lock().unwrap().restart_when_idle,
+            "the deferred restart must be recorded for the turn-end hook",
+        );
+    }
+
+    /// Idle: an immediate replace is safe and is what should happen — this is
+    /// the ordinary `/model` case. Deferring here would strand the change
+    /// until some future turn happened to end.
+    #[test]
+    fn request_restart_when_idle_does_not_defer_on_an_idle_pane() {
+        let c = controller();
+        c.health_monitor.set_active_turn(false);
+
+        assert!(
+            !c.request_restart_when_idle(),
+            "no turn in flight — the caller should replace the controller immediately",
+        );
+        assert!(
+            !c.inner.lock().unwrap().restart_when_idle,
+            "nothing to defer, so nothing should be recorded",
+        );
+    }
+
+    /// The flag is consumed, not merely read: the turn-end hook uses
+    /// `mem::replace`, so a single deferred change causes exactly one restart
+    /// rather than one at the end of every subsequent turn.
+    #[test]
+    fn the_deferred_restart_flag_is_consumed_exactly_once() {
+        let c = controller();
+        c.health_monitor.set_active_turn(true);
+        c.request_restart_when_idle();
+
+        let first = std::mem::replace(&mut c.inner.lock().unwrap().restart_when_idle, false);
+        let second = std::mem::replace(&mut c.inner.lock().unwrap().restart_when_idle, false);
+        assert!(first, "the first turn-end must see the deferred restart");
+        assert!(!second, "a later turn-end must not restart again");
+    }
+
+    /// Repeated changes mid-turn (a user flipping model then effort) collapse
+    /// into one restart, not a queue of them.
+    #[test]
+    fn repeated_mid_turn_changes_collapse_into_one_restart() {
+        let c = controller();
+        c.health_monitor.set_active_turn(true);
+        assert!(c.request_restart_when_idle());
+        assert!(c.request_restart_when_idle());
+        assert!(c.request_restart_when_idle());
+
+        assert!(std::mem::replace(&mut c.inner.lock().unwrap().restart_when_idle, false));
+        assert!(!c.inner.lock().unwrap().restart_when_idle);
     }
 
     /// Shorthand for a retry-batch entry with an explicit queue seq
@@ -6158,6 +6307,7 @@ mod resume_poison_tests {
             status_version: 0,
             session_id: session_id.map(str::to_string),
             resume_poisoned: None,
+            restart_when_idle: false,
             resume: persistent_resume::ResumeState::default(),
             spawning_in_progress: false,
             pending_send_messages: VecDeque::new(),

--- a/frontend/app/view/agent/runtime-apply.ts
+++ b/frontend/app/view/agent/runtime-apply.ts
@@ -10,10 +10,23 @@
  * its own, so we rebuild cmd:args AND forcerestart — killing the idle process
  * so the next send_message spawns with the new flags.
  *
- * forcerestart is safe when the agent is idle (STATUS_DONE). If triggered
- * mid-turn the streaming turn is interrupted; the partial response stays in the
- * blockfile but the pane recovers via TurnReset (slash path) or has no
- * TurnStart outstanding (UI dropdown path).
+ * forcerestart is safe when the agent is idle (STATUS_DONE), and — since
+ * 2026-08-30 — safe mid-turn too, because srv defers it.
+ *
+ * This comment previously claimed that a mid-turn forcerestart was survivable
+ * because "the pane recovers via TurnReset (slash path) or has no TurnStart
+ * outstanding (UI dropdown path)". Neither was true: `commands/global/runtime.ts`
+ * contains no TurnReset, and "no TurnStart outstanding" only holds when the pane
+ * is idle — the case the sentence had already excluded. Both paths fell through
+ * to nothing, and the kill destroyed the user's in-flight message outright (the
+ * turn simply went silent — diagnosed live on AgentX, 2026-08-28).
+ *
+ * The fix lives in srv rather than here, so it covers every caller of this
+ * function and survives a pane close: `resync_controller`'s forced-replace path
+ * asks a persistent controller to restart itself at the end of the current turn
+ * (`PersistentSubprocessController::request_restart_when_idle`) instead of
+ * tearing it down mid-flight. Nothing is lost by waiting — these flags are baked
+ * in at spawn, so they could never have applied to the turn already running.
  *
  * Shared by the `/model`·`/effort`·`/mode` slash commands
  * (`commands/global/runtime.ts`) AND the GUI control-bar dropdowns


### PR DESCRIPTION
## The bug

Changing the model while an agent is working makes the pane go silent — the message you sent gets no response, no error, and nothing respawns. Diagnosed live on AgentX (2026-08-28), block `66844b93`:

```
17:30:08  AgentInput accepted        -> turn_active = true
17:30:21  ControllerResync force     -> "persistent process kill requested"
17:30:21  process exited (-1)
          ...nothing. No response, no error, no respawn.
17:31:41  user gives up and types again
```

## Why the turn vanished

Three mechanisms combined, each individually reasonable:

1. **`stop_process` records a `StopRequested`**, which `persistent_resume` reads as an explicit *user* stop and therefore deliberately suppresses the retry. Correct for a real stop; wrong here — this was a replace, not a stop.
2. **`remove_controller_entry_only` discards the old controller**, and its `pending_send_messages` queue with it.
3. **The replacement controller's `start()` does nothing** but log *"spawns on first message"* — so it sits waiting for input that already happened.

And the message had already been written to the dead process's stdin, so there was no queue entry left to replay even in principle.

## The fix

`resync_controller`'s forced-replace path now asks a persistent controller to restart itself **at the end of the current turn** rather than tearing it down mid-flight. The turn-end hook is the stdout reader's `is_result_frame` branch — documented in that file as the only place `turn_active` returns to false between turns — which stops the process so the next message respawns it, picking up the new `cli_args` that `input.rs` rebuilds from block meta at spawn.

**Nothing is lost by waiting.** Model/effort flags are baked in at spawn, so they could never have applied to the turn already running.

Two deliberate narrowings:
- **`force` only.** A controller-*type* change is a genuine replacement that has to happen immediately.
- **Keyed on `is_active_turn`, not `stdin_tx.is_some()`.** A live process *between* turns is idle and should still be replaced right away — that's the common `/model` case, and deferring it would strand the change until some future turn happened to end.

## Correcting my own earlier proposal

This is **not** the fix I first suggested. I proposed simply skipping the resync while busy, reasoning that `useAgentCommands` rewrites `cmd:args` before every send so the change would apply on the next turn anyway.

That was wrong. `decide_send_action` routes to `DeliverDirect` whenever `stdin_tx` is live — it writes to the already-running process and ignores the config entirely. Skipping would have turned the bug from "loses your turn" into "silently does nothing until the process happens to die," which is arguably worse.

## Also corrected

`runtime-apply.ts`'s comment claimed a mid-turn forcerestart was survivable because *"the pane recovers via TurnReset (slash path) or has no TurnStart outstanding (UI dropdown path)"*. Neither held — there is no `TurnReset` anywhere in `commands/global/runtime.ts`, and "no TurnStart outstanding" is only true when the pane is idle, the case that sentence had already excluded. Both paths fell through to nothing, which is why this survived unnoticed.

## Testing

4 tests: defers while a turn is in flight, replaces immediately when idle, consumes the flag exactly once (so one deferred change causes one restart, not one per subsequent turn), and repeated mid-turn changes collapse into a single restart.

`cargo test -p agentmux-srv` — **2849 passed**, 0 failed. `npx tsc --noEmit` clean.

**Not verified in a live pane.** The mechanism is unit-tested and the diagnosis came from a real incident log, but I haven't reproduced the fix end-to-end by changing a model mid-turn in a running instance.

<!-- agentmux:agent_id=agent2 -->