### PR TITLE
fix(agent-picker): finish the snapshot-preview data-gap fixes from the 08-24 audit

### DIFF
--- a/.changesets/1788205309-fix-agent-picker-distinguish-snapshot-check-failures-and-cro-8csk.md
+++ b/.changesets/1788205309-fix-agent-picker-distinguish-snapshot-check-failures-and-cro-8csk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-picker): distinguish snapshot-check failures and cross-channel rows from a genuinely empty conversation

--- a/agentmux-srv/src/backend/rpc_types/instance.rs
+++ b/agentmux-srv/src/backend/rpc_types/instance.rs
@@ -174,6 +174,17 @@ pub struct RecentSessionRow {
     /// block. False when the snapshot doesn't exist yet (no preview)
     /// or the block_id_hint was empty.
     pub has_snapshot: bool,
+    /// True when `has_snapshot` is false because the filestore lookup
+    /// itself ERRORED (I/O error, lock contention, DB read failure) —
+    /// distinct from a genuine `Ok(None)` (the block simply never wrote
+    /// a snapshot). Without this, a transient storage error renders
+    /// identically to "never had history," with no signal to the user
+    /// that this row's real state is unknown rather than confirmed
+    /// empty. See
+    /// docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+    /// §5.
+    #[serde(default)]
+    pub snapshot_check_failed: bool,
     /// When the agent definition was first created (ms since epoch).
     /// Shown as "Created" in the My Agents card.
     pub agent_created_at: i64,

--- a/agentmux-srv/src/backend/storage/filestore/core.rs
+++ b/agentmux-srv/src/backend/storage/filestore/core.rs
@@ -66,6 +66,12 @@ impl FileStore {
         Ok(store)
     }
 
+    /// Raw connection access for tests that need to force a specific
+    /// failure mode (e.g. dropping a table) — mirrors `Store::conn()`.
+    pub(crate) fn conn(&self) -> &Mutex<Connection> {
+        &self.conn
+    }
+
     /// Run `PRAGMA wal_checkpoint(TRUNCATE)` on the filestore connection.
     /// Same semantics as `Store::checkpoint` — 5s busy_timeout, partial
     /// truncate on contention is safe.

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -391,9 +391,18 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Stat first (cheap) — gives us the modts for
                     // sorting. Only fetch the full content if the
                     // snapshot exists.
-                    let (has_snapshot, last_active_at, mut preview, node_count) =
+                    //
+                    // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+                    // §5: `Ok(None)` (the block genuinely never wrote a
+                    // snapshot) and `Err(_)` (a transient filestore I/O
+                    // error, lock contention, DB read failure) used to
+                    // collapse into the same `_ =>` arm — a real error on a
+                    // row that DOES have history rendered identically to
+                    // "never had one," silently. Split so the row can carry
+                    // that distinction downstream instead of losing it here.
+                    let (has_snapshot, last_active_at, mut preview, node_count, snapshot_check_failed) =
                         if inst.block_id.is_empty() {
-                            (false, inst.started_at, String::new(), 0usize)
+                            (false, inst.started_at, String::new(), 0usize, false)
                         } else {
                             match filestore.stat(&inst.block_id, "output.state.json") {
                                 Ok(Some(file)) => {
@@ -406,9 +415,23 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                         &filestore,
                                         &inst.block_id,
                                     );
-                                    (true, modts, preview, node_count)
+                                    (true, modts, preview, node_count, false)
                                 }
-                                _ => (false, inst.started_at, String::new(), 0usize),
+                                Ok(None) => (false, inst.started_at, String::new(), 0usize, false),
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        definition_id = %inst.definition_id,
+                                        block_id = %inst.block_id,
+                                        "listrecentsessions: filestore.stat(output.state.json) failed — \
+                                         row will report snapshot_check_failed instead of silently \
+                                         looking like it never had a snapshot"
+                                    );
+                                    if !degraded.contains(&"snapshot_stat") {
+                                        degraded.push("snapshot_stat");
+                                    }
+                                    (false, inst.started_at, String::new(), 0usize, true)
+                                }
                             }
                         };
 
@@ -543,6 +566,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         node_count,
                         last_active_at,
                         has_snapshot,
+                        snapshot_check_failed,
                         agent_created_at: def.map(|d| d.created_at).unwrap_or(0),
                         started_at: inst.started_at,
                         agent_type: def.map(|d| d.agent_type.clone()).unwrap_or_default(),
@@ -1077,6 +1101,81 @@ mod tests {
         let row = &result.rows[0];
         assert!(!row.has_snapshot);
         assert_eq!(row.preview, "", "no summary persisted yet — preview must stay empty, not fabricated");
+    }
+
+    /// docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+    /// §5, bullet 1: `filestore.stat()`'s `Err` (I/O error, lock
+    /// contention, DB read failure) used to collapse into the exact same
+    /// branch as `Ok(None)` (genuinely no snapshot) — a transient storage
+    /// error on a row that DOES have real history rendered identically to
+    /// "never had one," with no log line. Forces the failure
+    /// deterministically the same way the identity_links test above does
+    /// (`DROP TABLE`), rather than relying on real I/O flakiness.
+    #[tokio::test]
+    async fn filestore_stat_error_is_distinguished_from_genuinely_no_snapshot() {
+        let state = test_state();
+        let mut def = local_agent_def("def-local-3");
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state
+            .wstore
+            .instance_create(&local_agent_instance("inst-local-3", "def-local-3", "block-local-3"))
+            .unwrap();
+
+        {
+            let conn = state.filestore.conn().lock().unwrap();
+            conn.execute("DROP TABLE db_wave_file", []).unwrap();
+        }
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+        assert_eq!(result.rows.len(), 1, "a stat() failure on one row must not zero out the whole list");
+        let row = &result.rows[0];
+        assert!(!row.has_snapshot, "a failed stat() is not evidence a snapshot exists");
+        assert!(
+            row.snapshot_check_failed,
+            "a stat() I/O error must be distinguishable from a genuine Ok(None) — \
+             otherwise a transient failure looks identical to \"never had history\""
+        );
+        assert!(
+            result.degraded.contains(&"snapshot_stat".to_string()),
+            "got: {:?}",
+            result.degraded
+        );
+    }
+
+    /// Counterpart: a genuine `Ok(None)` (the block really never wrote a
+    /// snapshot) must NOT set `snapshot_check_failed` — only an actual
+    /// `Err` does. Without this, the fix above could be made to pass by
+    /// setting the flag unconditionally whenever `has_snapshot` is false,
+    /// which would just move the ambiguity rather than remove it.
+    #[tokio::test]
+    async fn genuinely_missing_snapshot_does_not_set_the_check_failed_flag() {
+        let state = test_state();
+        let mut def = local_agent_def("def-local-4");
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state
+            .wstore
+            .instance_create(&local_agent_instance("inst-local-4", "def-local-4", "block-local-4"))
+            .unwrap();
+
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
+        let row = &result.rows[0];
+        assert!(!row.has_snapshot);
+        assert!(
+            !row.snapshot_check_failed,
+            "a genuine Ok(None) — the block simply never wrote a snapshot — is not a check failure"
+        );
     }
 
     /// reagent P1, PR #2786: without a dedup gate, a definition that can

--- a/docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+++ b/docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-08-24
 **Author:** AgentY
-**Type:** Investigation + UX/architecture recommendations, since implemented
-(§2, §3, §4 shipped; §5/§5a shipped separately — PR #2786)
+**Type:** Investigation + UX/architecture recommendations — fully implemented
+as of 2026-08-31.
 **Scope:** `frontend/app/view/agent/components/AgentPicker.tsx`,
 `AgentPickerFilterBar.tsx`, `MyAgentsList.tsx`,
 `frontend/app/view/agent/styles/_recent-sessions.scss`,
@@ -11,8 +11,23 @@
 
 **Status update (2026-08-24, later same day):** §2 (field reorder), §3
 (sort control), and §4 (distinct account-failure text) implemented —
-see the PR that shipped this report's own recommendations. §5/§5a (the
-snapshot-preview fallback) shipped earlier, separately, as PR #2786.
+see the PR that shipped this report's own recommendations. §5a (the
+Haiku on-demand summary fallback) shipped earlier, separately, as PR #2786.
+
+**Correction (2026-08-31):** this status line previously also claimed "§5
+… shipped … PR #2786," which was inaccurate — PR #2786 shipped §5a only.
+§5's own two bullets (the `filestore.stat()` `Err`/`Ok(None)` conflation,
+and the cross-channel "no conversation snapshot" copy) were never actually
+implemented despite the claim, and shipped separately just now: the stat()
+error case sets a new `snapshot_check_failed` field (logged + tracked via
+the existing `degraded` mechanism, reusing §4's precedent of giving a real
+source failure its own distinct fallback text instead of reusing the
+genuinely-empty case's copy), and a cross-channel row (`block_id_hint ===
+""`) now reads "(history may exist in another version)" instead of the
+flatly inaccurate "(no conversation snapshot)". See
+`frontend/app/view/agent/components/MyAgentsList.tsx`'s `noSnapshotText`
+and `agentmux-srv/src/server/agent_handlers/session.rs`'s
+`snapshot_check_failed` handling.
 
 Prompted by direct user feedback: "a lot of the fields are out of order,"
 a request for name/launch-date/type sort controls at the right edge of the
@@ -163,13 +178,17 @@ nothing, but the row's real conversation may well exist in a *different*
 channel's filestore. `"(no conversation snapshot)"` reads as "there is no
 history," when the more accurate statement is "no history in THIS channel."
 
-**Recommendation:**
-- Fix the error-swallowing: distinguish `Err` from `Ok(None)` in the match
-  arm, log the error case, and consider a third UI state (or at least a
-  console/log signal) instead of silently reporting "no snapshot."
-- For the cross-channel case, adjust the copy to hint at the real situation
-  — e.g. "(history may exist in another version)" — rather than the flatly
-  incorrect-sounding "no conversation snapshot."
+**Implemented (2026-08-31):**
+- The error-swallowing is fixed: the match arm now distinguishes `Err` from
+  `Ok(None)`, logs the error case (`tracing::warn!`), and marks the new
+  `"snapshot_stat"` degraded source. The row carries a new
+  `snapshot_check_failed: bool` field so the frontend can render a third,
+  distinct state ("(couldn't check for history)") instead of silently
+  reporting "no snapshot."
+- The cross-channel case now reads "(history may exist in another version)"
+  — exactly the wording proposed here — driven by the existing
+  `block_id_hint === ""` signal the row already carried, no backend change
+  needed for this half.
 
 ### 5a. Addendum — a real fallback source exists (correction to an earlier draft of this report)
 
@@ -233,11 +252,12 @@ worth deciding before implementing.
 
 ## 7. Suggested next steps, in order
 
-1. Confirm the proposed field-order change and sort-control placement with
-   the user before implementing (design judgment call, not a pure bug fix).
-2. Fix `has_snapshot`'s `Err`/`Ok(None)` conflation (`session.rs:360-379`) —
-   smallest, most clearly a bug of the four findings here.
-3. Give the `identity_links`-failure case distinct fallback text from the
-   genuinely-empty case, matching the existing `FETCH_ERROR` pattern.
-4. Implement the sort control (client-side, over `filteredRows()`).
-5. Reorder row fields per §2, if confirmed.
+All five shipped as of 2026-08-31.
+
+1. ~~Confirm the proposed field-order change and sort-control placement with
+   the user before implementing~~ — confirmed, implemented per §2/§3.
+2. ~~Fix `has_snapshot`'s `Err`/`Ok(None)` conflation~~ — implemented per §5.
+3. ~~Give the `identity_links`-failure case distinct fallback text~~ —
+   implemented per §4.
+4. ~~Implement the sort control~~ — implemented per §3.
+5. ~~Reorder row fields per §2~~ — implemented.

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -146,6 +146,40 @@ describe("MyAgentsList — populated", () => {
         ).toBeInTheDocument();
     });
 
+    // docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+    // §5, bullet 2: a cross-channel row (no local block_id at all) reads
+    // "no conversation snapshot" identically to a row that genuinely never
+    // had one — but its history may well exist in a different channel's
+    // filestore. Distinguished here by `block_id_hint === ""`, the same
+    // signal `session.rs` already uses server-side to skip the stat() call
+    // entirely for a synthetic cross-channel row.
+    it("renders a distinct hint for a cross-channel row instead of claiming no history exists", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ preview: "", has_snapshot: false, node_count: 0, block_id_hint: "" }),
+        ]));
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-my-agents-entry");
+        expect(
+            screen.getByText("(history may exist in another version)"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("(no conversation snapshot)")).toBeNull();
+    });
+
+    // §5, bullet 1: a real filestore.stat() error must not look identical
+    // to a genuine "never had a snapshot" — see session.rs's
+    // `snapshot_check_failed` field.
+    it("renders a distinct hint when the snapshot check itself failed", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
+            makeRow({ preview: "", has_snapshot: false, node_count: 0, snapshot_check_failed: true }),
+        ]));
+        render(() => <MyAgentsList onReattach={() => {}} />);
+        await screen.findByTestId("agent-my-agents-entry");
+        expect(
+            screen.getByText("(couldn't check for history)"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("(no conversation snapshot)")).toBeNull();
+    });
+
     it("fires onReattach with the row when an entry is clicked", async () => {
         const onReattach = vi.fn();
         const row = makeRow({ instance_id: "click-me" });

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -112,6 +112,33 @@ export const FETCH_ERROR = "Couldn't load your agents — check the connection a
  * rows isn't told they have no agents at all.
  * SPEC_AGENT_PICKER_FILTER_SEARCH_2026_08_17.md. */
 export const noMatchText = (query: string): string => `No agents match "${query}".`;
+
+/**
+ * Copy for a row with no preview text and no snapshot, split into its
+ * three genuinely distinct causes — collapsing them into one generic
+ * "(no conversation snapshot)" made a real backend error and a
+ * cross-channel row both read as "this agent has no history," which
+ * isn't true for either. See
+ * docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md
+ * §5.
+ *
+ * - `snapshot_check_failed` — the filestore lookup itself errored
+ *   (transient I/O/lock/DB failure); the real state is unknown, not
+ *   confirmed empty. Checked first: a stat() error on a cross-channel
+ *   row can't actually happen (session.rs skips the call entirely when
+ *   `block_id_hint` is empty), but ordering this first keeps the two
+ *   conditions from ever silently depending on which one wins.
+ * - `block_id_hint === ""` — a synthetic cross-channel row (no local
+ *   SQLite instance backs it); this channel's filestore genuinely has
+ *   nothing, but the real conversation may exist in another version.
+ * - otherwise — a genuine, confirmed `Ok(None)`: the block really never
+ *   wrote a snapshot.
+ */
+export const noSnapshotText = (row: Pick<RecentSessionRow, "snapshot_check_failed" | "block_id_hint">): string => {
+    if (row.snapshot_check_failed) return "(couldn't check for history)";
+    if (!row.block_id_hint) return "(history may exist in another version)";
+    return "(no conversation snapshot)";
+};
 /** Backend hard cap (`CommandListRecentSessionsData`, instance.rs) — the
  * limit MyAgentsList requests once a name filter is active, so filtering
  * covers the full available set instead of just the default first page. */
@@ -555,9 +582,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                                                 when={row.preview}
                                                 fallback={
                                                     <span class="agent-recent-sessions-preview agent-recent-sessions-preview--empty">
-                                                        {row.has_snapshot
-                                                            ? "(no user message yet)"
-                                                            : "(no conversation snapshot)"}
+                                                        {row.has_snapshot ? "(no user message yet)" : noSnapshotText(row)}
                                                     </span>
                                                 }
                                             >

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -890,6 +890,12 @@ declare global {
         node_count: number;
         last_active_at: number;
         has_snapshot: boolean;
+        /**
+         * True when `has_snapshot` is false because the filestore lookup
+         * itself ERRORED (I/O error, lock contention, DB read failure) —
+         * distinct from a genuine "the block never wrote a snapshot".
+         */
+        snapshot_check_failed?: boolean;
         /** When the agent definition was first created (ms epoch). */
         agent_created_at: number;
         /** When this instance was most recently launched (ms epoch). */


### PR DESCRIPTION
## Summary

User-reported symptom: a My Agents row still shows "(no conversation
snapshot)" when it shouldn't. Traced to `docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md`
§5 — the report's own status line claimed "§5/§5a shipped ... PR #2786",
but that's only true for §5a (the Haiku on-demand summary fallback). Both
§5 bullets were never actually implemented:

- `filestore.stat()`'s `Err` (I/O error, lock contention, DB read failure)
  collapsed into the same `_ =>` arm as a genuine `Ok(None)` — a transient
  storage error rendered identically to "never had a snapshot," silently.
- A cross-channel row (synthetic instance, no local `block_id`) also read
  as "no conversation snapshot," when its real history may exist in a
  different channel entirely.

## Changes

- `session.rs`: splits the `stat()` match into `Ok(Some)` / `Ok(None)` /
  `Err(e)`. The error case logs a warning, marks a new `"snapshot_stat"`
  degraded source (same mechanism §4's `identity_links` fix already uses),
  and sets a new `RecentSessionRow.snapshot_check_failed` field.
- `MyAgentsList.tsx`: new `noSnapshotText()` picks between three distinct
  messages instead of one generic string — `"(couldn't check for
  history)"` (stat() errored), `"(history may exist in another
  version)"` (cross-channel, `block_id_hint` empty — exact wording the
  report proposed), or the original `"(no conversation snapshot)"` (a
  real, confirmed empty state).
- `FileStore` gained a `conn()` accessor (mirrors `Store::conn()`) so a
  test can force the `stat()` error deterministically via `DROP TABLE` —
  same technique the existing `identity_links` failure test already uses.
- Corrected the report's own status line/§5/§7 to reflect what's actually
  shipped now.

## Test plan

- [x] `cargo test -p agentmux-srv` — 2871 passed (+2 new)
- [x] `npx vitest run` — 3439 passed (+2 new)
- [x] `npx tsc --noEmit` — clean
- [x] New tests written first, confirmed failing before the fix (backend:
      compile error; frontend: 2 assertion failures) per TDD

<!-- agentmux:agent_id=agentx -->