### PR TITLE
docs(claude): the dev-agent exit-200 signature is ambiguous, not Gap B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,14 +64,38 @@ On Windows, `task dev` builds a production-parallel layout in `dist/cef-dev/` (l
 
 This `.cmd` wrapper prepends `Git\bin` to PATH (fixing Gap B) and calls `task.exe dev` by explicit extension (fixing Gap A). On macOS/Linux `task dev` works directly — no wrapper needed.
 
-**Diagnosing failed shells:** Check `shell.exit` events in the server log:
+**Always redirect the wrapper's output to a file and read it** — `ShellStatus`
+returns only `running`/`exit_code`/`line_count`, and the signatures below are
+NOT sufficient to identify the cause on their own:
+
+```json
+{ "cmd": "C:\\<repo>\\scripts\\dev-agent.cmd TITLE=my-branch > C:\\<repo>\\devrun.log 2>&1" }
+```
+
+**`TITLE=` must not contain spaces.** Quotes do not survive the
+MCP Shell → `cmd /C` → `.cmd` → `task` chain, so `TITLE="zoom fix PR 1234"`
+reaches go-task as separate arguments and it tries to run `zoom` as a task.
+
+**Signatures from `shell.exit` events in the server log** — treat as hints, not
+diagnoses:
 ```bash
 grep "shell\." ~/.agentmux/logs/agentmuxsrv-*.log.$(date +%Y-%m-%d)
 # line_count:2  + exit:1   + <100ms  → Gap A (bash cmd not found in MSYS2)
-# line_count:53 + exit:200 + <500ms  → Gap B (bash.exe not in cmd.exe PATH)
+# line_count:53 + exit:200 + <500ms  → AMBIGUOUS, see below
 ```
 
-See `docs/retro/retro-task-dev-agent-shell-path-2026-06-27.md` for full analysis.
+`line_count:53 + exit:200` was previously documented as meaning Gap B
+(`bash.exe` not in cmd.exe PATH). It has (at least) **two** causes: an invalid
+argument makes go-task print its full task list and exit 200, which is also ~53
+lines. The two are indistinguishable by signature — the real error is on the
+**last line** of the output, which is why the redirect above is mandatory:
+
+```
+task: Task "PR" does not exist        ← bad argument, not a PATH problem
+```
+
+See `docs/retro/retro-task-dev-agent-shell-path-2026-06-27.md` for the original
+Gap A/B analysis.
 
 #### Launching `task package` from an agent / MCP Shell (Windows)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,11 @@ On Windows, `task dev` builds a production-parallel layout in `dist/cef-dev/` (l
 **Use `scripts\dev-agent.cmd` instead of `task dev` directly:**
 
 ```json
-{ "cmd": "C:\\<repo>\\scripts\\dev-agent.cmd TITLE=\"zoom-fix: PR #1234\"" }
+{ "cmd": "C:\\<repo>\\scripts\\dev-agent.cmd TITLE=zoom-fix-pr1234 > C:\\<repo>\\devrun.log 2>&1" }
 ```
+
+Note the title has **no spaces** and the output is redirected — both are
+required, for the reasons under "Diagnosing failed shells" below.
 
 This `.cmd` wrapper prepends `Git\bin` to PATH (fixing Gap B) and calls `task.exe dev` by explicit extension (fixing Gap A). On macOS/Linux `task dev` works directly — no wrapper needed.
 


### PR DESCRIPTION
Hit this first-hand today.

`scripts/dev-agent.cmd TITLE="drag-ghost PR 2847"` exited **200 with 53 lines** — which `CLAUDE.md`'s table maps to *"Gap B (bash.exe not in cmd.exe PATH)"*. It wasn't Gap B. The quotes don't survive the `mcp__agentmux__Shell` → `cmd /C` → `.cmd` → `task` chain, so go-task received `PR` as a task name, printed its **full task list**, and exited 200. That listing is coincidentally ~53 lines.

```
task: Task "PR" does not exist
```

The signatures are therefore indistinguishable, and the entry pointed me at a PATH problem that couldn't exist — `dev-agent.cmd` is the thing that *fixes* Gap B. I burned a diagnostic pass on it.

## Changes

- Mark `line_count:53 + exit:200` **ambiguous**, with the actual discriminator: the last line of the output.
- Promote output redirection from an example to a **requirement** — `ShellStatus` returns only `running`/`exit_code`/`line_count`, so without a redirect there is literally nothing to read. (This is already stated in the `task package` section; the `task dev` section didn't say it.)
- Document that `TITLE=` must not contain spaces, with the reason.

Docs only. The original Gap A/B retro link is kept.

<!-- agentmux:agent_id=agenta-07017 -->