### PR TITLE
fix(layout): drop pane-interior padding in floating panes

### DIFF
--- a/.changesets/1788196002-fix-layout-floating-panes-no-longer-show-a-padding-border-wekx.md
+++ b/.changesets/1788196002-fix-layout-floating-panes-no-longer-show-a-padding-border-wekx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): floating panes no longer show a padding border

--- a/frontend/app/workspace/floating-pane-workspace.scss
+++ b/frontend/app/workspace/floating-pane-workspace.scss
@@ -18,4 +18,31 @@
     .block-mask {
         border-color: transparent !important;
     }
+
+    // Drop the pane-interior padding for the same reason the focus ring goes:
+    // it is chrome that only makes sense between panes.
+    //
+    // `.block-content` carries `padding: 5px` by default (`block.scss:31`),
+    // opted out per-view via `noPadding` -> `.block-no-padding`
+    // (`block.tsx:245`). Views that opt out — agent, term, editor, browser,
+    // drone, swarm — render flush. Views that do NOT — **armory**, sysinfo,
+    // identity, memory — keep the 5px.
+    //
+    // Docked that is correct: it is interior breathing room next to sibling
+    // panes. In a floater the single pane fills the whole window, so the same
+    // 5px sits directly against the window edge, over the dark
+    // `#1e1e2e` window-class brush (`floating_pane.rs:765`), and reads as a
+    // thick border. That is exactly why a floating Armory looks bordered while
+    // a floating agent or terminal does not — measured at 6px of inset
+    // (5px padding + 1px block) for armory/sysinfo versus 0px for agent/term.
+    //
+    // Scoped to the floater rather than setting `noPadding` on Armory, because
+    // the docked rendering is right as it stands and must not change.
+    //
+    // No `!important` needed here, unlike the rule above: this is
+    // `.floating-pane-workspace .block .block-content` (0,3,0), which already
+    // outranks `.block .block-content` (0,2,0) without relying on source order.
+    .block .block-content {
+        padding: 0;
+    }
 }


### PR DESCRIPTION
Fixes the "thick border" on torn-off panes that the repo owner reported.

The observation that cracked it was theirs: floating **sysinfo and agent look normal, Armory does not**. A view-type-dependent difference rules out every window-level cause I had been ranking first — `WS_THICKFRAME`/DWM artifacts and the `#1e1e2e` window-class brush would affect *all* floaters identically.

## Measured, not inferred

Over CDP against the live dev instance:

| view | `.block-content` padding | inset from block edge |
|---|---|---|
| agent (floating) | 0px | 1px |
| term (floating) | 0px | 1px |
| sysinfo (floating) | **5px** | **6px** |
| armory (docked) | **5px** | **6px** |

`.block-content` carries `padding: 5px` by default (`block.scss:31`), opted out per-view via `noPadding` → `.block-no-padding` (`block.tsx:245`). **agent, term, editor, browser, drone, swarm** opt out. **armory, sysinfo, identity, memory** do not.

Docked that is correct — interior breathing room beside sibling panes. In a floater the single pane fills the whole window, so the same 5px sits against the window edge over the dark window-class brush and reads as a border.

## Why scoped to the floater

Setting `noPadding` on Armory would also change its **docked** rendering, which is right as it stands. The defect is specific to a pane filling an entire window, so the fix belongs to that context.

No `!important`: `.floating-pane-workspace .block .block-content` (0,3,0) already outranks `.block .block-content` (0,2,0) without relying on source order — unlike the focus-ring rule directly above it, whose comment explains why *it* needs one.

## Verification

With the change loaded via HMR into the running dev instance, the sysinfo floater's `.block-content` went **5px → 0px** and its inset **6px → 1px**, confirmed with no injected stylesheet present (`injectedStylePresent: false`), so it was the real stylesheet and not a probe artifact.

`tsc --noEmit` clean. The file is in `.stylelintignore`, and `lint:scss` reports the same pre-existing failures on `main` (577) as with this change — none introduced here.

## Known gap

sysinfo also carries the 5px and was therefore also affected, despite being reported as looking *normal*. Its screenshot does show a faint frame, so this most likely fixes a subtler instance of the same defect — but that is my inference, not a confirmed report, and it is worth a look on the built artifact.

<!-- agentmux:agent_id=agenta-07017 -->