### PR TITLE
fix(srv): run output.idx scans on the blocking pool

### DIFF
--- a/.changesets/1788155951-fix-srv-run-output-idx-scans-on-the-blocking-pool-atz4.md
+++ b/.changesets/1788155951-fix-srv-run-output-idx-scans-on-the-blocking-pool-atz4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): run output.idx scans on the blocking pool

--- a/agentmux-srv/src/server/app_api/blockfile.rs
+++ b/agentmux-srv/src/server/app_api/blockfile.rs
@@ -35,7 +35,25 @@ fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 if let Some((gfs, zone)) =
                     global_output_source(&filestore, &global_store, &wstore, &cmd.block_id, &cmd.filename)
                 {
-                    if let Some(count) = global_zone_line_count(&gfs, &zone) {
+                    // Blocking pool (#2841): this extends or, when it can't
+                    // anchor on the existing index, fully rebuilds `output.idx`
+                    // — a streaming scan proportional to transcript size.
+                    let count = match tokio::task::spawn_blocking(move || {
+                        global_zone_line_count(&gfs, &zone)
+                    })
+                    .await
+                    {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::warn!(
+                                block_id = %cmd.block_id,
+                                error = %e,
+                                "blockfile:line_count: global zone count task failed; falling back"
+                            );
+                            None
+                        }
+                    };
+                    if let Some(count) = count {
                         return Ok(Some(
                             serde_json::to_value(&BlockfileLineCountResult { count }).unwrap(),
                         ));
@@ -131,19 +149,33 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // index of every non-blank line in `output`. It lets us seek directly
                 // to the requested line range instead of loading the whole file.
                 //
-                // The index is a pure cache of `output` with NO incremental mutation:
-                // its 8-byte header records the `output` size it was built for. If that
-                // equals `output`'s current size the index is fresh; otherwise we rebuild
-                // it from a single streaming scan (rebuild_output_idx). Because the index
-                // is always derived from the current `output` in one shot, it can never
-                // desync, mis-handle chunk-split lines, or miscount blank lines — the
-                // failure modes an incremental index would have.
+                // The index is a pure cache of `output`: its 8-byte header records
+                // the `output` size it was built for. If that equals `output`'s
+                // current size the index is fresh; otherwise THIS path rebuilds it
+                // from a single streaming scan (rebuild_output_idx), so the result
+                // is always derived from the current `output` in one shot and can
+                // never desync, mis-handle chunk-split lines, or miscount blanks.
+                //
+                // Note this describes the read_range path only. The line_count path
+                // does mutate the index incrementally (`extend_output_idx`, #2838),
+                // scanning just the appended bytes and anchoring on the start of the
+                // last indexed line so a straddling partial line isn't double-counted.
+                // Both produce an exact count; they differ only in cost.
                 //
                 // Gated to non-circular files: circular `output` (terminal ring buffers)
                 // drops early bytes, so absolute byte offsets wouldn't map cleanly.
                 use crate::backend::blockcontroller::shell::{rebuild_output_idx, OUTPUT_IDX_HEADER_LEN};
                 if cmd.filename == "output" {
-                    let idx_result: Option<BlockfileReadRangeResult> = (|| {
+                    // Runs on the blocking pool (#2841). A full rebuild is a
+                    // streaming scan of `output`, which reaches hundreds of MB
+                    // on a long-lived agent, and every index/output read below
+                    // is blocking file I/O as well — none of it may occupy a
+                    // Tokio runtime worker. The closure body is unchanged; only
+                    // where it runs is.
+                    let idx_result: Option<BlockfileReadRangeResult> = {
+                        let filestore = filestore.clone();
+                        let read_block = read_block.clone();
+                        let compute = move || -> Option<BlockfileReadRangeResult> {
                         let out_stat = filestore.stat(&read_block, "output").ok()??;
                         if out_stat.opts.circular {
                             return None; // circular files: fall back to slow path
@@ -261,7 +293,22 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         })();
 
                         Some(BlockfileReadRangeResult { lines, total: total_lines, stamps })
-                    })();
+                        };
+                        // A panic in the scan must degrade to the slow path
+                        // below, not fail the read — but it is logged rather
+                        // than silently swallowed.
+                        match tokio::task::spawn_blocking(compute).await {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!(
+                                    block_id = %cmd.block_id,
+                                    error = %e,
+                                    "blockfile:read_range: output.idx task failed; falling back"
+                                );
+                                None
+                            }
+                        }
+                    };
                     if let Some(result) = idx_result {
                         tracing::debug!(
                             block_id = %cmd.block_id,


### PR DESCRIPTION
Closes #2841.

`rebuild_output_idx` is a streaming scan of `output`, which reaches hundreds of MB on a long-lived agent. It ran synchronously on a Tokio worker from two async handlers, so one rebuild could occupy a runtime worker for seconds.

#2838 made the *common* path cheap (a stale index is extended by scanning only appended bytes) but did not change **where** the work runs. The remaining full-rebuild cases — first cross-channel open, corrupt/truncated index, `output` shrinking on rotation — are exactly the ones where the file is largest and the scan longest.

## Both call sites offloaded

- **`blockfile:line_count`** wraps `global_zone_line_count`, which extends or fully rebuilds the index.
- **`blockfile:read_range`** wraps its entire `output.idx` fast-path closure — that covers the rebuild *and* the surrounding index/output reads, which are blocking file I/O too. The closure body is byte-identical; only where it runs changed.

`read_range` was not named in the issue, but it calls `rebuild_output_idx` on the same runtime and is the path that runs on pane open with the largest transcripts, so leaving it would have fixed the smaller half.

## Why nothing became `async`

The issue anticipated a signature change up the chain. It isn't needed: `global_zone_line_count` stays a sync fn — so its six existing tests keep working unchanged — and the offload happens at the call site instead.

A `JoinError` degrades to the pre-existing slow path rather than failing the request, and is logged rather than silently swallowed.

## Stale comment

`read_range`'s "the index is a pure cache of `output` with **NO incremental mutation**" was true when written and #2838 made it false — `line_count` now extends the index in place. Corrected, scoped to which path each statement describes.

## Verification

- `cargo check -p agentmux-srv` — clean (no new warnings)
- `cargo test -p agentmux-srv output_idx` — 4 passed
- `cargo test -p agentmux-srv zone_line_count` — 6 passed

Behaviour is unchanged by design: this moves work between threads, it does not alter what the index or the counts contain. The exactness guarantee from #2838's codex P1 (`useHistoryPagination` derives `offset = total - PAGE_SIZE`, so an undercount silently drops newest history) is untouched.

<!-- agentmux:agent_id=agenta-07017 -->