### PR TITLE
feat(term): configurable scroll wheel sensitivity setting

### DIFF
--- a/.changesets/1788222661-feat-term-add-configurable-scroll-wheel-sensitivity-setting-15zh.md
+++ b/.changesets/1788222661-feat-term-add-configurable-scroll-wheel-sensitivity-setting-15zh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(term): add configurable scroll wheel sensitivity setting

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -82,6 +82,9 @@ pub struct SettingsType {
     #[serde(rename = "term:transparency", default, skip_serializing_if = "Option::is_none")]
     pub term_transparency: Option<f64>,
 
+    #[serde(rename = "term:scrollsensitivity", default, skip_serializing_if = "Option::is_none")]
+    pub term_scroll_sensitivity: Option<f64>,
+
     #[serde(rename = "term:allowbracketedpaste", default, skip_serializing_if = "Option::is_none")]
     pub term_allow_bracketed_paste: Option<bool>,
 

--- a/docs/specs/SPEC_TERMINAL_SCROLL_SENSITIVITY_SETTING_2026_08_31.md
+++ b/docs/specs/SPEC_TERMINAL_SCROLL_SENSITIVITY_SETTING_2026_08_31.md
@@ -1,0 +1,147 @@
+# SPEC — Terminal scroll wheel sensitivity setting
+
+**Status:** proposed → implementing
+**Date:** 2026-08-31
+**Author:** agent3
+**Related:**
+- `frontend/app/view/term/termwrap.ts:137` (`new Terminal({...})` construction)
+- `frontend/app/view/term/termwrap.ts:206-210` (`attachCustomWheelEventHandler` — macOS momentum-scroll debounce + Ctrl+Wheel passthrough)
+- `frontend/app/view/settings/sections/terminal-section.tsx` (Terminal settings UI section)
+- `agentmux-srv/src/backend/wconfig/types.rs` (`SettingsType`, Rust-side settings struct)
+- `schema/settings.json`, `frontend/types/gotypes.d.ts`, `settings-template.jsonc` (settings schema/type/template, hand-maintained in parallel per existing convention)
+
+---
+
+## 1. Why
+
+A user asked whether AgentMux lets them control how many lines the mouse wheel
+scrolls inside a terminal pane, and whether that can override the OS-level
+setting (Windows Control Panel → Mouse → "lines to scroll").
+
+Investigation found:
+
+- Terminal wheel scrolling is handled entirely by xterm.js's own internal
+  wheel-to-line logic. AgentMux's only customization
+  (`attachCustomWheelEventHandler`, `termwrap.ts:206-210`) exists purely to
+  suppress macOS trackpad momentum-scroll jitter and to let Ctrl+Wheel fall
+  through to the zoom handler — it never touches line count.
+- xterm.js's `scrollSensitivity` option (multiplier on scroll-wheel delta,
+  library default `1`) is never set anywhere in this codebase, so every
+  terminal pane scrolls at xterm.js's built-in default rate.
+- The app does **not** read the OS "lines per scroll" setting
+  (`SPI_GETWHEELSCROLLLINES` or equivalent) at all — terminal scroll speed is
+  already fully independent of the OS setting, just not configurable by the
+  user today.
+- No existing settings key or UI control exists for this.
+
+This spec adds a user-facing setting that maps directly onto xterm.js's
+`scrollSensitivity`, so the user can make terminal-pane scrolling faster or
+slower than both xterm.js's default and whatever the OS is configured to.
+
+## 2. Goals
+
+- A new setting, `term:scrollsensitivity`, a positive number multiplier
+  (default `1`, matching xterm.js's own default so existing behavior is
+  unchanged out of the box).
+- Applied to `scrollSensitivity` in the `new Terminal({...})` options passed
+  in `termwrap.ts`'s constructor.
+- A control in the Terminal settings section, next to the other terminal
+  tuning knobs (font size, scrollback, transparency).
+- Since this is an `ITerminalOptions` (not `ITerminalInitOnlyOptions`) field,
+  xterm.js supports updating it live via `terminal.options.scrollSensitivity
+  = ...` without recreating the terminal — but plumbing a live-update path
+  for every open pane is out of scope for this pass (see §4). The setting
+  takes effect for panes opened/reloaded after the change, consistent with
+  how `term:fontfamily`/`term:theme` already behave (checked at construction
+  time only).
+
+## 3. Non-goals
+
+- No attempt to read or mirror the OS-level "lines per scroll" setting. The
+  app already doesn't consult it; this spec doesn't change that, it only adds
+  an independent app-level knob.
+- No separate control for `fastScrollSensitivity` (the modifier-held fast
+  scroll multiplier) — one setting is enough to answer the user's ask; a
+  second knob can be added later if requested.
+- No live-reload of already-open terminal panes when the setting changes
+  (see §2's note) — same limitation as other construction-time terminal
+  settings already in this file.
+
+## 4. Design
+
+### 4.1 Setting
+
+`term:scrollsensitivity` — `number`, optional, default `1` when absent.
+Range enforced in the settings UI: `0.1`–`10` (mirrors the shape of
+`term:transparency`'s bounded slider-adjacent number input, though this uses
+a plain number input like `term:fontsize` since the useful range spans more
+than 0–1).
+
+### 4.2 Frontend wiring
+
+`termwrap.ts`'s constructor reads the setting via `getSettingsKeyAtom` (the
+same pattern used for `term:predictiveecho` in `init()`) and passes it
+through to the `Terminal` constructor:
+
+```ts
+const scrollSensitivity = getSettingsKeyAtom("term:scrollsensitivity")();
+this.terminal = new Terminal({
+    ...options,
+    cursorBlink: false,
+    scrollOnUserInput: false,
+    smoothScrollDuration: 0,
+    scrollSensitivity: typeof scrollSensitivity === "number" && scrollSensitivity > 0 ? scrollSensitivity : 1,
+});
+```
+
+### 4.3 Settings UI
+
+Add a `SettingRow` in `terminal-section.tsx`, placed after "Terminal
+transparency" (grouped with the other numeric tuning controls, before the
+predictive-echo toggle group):
+
+```tsx
+<SettingRow
+    label="Scroll sensitivity"
+    description="Scroll wheel speed multiplier for terminal panes (0.1–10, default 1). Independent of the OS scroll-speed setting."
+    control={
+        <input
+            class="setting-number setting-number--wide"
+            type="number" min={0.1} max={10} step={0.1}
+            value={(s()["term:scrollsensitivity"] as number) ?? 1}
+            onBlur={(e) => {
+                const v = parseFloat(e.currentTarget.value);
+                if (!isNaN(v) && v >= 0.1 && v <= 10) set("term:scrollsensitivity", v);
+            }}
+        />
+    }
+/>
+```
+
+### 4.4 Schema / type / template updates
+
+Per this repo's existing convention (no generator ties these together — each
+is hand-maintained and kept in sync manually), add the new key to all of:
+
+- `agentmux-srv/src/backend/wconfig/types.rs` — `pub term_scroll_sensitivity: Option<f64>` with `#[serde(rename = "term:scrollsensitivity", ...)]`.
+- `frontend/types/gotypes.d.ts` — `"term:scrollsensitivity"?: number;` in `SettingsType`.
+- `schema/settings.json` — `"term:scrollsensitivity": { "type": "number", "minimum": 0.1, "maximum": 10, "default": 1, "description": "..." }`.
+- `settings-template.jsonc` — commented-out example line under `-- Terminal --`.
+
+## 5. Alternatives considered
+
+- **Reading `SPI_GETWHEELSCROLLLINES` on Windows and deriving a default from
+  it.** Rejected: adds a platform-specific API call for a value that xterm.js
+  doesn't consume in the same units (xterm.js's sensitivity is a multiplier
+  on wheel delta, not a discrete line count), and the user's actual ask was
+  for an in-app override, not OS mirroring.
+- **Exposing `fastScrollSensitivity` too.** Deferred — keeps this change
+  minimal; can be added the same way later if wanted.
+
+## 6. Testing
+
+- Manual: set `term:scrollsensitivity` to `0.3` and `3` in Settings, open a
+  new terminal/agent pane, verify wheel scroll is visibly slower/faster than
+  default.
+- Verify absent setting (fresh install / unset) still scrolls at the
+  unchanged xterm.js default rate (regression check).

--- a/frontend/app/view/settings/sections/terminal-section.tsx
+++ b/frontend/app/view/settings/sections/terminal-section.tsx
@@ -117,6 +117,21 @@ export function TerminalSection(): JSX.Element {
                 }
             />
             <SettingRow
+                label="Scroll sensitivity"
+                description="Scroll wheel speed multiplier for terminal panes (0.1–10, default 1). Independent of the OS scroll-speed setting."
+                control={
+                    <input
+                        class="setting-number setting-number--wide"
+                        type="number" min={0.1} max={10} step={0.1}
+                        value={(s()["term:scrollsensitivity"] as number) ?? 1}
+                        onBlur={(e) => {
+                            const v = parseFloat(e.currentTarget.value);
+                            if (!isNaN(v) && v >= 0.1 && v <= 10) set("term:scrollsensitivity", v);
+                        }}
+                    />
+                }
+            />
+            <SettingRow
                 label="Predictive echo"
                 description="Show local predictive echo of typed characters while waiting on a slow/remote shell"
                 control={

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -134,7 +134,22 @@ export class TermWrap {
         //   CoreAnimation observer firing continuously and driving sustained ~190% host CPU
         //   even when no PTY output is arriving. Focus/blur listeners re-enable blink only
         //   for the active pane.
-        this.terminal = new Terminal({ ...options, cursorBlink: false, scrollOnUserInput: false, smoothScrollDuration: 0 });
+        // term:scrollsensitivity overrides xterm.js's own wheel-scroll multiplier
+        // (default 1). This is the only scroll-speed knob in the app — AgentMux
+        // never reads the OS "lines per scroll" setting, so this is independent
+        // of it. See SPEC_TERMINAL_SCROLL_SENSITIVITY_SETTING_2026_08_31.md.
+        const scrollSensitivitySetting = getSettingsKeyAtom("term:scrollsensitivity")();
+        const scrollSensitivity =
+            typeof scrollSensitivitySetting === "number" && scrollSensitivitySetting > 0
+                ? scrollSensitivitySetting
+                : 1;
+        this.terminal = new Terminal({
+            ...options,
+            cursorBlink: false,
+            scrollOnUserInput: false,
+            smoothScrollDuration: 0,
+            scrollSensitivity,
+        });
         // Reverse-wraparound (DECSET ?45): Backspace at column 0 of a soft-wrapped
         // line moves to the END of the previous row, matching real terminals.
         // bash/readline emits a bare BS (0x08) for the cross-wrap delete and relies

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1711,6 +1711,7 @@ declare global {
         "term:scrollback"?: number;
         "term:copyonselect"?: boolean;
         "term:transparency"?: number;
+        "term:scrollsensitivity"?: number;
         "term:allowbracketedpaste"?: boolean;
         "term:shiftenternewline"?: boolean;
         "term:predictiveecho"?: boolean;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -53,6 +53,13 @@
         "term:transparency": {
           "type": "number"
         },
+        "term:scrollsensitivity": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 10,
+          "default": 1,
+          "description": "Scroll wheel speed multiplier for terminal panes (xterm.js scrollSensitivity). Default 1 (unchanged from xterm.js's own default). Independent of the OS-level scroll-speed setting — AgentMux does not read or mirror it."
+        },
         "term:allowbracketedpaste": {
           "type": "boolean"
         },

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -11,6 +11,7 @@
     // "term:scrollback":          1000,
     // "term:copyonselect":        true,
     // "term:transparency":        0.5,
+    // "term:scrollsensitivity":   1,
     // "term:localshellpath":      "/bin/bash",
     // "term:localshellopts":      [],
     // "term:disablewebgl":        false,


### PR DESCRIPTION
## Summary
- Adds a new `term:scrollsensitivity` setting (0.1–10, default 1) that maps directly onto xterm.js's `scrollSensitivity` wheel-scroll multiplier, with a control in the Terminal settings section.
- AgentMux never reads the OS "lines per scroll" setting — this is a standalone app-level override, not a mirror of the OS value.
- Full design/rationale in `docs/specs/SPEC_TERMINAL_SCROLL_SENSITIVITY_SETTING_2026_08_31.md`.

## Changes
- `frontend/app/view/term/termwrap.ts` — reads the setting and passes it to `new Terminal({...})` as `scrollSensitivity`.
- `frontend/app/view/settings/sections/terminal-section.tsx` — new "Scroll sensitivity" number input.
- `agentmux-srv/src/backend/wconfig/types.rs`, `frontend/types/gotypes.d.ts`, `schema/settings.json`, `settings-template.jsonc` — settings key added in parallel per this repo's existing hand-maintained convention.
- Changeset: `.changesets/1788222661-feat-term-add-configurable-scroll-wheel-sensitivity-setting-15zh.md`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `cargo check -p agentmux-srv` clean
- [ ] Manual: set `term:scrollsensitivity` to a low/high value in Settings, open a terminal/agent pane, confirm wheel scroll speed changes accordingly
- [ ] Manual: confirm default (unset) behavior is unchanged from before this PR

<!-- agentmux:agent_id=agent3 -->