### PR TITLE
fix(agent): widen the transient-failure auto-retry ladder, add jitter

### DIFF
--- a/.changesets/1788206573-fix-agent-widen-the-transient-failure-auto-retry-ladder-to-4-nazl.md
+++ b/.changesets/1788206573-fix-agent-widen-the-transient-failure-auto-retry-ladder-to-4-nazl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): widen the transient-failure auto-retry ladder to ~4min with jitter

--- a/docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md
+++ b/docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md
@@ -66,6 +66,27 @@ The budget is deliberately capped: an auto-retry stays inside the same
 resets only on a genuine turn success or a genuinely fresh user message.
 That design is sound and is preserved.
 
+## 3.1 This was already diagnosed, a month earlier
+
+Both gaps fixed below were identified in
+`REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md`'s "Gaps vs.
+best practice" section on **2026-07-27**, verbatim:
+
+> 1. **Not exponential.** 5s → 10s is a fixed doubling for exactly two steps,
+>    not real exponential growth — a THIRD consecutive 429 has no automatic
+>    retry left at all and drops straight to manual, even though 429 bursts
+>    are frequently short and self-clearing over more than two attempts.
+> 2. **No jitter.** `armAutoRetry` fires at exactly T+5s / T+10s,
+>    deterministically. Multiple agent panes sharing one account/quota (a real
+>    scenario in this app — several agents, one Anthropic subscription) would
+>    all retry in lockstep and collide on the SAME rate limit again.
+
+The analysis was correct and nothing acted on it for five weeks. Worth noting
+as a process observation, not just a code one: the finding was filed inside a
+report about a *different* headline bug (login persistence + stuck working
+state), so it never became a tracked item of its own. A correct diagnosis
+buried in a larger document is, in practice, close to no diagnosis at all.
+
 ## 4. What changed in this PR
 
 ### 4.1 The ladder was too short (fixed)

--- a/docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md
+++ b/docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md
@@ -1,0 +1,151 @@
+# Transient API failure (429 / 529 / network) retry — where we are
+
+**Date:** 2026-08-31
+**Author:** AgentY
+**Status:** Assessment. One gap fixed in the same PR (§4.1); the rest recorded,
+not fixed.
+**Scope:** `agentmux-srv/src/agents/failure.rs`,
+`frontend/app/view/agent/hooks/useAgentFailure.ts`,
+`frontend/app/view/agent/failure/failure-accessory.ts`,
+`frontend/app/view/agent/providers/claude-translator.ts`,
+`frontend/app/store/agent-pane-state/reducer.ts`
+**Related:** `SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md` (the design; still
+marked Draft/proposed though largely implemented),
+`SPEC_AGENT_ERROR_FRAMEWORK_2026_06_20.md`,
+`SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md`,
+`docs/retro/retro-busy-animation-stuck-on-429-2026-06-24.md`
+
+---
+
+## 1. Short answer
+
+Retry for transient provider failures **is implemented**, at two independent
+layers, and both work. The weakness was **policy, not plumbing**: the auto-retry
+budget was two attempts totalling ~15 seconds, which is shorter than a typical
+Anthropic 429/529 episode — so a genuinely transient, genuinely retryable
+failure routinely exhausted the budget and dropped to manual-only. That is
+fixed (§4.1).
+
+Three gaps remain open and are recorded in §5. The most significant: **auto-retry
+only exists while an agent pane is mounted** — it is a frontend hook, so a turn
+driven headlessly gets no retry at all.
+
+## 2. Layer 1 — the CLI's own backoff (we observe, we don't drive)
+
+When Claude CLI hits a 429 it runs its *own* retry loop and emits
+`rate_limit_event` NDJSON lines carrying `retry_after_ms`.
+
+- `claude-translator.ts:60-63` translates it to a `provider_waiting` event.
+- `agent-pane-state/reducer.ts` records `retryAfterMs` on the turn phase and
+  uses it to size the stuck-stream watchdog
+  (`retryAfterMs + LIVENESS_RECOVERY_MS`, `reducer.ts:318-334`) so a legitimate
+  backoff isn't misread as a stall.
+- The pane shows a waiting state rather than a silently-spinning progress bar.
+
+This is the fix from `retro-busy-animation-stuck-on-429-2026-06-24.md`, and it
+shipped. **No AgentMux-side retry happens or should happen here** — the CLI is
+still alive and retrying; our job is only to not misdiagnose it as a hang.
+
+## 3. Layer 2 — AgentMux retry after the turn actually fails
+
+When the CLI gives up and the process exits:
+
+- `agents/failure.rs` classifies the exit. `RateLimited` (429, `failure.rs:26`),
+  `Overloaded` (529, `failure.rs:28`) and `Network` are marked
+  `retryable: true`.
+- The classification reaches the pane as an `agentfailure` WPS event and is
+  persisted to block meta (`agent:last_failure`), so the recovery banner
+  survives tab switches and reloads.
+- `failure-accessory.ts:73-75` — `isTransient()` gates auto-retry to exactly
+  those three classes. Everything else (auth, context_exceeded, killed, …) gets
+  a banner with class-appropriate manual actions but never auto-fires.
+- `useAgentFailure.ts` arms a countdown and re-sends the last user message.
+
+The budget is deliberately capped: an auto-retry stays inside the same
+"episode", so a persistently-throttled turn cannot loop forever. The budget
+resets only on a genuine turn success or a genuinely fresh user message.
+That design is sound and is preserved.
+
+## 4. What changed in this PR
+
+### 4.1 The ladder was too short (fixed)
+
+`AUTO_RETRY_BACKOFF_S` was `[5, 10]` — two attempts, ~15s of total coverage,
+then manual-only. Anthropic overload episodes commonly outlast that, so the
+common case was: classifier correctly says "retryable", UI correctly offers
+auto-retry, budget correctly exhausts — and the user is left clicking *Retry
+now* by hand against a failure the system already knew was transient.
+
+Now `[5, 15, 30, 60, 120]` — five attempts, ~3.9 minutes of coverage.
+
+Still bounded, and deliberately so: a turn still failing after ~4 minutes is
+more likely a sustained outage or an account-level limit than a blip, and at
+that point a human should decide rather than have the app hammer the API
+indefinitely.
+
+### 4.2 Retries were unjittered (fixed)
+
+Every rung fired on an exact second boundary. AgentMux drives many agents
+concurrently — Fleet broadcast, cron sweeps, loops — so a provider-wide 529
+fails them together and they would all retry on the *same* second, plausibly
+re-triggering the overload they were backing off from.
+
+Each rung now carries ±20% jitter (`jitteredBackoffSeconds`, floored at 1s so
+the visible countdown never starts at zero). Pure and injectable, so the ladder
+stays deterministic under test.
+
+## 5. Gaps NOT addressed here
+
+### 5.1 Auto-retry is pane-scoped — headless turns get none (most significant)
+
+`useAgentFailure` is a SolidJS hook, mounted in exactly one place:
+`agent-view.tsx:1815`. **If no agent pane is mounted, nothing retries.**
+
+The classification, the WPS event and the persisted block meta are all
+server-side and work regardless — it is only the *acting on them* that lives in
+the view layer. So a turn driven by cron (`CronCreate`), a loop (`Loop`), a
+Fleet broadcast, or an MCP `SendMessage` to an agent whose pane isn't rendered
+will classify the 429 correctly, persist it correctly, surface it correctly the
+next time a human opens the pane — and never retry.
+
+Note this is *not* simply "the tab is in the background": inactive workspace
+tabs stay mounted (`workspace.tsx` renders all tabs and hides them with
+`display:none`), so those panes still retry. The exposure is panes that are
+genuinely not rendered — a closed pane, or a non-active block in a pane's
+block stack.
+
+Fixing this properly means moving the retry decision behind the pane, into the
+persistent controller (`backend/blockcontroller/persistent.rs`), which already
+has the classification (`classify_exit_line`) and today explicitly does nothing
+with it — its own doc comment says the banner is surfaced *"just without
+auto-retry."* That is a real design change (who owns retry, how it interacts
+with the pane's budget, what a headless agent does when the budget caps) and
+wants its own spec.
+
+### 5.2 The backoff ignores server-provided timing
+
+`retryAfterMs` is plumbed for Layer 1 (the CLI's own backoff, used by the stall
+watchdog) but Layer 2's ladder is fixed. If a failing turn's evidence carries a
+`Retry-After` or an equivalent hint, honouring it would beat any hardcoded
+ladder. Requires plumbing the hint through `AgentFailure`, which today has no
+field for it.
+
+### 5.3 The spec is still marked Draft
+
+`SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md` reads `Status: Draft / proposed`
+while most of its §3 action matrix, §5 actions and §6 budget are implemented and
+under test. Same stale-status class as the docs cleanup in PR #2866. Not updated
+here because a careful pass would need to check each row of the matrix against
+the code, which is a separate piece of work from this one.
+
+## 6. Verification
+
+`useAgentFailure.test.ts` — 8 passing, covering the full ladder, the cap, the
+jitter band, and all three budget-reset paths. Ladder expectations derive from a
+single `LADDER_MS` constant so a future policy change updates one place.
+Full `frontend/app/view/agent` suite: 1572 passing across 120 files.
+`tsc --noEmit` clean.
+
+Not verified by observation: I did not reproduce a live 429/529 against the
+provider. The change is a policy constant plus a pure helper, both unit-tested,
+but the end-to-end behaviour under a real sustained overload is unobserved.

--- a/docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md
+++ b/docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md
@@ -187,9 +187,18 @@ button becomes a **countdown that fires itself**:
 - **Click → retry immediately** (cancel the timer, run §5.1).
 - **At 0 → auto-fire** the same Retry.
 - **Dismiss/×** cancels the timer (no retry).
-- **Bounded:** at most **2 auto-retries**, backoff `5s → 10s`, then the banner stays with a
+- **Bounded:** a fixed ladder of auto-retries, then the banner stays with a
   manual **Retry now** only (no more auto-firing) and a note "auto-retry stopped after N
   attempts." Prevents an infinite hammer on a sustained 429.
+  - *As designed (2026-06):* 2 auto-retries, backoff `5s → 10s`.
+  - *As shipped (2026-08-31):* 5 auto-retries, `5s → 15s → 30s → 60s → 120s`,
+    each ±20% jittered — ~3.9 min of coverage. The original ~15s was shorter
+    than a typical 429/529 episode, so genuinely transient failures exhausted
+    the budget while still retryable; jitter keeps a Fleet/cron burst from
+    retrying in lockstep. The live value is `AUTO_RETRY_BACKOFF_S` in
+    `frontend/app/view/agent/hooks/useAgentFailure.ts` — treat that as the
+    source of truth over this line. See
+    `docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md`.
 - Implementation: a `createSignal` countdown + `setInterval`/`setTimeout` in the banner,
   cleaned up on `onCleanup` and on `lastFailure` change. Attempt count tracked on
   `AgentPaneState` (e.g. `failureAutoRetries: number`, reset on `TurnReset`).

--- a/docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md
+++ b/docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md
@@ -54,7 +54,7 @@ Beyond the three reported symptoms: every future feature that needs to know "is 
 **Goals**
 - `AgentPaneState` becomes the sole place that can answer "is there an active failure for this pane, and did it end the current turn."
 - A backend `AgentFailure` for a pane whose `turnPhase` is `Submitting`/`Streaming`/`Interrupting` **always** force-transitions that phase to `Done{outcome: "errored"}` on receipt — no dependency on the CLI process actually exiting, no 3-minute backstop needed for this case.
-- The auto-retry countdown (5s → 10s, capped at 2) moves onto the established `schedule-*-timeout` / `*TimeoutElapsed` pattern already used for `SubmitTimeoutElapsed`/`InterruptTimeoutElapsed`, so it's driven by dispatched commands and testable the same way (fake timers + assert on `update()` output), instead of a hook-local `setInterval`.
+- The auto-retry countdown (a bounded ladder — `AUTO_RETRY_BACKOFF_S` in `useAgentFailure.ts` is the source of truth; `5s → 10s` capped at 2 when this spec was written, `5s → 15s → 30s → 60s → 120s` jittered as of 2026-08-31) moves onto the established `schedule-*-timeout` / `*TimeoutElapsed` pattern already used for `SubmitTimeoutElapsed`/`InterruptTimeoutElapsed`, so it's driven by dispatched commands and testable the same way (fake timers + assert on `update()` output), instead of a hook-local `setInterval`.
 - `useAgentFailure.ts` shrinks to: subscribe to the wave event, dispatch a command, read `state.failure` back out, wire the passed-in recovery effects (`onRetry`, `onLoginAgain`, etc.) — genuinely presentation-only, with no state of its own that anything else needs to agree with.
 - Fix the `StreamFlushObserved` clear-on-activity gap (Issue 2) as part of the same reducer touch-up, since it's in the immediately adjacent code.
 
@@ -85,7 +85,8 @@ export interface PaneFailure {
         /** Seconds remaining until the next scheduled retry, or null
          *  if no auto-retry is armed (budget exhausted / non-transient). */
         remainingS: number | null;
-        /** How many auto-retries have fired this episode (capped at 2). */
+        /** How many auto-retries have fired this episode (capped at the
+         *  `AUTO_RETRY_BACKOFF_S` ladder length). */
         count: number;
     } | null;
     /** True while a user-initiated or auto-fired retry is in flight
@@ -156,7 +157,8 @@ case "AutoRetryElapsed": {
     if (!state.failure) return { state, events: [] }; // already cleared/retried manually
     const count = state.failure.autoRetry?.count ?? 0;
     const events: AgentPaneEvent[] = [{ type: "auto-retry-fired" }];
-    // AUTO_RETRY_BACKOFF_S = [5, 10] then manual-only, same budget as today.
+    // Ladder length comes from AUTO_RETRY_BACKOFF_S, then manual-only —
+    // same budget semantics as the hook, whatever the rungs currently are.
     if (count >= AUTO_RETRY_BACKOFF_S.length) {
         return { state: { ...state, failure: { ...state.failure, autoRetry: null } }, events };
     }

--- a/docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md
+++ b/docs/specs/SPEC_PERSISTENT_CONTROLLER_FAILURE_CLASSIFICATION_2026_08_04.md
@@ -49,12 +49,14 @@ already works correctly — **for every provider except Claude**:
   to.
 - `frontend/app/view/agent/hooks/useAgentFailure.ts` — subscribes to that
   event, and for `isTransient(code)` classes (`rate_limited` / `overloaded`
-  / `network`, `failure-accessory.ts:79-81`) already arms a 5s → 10s
-  auto-retry countdown, capped at 2 attempts
-  (`AUTO_RETRY_BACKOFF_S = [5, 10]`, `useAgentFailure.ts:44`), plus a
-  manual Retry action beyond that. This is genuinely "best practice" retry
-  UX (bounded, exponential-ish, user-visible, cancelable) — nothing about
-  the *policy* needs to change.
+  / `network`, `failure-accessory.ts:79-81`) already arms an auto-retry
+  countdown, capped at the `AUTO_RETRY_BACKOFF_S` ladder length
+  (`[5, 10]` when this spec was written; widened to
+  `[5, 15, 30, 60, 120]` with ±20% jitter on 2026-08-31 — see that constant
+  in `useAgentFailure.ts` for the live values), plus a manual Retry action
+  beyond that. This is genuinely "best practice" retry UX (bounded,
+  exponential, user-visible, cancelable) — nothing about the *policy*
+  needed to change for this spec's own work.
 
 All four pieces are wired together correctly today in
 `agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs`
@@ -193,9 +195,11 @@ already in that set.
 
 ## Non-goals
 
-- **No change to the auto-retry policy itself** (5s/10s countdown, 2-attempt
-  cap) — that's `SPEC_AGENT_FAILURE_RECOVERY_UI`'s design, already shipped,
-  already correct.
+- **No change to the auto-retry policy itself** (a bounded countdown ladder;
+  `5s/10s` with a 2-attempt cap when this spec was written, widened to
+  `5s → 15s → 30s → 60s → 120s` jittered on 2026-08-31 — `AUTO_RETRY_BACKOFF_S`
+  in `useAgentFailure.ts` is the source of truth) — that's
+  `SPEC_AGENT_FAILURE_RECOVERY_UI`'s design, already shipped.
 - **No change to `persistent_resume`'s stale-`--resume` retry mechanism** —
   this spec only adds classification on the paths that mechanism has
   already decided are NOT being retried; the mechanism itself is untouched.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1797,8 +1797,9 @@ const AgentPresentationView = ({
         commands.stopAgent();
     };
 
-    // Failure-recovery accessory row (per-error-class actions + 5s auto-retry
-    // for transient throttling). SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.
+    // Failure-recovery accessory row (per-error-class actions + a bounded
+    // auto-retry ladder for transient throttling — see AUTO_RETRY_BACKOFF_S in
+    // useAgentFailure.ts). SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.
     const retryLastTurn = () => {
         const last = [...getDocument()].reverse().find((n) => n.type === "user_message");
         const msg = last && "message" in last ? (last as { message?: string }).message : undefined;

--- a/frontend/app/view/agent/hooks/useAgentFailure.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.test.ts
@@ -4,12 +4,15 @@
 /**
  * useAgentFailure auto-retry budget (§6). Pins the invariants reagent
  * flagged on #1485 and #1987:
- *   1. a sustained transient failure auto-retries at most twice, then caps
- *      (no infinite hammer);
+ *   1. a sustained transient failure auto-retries at most once per rung of
+ *      `AUTO_RETRY_BACKOFF_S`, then caps (no infinite hammer). The ladder
+ *      widened from [5, 10] to [5, 15, 30, 60, 120] — ~15s of coverage was
+ *      shorter than a typical 429/529 episode — so these tests derive their
+ *      expectations from `LADDER_MS` rather than hardcoding the count;
  *   2. the budget is restored after a genuine turn success (`turn-ended`
  *      with outcome "completed" — the reducer's own authoritative verdict,
  *      not an inference from raw process-exit timing), so a later
- *      unrelated transient still gets 2 (#1485);
+ *      unrelated transient gets the full ladder again (#1485);
  *   3. the budget is ALSO restored when the user composes and sends a
  *      genuinely fresh message while the failure row is still showing,
  *      bypassing Retry (simulated here as an external `state.failure`
@@ -44,7 +47,7 @@ vi.mock("@/app/store/global", () => ({
     getBlockMetaKeyAtom: (_blockId: string, _key: string) => () => hub.persistedFailure,
 }));
 
-import { useAgentFailure, type UseAgentFailureResult } from "./useAgentFailure";
+import { jitteredBackoffSeconds, useAgentFailure, type UseAgentFailureResult } from "./useAgentFailure";
 
 const BLOCK_ID = "b";
 const transient = (): AgentFailure => ({ code: "rate_limited", title: "Throttled", detail: "429", retryable: true });
@@ -147,38 +150,91 @@ describe("useAgentFailure P1.2 — persisted meta seed on mount", () => {
     });
 });
 
+/** The production ladder, in ms. Kept here so a change to the backoff policy
+ *  updates every budget test from one place. Jitter is pinned to its midpoint
+ *  in `beforeEach`, so these land on their nominal values. */
+const LADDER_MS = [5000, 15000, 30000, 60000, 120000];
+
+/** Drive a sustained transient failure through every rung, exhausting the
+ *  auto-retry budget. Leaves the hook capped (manual-retry only). */
+function burnBudgetToCap(failingTurn: () => void): number {
+    for (const delay of LADDER_MS) {
+        failingTurn();
+        vi.advanceTimersByTime(delay);
+    }
+    return LADDER_MS.length;
+}
+
 describe("useAgentFailure auto-retry budget (§6)", () => {
     beforeEach(() => {
         hub.handlers.clear();
         hub.persistedFailure = null;
         __resetListeners();
         vi.useFakeTimers();
+        // Pin jitter to its midpoint (factor exactly 1.0) so the ladder below
+        // lands on its nominal seconds. Jitter itself is covered separately.
+        vi.spyOn(Math, "random").mockReturnValue(0.5);
     });
-    afterEach(() => vi.useRealTimers());
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
 
-    it("auto-retries a sustained transient failure exactly twice, then caps", async () => {
+    it("auto-retries a sustained transient failure across the full ladder, then caps", async () => {
         await createRoot(async (dispose) => {
             const onRetry = vi.fn();
             const { ui } = mkUI(onRetry);
             await Promise.resolve(); // flush onMount subscriptions
 
-            failingTurn(); // failure 1 → arm 5s
+            // [5, 15, 30, 60, 120] — exponential, bounded. Covers ~4 minutes,
+            // which spans a typical 429/529 episode; the old [5, 10] ladder
+            // gave up after ~15s while the failure was still retryable.
+            const ladderMs = [5000, 15000, 30000, 60000, 120000];
+
+            failingTurn(); // failure 1 → arm the first rung
             expect(hasRetryCountdown(ui)).toBe(true);
-            vi.advanceTimersByTime(5000); // auto-retry 1
+            vi.advanceTimersByTime(ladderMs[0]);
             expect(onRetry).toHaveBeenCalledTimes(1);
 
-            failingTurn(); // failure 2 → arm 10s
-            vi.advanceTimersByTime(10000); // auto-retry 2
-            expect(onRetry).toHaveBeenCalledTimes(2);
+            for (let i = 1; i < ladderMs.length; i++) {
+                failingTurn();
+                // Each rung must fire only at its own (longer) delay: prove the
+                // ladder actually grew rather than staying at the old 10s.
+                vi.advanceTimersByTime(ladderMs[i] - 1000);
+                expect(onRetry).toHaveBeenCalledTimes(i);
+                vi.advanceTimersByTime(1000);
+                expect(onRetry).toHaveBeenCalledTimes(i + 1);
+            }
 
-            failingTurn(); // failure 3 → capped (no countdown)
-            vi.advanceTimersByTime(60000);
-            expect(onRetry).toHaveBeenCalledTimes(2); // cap holds — no 3rd auto-retry
+            failingTurn(); // one past the ladder → capped
+            vi.advanceTimersByTime(600000);
+            expect(onRetry).toHaveBeenCalledTimes(ladderMs.length); // cap holds
             // Manual retry still offered (label without countdown).
             expect((ui.row()?.actions ?? []).some((a) => a.label === "Retry now")).toBe(true);
 
             dispose();
         });
+    });
+
+    it("jitters each rung within ±20% and never counts down from zero", () => {
+        // Fleet broadcasts / cron sweeps can fail many agents on the same
+        // instant; without jitter they all retry on the identical second and
+        // can re-trigger the 529 they're backing off from.
+        expect(jitteredBackoffSeconds(60, () => 0.5)).toBe(60); // midpoint → no change
+        expect(jitteredBackoffSeconds(60, () => 0)).toBe(48); // -20%
+        expect(jitteredBackoffSeconds(60, () => 1)).toBe(72); // +20%
+
+        // Floor: a small rung must never produce a 0s countdown.
+        expect(jitteredBackoffSeconds(1, () => 0)).toBeGreaterThanOrEqual(1);
+
+        // Every rung stays inside the band for any rand() in [0, 1).
+        for (const base of [5, 15, 30, 60, 120]) {
+            for (const r of [0, 0.25, 0.5, 0.75, 0.99]) {
+                const s = jitteredBackoffSeconds(base, () => r);
+                expect(s).toBeGreaterThanOrEqual(Math.round(base * 0.8));
+                expect(s).toBeLessThanOrEqual(Math.round(base * 1.2));
+            }
+        }
     });
 
     it("a sustained run of failures does NOT reset the cap", async () => {
@@ -187,11 +243,10 @@ describe("useAgentFailure auto-retry budget (§6)", () => {
             mkUI(onRetry);
             await Promise.resolve();
 
-            failingTurn(); vi.advanceTimersByTime(5000);
-            failingTurn(); vi.advanceTimersByTime(10000);
+            const cap = burnBudgetToCap(failingTurn);
             failingTurn();
-            vi.advanceTimersByTime(60000);
-            expect(onRetry).toHaveBeenCalledTimes(2); // repeated failures never reset the budget
+            vi.advanceTimersByTime(600000);
+            expect(onRetry).toHaveBeenCalledTimes(cap); // repeated failures never reset the budget
 
             dispose();
         });
@@ -204,9 +259,8 @@ describe("useAgentFailure auto-retry budget (§6)", () => {
             await Promise.resolve();
 
             // Burn the budget to the cap.
-            failingTurn(); vi.advanceTimersByTime(5000);
-            failingTurn(); vi.advanceTimersByTime(10000);
-            expect(onRetry).toHaveBeenCalledTimes(2);
+            const cap = burnBudgetToCap(failingTurn);
+            expect(onRetry).toHaveBeenCalledTimes(cap);
 
             // The retried turn genuinely succeeds — the reducer's own
             // authoritative verdict, not an inference from process-exit timing.
@@ -214,9 +268,9 @@ describe("useAgentFailure auto-retry budget (§6)", () => {
 
             // A fresh transient failure now auto-retries again on a full budget.
             fire("agentfailure", transient());
-            expect(hasRetryCountdown(ui)).toBe(true);
-            vi.advanceTimersByTime(5000);
-            expect(onRetry).toHaveBeenCalledTimes(3);
+            expect(hasRetryCountdown(ui)).toBe(true); // back at the first rung
+            vi.advanceTimersByTime(LADDER_MS[0]);
+            expect(onRetry).toHaveBeenCalledTimes(cap + 1);
 
             dispose();
         });
@@ -241,9 +295,8 @@ describe("useAgentFailure auto-retry budget (§6)", () => {
             await Promise.resolve();
 
             // Burn the budget to the cap.
-            failingTurn(); vi.advanceTimersByTime(5000);
-            failingTurn(); vi.advanceTimersByTime(10000);
-            expect(onRetry).toHaveBeenCalledTimes(2);
+            const cap = burnBudgetToCap(failingTurn);
+            expect(onRetry).toHaveBeenCalledTimes(cap);
 
             failingTurn(); // failure 3 → would be capped on the old budget
             expect(hasRetryCountdown(ui)).toBe(false);
@@ -254,9 +307,9 @@ describe("useAgentFailure auto-retry budget (§6)", () => {
 
             // A new transient failure now auto-retries again on a full budget.
             fire("agentfailure", transient());
-            expect(hasRetryCountdown(ui)).toBe(true);
-            vi.advanceTimersByTime(5000);
-            expect(onRetry).toHaveBeenCalledTimes(3);
+            expect(hasRetryCountdown(ui)).toBe(true); // back at the first rung
+            vi.advanceTimersByTime(LADDER_MS[0]);
+            expect(onRetry).toHaveBeenCalledTimes(cap + 1);
 
             dispose();
         });
@@ -272,11 +325,11 @@ describe("useAgentFailure auto-retry budget (§6)", () => {
             vi.advanceTimersByTime(5000); // auto-retry 1 fires -> doRetry() clears via `clear()`
             expect(onRetry).toHaveBeenCalledTimes(1);
 
-            failingTurn(); // failure 2 → must arm the SECOND tier (10s), not reset to first (5s)
+            failingTurn(); // failure 2 → must arm the SECOND rung (15s), not reset to the first (5s)
             expect(onRetry).toHaveBeenCalledTimes(1);
             vi.advanceTimersByTime(5000); // if the budget had wrongly reset, this would already fire
             expect(onRetry).toHaveBeenCalledTimes(1);
-            vi.advanceTimersByTime(5000); // completes the real 10s tier
+            vi.advanceTimersByTime(LADDER_MS[1] - 5000); // completes the real second rung
             expect(onRetry).toHaveBeenCalledTimes(2);
 
             dispose();

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -209,8 +209,8 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
         });
 
         // Restore the full auto-retry budget once the LAST turn genuinely
-        // succeeded — a later unrelated transient failure must get its own 2
-        // auto-retries, not inherit a stale count from turns ago. `turn-ended`
+        // succeeded — a later unrelated transient failure must get its own full
+        // ladder, not inherit a stale count from turns ago. `turn-ended`
         // with outcome "completed" is the reducer's own authoritative verdict
         // (emitted only by the real `TurnEnd` command, driven by the CLI's own
         // session_end/result frame on stdout) — a strictly more reliable

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -16,7 +16,7 @@
  * agree with. See docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md.
  *
  * What stays hook-local: the expanded-body toggle, the `retrying` flag, and
- * the 5s/10s auto-retry countdown/budget. None of these are facts anything
+ * the auto-retry countdown/budget. None of these are facts anything
  * else in the app needs to agree on — they're pure view-presentation timing,
  * the same class as a `<Show>` toggle — so there's no drift risk in keeping
  * them here (same rationale the spec used to leave `expanded` local).
@@ -24,9 +24,12 @@
  * The actual recovery *effects* (re-run the turn, re-auth, open Armory) are
  * passed in by the caller so this hook stays presentation-only otherwise.
  *
- * Auto-retry: for transient classes (rate-limit / overload / network) a 5 s
+ * Auto-retry: for transient classes (rate-limit / overload / network) a
  * countdown arms; clicking Retry fires immediately, reaching 0 fires
- * automatically, Dismiss cancels — capped at 2 auto-retries (5 s → 10 s).
+ * automatically, Dismiss cancels. Bounded by `AUTO_RETRY_BACKOFF_S` —
+ * 5 rungs (5 s → 15 s → 30 s → 60 s → 120 s, each ±20% jittered), ~3.9 min
+ * of coverage, then manual-only. See that constant for why the ladder is
+ * this long and why it is nonetheless finite.
  *
  * Spec: docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md §4–§6.
  */
@@ -240,7 +243,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
     // clears `state.failure` the instant that happens, which this effect
     // observes directly. An auto-fired or manually-clicked Retry ALSO clears
     // `state.failure` (via `clear()`), but must NOT reset the budget — same
-    // episode, still capped at 2 (`armAutoRetry`) — so `doRetry` sets
+    // episode, still bound by the same ladder cap (`armAutoRetry`) — so `doRetry` sets
     // `selfInitiatedClear` first; this effect consumes (and resets) that
     // flag on every transition it observes.
     //

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -41,7 +41,42 @@ import type { AgentPaneModel } from "@/app/store/agent-pane-model";
 import type { PaneFailure } from "@/app/store/agent-pane-state/types";
 import { failureToRow, isTransient, type FailureRow } from "../failure/failure-accessory";
 
-const AUTO_RETRY_BACKOFF_S = [5, 10] as const; // then manual-only
+/**
+ * Auto-retry ladder for transient provider failures (429 rate-limited, 529
+ * overloaded, network). Exponential, bounded, then manual-only.
+ *
+ * Was `[5, 10]` — two attempts, ~15s of coverage. That is shorter than a
+ * typical Anthropic 429/529 episode, so a genuinely transient overload
+ * routinely exhausted the budget and dropped to manual-only while still
+ * being retryable. This ladder covers ~4 minutes across 5 attempts, which
+ * spans the common case without becoming an unbounded retry loop (the cap
+ * is what stops a persistently-throttled turn from retrying forever — see
+ * `endEpisode`).
+ *
+ * Deliberately NOT infinite: a turn that is still failing after ~4 minutes
+ * is more likely a sustained outage or an account-level limit than a blip,
+ * and at that point a human should decide. `SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md` §6.
+ */
+const AUTO_RETRY_BACKOFF_S = [5, 15, 30, 60, 120] as const; // then manual-only
+
+/** Jitter fraction applied to each ladder rung (±20%). */
+const AUTO_RETRY_JITTER = 0.2;
+
+/**
+ * Spread concurrent retries so a fleet doesn't re-hit the API in lockstep.
+ *
+ * A Fleet broadcast, a cron sweep, or several loops can put many agents into
+ * the same failure at the same instant; without jitter every one of them
+ * retries on the identical second and can re-trigger the very 529 they are
+ * backing off from. Applies ±`AUTO_RETRY_JITTER` and floors at 1s so the
+ * visible countdown never starts at 0.
+ *
+ * Pure, with an injectable source, so the ladder is testable deterministically.
+ */
+export function jitteredBackoffSeconds(baseSeconds: number, rand: () => number = Math.random): number {
+    const factor = 1 + (rand() * 2 - 1) * AUTO_RETRY_JITTER;
+    return Math.max(1, Math.round(baseSeconds * factor));
+}
 
 export interface UseAgentFailureOptions {
     blockId: string;
@@ -128,7 +163,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
 
     const armAutoRetry = () => {
         if (autoRetries >= AUTO_RETRY_BACKOFF_S.length) return; // capped → manual only
-        const seconds = AUTO_RETRY_BACKOFF_S[autoRetries];
+        const seconds = jitteredBackoffSeconds(AUTO_RETRY_BACKOFF_S[autoRetries]);
         autoRetries += 1;
         setAutoRetryIn(seconds);
         countdown = setInterval(() => {


### PR DESCRIPTION
## Where we actually are

Retry for 429 / 529 / network **is implemented**, at two independent layers, and both work:

1. **The CLI's own backoff.** Claude CLI retries a 429 internally and emits `rate_limit_event` with `retry_after_ms`. We translate that to `provider_waiting` and use the hint to size the stall watchdog, so a legitimate backoff isn't misread as a hang. (The fix from `retro-busy-animation-stuck-on-429-2026-06-24.md` — shipped.) No AgentMux retry happens here, correctly: the CLI is alive and retrying.
2. **Our post-failure auto-retry.** When the CLI gives up, `agents/failure.rs` classifies the exit — `RateLimited` (429), `Overloaded` (529), `Network` are `retryable: true` — and `useAgentFailure` arms a countdown that re-sends the last user message.

So the plumbing was fine. **The weakness was policy.**

## The problem

`AUTO_RETRY_BACKOFF_S` was `[5, 10]` — two attempts, **~15 seconds** of coverage, then manual-only. Anthropic overload episodes routinely outlast that. The common case was: classifier correctly says "retryable" → UI correctly offers auto-retry → budget correctly exhausts → **user hand-clicks *Retry now* against a failure the system already knew was transient.**

## Changes

- **Ladder → `[5, 15, 30, 60, 120]`** — five attempts, ~3.9 minutes. Still bounded on purpose: a turn still failing after ~4 minutes is more likely a sustained outage or an account-level limit than a blip, and a human should decide rather than have the app hammer the API indefinitely. The existing episode/cap semantics (budget resets only on genuine turn success or a genuinely fresh user message) are untouched.
- **±20% jitter** via `jitteredBackoffSeconds`, floored at 1s so the countdown never starts at zero. AgentMux drives many agents concurrently — Fleet broadcast, cron sweeps, loops — so a provider-wide 529 fails them together, and unjittered rungs had every one retry on the *same second*, plausibly re-triggering the overload they were backing off from. Pure with an injectable rand, so the ladder stays deterministic under test.

Tests now derive expectations from a single `LADDER_MS` constant rather than hardcoding counts, so the next policy change updates one place.

## Gap this does NOT fix (documented, not hidden)

**Auto-retry is pane-scoped.** `useAgentFailure` is a Solid hook mounted in exactly one place (`agent-view.tsx:1815`). If no agent pane is rendered, *nothing retries* — a turn driven by cron, a loop, a Fleet broadcast, or an MCP send to an unrendered pane will classify the 429 correctly, persist it correctly, surface it correctly when a human next opens the pane, and never retry.

Worth being precise: this is **not** "the tab is backgrounded" — inactive workspace tabs stay mounted (`workspace.tsx` hides them with `display:none`), so those panes do retry. The exposure is genuinely unrendered panes.

Fixing it means moving the retry decision behind the pane into the persistent controller — which already *has* the classification (`classify_exit_line`) and today explicitly ignores it, its own doc comment reading *"just without auto-retry."* That's a real design change (who owns retry, how it reconciles with the pane's budget, what a headless agent does at cap) and wants its own spec rather than being smuggled in here.

Two smaller gaps also recorded in the report: the ladder ignores server-provided `Retry-After` hints (no field on `AgentFailure` today), and `SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md` is still marked Draft though largely implemented.

## Test plan

- `useAgentFailure.test.ts` — 8/8, covering the full ladder, the cap, the jitter band, and all three budget-reset paths
- `frontend/app/view/agent` — 1572/1572 across 120 files
- `tsc --noEmit` — clean

**Not verified by observation:** I did not reproduce a live 429/529 against the provider. This is a policy constant plus a pure helper, both unit-tested, but end-to-end behaviour under a real sustained overload is unobserved.

<!-- agentmux:agent_id=agenty -->