### PR TITLE
Manoz@Area54: fix(agent-pane): drop composer strip's duplicate centered token/elapsed stats

### DIFF
--- a/.changesets/1788221656-fix-agent-pane-drop-composer-strip-s-duplicate-centered-toke-7dig.md
+++ b/.changesets/1788221656-fix-agent-pane-drop-composer-strip-s-duplicate-centered-toke-7dig.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): drop composer strip's duplicate centered token/elapsed stats

--- a/docs/specs/SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md
@@ -1,0 +1,133 @@
+# Spec: Drop the composer strip's centered token/elapsed stats
+
+**Date:** 2026-08-31
+**Status:** Proposed
+**Motivated by:** direct report — the centered stats readout that
+sometimes appears in `AgentComposerStrip` (above the textarea) is
+confusing because `AgentWorkingRow` ("Worked" row, below the transcript)
+already shows overlapping stats, with no label distinguishing the two.
+
+## Problem
+
+Two independent components render a near-identical `↑in ↓out  ·  Ns`
+readout, in different places in the same pane, sometimes simultaneously:
+
+| | `AgentComposerStrip` (center, above textarea) | `AgentWorkingRow` ("Worked" row, below transcript) |
+|---|---|---|
+| **While a turn is loading** | `rightText()` (`AgentComposerStrip.tsx:587-598`): live `turnTokens` (`↑in ↓out`) + live elapsed, ticking every second | `rightText()` (`AgentFooter.tsx:286-296`): live `turnTokens` (`↑in ↓out`) + live elapsed, ticking every second — **the same data, the same format, at the same time** |
+| **Once idle (turn complete)** | `sessionTotals`: **cumulative** tokens + duration across every turn in the pane's lifetime, since launch | `workedSummary`/`workedSecondary` (`AgentFooter.tsx:277-284`): **per-turn** tokens/duration/cost/turn-count for only the just-finished turn |
+
+While loading, the two rows show literally the same live numbers twice.
+Once idle, they show *different* numbers in the *same visual shape*
+(`↑X ↓Y  ·  Ns`) with no label saying "this turn" vs. "total this
+session" — a user has no way to tell which is which without already
+knowing the two components' separate designs. Confirmed via
+`docs/specs/SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md`, the spec that
+originally split per-turn (`sessionStats`, feeding `AgentWorkingRow`)
+from cumulative (`sessionTotals`, feeding `AgentComposerStrip`) — that
+split was about fixing *what number* `AgentComposerStrip` showed, not
+about whether it should show one there at all.
+
+`AgentComposerStrip`'s stats zone never shows `cost_usd` (confirmed —
+`sessionTotals`/`cost_usd` has no other reference in the file beyond
+feeding this one readout), so removing it loses no information
+`AgentWorkingRow` doesn't already have a version of.
+
+## Decision
+
+Drop `AgentComposerStrip`'s centered stats display entirely.
+`AgentWorkingRow` becomes the sole place a user checks for token/cost/
+elapsed stats — both the live in-flight numbers and the post-turn
+summary already live there, and it already puts the two side by side
+with a `$cost · N turns` secondary line the composer strip never had.
+
+## Design
+
+### Scope: remove the content, not the layout scaffolding
+
+`AgentComposerStrip.tsx`'s row-layout algorithm treats the stats zone as
+a third, always-centered concern alongside the left/right slot rows —
+this is the file's own most heavily documented, most-revised piece of
+logic (7 revisions across 2 days per the module doc comment;
+`docs/specs/SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26.md` and
+`docs/specs/SPEC_COMPOSER_STRIP_DYNAMIC_BALANCE_2026_08_24.md`). The
+scaffolding already handles "the stats zone has no content" as a normal,
+existing case — `statsZone()`'s `<Show when={rightText()}>` renders
+nothing when `rightText()` is empty, and `computeStatsInline` (line
+435-443) degrades to `rowCount === 1` (a harmless, inert value — nothing
+downstream renders regardless) once `statsWidth === 0`. **Making
+`rightText()` permanently empty is therefore a safe, self-contained
+change that doesn't require touching the row-fitting math** — the
+opposite (ripping out `statsZone`/`statsInline`/`computeStatsInline`/the
+two mount `<Show>`s) would mean editing exactly the part of this file
+its own doc comments warn hardest against touching casually, for no
+functional gain (dead-but-inert code, not dead-and-wrong code). That
+larger cleanup is listed as an explicit non-goal below, not bundled in.
+
+### `frontend/app/view/agent/components/AgentComposerStrip.tsx`
+
+- Remove `sessionTotals` and `turnTokens` from `AgentComposerStripProps`
+  (lines ~501-509) — grep-confirmed each has exactly one use site in
+  this file, both inside `rightText()`.
+- Remove `rightText` (lines 587-598), `elapsedMs` (582-585), and
+  `loadStartMs` (574 + its `createEffect` at 576-581) — all three exist
+  solely to feed `rightText()`, confirmed by grep (no other reference in
+  the file).
+- `statsZone()` (1319-1326) keeps its shape but `rightText()` no longer
+  exists to call — replace its `<Show when={rightText()}>` body with
+  nothing (or delete `statsZone`'s inner `<Show>` + span entirely, since
+  it can now never have content — equivalent either way; prefer
+  deleting so a future reader isn't left wondering what the dead `<Show>`
+  was ever for).
+- Leave `statsRefs`, `statsInline()`, `computeStatsInline`, the
+  `ResizeObserver` measurement effect (~1031-1091), and the two
+  `<Show when={!statsInline()}>`/`<Show when={statsInline()}>` mount
+  points (1349, 1379) as-is — per the scope note above, these become
+  permanently inert (always measuring/reserving 0 width for an
+  always-empty zone) but stay correct, and touching them is the larger,
+  separate cleanup called out in Non-goals.
+
+### `frontend/app/view/agent/agent-view.tsx`
+
+- Drop `sessionTotals={agentAtoms().sessionTotalsAtom[0]()}` from the
+  `<AgentComposerStrip>` call site (~line 2395).
+- Drop `turnTokens={agentAtoms().turnTokensAtom[0]()}` from the same
+  call site (~line 2396) — **only this one wiring**, not the
+  `turnTokensAtom` itself or its projection (~line 749): `turnTokensAtom`
+  still feeds `AgentWorkingRow`'s own `turnTokens` prop elsewhere in this
+  file, which stays unchanged.
+
+### Tests
+
+`AgentComposerStrip.test.tsx` has no test that constructs `sessionTotals`/
+`turnTokens` props or asserts on `.agent-composer-strip-stats` content
+(grep-confirmed — the one hit is a comment, not an assertion), so no
+existing test needs updating for the removal itself. Add:
+
+- A render test confirming `.agent-composer-strip-stats` never appears
+  in the DOM regardless of `loading`/turn state (guards against the
+  props being silently reintroduced later).
+
+## Non-goals
+
+- **No change to `AgentWorkingRow`** — it already correctly shows both
+  the live in-flight readout and the post-turn per-turn summary; it's
+  the surviving, single source of truth for these stats after this
+  change.
+- **No removal of the `sessionTotals` state plumbing**
+  (`agent-pane-state/reducer.ts`'s `accumulateStats`, the `sessionTotals`
+  field in `agent-pane-state/types.ts`, `sessionTotalsAtom` in
+  `view/agent/state.ts`, the projection in `agent-pane-state-store.ts`).
+  After this change `AgentComposerStrip` was its only consumer
+  (grep-confirmed), so this state becomes fully unused — but removing a
+  reducer-level accumulator is separate, larger-blast-radius surgery
+  than a display change, and not needed to fix the reported confusion.
+  Worth a follow-up cleanup pass, not bundled here.
+- **No removal of `AgentComposerStrip`'s row-layout scaffolding**
+  (`statsZone`, `statsInline`, `computeStatsInline`, the stats-width
+  `ResizeObserver` effect) — see the Scope note above. A separate,
+  dedicated pass if the dead weight is ever worth the risk of touching
+  this file's most fragile logic again.
+- **No new label/disambiguation UI** for `AgentWorkingRow`'s existing
+  per-turn vs. cumulative numbers — out of scope; this spec only removes
+  the duplicate, it doesn't redesign the surviving one.

--- a/docs/specs/SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md
@@ -97,6 +97,27 @@ larger cleanup is listed as an explicit non-goal below, not bundled in.
   still feeds `AgentWorkingRow`'s own `turnTokens` prop elsewhere in this
   file, which stays unchanged.
 
+### `frontend/app/view/agent/styles/_composer-strip.scss`
+
+Two follow-ups found by review (both applied, not deferred — small,
+low-risk, CSS-only):
+
+- **Dead CSS (ReAgent P2).** `.agent-composer-strip-stats` (the content
+  span's own rule block, including its now-doubly-dead `--compacting`/
+  `--reconnecting` modifiers — those were already orphaned by an earlier,
+  unrelated relocation to `AgentWorkingRow`, 2026-08-27) styled an
+  element that no longer renders anywhere. Removed the whole block.
+- **Phantom layout gap (Codex P2).** The wrapper span
+  (`.agent-composer-strip-stats-zone`) still mounts even with no
+  content, and an empty flex item still counts for `column-gap`/
+  `row-gap` purposes — `computeStatsInline()`'s fit check assumes a
+  `statsWidth === 0` zone contributes no extra gap, so the real DOM
+  could wrap where the layout decision said it wouldn't. Added
+  `.agent-composer-strip-stats-zone:empty { display: none; }`, which
+  removes it from flex layout entirely for as long as it stays empty
+  (unconditionally true after this change) and self-corrects if it ever
+  gains content again.
+
 ### Tests
 
 `AgentComposerStrip.test.tsx` has no test that constructs `sessionTotals`/

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2392,8 +2392,6 @@ const AgentPresentationView = ({
                 State (detailsOpen) is reducer-owned (PR #1068). */}
             <AgentComposerStrip
                 loading={showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]())}
-                sessionTotals={agentAtoms().sessionTotalsAtom[0]()}
-                turnTokens={agentAtoms().turnTokensAtom[0]()}
                 processCount={processCount()}
                 onProcessBadgeClick={() => {
                     createBlock({ meta: { view: "swarm" } });

--- a/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.test.tsx
@@ -39,6 +39,26 @@ const baseProps = {
     providerId: "claude",
 };
 
+// SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md: the centered stats
+// zone (token/elapsed readout) duplicated AgentWorkingRow's "Worked" row
+// and was removed. Guards against the props/content being silently
+// reintroduced later.
+describe("AgentComposerStrip — no centered stats zone content (SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md)", () => {
+    it("never renders .agent-composer-strip-stats while loading", () => {
+        const { container } = render(() => (
+            <AgentComposerStrip {...baseProps} loading={true} />
+        ));
+        expect(container.querySelector(".agent-composer-strip-stats")).toBeNull();
+    });
+
+    it("never renders .agent-composer-strip-stats while idle", () => {
+        const { container } = render(() => (
+            <AgentComposerStrip {...baseProps} loading={false} />
+        ));
+        expect(container.querySelector(".agent-composer-strip-stats")).toBeNull();
+    });
+});
+
 describe("AgentComposerStrip — Tier 3 predictive countdown", () => {
     it("renders no countdown text when the window is unknown", () => {
         render(() => (

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -125,13 +125,10 @@
  * — see docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md.
  */
 
-import { useTick } from "@/app/hook/useTick";
 import { compactionThreshold } from "@/app/store/agent-pane-state/context-window";
 import type { CompactionState } from "@/app/store/agent-pane-state/types";
 import { formatCompactNumber, formatExactNumber } from "@/util/format-count";
-import { formatElapsedCompact } from "@/util/format-time";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount, untrack, type JSX } from "solid-js";
-import type { SessionStats, TurnTokens } from "../types";
 import { AgentRuntimeDropup } from "./AgentRuntimeDropup";
 import { RuntimeBadge } from "./RuntimeBadge";
 
@@ -444,10 +441,6 @@ export function computeStatsInline(
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function fmtTokens(t: TurnTokens): string {
-    return `↑${formatCompactNumber(t.input)} ↓${formatCompactNumber(t.output)}`;
-}
-
 type CtxBand = "low" | "mid" | "high" | "critical";
 
 function ctxBand(tokens: number, contextWindow: number): CtxBand {
@@ -495,14 +488,6 @@ function compactionCountdownText(tokens: number, window: number): string | null 
 interface AgentComposerStripProps {
     /** True while a turn is in flight. */
     loading?: boolean;
-    /**
-     * Cumulative cost/tokens/duration across every completed turn in this
-     * pane's lifetime; non-null after the first TurnEnd. Sums, rather than
-     * replaces, on each turn — see SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md.
-     */
-    sessionTotals?: SessionStats | null;
-    /** Live tokens for the in-flight turn. */
-    turnTokens?: TurnTokens | null;
     /** Count of OS processes tracked for this agent block. */
     processCount?: number;
     /** Fires when the user clicks the ⚙N process badge. */
@@ -570,37 +555,6 @@ interface AgentComposerStripProps {
 // ── Component ──────────────────────────────────────────────────────────────
 
 export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element => {
-    const tick = useTick(1000);
-    const [loadStartMs, setLoadStartMs] = createSignal<number | null>(null);
-    createEffect(() => {
-        if (props.loading) {
-            setLoadStartMs((prev) => prev ?? Date.now());
-        } else {
-            setLoadStartMs(null);
-        }
-    });
-    const elapsedMs = createMemo(() => {
-        const s = loadStartMs();
-        return s != null ? (tick(), Date.now() - s) : 0;
-    });
-
-    const rightText = createMemo((): string => {
-        const parts: string[] = [];
-        if (props.loading) {
-            if (props.turnTokens) parts.push(fmtTokens(props.turnTokens));
-            parts.push(formatElapsedCompact(elapsedMs()));
-        } else if (props.sessionTotals) {
-            const s = props.sessionTotals;
-            if (s.input_tokens != null || s.output_tokens != null) {
-                parts.push(fmtTokens({ input: s.input_tokens ?? 0, output: s.output_tokens ?? 0 }));
-            }
-            if (s.duration_ms != null) {
-                parts.push(formatElapsedCompact(s.duration_ms));
-            }
-        }
-        return parts.join("  ·  ");
-    });
-
     // Show model/effort controls only for Claude agents (controls are claude-specific;
     // non-claude providers (codex/gemini/kimi) have different model enumerations and
     // buildRuntimeArgs silently drops effort for them — spec §1.3).
@@ -1040,9 +994,19 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     // time gets the real on-screen footprint regardless of which
     // position is currently active.
     //
-    // Depends on `rightText()` (the stats zone's own content changing
-    // width) AND `stripWidth()`/`slotWidths()` (ReAgent P1, PR #2812,
-    // re-review) — NOT on `layout()` or `statsWidth()` itself, which
+    // 2026-08-31 (SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md):
+    // the stats zone's content was removed (duplicated AgentWorkingRow —
+    // see that spec), so `statsZone()` below never renders a content
+    // span anymore and this effect now always measures 0. Left in place
+    // rather than removed — see that spec's Non-goals — a permanently-0
+    // `statsWidth` is harmless input to `statsInline` (line ~1000-ish
+    // below), not wrong input, and this effect's own history (right
+    // below) is worth keeping intact for whoever eventually does remove
+    // this scaffolding for real.
+    //
+    // Previously depended on `rightText()` (the stats zone's own content
+    // changing width) AND `stripWidth()`/`slotWidths()` (ReAgent P1, PR
+    // #2812, re-review) — NOT on `layout()` or `statsWidth()` itself, which
     // would be circular (the `layout` memo's `statsInline` reads
     // `statsWidth()`). `stripWidth()`/`slotWidths()` are the actual root
     // inputs behind `statsInline`'s placement flip: without depending on
@@ -1073,7 +1037,6 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     let statsRefs: { single?: HTMLElement; multi?: HTMLElement } = {};
     const [statsWidth, setStatsWidth] = createSignal(0);
     createEffect(() => {
-        rightText();
         stripWidth();
         slotWidths();
         const zone = statsRefs.single?.isConnected ? statsRefs.single : statsRefs.multi?.isConnected ? statsRefs.multi : undefined;
@@ -1288,8 +1251,20 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
         );
     };
 
-    // Stats zone — token/elapsed stats. Always centered (this zone's
-    // identity at every tier). Rendered in ONE of two places, mutually
+    // Stats zone — no longer shows content (2026-08-31,
+    // SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md: this centered
+    // token/elapsed readout duplicated AgentWorkingRow's "Worked" row,
+    // confusingly — while loading, both showed the identical live
+    // turnTokens+elapsed; once idle, this zone showed CUMULATIVE
+    // session totals in the same visual shape AgentWorkingRow uses for
+    // PER-TURN stats, with no label distinguishing the two).
+    // AgentWorkingRow is now the sole surface for these stats. The
+    // wrapper span (and the row-layout accommodation below) stays —
+    // removing it would mean touching this file's most fragile,
+    // heavily-revised logic (module doc comment above) for a
+    // permanently-inert case, not a functional gain; see that spec's
+    // Non-goals. Was: always centered (this zone's identity at every
+    // tier). Rendered in ONE of two places, mutually
     // exclusive (`statsInline()` vs. not — since 2026-08-26 this is its
     // own decision, no longer synonymous with `rows().length === 1`: a
     // single slot row can have the stats evicted to their own line
@@ -1317,13 +1292,7 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     // mounting this instance, so the measurement effect above can tell
     // them apart (see that effect's own doc comment).
     const statsZone = (variant: "single" | "multi") => (
-        <span class="agent-composer-strip-stats-zone" ref={(el) => (statsRefs[variant] = el)}>
-            <Show when={rightText()}>
-                <span class="agent-composer-strip-stats">
-                    {rightText()}
-                </span>
-            </Show>
-        </span>
+        <span class="agent-composer-strip-stats-zone" ref={(el) => (statsRefs[variant] = el)} />
     );
 
     return (

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -88,6 +88,20 @@
     display: contents;
 }
 
+// Codex P2, PR #2874: since SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md
+// removed the stats zone's content, `.agent-composer-strip-stats-zone`
+// (AgentComposerStrip.tsx's `statsZone()`) now ALWAYS renders empty — but an
+// empty flex item still counts for `column-gap`/`row-gap` purposes, while
+// `computeStatsInline()` assumes a `statsWidth === 0` zone contributes no
+// extra gap. That mismatch could make the layout decide "fits in one row"
+// while the real DOM still applies the phantom gap and wraps anyway. `:empty`
+// removes the zone from flex layout entirely whenever it has no content —
+// unconditionally true post-removal, and still correct if this zone ever
+// gains content again (it simply stops matching `:empty` at that point).
+.agent-composer-strip-stats-zone:empty {
+    display: none;
+}
+
 // ── Rows (Rev 7) ─────────────────────────────────────────────────────────
 // Replaces the pre-Rev-7 `-controls`/`-right` zones (see this file's own
 // header comment and docs/specs/SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26.md)
@@ -360,52 +374,6 @@
     .agent-composer-strip-slot-measure
     > :is(.agent-runtime-dropup-trigger, .agent-composer-strip-compact-btn, .agent-composer-strip-process-badge, .agent-composer-strip-log-btn) {
     order: 1;
-}
-
-.agent-composer-strip-stats {
-    // This is a plain <span> (AgentComposerStrip.tsx), and its parent
-    // (.agent-composer-strip-stats-zone) is not a flex/grid container —
-    // unlike -controls/-right's children, nothing blockifies this element,
-    // so it stays genuinely `display: inline` unless overridden here.
-    // `min-width` has no effect on non-replaced inline elements per the
-    // CSS box model spec — without this, the min-width below silently did
-    // nothing (reagent P1, PR #2577). `inline-block` keeps it sitting
-    // inline with any siblings while making min-width actually apply.
-    display: inline-block;
-    font-family: var(--termfontfamily, monospace);
-    font-size: 11px;
-    color: var(--secondary-text-color);
-    letter-spacing: 0.01em;
-    white-space: nowrap;
-    // Reserves a stable footprint for this text so the strip doesn't
-    // reflow every second while a turn is in flight. The text ticks live
-    // (useTick(1000) in AgentComposerStrip.tsx) and its rendered length
-    // isn't fixed — e.g. "9s" → "10s" or "↑890 ↓340" → "↑1.2k ↓340" — so
-    // without a floor, a wrap decision sitting right at the boundary can
-    // flip every tick even though the pane itself never resized. 12ch
-    // comfortably covers the common in-flight range (per-turn tokens,
-    // elapsed up to several minutes); a genuinely long single turn can
-    // still exceed it and reflow, same as every other width in this file —
-    // that's an occasional, real width change, not tick-driven jitter.
-    min-width: 12ch;
-
-    // Live "Compacting… Ns" readout (Tier 1/2 —
-    // SPEC_COMPACTION_DETECTION_AND_HANDLING_2026_07_31.md). Reuses the
-    // same amber the ctx meter's "high" band uses so the state reads as
-    // "notable but not an error" at a glance.
-    &--compacting {
-        color: var(--warning-color, #d9a441);
-        font-weight: 500;
-    }
-
-    // Live "Reconnecting… Ns" readout (a stale-`--resume` recovery in
-    // progress — STATUS_STALE_RESUME_LIVE_REPRO_AND_FIX_PLAN_2026_08_23.md
-    // §6.2). Same treatment as `--compacting` — "notable but not an error,"
-    // not the failure-red used elsewhere for a genuine `AgentFailure`.
-    &--reconnecting {
-        color: var(--warning-color, #d9a441);
-        font-weight: 500;
-    }
 }
 
 .agent-composer-strip-process-badge {


### PR DESCRIPTION
## Summary

The agent pane's composer strip (above the textarea) showed a centered token/elapsed readout that duplicated `AgentWorkingRow`'s "Worked" row (below the transcript), confusingly:

- **While loading**, both showed the identical live `turnTokens` + elapsed, ticking every second, in two places at once.
- **Once idle**, they diverged silently: the composer strip showed *cumulative* session totals (all turns since launch); the Worked row shows *per-turn* stats for just the last turn — same `↑X ↓Y · Ns` visual shape, no label saying which is which.

`AgentWorkingRow` is now the sole surface for these stats — it already covers both cases, plus `$cost · N turns` the composer strip never showed at all.

## Change

Removes the stats *content* only (`sessionTotals`/`turnTokens` props, `rightText`, `elapsedMs`/`loadStartMs`) from `AgentComposerStrip`, and the two prop wirings from `agent-view.tsx`. Deliberately leaves the row-layout scaffolding (`statsZone`/`statsInline`/`computeStatsInline`/the width-measurement effect) in place — that's this file's most heavily revised, most fragile logic (7 revisions in 2 days per its own module doc comment), it already treats "empty stats zone" as a normal existing case, and touching it would be risk for no functional gain. Full reasoning in the spec.

`turnTokensAtom` state/projection is untouched — it still feeds `AgentWorkingRow`'s own `turnTokens` prop elsewhere in `agent-view.tsx`. `sessionTotalsAtom` becomes fully unused after this (grep-confirmed `AgentComposerStrip` was its only consumer) — flagged as an optional follow-up cleanup in the spec's Non-goals, not bundled into this PR (reducer-level accumulator removal is separate, larger-blast-radius surgery).

See `docs/specs/SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md` for the full investigation and design.

## Test plan
- [x] New regression test: `.agent-composer-strip-stats` never renders while loading or idle
- [x] `npx vitest run frontend/app/view/agent/components/AgentComposerStrip.test.tsx` — 52/52 passing (50 existing unaffected + 2 new)
- [x] `npx vitest run frontend/app/view/agent` — 120 files / 1571 tests passing (no regressions from the wiring removal)
- [x] `npx tsc --noEmit` — clean

<!-- agentmux:agent_id=manoz -->