### PR TITLE
feat(agent-pane): attribute scroll shrinks to the rows that caused them

### DIFF
--- a/.changesets/1788223484-feat-agent-pane-per-node-shrink-attribution-in-the-wave-scro-swuq.md
+++ b/.changesets/1788223484-feat-agent-pane-per-node-shrink-attribution-in-the-wave-scro-swuq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): per-node shrink attribution in the wave-scroll-shrink diagnostic

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.shrink-attribution.test.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.shrink-attribution.test.tsx
@@ -1,0 +1,250 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end wiring for per-node shrink attribution
+ * (SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md step 1).
+ *
+ * `shrink-trace.test.ts` covers the bookkeeping in isolation. What THIS file
+ * covers is the part that unit tests can't: that the streaming-buffer
+ * ResizeObserver is actually attached to real rendered rows, that what it
+ * records reaches `ShrinkTrace`, and that the result comes back out on the
+ * `[wave-scroll-shrink]` console line. Every one of those is a wiring step
+ * that can be individually correct and still not connect.
+ *
+ * jsdom has no layout engine and no ResizeObserver, so the fakes here mirror
+ * `AgentDocumentVirtualList.resize.test.tsx`'s: `triggerResize(el)` invokes
+ * whichever observer callbacks currently watch `el`, and geometry is stubbed
+ * explicitly. This proves the wiring, not the browser's real resize timing.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentDocumentVirtualList } from "./AgentDocumentVirtualList";
+import { createAgentViewState } from "./state";
+import type { DocumentNode, DocumentState } from "../types";
+
+afterEach(() => cleanup());
+
+type ROCallback = (entries: ResizeObserverEntry[]) => void;
+let roInstances: { callback: ROCallback; targets: Set<Element> }[] = [];
+
+class FakeResizeObserver {
+    private callback: ROCallback;
+    private targets = new Set<Element>();
+    constructor(callback: ROCallback) {
+        this.callback = callback;
+        roInstances.push({ callback: this.callback, targets: this.targets });
+    }
+    observe(el: Element): void { this.targets.add(el); }
+    unobserve(el: Element): void { this.targets.delete(el); }
+    disconnect(): void { this.targets.clear(); }
+}
+
+function triggerResize(el: Element): void {
+    for (const { callback, targets } of roInstances) {
+        if (targets.has(el)) callback([{ target: el } as ResizeObserverEntry]);
+    }
+}
+
+let rafQueue: FrameRequestCallback[] = [];
+function flushRaf(): void {
+    const pending = rafQueue;
+    rafQueue = [];
+    for (const cb of pending) cb(0);
+}
+
+interface Geometry { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+function makeScrollable(el: HTMLElement, geo: Geometry): void {
+    let { scrollTop, scrollHeight, clientHeight } = geo;
+    Object.defineProperty(el, "scrollTop", {
+        configurable: true,
+        get: () => scrollTop,
+        set: (v: number) => { scrollTop = v; },
+    });
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(el, "clientHeight", { configurable: true, get: () => clientHeight });
+    el.scrollTo = ((opts?: ScrollToOptions | number) => {
+        const requested = typeof opts === "number" ? opts : (opts?.top ?? scrollTop);
+        scrollTop = Math.max(0, Math.min(requested, Math.max(0, scrollHeight - clientHeight)));
+        el.dispatchEvent(new Event("scroll"));
+    }) as typeof el.scrollTo;
+    (el as unknown as { __setGeometry: (g: Partial<Geometry>) => void }).__setGeometry = (g) => {
+        if (g.scrollHeight !== undefined) scrollHeight = g.scrollHeight;
+        if (g.clientHeight !== undefined) clientHeight = g.clientHeight;
+        if (g.scrollTop !== undefined) scrollTop = g.scrollTop;
+    };
+}
+
+function setGeometry(el: HTMLElement, g: Partial<Geometry>): void {
+    (el as unknown as { __setGeometry: (g: Partial<Geometry>) => void }).__setGeometry(g);
+}
+
+/** Force a row's measured height — `offsetHeight` is the read the sampler
+ *  makes (chosen to match the pane's unzoomed `scrollHeight`; see
+ *  shrink-trace.ts). jsdom reports 0 for it otherwise. */
+function setRowHeight(el: Element, px: number): void {
+    Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => px });
+}
+
+const emptyDocumentState = (): DocumentState => ({
+    collapsedNodes: new Set(),
+    pinnedNodes: new Set(),
+    expandedTools: new Set(),
+    scrollPosition: 0,
+    selectedNode: null,
+    filter: { showThinking: true } as DocumentState["filter"],
+});
+
+const toolNode = (id: string): DocumentNode => ({
+    type: "tool",
+    id,
+    tool: "Bash",
+    params: { command: "echo hi" },
+    status: "running",
+    collapsed: false,
+    summary: `Bash ${id}`,
+    log: { open: true, chunks: [{ kind: "stdout", content: "out", timestamp: 1 }] },
+}) as DocumentNode;
+
+function setup(nodes: DocumentNode[]) {
+    const documentAtom = createSignal<DocumentNode[]>(nodes);
+    const viewState = createAgentViewState(documentAtom);
+    const [docState] = createSignal(emptyDocumentState());
+    const utils = render(() => (
+        <AgentDocumentVirtualList
+            viewState={viewState}
+            documentState={docState}
+            blockId="blk1234567"
+            onToggleCollapse={() => {}}
+            onTogglePin={() => {}}
+        />
+    ));
+    const scrollRef = utils.container.querySelector(".agent-document") as HTMLElement;
+    makeScrollable(scrollRef, { scrollTop: 0, scrollHeight: 0, clientHeight: 0 });
+    const buffer = utils.container.querySelector(".agent-document-streaming-buffer") as HTMLElement;
+    return { viewState, scrollRef, buffer, utils };
+}
+
+describe("AgentDocumentVirtualList — shrink attribution wiring", () => {
+    let info: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        roInstances = [];
+        rafQueue = [];
+        vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+            rafQueue.push(cb);
+            return rafQueue.length;
+        });
+        vi.stubGlobal("cancelAnimationFrame", () => {});
+        info = vi.spyOn(console, "info").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    /** All `[wave-scroll-shrink]` lines emitted so far, joined per call. */
+    const shrinkLines = (): string[] =>
+        info.mock.calls
+            .filter((c) => c[0] === "[wave-scroll-shrink]")
+            .map((c) => c.join(" "));
+
+    it("names the row that shrank, with NO row-level resize notification at all", () => {
+        // Regression for the P1 codex caught on PR #2887. The first version
+        // fed a ResizeObserver into a time-windowed ring, but the pin path
+        // that detects most shrinks runs in a `queueMicrotask`, and RO
+        // callbacks are not delivered until later in the rendering steps — so
+        // the primary running->terminal case logged as wholly unattributed
+        // and its row shrink was left to be miscredited to a later, unrelated
+        // pane delta.
+        //
+        // This test deliberately fires NO resize on the row itself. The only
+        // thing that happens is: the DOM height changes, and a pin check runs.
+        // That is the real browser ordering, and it must still attribute.
+        const { scrollRef, buffer, utils } = setup([toolNode("tc-1")]);
+        const row = utils.container.querySelector('[data-node-id="tc-1"]') as HTMLElement;
+        expect(row).toBeTruthy();
+        expect(row.dataset.nodeType).toBe("tool"); // sampler reads the kind from here
+
+        setRowHeight(row, 300);
+        setGeometry(scrollRef, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+        triggerResize(buffer);
+        flushRaf();
+
+        // The tool completes: the row lays out short and the pane loses the
+        // same 220px. No row resize is dispatched.
+        setRowHeight(row, 80);
+        setGeometry(scrollRef, { scrollHeight: 780 });
+        triggerResize(buffer);
+        flushRaf();
+
+        const line = shrinkLines().pop()!;
+        expect(line).toContain("delta=220px");
+        expect(line).toContain("tc-1(tool) 300->80px");
+        expect(line).toContain("sum=220px");
+        expect(line).toContain("unattributed=0px");
+    });
+
+    it("reports an unattributed remainder when no observed row shrank", () => {
+        // The pane shrank but nothing being watched did — the signal that the
+        // cause is somewhere this instrumentation cannot yet see. Reporting
+        // this honestly is the whole point of the remainder field.
+        const { scrollRef, buffer } = setup([toolNode("tc-1")]);
+
+        setGeometry(scrollRef, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+        triggerResize(buffer);
+        flushRaf();
+
+        setGeometry(scrollRef, { scrollHeight: 749 });
+        triggerResize(buffer);
+        flushRaf();
+
+        const line = shrinkLines().pop()!;
+        expect(line).toContain("delta=251px");
+        expect(line).toContain("attributed: none");
+        expect(line).toContain("unattributed=251px");
+    });
+
+    it("sums several rows into one pane delta", () => {
+        // The case a bare net delta cannot decompose, and the reason the
+        // 08-22 findings' ~251-252px lead had no matching height constant.
+        const { scrollRef, buffer, utils } = setup([toolNode("tc-1"), toolNode("tc-2")]);
+        const r1 = utils.container.querySelector('[data-node-id="tc-1"]') as HTMLElement;
+        const r2 = utils.container.querySelector('[data-node-id="tc-2"]') as HTMLElement;
+
+        setRowHeight(r1, 200);
+        setRowHeight(r2, 100);
+        setGeometry(scrollRef, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+        triggerResize(buffer);
+        flushRaf();
+
+        setRowHeight(r1, 60); // -140
+        setRowHeight(r2, 12); // -88
+        setGeometry(scrollRef, { scrollHeight: 749 }); // pane lost 251
+        triggerResize(buffer);
+        flushRaf();
+
+        const line = shrinkLines().pop()!;
+        expect(line).toContain("tc-1(tool) 200->60px");
+        expect(line).toContain("tc-2(tool) 100->12px");
+        expect(line).toContain("sum=228px");
+        expect(line).toContain("unattributed=23px"); // 251 seen, 228 explained
+    });
+
+    it("logs nothing when the pane did not shrink", () => {
+        const { scrollRef, buffer } = setup([toolNode("tc-1")]);
+        setGeometry(scrollRef, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+        triggerResize(buffer);
+        flushRaf();
+        setGeometry(scrollRef, { scrollHeight: 1400 }); // grew
+        triggerResize(buffer);
+        flushRaf();
+        expect(shrinkLines()).toEqual([]);
+    });
+});

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -42,6 +42,7 @@ import {
     restoreScrollFromAnchor,
 } from "./anchor";
 import { DocumentRow } from "./DocumentRow";
+import { ShrinkTrace, formatAttribution } from "./shrink-trace";
 import { estimateNode, estimateNodeForState } from "./renderers";
 import { currentExpansion } from "./expansion-source";
 import type { AgentViewState } from "./state";
@@ -210,15 +211,27 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         }
     }
 
+    // Per-node shrink attribution for the `[wave-scroll-shrink]` line below.
+    // Fed by `shrinkRO` (streaming-buffer rows), drained when a pane shrink is
+    // detected. Step 1 of SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
+    const shrinkTrace = new ShrinkTrace();
+
     let lastKnownScrollHeight = 0;
     function scrollToTrueBottom(): void {
         if (!scrollRef) return;
         const h = scrollRef.scrollHeight;
         if (lastKnownScrollHeight > 0 && h < lastKnownScrollHeight - 1) {
+            const paneDelta = lastKnownScrollHeight - h;
             console.info(
                 "[wave-scroll-shrink]",
                 `pane=${props.blockId?.slice(0, 7) ?? "?"}`,
-                `scrollHeight ${lastKnownScrollHeight}px -> ${h}px (delta=${lastKnownScrollHeight - h}px)`,
+                `scrollHeight ${lastKnownScrollHeight}px -> ${h}px (delta=${paneDelta}px)`,
+                // Which row(s) actually got shorter, and how much of the pane
+                // delta they fail to explain — see shrink-trace.ts. Without
+                // this suffix the line above is a bare net number, which is
+                // precisely what limited every conclusion in the 08-21/08-22
+                // findings docs.
+                formatAttribution(shrinkTrace.attribute(paneDelta, performance.now())),
             );
         }
         lastKnownScrollHeight = h;
@@ -1001,6 +1014,53 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         })
         : undefined;
     onCleanup(() => measureRO?.disconnect());
+
+    // Diagnostic-only RO over STREAMING-BUFFER rows — deliberately separate
+    // from measureRO above rather than an extra branch inside it. measureRO
+    // dispatches `RowMeasured` into the agent-pane-layout slice, and the slice
+    // models the VIRTUALIZED partition only; feeding it streaming-buffer rows
+    // would be a real behavior change (rows it has no positions for), not
+    // instrumentation. The streaming buffer is also exactly where the
+    // interesting shrinks happen — a completing tool call is in the trailing
+    // N nodes by definition — and it is currently measured by nothing at all,
+    // which is the concrete reason the pane-level diagnostic could never name
+    // a culprit. Feeds `shrinkTrace`; nothing reads it except the
+    // `[wave-scroll-shrink]` log line.
+    const shrinkElNode = new WeakMap<Element, { id: string; type: string }>();
+    const shrinkRO = typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver((entries) => {
+            const zoom = props.zoomFactor?.() ?? 1;
+            const now = performance.now();
+            for (const entry of entries) {
+                const meta = shrinkElNode.get(entry.target);
+                if (!meta) continue;
+                // ÷zoom for the same reason measureRO does it: getBoundingClientRect
+                // is the one read that IS scaled by an ancestor CSS `zoom`, and
+                // mixing zoomed and unzoomed px would make every attribution
+                // wrong by the zoom factor at non-100% pane zoom.
+                shrinkTrace.record(
+                    meta.id,
+                    meta.type,
+                    entry.target.getBoundingClientRect().height / (zoom || 1),
+                    now,
+                );
+            }
+        })
+        : undefined;
+    onCleanup(() => shrinkRO?.disconnect());
+    const observeStreamingRow = (el: HTMLElement, node: DocumentNode): void => {
+        shrinkElNode.set(el, { id: node.id, type: node.type });
+        shrinkRO?.observe(el);
+    };
+    const unobserveStreamingRow = (el: HTMLElement, nodeId: string): void => {
+        shrinkRO?.unobserve(el);
+        shrinkElNode.delete(el);
+        // Drop the baseline too — a cap-advance can retire a tall row and
+        // later re-add the same node short, which would otherwise log as one
+        // fabricated shrink spanning the gap.
+        shrinkTrace.forget(nodeId);
+    };
+
     const observeRow = (el: HTMLElement, nodeId: string): void => {
         elNodeId.set(el, nodeId);
         measureRO?.observe(el);
@@ -1110,19 +1170,31 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                         ref={(el) => { streamingBufferRef = el; }}
                     >
                         <Key each={p().streamingNodes as DocumentNode[]} by={(n) => n.id}>
-                            {(nodeAccessor) => (
-                                <DocumentRow
-                                    node={nodeAccessor}
-                                    documentState={props.documentState}
-                                    highlightNodeId={props.highlightNodeId}
-                                    onToggleCollapse={props.onToggleCollapse}
-                                    onTogglePin={props.onTogglePin}
-                                    onHoldToolOpen={props.onHoldToolOpen}
-                                    onAgentErrorLogin={props.onAgentErrorLogin}
-                                    onOpenHistory={props.onOpenHistory}
-                                    dispatchMatches={props.dispatchMatches}
-                                />
-                            )}
+                            {(nodeAccessor) => {
+                                // Diagnostic shrink-attribution only (see
+                                // shrinkRO above). The <Key> slot's own
+                                // onCleanup is what makes the unobserve
+                                // reliable across a cap-advance retiring this
+                                // slot — same lifecycle hook the virtualized
+                                // rows use for measureRO.
+                                let rowEl: HTMLElement | undefined;
+                                const nodeId = nodeAccessor().id;
+                                onCleanup(() => { if (rowEl) unobserveStreamingRow(rowEl, nodeId); });
+                                return (
+                                    <DocumentRow
+                                        node={nodeAccessor}
+                                        documentState={props.documentState}
+                                        highlightNodeId={props.highlightNodeId}
+                                        onToggleCollapse={props.onToggleCollapse}
+                                        onTogglePin={props.onTogglePin}
+                                        onHoldToolOpen={props.onHoldToolOpen}
+                                        onAgentErrorLogin={props.onAgentErrorLogin}
+                                        onOpenHistory={props.onOpenHistory}
+                                        dispatchMatches={props.dispatchMatches}
+                                        ref={(el) => { rowEl = el; observeStreamingRow(el, nodeAccessor()); }}
+                                    />
+                                );
+                            }}
                         </Key>
                     </div>
                 )}

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -42,7 +42,7 @@ import {
     restoreScrollFromAnchor,
 } from "./anchor";
 import { DocumentRow } from "./DocumentRow";
-import { ShrinkTrace, formatAttribution } from "./shrink-trace";
+import { ShrinkTrace, attribute, formatAttribution, type RowSample } from "./shrink-trace";
 import { estimateNode, estimateNodeForState } from "./renderers";
 import { currentExpansion } from "./expansion-source";
 import type { AgentViewState } from "./state";
@@ -212,14 +212,47 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     }
 
     // Per-node shrink attribution for the `[wave-scroll-shrink]` line below.
-    // Fed by `shrinkRO` (streaming-buffer rows), drained when a pane shrink is
-    // detected. Step 1 of SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
+    // Step 1 of SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
     const shrinkTrace = new ShrinkTrace();
+
+    /**
+     * Snapshot every streaming-buffer row's height. DOM reads only — no
+     * reactive reads, since this runs from `queueMicrotask` and
+     * ResizeObserver callbacks where establishing a tracked dependency would
+     * be surprising.
+     *
+     * `offsetHeight`, not `getBoundingClientRect().height`, to match the
+     * pane's `scrollHeight`: both are unzoomed under an ancestor CSS `zoom`,
+     * whereas the rect IS scaled by it (the same asymmetry the measure RO
+     * above compensates for with its ÷zoom). Mixing the two would make every
+     * attribution wrong by the zoom factor at non-100% pane zoom.
+     */
+    function sampleStreamingRows(): RowSample[] {
+        if (!streamingBufferRef) return [];
+        const out: RowSample[] = [];
+        for (const child of streamingBufferRef.children) {
+            const el = child as HTMLElement;
+            const id = el.dataset.nodeId;
+            if (!id) continue;
+            out.push({ id, type: el.dataset.nodeType ?? "?", px: el.offsetHeight });
+        }
+        return out;
+    }
 
     let lastKnownScrollHeight = 0;
     function scrollToTrueBottom(): void {
         if (!scrollRef) return;
         const h = scrollRef.scrollHeight;
+        // Sampled unconditionally (not just on a shrink) — every call has to
+        // update the baseline, or the next diff would span two intervals.
+        // Read in the SAME layout-clean instant as `h` above, so the row
+        // deltas cover exactly the window the pane delta does. Doing this via
+        // a ResizeObserver instead was the bug codex caught on PR #2887: RO
+        // callbacks are delivered later in the rendering steps than the
+        // `queueMicrotask` pin path that detects most shrinks, so the primary
+        // running->terminal case logged as unattributed and its row shrink
+        // was left to be miscredited to a later, unrelated pane delta.
+        const rowShrinks = shrinkTrace.sample(sampleStreamingRows());
         if (lastKnownScrollHeight > 0 && h < lastKnownScrollHeight - 1) {
             const paneDelta = lastKnownScrollHeight - h;
             console.info(
@@ -231,7 +264,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 // this suffix the line above is a bare net number, which is
                 // precisely what limited every conclusion in the 08-21/08-22
                 // findings docs.
-                formatAttribution(shrinkTrace.attribute(paneDelta, performance.now())),
+                formatAttribution(attribute(paneDelta, rowShrinks)),
             );
         }
         lastKnownScrollHeight = h;
@@ -1014,53 +1047,6 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         })
         : undefined;
     onCleanup(() => measureRO?.disconnect());
-
-    // Diagnostic-only RO over STREAMING-BUFFER rows — deliberately separate
-    // from measureRO above rather than an extra branch inside it. measureRO
-    // dispatches `RowMeasured` into the agent-pane-layout slice, and the slice
-    // models the VIRTUALIZED partition only; feeding it streaming-buffer rows
-    // would be a real behavior change (rows it has no positions for), not
-    // instrumentation. The streaming buffer is also exactly where the
-    // interesting shrinks happen — a completing tool call is in the trailing
-    // N nodes by definition — and it is currently measured by nothing at all,
-    // which is the concrete reason the pane-level diagnostic could never name
-    // a culprit. Feeds `shrinkTrace`; nothing reads it except the
-    // `[wave-scroll-shrink]` log line.
-    const shrinkElNode = new WeakMap<Element, { id: string; type: string }>();
-    const shrinkRO = typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver((entries) => {
-            const zoom = props.zoomFactor?.() ?? 1;
-            const now = performance.now();
-            for (const entry of entries) {
-                const meta = shrinkElNode.get(entry.target);
-                if (!meta) continue;
-                // ÷zoom for the same reason measureRO does it: getBoundingClientRect
-                // is the one read that IS scaled by an ancestor CSS `zoom`, and
-                // mixing zoomed and unzoomed px would make every attribution
-                // wrong by the zoom factor at non-100% pane zoom.
-                shrinkTrace.record(
-                    meta.id,
-                    meta.type,
-                    entry.target.getBoundingClientRect().height / (zoom || 1),
-                    now,
-                );
-            }
-        })
-        : undefined;
-    onCleanup(() => shrinkRO?.disconnect());
-    const observeStreamingRow = (el: HTMLElement, node: DocumentNode): void => {
-        shrinkElNode.set(el, { id: node.id, type: node.type });
-        shrinkRO?.observe(el);
-    };
-    const unobserveStreamingRow = (el: HTMLElement, nodeId: string): void => {
-        shrinkRO?.unobserve(el);
-        shrinkElNode.delete(el);
-        // Drop the baseline too — a cap-advance can retire a tall row and
-        // later re-add the same node short, which would otherwise log as one
-        // fabricated shrink spanning the gap.
-        shrinkTrace.forget(nodeId);
-    };
-
     const observeRow = (el: HTMLElement, nodeId: string): void => {
         elNodeId.set(el, nodeId);
         measureRO?.observe(el);
@@ -1170,31 +1156,19 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                         ref={(el) => { streamingBufferRef = el; }}
                     >
                         <Key each={p().streamingNodes as DocumentNode[]} by={(n) => n.id}>
-                            {(nodeAccessor) => {
-                                // Diagnostic shrink-attribution only (see
-                                // shrinkRO above). The <Key> slot's own
-                                // onCleanup is what makes the unobserve
-                                // reliable across a cap-advance retiring this
-                                // slot — same lifecycle hook the virtualized
-                                // rows use for measureRO.
-                                let rowEl: HTMLElement | undefined;
-                                const nodeId = nodeAccessor().id;
-                                onCleanup(() => { if (rowEl) unobserveStreamingRow(rowEl, nodeId); });
-                                return (
-                                    <DocumentRow
-                                        node={nodeAccessor}
-                                        documentState={props.documentState}
-                                        highlightNodeId={props.highlightNodeId}
-                                        onToggleCollapse={props.onToggleCollapse}
-                                        onTogglePin={props.onTogglePin}
-                                        onHoldToolOpen={props.onHoldToolOpen}
-                                        onAgentErrorLogin={props.onAgentErrorLogin}
-                                        onOpenHistory={props.onOpenHistory}
-                                        dispatchMatches={props.dispatchMatches}
-                                        ref={(el) => { rowEl = el; observeStreamingRow(el, nodeAccessor()); }}
-                                    />
-                                );
-                            }}
+                            {(nodeAccessor) => (
+                                <DocumentRow
+                                    node={nodeAccessor}
+                                    documentState={props.documentState}
+                                    highlightNodeId={props.highlightNodeId}
+                                    onToggleCollapse={props.onToggleCollapse}
+                                    onTogglePin={props.onTogglePin}
+                                    onHoldToolOpen={props.onHoldToolOpen}
+                                    onAgentErrorLogin={props.onAgentErrorLogin}
+                                    onOpenHistory={props.onOpenHistory}
+                                    dispatchMatches={props.dispatchMatches}
+                                />
+                            )}
                         </Key>
                     </div>
                 )}

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -122,6 +122,11 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 "agent-node-search-match": isSearchMatch(),
             }}
             data-node-id={props.node().id}
+            // Read by AgentDocumentVirtualList's shrink-attribution sampler
+            // (shrink-trace.ts) so it can name the KIND of node that shrank
+            // straight from the DOM, without a reactive read from inside a
+            // microtask/ResizeObserver callback.
+            data-node-type={props.node().type}
             tabindex="0"
             onKeyDown={handleRowKey}
             style={props.style}

--- a/frontend/app/view/agent/virtualization/shrink-trace.test.ts
+++ b/frontend/app/view/agent/virtualization/shrink-trace.test.ts
@@ -1,0 +1,124 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ShrinkTrace — per-node height-shrink attribution
+ * (SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md step 1).
+ *
+ * Pure bookkeeping, no DOM: the ResizeObserver that feeds it lives in
+ * AgentDocumentVirtualList. Time is passed in explicitly rather than read from
+ * `performance.now()` so the window logic is deterministic here.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { ATTRIBUTION_WINDOW_MS, ShrinkTrace, formatAttribution } from "./shrink-trace";
+
+describe("ShrinkTrace", () => {
+    it("does not report the first observation of a node as a shrink", () => {
+        const t = new ShrinkTrace();
+        t.record("n1", "tool", 300, 1000);
+        expect(t.attribute(0, 1000).shrinks).toEqual([]);
+    });
+
+    it("records a shrink and ignores growth", () => {
+        const t = new ShrinkTrace();
+        t.record("n1", "tool", 300, 1000);
+        t.record("n1", "tool", 500, 1010); // growth — not a shrink
+        t.record("n1", "tool", 120, 1020); // shrink 500 -> 120
+        const a = t.attribute(380, 1020);
+        expect(a.shrinks).toEqual([
+            { nodeId: "n1", nodeType: "tool", fromPx: 500, toPx: 120, atMs: 1020 },
+        ]);
+        expect(a.attributedPx).toBe(380);
+        expect(a.unattributedPx).toBe(0);
+    });
+
+    it("sums several rows and reports the unattributed remainder", () => {
+        // The case the 08-22 findings could not distinguish: a pane delta that
+        // is a SUM of small shrinks, not one component of that size. This is
+        // why the ~251-252px lead had no matching height constant.
+        const t = new ShrinkTrace();
+        t.record("tool-a", "tool", 200, 1000);
+        t.record("md-b", "markdown", 100, 1000);
+        t.record("tool-a", "tool", 60, 1005); // -140
+        t.record("md-b", "markdown", 12, 1006); // -88
+
+        const a = t.attribute(251, 1006);
+        expect(a.attributedPx).toBe(228);
+        expect(a.unattributedPx).toBe(23); // 251 observed at the pane, 228 explained
+        expect(a.shrinks.map((s) => s.nodeId)).toEqual(["tool-a", "md-b"]);
+    });
+
+    it("reports a negative remainder when rows shrank more than the pane did", () => {
+        // Something else grew in the same frame. Sign matters: this is a
+        // different situation from an under-explained shrink and must not be
+        // rounded away or reported as zero.
+        const t = new ShrinkTrace();
+        t.record("n1", "tool", 500, 1000);
+        t.record("n1", "tool", 100, 1001);
+        expect(t.attribute(150, 1001).unattributedPx).toBe(-250);
+    });
+
+    it("excludes shrinks older than the attribution window", () => {
+        const t = new ShrinkTrace();
+        t.record("old", "tool", 400, 1000);
+        t.record("old", "tool", 100, 1000); // -300, will fall outside the window
+        t.record("new", "markdown", 50, 5000);
+        t.record("new", "markdown", 20, 5000); // -30, inside
+
+        const a = t.attribute(30, 5000, ATTRIBUTION_WINDOW_MS);
+        expect(a.shrinks.map((s) => s.nodeId)).toEqual(["new"]);
+        expect(a.attributedPx).toBe(30);
+    });
+
+    it("does not credit the same shrink to two consecutive pane deltas", () => {
+        const t = new ShrinkTrace();
+        t.record("n1", "tool", 300, 1000);
+        t.record("n1", "tool", 100, 1001);
+
+        expect(t.attribute(200, 1001).attributedPx).toBe(200);
+        // Second pin check, same window — the shrink was already consumed.
+        expect(t.attribute(200, 1002).attributedPx).toBe(0);
+    });
+
+    it("forgets a node's baseline on unmount so a remount is not a fake shrink", () => {
+        // A node can leave the streaming buffer tall (cap-advance) and later
+        // re-render short. Without forget(), the gap would register as one
+        // enormous fabricated shrink.
+        const t = new ShrinkTrace();
+        t.record("n1", "tool", 900, 1000);
+        t.forget("n1");
+        t.record("n1", "tool", 40, 1010);
+        expect(t.attribute(0, 1010).shrinks).toEqual([]);
+    });
+
+    it("keeps the ring bounded under a long burst", () => {
+        const t = new ShrinkTrace();
+        for (let i = 0; i < 500; i++) {
+            t.record(`n${i}`, "tool", 100, 1000);
+            t.record(`n${i}`, "tool", 50, 1000);
+        }
+        expect(t.attribute(0, 1000).shrinks.length).toBeLessThanOrEqual(64);
+    });
+});
+
+describe("formatAttribution", () => {
+    it("names the rows, the sum, and the remainder", () => {
+        const t = new ShrinkTrace();
+        t.record("tc-9abcdef01", "tool", 13400, 1000);
+        t.record("tc-9abcdef01", "tool", 120, 1001);
+        const s = formatAttribution(t.attribute(13502, 1001));
+        expect(s).toContain("tc-9abc(tool) 13400->120px");
+        expect(s).toContain("sum=13280px");
+        expect(s).toContain("unattributed=222px");
+    });
+
+    it("is explicit when nothing observed shrank", () => {
+        const t = new ShrinkTrace();
+        // The important case: the pane shrank but no observed row did, so the
+        // cause is somewhere not being watched.
+        expect(formatAttribution(t.attribute(251, 1000))).toContain("none");
+        expect(formatAttribution(t.attribute(251, 1000))).toContain("unattributed=251px");
+    });
+});

--- a/frontend/app/view/agent/virtualization/shrink-trace.test.ts
+++ b/frontend/app/view/agent/virtualization/shrink-trace.test.ts
@@ -5,120 +5,122 @@
  * ShrinkTrace — per-node height-shrink attribution
  * (SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md step 1).
  *
- * Pure bookkeeping, no DOM: the ResizeObserver that feeds it lives in
- * AgentDocumentVirtualList. Time is passed in explicitly rather than read from
- * `performance.now()` so the window logic is deterministic here.
+ * Pure snapshot-diffing, no DOM and no clock: the caller reads row heights out
+ * of the DOM and hands them in. See the module header for why this is sampled
+ * synchronously rather than driven by a ResizeObserver.
  */
 
 import { describe, expect, it } from "vitest";
 
-import { ATTRIBUTION_WINDOW_MS, ShrinkTrace, formatAttribution } from "./shrink-trace";
+import { ShrinkTrace, attribute, formatAttribution, type RowSample } from "./shrink-trace";
 
-describe("ShrinkTrace", () => {
-    it("does not report the first observation of a node as a shrink", () => {
+const row = (id: string, px: number, type = "tool"): RowSample => ({ id, type, px });
+
+describe("ShrinkTrace.sample", () => {
+    it("treats the first sample of a node as a baseline, not a shrink", () => {
         const t = new ShrinkTrace();
-        t.record("n1", "tool", 300, 1000);
-        expect(t.attribute(0, 1000).shrinks).toEqual([]);
+        expect(t.sample([row("n1", 300)])).toEqual([]);
     });
 
-    it("records a shrink and ignores growth", () => {
+    it("reports a shrink between consecutive samples", () => {
         const t = new ShrinkTrace();
-        t.record("n1", "tool", 300, 1000);
-        t.record("n1", "tool", 500, 1010); // growth — not a shrink
-        t.record("n1", "tool", 120, 1020); // shrink 500 -> 120
-        const a = t.attribute(380, 1020);
-        expect(a.shrinks).toEqual([
-            { nodeId: "n1", nodeType: "tool", fromPx: 500, toPx: 120, atMs: 1020 },
+        t.sample([row("n1", 300)]);
+        expect(t.sample([row("n1", 120)])).toEqual([
+            { nodeId: "n1", nodeType: "tool", fromPx: 300, toPx: 120 },
         ]);
+    });
+
+    it("ignores growth", () => {
+        const t = new ShrinkTrace();
+        t.sample([row("n1", 100)]);
+        expect(t.sample([row("n1", 500)])).toEqual([]);
+    });
+
+    it("reports several rows shrinking in the same sample", () => {
+        const t = new ShrinkTrace();
+        t.sample([row("a", 200), row("b", 100, "markdown")]);
+        const shrinks = t.sample([row("a", 60), row("b", 12, "markdown")]);
+        expect(shrinks).toEqual([
+            { nodeId: "a", nodeType: "tool", fromPx: 200, toPx: 60 },
+            { nodeId: "b", nodeType: "markdown", fromPx: 100, toPx: 12 },
+        ]);
+    });
+
+    it("does not report the same shrink twice", () => {
+        const t = new ShrinkTrace();
+        t.sample([row("n1", 300)]);
+        expect(t.sample([row("n1", 100)])).toHaveLength(1);
+        expect(t.sample([row("n1", 100)])).toEqual([]); // unchanged since
+    });
+
+    it("drops a node that disappeared, so a remount is not a fake shrink", () => {
+        // A cap-advance can retire a tall row; the same node can later render
+        // again much shorter. Without pruning, that gap would look like one
+        // enormous shrink that never actually happened on screen.
+        const t = new ShrinkTrace();
+        t.sample([row("n1", 900)]);
+        t.sample([]); // n1 unmounted
+        expect(t.sample([row("n1", 40)])).toEqual([]); // re-baselined, not a shrink
+    });
+
+    it("tracks rows independently as the buffer window slides", () => {
+        const t = new ShrinkTrace();
+        t.sample([row("a", 100), row("b", 200)]);
+        // `a` scrolls out of the buffer, `c` enters; `b` shrinks.
+        const shrinks = t.sample([row("b", 150), row("c", 300)]);
+        expect(shrinks).toEqual([{ nodeId: "b", nodeType: "tool", fromPx: 200, toPx: 150 }]);
+    });
+});
+
+describe("attribute", () => {
+    it("sums the shrinks and reports a zero remainder on an exact match", () => {
+        const a = attribute(380, [{ nodeId: "n1", nodeType: "tool", fromPx: 500, toPx: 120 }]);
         expect(a.attributedPx).toBe(380);
         expect(a.unattributedPx).toBe(0);
     });
 
-    it("sums several rows and reports the unattributed remainder", () => {
+    it("reports a positive remainder when observed rows under-explain the pane", () => {
         // The case the 08-22 findings could not distinguish: a pane delta that
-        // is a SUM of small shrinks, not one component of that size. This is
+        // is a SUM, with some of it coming from somewhere unobserved. This is
         // why the ~251-252px lead had no matching height constant.
-        const t = new ShrinkTrace();
-        t.record("tool-a", "tool", 200, 1000);
-        t.record("md-b", "markdown", 100, 1000);
-        t.record("tool-a", "tool", 60, 1005); // -140
-        t.record("md-b", "markdown", 12, 1006); // -88
-
-        const a = t.attribute(251, 1006);
+        const a = attribute(251, [
+            { nodeId: "a", nodeType: "tool", fromPx: 200, toPx: 60 },
+            { nodeId: "b", nodeType: "markdown", fromPx: 100, toPx: 12 },
+        ]);
         expect(a.attributedPx).toBe(228);
-        expect(a.unattributedPx).toBe(23); // 251 observed at the pane, 228 explained
-        expect(a.shrinks.map((s) => s.nodeId)).toEqual(["tool-a", "md-b"]);
+        expect(a.unattributedPx).toBe(23);
     });
 
     it("reports a negative remainder when rows shrank more than the pane did", () => {
-        // Something else grew in the same frame. Sign matters: this is a
-        // different situation from an under-explained shrink and must not be
-        // rounded away or reported as zero.
-        const t = new ShrinkTrace();
-        t.record("n1", "tool", 500, 1000);
-        t.record("n1", "tool", 100, 1001);
-        expect(t.attribute(150, 1001).unattributedPx).toBe(-250);
+        // Something else grew in the same window. Sign matters — this is a
+        // different situation from an under-explained shrink, and must not be
+        // clamped to zero.
+        const a = attribute(150, [{ nodeId: "n1", nodeType: "tool", fromPx: 500, toPx: 100 }]);
+        expect(a.unattributedPx).toBe(-250);
     });
 
-    it("excludes shrinks older than the attribution window", () => {
-        const t = new ShrinkTrace();
-        t.record("old", "tool", 400, 1000);
-        t.record("old", "tool", 100, 1000); // -300, will fall outside the window
-        t.record("new", "markdown", 50, 5000);
-        t.record("new", "markdown", 20, 5000); // -30, inside
-
-        const a = t.attribute(30, 5000, ATTRIBUTION_WINDOW_MS);
-        expect(a.shrinks.map((s) => s.nodeId)).toEqual(["new"]);
-        expect(a.attributedPx).toBe(30);
-    });
-
-    it("does not credit the same shrink to two consecutive pane deltas", () => {
-        const t = new ShrinkTrace();
-        t.record("n1", "tool", 300, 1000);
-        t.record("n1", "tool", 100, 1001);
-
-        expect(t.attribute(200, 1001).attributedPx).toBe(200);
-        // Second pin check, same window — the shrink was already consumed.
-        expect(t.attribute(200, 1002).attributedPx).toBe(0);
-    });
-
-    it("forgets a node's baseline on unmount so a remount is not a fake shrink", () => {
-        // A node can leave the streaming buffer tall (cap-advance) and later
-        // re-render short. Without forget(), the gap would register as one
-        // enormous fabricated shrink.
-        const t = new ShrinkTrace();
-        t.record("n1", "tool", 900, 1000);
-        t.forget("n1");
-        t.record("n1", "tool", 40, 1010);
-        expect(t.attribute(0, 1010).shrinks).toEqual([]);
-    });
-
-    it("keeps the ring bounded under a long burst", () => {
-        const t = new ShrinkTrace();
-        for (let i = 0; i < 500; i++) {
-            t.record(`n${i}`, "tool", 100, 1000);
-            t.record(`n${i}`, "tool", 50, 1000);
-        }
-        expect(t.attribute(0, 1000).shrinks.length).toBeLessThanOrEqual(64);
+    it("attributes nothing when no row shrank", () => {
+        const a = attribute(251, []);
+        expect(a.attributedPx).toBe(0);
+        expect(a.unattributedPx).toBe(251);
     });
 });
 
 describe("formatAttribution", () => {
     it("names the rows, the sum, and the remainder", () => {
-        const t = new ShrinkTrace();
-        t.record("tc-9abcdef01", "tool", 13400, 1000);
-        t.record("tc-9abcdef01", "tool", 120, 1001);
-        const s = formatAttribution(t.attribute(13502, 1001));
+        const s = formatAttribution(
+            attribute(13502, [{ nodeId: "tc-9abcdef01", nodeType: "tool", fromPx: 13400, toPx: 120 }]),
+        );
         expect(s).toContain("tc-9abc(tool) 13400->120px");
         expect(s).toContain("sum=13280px");
         expect(s).toContain("unattributed=222px");
     });
 
     it("is explicit when nothing observed shrank", () => {
-        const t = new ShrinkTrace();
-        // The important case: the pane shrank but no observed row did, so the
-        // cause is somewhere not being watched.
-        expect(formatAttribution(t.attribute(251, 1000))).toContain("none");
-        expect(formatAttribution(t.attribute(251, 1000))).toContain("unattributed=251px");
+        // The important signal: the pane shrank but nothing being watched did,
+        // so the cause is somewhere this instrumentation cannot yet see.
+        const s = formatAttribution(attribute(251, []));
+        expect(s).toContain("none");
+        expect(s).toContain("unattributed=251px");
     });
 });

--- a/frontend/app/view/agent/virtualization/shrink-trace.ts
+++ b/frontend/app/view/agent/virtualization/shrink-trace.ts
@@ -16,102 +16,105 @@
  * 08-31 without a culprit for exactly this reason — no fixed-height component
  * of that size exists, so the number was almost certainly a sum.
  *
- * This module records each observed row's height as it changes and keeps a
- * bounded log of the SHRINKS only. When the pane-level diagnostic fires, it
- * asks for the shrinks seen in the immediately-preceding window and reports
- * them alongside the pane delta — turning "the pane lost 251px" into "tool node
- * tc-9 went 13400px -> 120px, and 222px is still unaccounted for".
+ * This module diffs a SNAPSHOT of the rendered rows' heights against the
+ * previous snapshot, and reports which rows shrank plus how much of the pane
+ * delta they fail to explain.
  *
- * The unattributed remainder is the point, not a rounding detail: it is what
- * tells you whether the observed rows explain the pane's shrink or whether
- * something not being observed (the virtualized region, the working-row
- * overlay, the panel's own padding/margin collapse) is responsible. A
- * conclusion drawn from attribution alone, without checking that remainder,
- * would repeat the exact error the 08-21/08-22 findings were corrected for.
+ * ## Why snapshot-diffing rather than a ResizeObserver
+ *
+ * The first version of this fed a `ResizeObserver` into a time-windowed ring
+ * buffer. That is broken for the primary case, and codex caught it on PR #2887:
+ * the pin effect defers `scrollToTrueBottom()` with `queueMicrotask`, and
+ * reading `scrollHeight` there forces a layout flush — so the PANE shrink is
+ * detected during the microtask checkpoint, while `ResizeObserver` callbacks
+ * are not delivered until later in the rendering steps. A tool going
+ * running->terminal would therefore log as wholly unattributed, and its row
+ * shrink would still be sitting in the ring afterwards to be miscredited to
+ * some unrelated later pane delta. Systematically wrong on the one case the
+ * instrumentation exists for, and wrong in the direction that invents
+ * false attributions.
+ *
+ * Sampling synchronously from the caller removes the ordering dependency
+ * instead of trying to schedule around it: both numbers are then read from the
+ * same layout-clean instant, and the row window is exactly the pane window
+ * (previous pin check -> this one) rather than a 250ms approximation of it.
+ * The caller reads `scrollHeight` immediately before sampling, so layout is
+ * already flushed and the per-row reads cost no extra reflow.
+ *
+ * Heights are `offsetHeight`, deliberately, to match the pane's `scrollHeight`:
+ * both are unzoomed under an ancestor CSS `zoom`, whereas
+ * `getBoundingClientRect().height` is scaled by it. Mixing the two would make
+ * every attribution wrong by the zoom factor at non-100% pane zoom.
  *
  * Deliberately NOT gated on `import.meta.env.DEV`, unlike `perf-probe.ts`: the
  * most useful data so far came from `task package` local builds, where a DEV
- * gate would compile this out entirely. Cost is bounded instead by only
- * recording numbers on resize and only formatting a string when a pane shrink
- * has already been detected.
+ * gate would compile this out entirely.
  */
 
-/** One observed row getting shorter. Growth is not recorded — the pane pin
- *  handles growth invisibly (it teleports to a bottom that is further away,
- *  which is what it already does every frame while streaming). */
+/** One row's height at sample time, as read by the caller from the DOM. */
+export interface RowSample {
+    id: string;
+    /** `DocumentNode["type"]` — "tool", "markdown", "thinking", … */
+    type: string;
+    px: number;
+}
+
+/** One observed row that got shorter since the previous sample. Growth is not
+ *  reported — the pin handles growth invisibly (it teleports to a bottom that
+ *  moved further away, which it already does every frame while streaming). */
 export interface RowShrink {
     nodeId: string;
-    /** `DocumentNode["type"]` — "tool", "markdown", "thinking", … */
     nodeType: string;
     fromPx: number;
     toPx: number;
-    atMs: number;
 }
-
-/** Bounded so a long streaming session can't grow this without limit. Sized to
- *  comfortably cover one pin-check interval's worth of resizes (the 08-21 data
- *  showed pin checks ~160ms apart under load; a burst of that length is a
- *  handful of rows, not dozens). */
-const RING_SIZE = 64;
-
-/** How far back `attribute()` looks for shrinks to blame a pane delta on.
- *  Pin checks in the 08-21 dataset were ~160ms apart at their closest; this
- *  covers that with margin without reaching back into a previous, unrelated
- *  turn's activity. */
-export const ATTRIBUTION_WINDOW_MS = 250;
 
 export interface Attribution {
     shrinks: RowShrink[];
-    /** Sum of the per-row shrinks in the window. */
+    /** Sum of the per-row shrinks. */
     attributedPx: number;
-    /** paneDeltaPx - attributedPx. Positive means observed rows do NOT fully
-     *  explain the pane shrink; negative means rows shrank more than the pane
-     *  did (something else grew at the same time). Either way, a non-zero
-     *  value means "do not stop here". */
+    /** paneDeltaPx - attributedPx. Positive means the observed rows do NOT
+     *  fully explain the pane shrink (something unobserved did — the
+     *  virtualized region, the working-row overlay, the panel's own
+     *  padding/margin collapse). Negative means rows shrank more than the pane
+     *  did, i.e. something grew at the same time. Either way a non-zero value
+     *  means "do not stop here" — reporting it is what keeps this diagnostic
+     *  from manufacturing the same over-confident conclusions the 08-21/08-22
+     *  findings had to be corrected for. */
     unattributedPx: number;
 }
 
 export class ShrinkTrace {
     private heights = new Map<string, number>();
-    private ring: RowShrink[] = [];
 
     /**
-     * Record a row's current height. The first observation for a node only
-     * establishes a baseline — it is never a shrink, because there is nothing
-     * to have shrunk from. (A row mounting at 0px and laying out at its real
-     * height would otherwise register as growth on the second call and noise
-     * on every subsequent remount.)
+     * Diff `samples` against the previous call and return the rows that got
+     * shorter. Ids absent from `samples` are dropped, so a row that unmounted
+     * (a streaming-buffer cap-advance retiring it) cannot later appear to have
+     * shrunk across the gap when the same node re-renders at a new height.
+     *
+     * The first sample of a node only establishes a baseline — it is never a
+     * shrink, because there is nothing to have shrunk from.
      */
-    record(nodeId: string, nodeType: string, px: number, atMs: number): void {
-        const prev = this.heights.get(nodeId);
-        this.heights.set(nodeId, px);
-        if (prev === undefined || px >= prev) return;
-        this.ring.push({ nodeId, nodeType, fromPx: prev, toPx: px, atMs });
-        if (this.ring.length > RING_SIZE) this.ring.shift();
+    sample(samples: RowSample[]): RowShrink[] {
+        const shrinks: RowShrink[] = [];
+        const next = new Map<string, number>();
+        for (const s of samples) {
+            const prev = this.heights.get(s.id);
+            next.set(s.id, s.px);
+            if (prev !== undefined && s.px < prev) {
+                shrinks.push({ nodeId: s.id, nodeType: s.type, fromPx: prev, toPx: s.px });
+            }
+        }
+        this.heights = next;
+        return shrinks;
     }
+}
 
-    /**
-     * Drop a node's baseline. Called when its row unmounts — without this, a
-     * node that leaves the streaming buffer tall and later re-renders short
-     * (history reload, cap-advance re-add) would report a fabricated shrink
-     * spanning the gap.
-     */
-    forget(nodeId: string): void {
-        this.heights.delete(nodeId);
-    }
-
-    /**
-     * Explain `paneDeltaPx` using shrinks recorded in the preceding
-     * `windowMs`. Consumed entries are removed so the next pane shrink can't
-     * be credited to the same rows twice.
-     */
-    attribute(paneDeltaPx: number, nowMs: number, windowMs: number = ATTRIBUTION_WINDOW_MS): Attribution {
-        const cutoff = nowMs - windowMs;
-        const shrinks = this.ring.filter((s) => s.atMs >= cutoff);
-        this.ring = [];
-        const attributedPx = shrinks.reduce((sum, s) => sum + (s.fromPx - s.toPx), 0);
-        return { shrinks, attributedPx, unattributedPx: paneDeltaPx - attributedPx };
-    }
+/** Stateless — the sample diff already scoped these to the right window. */
+export function attribute(paneDeltaPx: number, shrinks: RowShrink[]): Attribution {
+    const attributedPx = shrinks.reduce((sum, s) => sum + (s.fromPx - s.toPx), 0);
+    return { shrinks, attributedPx, unattributedPx: paneDeltaPx - attributedPx };
 }
 
 /**

--- a/frontend/app/view/agent/virtualization/shrink-trace.ts
+++ b/frontend/app/view/agent/virtualization/shrink-trace.ts
@@ -112,12 +112,6 @@ export class ShrinkTrace {
         const attributedPx = shrinks.reduce((sum, s) => sum + (s.fromPx - s.toPx), 0);
         return { shrinks, attributedPx, unattributedPx: paneDeltaPx - attributedPx };
     }
-
-    /** Test/teardown hook — drops all baselines and pending shrinks. */
-    reset(): void {
-        this.heights.clear();
-        this.ring = [];
-    }
 }
 
 /**

--- a/frontend/app/view/agent/virtualization/shrink-trace.ts
+++ b/frontend/app/view/agent/virtualization/shrink-trace.ts
@@ -1,0 +1,135 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-node height-shrink attribution — step 1 of
+ * docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
+ *
+ * The existing `[wave-scroll-shrink]` diagnostic
+ * (`AgentDocumentVirtualList.scrollToTrueBottom`) reports that the pane's
+ * `scrollHeight` got smaller between two pin-check calls. It cannot say WHICH
+ * content shrank, and that limit is why every conclusion in
+ * `FINDINGS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_21.md` and its 08-22 live-data
+ * follow-up had to be hedged: a pane-level net delta is consistent with one big
+ * collapse, several small ones, or a growth and a shrink cancelling out. The
+ * 08-22 doc's last remaining lead (a recurring ~251-252px shrink) was closed on
+ * 08-31 without a culprit for exactly this reason — no fixed-height component
+ * of that size exists, so the number was almost certainly a sum.
+ *
+ * This module records each observed row's height as it changes and keeps a
+ * bounded log of the SHRINKS only. When the pane-level diagnostic fires, it
+ * asks for the shrinks seen in the immediately-preceding window and reports
+ * them alongside the pane delta — turning "the pane lost 251px" into "tool node
+ * tc-9 went 13400px -> 120px, and 222px is still unaccounted for".
+ *
+ * The unattributed remainder is the point, not a rounding detail: it is what
+ * tells you whether the observed rows explain the pane's shrink or whether
+ * something not being observed (the virtualized region, the working-row
+ * overlay, the panel's own padding/margin collapse) is responsible. A
+ * conclusion drawn from attribution alone, without checking that remainder,
+ * would repeat the exact error the 08-21/08-22 findings were corrected for.
+ *
+ * Deliberately NOT gated on `import.meta.env.DEV`, unlike `perf-probe.ts`: the
+ * most useful data so far came from `task package` local builds, where a DEV
+ * gate would compile this out entirely. Cost is bounded instead by only
+ * recording numbers on resize and only formatting a string when a pane shrink
+ * has already been detected.
+ */
+
+/** One observed row getting shorter. Growth is not recorded — the pane pin
+ *  handles growth invisibly (it teleports to a bottom that is further away,
+ *  which is what it already does every frame while streaming). */
+export interface RowShrink {
+    nodeId: string;
+    /** `DocumentNode["type"]` — "tool", "markdown", "thinking", … */
+    nodeType: string;
+    fromPx: number;
+    toPx: number;
+    atMs: number;
+}
+
+/** Bounded so a long streaming session can't grow this without limit. Sized to
+ *  comfortably cover one pin-check interval's worth of resizes (the 08-21 data
+ *  showed pin checks ~160ms apart under load; a burst of that length is a
+ *  handful of rows, not dozens). */
+const RING_SIZE = 64;
+
+/** How far back `attribute()` looks for shrinks to blame a pane delta on.
+ *  Pin checks in the 08-21 dataset were ~160ms apart at their closest; this
+ *  covers that with margin without reaching back into a previous, unrelated
+ *  turn's activity. */
+export const ATTRIBUTION_WINDOW_MS = 250;
+
+export interface Attribution {
+    shrinks: RowShrink[];
+    /** Sum of the per-row shrinks in the window. */
+    attributedPx: number;
+    /** paneDeltaPx - attributedPx. Positive means observed rows do NOT fully
+     *  explain the pane shrink; negative means rows shrank more than the pane
+     *  did (something else grew at the same time). Either way, a non-zero
+     *  value means "do not stop here". */
+    unattributedPx: number;
+}
+
+export class ShrinkTrace {
+    private heights = new Map<string, number>();
+    private ring: RowShrink[] = [];
+
+    /**
+     * Record a row's current height. The first observation for a node only
+     * establishes a baseline — it is never a shrink, because there is nothing
+     * to have shrunk from. (A row mounting at 0px and laying out at its real
+     * height would otherwise register as growth on the second call and noise
+     * on every subsequent remount.)
+     */
+    record(nodeId: string, nodeType: string, px: number, atMs: number): void {
+        const prev = this.heights.get(nodeId);
+        this.heights.set(nodeId, px);
+        if (prev === undefined || px >= prev) return;
+        this.ring.push({ nodeId, nodeType, fromPx: prev, toPx: px, atMs });
+        if (this.ring.length > RING_SIZE) this.ring.shift();
+    }
+
+    /**
+     * Drop a node's baseline. Called when its row unmounts — without this, a
+     * node that leaves the streaming buffer tall and later re-renders short
+     * (history reload, cap-advance re-add) would report a fabricated shrink
+     * spanning the gap.
+     */
+    forget(nodeId: string): void {
+        this.heights.delete(nodeId);
+    }
+
+    /**
+     * Explain `paneDeltaPx` using shrinks recorded in the preceding
+     * `windowMs`. Consumed entries are removed so the next pane shrink can't
+     * be credited to the same rows twice.
+     */
+    attribute(paneDeltaPx: number, nowMs: number, windowMs: number = ATTRIBUTION_WINDOW_MS): Attribution {
+        const cutoff = nowMs - windowMs;
+        const shrinks = this.ring.filter((s) => s.atMs >= cutoff);
+        this.ring = [];
+        const attributedPx = shrinks.reduce((sum, s) => sum + (s.fromPx - s.toPx), 0);
+        return { shrinks, attributedPx, unattributedPx: paneDeltaPx - attributedPx };
+    }
+
+    /** Test/teardown hook — drops all baselines and pending shrinks. */
+    reset(): void {
+        this.heights.clear();
+        this.ring = [];
+    }
+}
+
+/**
+ * Render an attribution as a single log-line suffix. Node ids are truncated to
+ * 7 chars to match the existing `pane=` field's convention in the same line.
+ */
+export function formatAttribution(a: Attribution): string {
+    if (a.shrinks.length === 0) {
+        return `attributed: none (no observed row shrank; unattributed=${Math.round(a.unattributedPx)}px)`;
+    }
+    const parts = a.shrinks.map(
+        (s) => `${s.nodeId.slice(0, 7)}(${s.nodeType}) ${Math.round(s.fromPx)}->${Math.round(s.toPx)}px`,
+    );
+    return `attributed: ${parts.join(" | ")} (sum=${Math.round(a.attributedPx)}px, unattributed=${Math.round(a.unattributedPx)}px)`;
+}


### PR DESCRIPTION
## Summary

Step 1 of `SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md` (#2868), and the gate on steps 2-5. **Diagnostic only — no behavior change.**

The existing `[wave-scroll-shrink]` line reports that the pane's `scrollHeight` got smaller between two pin checks, but not *which* content shrank. That's why every conclusion in the 08-21 and 08-22 findings docs had to be hedged, and why the 08-22 doc's recurring ~251–252px lead was closed on 08-31 with no culprit: no component of that height exists, so the number was almost certainly a **sum** of smaller shrinks — which a net delta cannot decompose.

**`shrink-trace.ts`** — records observed row heights, keeps a bounded log of shrinks only, attributes a pane delta to the rows that shrank in the preceding 250ms window, and reports the **unattributed remainder** explicitly. That remainder is the point: it says whether the observed rows explain the shrink or whether something unobserved did. Drawing a conclusion without it would repeat the exact error those two docs were corrected for.

**A second, diagnostic-only `ResizeObserver` over streaming-buffer rows** — which nothing measured before. Kept separate from `measureRO` deliberately: that one dispatches `RowMeasured` into the agent-pane-layout slice, and the slice models the *virtualized* partition only, so feeding it streaming rows would be a behavior change rather than instrumentation. The streaming buffer is also where the interesting shrinks are — a completing tool call is in the trailing N nodes by definition.

Sample output shape:

```
[wave-scroll-shrink] pane=43c1dea scrollHeight 14525px -> 1023px (delta=13502px)
  attributed: tc-9abc(tool) 13400->120px (sum=13280px, unattributed=222px)
```

**Not gated on `import.meta.env.DEV`**, unlike `perf-probe.ts` — the most useful data so far came from `task package` builds, where a DEV gate compiles it out entirely. Cost is bounded by recording only numbers on resize, and formatting a string only once a pane shrink has already been detected.

## Test plan

- [x] `shrink-trace.test.ts` — 10 new unit tests, incl. the multi-row-sum case that the 251px lead turned out to be, the negative-remainder case (rows shrank more than the pane), window expiry, double-crediting, and the unmount/remount fake-shrink guard.
- [x] `npx vitest run frontend/app/view/agent/virtualization/` — 146/146 pass.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] Verified `DocumentRow`'s `ref` sits on the single outer `.agent-document-row` wrapper shared by every node type, so all streaming rows are observed uniformly rather than a subset (which would silently skew every attribution).
- [x] `task dev` running from this branch; instrumentation loaded, `[fe]` console bridge confirmed flowing.
- [ ] **Not yet observed live.** No `[wave-scroll-shrink]` line has been captured from a real streaming session with this build — that needs agent activity with chained tool calls in that instance. The attribution *logic* is unit-tested; the *emission* is not yet confirmed end to end. Flagging rather than claiming it works.

<!-- agentmux:agent_id=agent1 -->