### PR TITLE
docs(flicker): systemic analysis of the flash class + render-architecture spec

### DIFF
--- a/.changesets/1788205456-docs-flicker-systemic-analysis-of-the-flash-class-render-arc-9r7f.md
+++ b/.changesets/1788205456-docs-flicker-systemic-analysis-of-the-flash-class-render-arc-9r7f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(flicker): systemic analysis of the flash class + render-architecture spec, fix stale statuses and dangling spec refs

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[cfg(target_os = "linux")]
 use crate::state::AppState;
 
-/// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
+/// Linux startup white-flash fix (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md).
 ///
 /// Bound on how long the real window + native splash can stay hidden/up
 /// waiting for the frontend's first-paint signal before we show anyway.
@@ -54,7 +54,7 @@ static PAINT_GATE_NEXT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::
 /// still the one this specific timeout was scheduled for; if `on_load_end`
 /// re-armed the gate since (reload/retry mid-startup), this stale timeout is
 /// a no-op instead of revealing the window ahead of the *current*
-/// navigation's real paint (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md,
+/// navigation's real paint (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md,
 /// reagent PR #2151 review).
 ///
 /// Must run on the CEF UI thread.
@@ -183,7 +183,7 @@ const SHOW_WINDOW_RETRY_DELAY_MS: i64 = 50;
 /// primary resolution path and `ShowWindowRetryTask`'s retry path so BOTH
 /// respect the same Linux paint gating
 /// (`linux_paint_gate_pending`/`reveal_gated_window`,
-/// `SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md`) — reagentx P1 on this PR:
+/// `REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md`) — reagentx P1 on this PR:
 /// the retry path originally called `window.show()` unconditionally on every
 /// platform, bypassing the gate entirely. Whenever a *retry* (not the first
 /// `on_load_end` pass) is what actually resolves the window, that would
@@ -467,7 +467,7 @@ impl AgentMuxHandler {
         // has painted anything (the white-flash bug this gate fixes). Linux
         // writes the ready-file from `reveal_gated_window` instead, gated on the
         // same first-paint confirmation that unblocks the real window's show()
-        // below. See docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
+        // below. See docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md.
         #[cfg(target_os = "macos")]
         {
             if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
@@ -503,7 +503,7 @@ impl AgentMuxHandler {
                         // dismiss above) until the frontend confirms a real
                         // compositor paint, instead of doing it here on mere
                         // load-complete — see reveal_gated_window and
-                        // docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
+                        // docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md.
                         // Falls back to the old immediate-show behavior if the
                         // window label can't be resolved (can't gate safely on
                         // an unknown label). Shared with ShowWindowRetryTask's

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -414,7 +414,7 @@ pub fn set_window_init_status(state: &Arc<AppState>, args: &serde_json::Value) -
 }
 
 /// First-paint signal from the frontend (Linux startup white-flash fix, see
-/// docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md). Sent via a
+/// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md). Sent via a
 /// double-`requestAnimationFrame` at the very top of `bootstrap.ts` — the
 /// earliest reliable proxy for "the compositor actually presented a frame",
 /// as opposed to CEF's `on_load_end` which only means "main-frame HTML

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -115,7 +115,7 @@ pub struct AppState {
     /// Window initialization status ("ready" or "wave-ready")
     pub window_init_status: Mutex<String>,
 
-    /// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
+    /// Linux startup white-flash fix (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md).
     /// Window labels whose native `window.show()`/focus + splash-ready-file has
     /// been deferred by `on_load_end` pending a real first-paint confirmation
     /// from the frontend (`report_first_paint` IPC command) or a safety-net

--- a/docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md
+++ b/docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md
@@ -1,0 +1,354 @@
+# Why the tab flash keeps coming back — a systemic analysis
+
+**Date:** 2026-08-31
+**Author:** AgentY
+**Status:** Analysis, written while the tab-close flash was still open and
+**revised after it was fixed** by PR #2818 (§§8-9 of
+`SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md`). The outcome is recorded in
+§0 below and is the single most useful thing in this document — it is a
+controlled test of the thesis. Companion design:
+`SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md`.
+**Trigger (at time of writing):** After PR #2811 landed four stacked
+root-cause fixes (§§2-3, §5, §6, §7), the repo owner reported the flash was
+**still present**, on the same gesture: closing a tab through the confirm
+modal.
+
+---
+
+## 0. Outcome — what actually fixed it, and what that proves
+
+**Fixed by PR #2818** with two changes, neither of which was another ordering fix:
+
+- **§8 Optimistic removal.** The tab leaves the strip the instant the confirm
+  modal opens; cancel or RPC failure puts it back. *"A tab that is not rendered
+  cannot flash, whatever order the backend's updates arrive in."* The strip
+  stops depending on backend update ordering at all.
+- **§9 Targeted reveal gate.** `holdRevealGate(targetTabId)` now names its
+  destination, and `workspace.tsx` hides only that tab once it becomes active —
+  instead of gating "whoever is active right now."
+
+**Scorecard against this report's predictions:**
+
+| Claim | Verdict |
+|---|---|
+| The flash is architectural, not a bug with a root cause | **Confirmed** — the fix that worked changed the architecture of the strip, not an ordering |
+| Suppressors (gates/debounce/`batch()`) can't close this class; only making the bad state unrepresentable can | **Confirmed** — §8 is verbatim that move, and its own text says "make the flash structurally impossible" |
+| §3.5 — the reveal gate is keyed on `tid === tabId()` and is one reactive step behind what it gates | **Confirmed and fixed** — this is exactly what §9 repaired; the real symptom was the *destination* tab's pane blanking toward the 800ms cap |
+| §3.3 — the native pane compositor (`sendClip` → rAF → async HTTP) is the leading residual cause | **Not the cause here.** Plausible mechanism, wrong ranking. It remains a real unsynchronized seam (§3.3), with documented precedent, but it was not what the owner was seeing |
+
+Two things I got wrong, recorded so the next pass doesn't repeat them:
+
+1. **I ranked a novel hypothesis above a defect I had already confirmed.**
+   §3.5 was verified by code reading; §3.3 was inferred. I led with §3.3
+   because it was a better *story* — it explained the "after the modal closes"
+   trigger. The confirmed defect was the real one.
+2. **A verification gap was doing more work than any code defect.** Per §8's
+   own writeup, *none* of §§5-7 was ever tested against a build containing all
+   of them at once — v0.55.25 predated the merge, and the dev instance had only
+   §§3-6. Some "still broken" sightings were of incomplete builds. Four fixes
+   were reasoned about without a single clean observation. That is the
+   strongest argument in this document for the "measure first" discipline in §5.
+
+---
+
+## 1. The thing that should worry us
+
+Four consecutive fixes, each one correctly root-caused, each one verified by
+tests, each one landing a real defect — and the symptom did not move.
+
+That is not four bad diagnoses. Re-reading them, all four were *true*:
+
+| § | Defect found | Real? |
+|---|---|---|
+| §2-3 | Close-button click bubbled to the tab's `onSelect`, racing `SetActiveTab` against `CloseTab` | Yes — verified, tested |
+| §5 | Client pre-selected the neighbor via a second RPC, splitting one atomic transition into two round trips | Yes — verified, tested |
+| §6 | `updateWaveObjects` applied a multi-object response as N unbatched Solid writes | Yes — verified, tested |
+| §7 | Two WS push paths delivered the same pair unbatched, and *always arrived before* the response body §6 fixed | Yes — verified, tested |
+
+When four sequential true root causes don't fix a symptom, the symptom is not
+"a bug with a root cause." It is **an emergent property of the architecture** —
+the system has enough independent, unsynchronized paths to the screen that
+closing any one of them just promotes the next one to visibility.
+
+Each fix was a correct answer to "which path painted first *this time*."
+None of them addressed "why is there more than one path at all."
+
+## 2. The historical pattern
+
+This is not a two-week-old problem. A scan of the repo's own history turns up
+roughly twenty separate flash/flicker/strobe incidents, each fixed
+independently, each with its own spec or retro:
+
+- `#774` / `SPEC_TAB_CONTENT_REVEAL_GATE.md` — tab-switch mount cascade → **reveal gate**
+- `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` — "negative-of-a-photo" first-paint flash → **opacity fade on gate lift**
+- `#1769` — browser-pane black flash on macOS/Linux
+- `#1809` — activity-summary label flash
+- `#2095` — cross-tab drag hover strobe
+- `#2098` — flyout menus over browser panes (macOS occlusion)
+- `#2151` — Linux: gate window-show/splash-dismiss on real first paint
+- `#2163` → **reverted** by `#2169` — CEF New Window startup color flash
+- `#2171` / `#2173` / `#2174` — Windows console-window flashes
+- `#2293` — activity-dock landing/departure flash
+- `#2328` — My Agents loading state during retry
+- `#2370` — pin scroll from content ResizeObserver
+- `#2525` / `#2567` — submenu positioning flash
+- `#2629` — Agent Picker loading flicker → **another combined reveal gate**
+- `#2642` — browser-pane loading-brain flicker on load-state flips
+- `SPEC_BROWSER_PANE_LOADING_INDICATOR_FLICKER_2026_08_17.md` — CEF frame-blind `OnLoadingStateChange`
+- `SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md` — block-stack mount → **leaf-scoped reveal gate**
+- `#2761` — generalize the reveal gate to leaf/pane scope
+- `retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md` — *a debounce fix that did not fix it*
+- `#2770` — activity dock flashing stale shell rows
+- `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §§2-3, 5, 6, 7 — this one
+
+A full sweep of `docs/specs`, `docs/retro`, `docs/reports` and `docs/status`
+puts the real number closer to **forty documents across eleven families** —
+tab strip, pane/block mount, activity dock, browser-pane indicators,
+startup/splash, terminal streaming, menus/popovers, modals,
+transparency/compositor, scroll-pin, and working-row animation.
+
+Four things stand out.
+
+**First, the recurring fix vocabulary is always a *suppressor*, never a
+*structure*:** reveal gate, second reveal gate, leaf-scoped reveal gate, opacity
+fade, debounce, throttle, settle detector, hard-cap timer, `batch()`, reorder
+the emissions. Every one of these hides or delays a symptom on one path. None
+of them makes an incorrect intermediate state *impossible to express*.
+
+**Second, at least three of these were themselves follow-ups to a fix that
+"should have worked"** — the 08-24 activity-dock retro is literally titled
+*"flicker survives debounce fix"*, `#2169` reverted `#2163`, and this spec ran
+to a fifth attempt. That is the signature of suppressing a symptom whose cause
+lives somewhere the suppressor can't reach.
+
+**Third, the same three anti-patterns recur across unrelated families**, each
+already named in the repo's own docs:
+
+- *Whitelist instead of observe.* `REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md`
+  documents **three prior passes** that "each added one more named dependency
+  or observer rather than a structural fix," while the real signal — the
+  content box growing — was never observed at all.
+- *Coalesce volume, not settlement.* `SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md`
+  debounced the request storm; one day later the retro records the flicker
+  survived, because the intermediate states were **genuinely different true
+  backend states**, not redundant repaints. Fewer repaints of a wrong frame is
+  still a wrong frame.
+- *Gate granularity always trails the defect.* The gate was per-tab (`#774`);
+  the flicker reappeared per-leaf (`#2761`); the per-leaf fix then introduced a
+  stuck-spinner regression (retro 08-23) **and** a new flicker on the
+  previously-clean close path.
+
+**Fourth — and most relevant to §3.3 — the repo has already concluded twice, in
+writing, that native-layer gaps cannot be masked by DOM-layer guards.**
+`REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md` §4.3 says the DOM
+`visibility:hidden` guard "cannot mask any of it" for a non-atomic native
+show, and `SPEC_BROWSER_PANE_LOADING_INDICATOR_FLICKER_2026_08_17.md` Cause 2
+finds that a `data-pane-overlay` element's mount/unmount round-trips through
+the Windows airspace-clip mechanism (`SetWindowRgn`, `clip.rs`) and performs
+"a hard non-animated full native-HWND hide, not a DOM redraw." That is the same
+machinery `usePaneOverlay` puts every modal through.
+
+## 3. The actual architecture (as built)
+
+Reading the tab/window render path end to end, here is what is actually there.
+
+### 3.1 State is a bag of independent reactive cells with no transaction boundary
+
+`frontend/app/store/wos.ts` is a `Map<oref, WaveObjectValue>` where **each
+object owns its own private Solid signal** (`wos.ts:149`, `createSignal` per
+object at `wos.ts:153`). There is no notion of a consistent snapshot across
+objects. "One tab closed" is inherently a multi-object fact:
+
+- `Workspace.tabids` — the list (drives *both* the tab strip and the content stack)
+- `Workspace.activetabid` — which one is live
+- `Tab` — the tab object itself
+- `LayoutState` — its pane tree, a *separate* object again
+- `Block` objects — one per pane, separate again
+- `layoutModelMap` (`frontend/layout/lib/layoutModelHooks.ts:13`) — a **plain non-reactive `Map`** holding the live layout model per tab
+
+Six places, no shared version, no epoch, no transaction. The version guard in
+`updateWaveObject` (`wos.ts:280`) is **per object** — it can't detect that
+object A is from a newer transition than object B. Any multi-object change is
+therefore, structurally, a sequence of independently-observable intermediate
+states. `batch()` narrows the window in one delivery path; it does not make the
+intermediate states unrepresentable.
+
+### 3.2 There are three transport paths to that state, mutually unordered
+
+For one `CloseTab` call the same `[delete tab, update workspace]` pair arrives:
+
+1. **Wave-obj bridge** (`agentmux-srv/src/server/wave_obj_bridge.rs`) — fires
+   off the reducer event stream, *while the HTTP handler is still running*.
+   Two separate frames (the second needs an async SQLite fetch), so they can't
+   be batched into one.
+2. **Response-broadcast loop** (`run_service_call`,
+   `agentmux-srv/src/server/service/mod.rs`) — after the handler returns,
+   before the response body reaches the caller. Reaches the calling renderer
+   too, despite the code comment claiming it's "for everybody else."
+3. **HTTP response body** — `respData.updates` in `callBackendService`
+   (`wos.ts:137`). Arrives last; by then paths 1-2 have already applied and
+   the per-object version guard turns it into a no-op.
+
+§6 batched path 3. §7 batched path 2 and re-ordered path 1. **But the
+architecture still has three paths**, and nothing enforces a global ordering or
+a shared transaction id between them. The next multi-object gesture that
+happens to interleave differently produces a new flash with a new "root cause."
+
+### 3.3 A fourth pipeline that no amount of `batch()` can reach
+
+This is the part I think has been missed in all four previous passes, and it
+matches the reported trigger — *"after the modal closes"* — exactly.
+
+Panes are **native surfaces composited by the Rust/CEF host**, not just DOM. To
+render a modal above a pane, the frontend punches a hole in the native overlay:
+`usePaneOverlay` (`frontend/app/platform/pane-overlay.ts:265`) registers the
+modal's rect and calls `sendClip()`. And `sendClip` (`pane-overlay.ts:83`):
+
+```ts
+requestAnimationFrame(() => {
+    clipScheduled = false;
+    flushChain = flushChain.then(() => flushClip()).catch(() => {});
+});
+```
+
+`flushClip()` then does an **async HTTP round-trip to the Rust host** to update
+the native clip.
+
+So when the confirm modal closes:
+
+- **DOM pipeline:** the modal unmounts synchronously, this frame.
+- **Native pipeline:** clip removal is deferred to a rAF, then chained onto a
+  promise queue, then an async HTTP call, then a native re-composite —
+  **several frames later, on a different compositor.**
+
+There is no shared frame boundary and no acknowledgement handshake between the
+two. For that interval the native pane layer and the DOM disagree about what
+should be on screen. That is a visible flash that is *structurally invisible*
+to every fix attempted so far, because every one of them operated inside the
+Solid/WOS pipeline.
+
+**Status: real seam, but NOT the cause of the tab-close flash** (see §0). PR
+#2818 fixed that symptom without touching this pipeline, so whatever the modal's
+clip release costs, it was not what the owner was seeing.
+
+It stays in this report because the seam itself is real and **already
+documented twice as a confirmed root cause elsewhere** (§2, fourth point): the
+same `data-pane-overlay` → `SetWindowRgn` path produced a hard native-HWND hide
+in the browser-pane indicator bug, and the non-atomic native show produced the
+new-window color flash. Expect it to surface again in an overlay-heavy path. It
+should be ranked on evidence next time, not on narrative fit.
+
+### 3.4 All tabs are mounted at all times, most of them zero-sized
+
+`frontend/app/workspace/workspace.tsx:35-40` keeps **every** tab's content
+mounted simultaneously, switching with `display: none`, to preserve xterm.js
+scrollback. Consequences:
+
+- A hidden tab's container measures **0×0**. Its `TileLayout` geometry is
+  computed against that.
+- `useTileLayout` (`layoutModelHooks.ts:69`) puts a **ResizeObserver** on the
+  container → `onContainerResize` → `model.updateTree()`
+  (`layoutResize.ts:216`). So the instant a tab becomes visible, the observer
+  fires 0×0 → real-size and **relayouts the entire pane tree**.
+- The codebase already carries scar tissue for exactly this: `layoutModel.ts:443`
+  hard-codes a `Math.max(100000, …)` floor because a zero-size measurement
+  once parked an overlay on top of a live tab ("the dead source tab of the
+  2026-07-11 field sessions"), and `droppable-tab.tsx:246` uses a **double
+  `requestAnimationFrame`** to re-measure after a display flip.
+
+So every tab activation is, by construction, a *measure-wrong-then-correct*
+sequence. The reveal gate exists to hide that sequence — which brings us to the
+last structural problem.
+
+### 3.5 The reveal gate is keyed on the very signal it is trying to gate
+
+`workspace.tsx:65-69`:
+
+```ts
+visibility: tid === tabId() && tabSwitching() ? "hidden" : null,
+```
+
+The gate applies to whichever tab is **currently active**. But `activeTabId` is
+derived from `Workspace.activetabid` (`window-identity.ts:44-49`) — the same
+object whose change *is* the transition. So during a close:
+
+- `holdRevealGate()` is called first — at that moment `tabId()` is still the
+  **outgoing** tab, so the gate hides *the tab that is about to be deleted*,
+  which needs no hiding at all.
+- Only once the workspace update lands does `tabId()` flip, and only then does
+  the gate cover the **incoming** tab.
+
+The gate is one reactive step behind the thing it protects, and it is a
+*time-based* suppressor (`SETTLE_MS = 80`, `MAX_GATE_MS = 800`,
+`tab-reveal.ts:51-62`) with no causal link to "the new tab has actually
+finished measuring." It guesses. Sometimes it guesses right.
+
+## 4. Diagnosis
+
+The flash is not a bug in the tab-close path. It is the visible symptom of four
+structural properties, any one of which is sufficient to produce it:
+
+1. **No transactional boundary over state.** Multi-object truths are stored as
+   independent reactive cells, so incoherent intermediate states are always
+   representable.
+2. **No ordering contract across transports.** Three paths deliver the same
+   change; whichever wins the race defines what the user sees.
+3. **No cross-compositor synchronization.** DOM and native pane surfaces are
+   updated by separate, asynchronous, unacknowledged channels.
+4. **Correctness of the visible frame is enforced by timers, not by
+   construction.** Reveal gates, debounces and settle detectors *hide* wrong
+   frames for a guessed duration instead of preventing them.
+
+Under these properties, "fix the flash" is not a finite task. Each fix removes
+one member of a combinatorial set of (transport × object-pair × compositor)
+interleavings. That is why four correct fixes moved nothing, and why the
+codebase has ~20 of these incidents rather than one.
+
+## 5. What this argues for
+
+Not another gate. The companion spec
+(`SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md`) proposes the structural
+changes; in one line each:
+
+- **A workspace-transition epoch** so multi-object changes are versioned and
+  applied as one unit, making torn state unrepresentable rather than merely
+  unlikely.
+- **One transport for object updates**, with the other two demoted to
+  cache-warmers that can never drive a paint.
+- **Causal reveal** — reveal on an observed "measured and stable" signal from
+  the layout model, replacing the 80ms/800ms timers.
+- **A frame contract with the native compositor** so DOM and native clip
+  changes commit together, or the DOM waits.
+
+## 6. Honest limits of this analysis
+
+- Written from code and document history. I never visually reproduced the
+  flash myself; §0's outcome comes from the fix that shipped.
+- §3.3 was my leading hypothesis and was **wrong for this symptom** (§0). The
+  mechanism is real and documented elsewhere; my ranking of it was not.
+- §3.4 (zero-size measurement) is confirmed by code reading, but its
+  contribution to *this* flash remains unquantified — PR #2818 did not address
+  it and the symptom went away, so it was likely not a contributor here.
+- §3.1/§3.2 (no transaction boundary, three racing transports) remain true of
+  the system as built. PR #2818 made the *tab strip* immune to them by not
+  depending on backend ordering; it did not remove them. Any other surface that
+  still renders straight from multi-object backend state retains the exposure.
+
+## 7. The transferable lesson
+
+The fix that worked did not win the race — it **left the race**. The strip
+stopped deriving its rendering from a backend transition it could not order.
+
+That generalizes into a design rule worth applying before the next flicker
+bug is filed:
+
+> When a user gesture has a known, predictable outcome, render the outcome
+> immediately and reconcile afterwards. Do not render the *transition*, and do
+> not try to make the transition atomic — make it invisible.
+
+And a review heuristic, since this class has now cost ~40 documents:
+
+> If a proposed fix is a gate, a debounce, a `batch()`, a delay constant, or an
+> emission reorder, it is a **suppressor**. Suppressors are legitimate only
+> when the intermediate state is genuinely unavoidable. First ask: can this
+> surface stop depending on the ordering altogether?

--- a/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
+++ b/docs/specs/SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md
@@ -1,12 +1,18 @@
 # Tab close (X) button — spurious select flash
 
-**Status:** §§2-3 (click-bubble race), §5 (double round trip), §6
-(unbatched RPC-response application), and §7 (unbatched WS-push
-application — the reason the flash survived §§5-6) are all implemented on
-branch `fix/tab-close-select-flash` (PR #2811, open — not yet merged to
-`main`, so no release build contains any of this yet).
+**Status:** **RESOLVED.** §§2-3 (click-bubble race), §5 (double round trip),
+§6 (unbatched RPC-response application) and §7 (unbatched WS-push application)
+merged in PR #2811 (`c0eb56d87`) — all four were real defects, but the flash
+survived them. It was actually fixed by §8 (**optimistic tab removal** — the
+strip stops depending on backend update ordering at all) and §9 (**targeted
+reveal gate**), merged in PR #2818 (`a2fbe5b4d`).
 **Owner:** unassigned
 **Date:** 2026-08-25
+**Why it took five rounds:** analysed in
+`docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md` — §§2-7 each
+tried to *win* an ordering race; only §8 left the race. That report also
+records the verification gap (no build ever contained §§5-7 together during
+testing) and the wider ~40-document flicker family this belongs to.
 **Scope:** `frontend/app/tab/tab.tsx`, `frontend/app/tab/tabbar.tsx`,
 `frontend/app/tab/droppable-tab.tsx`, `agentmux-srv/src/reducer/tab.rs`
 (`handle_set_active_tab`, `handle_delete_tab`)

--- a/docs/specs/SPEC_TAB_CONTENT_REVEAL_GATE.md
+++ b/docs/specs/SPEC_TAB_CONTENT_REVEAL_GATE.md
@@ -1,6 +1,7 @@
 # Tab content reveal gate
 
-**Status:** Proposed (implemented — see note below)
+**Status:** Implemented — but this document describes the ORIGINAL design; two
+later specs changed its behaviour. Read those before relying on anything below.
 **Owner:** AgentA
 **Date:** 2026-05-09
 
@@ -8,6 +9,25 @@
 > exist, wired into `startup-splash.ts` and `editor-model.ts`. Status field
 > was never updated. See
 > `docs/reports/REPORT_DOCS_AND_DEAD_CODE_CLEANUP_AUDIT_2026_08_07.md`.
+>
+> **2026-08-31 amendment — the gate is no longer one global boolean:**
+> - `SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md` added a **leaf-scoped**
+>   gate (`gatingNodeIds()`, `holdLeafRevealGate`/`scheduleLeafRevealLift` with
+>   generation tokens) alongside this whole-tab one, for pane-local mounts that
+>   bypass `setActiveTab`.
+> - `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §9 made the whole-tab
+>   gate **targeted**: `holdRevealGate(targetTabId)` names its destination, and
+>   `workspace.tsx` hides only that tab once it becomes active. Previously it
+>   gated whichever tab was active *at the time*, which — because `activeTabId`
+>   derives from the same `Workspace` object whose mutation is the transition —
+>   meant it gated the OUTGOING tab during a close and let the incoming one
+>   blank toward the 800ms cap.
+>
+> The timer-based lift below (80ms clean-frame settle / 800ms hard cap) is
+> unchanged and remains the known weak point — it guesses at readiness rather
+> than observing it. See
+> `docs/specs/SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md` §3.4 for the
+> proposed causal replacement.
 **Driving observation:** Switching tabs in AgentMux reveals content in stages — title bar updates first, then pane shells, then block content fills in pane-by-pane, then final layout settles. The user perceives this as visual jank: "different parts of the window appear at different times." Reported as a general cleanup concern, not specific to any one pane type.
 
 ## Symptom

--- a/docs/specs/SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md
+++ b/docs/specs/SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md
@@ -1,0 +1,306 @@
+# Tab / window render architecture — coherent-frame design
+
+**Date:** 2026-08-31
+**Status:** Proposal. Not implemented. Revised after PR #2818 fixed the
+tab-close flash by *optimistic removal* (§§8-9 of the 08-25 spec) — see §0.
+That resolution validates this spec's thesis and **shrinks its urgency**: the
+cheap structural move beat the expensive one. Read §0 before funding any phase
+here.
+**Owner:** unassigned
+**Companion:** `docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md`
+(the evidence and diagnosis this spec responds to — read it first)
+**Scope:** `frontend/app/store/wos.ts`, `frontend/app/store/global.ts`,
+`frontend/app/store/window-identity.ts`, `frontend/app/store/tab-reveal.ts`,
+`frontend/app/workspace/workspace.tsx`, `frontend/app/tab/*`,
+`frontend/layout/lib/{layoutModel,layoutModelHooks,layoutResize}.ts`,
+`frontend/app/platform/pane-overlay.ts`,
+`agentmux-srv/src/server/{wave_obj_bridge.rs,service/mod.rs}`,
+`agentmux-srv/src/backend/eventbus.rs`
+**Related:** `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` (the four-layer
+fix that motivated this), `SPEC_TAB_CONTENT_REVEAL_GATE.md`,
+`SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md`,
+`SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`,
+`SPEC_TAB_BAR_FIRST_PRINCIPLES_2026_04_25.md`
+
+---
+
+## 0. What the tab-close resolution changed about this spec
+
+PR #2818 fixed the flash with two changes: **optimistic removal** (the tab
+leaves the strip when the modal opens, restored on cancel/failure — so the
+strip never depends on backend ordering) and a **targeted reveal gate**
+(`holdRevealGate(targetTabId)` names its destination instead of gating whoever
+is active).
+
+Three consequences for this document:
+
+1. **The thesis holds.** The winning fix is exactly the move this spec argues
+   for — make the bad state unrepresentable rather than suppress it. §8's own
+   words: *"a tab that is not rendered cannot flash, whatever order the
+   backend's updates arrive in."*
+2. **But the cheap version won.** This spec proposed a global epoch/transaction
+   system (§3.1) to make torn state impossible *everywhere*. PR #2818 got the
+   same guarantee *for one surface* by decoupling it from backend ordering
+   entirely — no protocol change, ~150 lines, one file. **Prefer the local
+   decoupling every time it applies.** §3.1 is only justified for surfaces that
+   genuinely cannot predict their own outcome.
+3. **§3.4's defect was real and is now partly fixed.** The reveal gate being
+   keyed on "currently active" rather than "the destination" was the confirmed
+   cause of the residual pane blank. §9 fixed the targeting. The *timer-based*
+   reveal (80ms settle / 800ms cap) is untouched and remains a suppressor.
+
+**Revised recommendation:** do not fund §3.1/§3.2 on the strength of the tab
+flash — that case is closed. Fund them only if a surface appears that (a) can't
+predict its outcome, and (b) demonstrably tears. §3.4's causal-reveal work is
+the highest-value remaining item; §3.3 is a real seam awaiting its own
+evidence (it was **not** the tab-close cause — see the report's §0).
+
+## 1. Problem statement
+
+Roughly twenty separate flash/flicker defects have been fixed in this codebase
+over ~4 months, each independently root-caused and each fixed with a *symptom
+suppressor* (reveal gate, debounce, settle detector, `batch()`, emission
+reordering). The most recent — the tab-close flash — absorbed **four**
+consecutive correct root-cause fixes without the symptom moving.
+
+The companion report's conclusion: the flash is an emergent property of four
+architectural properties, not a bug with a root cause. This spec defines the
+target architecture that removes those properties.
+
+**Design goal, stated as an invariant:**
+
+> **F1 (Coherent Frame).** Every painted frame reflects exactly one committed
+> workspace state. No frame may show a mixture of two states, and no frame may
+> show a state that was never committed.
+
+Today F1 is *hoped for* via timers. This spec makes it *enforced by
+construction*.
+
+## 2. Current architecture (as-built)
+
+### 2.1 The four independent pipelines
+
+| # | Pipeline | Scheduling | Ordering guarantee |
+|---|---|---|---|
+| P1 | Solid reactive DOM | synchronous, batchable | within one `batch()` only |
+| P2 | WOS object cache | 3 transports (bridge WS / response-broadcast WS / HTTP body) | **none across transports** |
+| P3 | Layout geometry | ResizeObserver → `updateTree()` | reactive to DOM size, i.e. *after* paint |
+| P4 | Native pane compositor | rAF → promise chain → async HTTP → Rust | **none w.r.t. P1** |
+
+F1 is violable at every seam between these.
+
+### 2.2 State fragmentation
+
+One logical fact — "tab X closed, tab Y is now active" — lives in six places
+with no shared version:
+
+`Workspace.tabids`, `Workspace.activetabid`, the `Tab` object, its
+`LayoutState`, the `Block` objects, and the **non-reactive** `layoutModelMap`
+(`layoutModelHooks.ts:13`).
+
+`updateWaveObject`'s version guard (`wos.ts:280`) is per-object, so it cannot
+reject "object A from transition N+1 alongside object B from transition N."
+
+### 2.3 The suppressor layer
+
+`tab-reveal.ts` hides content under `visibility: hidden` for a *guessed*
+duration (`SETTLE_MS = 80`, `MAX_GATE_MS = 800`) and reveals on "no long tasks
+for 80ms." It is keyed on `tid === tabId()` (`workspace.tsx:65`) where
+`activeTabId` derives from the same `Workspace` object whose mutation *is* the
+transition — so the gate is one reactive step behind what it gates (report
+§3.5).
+
+### 2.4 Zero-size measurement
+
+All tabs stay mounted, inactive ones `display: none` (`workspace.tsx:35-40`),
+so hidden tabs measure 0×0 and every activation triggers a
+measure-wrong-then-correct relayout via the container ResizeObserver
+(`layoutModelHooks.ts:69` → `layoutResize.ts:216`). Existing scar tissue:
+`layoutModel.ts:443`'s `Math.max(100000, …)` floor, `droppable-tab.tsx:246`'s
+double-rAF re-measure.
+
+## 3. Target architecture
+
+Four new abstractions. They are independent — each is separately valuable and
+separately shippable — but together they make F1 structural.
+
+**Apply §0's lesson first.** Before reaching for any of these, ask the cheaper
+question: *can this surface stop depending on the ordering altogether?* PR
+#2818 answered yes for the tab strip and needed none of the machinery below.
+The abstractions here are for surfaces where the answer is genuinely no.
+
+**Prior committed direction, not a fresh idea.** §3.1/§3.2 continue work the
+repo already scoped: `SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md` generalizes
+"state reconstructed or duplicated outside a single reducer authority" as a
+systemic pattern, and `SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md` →
+`SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md` already commit to strong
+reducer authority over layout. Anyone picking this up should reconcile with
+those rather than starting from this document. Note also
+`SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`'s open gap: `UpdateObjectMeta` for
+`OTYPE_WINDOW`/`OTYPE_LAYOUT`/`OTYPE_CLIENT` **bypasses the event bus entirely**
+— a fourth transport hole that §3.2's "one authoritative transport" must close.
+
+### 3.1 `WorkspaceEpoch` — a transaction boundary over multi-object state
+
+**Problem solved:** §2.2 fragmentation; torn state is representable today.
+
+The reducer already produces every multi-object change as one atomic
+transition. Give that transition an identity and carry it to the client.
+
+- Backend: every reducer dispatch stamps a monotonic `epoch: u64` on **all**
+  `WaveObjUpdate`s it produces. Same transition → same epoch.
+- Wire: updates travel as `{ epoch, updates: [...] }`, never as bare objects.
+- Frontend: `wos.ts` gains an epoch-aware apply:
+  - Updates from epoch **N+1** apply as one `batch()`.
+  - An update whose epoch is **older** than the cell's current epoch is
+    dropped (this is today's version guard, generalized from per-object to
+    per-transition).
+  - A **partial** epoch — some objects arrived, some haven't — is held in a
+    staging buffer and not committed until complete, or until a short bounded
+    timeout elapses (then applied with a loud `console.warn`; a stuck staging
+    buffer must degrade to today's behaviour, never to a frozen UI).
+
+**Result:** "tab deleted but workspace not yet updated" stops being a state the
+UI can render. It isn't merely unlikely — it is unrepresentable.
+
+**Cost / risk:** touches every `WaveObjUpdate` producer. The staging buffer is
+the risky part (a missing object could stall a commit) — hence the bounded
+timeout and the warn. Ship behind a flag; compare warn-rate before flipping the
+default.
+
+### 3.2 One authoritative transport (`P2` collapse)
+
+**Problem solved:** §2.1's three racing transports — the direct cause of §7.
+
+Exactly one path may drive a paint:
+
+- **Authoritative:** the WS event stream, carrying whole epochs
+  (`waveobj:batchedupdates`, already introduced by §7 — generalize it to carry
+  `epoch`).
+- **Demoted:** the HTTP response body's `updates` become a *cache warm* only —
+  applied only if their epoch is **newer** than what the WS stream has already
+  delivered (i.e. normally a no-op, as it already is in practice).
+- **Removed:** the per-update fan-out in the bridge. The bridge emits **one
+  epoch frame** per reducer event, never N frames. Where it genuinely needs an
+  async fetch to build the frame (`emit_fetched`), it fetches *first*, then
+  emits once.
+
+This subsumes §7's parent-before-child emission ordering: with one frame per
+epoch there is no intra-transition order left to get wrong. Keep the §7
+ordering and its tests until the epoch frame ships — they are the correct
+behaviour under the current design.
+
+### 3.3 `PaneSurfaceSync` — a frame contract with the native compositor
+
+**Problem solved:** §2.1's P4 seam (report §3.3) — the leading hypothesis for
+the *residual* flash, and the one seam no prior fix has touched.
+
+Today the DOM commits immediately while the native pane clip commits several
+frames later via rAF → promise chain → async HTTP (`pane-overlay.ts:83-93`).
+
+Options, cheapest first:
+
+- **(a) Reserve-then-release.** When a modal/overlay unmounts, keep its clip
+  hole registered until the host acknowledges the new clip, *then* release. Trades
+  a few frames of stale-but-coherent for incoherent — strictly better under F1.
+- **(b) Acknowledged clip.** `flushClip` returns a host ack; the DOM change that
+  *depends* on the clip is gated on it. Correct, more invasive, adds a round
+  trip to interactive paths.
+- **(c) Host-side compositing of overlays.** Longest-horizon: the host composites
+  the overlay itself so there is only ever one compositor. Removes the seam
+  entirely; large change.
+
+Recommend **(a)** first — it is small, reversible, and if the hypothesis is
+right it should visibly move the symptom on its own.
+
+### 3.4 `LayoutReadiness` — causal reveal, replacing timed gates
+
+**Problem solved:** §2.3 (guessing) and §2.4 (measure-wrong-then-correct).
+
+Replace "reveal when no long task fired for 80ms" with "reveal when the layout
+model reports it has measured against real bounds."
+
+- `LayoutModel` gains an explicit `measuredEpoch` / `isStable` signal, set when
+  `updateTree()` completes against a **non-zero** container rect.
+- The reveal gate consumes *that*, not a timer. `MAX_GATE_MS` survives only as
+  a safety valve (with a warn when it fires — a hit means the causal signal is
+  wrong and should be fixed, not tuned).
+- Key the gate on the **incoming** tab id explicitly rather than on
+  `tid === tabId()`, removing the one-step-behind defect (§2.3).
+
+Optional follow-on, if measurement shows it matters: give hidden tabs
+`content-visibility: hidden` or keep them sized-but-clipped so their containers
+retain real dimensions, eliminating the 0×0 measurement class outright. This
+would let `layoutModel.ts:443`'s `Math.max(100000, …)` floor and
+`droppable-tab.tsx:246`'s double-rAF be deleted — a good proxy for whether the
+class is genuinely gone.
+
+## 4. What gets deleted
+
+A design is only structural if it *removes* the suppressors. On completion:
+
+- `tab-reveal.ts`'s hand-rolled long-task detector → replaced by §3.4's causal signal
+- `MAX_GATE_MS` / `SETTLE_MS` as behaviour → demoted to instrumented safety valve
+- `layoutModel.ts:443`'s zero-rect floor → unnecessary (§3.4 follow-on)
+- `droppable-tab.tsx:246`'s double-rAF re-measure → unnecessary (§3.4 follow-on)
+- §7's parent-before-child bridge ordering → subsumed by one-frame-per-epoch (§3.2)
+
+If a phase lands and deletes nothing, that phase did not do its job.
+
+## 5. Phasing — measurement first
+
+> **Revised per §0.** The tab-close case is closed; do not run this phasing for
+> it. What follows applies to the *next* member of this class. Phase 0 is the
+> part that generalizes — and PR #2818's own writeup shows why: none of §§5-7
+> was ever tested against a build containing all of them, so several "still
+> broken" reports were of incomplete builds. Reasoning ran four fixes deep
+> without one clean observation.
+
+**Phase 0 — Instrument, and verify the build under test. Blocking.**
+
+Before any further change:
+
+- **Confirm the build actually contains the fix** (label/commit check). This
+  alone would have saved two of the five tab-close rounds.
+
+- A dev-only frame log that timestamps: each WOS epoch/update application, each
+  `activeTabId` flip, each `tabSwitching` transition, each `updateTree()`, each
+  `flushClip()` send **and host ack**.
+- Capture one close-via-modal gesture end to end.
+- **Deliverable:** the ordered list of what painted between the modal closing
+  and the settled frame. This either confirms §3.3 or redirects the whole plan.
+
+Phase 0 is cheap, is the only step that can *falsify* this spec, and prevents a
+fifth confident-but-wrong fix.
+
+**Phase 1 — `PaneSurfaceSync` option (a)** (§3.3). Smallest change with the
+highest prior on being the residual cause. Re-test the gesture.
+
+**Phase 2 — `WorkspaceEpoch`** (§3.1) + **transport collapse** (§3.2). The
+structural core. Behind a flag; compare staging-buffer warn rates.
+
+**Phase 3 — `LayoutReadiness`** (§3.4) and deletion of the suppressor layer (§4).
+
+## 6. Non-goals
+
+- Not a rewrite of the reducer, the WOS cache, or TileLayout. Every proposal
+  here is additive-then-subtractive on existing structures.
+- Not a change to the all-tabs-stay-mounted policy (xterm.js scrollback depends
+  on it) — §3.4's follow-on changes how hidden tabs are *sized*, not whether
+  they are mounted.
+- Not a performance project. F1 is about *coherence*; if a phase trades a few
+  frames of latency for a coherent frame, that is the intended trade.
+
+## 7. Open questions
+
+1. **Is §3.3 actually the residual cause?** Phase 0 answers this. If it is not,
+   Phase 1 should be reordered behind Phase 2.
+2. **Can a partial epoch actually occur** given the bridge's fetch-then-emit
+   change, or is the staging buffer dead weight? If it can't, drop it and apply
+   epochs directly — simpler and removes the stall risk.
+3. **Do LAN/multi-window renderers need epoch coordination**, or is per-renderer
+   monotonicity enough? Suspect the latter; unverified.
+4. **Does the confirm modal need to exist on this path at all?** The gesture is
+   reversible (tabs are restorable). Removing the modal would sidestep the P4
+   seam for *this* gesture — though not for menus, dropdowns or any other
+   overlay, so it is a mitigation, not a fix.

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -19,7 +19,7 @@ import { invokeCommand } from "@/app/platform/ipc";
 initLogPipe();
 
 // ── First-paint signal (Linux startup white-flash fix) ──────────────────────
-// docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
+// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md.
 //
 // Tell the host the moment the browser has actually composited a frame — not
 // "main-frame load complete" (CEF's `on_load_end`, which can fire before


### PR DESCRIPTION
## Summary

The tab-close flash took five rounds to fix (`SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §§2-9). §§2-7 each closed a **real** ordering hole — click bubbling, a double round trip, unbatched response application, unbatched WS-push application — and not one of them moved the symptom. §8's *optimistic removal* fixed it by making the tab strip stop depending on backend update ordering at all.

That outcome is worth recording, because a sweep of `docs/` turns up **~40 documents across 11 families** describing the same class (tab strip, pane/block mount, activity dock, browser-pane indicators, startup/splash, terminal streaming, menus, modals, transparency/compositor, scroll-pin, working-row).

## New docs

**`docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md`**
Why suppressors keep failing on this class, the four unsynchronized render pipelines behind it, and — most usefully — a **scorecard** treating #2818 as a controlled test of the report's own predictions:

- ✅ Confirmed: the flash was architectural; only making the bad state unrepresentable closes it.
- ✅ Confirmed and fixed: the reveal gate was keyed on `tid === tabId()`, one reactive step behind what it gates (repaired by §9's targeted gate).
- ❌ **Refuted:** my leading hypothesis (the native pane compositor's `sendClip` → rAF → async HTTP seam) was *not* the cause. Real seam, documented twice elsewhere as a root cause, but I ranked an inferred hypothesis above a defect I had already verified by reading code.

It also records the finding that outranks any code defect here: **none of §§5-7 was ever tested against a build containing all of them** — some "still broken" reports were of incomplete builds.

**`docs/specs/SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md`**
The tab/window render architecture as built, plus four candidate abstractions (`WorkspaceEpoch`, transport collapse, `PaneSurfaceSync`, `LayoutReadiness`). Its §0 deliberately **argues down its own scope**: this spec proposed a global epoch/transaction system; #2818 got the same guarantee for one surface in ~150 lines and one file. Prefer local decoupling; fund the epoch work only for surfaces that genuinely cannot predict their own outcome. It also reconciles with the already-committed direction in `SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md` and `SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md` rather than starting fresh.

## Docs cleanup

Accuracy fixes surfaced while writing the above:

- **`SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md`** — status claimed PR #2811 was open and unmerged (a stale line I wrote pre-merge). Both #2811 and #2818 have landed; marked RESOLVED with what actually fixed it.
- **`SPEC_TAB_CONTENT_REVEAL_GATE.md`** — was `Proposed (implemented)` and still described the original one-global-boolean design. Two later specs changed its behaviour (leaf-scoped gate #2761; targeted gate #2818 §9). Amended with both, and flags the timer-based lift (80ms/800ms) as the remaining weak point.
- **8 dangling source references** in `navigation.rs`, `backend.rs`, `state/mod.rs`, `bootstrap.ts` pointed at `docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md`, which was **never committed** (a gap the 07-14 report had already flagged). Redirected to `REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md`, which holds the diagnosis.

**Left alone deliberately:** the browser-pane loading-indicator spec (Draft) and working-row tool-burst spec (proposed) — verified against git, no fix has shipped for either, so both statuses are accurate.

## Takeaway the docs propose keeping

> If a proposed fix is a gate, a debounce, a `batch()`, a delay constant, or an emission reorder, it is a **suppressor**. Suppressors are legitimate only when the intermediate state is genuinely unavoidable. First ask: can this surface stop depending on the ordering altogether?

## Test plan

Docs + comment-only changes; no runtime behaviour touched.

- `npx tsc --noEmit` — clean
- `cargo check -p agentmux-cef` — clean (the two `unused doc comment` warnings are pre-existing, in files this PR doesn't touch)

<!-- agentmux:agent_id=agenty -->