### PR TITLE
fix(cef): restore ctrl+wheel zoom in floating panes

### DIFF
--- a/.changesets/1788224397-fix-cef-restore-ctrl-wheel-zoom-in-floating-panes-utat.md
+++ b/.changesets/1788224397-fix-cef-restore-ctrl-wheel-zoom-in-floating-panes-utat.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): restore ctrl+wheel zoom in floating panes

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -1030,6 +1030,15 @@ impl AgentMuxHandler {
                         label: lbl.to_string(),
                     },
                 );
+
+                // Restore the WndProcs the Ctrl+Wheel hook subclassed and drop
+                // its bookkeeping. Windows reuses HWND values, so leaving stale
+                // entries behind would let a future window inherit a hook whose
+                // context points at a dead floater. See floater_wheel.rs.
+                #[cfg(target_os = "windows")]
+                unsafe {
+                    crate::floater_wheel::remove_floater_ctrl_wheel_hook(lbl);
+                }
             }
         }
 

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -360,7 +360,7 @@ impl AgentMuxHandler {
 
     pub(crate) fn on_load_end(
         &mut self,
-        browser: Option<&mut Browser>,
+        mut browser: Option<&mut Browser>,
         frame: Option<&mut Frame>,
         _http_status_code: i32,
     ) {
@@ -370,6 +370,39 @@ impl AgentMuxHandler {
 
         if frame.is_main() != 1 {
             return;
+        }
+
+        // Ctrl+Wheel recovery for floating panes. Installed here rather than in
+        // `on_after_created` because Chromium recreates
+        // `Chrome_RenderWidgetHostHWND` on every page load, so a subclass
+        // installed once ends up stranded on a destroyed HWND — the same reason
+        // `install_browser_pane_focus_redirect` is wired from BOTH create and
+        // load-end. Main-frame load-end covers first paint and every subsequent
+        // navigation, including a pane-pool window being promoted to a real
+        // floater (which re-navigates and may change label). Idempotent:
+        // already-subclassed HWNDs are skipped. See floater_wheel.rs.
+        #[cfg(target_os = "windows")]
+        if let Some(b) = browser.as_mut() {
+            // Reborrow `&mut &mut Browser` down to `&mut Browser` for
+            // `window_label_for`/`host`; the outer Option must stay usable
+            // below, so it cannot be moved out of.
+            let b: &mut Browser = b;
+            if let Some(label) = self.window_label_for(b) {
+                if label.starts_with("floating-") {
+                    if let Some(host) = b.host() {
+                        let wh = host.window_handle();
+                        if !wh.0.is_null() {
+                            unsafe {
+                                crate::floater_wheel::install_floater_ctrl_wheel_hook(
+                                    &self.state,
+                                    wh.0 as *mut std::ffi::c_void,
+                                    &label,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // Re-inject the host IPC creds on EVERY main-frame load of OUR OWN

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -384,21 +384,40 @@ impl AgentMuxHandler {
         #[cfg(target_os = "windows")]
         if let Some(b) = browser.as_mut() {
             // Reborrow `&mut &mut Browser` down to `&mut Browser` for
-            // `window_label_for`/`host`; the outer Option must stay usable
-            // below, so it cannot be moved out of.
+            // `window_label_for`; the outer Option must stay usable below, so it
+            // cannot be moved out of.
             let b: &mut Browser = b;
             if let Some(label) = self.window_label_for(b) {
                 if label.starts_with("floating-") {
-                    if let Some(host) = b.host() {
-                        let wh = host.window_handle();
-                        if !wh.0.is_null() {
-                            unsafe {
-                                crate::floater_wheel::install_floater_ctrl_wheel_hook(
-                                    &self.state,
-                                    wh.0 as *mut std::ffi::c_void,
-                                    &label,
-                                );
-                            }
+                    // Resolve via the cached outer HWND, NOT
+                    // `BrowserHost::window_handle()`. That returns null after
+                    // page load for `set_as_child`-embedded browsers — exactly
+                    // the embedding floaters use — which is already diagnosed in
+                    // SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md and worked around
+                    // the same way elsewhere in this codebase. Trusting it here
+                    // would make the hook silently fail to install on the very
+                    // path it exists for. (reagentx P1 on PR #2884.)
+                    let hwnd = unsafe {
+                        crate::commands::window::resolve_window_hwnd(
+                            &self.state,
+                            &label,
+                        )
+                    };
+                    if hwnd.is_null() {
+                        // Loud rather than silent: a missing hook presents as
+                        // "Ctrl+Wheel does nothing", indistinguishable from the
+                        // original bug.
+                        tracing::warn!(
+                            "[floater-wheel] no HWND for label={} — ctrl+wheel hook NOT installed",
+                            label
+                        );
+                    } else {
+                        unsafe {
+                            crate::floater_wheel::install_floater_ctrl_wheel_hook(
+                                &self.state,
+                                hwnd,
+                                &label,
+                            );
                         }
                     }
                 }

--- a/agentmux-cef/src/commands/pane_pool.rs
+++ b/agentmux-cef/src/commands/pane_pool.rs
@@ -528,6 +528,22 @@ pub fn promote_pane_pool_window(
             }
         }
 
+        // Re-point the Ctrl+Wheel hook at the NEW label. Promotion relabels the
+        // browser and bootstraps the renderer via `pool:pane-promote` +
+        // `history.replaceState` — there is NO navigation, so `on_load_end`
+        // never fires again and the hook's context would keep emitting to the
+        // dead `floating-pool-*` label. Every Ctrl+Wheel in a pool-promoted
+        // floater would then be discarded, and close-time cleanup (keyed on the
+        // new label) would not find the context either.
+        //
+        // This REWRITES the existing context rather than installing a second
+        // one. Contexts are keyed by HWND and `find_context` walks UP from the
+        // deepest descendant, so a fresh entry on the outer popup would still
+        // lose to the stale entry on the browser HWND beneath it.
+        // (codex P1 on PR #2884.)
+        #[cfg(target_os = "windows")]
+        crate::floater_wheel::relabel_floater_ctrl_wheel_hook(&label, &new_label);
+
         // Bind this floater to the source window's cascade hook. Deferred from
         // spawn time because the parent HWND is only known at tear-off.
         crate::floating_pane::register_floater_hwnd(

--- a/agentmux-cef/src/floater_wheel.rs
+++ b/agentmux-cef/src/floater_wheel.rs
@@ -1,0 +1,328 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Ctrl+Wheel recovery for floating panes (Windows).
+//!
+//! # Why this exists
+//!
+//! A floating pane hosts its browser as a **child HWND**
+//! (`floating_pane.rs`, `WindowInfo::set_as_child`), unlike the main window,
+//! which is CEF **Views**-hosted (`app/mod.rs`). Child-HWND CEF browsers do not
+//! dispatch Ctrl+Wheel to the renderer at all — CEF consumes it for its own
+//! native, `HostZoomMap`-shared page zoom before the DOM ever sees it.
+//!
+//! This was measured rather than assumed
+//! (`docs/analysis/ANALYSIS_FLOATER_CTRL_SCROLL_ZOOM_2026_08_31.md` §7), with a
+//! `wheel` recorder installed in each window and driven by a real mouse:
+//!
+//! | window                  | input        | events reaching the DOM |
+//! |-------------------------|--------------|-------------------------|
+//! | main, docked terminal   | Ctrl+Scroll  | 22 / 22, `ctrl: true`   |
+//! | floater, same terminal  | Ctrl+Scroll  | **0**                   |
+//! | floater, same terminal  | plain scroll | 49, `ctrl: false`       |
+//!
+//! So the floater receives wheel input normally and **only** Ctrl+Wheel is
+//! suppressed. Every in-page mechanism was proven working end to end (§6): the
+//! per-view handlers, the `term:zoom` RPC, the read-back, and the font
+//! application. The single missing link is the DOM event.
+//!
+//! # What it does
+//!
+//! Rather than reimplement zoom per view type — `term`, `armory`, `editor`,
+//! `swarm` and `warden` each own a capture-phase Ctrl+Wheel handler — this hook
+//! **restores the event Chromium swallowed** and lets those existing handlers
+//! run unchanged. `MK_CONTROL` in `wParam` is set by the system from global key
+//! state and is delivered to the WndProc regardless of what CEF later does with
+//! the message, so it is a reliable trigger.
+//!
+//! The precedent is `browser_pane/hwnd.rs:403`, which needed the same
+//! interception for the same reason: browser panes are *also* child-HWND
+//! browsers. They got a workaround; floaters never did.
+//!
+//! # KNOWN LIMITATION — Windows only
+//!
+//! This whole file is `cfg(windows)`. The browser-pane equivalent carries the
+//! same gap (`browser_pane/hwnd.rs:395`), and no macOS/Linux counterpart exists
+//! for either. On those platforms Ctrl+Wheel over a floater still falls through
+//! to CEF's native shared zoom. Stated rather than hidden.
+
+#![cfg(target_os = "windows")]
+
+use std::sync::{Arc, Weak};
+
+/// Map of subclassed HWND -> its original WndProc, so the hook can delegate
+/// everything it does not handle. Covers the browser's outer child HWND and
+/// every Chromium descendant, because mouse input is delivered to the deepest
+/// descendant under the cursor, not to the ancestor.
+static FLOATER_WHEEL_WNDPROCS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, isize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Per-floater context, keyed by the HWND the hook was installed on. Only the
+/// outermost installed HWND is keyed; descendants walk up via `GetParent` to
+/// find it, mirroring `browser_pane::hwnd`'s `find_context`.
+#[derive(Clone)]
+struct FloaterWheelContext {
+    state: Weak<crate::state::AppState>,
+    /// The floater's window label (`floating-<uuid>`), used to route the event
+    /// to *that* window's renderer. `emit_event_from_state`'s "main"/
+    /// first-available fallback would deliver it to the wrong window — the same
+    /// defect reagentx caught for `browser-pane-clicked` on PR #2597.
+    label: String,
+}
+
+static FLOATER_WHEEL_CONTEXT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, FloaterWheelContext>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+const WM_MOUSEWHEEL: u32 = 0x020A;
+/// `MK_CONTROL`, low word of `wParam`.
+const MK_CONTROL: usize = 0x0008;
+
+/// Walk up the parent chain looking for a registered floater context. The
+/// bound of 8 matches `browser_pane::hwnd::find_context`; Chromium's hierarchy
+/// under the browser is only 2-3 deep.
+unsafe fn find_context(mut hwnd: *mut std::ffi::c_void) -> Option<FloaterWheelContext> {
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetParent;
+    for _ in 0..8 {
+        if let Ok(map) = FLOATER_WHEEL_CONTEXT.lock() {
+            if let Some(ctx) = map.get(&(hwnd as usize)) {
+                return Some(ctx.clone());
+            }
+        }
+        let parent = GetParent(hwnd);
+        if parent.is_null() || parent == hwnd {
+            return None;
+        }
+        hwnd = parent;
+    }
+    None
+}
+
+unsafe extern "system" fn wndproc_hook(
+    hwnd: *mut std::ffi::c_void,
+    msg: u32,
+    wparam: usize,
+    lparam: isize,
+) -> isize {
+    use windows_sys::Win32::UI::WindowsAndMessaging::CallWindowProcW;
+
+    if msg == WM_MOUSEWHEEL && (wparam & MK_CONTROL) != 0 {
+        // High word of wParam, signed: positive = wheel forward/away from the
+        // user (zoom in), negative = toward the user (zoom out). Passed through
+        // as a DOM-style `deltaY`, whose sign convention is the OPPOSITE
+        // (positive deltaY = scroll down = zoom out), so it is negated here.
+        // The per-view handlers all branch on `ev.deltaY > 0`.
+        let raw_delta = (wparam >> 16) as u16 as i16;
+        let delta_y = -(raw_delta as f64);
+
+        if let Some(ctx) = find_context(hwnd) {
+            if let Some(state) = ctx.state.upgrade() {
+                crate::events::emit_event_to_window(
+                    &state,
+                    &ctx.label,
+                    "floater:ctrl-wheel",
+                    &serde_json::json!({ "deltaY": delta_y }),
+                );
+                // Consume: do NOT call the original WndProc. Letting it run is
+                // what produces CEF's native shared page zoom.
+                return 0;
+            }
+        }
+
+        // No context, or state dropped. Deliberately fall through to the
+        // original WndProc rather than returning 0 here.
+        //
+        // `browser_pane/hwnd.rs:403` does the opposite — its `return 0` sits
+        // outside the context lookup, so an unresolvable HWND silently eats the
+        // input and does nothing at all. That is a latent bug there, and
+        // repeating it would mean a floater whose context went missing would
+        // lose Ctrl+Wheel entirely with no fallback. Falling through at least
+        // leaves CEF's native zoom, which is degraded but not dead.
+        tracing::warn!(
+            "[floater-wheel] ctrl+wheel with no floater context for hwnd {:p} — falling through",
+            hwnd
+        );
+    }
+
+    let original = FLOATER_WHEEL_WNDPROCS
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&(hwnd as usize)).copied())
+        .unwrap_or(0);
+    if original != 0 {
+        return CallWindowProcW(Some(std::mem::transmute(original)), hwnd, msg, wparam, lparam);
+    }
+    windows_sys::Win32::UI::WindowsAndMessaging::DefWindowProcW(hwnd, msg, wparam, lparam)
+}
+
+/// Subclass `hwnd` and every Chromium descendant so Ctrl+Wheel can be recovered
+/// and forwarded to `label`'s renderer.
+///
+/// **Must be re-invoked after every navigation.** Chromium recreates
+/// `Chrome_RenderWidgetHostHWND` on each page load, so a subclass installed once
+/// ends up stranded on a destroyed HWND — the same reason
+/// `install_browser_pane_focus_redirect` is wired from both
+/// `on_after_created_browser_pane` and `on_load_end_browser_pane`. Re-invoking
+/// is cheap and idempotent: already-subclassed HWNDs are skipped.
+pub unsafe fn install_floater_ctrl_wheel_hook(
+    state: &Arc<crate::state::AppState>,
+    hwnd: *mut std::ffi::c_void,
+    label: &str,
+) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumChildWindows, SetWindowLongPtrW, GWLP_WNDPROC,
+    };
+
+    if hwnd.is_null() {
+        return;
+    }
+
+    if let Ok(mut map) = FLOATER_WHEEL_CONTEXT.lock() {
+        map.insert(
+            hwnd as usize,
+            FloaterWheelContext {
+                state: Arc::downgrade(state),
+                label: label.to_string(),
+            },
+        );
+    }
+
+    // Subclass the outer HWND once. Re-calling SetWindowLongPtrW would replace
+    // our hook with itself and poison the original-WndProc map.
+    let already = FLOATER_WHEEL_WNDPROCS
+        .lock()
+        .ok()
+        .map(|m| m.contains_key(&(hwnd as usize)))
+        .unwrap_or(false);
+    if !already {
+        let original = SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wndproc_hook as *const () as isize);
+        if original != 0 {
+            if let Ok(mut map) = FLOATER_WHEEL_WNDPROCS.lock() {
+                map.insert(hwnd as usize, original);
+            }
+            tracing::info!(
+                "[floater-wheel] installed ctrl+wheel hook on {:p} label={}",
+                hwnd,
+                label
+            );
+        }
+    }
+
+    unsafe extern "system" fn enum_children(child: *mut std::ffi::c_void, _lp: isize) -> i32 {
+        let already = FLOATER_WHEEL_WNDPROCS
+            .lock()
+            .ok()
+            .map(|m| m.contains_key(&(child as usize)))
+            .unwrap_or(false);
+        if already {
+            return 1;
+        }
+        let orig = SetWindowLongPtrW(child, GWLP_WNDPROC, wndproc_hook as *const () as isize);
+        if orig != 0 {
+            if let Ok(mut map) = FLOATER_WHEEL_WNDPROCS.lock() {
+                map.insert(child as usize, orig);
+            }
+        }
+        1 // continue enumeration
+    }
+    EnumChildWindows(hwnd, Some(enum_children), 0);
+}
+
+/// Restore original WndProcs and drop bookkeeping for a closing floater.
+///
+/// Called from the floater's close path. Skips `SetWindowLongPtrW` on HWNDs the
+/// OS has already destroyed (guarded by `IsWindow`) but still clears the map
+/// entries, so a later HWND value reused by Windows can't inherit a stale hook.
+pub unsafe fn remove_floater_ctrl_wheel_hook(label: &str) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        IsWindow, SetWindowLongPtrW, GWLP_WNDPROC,
+    };
+
+    let roots: Vec<usize> = match FLOATER_WHEEL_CONTEXT.lock() {
+        Ok(map) => map
+            .iter()
+            .filter(|(_, ctx)| ctx.label == label)
+            .map(|(h, _)| *h)
+            .collect(),
+        Err(_) => return,
+    };
+    if roots.is_empty() {
+        return;
+    }
+
+    // Un-subclass the root and everything beneath it. Children are collected
+    // first (EnumChildWindows can't run while we mutate), then restored.
+    for root in &roots {
+        let root_ptr = *root as *mut std::ffi::c_void;
+        let mut targets: Vec<usize> = vec![*root];
+        if IsWindow(root_ptr) != 0 {
+            unsafe extern "system" fn collect(child: *mut std::ffi::c_void, lp: isize) -> i32 {
+                let out = &mut *(lp as *mut Vec<usize>);
+                out.push(child as usize);
+                1
+            }
+            windows_sys::Win32::UI::WindowsAndMessaging::EnumChildWindows(
+                root_ptr,
+                Some(collect),
+                &mut targets as *mut Vec<usize> as isize,
+            );
+        }
+        if let Ok(mut map) = FLOATER_WHEEL_WNDPROCS.lock() {
+            for h in targets {
+                if let Some(orig) = map.remove(&h) {
+                    let hp = h as *mut std::ffi::c_void;
+                    if IsWindow(hp) != 0 {
+                        SetWindowLongPtrW(hp, GWLP_WNDPROC, orig);
+                    }
+                }
+            }
+        }
+    }
+
+    if let Ok(mut map) = FLOATER_WHEEL_CONTEXT.lock() {
+        map.retain(|_, ctx| ctx.label != label);
+    }
+    tracing::info!("[floater-wheel] removed ctrl+wheel hook for label={}", label);
+}
+
+#[cfg(test)]
+mod tests {
+    //! The Win32 calls need a real HWND and message pump, so what is testable
+    //! here is the wheel-delta sign conversion — the one piece of pure logic,
+    //! and the piece most likely to be silently inverted.
+
+    /// Mirrors the conversion in `wndproc_hook`.
+    fn delta_y_from_wparam(wparam: usize) -> f64 {
+        let raw = (wparam >> 16) as u16 as i16;
+        -(raw as f64)
+    }
+
+    const WHEEL_DELTA: usize = 120;
+
+    #[test]
+    fn wheel_forward_becomes_negative_delta_y_zoom_in() {
+        // Wheel away from the user: positive WM_MOUSEWHEEL delta. The per-view
+        // handlers zoom IN when `ev.deltaY <= 0`, so this must be negative.
+        let w = (WHEEL_DELTA << 16) | super::MK_CONTROL;
+        assert_eq!(delta_y_from_wparam(w), -120.0);
+    }
+
+    #[test]
+    fn wheel_toward_user_becomes_positive_delta_y_zoom_out() {
+        // Negative i16 in the high word, i.e. -120.
+        let raw: i16 = -120;
+        let w = ((raw as u16 as usize) << 16) | super::MK_CONTROL;
+        assert_eq!(delta_y_from_wparam(w), 120.0);
+    }
+
+    #[test]
+    fn mk_control_bit_is_read_from_the_low_word() {
+        // A wheel delta large enough to occupy the high word must not be
+        // mistaken for the modifier bits.
+        let with_ctrl = (WHEEL_DELTA << 16) | super::MK_CONTROL;
+        let without = WHEEL_DELTA << 16;
+        assert_ne!(with_ctrl & super::MK_CONTROL, 0);
+        assert_eq!(without & super::MK_CONTROL, 0);
+    }
+}

--- a/agentmux-cef/src/floater_wheel.rs
+++ b/agentmux-cef/src/floater_wheel.rs
@@ -76,6 +76,9 @@ static FLOATER_WHEEL_CONTEXT: std::sync::LazyLock<
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 const WM_MOUSEWHEEL: u32 = 0x020A;
+/// Sent to a window as it is being destroyed, after its children are gone. Used
+/// to purge map entries so a reused HWND value can't inherit a stale hook.
+const WM_NCDESTROY: u32 = 0x0082;
 /// `MK_CONTROL`, low word of `wParam`.
 const MK_CONTROL: usize = 0x0008;
 
@@ -107,6 +110,30 @@ unsafe extern "system" fn wndproc_hook(
 ) -> isize {
     use windows_sys::Win32::UI::WindowsAndMessaging::CallWindowProcW;
 
+    // Purge before anything else. Chromium destroys and recreates
+    // `Chrome_RenderWidgetHostHWND` on every navigation; without this the dead
+    // descendant stays in FLOATER_WHEEL_WNDPROCS, and because Windows reuses
+    // numeric HWND values, a later widget landing on the same value would be
+    // seen as "already subclassed" and skipped — silently losing Ctrl+Wheel on
+    // the very window this hook exists to fix. Destruction has already restored
+    // the system WndProc, so only the bookkeeping needs clearing.
+    // (codex P2 on PR #2884.)
+    if msg == WM_NCDESTROY {
+        let original = FLOATER_WHEEL_WNDPROCS
+            .lock()
+            .ok()
+            .and_then(|mut m| m.remove(&(hwnd as usize)))
+            .unwrap_or(0);
+        if let Ok(mut m) = FLOATER_WHEEL_CONTEXT.lock() {
+            m.remove(&(hwnd as usize));
+        }
+        // Still chain, so the original WndProc sees its own destruction.
+        if original != 0 {
+            return CallWindowProcW(Some(std::mem::transmute(original)), hwnd, msg, wparam, lparam);
+        }
+        return windows_sys::Win32::UI::WindowsAndMessaging::DefWindowProcW(hwnd, msg, wparam, lparam);
+    }
+
     if msg == WM_MOUSEWHEEL && (wparam & MK_CONTROL) != 0 {
         // High word of wParam, signed: positive = wheel forward/away from the
         // user (zoom in), negative = toward the user (zoom out). Passed through
@@ -116,13 +143,47 @@ unsafe extern "system" fn wndproc_hook(
         let raw_delta = (wparam >> 16) as u16 as i16;
         let delta_y = -(raw_delta as f64);
 
+        // Forward WHERE the user scrolled, not just how much. `lParam` carries
+        // SCREEN coordinates for WM_MOUSEWHEEL (unlike most mouse messages,
+        // which are client-relative). Converted to client space here because
+        // only the host knows which HWND the point should be relative to.
+        //
+        // This matters because Ctrl+Wheel is not uniform across a pane: an
+        // agent shell sub-block (`AgentShellSubblock.tsx`) and a tool preview
+        // (`ToolBlock.tsx`) register their own independently scoped handlers,
+        // and the pane header follows a different zoom path entirely. Aiming
+        // every synthetic event at the block centre would zoom the whole block
+        // regardless of what the cursor was over. (codex P2 on PR #2884.)
+        let screen_x = (lparam & 0xFFFF) as i16 as i32;
+        let screen_y = ((lparam >> 16) & 0xFFFF) as i16 as i32;
+        let mut pt = windows_sys::Win32::Foundation::POINT { x: screen_x, y: screen_y };
+        // Client-relative to the top-level window, whose client area is the
+        // renderer viewport (floating_pane_wndproc returns 0 from
+        // WM_NCCALCSIZE, so client == whole window). Physical px; the frontend
+        // divides by devicePixelRatio to reach CSS px.
+        let root = windows_sys::Win32::UI::WindowsAndMessaging::GetAncestor(
+            hwnd,
+            windows_sys::Win32::UI::WindowsAndMessaging::GA_ROOT,
+        );
+        let anchor = if root.is_null() { hwnd } else { root };
+        let converted =
+            windows_sys::Win32::Graphics::Gdi::ScreenToClient(anchor, &mut pt) != 0;
+
         if let Some(ctx) = find_context(hwnd) {
             if let Some(state) = ctx.state.upgrade() {
+                let mut payload = serde_json::json!({ "deltaY": delta_y });
+                // Omit the point rather than sending a bogus one if the
+                // conversion failed; the frontend falls back to the block
+                // centre only when it is absent.
+                if converted {
+                    payload["clientXPhysical"] = serde_json::json!(pt.x);
+                    payload["clientYPhysical"] = serde_json::json!(pt.y);
+                }
                 crate::events::emit_event_to_window(
                     &state,
                     &ctx.label,
                     "floater:ctrl-wheel",
-                    &serde_json::json!({ "deltaY": delta_y }),
+                    &payload,
                 );
                 // Consume: do NOT call the original WndProc. Letting it run is
                 // what produces CEF's native shared page zoom.
@@ -227,6 +288,35 @@ pub unsafe fn install_floater_ctrl_wheel_hook(
         1 // continue enumeration
     }
     EnumChildWindows(hwnd, Some(enum_children), 0);
+}
+
+/// Re-point every context registered under `old_label` at `new_label`.
+///
+/// Needed by the pane-pool promotion path, which relabels the browser
+/// (`floating-pool-*` → `floating-*`) and bootstraps the renderer through
+/// `pool:pane-promote` + `history.replaceState` **without navigating**. Since
+/// the hook is installed from `on_load_end`, nothing else would ever refresh the
+/// label, and every forwarded wheel would be emitted to a label that no longer
+/// resolves to a browser — silently dropping Ctrl+Wheel on exactly the floaters
+/// that came from the pool. Close-time cleanup, keyed on the new label, would
+/// also fail to find the context. (codex P1 on PR #2884.)
+pub fn relabel_floater_ctrl_wheel_hook(old_label: &str, new_label: &str) {
+    let Ok(mut map) = FLOATER_WHEEL_CONTEXT.lock() else { return };
+    let mut n = 0usize;
+    for ctx in map.values_mut() {
+        if ctx.label == old_label {
+            ctx.label = new_label.to_string();
+            n += 1;
+        }
+    }
+    if n > 0 {
+        tracing::info!(
+            "[floater-wheel] relabelled {} ctrl+wheel context(s) {} -> {}",
+            n,
+            old_label,
+            new_label
+        );
+    }
 }
 
 /// Restore original WndProcs and drop bookkeeping for a closing floater.

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -34,6 +34,8 @@ mod srv_ipc;
 mod memory_heartbeat;
 mod memory_pressure;
 mod browser_pane;
+#[cfg(target_os = "windows")]
+mod floater_wheel;
 mod credential_broker;
 #[cfg(target_os = "windows")]
 mod floating_pane;

--- a/frontend/app/workspace/floater-ctrl-wheel.ts
+++ b/frontend/app/workspace/floater-ctrl-wheel.ts
@@ -32,15 +32,40 @@
 
 import { listenEvent } from "@/app/platform/ipc";
 
-type CtrlWheelPayload = { deltaY?: number };
+type CtrlWheelPayload = {
+    deltaY?: number;
+    /** Physical (device) px, client-relative to the floater's top-level window. */
+    clientXPhysical?: number;
+    clientYPhysical?: number;
+};
 
-/** Element to aim the synthesised event at. */
-function resolveTarget(): Element | null {
-    // A floater wraps exactly one block, so its content is the only sensible
-    // target. Aim at the deepest element at the block's centre so the event
-    // propagates through the view root that owns the capture-phase handler,
-    // rather than being dispatched directly on the root (which would skip
-    // nothing, but would misreport `event.target` to anything inspecting it).
+/** Where the event happened, in CSS px, or null if the host couldn't supply it. */
+function resolvePoint(p: CtrlWheelPayload): { x: number; y: number } | null {
+    if (typeof p.clientXPhysical !== "number" || typeof p.clientYPhysical !== "number") {
+        return null;
+    }
+    const dpr = window.devicePixelRatio || 1;
+    return { x: Math.round(p.clientXPhysical / dpr), y: Math.round(p.clientYPhysical / dpr) };
+}
+
+/**
+ * Element to aim the synthesised event at.
+ *
+ * Uses the real cursor position when the host supplied it, because Ctrl+Wheel is
+ * NOT uniform across a pane: agent shell sub-blocks (`AgentShellSubblock.tsx`)
+ * and tool previews (`ToolBlock.tsx`) register their own independently scoped
+ * handlers, and the pane header takes a different zoom path. Aiming everything
+ * at the block centre would zoom the whole block no matter what was under the
+ * cursor.
+ *
+ * Falls back to the block centre only when the point is missing or lands outside
+ * the document — better a whole-block zoom than none.
+ */
+function resolveTarget(point: { x: number; y: number } | null): Element | null {
+    if (point) {
+        const hit = document.elementFromPoint(point.x, point.y);
+        if (hit) return hit;
+    }
     const block = document.querySelector("[data-blockid]");
     if (!block) return null;
     const r = block.getBoundingClientRect();
@@ -61,7 +86,8 @@ export async function initFloaterCtrlWheel(): Promise<() => void> {
         const deltaY = typeof payload?.deltaY === "number" ? payload.deltaY : 0;
         if (deltaY === 0) return;
 
-        const target = resolveTarget();
+        const point = resolvePoint(payload);
+        const target = resolveTarget(point);
         if (!target) return;
 
         target.dispatchEvent(
@@ -69,6 +95,11 @@ export async function initFloaterCtrlWheel(): Promise<() => void> {
                 ctrlKey: true,
                 deltaY,
                 deltaMode: 0, // DOM_DELTA_PIXEL, matching a real wheel event
+                // Carry the position through as well: handlers that inspect
+                // `clientX/Y` (or call `closest()` from `event.target`) then see
+                // the same geometry a real wheel would have produced.
+                clientX: point?.x ?? 0,
+                clientY: point?.y ?? 0,
                 bubbles: true,
                 cancelable: true,
                 composed: true,

--- a/frontend/app/workspace/floater-ctrl-wheel.ts
+++ b/frontend/app/workspace/floater-ctrl-wheel.ts
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Ctrl+Wheel recovery for floating panes.
+ *
+ * A floater hosts its browser as a child HWND, and CEF consumes Ctrl+Wheel for
+ * its own native page zoom before the renderer sees it — so no `wheel` event
+ * with `ctrlKey` ever reaches the DOM in a floating window. Measured, not
+ * assumed: a real mouse produced 22/22 ctrl-wheel events in the docked main
+ * window and **0** in a floater, while plain scrolling produced 49 in the same
+ * floater. See `docs/analysis/ANALYSIS_FLOATER_CTRL_SCROLL_ZOOM_2026_08_31.md`
+ * §7 and `agentmux-cef/src/floater_wheel.rs`.
+ *
+ * The host intercepts `WM_MOUSEWHEEL` with `MK_CONTROL` and emits
+ * `floater:ctrl-wheel`. This module turns that back into the DOM event that was
+ * swallowed.
+ *
+ * **Why re-dispatch rather than call a zoom function.** Ctrl+Wheel zoom is not
+ * implemented once — `term`, `armory`, `editor`, `swarm` and `warden` each
+ * register their own capture-phase handler on their own view root, and each
+ * writes `term:zoom` for its own block. Calling any one of them here would mean
+ * duplicating that dispatch and re-deciding which view is in the floater.
+ * Synthesising the event instead lets every one of those handlers run exactly
+ * as it does when docked, so this file needs no knowledge of view types and
+ * does not have to change when a new one is added.
+ *
+ * Untrusted events are sufficient: those handlers read only `ctrlKey` and
+ * `deltaY`, then call `preventDefault()`/`stopPropagation()` and write meta.
+ * None of them check `isTrusted`.
+ */
+
+import { listenEvent } from "@/app/platform/ipc";
+
+type CtrlWheelPayload = { deltaY?: number };
+
+/** Element to aim the synthesised event at. */
+function resolveTarget(): Element | null {
+    // A floater wraps exactly one block, so its content is the only sensible
+    // target. Aim at the deepest element at the block's centre so the event
+    // propagates through the view root that owns the capture-phase handler,
+    // rather than being dispatched directly on the root (which would skip
+    // nothing, but would misreport `event.target` to anything inspecting it).
+    const block = document.querySelector("[data-blockid]");
+    if (!block) return null;
+    const r = block.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) return null;
+    const cx = Math.round(r.left + r.width / 2);
+    const cy = Math.round(r.top + r.height / 2);
+    return document.elementFromPoint(cx, cy) ?? block;
+}
+
+/**
+ * Start listening for host-forwarded Ctrl+Wheel. Returns an unsubscribe fn.
+ *
+ * Safe to call in any window: the host only emits this event to `floating-*`
+ * labels, so in the main window the listener simply never fires.
+ */
+export async function initFloaterCtrlWheel(): Promise<() => void> {
+    return listenEvent<CtrlWheelPayload>("floater:ctrl-wheel", (payload) => {
+        const deltaY = typeof payload?.deltaY === "number" ? payload.deltaY : 0;
+        if (deltaY === 0) return;
+
+        const target = resolveTarget();
+        if (!target) return;
+
+        target.dispatchEvent(
+            new WheelEvent("wheel", {
+                ctrlKey: true,
+                deltaY,
+                deltaMode: 0, // DOM_DELTA_PIXEL, matching a real wheel event
+                bubbles: true,
+                cancelable: true,
+                composed: true,
+            })
+        );
+    });
+}

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -51,6 +51,7 @@ import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 
 import { REDOCK_DWELL_MS, REDOCK_VELOCITY_PX_PER_S } from "./floating-pane-constants";
+import { initFloaterCtrlWheel } from "./floater-ctrl-wheel";
 import "./floating-pane-workspace.scss";
 
 /**
@@ -122,6 +123,26 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     );
             }
         }
+    });
+
+    // Ctrl+Wheel recovery. CEF swallows Ctrl+Wheel in a child-HWND browser, so
+    // no wheel event with `ctrlKey` ever reaches this window's DOM and none of
+    // the per-view zoom handlers can fire. The host intercepts the Win32
+    // message and forwards it; this re-dispatches it as the DOM event that was
+    // swallowed. See floater-ctrl-wheel.ts and floater_wheel.rs.
+    onMount(() => {
+        let dispose: (() => void) | null = null;
+        let disposed = false;
+        void initFloaterCtrlWheel().then((fn) => {
+            // The listener resolves async; if this component unmounted first,
+            // tear it down immediately rather than leaking it.
+            if (disposed) fn();
+            else dispose = fn;
+        });
+        onCleanup(() => {
+            disposed = true;
+            dispose?.();
+        });
     });
 
     // Pane-header drag — Windows: Win32BeginMoveTask host-side loop (PR #1276).


### PR DESCRIPTION
Fixes the repo owner's report that Ctrl+Scroll zoom stops working once a pane is torn off. Implements §8 of the analysis merged in #2881.

## Cause

A floater hosts its browser as a **child HWND** (`floating_pane.rs`, `WindowInfo::set_as_child`); the main window is CEF **Views**-hosted. Child-HWND CEF browsers never dispatch Ctrl+Wheel to the renderer — CEF consumes it for its own native `HostZoomMap`-shared page zoom first.

Measured with a `wheel` recorder in each window, driven by a real mouse:

| window | input | events reaching the DOM |
|---|---|---|
| main, docked terminal | Ctrl+Scroll | **22 / 22, `ctrl: true`** |
| floater, same terminal | Ctrl+Scroll | **0** |
| floater, same terminal | plain scroll | **49, `ctrl: false`** |

The floater receives wheel input normally; only Ctrl+Wheel is suppressed. Everything in-page was already proven working end to end — per-view handlers, the `term:zoom` RPC, read-back, font application. The single missing link was the DOM event.

**Browser panes are also child-HWND browsers and already needed this exact interception** (`browser_pane/hwnd.rs:403`, whose comment names CEF's native shared zoom as the reason). Floaters never got one.

## Approach

**Host** — `floater_wheel.rs` subclasses the floater's browser HWND and every Chromium descendant (mouse input goes to the deepest descendant, not the ancestor), intercepts `WM_MOUSEWHEEL` with `MK_CONTROL`, and emits `floater:ctrl-wheel` to *that window's* renderer via `emit_event_to_window` — not `emit_event_from_state`, whose "main"/first-available fallback is the bug reagentx caught for `browser-pane-clicked` on #2597.

Installed from **`on_load_end`, not `on_after_created`**: Chromium recreates `Chrome_RenderWidgetHostHWND` on every page load, so a once-installed subclass strands on a destroyed HWND. This is why `install_browser_pane_focus_redirect` is wired from both. Idempotent, and it also covers a pane-pool window being promoted to a real floater (which re-navigates). Un-subclassed on close, since Windows reuses HWND values.

**Frontend** — `floater-ctrl-wheel.ts` **re-dispatches the swallowed DOM event** rather than calling a zoom function. Ctrl+Wheel zoom is implemented five times over (`term`, `armory`, `editor`, `swarm`, `warden`), each on its own view root writing `term:zoom` for its own block. Synthesising the event lets all of them run unchanged, so this file needs no knowledge of view types and won't need editing when a sixth is added. Untrusted events suffice — none of those handlers check `isTrusted`.

## One deliberate divergence from the precedent

`browser_pane/hwnd.rs:403` puts its `return 0` **outside** the context lookup, so an HWND it can't resolve silently eats Ctrl+Wheel and does nothing. This hook falls through to the original WndProc instead, leaving CEF's native zoom — degraded but not dead. That is a latent bug in the browser-pane hook; it's noted in the analysis and **not** fixed here.

## Known limitation, inherited

**Windows only.** The browser-pane equivalent is `cfg(windows)`-gated with no macOS/Linux counterpart either (`hwnd.rs:395`). Stated rather than hidden.

## Verification

- `cargo test -p agentmux-cef floater_wheel` — **3 passed**
- `cargo check -p agentmux-cef` — clean
- `tsc --noEmit` — clean

The 3 tests cover the wheel-delta sign conversion: `WM_MOUSEWHEEL`'s convention is the **opposite** of DOM `deltaY` (positive = away from user = zoom in, vs positive `deltaY` = scroll down = zoom out), and silently inverting it would make zoom run backwards.

**Not yet verified against a live floater** — that needs a host rebuild. Worth a manual check that Ctrl+Scroll zooms a torn-off terminal *and* in the correct direction.

<!-- agentmux:agent_id=agenta-07017 -->