### PR TITLE
feat(swarm): show each agent's long-running tool calls as a row bucket

### DIFF
--- a/.changesets/1788173554-feat-swarm-show-each-agent-s-long-running-tool-calls-as-a-ro-tcik.md
+++ b/.changesets/1788173554-feat-swarm-show-each-agent-s-long-running-tool-calls-as-a-ro-tcik.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): show each agent's long-running tool calls as a row bucket

--- a/frontend/app/view/swarm/swarm-agent-row.render.test.tsx
+++ b/frontend/app/view/swarm/swarm-agent-row.render.test.tsx
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The PR #2862 regression, pinned end-to-end through the actual component.
+ *
+ * Both reviewers independently found that an agent whose ONLY activity was a
+ * promoted Bash/sleep call rendered nothing: the long-running rows weren't in
+ * `totalRows`, so `hasChildren()` was false, so there was no expand affordance,
+ * so the collapse gate never mounted the bucket. `agentChildRowCount`'s unit
+ * tests cover the sum; these cover the wiring the sum feeds.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { DockNodeStatusCommand: () => Promise.resolve() },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { __resetAllSlots, dispatch, registerPane } from "@/app/store/agent-document-store";
+import { AgentRow } from "./swarm-view";
+import type { AgentTreeNode, SwarmViewModel } from "./swarm-model";
+import type { DocumentNode } from "@/app/view/agent/types";
+
+afterEach(() => {
+    cleanup();
+    __resetAllSlots();
+});
+
+const BLOCK = "b1";
+
+/** A pane whose only activity is a bare sleep — promoted immediately. */
+function seedSleepingPane() {
+    registerPane(BLOCK, () => {});
+    const node: DocumentNode = {
+        type: "tool",
+        id: "t1",
+        tool: "Bash",
+        toolName: "Bash",
+        status: "running",
+        timestamp: Date.now(),
+        params: { command: "sleep 300" },
+        collapsed: false,
+        summary: "",
+    } as DocumentNode;
+    dispatch(BLOCK, { type: "StreamFlush", newNodes: [node], updatedNodes: [] }, "system");
+}
+
+function treeNode(): AgentTreeNode {
+    return {
+        blockId: BLOCK,
+        agentName: "AgentX",
+        agentProvider: "claude",
+        activitySummary: null,
+        contextTokens: null,
+        agentStatus: "running",
+        agentToolRows: [],
+        workflowRows: [],
+        shellRows: [],
+        cronRows: [],
+    } as AgentTreeNode;
+}
+
+function modelStub(collapsed: boolean): SwarmViewModel {
+    return {
+        isAgentCollapsed: () => collapsed,
+        toggleAgentCollapsed: () => {},
+        isSelected: () => false,
+        toggleSelected: () => {},
+    } as unknown as SwarmViewModel;
+}
+
+function renderRow(collapsed: boolean) {
+    return render(() => (
+        <AgentRow node={treeNode()} focusedBlockId={() => null} model={modelStub(collapsed)} />
+    ));
+}
+
+describe("AgentRow — an agent whose only activity is a long-running tool call", () => {
+    it("shows the collapsed count, so the work is discoverable without expanding", () => {
+        seedSleepingPane();
+        const { container } = renderRow(true);
+        expect(container.querySelector(".swarm-agent-collapsed-count")?.textContent).toBe("1");
+    });
+
+    it("renders the bucket and the row once expanded", () => {
+        seedSleepingPane();
+        const { container } = renderRow(false);
+        expect(container.querySelector(".swarm-bucket--longrunning")).not.toBeNull();
+        expect(container.querySelector(".swarm-longrunning-title")?.textContent).toBe("sleep 300");
+    });
+
+    it("shows the countdown, since a whole-command sleep knows its remaining time", () => {
+        seedSleepingPane();
+        const { container } = renderRow(false);
+        expect(container.querySelector(".swarm-longrunning-remaining")?.textContent).toMatch(/^~\d+s left$/);
+    });
+
+    it("renders no bucket for an agent with nothing running", () => {
+        registerPane(BLOCK, () => {});
+        const { container } = renderRow(false);
+        expect(container.querySelector(".swarm-bucket--longrunning")).toBeNull();
+    });
+});

--- a/frontend/app/view/swarm/swarm-child-count.test.ts
+++ b/frontend/app/view/swarm/swarm-child-count.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `agentChildRowCount` drives the expand chevron, the collapsed-count badge and
+ * `hasChildren` — so a bucket missing from the sum is invisible in the UI, not
+ * merely miscounted. Both reviewers independently caught exactly that on
+ * PR #2862 (the long-running bucket omitted). These tests enumerate every
+ * bucket so the next omission fails here instead of shipping.
+ */
+
+import { describe, expect, it } from "vitest";
+import { agentChildRowCount } from "./swarm-view";
+import type { AgentTreeNode } from "./swarm-model";
+
+function node(over: Partial<AgentTreeNode> = {}): AgentTreeNode {
+    return {
+        blockId: "b1",
+        agentName: "AgentX",
+        agentProvider: "claude",
+        activitySummary: null,
+        contextTokens: null,
+        agentStatus: "running",
+        agentToolRows: [],
+        workflowRows: [],
+        shellRows: [],
+        cronRows: [],
+        ...over,
+    } as AgentTreeNode;
+}
+
+const one = [{} as never];
+
+describe("agentChildRowCount", () => {
+    it("is zero for an agent with nothing running", () => {
+        expect(agentChildRowCount(node(), 0)).toBe(0);
+    });
+
+    /** The PR #2862 bug: an agent whose ONLY activity is a promoted Bash/sleep
+     *  call must still report children, or it renders no chevron, stays
+     *  collapsed, and the bucket never mounts. */
+    it("counts a long-running tool call even when every other bucket is empty", () => {
+        expect(agentChildRowCount(node(), 1)).toBe(1);
+        expect(agentChildRowCount(node(), 3)).toBe(3);
+    });
+
+    it.each([
+        ["agentToolRows", { agentToolRows: one }],
+        ["workflowRows", { workflowRows: one }],
+        ["shellRows", { shellRows: one }],
+        ["cronRows", { cronRows: one }],
+    ])("counts %s", (_label, over) => {
+        expect(agentChildRowCount(node(over as Partial<AgentTreeNode>), 0)).toBe(1);
+    });
+
+    it("sums every bucket together", () => {
+        const n = node({ agentToolRows: one, workflowRows: one, shellRows: one, cronRows: one });
+        expect(agentChildRowCount(n, 2)).toBe(6);
+    });
+});

--- a/frontend/app/view/swarm/swarm-longrunning.test.ts
+++ b/frontend/app/view/swarm/swarm-longrunning.test.ts
@@ -1,0 +1,97 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `HistoryLoaded` fires a fire-and-forget `DockNodeStatusCommand` push for
+// `muxspect dock`'s snapshot cache; there is no RPC client in a unit test.
+// Stubbed rather than worked around, since this file is about the selector.
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { DockNodeStatusCommand: () => Promise.resolve() },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+import { __resetAllSlots, dispatch, registerPane } from "@/app/store/agent-document-store";
+import { TOOL_PROMOTION_MS } from "@/app/view/agent/activity/tool-adapter";
+import { longRunningToolRows } from "./swarm-longrunning";
+import type { DocumentNode } from "@/app/view/agent/types";
+
+afterEach(__resetAllSlots);
+
+const START = 1_000_000;
+
+function bash(over: Partial<DocumentNode> = {}): DocumentNode {
+    return {
+        type: "tool",
+        id: "t1",
+        tool: "Bash",
+        toolName: "Bash",
+        status: "running",
+        timestamp: START,
+        params: { command: "cargo test -p agentmux-srv" },
+        collapsed: false,
+        summary: "",
+        ...over,
+    } as DocumentNode;
+}
+
+/** Register a pane and seed its document with `nodes`. */
+function paneWith(blockId: string, nodes: DocumentNode[]) {
+    registerPane(blockId, () => {});
+    dispatch(blockId, { type: "StreamFlush", newNodes: nodes, updatedNodes: [] }, "system");
+}
+
+describe("longRunningToolRows", () => {
+    it("returns nothing for an unmounted pane — zero, never a crash", () => {
+        expect(longRunningToolRows("never-registered", START)).toEqual([]);
+        expect(longRunningToolRows(null, START)).toEqual([]);
+    });
+
+    it("omits a Bash call that hasn't crossed the promotion threshold", () => {
+        paneWith("b1", [bash()]);
+        expect(longRunningToolRows("b1", START + TOOL_PROMOTION_MS - 1)).toEqual([]);
+    });
+
+    it("includes one past the threshold", () => {
+        paneWith("b1", [bash()]);
+        const rows = longRunningToolRows("b1", START + TOOL_PROMOTION_MS);
+        expect(rows.map((r) => r.id)).toEqual(["t1"]);
+        expect(rows[0].title).toBe("cargo test -p agentmux-srv");
+    });
+
+    /** The case this bucket exists for: a bare sleep is promoted immediately by
+     *  `sleep-detect.ts`, so Swarm must show it at once too — not 30s later. */
+    it("includes a whole-command sleep immediately, with its countdown data", () => {
+        paneWith("b1", [bash({ params: { command: "sleep 300" } })]);
+        const rows = longRunningToolRows("b1", START);
+        expect(rows.map((r) => r.id)).toEqual(["t1"]);
+        expect(rows[0].sleepMs).toBe(300_000);
+    });
+
+    it("carries no sleepMs for a call whose remaining time isn't knowable", () => {
+        paneWith("b1", [bash()]);
+        expect(longRunningToolRows("b1", START + TOOL_PROMOTION_MS)[0].sleepMs).toBeUndefined();
+    });
+
+    /** Swarm answers "what is this agent on RIGHT NOW". A finished call lingers
+     *  in toolActivities through the dock's retention window so its dock row can
+     *  resolve in place — but it is not current work. */
+    it("excludes a finished call still inside the dock's retention window", () => {
+        paneWith("b1", [bash({ status: "success", duration: 45 })]);
+        expect(longRunningToolRows("b1", START + 46_000)).toEqual([]);
+    });
+
+    it("orders newest-first, matching the other Swarm buckets", () => {
+        paneWith("b1", [
+            bash({ id: "old", timestamp: START, params: { command: "sleep 300" } }),
+            bash({ id: "new", timestamp: START + 5_000, params: { command: "sleep 300" } }),
+        ]);
+        expect(longRunningToolRows("b1", START + 6_000).map((r) => r.id)).toEqual(["new", "old"]);
+    });
+
+    it("keeps panes independent — one agent's work never shows on another's row", () => {
+        paneWith("b1", [bash({ id: "a", params: { command: "sleep 300" } })]);
+        paneWith("b2", [bash({ id: "b", params: { command: "sleep 300" } })]);
+        expect(longRunningToolRows("b1", START).map((r) => r.id)).toEqual(["a"]);
+        expect(longRunningToolRows("b2", START).map((r) => r.id)).toEqual(["b"]);
+    });
+});

--- a/frontend/app/view/swarm/swarm-longrunning.ts
+++ b/frontend/app/view/swarm/swarm-longrunning.ts
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Long-running tool activity, per agent, for the Swarm pane.
+ *
+ * Swarm already answers "what is this agent doing" for the things srv owns —
+ * subagent dispatches, Shell-MCP shells, crons. Ordinary Bash tool calls are
+ * the gap: a `sleep 300` or a 4-minute build shows in that pane's own Activity
+ * Dock and nowhere else, so the fleet view can't answer "which agents are
+ * sitting on a wait right now" without opening each one.
+ *
+ * This is step 4 of `REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md`
+ * §3 — "feed the same signal to Swarm ... same data, same adapter output, new
+ * renderer".
+ *
+ * ## Why this reads the document store directly
+ *
+ * The other three buckets come from srv because shells, crons and subagents are
+ * srv-owned objects. A Bash tool call is not: it exists only in the CLI's
+ * transcript stream, and the classification of "long-running" lives entirely in
+ * `tool-adapter.ts` (srv sees raw `ToolNode` statuses via `DockNodeStatusCommand`
+ * but explicitly does NOT model the dock's promotion rules — see
+ * `dock_snapshot.rs`'s own doc comment saying that reclassification "happens
+ * entirely client-side ... which the server has no visibility into").
+ *
+ * Rather than duplicate that classifier in Rust, this reuses it: `slots` in
+ * `agent-document-store.ts` is a module-level map keyed by block id, and Swarm
+ * runs in the same renderer process, so `toolActivities` can be applied to any
+ * pane's nodes directly. One classifier, every consumer reuses it — the same
+ * discipline `isAcceptedBackgroundLaunch` established.
+ *
+ * ## Known limitation, stated rather than hidden
+ *
+ * `snapshot()` only returns state for a pane that is currently REGISTERED —
+ * `registerPane` on mount, `unregisterPane` on unmount. An agent whose pane
+ * isn't mounted contributes nothing here, and reads as zero rather than
+ * unknown. That's the same population that has a live dock at all, so the two
+ * views agree; it is NOT full fleet coverage of unopened panes. Closing that
+ * would need srv to model the promotion rules, which is a much larger change
+ * than this bucket justifies.
+ */
+
+import { snapshot } from "@/app/store/agent-document-store";
+import { toolActivities } from "@/app/view/agent/activity/tool-adapter";
+import type { PinnedActivity } from "@/app/view/agent/activity/types";
+
+/** One long-running tool call, as Swarm needs to render it. */
+export interface LongRunningToolRow {
+    id: string;
+    /** The command text (dock row title), e.g. `sleep 300`. */
+    title: string;
+    startedAt: number;
+    /** Set only for a whole-command sleep — enables a real countdown. */
+    sleepMs?: number;
+}
+
+/**
+ * The RUNNING long-running tool calls attached to `blockId`, newest first —
+ * matching the other buckets' ordering convention.
+ *
+ * Running only: a finished call lingers in `toolActivities` through the dock's
+ * retention window so its row can resolve in place, but Swarm is answering
+ * "what is this agent on right now", where a completed call is noise.
+ *
+ * Returns `[]` for an unmounted pane (see the module doc's limitation note) and
+ * for a block id that never existed, so callers need no special-casing.
+ */
+export function longRunningToolRows(blockId: string | null, now: number): LongRunningToolRow[] {
+    if (!blockId) return [];
+    const state = snapshot(blockId);
+    if (!state) return [];
+    return toolActivities(state.nodes, now)
+        .filter((a: PinnedActivity) => a.status === "running")
+        .map((a) => ({
+            id: a.id,
+            title: a.title,
+            startedAt: a.startedAt,
+            ...(a.sleepMs != null ? { sleepMs: a.sleepMs } : {}),
+        }))
+        .sort((a, b) => b.startedAt - a.startedAt);
+}

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -253,6 +253,18 @@
     &--cron .swarm-bucket-label {
         color: var(--info-color);
     }
+    // Long-running tool calls (step 4 of
+    // REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md §3).
+    // Deliberately NOT a fifth saturated hue: the four above are all declared,
+    // addressable objects (a dispatch, a workflow, a shell, a cron), whereas
+    // this bucket is INFERRED from a tool call still running past a threshold.
+    // A quieter label carries that distinction, and grey still reads apart at a
+    // glance from blue/amber/green/purple. The alternative — minting a fifth
+    // theme token, as `--info-color` was minted for cron — would assert a
+    // semantic peer relationship this bucket doesn't have.
+    &--longrunning .swarm-bucket-label {
+        color: var(--secondary-text-color);
+    }
 }
 
 .swarm-bucket-header {

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -1039,3 +1039,41 @@
     }
 }
 
+
+// ── Long-running tool calls bucket ───────────────────────────────────────────
+// Step 4 of REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md §3.
+// Deliberately the same row geometry as .swarm-shell-row: both are flat,
+// mechanical, read-only rows, and a reader scanning an agent's children should
+// not have to re-orient between them.
+.swarm-longrunning-row {
+    display: flex;
+    align-items: center;
+    height: 30px;
+    padding: 0 6px 0 30px;
+    gap: 8px;
+    user-select: none;
+}
+
+.swarm-longrunning-title {
+    flex: 1;
+    font-size: 12px;
+    font-family: var(--monospace-font, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--main-text-color);
+}
+
+.swarm-longrunning-elapsed {
+    flex-shrink: 0;
+    font-size: 10px;
+    color: var(--secondary-text-color);
+}
+
+// Only present for a whole-command sleep — the one case where the remaining
+// time is known rather than guessed. Dimmer than the elapsed clock beside it.
+.swarm-longrunning-remaining {
+    flex-shrink: 0;
+    font-size: 10px;
+    color: var(--tertiary-text-color, rgba(255, 255, 255, 0.35));
+}

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -228,9 +228,22 @@ function AgentRow({
         phaseToDisplayStatus(node.blockId, node.agentStatus)
     );
     const collapsed = createMemo(() => model.isAgentCollapsed(node.blockId));
-    const totalRows = createMemo(
-        () => node.agentToolRows.length + node.workflowRows.length + node.shellRows.length + node.cronRows.length
-    );
+    // Computed HERE, not inside LongRunningBucket, so it can feed `totalRows`
+    // below (reagent P1 on PR #2862). Left in the bucket, an agent whose only
+    // active work was a promoted Bash/sleep call had `hasChildren() === false`
+    // -> no expand chevron -> collapsed by default -> the children container's
+    // `Show when={!collapsed()}` never rendered the bucket at all. That is the
+    // single most common case for this feature, so the bucket was invisible
+    // exactly when it mattered.
+    //
+    // Ticks in the view rather than the model because promotion is time-based:
+    // the list changes with the clock, not only with backend events.
+    const tick = useTick(1000);
+    const longRunningRows = createMemo(() => {
+        tick();
+        return longRunningToolRows(node.blockId, Date.now());
+    });
+    const totalRows = createMemo(() => agentChildRowCount(node, longRunningRows().length));
     const hasChildren = createMemo(() => totalRows() > 0);
 
     const [summaryFlash, setSummaryFlash] = createSignal(false);
@@ -336,7 +349,7 @@ function AgentRow({
                     <WorkflowBucket rows={node.workflowRows} model={model} />
                     <ShellBucket rows={node.shellRows} />
                     <CronBucket rows={node.cronRows} />
-                    <LongRunningBucket blockId={node.blockId} />
+                    <LongRunningBucket rows={longRunningRows()} />
                 </div>
             </Show>
         </div>
@@ -448,20 +461,40 @@ function ShellRow({ shell }: { shell: ActiveShell }): JSX.Element {
 // (TOOL_PROMOTION_MS), so the list changes with the clock and not only with
 // backend events. Keeping the clock dependency in the view leaves
 // `buildTree`'s memo free of it.
-function LongRunningBucket({ blockId }: { blockId: string | null }): JSX.Element {
-    const tick = useTick(1000);
-    const rows = createMemo(() => {
-        tick();
-        return longRunningToolRows(blockId, Date.now());
-    });
+/**
+ * Total child rows under one agent — drives the expand chevron, the
+ * collapsed-count badge, and `hasChildren`.
+ *
+ * Exported and kept as a plain sum so every bucket's contribution is asserted
+ * in one place. BOTH reviewers independently caught the same omission on
+ * PR #2862: the long-running bucket wasn't in this sum, so an agent whose only
+ * activity was a promoted Bash/sleep call reported `hasChildren() === false` —
+ * no chevron, collapsed by default, and the children container's
+ * `Show when={!collapsed()}` meant the bucket never rendered at all. The
+ * feature was invisible in precisely its primary case.
+ *
+ * A future sixth bucket must be added here too; the test file enumerates each
+ * one so forgetting is a failing test rather than an invisible feature.
+ */
+export function agentChildRowCount(node: AgentTreeNode, longRunningCount: number): number {
     return (
-        <Show when={rows().length > 0}>
+        node.agentToolRows.length +
+        node.workflowRows.length +
+        node.shellRows.length +
+        node.cronRows.length +
+        longRunningCount
+    );
+}
+
+function LongRunningBucket({ rows }: { rows: LongRunningToolRow[] }): JSX.Element {
+    return (
+        <Show when={rows.length > 0}>
             <div class="swarm-bucket swarm-bucket--longrunning">
                 <div class="swarm-bucket-header">
                     <span class="swarm-bucket-label">Running</span>
-                    <span class="swarm-bucket-count">{rows().length}</span>
+                    <span class="swarm-bucket-count">{rows.length}</span>
                 </div>
-                <For each={rows()}>{(row) => <LongRunningRow row={row} />}</For>
+                <For each={rows}>{(row) => <LongRunningRow row={row} />}</For>
             </div>
         </Show>
     );

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -215,7 +215,11 @@ export function countdownSecondsRemaining(model: SwarmViewModel, rowKey: string,
 
 const fmtCtx = formatCompactNumber;
 
-function AgentRow({
+// Exported for `swarm-agent-row.render.test.tsx`, which pins the PR #2862
+// regression both reviewers caught: an agent whose only activity is a
+// long-running tool call must still show the expand affordance and render the
+// bucket. Same test-only export precedent as `DispatchActivityFeedEntry`.
+export function AgentRow({
     node,
     focusedBlockId,
     model,

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -16,6 +16,7 @@ import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
 import { getBlockTurnPhase } from "@/app/store/agentActivity";
 import { recordTurn } from "@/app/store/token-usage";
 import { useTick } from "@/app/hook/useTick";
+import { longRunningToolRows, type LongRunningToolRow } from "./swarm-longrunning";
 import { formatCompactNumber } from "@/util/format-count";
 import { formatElapsedClock } from "@/util/format-time";
 import { focusBlock } from "@/app/util/focus-block";
@@ -335,6 +336,7 @@ function AgentRow({
                     <WorkflowBucket rows={node.workflowRows} model={model} />
                     <ShellBucket rows={node.shellRows} />
                     <CronBucket rows={node.cronRows} />
+                    <LongRunningBucket blockId={node.blockId} />
                 </div>
             </Show>
         </div>
@@ -427,6 +429,65 @@ function ShellRow({ shell }: { shell: ActiveShell }): JSX.Element {
             <button class="swarm-shell-stop" title="Stop" onClick={handleStop}>
                 <i class="fa-solid fa-stop" />
             </button>
+        </div>
+    );
+}
+
+// Long-running tool calls — step 4 of
+// REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md §3 ("feed the
+// same signal to Swarm"). The gap the other four buckets leave: a `sleep 300`
+// or a four-minute build is an ordinary Bash tool call, owned by the CLI rather
+// than by srv, so it appeared in that pane's own Activity Dock and nowhere
+// else — the fleet view couldn't answer "which agents are sitting on a wait".
+//
+// Placed last, below Shell/Cron: those are declared, addressable objects with
+// their own lifecycle, whereas this bucket is inferred from a running tool
+// call. Same most-abstract-first ordering the Shell/Cron comments describe.
+//
+// Ticks here rather than in the model: promotion is time-based
+// (TOOL_PROMOTION_MS), so the list changes with the clock and not only with
+// backend events. Keeping the clock dependency in the view leaves
+// `buildTree`'s memo free of it.
+function LongRunningBucket({ blockId }: { blockId: string | null }): JSX.Element {
+    const tick = useTick(1000);
+    const rows = createMemo(() => {
+        tick();
+        return longRunningToolRows(blockId, Date.now());
+    });
+    return (
+        <Show when={rows().length > 0}>
+            <div class="swarm-bucket swarm-bucket--longrunning">
+                <div class="swarm-bucket-header">
+                    <span class="swarm-bucket-label">Running</span>
+                    <span class="swarm-bucket-count">{rows().length}</span>
+                </div>
+                <For each={rows()}>{(row) => <LongRunningRow row={row} />}</For>
+            </div>
+        </Show>
+    );
+}
+
+function LongRunningRow({ row }: { row: LongRunningToolRow }): JSX.Element {
+    const tick = useTick(1000);
+    const elapsed = createMemo(() => {
+        tick();
+        return formatElapsedClock(Date.now() - row.startedAt);
+    });
+    // Only a whole-command sleep knows its own remaining time (sleep-detect.ts);
+    // everything else shows elapsed alone rather than a guess. Clamped at 0 —
+    // the process is reaped slightly after its own deadline.
+    const remaining = createMemo(() => {
+        if (row.sleepMs == null) return "";
+        tick();
+        return `~${Math.ceil(Math.max(0, row.startedAt + row.sleepMs - Date.now()) / 1000)}s left`;
+    });
+    return (
+        <div class="swarm-longrunning-row" title={row.title}>
+            <span class="swarm-longrunning-title">{row.title}</span>
+            <span class="swarm-longrunning-elapsed">{elapsed()}</span>
+            <Show when={remaining()}>
+                <span class="swarm-longrunning-remaining">{remaining()}</span>
+            </Show>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Step 4 of `REPORT_LONGRUNNING_TOOLCALL_AUTODETECT_STATUS_2026_07_26.md` §3 — and the last piece of the original *"sleeps should appear as a section in Swarm"* ask.

Swarm already answers "what is this agent doing" for the things srv owns: subagent dispatches, Shell-MCP shells, crons. An ordinary Bash tool call was the gap — a `sleep 300` or a four-minute build showed in that pane's own Activity Dock and **nowhere else**, so the fleet view couldn't answer "which agents are sitting on a wait right now" without opening each one.

## Reusing the classifier instead of duplicating it

The other buckets come from srv because shells, crons and subagents are srv-owned objects. A Bash tool call isn't — it exists only in the CLI's transcript stream, and the promotion rules live entirely in `tool-adapter.ts`. `dock_snapshot.rs` says as much itself: that reclassification *"happens entirely client-side ... which the server has no visibility into"*.

So rather than re-implement the rules in Rust, this reuses them. `slots` in `agent-document-store.ts` is a module-level map keyed by block id, and Swarm runs in the same renderer process, so `toolActivities` applies directly to any mounted pane's nodes. One classifier, every consumer reuses it — the discipline `isAcceptedBackgroundLaunch` already established.

A useful consequence: a bare `sleep` appears in Swarm **the instant it starts**, consistent with the dock, because it inherits `sleep-detect.ts`'s immediate promotion and its `sleepMs` — so the row shows the same `~Ns left` countdown rather than a second, drifting implementation of it.

## Known limitation — stated, not hidden

`snapshot()` only returns state for a **registered** pane (`registerPane` on mount, `unregisterPane` on unmount). An agent whose pane isn't mounted contributes nothing and reads as **zero rather than unknown**.

That's the same population that has a live dock at all, so the two views always agree — but it is *not* full fleet coverage of unopened panes, and I don't want that oversold. Closing it properly would require srv to model the dock's promotion rules, which is a much larger change than this bucket justifies. Documented at the top of `swarm-longrunning.ts`.

## Details

- Ticks in the **view**, not the model: promotion is time-based, so the list changes with the clock and not only with backend events. Keeping the clock dependency out of `buildTree`'s memo avoids rebuilding the whole tree every second.
- **Running only.** A finished call lingers in `toolActivities` through the dock's retention window so its dock row can resolve in place — but Swarm answers "what is this agent on *right now*", where a completed call is noise.
- Placed below Shell/Cron, matching those buckets' own most-abstract-first ordering rationale: they're declared, addressable objects with a lifecycle; this one is inferred from a running tool call.
- Row geometry deliberately matches `.swarm-shell-row` so a reader scanning an agent's children doesn't have to re-orient.

## Testing

8 selector tests: threshold in/out, immediate sleep promotion with countdown data, no countdown when unknowable, finished calls excluded, newest-first ordering, per-pane isolation, and an unmounted pane returning empty rather than throwing.

`npx vitest run frontend/app/view` — **1935 passed**. `npx tsc --noEmit` clean. New SCSS is stylelint-clean (the 17 pre-existing errors in that file are unchanged from `main`).

**Not verified in a live pane** — the selector is unit-tested against the real document store and reducer, but I haven't watched the bucket render in a running Swarm.

<!-- agentmux:agent_id=agent2 -->