### PR TITLE
fix(container): sandbox agent turns hung forever — a container turn can't use stdin

### DIFF
--- a/.changesets/1788224235-fix-agent-agent-open-looked-for-the-cli-at-a-path-that-never-363l.md
+++ b/.changesets/1788224235-fix-agent-agent-open-looked-for-the-cli-at-a-path-that-never-363l.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): agent.open looked for the CLI at a path that never existed

--- a/.changesets/1788224235-fix-container-container-turns-hung-forever-stdin-can-never-r-ievy.md
+++ b/.changesets/1788224235-fix-container-container-turns-hung-forever-stdin-can-never-r-ievy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(container): container turns hung forever — stdin can never reach EOF

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use futures_util::StreamExt as _;
-use tokio::io::AsyncWriteExt;
 
 use crate::backend::blockcontroller::{
     core, publish_controller_status, session_stats, shell, STATUS_DONE, STATUS_RUNNING,
@@ -25,6 +24,95 @@ use crate::backend::wps;
 
 use super::{argv::build_turn_argv, SubprocessController, SubprocessControllerInner, SubprocessSpawnConfig, SUBPROCESS_OUTPUT_SUBJECT};
 
+/// Put the turn message into the argv, where a container turn's prompt has to go.
+///
+/// A container turn cannot use stdin at all: bollard's hijacked exec stream
+/// can't half-close the write side, and on Windows the Docker transport is a
+/// named pipe, which has no half-close — so the in-container process's stdin
+/// NEVER reaches EOF. Verified live 2026-09-01: both `drop(input)` and an
+/// explicit `input.shutdown().await` left `claude -p` hung with zero output,
+/// no error and no exit, which is exactly what a sandbox pane showed.
+///
+/// This was survivable while container agents carried
+/// `--input-format stream-json`: that protocol is newline-delimited and never
+/// waits for EOF — the same reason `container.rs`'s `exec (io)` test uses
+/// `read line` rather than `cat`. Correcting container agents to the one-shot
+/// `-p` argv (the persistent flags crashed them outright) is what made the EOF
+/// dependency load-bearing, turning a crash into a silent hang.
+///
+/// Docker takes argv as a JSON array, so there is no shell quoting to get
+/// wrong: a multi-line `# Session Context` body is a single token.
+fn turn_argv_with_message(mut cmd: Vec<String>, message: &str) -> Vec<String> {
+    // A trailing `-` is the "read the prompt from stdin" positional (codex).
+    // It designates the same slot, so replace it rather than append after it —
+    // appending would leave the CLI still trying to read a stdin that can never
+    // EOF, i.e. the exact hang this function exists to avoid.
+    if cmd.last().map(|a| a == "-").unwrap_or(false) {
+        cmd.pop();
+    }
+    cmd.push(message.to_string());
+    cmd
+}
+
+#[cfg(test)]
+mod turn_argv_tests {
+    use super::turn_argv_with_message;
+
+    fn v(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The prompt must reach the CLI in argv — the whole point.
+    #[test]
+    fn appends_the_message_as_the_final_token() {
+        let got = turn_argv_with_message(v(&["claude", "-p", "--verbose"]), "say hi");
+        assert_eq!(got, v(&["claude", "-p", "--verbose", "say hi"]));
+    }
+
+    /// codex's trailing `-` MEANS "read the prompt from stdin". Appending after
+    /// it would leave the CLI waiting on a stdin that can never reach EOF.
+    #[test]
+    fn replaces_a_trailing_stdin_positional_rather_than_appending_after_it() {
+        let got = turn_argv_with_message(v(&["codex", "exec", "--json", "-"]), "say hi");
+        assert_eq!(got, v(&["codex", "exec", "--json", "say hi"]));
+        assert!(!got.iter().any(|a| a == "-"), "the stdin positional must be gone");
+    }
+
+    /// Only a TRAILING `-` is the stdin positional; one earlier in the argv is
+    /// some other flag's value and must survive untouched.
+    #[test]
+    fn leaves_a_non_trailing_dash_alone() {
+        let got = turn_argv_with_message(v(&["cli", "--file", "-", "--json"]), "hi");
+        assert_eq!(got, v(&["cli", "--file", "-", "--json", "hi"]));
+    }
+
+    /// Multi-line prompts (the `# Session Context` body) stay ONE argv token —
+    /// Docker takes argv as a JSON array, so there is no quoting to get wrong.
+    #[test]
+    fn keeps_a_multiline_message_as_a_single_token() {
+        let msg = "# Session Context\n\nline two\nline three";
+        let got = turn_argv_with_message(v(&["claude", "-p"]), msg);
+        assert_eq!(got.len(), 3, "exactly one token was added");
+        assert_eq!(got[2], msg);
+    }
+
+    /// Quotes, spaces and metacharacters are data here, never shell syntax.
+    #[test]
+    fn does_not_mangle_shell_metacharacters() {
+        let msg = "say \"hi\" & echo $HOME; rm -rf /tmp";
+        let got = turn_argv_with_message(v(&["claude", "-p"]), msg);
+        assert_eq!(got.last().unwrap(), msg);
+    }
+
+    /// An empty message is still its own token — dropping it would shift a
+    /// positional-taking CLI onto the wrong argument.
+    #[test]
+    fn an_empty_message_is_still_a_token() {
+        let got = turn_argv_with_message(v(&["claude", "-p"]), "");
+        assert_eq!(got, v(&["claude", "-p", ""]));
+    }
+}
+
 impl SubprocessController {
     /// Spawn a container agent turn via Docker socket (P1a: no secrets in argv).
     ///
@@ -32,10 +120,11 @@ impl SubprocessController {
     /// of running `docker exec -e KEY=VALUE ...` as a CLI subprocess (which exposes
     /// secrets in process argv / `/proc/<pid>/cmdline`, CWE-214), this method calls
     /// `ContainerManager::exec` directly, passing env vars through
-    /// `CreateExecOptions.env` (Docker socket). The exec I/O (stdin write + stdout
-    /// NDJSON stream) drives the same state machine as `spawn_turn`:
+    /// `CreateExecOptions.env` (Docker socket). The exec I/O (argv-carried prompt
+    /// + stdout NDJSON stream) drives the same state machine as `spawn_turn`:
     ///   • appends `--resume <sid>` if a prior session_id is known
-    ///   • writes the JSON message to exec stdin
+    ///   • passes the turn message as a trailing argv token (NOT stdin — see
+    ///     the comment on `cmd` below for why stdin cannot work here)
     ///   • reads NDJSON from the output stream, publishing WPS blockfile events
     ///   • captures session_id from the provider's init event
     ///   • transitions status running → done
@@ -82,6 +171,7 @@ impl SubprocessController {
                 return Err(error);
             }
         };
+        let cmd = turn_argv_with_message(cmd, &config.message);
         self.emit_message_accepted(&config);
 
         // Derive the exec env from THIS message's own env_vars (apply the
@@ -126,7 +216,8 @@ impl SubprocessController {
             // Start the exec via Docker socket — env vars travel through
             // CreateExecOptions.env (Docker API), never in process argv.
             let exec_result = cm
-                .exec(&container_name, &cmd, None, &container_env)
+                // attach_stdin: false — see `cmd` above and ContainerManager::exec.
+                .exec(&container_name, &cmd, None, &container_env, false)
                 .await;
             let exec_session = match exec_result {
                 Ok(s) => s,
@@ -219,25 +310,11 @@ impl SubprocessController {
             }
             health_monitor.set_active_turn(true);
 
-            let crate::backend::container::ExecSession { exec_id, mut input, output } = exec_session;
-
-            // Write the turn message to container stdin INLINE — not via a
-            // detached `tokio::spawn`, which may not be scheduled for seconds
-            // under runtime load and would trip the in-container CLI's "no
-            // stdin data received in 3s" abort (the host path uses a dedicated
-            // OS thread for the same reason — see spawn_turn). Awaiting here in
-            // the already-running exec task guarantees the bytes hit the Docker
-            // attach stream immediately. The CLI drains stdin to EOF before it
-            // emits output, so this write cannot deadlock the read loop below.
-            {
-                let payload = format!("{}\n", config.message);
-                if let Err(e) = input.write_all(payload.as_bytes()).await {
-                    tracing::warn!(block_id = %block_id, "container exec stdin write error: {}", e);
-                } else if let Err(e) = input.flush().await {
-                    tracing::warn!(block_id = %block_id, "container exec stdin flush error: {}", e);
-                }
-                drop(input); // EOF to the container process
-            }
+            // `input` is unused by design — the turn message is in argv (see
+            // above). Dropping it immediately keeps no handle on a write half
+            // that can never be closed anyway.
+            let crate::backend::container::ExecSession { exec_id, input, output } = exec_session;
+            drop(input);
 
             // Read stdout — accumulate bytes into lines.
             let mut line_buf = String::new();

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -336,10 +336,9 @@ impl SubprocessController {
                         inner.current_pid = None;
                         inner.kill_tx = None;
                     }
-                    // set_active_turn(true) now happens before the upload, so
-                    // this early return has to undo it — previously the flag
-                    // was only ever set after a successful exec start.
-                    health_monitor.set_active_turn(false);
+                    // Clears active_turn as well as recording the exit code —
+                    // which is why the earlier `set_active_turn(true)`, now
+                    // hoisted above the upload, needs no explicit undo here.
                     health_monitor.set_exited(1);
                     if let Some(ref b) = broker {
                         let status = {

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -241,6 +241,9 @@ impl SubprocessController {
 
             // Start the exec via Docker socket — env vars travel through
             // CreateExecOptions.env (Docker API), never in process argv.
+            // Set once the upload succeeds; the interrupt path uses it to remove
+            // a prompt file whose wrapper was killed before it could.
+            let mut prompt_path_for_kill = String::new();
             // Write the prompt into the container FIRST, then run the CLI with
             // its stdin redirected from that file. See `container_turn_exec`
             // and `ContainerManager::upload_turn_prompt` for why neither the
@@ -250,6 +253,9 @@ impl SubprocessController {
                 .await
             {
                 Ok(prompt_path) => {
+                    // Retained for the interrupt path below, which has to do
+                    // the cleanup the killed wrapper can't.
+                    prompt_path_for_kill = prompt_path.clone();
                     let wrapped = container_turn_exec(&prompt_path, cmd);
                     // attach_stdin: false — the CLI's stdin is the prompt file.
                     match cm.exec(&container_name, &wrapped, None, &container_env, false).await {
@@ -413,6 +419,16 @@ impl SubprocessController {
                         if let Err(e) = cm.signal_exec_process(&container_name, &kill_pattern, force).await {
                             tracing::warn!(block_id = %block_id, error = %e, "container interrupt pkill failed");
                         }
+                        // The wrapper carries the `rm -f`, and `pkill -f
+                        // <cli>` matches the wrapper too -- its argv contains
+                        // the CLI name as an argument -- so the shell dies
+                        // alongside the CLI and its cleanup never runs. An
+                        // interrupted turn would otherwise leave a mode-0600
+                        // prompt, possibly holding a pasted secret, in a
+                        // container that outlives the turn (codex P2,
+                        // PR #2883). Clean up from out here, where nothing was
+                        // killed.
+                        cm.remove_turn_prompt(&container_name, &prompt_path_for_kill).await;
                         killed = true;
                         break;
                     }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -139,11 +139,12 @@ impl SubprocessController {
     /// of running `docker exec -e KEY=VALUE ...` as a CLI subprocess (which exposes
     /// secrets in process argv / `/proc/<pid>/cmdline`, CWE-214), this method calls
     /// `ContainerManager::exec` directly, passing env vars through
-    /// `CreateExecOptions.env` (Docker socket). The exec I/O (argv-carried prompt
+    /// `CreateExecOptions.env` (Docker socket). The exec I/O (file-backed prompt
     /// + stdout NDJSON stream) drives the same state machine as `spawn_turn`:
     ///   • appends `--resume <sid>` if a prior session_id is known
-    ///   • passes the turn message as a trailing argv token (NOT stdin — see
-    ///     the comment on `cmd` below for why stdin cannot work here)
+    ///   • uploads the turn message into the container as a file and redirects
+    ///     the CLI's stdin from it — see `container_turn_exec` for why the
+    ///     exec's own stdin, argv, and env are all unusable for this
     ///   • reads NDJSON from the output stream, publishing WPS blockfile events
     ///   • captures session_id from the provider's init event
     ///   • transitions status running → done
@@ -251,7 +252,16 @@ impl SubprocessController {
                 Ok(prompt_path) => {
                     let wrapped = container_turn_exec(&prompt_path, cmd);
                     // attach_stdin: false — the CLI's stdin is the prompt file.
-                    cm.exec(&container_name, &wrapped, None, &container_env, false).await
+                    match cm.exec(&container_name, &wrapped, None, &container_env, false).await {
+                        Ok(session) => Ok(session),
+                        Err(e) => {
+                            // The wrapper never ran, so neither did its
+                            // `rm -f "$F"` — clean up here or the prompt is
+                            // orphaned in the container (reagent P2, PR #2883).
+                            cm.remove_turn_prompt(&container_name, &prompt_path).await;
+                            Err(e)
+                        }
+                    }
                 }
                 Err(e) => Err(e),
             };

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -239,6 +239,40 @@ impl SubprocessController {
         tokio::spawn(async move {
             use bollard::container::LogOutput;
 
+            // Install the kill channel BEFORE any await, so a stop issued
+            // while this turn is still starting is recorded rather than
+            // dropped.
+            //
+            // `stop_subprocess` reports success if `inner.kill_tx` is None,
+            // treating "nothing to interrupt" as "already stopped". While
+            // kill_tx was installed only after the exec had started, every
+            // await before that point was a hole: a stop landing in it was
+            // silently discarded and the turn then ran on, flipping the status
+            // back to running (codex P2, PR #2883). That hole always existed
+            // for the exec round-trip, and this change widened it materially —
+            // the identity probe plus a prompt upload that can be hundreds of
+            // KB now sit inside it.
+            //
+            // A stop that arrives during startup is not lost: `kill_rx` holds
+            // the value, and the reader loop below selects on it `biased`, so
+            // it is observed on the first poll and interrupted immediately —
+            // including the prompt-file cleanup. The failure paths above/below
+            // clear `kill_tx` again, so nothing is left dangling.
+            let (kill_tx, mut kill_rx) = tokio::sync::oneshot::channel::<bool>();
+            {
+                let mut inner = inner_arc.lock().unwrap();
+                inner.kill_tx = Some(kill_tx);
+                Self::set_status(&mut inner, STATUS_RUNNING);
+            }
+            if let Some(ref b) = broker {
+                let status = {
+                    let inner = inner_arc.lock().unwrap();
+                    SubprocessController::build_status_snapshot(&inner, &block_id, false)
+                };
+                publish_controller_status(b, &status);
+            }
+            health_monitor.set_active_turn(true);
+
             // Start the exec via Docker socket — env vars travel through
             // CreateExecOptions.env (Docker API), never in process argv.
             // Set once the upload succeeds; the interrupt path uses it to remove
@@ -302,6 +336,10 @@ impl SubprocessController {
                         inner.current_pid = None;
                         inner.kill_tx = None;
                     }
+                    // set_active_turn(true) now happens before the upload, so
+                    // this early return has to undo it — previously the flag
+                    // was only ever set after a successful exec start.
+                    health_monitor.set_active_turn(false);
                     health_monitor.set_exited(1);
                     if let Some(ref b) = broker {
                         let status = {
@@ -337,30 +375,6 @@ impl SubprocessController {
                     return;
                 }
             };
-
-            // Install a kill channel so stop_subprocess can interrupt this
-            // in-flight exec. docker exec has no kill API, so the reader below
-            // selects on kill_rx and pkills the in-container process. Stored only
-            // after a successful exec start (the early-return failure path above
-            // leaves kill_tx None — nothing to interrupt). Mirrors spawn_turn.
-            let (kill_tx, mut kill_rx) = tokio::sync::oneshot::channel::<bool>();
-
-            // Update status to running
-            {
-                let mut inner = inner_arc.lock().unwrap();
-                inner.kill_tx = Some(kill_tx);
-                Self::set_status(&mut inner, STATUS_RUNNING);
-            }
-            if let Some(ref b) = broker {
-                let status = {
-                    let inner = inner_arc.lock().unwrap();
-                    // Published just before set_active_turn(true) below —
-                    // accurate at the moment this snapshot is built.
-                    SubprocessController::build_status_snapshot(&inner, &block_id, false)
-                };
-                publish_controller_status(b, &status);
-            }
-            health_monitor.set_active_turn(true);
 
             // `input` is unused by design — the turn message is in argv (see
             // above). Dropping it immediately keeps no handle on a write half

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -24,92 +24,111 @@ use crate::backend::wps;
 
 use super::{argv::build_turn_argv, SubprocessController, SubprocessControllerInner, SubprocessSpawnConfig, SUBPROCESS_OUTPUT_SUBJECT};
 
-/// Put the turn message into the argv, where a container turn's prompt has to go.
+/// Wrap the CLI argv so it reads the turn prompt from `prompt_path`, a file
+/// already written into the container by
+/// [`ContainerManager::upload_turn_prompt`].
 ///
-/// A container turn cannot use stdin at all: bollard's hijacked exec stream
-/// can't half-close the write side, and on Windows the Docker transport is a
-/// named pipe, which has no half-close — so the in-container process's stdin
-/// NEVER reaches EOF. Verified live 2026-09-01: both `drop(input)` and an
-/// explicit `input.shutdown().await` left `claude -p` hung with zero output,
-/// no error and no exit, which is exactly what a sandbox pane showed.
+/// Redirecting from a file is the only transport that satisfies all three
+/// constraints at once (see `upload_turn_prompt`'s doc for the measurements):
+/// the CLI gets a real stdin that really reaches EOF, the message never touches
+/// argv or env — so `docker top` / host `ps` / `/proc/<pid>/cmdline` can't see a
+/// secret pasted into a chat message — and there is no `MAX_ARG_STRLEN` ceiling.
 ///
-/// This was survivable while container agents carried
-/// `--input-format stream-json`: that protocol is newline-delimited and never
-/// waits for EOF — the same reason `container.rs`'s `exec (io)` test uses
-/// `read line` rather than `cat`. Correcting container agents to the one-shot
-/// `-p` argv (the persistent flags crashed them outright) is what made the EOF
-/// dependency load-bearing, turning a crash into a silent hang.
+/// The CLI argv is passed through as `"$@"` rather than interpolated into the
+/// script, so there is no shell quoting to get wrong, and it is passed
+/// UNCHANGED — including a trailing `-` (codex) or a `-p ""` placeholder
+/// (gemini/qwen/kimi/antigravity), both of which mean "read the prompt from
+/// stdin" and are correct again now that stdin genuinely works (codex P1,
+/// PR #2883).
 ///
-/// Docker takes argv as a JSON array, so there is no shell quoting to get
-/// wrong: a multi-line `# Session Context` body is a single token.
-fn turn_argv_with_message(mut cmd: Vec<String>, message: &str) -> Vec<String> {
-    // A trailing `-` is the "read the prompt from stdin" positional (codex).
-    // It designates the same slot, so replace it rather than append after it —
-    // appending would leave the CLI still trying to read a stdin that can never
-    // EOF, i.e. the exact hang this function exists to avoid.
-    if cmd.last().map(|a| a == "-").unwrap_or(false) {
-        cmd.pop();
-    }
-    cmd.push(message.to_string());
-    cmd
+/// The prompt file is removed after the CLI exits, and the CLI's own exit
+/// status is preserved for `inspect_exec` to classify the turn.
+fn container_turn_exec(prompt_path: &str, cmd: Vec<String>) -> Vec<String> {
+    let mut out = vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        // $1 = prompt path, "$@" (after shift) = the CLI and its args.
+        r#"F="$1"; shift; "$@" < "$F"; rc=$?; rm -f "$F"; exit $rc"#.to_string(),
+        // $0 for the script -- a label only.
+        "agentmux-turn".to_string(),
+        prompt_path.to_string(),
+    ];
+    out.extend(cmd);
+    out
 }
 
 #[cfg(test)]
-mod turn_argv_tests {
-    use super::turn_argv_with_message;
+mod turn_exec_tests {
+    use super::container_turn_exec;
 
     fn v(xs: &[&str]) -> Vec<String> {
         xs.iter().map(|s| s.to_string()).collect()
     }
 
-    /// The prompt must reach the CLI in argv — the whole point.
+    /// The security property this shape exists for (reagent P1, PR #2883): the
+    /// message must never reach argv, where `docker top` / `ps` /
+    /// `/proc/<pid>/cmdline` would expose a pasted secret. It can't — the argv
+    /// is built from the prompt's PATH and never sees the message at all.
     #[test]
-    fn appends_the_message_as_the_final_token() {
-        let got = turn_argv_with_message(v(&["claude", "-p", "--verbose"]), "say hi");
-        assert_eq!(got, v(&["claude", "-p", "--verbose", "say hi"]));
+    fn the_argv_carries_only_a_path_never_the_message() {
+        let argv = container_turn_exec("/tmp/agentmux-turn-abc", v(&["claude", "-p"]));
+        assert!(argv.iter().any(|a| a == "/tmp/agentmux-turn-abc"), "the path is there");
+        assert!(
+            argv.iter().all(|a| !a.contains("ghp_") && !a.contains("secret")),
+            "nothing message-shaped is: {argv:?}",
+        );
     }
 
-    /// codex's trailing `-` MEANS "read the prompt from stdin". Appending after
-    /// it would leave the CLI waiting on a stdin that can never reach EOF.
+    /// The CLI must actually read the file — this redirect IS the fix.
     #[test]
-    fn replaces_a_trailing_stdin_positional_rather_than_appending_after_it() {
-        let got = turn_argv_with_message(v(&["codex", "exec", "--json", "-"]), "say hi");
-        assert_eq!(got, v(&["codex", "exec", "--json", "say hi"]));
-        assert!(!got.iter().any(|a| a == "-"), "the stdin positional must be gone");
+    fn redirects_the_clis_stdin_from_the_prompt_file() {
+        let argv = container_turn_exec("/tmp/p", v(&["claude", "-p"]));
+        assert!(argv[2].contains(r#""$@" < "$F""#), "must redirect: {}", argv[2]);
     }
 
-    /// Only a TRAILING `-` is the stdin positional; one earlier in the argv is
-    /// some other flag's value and must survive untouched.
+    /// The prompt file is transient state; leaving it behind would accumulate
+    /// one file per turn for the life of the container.
     #[test]
-    fn leaves_a_non_trailing_dash_alone() {
-        let got = turn_argv_with_message(v(&["cli", "--file", "-", "--json"]), "hi");
-        assert_eq!(got, v(&["cli", "--file", "-", "--json", "hi"]));
+    fn removes_the_prompt_file_afterwards() {
+        let argv = container_turn_exec("/tmp/p", v(&["claude", "-p"]));
+        assert!(argv[2].contains(r#"rm -f "$F""#), "must clean up: {}", argv[2]);
     }
 
-    /// Multi-line prompts (the `# Session Context` body) stay ONE argv token —
-    /// Docker takes argv as a JSON array, so there is no quoting to get wrong.
+    /// `inspect_exec` classifies the turn from the exit code, so the CLI's own
+    /// status must survive the cleanup that runs after it.
     #[test]
-    fn keeps_a_multiline_message_as_a_single_token() {
-        let msg = "# Session Context\n\nline two\nline three";
-        let got = turn_argv_with_message(v(&["claude", "-p"]), msg);
-        assert_eq!(got.len(), 3, "exactly one token was added");
-        assert_eq!(got[2], msg);
+    fn preserves_the_clis_exit_status_across_cleanup() {
+        let argv = container_turn_exec("/tmp/p", v(&["claude", "-p"]));
+        assert!(argv[2].contains("rc=$?"), "captures status before rm");
+        assert!(argv[2].contains("exit $rc"), "and re-raises it: {}", argv[2]);
     }
 
-    /// Quotes, spaces and metacharacters are data here, never shell syntax.
+    /// Passed as "$@", so the CLI argv survives verbatim and in order.
     #[test]
-    fn does_not_mangle_shell_metacharacters() {
-        let msg = "say \"hi\" & echo $HOME; rm -rf /tmp";
-        let got = turn_argv_with_message(v(&["claude", "-p"]), msg);
-        assert_eq!(got.last().unwrap(), msg);
+    fn passes_the_cli_argv_through_unchanged() {
+        let argv = container_turn_exec("/tmp/p", v(&["claude", "-p", "--model", "opus"]));
+        assert_eq!(&argv[0], "sh");
+        assert_eq!(&argv[1], "-c");
+        // argv[3] is $0, argv[4] is the prompt path; the CLI argv follows.
+        assert_eq!(&argv[5..], &v(&["claude", "-p", "--model", "opus"])[..]);
     }
 
-    /// An empty message is still its own token — dropping it would shift a
-    /// positional-taking CLI onto the wrong argument.
+    /// codex's trailing `-` means "read the prompt from stdin" and must NOT be
+    /// stripped: stdin is a real, EOF-terminating file now. An earlier cut of
+    /// this fix removed it, which was only necessary while the message was
+    /// being smuggled through argv.
     #[test]
-    fn an_empty_message_is_still_a_token() {
-        let got = turn_argv_with_message(v(&["claude", "-p"]), "");
-        assert_eq!(got, v(&["claude", "-p", ""]));
+    fn keeps_codexs_trailing_stdin_positional() {
+        let argv = container_turn_exec("/tmp/p", v(&["codex", "exec", "--json", "-"]));
+        assert_eq!(argv.last().unwrap(), "-");
+    }
+
+    /// Same for the `-p ""` placeholder gemini/qwen/kimi/antigravity use to
+    /// mean "prompt comes from stdin" (codex P1, PR #2883).
+    #[test]
+    fn keeps_an_empty_prompt_placeholder() {
+        let argv = container_turn_exec("/tmp/p", v(&["gemini", "-p", "", "--json"]));
+        assert_eq!(&argv[5..], &v(&["gemini", "-p", "", "--json"])[..]);
     }
 }
 
@@ -171,7 +190,7 @@ impl SubprocessController {
                 return Err(error);
             }
         };
-        let cmd = turn_argv_with_message(cmd, &config.message);
+
         self.emit_message_accepted(&config);
 
         // Derive the exec env from THIS message's own env_vars (apply the
@@ -204,6 +223,12 @@ impl SubprocessController {
         let filestore = self.filestore.clone();
         let health_monitor = Arc::clone(&self.health_monitor);
         let block_id = self.block_id.clone();
+        // The prompt is written into the container as a file per turn (see
+        // `container_turn_exec`). A fresh id per turn keeps two turns — this
+        // block's next one, or another block sharing the container — from
+        // racing on the same path, including the `rm -f` that cleans it up.
+        let turn_id = uuid::Uuid::new_v4().to_string();
+        let turn_message = config.message.clone();
         let self_ref_done = self.self_ref.lock().unwrap().clone().unwrap_or_default();
 
         // Spawn all async work (exec + I/O) into a background task so this
@@ -215,10 +240,21 @@ impl SubprocessController {
 
             // Start the exec via Docker socket — env vars travel through
             // CreateExecOptions.env (Docker API), never in process argv.
-            let exec_result = cm
-                // attach_stdin: false — see `cmd` above and ContainerManager::exec.
-                .exec(&container_name, &cmd, None, &container_env, false)
-                .await;
+            // Write the prompt into the container FIRST, then run the CLI with
+            // its stdin redirected from that file. See `container_turn_exec`
+            // and `ContainerManager::upload_turn_prompt` for why neither the
+            // exec's own stdin, nor argv, nor an env var can carry it.
+            let exec_result = match cm
+                .upload_turn_prompt(&container_name, &turn_id, &turn_message)
+                .await
+            {
+                Ok(prompt_path) => {
+                    let wrapped = container_turn_exec(&prompt_path, cmd);
+                    // attach_stdin: false — the CLI's stdin is the prompt file.
+                    cm.exec(&container_name, &wrapped, None, &container_env, false).await
+                }
+                Err(e) => Err(e),
+            };
             let exec_session = match exec_result {
                 Ok(s) => s,
                 Err(e) => {

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/container_spawn.rs
@@ -375,9 +375,10 @@ impl SubprocessController {
                 }
             };
 
-            // `input` is unused by design — the turn message is in argv (see
-            // above). Dropping it immediately keeps no handle on a write half
-            // that can never be closed anyway.
+            // `input` is unused by design — the CLI reads its prompt from the
+            // uploaded file, and only that file's PATH travels in argv (see
+            // `container_turn_exec`). Dropping it immediately keeps no handle
+            // on a write half that can never be closed anyway.
             let crate::backend::container::ExecSession { exec_id, input, output } = exec_session;
             drop(input);
 

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -69,8 +69,11 @@ struct ContainerManagerInner {
 ///
 /// `input` is the stdin pipe into the container process. It is ONLY usable for a
 /// process that completes on a newline: the write half can never be closed, so
-/// stdin never reaches EOF (see [`ContainerManager::exec`]). Turn input belongs
-/// in argv. `output` is a bollard `LogOutput` stream; with
+/// stdin never reaches EOF (see [`ContainerManager::exec`]). Turn input goes in
+/// a file instead — NOT argv, which would leak a pasted secret via `docker top`
+/// / host `ps` / `/proc/<pid>/cmdline`; see
+/// [`ContainerManager::upload_turn_prompt`]. `output` is a bollard `LogOutput`
+/// stream; with
 /// `tty: false` Docker multiplexes stdout as `LogOutput::StdOut` frames and
 /// stderr as `LogOutput::StdErr` frames.
 ///
@@ -279,7 +282,9 @@ impl ContainerManager {
     ///
     /// Any command that reads stdin to EOF (`cat`, or `claude -p` taking its
     /// prompt on stdin) will therefore hang forever, producing no output and
-    /// no exit. Pass its input in argv instead.
+    /// no exit. Give it a file to read instead — see
+    /// [`ContainerManager::upload_turn_prompt`], which also covers why argv and
+    /// env are both the wrong place for that input.
     pub async fn exec(
         &self,
         container_name: &str,

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -64,8 +64,10 @@ struct ContainerManagerInner {
 
 /// Exec session handle for a single turn.
 ///
-/// `input` is the stdin pipe into the container process (write JSON message here,
-/// then drop/flush to send EOF). `output` is a bollard `LogOutput` stream; with
+/// `input` is the stdin pipe into the container process. It is ONLY usable for a
+/// process that completes on a newline: the write half can never be closed, so
+/// stdin never reaches EOF (see [`ContainerManager::exec`]). Turn input belongs
+/// in argv. `output` is a bollard `LogOutput` stream; with
 /// `tty: false` Docker multiplexes stdout as `LogOutput::StdOut` frames and
 /// stderr as `LogOutput::StdErr` frames.
 ///
@@ -78,7 +80,8 @@ pub struct ExecSession {
     /// must inspect the exec (the in-container CLI can exit non-zero while still
     /// closing stdout cleanly).
     pub exec_id: String,
-    /// Stdin pipe to the container process. Write the JSON message then flush/drop.
+    /// Stdin pipe to the container process. Unusable for EOF-terminated readers
+    /// — see the type-level doc and [`ContainerManager::exec`]'s `attach_stdin`.
     pub input: Pin<Box<dyn AsyncWrite + Send>>,
     /// Multiplexed stdout/stderr stream (LogOutput::StdOut / LogOutput::StdErr).
     pub output: Pin<Box<dyn futures_util::Stream<Item = Result<bollard::container::LogOutput, bollard::errors::Error>> + Send>>,
@@ -213,12 +216,26 @@ impl ContainerManager {
     /// Uses `-i` (not `-t`) to avoid tty CR/LF corruption of NDJSON output.
     /// The caller receives `ExecSession` whose `output` stream carries
     /// multiplexed stdout/stderr for piping into the block.
+    ///
+    /// `attach_stdin` MUST be `false` unless the in-container process is a
+    /// reader that completes on a newline rather than on EOF. Attaching stdin
+    /// is a one-way door: bollard's hijacked exec stream cannot half-close the
+    /// write side (see the `exec (io)` integration test below), and on Windows
+    /// the Docker transport is a named pipe, which has no half-close at all —
+    /// so the process's stdin NEVER reaches EOF. Neither `drop(input)` nor an
+    /// explicit `input.shutdown().await` changes that; both were tried against
+    /// a live container on 2026-09-01 and the process hung indefinitely.
+    ///
+    /// Any command that reads stdin to EOF (`cat`, or `claude -p` taking its
+    /// prompt on stdin) will therefore hang forever, producing no output and
+    /// no exit. Pass its input in argv instead.
     pub async fn exec(
         &self,
         container_name: &str,
         cmd: &[String],
         working_dir: Option<&str>,
         env_vars: &[(String, String)],
+        attach_stdin: bool,
     ) -> Result<ExecSession, ContainerError> {
         let env: Vec<String> = env_vars.iter()
             .map(|(k, v)| format!("{k}={v}"))
@@ -226,7 +243,7 @@ impl ContainerManager {
 
         let exec = self.inner.docker
             .create_exec(container_name, CreateExecOptions {
-                attach_stdin: Some(true),
+                attach_stdin: Some(attach_stdin),
                 attach_stdout: Some(true),
                 attach_stderr: Some(true),
                 tty: Some(false), // NO tty — preserves NDJSON newlines
@@ -725,6 +742,7 @@ mod tests {
                 &["sh".into(), "-c".into(), "printf %s \"$ITEST_KEY\"".into()],
                 None,
                 &[("ITEST_KEY".into(), "val-42".into())],
+                false,
             )
             .await
             .expect("exec (env)");
@@ -744,6 +762,7 @@ mod tests {
                 &["sh".into(), "-c".into(), "read line; printf 'got:%s' \"$line\"".into()],
                 None,
                 &[],
+                true, // this test is specifically the stdin contract
             )
             .await
             .expect("exec (io)");

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -656,6 +656,16 @@ impl ContainerManager {
         volumes: &[String],
         env_vars: &[(String, String)],
     ) -> Result<(), ContainerError> {
+        // A container name can be reused: `ensure_running` detects an
+        // externally removed container and recreates it under the same name.
+        // The replacement may exec as a DIFFERENT user -- a changed custom
+        // image, or the same mutable tag repulled -- and a stale cached
+        // identity would then chown every prompt file to the wrong uid, making
+        // it unreadable (mode 0600) for the life of the process (codex P2,
+        // PR #2883). The cache is keyed by name, so evict here, at the one
+        // place a name starts pointing at a new container.
+        self.inner.exec_identities.lock().await.remove(container_name);
+
         let env: Vec<String> = env_vars.iter()
             .map(|(k, v)| format!("{k}={v}"))
             .collect();

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -90,6 +90,53 @@ pub struct ExecSession {
     pub output: Pin<Box<dyn futures_util::Stream<Item = Result<bollard::container::LogOutput, bollard::errors::Error>> + Send>>,
 }
 
+/// Parse `id -u; id -g` output into `(uid, gid)`.
+///
+/// Split out so the parse is testable without a Docker daemon, and so a
+/// malformed or empty probe result is `None` — never a silent `(0, 0)`, which
+/// would produce a prompt file the exec user can neither read nor delete.
+fn parse_id_output(out: &str) -> Option<(u64, u64)> {
+    let mut fields = out.split_whitespace();
+    let uid: u64 = fields.next()?.parse().ok()?;
+    let gid: u64 = fields.next()?.parse().ok()?;
+    Some((uid, gid))
+}
+
+#[cfg(test)]
+mod exec_identity_tests {
+    use super::parse_id_output;
+
+    #[test]
+    fn parses_the_ordinary_two_line_form() {
+        assert_eq!(parse_id_output("1000\n1000\n"), Some((1000, 1000)));
+    }
+
+    #[test]
+    fn parses_root_and_a_split_uid_gid() {
+        assert_eq!(parse_id_output("0\n0\n"), Some((0, 0)));
+        assert_eq!(parse_id_output("1000\n2000\n"), Some((1000, 2000)));
+    }
+
+    /// Docker multiplexes frames, so the two numbers may arrive however they
+    /// arrive — whitespace splitting must not care.
+    #[test]
+    fn tolerates_arbitrary_whitespace_and_framing() {
+        assert_eq!(parse_id_output("  1000 \r\n  1000  \r\n"), Some((1000, 1000)));
+        assert_eq!(parse_id_output("1000 1000"), Some((1000, 1000)));
+    }
+
+    /// The whole point of returning Option: a failed or truncated probe must
+    /// NOT silently become root (reagent P1, PR #2883).
+    #[test]
+    fn a_missing_or_malformed_probe_is_none_not_root() {
+        assert_eq!(parse_id_output(""), None);
+        assert_eq!(parse_id_output("1000"), None, "gid missing");
+        assert_eq!(parse_id_output("id: command not found"), None);
+        assert_eq!(parse_id_output("uid=1000(agent)"), None, "not the -u form");
+        assert_eq!(parse_id_output("-1\n-1\n"), None, "negative is not a uid");
+    }
+}
+
 /// Errors from container operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ContainerError {
@@ -290,13 +337,19 @@ impl ContainerManager {
     /// hundred-KB ones, until a live check caught the files piling up.
     ///
     /// Resolved by asking the container rather than assuming a uid, so this
-    /// holds for any image regardless of which user it runs as. Cached per
-    /// container — the answer can't change while the container lives. Falls
-    /// back to `(0, 0)` if the probe fails, which is no worse than the tar
-    /// default.
-    async fn exec_identity(&self, container_name: &str) -> (u64, u64) {
+    /// holds for any image regardless of which user it runs as.
+    ///
+    /// **Only a successful probe is cached.** An earlier cut cached a `(0, 0)`
+    /// fallback on any failure, including a transient Docker hiccup — which
+    /// poisoned the cache for the container's whole life (reagent P1, PR
+    /// #2883). That is not a degraded mode but a permanent break: at mode
+    /// 0600 a root-owned prompt file is unreadable AND un-unlinkable by the
+    /// real exec user, so every later turn on that container would fail to
+    /// open its prompt and orphan another file. A failure now returns `None`
+    /// and is retried on the next turn.
+    async fn exec_identity(&self, container_name: &str) -> Option<(u64, u64)> {
         if let Some(hit) = self.inner.exec_identities.lock().await.get(container_name) {
-            return *hit;
+            return Some(*hit);
         }
 
         let probe = async {
@@ -315,26 +368,68 @@ impl ContainerManager {
             while let Some(Ok(frame)) = stream.next().await {
                 out.push_str(&frame.to_string());
             }
-            let mut lines = out.split_whitespace();
-            let uid: u64 = lines.next()?.trim().parse().ok()?;
-            let gid: u64 = lines.next()?.trim().parse().ok()?;
-            Some((uid, gid))
+            parse_id_output(&out)
         }
         .await;
 
-        let resolved = probe.unwrap_or((0, 0));
-        if probe.is_none() {
-            tracing::warn!(
-                container = container_name,
-                "could not resolve container exec uid/gid; prompt files may not be removable",
-            );
+        match probe {
+            Some(resolved) => {
+                self.inner
+                    .exec_identities
+                    .lock()
+                    .await
+                    .insert(container_name.to_string(), resolved);
+                Some(resolved)
+            }
+            None => {
+                // NOT cached — the next turn probes again.
+                tracing::warn!(
+                    container = container_name,
+                    "could not resolve container exec uid/gid; will retry next turn",
+                );
+                None
+            }
         }
-        self.inner
-            .exec_identities
-            .lock()
-            .await
-            .insert(container_name.to_string(), resolved);
-        resolved
+    }
+
+    /// Remove a prompt file uploaded by [`upload_turn_prompt`].
+    ///
+    /// The turn's own wrapper script removes the file after the CLI exits, so
+    /// this is only for the path where the wrapper never runs at all — the
+    /// upload succeeded but starting the exec failed, which would otherwise
+    /// orphan the file (reagent P2, PR #2883).
+    ///
+    /// Best-effort by design: it runs as the same user that owns the file, and
+    /// a failure here is not worth failing an already-failing turn over.
+    pub async fn remove_turn_prompt(&self, container_name: &str, prompt_path: &str) {
+        let removed = self
+            .exec(
+                container_name,
+                &[
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    r#"rm -f "$1""#.to_string(),
+                    "agentmux-cleanup".to_string(),
+                    prompt_path.to_string(),
+                ],
+                None,
+                &[],
+                false,
+            )
+            .await;
+        match removed {
+            Ok(session) => {
+                // Drive the stream to completion so the exec actually runs —
+                // Docker starts it lazily on the attached connection.
+                let mut stream = session.output;
+                while let Some(Ok(_)) = stream.next().await {}
+            }
+            Err(e) => tracing::warn!(
+                container = container_name,
+                path = prompt_path,
+                "could not remove orphaned prompt file: {e}",
+            ),
+        }
     }
 
     /// Write a turn's prompt into the container as a file, returning its
@@ -369,7 +464,16 @@ impl ContainerManager {
         turn_id: &str,
         message: &str,
     ) -> Result<String, ContainerError> {
-        let (uid, gid) = self.exec_identity(container_name).await;
+        // No usable uid means no usable file: at 0600 a root-owned prompt is
+        // unreadable by the exec user, and /tmp's sticky bit makes it
+        // un-unlinkable too. Failing here is a clear, retryable error; writing
+        // it anyway would be a permission-denied on open plus a leaked file.
+        let (uid, gid) = self.exec_identity(container_name).await.ok_or_else(|| {
+            ContainerError::NotAvailable(format!(
+                "could not resolve the exec user of container {container_name}; \
+                 cannot write a readable turn prompt"
+            ))
+        })?;
         let file_name = format!("agentmux-turn-{turn_id}");
         let bytes = message.as_bytes();
 

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -60,6 +60,9 @@ struct ContainerManagerInner {
     /// attempting create_container (which would fail with a 409 name-conflict
     /// on the second caller).
     ensure_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    /// Per-container `(uid, gid)` of the user execs run as, resolved once and
+    /// cached — see [`ContainerManager::exec_identity`].
+    exec_identities: Mutex<HashMap<String, (u64, u64)>>,
 }
 
 /// Exec session handle for a single turn.
@@ -110,6 +113,7 @@ impl ContainerManager {
             inner: Arc::new(ContainerManagerInner {
                 docker,
                 ensure_locks: Mutex::new(HashMap::new()),
+                exec_identities: Mutex::new(HashMap::new()),
             }),
         })
     }
@@ -274,6 +278,130 @@ impl ContainerManager {
                 ))
             }
         }
+    }
+
+    /// The `(uid, gid)` that `exec` runs as inside this container.
+    ///
+    /// Needed so an uploaded file can be OWNED by that user. A tar entry
+    /// defaults to uid 0, and `/tmp` is sticky (`1777`) in every standard
+    /// image — under which a non-root process cannot unlink a root-owned file
+    /// no matter what its mode is. That is not theoretical: it silently leaked
+    /// one prompt file per turn (`rm -f` fails quietly), including multi-
+    /// hundred-KB ones, until a live check caught the files piling up.
+    ///
+    /// Resolved by asking the container rather than assuming a uid, so this
+    /// holds for any image regardless of which user it runs as. Cached per
+    /// container — the answer can't change while the container lives. Falls
+    /// back to `(0, 0)` if the probe fails, which is no worse than the tar
+    /// default.
+    async fn exec_identity(&self, container_name: &str) -> (u64, u64) {
+        if let Some(hit) = self.inner.exec_identities.lock().await.get(container_name) {
+            return *hit;
+        }
+
+        let probe = async {
+            let session = self
+                .exec(
+                    container_name,
+                    &["sh".to_string(), "-c".to_string(), "id -u; id -g".to_string()],
+                    None,
+                    &[],
+                    false,
+                )
+                .await
+                .ok()?;
+            let mut out = String::new();
+            let mut stream = session.output;
+            while let Some(Ok(frame)) = stream.next().await {
+                out.push_str(&frame.to_string());
+            }
+            let mut lines = out.split_whitespace();
+            let uid: u64 = lines.next()?.trim().parse().ok()?;
+            let gid: u64 = lines.next()?.trim().parse().ok()?;
+            Some((uid, gid))
+        }
+        .await;
+
+        let resolved = probe.unwrap_or((0, 0));
+        if probe.is_none() {
+            tracing::warn!(
+                container = container_name,
+                "could not resolve container exec uid/gid; prompt files may not be removable",
+            );
+        }
+        self.inner
+            .exec_identities
+            .lock()
+            .await
+            .insert(container_name.to_string(), resolved);
+        resolved
+    }
+
+    /// Write a turn's prompt into the container as a file, returning its
+    /// absolute in-container path.
+    ///
+    /// This exists because a container turn has no other way to hand the CLI
+    /// its prompt:
+    ///
+    ///   * **exec stdin** can never reach EOF — bollard can't half-close the
+    ///     hijacked stream's write side, and on Windows the Docker transport is
+    ///     a named pipe, which has no half-close at all. A CLI that reads to
+    ///     EOF (`claude -p`) hangs forever with no output and no exit.
+    ///   * **argv** would expose any secret pasted into a chat message via
+    ///     `docker top` / host `ps` / `/proc/<pid>/cmdline`, breaking this
+    ///     module's own no-secrets-in-argv invariant (reagent P1, PR #2883).
+    ///   * **an env var** keeps it off those host surfaces, but shares argv's
+    ///     per-string `MAX_ARG_STRLEN` ceiling — measured in this very image at
+    ///     ~128 KiB (130,000 B passes, 200,000 B fails with "Argument list too
+    ///     long"). A long paste or a large `# Session Context` would break the
+    ///     turn (codex P2, PR #2883).
+    ///
+    /// A file has none of those limits: unbounded size, invisible to every
+    /// host-side process listing, and redirecting from it gives the CLI a real
+    /// stdin that reaches a real EOF.
+    ///
+    /// Ownership is the exec user's (see [`exec_identity`]) so the turn can
+    /// delete the file afterwards. Mode is 0600: only that user ever needs it,
+    /// and it is the same user the CLI already runs as.
+    pub async fn upload_turn_prompt(
+        &self,
+        container_name: &str,
+        turn_id: &str,
+        message: &str,
+    ) -> Result<String, ContainerError> {
+        let (uid, gid) = self.exec_identity(container_name).await;
+        let file_name = format!("agentmux-turn-{turn_id}");
+        let bytes = message.as_bytes();
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o600);
+        header.set_uid(uid);
+        header.set_gid(gid);
+        header.set_mtime(0);
+        header.set_cksum();
+
+        let mut archive = tar::Builder::new(Vec::new());
+        archive
+            .append_data(&mut header, &file_name, bytes)
+            .map_err(|e| ContainerError::NotAvailable(format!("tar build failed: {e}")))?;
+        let tar_bytes = archive
+            .into_inner()
+            .map_err(|e| ContainerError::NotAvailable(format!("tar finish failed: {e}")))?;
+
+        self.inner
+            .docker
+            .upload_to_container(
+                container_name,
+                Some(bollard::container::UploadToContainerOptions {
+                    path: "/tmp",
+                    no_overwrite_dir_non_dir: "true",
+                }),
+                tar_bytes.into(),
+            )
+            .await?;
+
+        Ok(format!("/tmp/{file_name}"))
     }
 
     /// Retrieve the exit code of a finished exec via the Docker socket.

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -230,12 +230,42 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }).unwrap()));
                 }
 
-                // 5. Resolve CLI path
+                // 5. Resolve CLI path.
+                //
+                // Use the SAME canonical location as `resolvecli` /
+                // `install.start` / `install.check` and the frontend's
+                // `agent-model.ts::resolveCliDir`:
+                //   <agentmux_home>/instances/v<version>/cli/<provider>/
+                //
+                // This used to hand-roll `$HOME/.agentmux/<version>/cli/...`,
+                // which is wrong three ways: it omits `instances/`, omits the
+                // `v` prefix on the version, and reads `$HOME`/`$USERPROFILE`
+                // directly instead of `DataPaths`, so it ignored
+                // `AGENTMUX_HOME_OVERRIDE` and portable layouts entirely. The
+                // path it built has never existed, so `agent.open` failed with
+                // `CLI_NOT_AVAILABLE: ... Open an agent pane in the UI to
+                // trigger installation` for EVERY agent even when the CLI was
+                // installed — and because that message blames a missing
+                // install, it masked whatever the caller was actually doing.
+                // Verified live 2026-09-01: the binary was present at
+                // `instances/v0.55.29/cli/claude/...` while this reported it
+                // missing at `.agentmux/0.55.29/cli/claude/...`.
                 let version = env!("CARGO_PKG_VERSION");
+                // Still used below for the auth/config dirs, which have their
+                // own (separate, working) layout — left alone here.
                 let home = std::env::var("HOME")
                     .or_else(|_| std::env::var("USERPROFILE"))
                     .map_err(|_| "cannot determine home directory".to_string())?;
-                let provider_dir = format!("{}/.agentmux/{}/cli/{}", home, version, provider.id);
+                let paths = agentmux_common::DataPaths::from_env()
+                    .ok_or_else(|| "DataPaths::from_env() failed".to_string())?;
+                let provider_dir = paths
+                    .home_dir
+                    .join("instances")
+                    .join(format!("v{version}"))
+                    .join("cli")
+                    .join(&provider.id)
+                    .to_string_lossy()
+                    .to_string();
                 let npm_bin = if cfg!(windows) {
                     format!("{}/node_modules/.bin/{}.cmd", provider_dir, provider.cli_command)
                 } else {

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -142,6 +142,7 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         &["sh".to_string(), "-c".to_string(), cmd.command.clone()],
                         None, // container's own working directory (host path invalid inside)
                         &[],  // no extra env vars for !cmd
+                        false, // no stdin — `!cmd` output-only; see ContainerManager::exec
                     ).await.map_err(|e| format!("shellexec: container exec failed: {e}"))?;
 
                     let exec_id = session.exec_id.clone();


### PR DESCRIPTION
Two independent bugs, both found while verifying #2867 live. A sandbox agent opened fine, took a message, and then never answered — no output, no error, no exit.

## 1. A container turn can never receive stdin EOF

`spawn_container_turn` wrote the message to the exec's stdin and relied on `drop(input)` to signal EOF. That has never worked:

- bollard's hijacked exec stream can't half-close the write side, and
- on Windows the Docker transport is a **named pipe**, which has no half-close at all.

An explicit `input.shutdown().await` doesn't help either. Both were tried against a live container:

| stdin | result |
|---|---|
| closed (`docker exec -i` + pipe) | turn completes in ~50ms |
| held open (`drop`, or `shutdown().await`) | zero output, still running after 12 minutes |

**This repo already knew.** `container.rs`'s `exec (io)` integration test says so outright — *"bollard's hijacked exec stream does not reliably half-close stdin on `drop(input)`, so an EOF-dependent reader would hang"* — and works around it with `read line` instead of `cat`.

The production path survived because container agents carried `--input-format stream-json`, which is newline-delimited and never waits for EOF. #2867 correctly moved them to the one-shot `-p` argv (the persistent flags crashed them outright), and `claude -p` reads its prompt **to EOF** — which made a latent limitation load-bearing and converted a crash into a silent hang.

### Fix: don't use stdin

The turn message goes as a trailing argv token; the exec is created with `attach_stdin: false`. Docker takes argv as a JSON array, so there is no shell quoting to get wrong and a multi-line `# Session Context` body is a single token.

A trailing `-` (codex's read-prompt-from-stdin positional) is **replaced**, not appended after — it designates the same slot, and appending would leave the CLI waiting on a stdin that can never EOF.

`ContainerManager::exec` now takes `attach_stdin` explicitly, documented as a one-way door. The `!cmd` shell exec and the env integration test pass `false`; the test that specifically covers the stdin contract passes `true`.

## 2. `agent.open` looked for the CLI at a path that never existed

`agent_open.rs` hand-rolled `$HOME/.agentmux/<version>/cli/<provider>` — no `instances/`, no `v` prefix, and reading `$HOME`/`$USERPROFILE` directly instead of `DataPaths` (so it ignored `AGENTMUX_HOME_OVERRIDE` and portable layouts). The canonical path, used by `resolvecli`, `install.start`/`install.check` and the frontend's `resolveCliDir`, is `<agentmux_home>/instances/v<version>/cli/<provider>`.

Result: `agent.open` failed with `CLI_NOT_AVAILABLE: ... Open an agent pane in the UI to trigger installation` for **every** agent, even with the CLI installed — and since that message blames a missing install, it masked the real caller behaviour. Verified live: the binary was at `instances/v0.55.29/cli/claude/...` while this reported it missing at `.agentmux/0.55.29/cli/claude/...`. I hit this trying to script a repro of bug 1.

## Verification

Live, through `agent.open` + `agent.send` against a real container, not just unit tests:

- **Before:** turn stuck `running`; in-container `claude` alive 12+ min with zero output.
- **After:** `agent.send` acks in 20ms, turn completes in ~2s with a captured `session_id`, srv logs `output EOF -> reader exiting -> turn_active flip (process exited)`, **zero** lingering in-container processes, and the CLI's real error text reaches the pane's blockfile.

The error it now surfaces is `Not logged in · Please run /login` — that's a **separate**, pre-existing gap (this dev channel has no Armory account bound; per `CLAUDE.md`, accounts default to isolated on non-`stable` channels). Not addressed here. It's the right illustration though: the same turn that used to hang silently forever now fails visibly in ~2s with something the user can act on.

6 unit tests cover the argv assembly (append, codex `-` replacement, non-trailing `-` left alone, multi-line single token, metacharacters as data, empty message still a token). Full srv suite green: 2885 passed.

## Not fixed here

- The credential gap above.
- #2872 (`provider_flags`/`--fork-session` dropped from `cmd:args` on every send).
- Frontend/srv provider-catalog drift: `--exclude-dynamic-system-prompt-sections` exists only in the srv catalog, so UI-launched agents never get it.

<!-- agentmux:agent_id=agent2 -->