### PR TITLE
fix(container): container agents never launch with --input-format stream-json

### DIFF
--- a/.changesets/1788205718-fix-container-container-agents-never-launch-with-input-forma-0g2y.md
+++ b/.changesets/1788205718-fix-container-container-agents-never-launch-with-input-forma-0g2y.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(container): container agents never launch with --input-format stream-json

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -15,6 +15,44 @@ use crate::backend::blockcontroller;
 
 use super::super::AppState;
 
+/// Drop `--input-format <value>` from a container agent's argv.
+///
+/// `--input-format stream-json` tells the CLI that every stdin line is a JSON
+/// envelope. That is true for the PERSISTENT controller, which owns a
+/// long-lived stdin and writes real envelopes — and false for a container
+/// agent, which runs one `docker exec` per turn and whose stdin is written by
+/// `container_spawn.rs` as the raw message text (`format!("{}\n", message)`).
+///
+/// Mixing the two is fatal rather than untidy: the first line the CLI reads is
+/// the startup markdown, and it dies with
+/// `Error parsing streaming input line: # Session Context: JSON Parse error:
+/// Unrecognized token '#'`, EOF'ing the exec in under a second. That is the
+/// whole reason container agents have never started (verified live,
+/// 2026-08-31).
+///
+/// The root cause is fixed at the source in `agent-model.ts`, which no longer
+/// picks `persistentLaunchArgs` for a container agent. This is the self-heal
+/// for blocks ALREADY persisted with the bad argv: `cmd:args` lives in block
+/// meta, so without this, every pane created before that fix keeps failing
+/// forever with no way back short of recreating the agent. Applied at the
+/// point of use so it cannot be bypassed by a block that never re-runs
+/// `resync_controller`.
+///
+/// Removes the flag and its value; tolerates a trailing `--input-format` with
+/// no value rather than panicking on a malformed argv.
+fn strip_stream_json_input_format(args: Vec<String>) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut it = args.into_iter();
+    while let Some(a) = it.next() {
+        if a == "--input-format" {
+            let _ = it.next(); // discard its value
+            continue;
+        }
+        out.push(a);
+    }
+    out
+}
+
 /// Per-agent git commit identity env vars for a spawned agent process
 /// (2026-08-22, docs/retro/retro-shared-git-identity-committer-misattribution-2026-08-22.md).
 ///
@@ -524,7 +562,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                             &block.meta, "agent:container_command", "claude",
                         );
                         let mut base_cmd = vec![container_command];
-                        base_cmd.extend(cli_args);
+                        base_cmd.extend(strip_stream_json_input_format(cli_args));
 
                         let config = blockcontroller::subprocess::SubprocessSpawnConfig {
                             cli_command: String::new(), // unused by spawn_container_turn
@@ -675,6 +713,75 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
 #[cfg(test)]
 mod tests {
     use super::git_identity_env_vars;
+    use super::strip_stream_json_input_format;
+
+    fn v(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The exact argv a container agent was getting before the fix — the
+    /// persistent controller's args, copied verbatim from a live broken block
+    /// (Moras, 2026-08-31). `--input-format stream-json` here is what killed
+    /// the exec on its first stdin line.
+    #[test]
+    fn strips_input_format_and_its_value_from_a_real_broken_argv() {
+        let got = strip_stream_json_input_format(v(&[
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose", "--include-partial-messages",
+            "--permission-prompt-tool", "stdio",
+            "--dangerously-skip-permissions",
+            "--model", "sonnet", "--effort", "high",
+        ]));
+        assert!(!got.iter().any(|a| a == "--input-format"), "the flag must be gone");
+        // Its VALUE must go too — a bare leftover `stream-json` would be
+        // parsed as a positional prompt argument.
+        assert_eq!(
+            got,
+            v(&[
+                "--output-format", "stream-json",
+                "--verbose", "--include-partial-messages",
+                "--permission-prompt-tool", "stdio",
+                "--dangerously-skip-permissions",
+                "--model", "sonnet", "--effort", "high",
+            ]),
+        );
+    }
+
+    /// `--output-format stream-json` is REQUIRED — it is how the pane parses
+    /// the container's output at all. Only the input side is wrong.
+    #[test]
+    fn leaves_output_format_untouched() {
+        let got = strip_stream_json_input_format(v(&["--output-format", "stream-json"]));
+        assert_eq!(got, v(&["--output-format", "stream-json"]));
+    }
+
+    #[test]
+    fn is_a_no_op_on_argv_that_never_had_the_flag() {
+        let args = v(&["--output-format", "stream-json", "--verbose"]);
+        assert_eq!(strip_stream_json_input_format(args.clone()), args);
+        assert_eq!(strip_stream_json_input_format(vec![]), Vec::<String>::new());
+    }
+
+    /// A malformed argv (flag with no value) must not panic — this runs on
+    /// every container turn, and a stale block could carry anything.
+    #[test]
+    fn tolerates_a_trailing_input_format_with_no_value() {
+        assert_eq!(
+            strip_stream_json_input_format(v(&["--verbose", "--input-format"])),
+            v(&["--verbose"]),
+        );
+    }
+
+    /// Defensive: if a block somehow carries the flag twice, remove both
+    /// rather than leaving a stray one that reintroduces the failure.
+    #[test]
+    fn removes_every_occurrence() {
+        let got = strip_stream_json_input_format(v(&[
+            "--input-format", "stream-json", "--verbose", "--input-format", "stream-json",
+        ]));
+        assert_eq!(got, v(&["--verbose"]));
+    }
 
     #[test]
     fn maps_agent_id_to_name_and_placeholder_email() {

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -15,37 +15,67 @@ use crate::backend::blockcontroller;
 
 use super::super::AppState;
 
-/// Drop `--input-format <value>` from a container agent's argv.
+/// Rebuild a container agent's argv from the provider's ONE-SHOT `launch_args`,
+/// carrying over the user's own runtime choices.
 ///
-/// `--input-format stream-json` tells the CLI that every stdin line is a JSON
-/// envelope. That is true for the PERSISTENT controller, which owns a
-/// long-lived stdin and writes real envelopes — and false for a container
-/// agent, which runs one `docker exec` per turn and whose stdin is written by
-/// `container_spawn.rs` as the raw message text (`format!("{}\n", message)`).
+/// A container agent runs one `docker exec` per turn: `container_spawn.rs`
+/// writes the raw message, closes stdin, and reads until EOF. There is no
+/// long-lived stdin and no control channel. The PERSISTENT argv is wrong for
+/// that in three separate ways, and it is what stale blocks carry:
 ///
-/// Mixing the two is fatal rather than untidy: the first line the CLI reads is
-/// the startup markdown, and it dies with
-/// `Error parsing streaming input line: # Session Context: JSON Parse error:
-/// Unrecognized token '#'`, EOF'ing the exec in under a second. That is the
-/// whole reason container agents have never started (verified live,
-/// 2026-08-31).
+///   * `--input-format stream-json` — makes the CLI parse every stdin line as
+///     a JSON envelope, so it meets the startup markdown and dies with
+///     `JSON Parse error: Unrecognized token '#'`. This is the crash that kept
+///     container agents from EVER starting (verified live, 2026-08-31).
+///   * missing `-p` — the one-shot print flag. Without it the CLI is not in
+///     the mode this path drives at all.
+///   * `--permission-prompt-tool stdio` (+ a non-bypass `--permission-mode`) —
+///     routes tool permissions through the control protocol, which only the
+///     persistent controller speaks. A container turn has nothing to answer
+///     `can_use_tool`, so it rejects or hangs on the first permission check.
 ///
-/// The root cause is fixed at the source in `agent-model.ts`, which no longer
-/// picks `persistentLaunchArgs` for a container agent. This is the self-heal
-/// for blocks ALREADY persisted with the bad argv: `cmd:args` lives in block
-/// meta, so without this, every pane created before that fix keeps failing
-/// forever with no way back short of recreating the agent. Applied at the
-/// point of use so it cannot be bypassed by a block that never re-runs
-/// `resync_controller`.
+/// An earlier cut of this deleted only `--input-format` and left the other two
+/// (codex P1 on PR #2867) — that unblocks the immediate crash while leaving the
+/// pane in the wrong CLI mode, which is a worse failure because it looks like
+/// it works. Rebuilding from `launch_args` fixes all three at once.
 ///
-/// Removes the flag and its value; tolerates a trailing `--input-format` with
-/// no value rather than panicking on a malformed argv.
-fn strip_stream_json_input_format(args: Vec<String>) -> Vec<String> {
+/// User choices are preserved rather than reset: `--model` and `--effort` are
+/// what `buildRuntimeArgs` writes from the /model and /effort controls, so
+/// dropping them would silently revert a user's model on every stale pane.
+///
+/// The root cause is fixed at the source in `launch-args.ts`; this is the
+/// self-heal for blocks ALREADY persisted with the bad argv, since `cmd:args`
+/// lives in block meta and would otherwise stay wrong forever. Applied at the
+/// point of use so a block that never re-runs `resync_controller` can't bypass
+/// it.
+fn container_argv(stale: Vec<String>, provider_id: &str) -> Vec<String> {
+    let Some(provider) = crate::backend::providers::get_provider(provider_id) else {
+        // Unknown provider — fall back to removing the one flag that is
+        // outright fatal rather than guessing at a base argv.
+        return strip_flag_with_value(stale, "--input-format");
+    };
+    let mut out: Vec<String> = provider.launch_args.iter().map(|s| s.to_string()).collect();
+    // Carry over the user's runtime selections from the stale argv.
+    let mut it = stale.into_iter();
+    while let Some(a) = it.next() {
+        if a == "--model" || a == "--effort" {
+            if let Some(v) = it.next() {
+                out.push(a);
+                out.push(v);
+            }
+        }
+    }
+    out
+}
+
+/// Remove `flag` and the value token following it, everywhere it appears.
+/// Tolerates a trailing `flag` with no value rather than panicking.
+fn strip_flag_with_value(args: Vec<String>, flag: &str) -> Vec<String> {
     let mut out = Vec::with_capacity(args.len());
     let mut it = args.into_iter();
     while let Some(a) = it.next() {
-        if a == "--input-format" {
-            let _ = it.next(); // discard its value
+        if a == flag {
+            let _ = it.next();
             continue;
         }
         out.push(a);
@@ -561,8 +591,12 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                         let container_command = crate::backend::obj::meta_get_string(
                             &block.meta, "agent:container_command", "claude",
                         );
+                        // Provider id for the one-shot argv rebuild below.
+                        let agent_provider = crate::backend::obj::meta_get_string(
+                            &block.meta, "agentProvider", "claude",
+                        );
                         let mut base_cmd = vec![container_command];
-                        base_cmd.extend(strip_stream_json_input_format(cli_args));
+                        base_cmd.extend(container_argv(cli_args, &agent_provider));
 
                         let config = blockcontroller::subprocess::SubprocessSpawnConfig {
                             cli_command: String::new(), // unused by spawn_container_turn
@@ -713,74 +747,88 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
 #[cfg(test)]
 mod tests {
     use super::git_identity_env_vars;
-    use super::strip_stream_json_input_format;
+    use super::{container_argv, strip_flag_with_value};
 
     fn v(xs: &[&str]) -> Vec<String> {
         xs.iter().map(|s| s.to_string()).collect()
     }
 
-    /// The exact argv a container agent was getting before the fix — the
-    /// persistent controller's args, copied verbatim from a live broken block
-    /// (Moras, 2026-08-31). `--input-format stream-json` here is what killed
-    /// the exec on its first stdin line.
-    #[test]
-    fn strips_input_format_and_its_value_from_a_real_broken_argv() {
-        let got = strip_stream_json_input_format(v(&[
+    /// The exact argv a container agent carried before the fix — the persistent
+    /// controller's args, copied verbatim from the live broken block (Moras,
+    /// 2026-08-31).
+    fn stale_persistent_argv() -> Vec<String> {
+        v(&[
             "--input-format", "stream-json",
             "--output-format", "stream-json",
             "--verbose", "--include-partial-messages",
             "--permission-prompt-tool", "stdio",
-            "--dangerously-skip-permissions",
+            "--permission-mode", "default",
             "--model", "sonnet", "--effort", "high",
-        ]));
-        assert!(!got.iter().any(|a| a == "--input-format"), "the flag must be gone");
-        // Its VALUE must go too — a bare leftover `stream-json` would be
-        // parsed as a positional prompt argument.
-        assert_eq!(
-            got,
-            v(&[
-                "--output-format", "stream-json",
-                "--verbose", "--include-partial-messages",
-                "--permission-prompt-tool", "stdio",
-                "--dangerously-skip-permissions",
-                "--model", "sonnet", "--effort", "high",
-            ]),
+        ])
+    }
+
+    /// All three persistent-only defects must go, not just the fatal one
+    /// (codex P1 on PR #2867): the parse crash, the missing one-shot `-p`, and
+    /// the control-protocol permission flags a container turn cannot answer.
+    #[test]
+    fn rebuilds_a_stale_persistent_argv_into_the_one_shot_form() {
+        let got = container_argv(stale_persistent_argv(), "claude");
+
+        assert!(!got.iter().any(|a| a == "--input-format"), "the fatal parse flag must go");
+        assert!(got.iter().any(|a| a == "-p"), "one-shot print mode must be present");
+        assert!(
+            !got.iter().any(|a| a == "--permission-prompt-tool"),
+            "the container turn has no control channel to answer can_use_tool",
+        );
+        assert!(
+            !got.iter().any(|a| a == "--permission-mode"),
+            "non-bypass permission mode needs the control protocol",
+        );
+        assert!(
+            got.iter().any(|a| a == "--output-format"),
+            "output-format stream-json is how the pane parses the turn at all",
         );
     }
 
-    /// `--output-format stream-json` is REQUIRED — it is how the pane parses
-    /// the container's output at all. Only the input side is wrong.
+    /// A user's model/effort selections must survive the rebuild — silently
+    /// resetting someone's model on every stale pane would be its own bug.
     #[test]
-    fn leaves_output_format_untouched() {
-        let got = strip_stream_json_input_format(v(&["--output-format", "stream-json"]));
-        assert_eq!(got, v(&["--output-format", "stream-json"]));
+    fn preserves_the_users_model_and_effort_choices() {
+        let got = container_argv(stale_persistent_argv(), "claude");
+        let pos = |f: &str| got.iter().position(|a| a == f);
+        assert_eq!(got[pos("--model").expect("--model kept") + 1], "sonnet");
+        assert_eq!(got[pos("--effort").expect("--effort kept") + 1], "high");
+    }
+
+    /// An argv with no user flags rebuilds to exactly the provider baseline.
+    #[test]
+    fn a_stale_argv_with_no_user_flags_becomes_the_plain_baseline() {
+        let got = container_argv(v(&["--input-format", "stream-json", "--verbose"]), "claude");
+        let baseline: Vec<String> = crate::backend::providers::get_provider("claude")
+            .unwrap()
+            .launch_args
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(got, baseline);
+    }
+
+    /// An unknown provider has no baseline to rebuild from, so fall back to
+    /// removing only the outright-fatal flag rather than guessing.
+    #[test]
+    fn an_unknown_provider_falls_back_to_removing_only_the_fatal_flag() {
+        let got = container_argv(v(&["--input-format", "stream-json", "--custom"]), "no-such-provider");
+        assert_eq!(got, v(&["--custom"]));
     }
 
     #[test]
-    fn is_a_no_op_on_argv_that_never_had_the_flag() {
-        let args = v(&["--output-format", "stream-json", "--verbose"]);
-        assert_eq!(strip_stream_json_input_format(args.clone()), args);
-        assert_eq!(strip_stream_json_input_format(vec![]), Vec::<String>::new());
-    }
-
-    /// A malformed argv (flag with no value) must not panic — this runs on
-    /// every container turn, and a stale block could carry anything.
-    #[test]
-    fn tolerates_a_trailing_input_format_with_no_value() {
+    fn strip_flag_with_value_removes_every_occurrence_and_tolerates_a_missing_value() {
         assert_eq!(
-            strip_stream_json_input_format(v(&["--verbose", "--input-format"])),
-            v(&["--verbose"]),
+            strip_flag_with_value(v(&["--x", "1", "--keep", "--x", "2"]), "--x"),
+            v(&["--keep"]),
         );
-    }
-
-    /// Defensive: if a block somehow carries the flag twice, remove both
-    /// rather than leaving a stray one that reintroduces the failure.
-    #[test]
-    fn removes_every_occurrence() {
-        let got = strip_stream_json_input_format(v(&[
-            "--input-format", "stream-json", "--verbose", "--input-format", "stream-json",
-        ]));
-        assert_eq!(got, v(&["--verbose"]));
+        assert_eq!(strip_flag_with_value(v(&["--keep", "--x"]), "--x"), v(&["--keep"]));
+        assert_eq!(strip_flag_with_value(vec![], "--x"), Vec::<String>::new());
     }
 
     #[test]

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -15,8 +15,8 @@ use crate::backend::blockcontroller;
 
 use super::super::AppState;
 
-/// Rebuild a container agent's argv from the provider's ONE-SHOT `launch_args`,
-/// carrying over the user's own runtime choices.
+/// Heal a container agent's argv IN PLACE when — and only when — it still
+/// carries the persistent controller's flags.
 ///
 /// A container agent runs one `docker exec` per turn: `container_spawn.rs`
 /// writes the raw message, closes stdin, and reads until EOF. There is no
@@ -37,33 +37,103 @@ use super::super::AppState;
 /// An earlier cut of this deleted only `--input-format` and left the other two
 /// (codex P1 on PR #2867) — that unblocks the immediate crash while leaving the
 /// pane in the wrong CLI mode, which is a worse failure because it looks like
-/// it works. Rebuilding from `launch_args` fixes all three at once.
+/// it works.
 ///
-/// User choices are preserved rather than reset: `--model` and `--effort` are
-/// what `buildRuntimeArgs` writes from the /model and /effort controls, so
-/// dropping them would silently revert a user's model on every stale pane.
+/// The cut after THAT rebuilt the argv wholesale from `launch_args`, which was
+/// worse again (reagent P1 on the same PR): this runs on EVERY container turn,
+/// not once per stale block, so a rebuild also threw away everything
+/// `agent-model.ts` legitimately appends after the base args —
+/// `agent.provider_flags` (user-configurable) and `--fork-session` (gated on
+/// `providerId === "claude"`, not on `agentMode`, so container agents reach it).
+/// It would have permanently broken both for container agents, on blocks whose
+/// argv this fix had already assembled correctly.
+///
+/// So: subtract, don't rebuild. Remove the flags the PERSISTENT argv carries
+/// that the one-shot argv does not, restore any one-shot flag that's missing,
+/// and leave every other token — the user's `--model`/`--effort`, their
+/// `provider_flags`, `--fork-session` — exactly where it was. Which flags are
+/// "persistent-only" is derived from the provider catalog rather than hardcoded,
+/// so a future flag moving between the two lists doesn't silently strand this.
+///
+/// An argv carrying NO persistent-only flag is returned untouched: it was built
+/// by the fixed `selectLaunchArgs` path and there is nothing to heal.
 ///
 /// The root cause is fixed at the source in `launch-args.ts`; this is the
 /// self-heal for blocks ALREADY persisted with the bad argv, since `cmd:args`
 /// lives in block meta and would otherwise stay wrong forever. Applied at the
 /// point of use so a block that never re-runs `resync_controller` can't bypass
 /// it.
-fn container_argv(stale: Vec<String>, provider_id: &str) -> Vec<String> {
+fn container_argv(argv: Vec<String>, provider_id: &str) -> Vec<String> {
     let Some(provider) = crate::backend::providers::get_provider(provider_id) else {
-        // Unknown provider — fall back to removing the one flag that is
-        // outright fatal rather than guessing at a base argv.
-        return strip_flag_with_value(stale, "--input-format");
+        // Unknown provider — no catalog to diff against, so remove the one flag
+        // that is outright fatal rather than guessing at the rest.
+        return strip_flag_with_value(argv, "--input-format");
     };
-    let mut out: Vec<String> = provider.launch_args.iter().map(|s| s.to_string()).collect();
-    // Carry over the user's runtime selections from the stale argv.
-    let mut it = stale.into_iter();
-    while let Some(a) = it.next() {
-        if a == "--model" || a == "--effort" {
-            if let Some(v) = it.next() {
-                out.push(a);
-                out.push(v);
+    let Some(persistent) = provider.persistent_launch_args else {
+        // Subprocess-shaped provider: its only argv IS the one-shot argv, so a
+        // container block could never have been given persistent flags.
+        return argv;
+    };
+
+    let one_shot = flags_with_arity(provider.launch_args);
+    let persistent_only: Vec<(&str, bool)> = flags_with_arity(persistent)
+        .into_iter()
+        .filter(|(flag, _)| !one_shot.iter().any(|(f, _)| f == flag))
+        .collect();
+
+    // Already one-shot-shaped — the frontend assembled this argv, hands off.
+    if !argv
+        .iter()
+        .any(|a| persistent_only.iter().any(|(f, _)| f == a))
+    {
+        return argv;
+    }
+
+    let mut out = argv;
+    for (flag, takes_value) in &persistent_only {
+        out = if *takes_value {
+            strip_flag_with_value(out, flag)
+        } else {
+            out.into_iter().filter(|a| a != flag).collect()
+        };
+    }
+
+    // Restore the one-shot flags the persistent argv never had (`-p` above all).
+    // Prepended so the provider's own baseline keeps its leading position.
+    let mut restored: Vec<String> = Vec::new();
+    for (flag, takes_value) in &one_shot {
+        if out.iter().any(|a| a == flag) {
+            continue;
+        }
+        restored.push(flag.to_string());
+        if *takes_value {
+            if let Some(pos) = provider.launch_args.iter().position(|a| a == flag) {
+                if let Some(v) = provider.launch_args.get(pos + 1) {
+                    restored.push(v.to_string());
+                }
             }
         }
+    }
+    restored.extend(out);
+    restored
+}
+
+/// Split an args list into `(flag, takes_a_value)` pairs.
+///
+/// Arity is read off the list itself — a flag whose next token is not another
+/// flag takes a value. That's what lets `container_argv` strip
+/// `--permission-prompt-tool stdio` (two tokens) and `--verbose` (one)
+/// correctly without a hardcoded table of every provider's flag shapes.
+fn flags_with_arity(args: &'static [&'static str]) -> Vec<(&'static str, bool)> {
+    let mut out = Vec::new();
+    for (i, tok) in args.iter().enumerate() {
+        if !tok.starts_with('-') {
+            continue;
+        }
+        let takes_value = args
+            .get(i + 1)
+            .is_some_and(|next| !next.starts_with('-'));
+        out.push((*tok, takes_value));
     }
     out
 }
@@ -747,7 +817,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
 #[cfg(test)]
 mod tests {
     use super::git_identity_env_vars;
-    use super::{container_argv, strip_flag_with_value};
+    use super::{container_argv, flags_with_arity, strip_flag_with_value};
 
     fn v(xs: &[&str]) -> Vec<String> {
         xs.iter().map(|s| s.to_string()).collect()
@@ -780,6 +850,7 @@ mod tests {
             !got.iter().any(|a| a == "--permission-prompt-tool"),
             "the container turn has no control channel to answer can_use_tool",
         );
+        assert!(!got.iter().any(|a| a == "stdio"), "its value token must go with it");
         assert!(
             !got.iter().any(|a| a == "--permission-mode"),
             "non-bypass permission mode needs the control protocol",
@@ -790,7 +861,7 @@ mod tests {
         );
     }
 
-    /// A user's model/effort selections must survive the rebuild — silently
+    /// A user's model/effort selections must survive the heal — silently
     /// resetting someone's model on every stale pane would be its own bug.
     #[test]
     fn preserves_the_users_model_and_effort_choices() {
@@ -800,25 +871,69 @@ mod tests {
         assert_eq!(got[pos("--effort").expect("--effort kept") + 1], "high");
     }
 
-    /// An argv with no user flags rebuilds to exactly the provider baseline.
+    /// reagent P1 on PR #2867. This runs on EVERY container turn, not once per
+    /// stale block, so it must not touch an argv the frontend already built
+    /// correctly — a rebuild-from-baseline silently deleted `provider_flags`
+    /// and `--fork-session` on every single turn, forever.
     #[test]
-    fn a_stale_argv_with_no_user_flags_becomes_the_plain_baseline() {
-        let got = container_argv(v(&["--input-format", "stream-json", "--verbose"]), "claude");
-        let baseline: Vec<String> = crate::backend::providers::get_provider("claude")
-            .unwrap()
-            .launch_args
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        assert_eq!(got, baseline);
+    fn leaves_an_already_correct_one_shot_argv_completely_untouched() {
+        let correct = v(&[
+            "-p", "--output-format", "stream-json",
+            "--verbose", "--include-partial-messages",
+            "--dangerously-skip-permissions",
+            "--exclude-dynamic-system-prompt-sections",
+            "--model", "opus",
+            "--my-custom-provider-flag", "42",   // agent.provider_flags
+            "--fork-session",                    // resolveForkSessionArgs
+        ]);
+        assert_eq!(container_argv(correct.clone(), "claude"), correct);
     }
 
-    /// An unknown provider has no baseline to rebuild from, so fall back to
+    /// …and when it DOES heal a stale argv, those same user-owned tokens still
+    /// have to come through. Healing is subtraction, not reconstruction.
+    #[test]
+    fn a_heal_preserves_provider_flags_and_fork_session_too() {
+        let mut stale = stale_persistent_argv();
+        stale.extend(v(&["--my-custom-provider-flag", "42", "--fork-session"]));
+
+        let got = container_argv(stale, "claude");
+
+        assert!(got.iter().any(|a| a == "--my-custom-provider-flag"), "provider_flags survive");
+        assert_eq!(
+            got[got.iter().position(|a| a == "--my-custom-provider-flag").unwrap() + 1],
+            "42",
+            "…with its value",
+        );
+        assert!(got.iter().any(|a| a == "--fork-session"), "fork-session survives");
+        assert!(!got.iter().any(|a| a == "--input-format"), "while still being healed");
+        assert!(got.iter().any(|a| a == "-p"));
+    }
+
+    /// An unknown provider has no baseline to diff against, so fall back to
     /// removing only the outright-fatal flag rather than guessing.
     #[test]
     fn an_unknown_provider_falls_back_to_removing_only_the_fatal_flag() {
         let got = container_argv(v(&["--input-format", "stream-json", "--custom"]), "no-such-provider");
         assert_eq!(got, v(&["--custom"]));
+    }
+
+    /// A subprocess-shaped provider has no persistent argv, so nothing it was
+    /// ever launched with could need healing.
+    #[test]
+    fn a_provider_with_no_persistent_variant_is_passed_through() {
+        let argv = v(&["--json", "--whatever"]);
+        assert_eq!(container_argv(argv.clone(), "codex"), argv);
+    }
+
+    /// Arity comes off the catalog, not a hardcoded table — this is what lets
+    /// a valued flag drop its value and a bare flag not eat the next one.
+    #[test]
+    fn flags_with_arity_reads_valued_and_bare_flags_off_the_list() {
+        static ARGS: &[&str] = &["-p", "--output-format", "stream-json", "--verbose"];
+        assert_eq!(
+            flags_with_arity(ARGS),
+            vec![("-p", false), ("--output-format", true), ("--verbose", false)],
+        );
     }
 
     #[test]

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -535,8 +535,17 @@ export class AgentViewModel implements ViewModel {
             const [envVar, value] = vendorOverride;
             envVars[envVar] = value;
         }
-        // Only set exit delay for subprocess mode — persistent processes must stay alive
-        if (provider.controllerType !== "persistent") {
+        // Only set exit delay for subprocess mode — persistent processes must stay alive.
+        //
+        // Keyed on the EFFECTIVE `isPersistent`, not `provider.controllerType`
+        // (codex P1 on PR #2867): a container agent is one-shot even on a
+        // persistent-controllerType provider, and it is exactly the path that
+        // needs this. Without the delay, a Claude that emits its result but
+        // doesn't exit leaves the container output reader waiting on an EOF
+        // that never comes — `run_lock` stays held and every later message
+        // queues forever. `agent_open.rs` already keys this off its own
+        // effective value; this is the same rule on the UI launch path.
+        if (!isPersistent) {
             envVars["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = "30000";
         }
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -25,6 +25,7 @@ import { parseSeedZoom } from "./agent-zoom-seed";
 import { resolveForkSessionArgs } from "./fork-session-args";
 import { HISTORY_TAB_FOR_META_KEY, openOrFocusHistoryTab } from "./open-history-tab";
 import { quickForkAgent } from "./quick-fork";
+import { isPersistentLaunch, selectLaunchArgs } from "./launch-args";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -420,11 +421,28 @@ export class AgentViewModel implements ViewModel {
                 ? `${agentmuxHome()}${persisted.slice("~/.agentmux".length)}`
                 : (persisted || `${agentmuxHome()}/agents/${slug}`);
 
-        // Build CLI args: use persistent args if available, otherwise standard launch args
-        const isPersistent = provider.controllerType === "persistent";
-        const cliArgs = isPersistent && provider.persistentLaunchArgs
-            ? [...provider.persistentLaunchArgs]
-            : [...provider.launchArgs];
+        // Build CLI args: use persistent args if available, otherwise standard launch args.
+        //
+        // A CONTAINER agent is never persistent, whatever the provider says.
+        // It runs one `docker exec` per turn (a subprocess-shaped lifecycle),
+        // so it must take `launchArgs` — NOT `persistentLaunchArgs`, which
+        // carry `--input-format stream-json`.
+        //
+        // Getting this wrong is not a cosmetic mismatch, it is fatal: the
+        // container's CLI then expects every stdin line to be a JSON envelope,
+        // while `container_spawn.rs` writes the raw message text, so the very
+        // first line dies with `Error parsing streaming input line: # Session
+        // Context: JSON Parse error: Unrecognized token '#'` and the exec EOFs
+        // in under a second. `--input-format stream-json` is only ever correct
+        // for the persistent controller, which owns a long-lived stdin and
+        // sends real envelopes over it.
+        //
+        // srv's own equivalent (`agent_open.rs`) already derives
+        // `is_persistent` AFTER applying this same container override; this is
+        // that rule, in the path the UI actually launches through.
+        const agentMode = overrides?.agentType ?? agent.agent_type ?? "host";
+        const isPersistent = isPersistentLaunch(provider, agentMode);
+        const cliArgs = selectLaunchArgs(provider, agentMode);
         if (agent.provider_flags) {
             cliArgs.push(...agent.provider_flags.split(/\s+/).filter(Boolean));
         }
@@ -657,7 +675,10 @@ export class AgentViewModel implements ViewModel {
                 agentOutputFormat: provider.styledOutputFormat,
                 agentName: instanceName,
                 agentIcon: agent.icon,
-                agentMode: overrides?.agentType ?? agent.agent_type ?? "host",
+                // Same value `isPersistent` was derived from above — one
+                // expression, so the controller/args choice and the mode this
+                // block advertises can never disagree.
+                agentMode,
                 ...(overrides?.containerImage || agent.container_image ? { "agent:container_image": overrides?.containerImage || agent.container_image } : {}),
                 controller: isPersistent ? "persistent" : "subprocess",
                 cmd: cliBin,

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -42,7 +42,7 @@ async function updateRuntime(
         // the change applies to the running agent. Shared with the GUI control
         // bar via applyRuntimeChange — the persistent rebuild/restart used to
         // live only here (#1503), so the dropdown silently no-op'd.
-        await applyRuntimeChange(ctx.blockId, ctx.provider(), updated);
+        await applyRuntimeChange(ctx.blockId, ctx.provider(), updated, ctx.block()?.meta?.["agentMode"] as string | undefined);
         return { ok: true, updated };
     } catch (err: any) {
         return { ok: false, error: err?.message ?? String(err) };

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -106,7 +106,12 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
 
     const updateRuntime = async (patch: Partial<AgentRuntimeConfig>) => {
         try {
-            await applyRuntimeChange(props.blockId, getProvider(props.providerId), { ...runtime(), ...patch });
+            await applyRuntimeChange(
+                props.blockId,
+                getProvider(props.providerId),
+                { ...runtime(), ...patch },
+                props.blockAtom()?.meta?.["agentMode"] as string | undefined,
+            );
         } catch {
             // Silent — settings retry on next change (matches the prior
             // AgentComposerStrip.updateRuntime tolerance).

--- a/frontend/app/view/agent/hooks/useAgentCommands.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.test.ts
@@ -2681,3 +2681,83 @@ describe("useAgentCommands — flushPendingControllerRefresh leaves the flag pen
         });
     });
 });
+
+/**
+ * The pre-turn `cmd:args` rebuild must obey the container rule.
+ *
+ * This is the fourth place the persistent-vs-one-shot rule was inlined
+ * (reagent P1 on PR #2867) and by far the most damaging: it runs before EVERY
+ * send, so it rewrote `--input-format stream-json` into `cmd:args` on every
+ * single turn — re-breaking a container agent no matter what launch time had
+ * chosen. `launch-args.ts` owns the rule now; these pin that this path uses it.
+ */
+describe("useAgentCommands — pre-turn cmd:args honours agentMode, not just controllerType", () => {
+    const claudeProvider = {
+        id: "claude",
+        controllerType: "persistent",
+        launchArgs: ["-p", "--output-format", "stream-json", "--verbose"],
+        persistentLaunchArgs: [
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose",
+        ],
+    } as any;
+
+    /** Run one send with the given agentMode and return the persisted cmd:args. */
+    const argsWrittenFor = async (agentMode: string | undefined): Promise<string[]> => {
+        const model = registerPane(BLOCK_ID, fullRegistration());
+        model.dispatchPane({ type: "InitReady", at: Date.now() }, "system");
+        model.dispatchPane({ type: "StreamSubscribe", at: Date.now() }, "system");
+        let written: string[] = [];
+        hub.setMeta.mockImplementation(async (_c: unknown, req: any) => {
+            if (req?.meta?.["cmd:args"]) written = req.meta["cmd:args"];
+        });
+        await createRoot(async (dispose) => {
+            const commands = useAgentCommands({
+                blockId: BLOCK_ID,
+                model,
+                block: () => ({ meta: { agentMode } }) as any,
+                provider: () => claudeProvider,
+                documentAtom: [() => [], () => {}] as any,
+                log: () => {},
+                setAuthUrl: () => {},
+                canRetry: () => false,
+                loginWaiting: () => false,
+                setAuthNotice: () => {},
+                notifyControllerHealthy: () => {},
+                forceControllerRefresh: async () => true,
+                beginRecoveryFlow: () => {},
+                endRecoveryFlow: () => {},
+                isCancelled: () => false,
+                resetCancelled: () => {},
+                isBackendTurnActive: () => false,
+                isBackendTurnConfirmedIdle: () => true,
+                backToPicker: async () => {},
+            });
+            model.dispatchPane({ type: "TurnStart", at: Date.now() }, "user");
+            await commands.sendMessage("hello", false);
+            dispose();
+        });
+        unregisterPane(BLOCK_ID);
+        return written;
+    };
+
+    /** The whole point: this is the flag that killed every container agent. */
+    it("never writes --input-format for a container agent", async () => {
+        expect(await argsWrittenFor("container")).not.toContain("--input-format");
+    });
+
+    it("writes the one-shot -p for a container agent", async () => {
+        expect(await argsWrittenFor("container")).toContain("-p");
+    });
+
+    /** A host agent is unchanged — it really does speak JSON envelopes. */
+    it("still writes --input-format for a host agent", async () => {
+        expect(await argsWrittenFor("host")).toContain("--input-format");
+    });
+
+    /** Blocks predating the agentMode meta key must keep host behaviour. */
+    it("treats a block with no agentMode as a host agent", async () => {
+        expect(await argsWrittenFor(undefined)).toContain("--input-format");
+    });
+});

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -32,6 +32,7 @@ import { snapshot as paneSnapshot } from "@/app/store/agent-pane-state-store";
 import { workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { AgentPaneModel } from "@/app/store/agent-pane-registration";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
+import { selectLaunchArgs } from "../launch-args";
 import { dispatchSlashCommand } from "../commands/dispatch";
 import { buildRegistry } from "../commands/registry";
 import type { SlashCommand, SlashCommandContext, SlashPickerSpec } from "../commands/types";
@@ -1264,9 +1265,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         const prov = opts.provider();
         if (prov) {
             const runtimeConfig = getRuntimeConfig(opts.block()?.meta);
-            const baseArgs = prov.controllerType === "persistent" && prov.persistentLaunchArgs
-                ? prov.persistentLaunchArgs
-                : prov.launchArgs;
+            // A container agent runs one `docker exec` per turn, so it must
+            // never be given the persistent controller's args — above all
+            // `--input-format stream-json`, which makes the CLI parse the
+            // startup markdown as JSON and die. This ran before EVERY send, so
+            // it rewrote the bad flags into cmd:args on every turn regardless
+            // of what launch time had chosen (reagent P1 on PR #2867 — the
+            // fourth copy of this rule, and the one that fires most often).
+            const agentMode = opts.block()?.meta?.["agentMode"] as string | undefined;
+            const baseArgs = selectLaunchArgs(prov, agentMode);
             const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig, prov.id);
             try {
                 await RpcApi.SetMetaCommand(TabRpcClient, {

--- a/frontend/app/view/agent/launch-args.test.ts
+++ b/frontend/app/view/agent/launch-args.test.ts
@@ -1,0 +1,91 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Container agents must never launch with `--input-format stream-json`.
+ *
+ * This is the fix for the reason container ("sandbox") agents had never once
+ * started: they inherited the PERSISTENT controller's args while running the
+ * SUBPROCESS controller's per-turn `docker exec`, whose stdin is raw text. The
+ * CLI met the startup markdown as its first line and died in under a second
+ * with `JSON Parse error: Unrecognized token '#'`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isPersistentLaunch, selectLaunchArgs, type LaunchArgsProvider } from "./launch-args";
+
+/** Claude's real shape, copied from providers/catalog.ts. */
+const claude: LaunchArgsProvider = {
+    controllerType: "persistent",
+    launchArgs: ["--output-format", "stream-json", "--verbose", "--include-partial-messages"],
+    persistentLaunchArgs: [
+        "--input-format", "stream-json",
+        "--output-format", "stream-json",
+        "--verbose", "--include-partial-messages",
+        "--permission-prompt-tool", "stdio",
+        "--permission-mode", "default",
+    ],
+};
+
+/** A provider that is subprocess-shaped to begin with. */
+const codex: LaunchArgsProvider = {
+    controllerType: "subprocess",
+    launchArgs: ["--json"],
+};
+
+describe("isPersistentLaunch", () => {
+    it("is true for a persistent provider on a host agent — unchanged behaviour", () => {
+        expect(isPersistentLaunch(claude, "host")).toBe(true);
+        expect(isPersistentLaunch(claude, undefined)).toBe(true);
+    });
+
+    /** The fix. A container agent is subprocess-shaped whatever the provider says. */
+    it("is FALSE for a container agent, even on a persistent provider", () => {
+        expect(isPersistentLaunch(claude, "container")).toBe(false);
+    });
+
+    it("stays false for a non-persistent provider regardless of mode", () => {
+        expect(isPersistentLaunch(codex, "host")).toBe(false);
+        expect(isPersistentLaunch(codex, "container")).toBe(false);
+    });
+});
+
+describe("selectLaunchArgs", () => {
+    /** The single assertion this whole fix exists for. */
+    it("never gives a container agent --input-format", () => {
+        const args = selectLaunchArgs(claude, "container");
+        expect(args).not.toContain("--input-format");
+    });
+
+    it("gives a container agent the plain launchArgs", () => {
+        expect(selectLaunchArgs(claude, "container")).toEqual(claude.launchArgs);
+    });
+
+    /** …while a host agent still gets them — the persistent controller owns a
+     *  long-lived stdin and genuinely does write JSON envelopes over it. */
+    it("still gives a host agent --input-format", () => {
+        const args = selectLaunchArgs(claude, "host");
+        expect(args).toContain("--input-format");
+        expect(args).toEqual(claude.persistentLaunchArgs);
+    });
+
+    /** --output-format is required in BOTH cases: it's how the pane parses the
+     *  agent's output at all. Only the input side differs. */
+    it("keeps --output-format stream-json for container and host alike", () => {
+        expect(selectLaunchArgs(claude, "container")).toContain("--output-format");
+        expect(selectLaunchArgs(claude, "host")).toContain("--output-format");
+    });
+
+    it("falls back to launchArgs when the provider declares no persistent variant", () => {
+        expect(selectLaunchArgs(codex, "host")).toEqual(["--json"]);
+    });
+
+    /** Returns a copy — callers push provider_flags onto the result, and
+     *  mutating the catalog would corrupt every later launch in the session. */
+    it("returns a fresh array, never the provider's own", () => {
+        const args = selectLaunchArgs(claude, "host");
+        expect(args).not.toBe(claude.persistentLaunchArgs);
+        args.push("--mutated");
+        expect(claude.persistentLaunchArgs).not.toContain("--mutated");
+    });
+});

--- a/frontend/app/view/agent/launch-args.ts
+++ b/frontend/app/view/agent/launch-args.ts
@@ -1,0 +1,58 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Which launch args a pane spawns with — the one rule that decides whether an
+ * agent gets `persistentLaunchArgs` or plain `launchArgs`.
+ *
+ * ## Why this is its own function
+ *
+ * It was previously inlined as `provider.controllerType === "persistent"`,
+ * which is wrong for container agents and had been silently breaking every one
+ * of them since the feature shipped (verified live, 2026-08-31 — no container
+ * agent had ever started on the dev machine).
+ *
+ * A container agent runs one `docker exec` per turn: a subprocess-shaped
+ * lifecycle, whatever the provider's own default controller is. Claude's
+ * `persistentLaunchArgs` carry **`--input-format stream-json`**, which tells
+ * the CLI that every stdin line is a JSON envelope. That contract is only
+ * honoured by the persistent controller, which owns a long-lived stdin and
+ * writes real envelopes. The container path (`container_spawn.rs`) writes the
+ * raw message text instead, so the CLI meets the startup markdown as its first
+ * line and dies immediately:
+ *
+ *     Error parsing streaming input line: # Session Context:
+ *     SyntaxError: JSON Parse error: Unrecognized token '#'
+ *
+ * srv's own copy of this rule (`agent_open.rs`) already applies the container
+ * override *before* deriving `is_persistent`. This is the same rule for the
+ * path the UI actually launches through — the two had drifted, and only the
+ * srv one was correct.
+ */
+
+/** The subset of a provider definition this decision needs. */
+export interface LaunchArgsProvider {
+    controllerType?: string;
+    launchArgs: string[];
+    persistentLaunchArgs?: string[];
+}
+
+/**
+ * True when this pane should launch with the persistent controller's args.
+ *
+ * `agentMode === "container"` forces `false` regardless of the provider —
+ * see the module doc for why this is fatal rather than cosmetic.
+ */
+export function isPersistentLaunch(provider: LaunchArgsProvider, agentMode: string | undefined): boolean {
+    return provider.controllerType === "persistent" && agentMode !== "container";
+}
+
+/**
+ * The args to launch with. Falls back to `launchArgs` whenever the provider
+ * declares no persistent variant, matching the previous inline behaviour.
+ */
+export function selectLaunchArgs(provider: LaunchArgsProvider, agentMode: string | undefined): string[] {
+    return isPersistentLaunch(provider, agentMode) && provider.persistentLaunchArgs
+        ? [...provider.persistentLaunchArgs]
+        : [...provider.launchArgs];
+}

--- a/frontend/app/view/agent/runtime-apply.ts
+++ b/frontend/app/view/agent/runtime-apply.ts
@@ -38,6 +38,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
 import { staticTabId } from "@/app/store/global";
 import { buildRuntimeArgs } from "./buildRuntimeArgs";
+import { isPersistentLaunch, selectLaunchArgs } from "./launch-args";
 import type { AgentRuntimeConfig } from "./types";
 import type { ProviderDefinition } from "./providers";
 
@@ -50,6 +51,19 @@ export async function applyRuntimeChange(
     blockId: string,
     provider: ProviderDefinition | undefined,
     updated: AgentRuntimeConfig,
+    /**
+     * `block.meta["agentMode"]` — "host" or "container". REQUIRED for
+     * correctness on container agents, defaulted only so existing callers
+     * that predate it keep compiling.
+     *
+     * This function used to branch on `provider.controllerType === "persistent"`
+     * alone — a third, unmigrated copy of the rule `launch-args.ts` now owns
+     * (reagent P1 on PR #2867). On a container agent that rewrote
+     * `--input-format stream-json` straight back into persisted `cmd:args` on
+     * every /model, /effort or /mode change, undoing the launch-time fix, and
+     * forced a controller restart the container path never needed.
+     */
+    agentMode?: string,
 ): Promise<void> {
     const oref = WOS.makeORef("block", blockId);
     await RpcApi.SetMetaCommand(TabRpcClient, {
@@ -57,8 +71,12 @@ export async function applyRuntimeChange(
         meta: { "agent:runtime": updated },
     });
 
-    if (provider?.controllerType === "persistent") {
-        const baseArgs = provider.persistentLaunchArgs ?? provider.launchArgs;
+    // Container agents are one-shot per `docker exec`, so they neither take
+    // persistent args nor need the restart — `input.rs` reads `cmd:args` fresh
+    // from block meta on every turn, so a runtime change applies to the next
+    // one with no controller churn at all.
+    if (provider && isPersistentLaunch(provider, agentMode)) {
+        const baseArgs = selectLaunchArgs(provider, agentMode);
         const updatedArgs = buildRuntimeArgs(baseArgs, updated, provider.id);
         await RpcApi.SetMetaCommand(TabRpcClient, {
             oref,


### PR DESCRIPTION
## Container agents have never once started

Confirmed on this machine: across **every srv log ever written**, the only container-related line is the startup Docker probe. No exec, no create, ever.

Docker was never the problem — daemon healthy, image present locally, probe succeeds every boot. Reproduced live with @a5af driving the real UI (2026-08-31): the container starts, the exec launches, and the CLI **inside** it dies on its first line of stdin in under a second.

```
19:36:20.647  restarted stopped container   agentmux-b64b63c1-…
19:36:20.647  container agent turn: bollard exec
19:36:21.439  container exec stderr:
              Error parsing streaming input line: # Session Context:
              SyntaxError: JSON Parse error: Unrecognized token '#'
19:36:21.446  container exec output EOF
```

The block's own meta shows why:

```
agentMode  = 'container'
controller = 'persistent'                          ← wrong
cmd:args   = ['--input-format', 'stream-json', …]  ← fatal
```

## The mismatch

`--input-format stream-json` tells the CLI that **every stdin line is a JSON envelope**. That's true for the **persistent** controller, which owns a long-lived stdin and writes real envelopes.

A container agent runs one `docker exec` per turn, and `container_spawn.rs` writes the raw message text (`format!("{}\n", message)`). So the CLI meets the startup markdown as its first line and dies.

**The container agent was getting the persistent controller's arguments with the subprocess controller's stdin behaviour.** Those can never work together.

## Root cause — one missing condition, in one of two copies of the same rule

`agent-model.ts` derived `isPersistent` from `provider.controllerType` alone, ignoring agent type — so a container agent on Claude got `persistentLaunchArgs`.

srv's own equivalent (`agent_open.rs:267`) **already applies the container override before deriving `is_persistent`**, and is correct. The same rule lived in two places and only one was right.

srv also overrides the *controller* at resync — the log even says *"container agent has persistent controller in meta — overriding to subprocess"* — but never re-derives `cmd:args`, so the bad argv survived the override that was supposed to fix exactly this.

## The fix

**Root cause** — extracted to `launch-args.ts` so the rule has one home, with `agentMode` computed once and reused for both `isPersistent` **and** the meta write. The mode a block advertises and the args it launches with can no longer disagree.

**Self-heal** — `cmd:args` lives in block meta, so every pane created before this fix would keep failing *forever*, with no route back short of recreating the agent. `strip_stream_json_input_format` drops the flag at the point of use in the container branch, where a block that never re-runs `resync_controller` can't bypass it.

## Found en route, deliberately not fixed here

`agent.open`'s CLI-presence gate (`agent_open.rs:238`) looks in `~/.agentmux/<version>/cli/`, but the CLI actually lives in `~/.agentmux/instances/v<version>/cli/`. The RPC open path therefore returns `CLI_NOT_AVAILABLE` for **host** agents too — I hit it twice this session and worked around it with a junction.

Unrelated to containers, and it *masked* this bug during investigation — I initially mis-diagnosed it as the container root cause until I noticed the identical error had appeared for a `host` agent earlier. Worth its own change.

## Testing

**9 frontend** — container never gets `--input-format`, host still does, `--output-format` preserved for both, returns a fresh array (callers push `provider_flags` onto it).

**5 srv** — strips the flag *and its value* from the real broken argv captured from the live block, leaves `--output-format` alone, no-ops on clean argv, tolerates a malformed trailing flag, removes repeated occurrences.

`npx vitest run frontend/app/view` — **1955 passed**. `cargo test -p agentmux-srv` — **2874 passed**. `tsc` clean.

**Not yet verified end-to-end.** The diagnosis came from a live reproduction and the fix is unit-tested, but I haven't re-run a container agent through the UI with these changes applied — that needs a fresh `task dev`. Worth doing before merge given this path has never worked.

<!-- agentmux:agent_id=agent2 -->