### PR TITLE
fix(cef): reject media-permission switches at both ingress paths

### DIFF
--- a/.changesets/1788225394-fix-cef-reject-media-permission-switches-from-agentmux-cef-e-68xy.md
+++ b/.changesets/1788225394-fix-cef-reject-media-permission-switches-from-agentmux-cef-e-68xy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): reject media-permission switches from AGENTMUX_CEF_EXTRA_FLAGS

--- a/agentmux-cef/src/app/mod.rs
+++ b/agentmux-cef/src/app/mod.rs
@@ -514,6 +514,34 @@ wrap_app! {
             command_line: Option<&mut CommandLine>,
         ) {
             if let Some(cmd) = command_line {
+                // Strip media-permission switches that arrived on the process
+                // command line, before anything else looks at it.
+                //
+                // The AGENTMUX_CEF_EXTRA_FLAGS guard further down covers only
+                // that one ingress. This covers the other: the launcher
+                // collects its own argv verbatim
+                // (`agentmux-launcher/src/main.rs:309`) and passes it to the
+                // host via `.args(args)` (`host_spawn.rs:41`/`:138`), so
+                // `agentmux.exe --enable-media-stream` reaches CEF without ever
+                // touching the env-var path.
+                //
+                // Both must be closed for the guarantee to hold — see
+                // docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.8
+                // for why this switch is a handler BYPASS rather than a grant,
+                // and therefore invisible to every handler-based guard.
+                for name in MEDIA_PERMISSION_SWITCHES {
+                    let sw = CefString::from(*name);
+                    if cmd.has_switch(Some(&sw)) != 0 {
+                        cmd.remove_switch(Some(&sw));
+                        tracing::warn!(
+                            switch = %name,
+                            "removed media-permission switch from the command line — \
+                             it would bypass the CEF permission handler and grant \
+                             camera/mic to every browser pane with no prompt"
+                        );
+                    }
+                }
+
                 // Proactive memory-pressure guard (SPEC_MEMORY_PRESSURE_
                 // SUPERVISION_2026_06_16 §5.H): if the system is already
                 // critically low on commit at launch, start in software
@@ -1131,11 +1159,16 @@ wrap_browser_process_handler! {
 fn is_media_permission_switch(token: &str) -> bool {
     let name = token.split_once('=').map(|(k, _)| k).unwrap_or(token);
     let name = name.trim().to_ascii_lowercase();
-    matches!(
-        name.as_str(),
-        "enable-media-stream" | "use-fake-ui-for-media-stream"
-    )
+    MEDIA_PERMISSION_SWITCHES.contains(&name.as_str())
 }
+
+/// The switch names rejected by both ingress guards. Single list so the
+/// env-var path (`is_media_permission_switch`) and the command-line path
+/// (`on_before_command_line_processing`'s `remove_switch` loop) can never
+/// drift apart — a switch blocked on one route and allowed on the other
+/// would be no guard at all.
+pub(crate) const MEDIA_PERMISSION_SWITCHES: &[&str] =
+    &["enable-media-stream", "use-fake-ui-for-media-stream"];
 
 #[cfg(test)]
 mod media_switch_guard_tests {

--- a/agentmux-cef/src/app/mod.rs
+++ b/agentmux-cef/src/app/mod.rs
@@ -759,6 +759,34 @@ wrap_app! {
                         if tok.is_empty() {
                             continue;
                         }
+                        // Media-permission switches are never accepted from
+                        // this variable. `--enable-media-stream` makes CEF skip
+                        // `OnRequestMediaAccessPermission` entirely and grant
+                        // ALL media permissions — per its own header, "this
+                        // method will not be called if the
+                        // --enable-media-stream command-line switch is used."
+                        //
+                        // That bypasses the handler rather than passing through
+                        // it, so every guard built on the handler becomes
+                        // invisible: browser panes (which deliberately have NO
+                        // permission handler, so CEF's Alloy default denies)
+                        // would silently gain camera and microphone for every
+                        // origin, with no prompt. This variable exists to A/B
+                        // GPU flags; it is a diagnostics hatch, and must not
+                        // double as a way to disable a security boundary.
+                        //
+                        // Rejected loudly rather than silently: someone who set
+                        // it deliberately deserves to know it did not apply.
+                        // See docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.8.
+                        if is_media_permission_switch(tok) {
+                            tracing::warn!(
+                                switch = %tok,
+                                "refusing media-permission switch from AGENTMUX_CEF_EXTRA_FLAGS — \
+                                 it would bypass the CEF permission handler and grant camera/mic \
+                                 to every browser pane with no prompt; ignoring"
+                            );
+                            continue;
+                        }
                         if let Some((k, v)) = tok.split_once('=') {
                             cmd.append_switch_with_value(
                                 Some(&CefString::from(k)),
@@ -1080,5 +1108,68 @@ wrap_browser_process_handler! {
         fn default_client(&self) -> Option<Client> {
             self.client.borrow().clone()
         }
+    }
+}
+
+/// True for any Chromium switch that would hand out media permissions without
+/// going through `CefPermissionHandler`.
+///
+/// `--enable-media-stream` is the documented one: CEF's own
+/// `cef_permission_handler.h` states `OnRequestMediaAccessPermission` "will not
+/// be called if the --enable-media-stream command-line switch is used". A
+/// browser pane installs no permission handler on purpose (so CEF's Alloy
+/// default denies); this switch turns that deliberate deny into a blanket
+/// grant for every origin, invisibly.
+///
+/// `use-fake-ui-for-media-stream` is included for the same reason — it
+/// auto-accepts media prompts, which is the identical outcome by a different
+/// route, and is the flag most likely to be reached for while testing.
+///
+/// Matching is on the switch NAME only, so `--enable-media-stream=1` and any
+/// `=value` spelling are caught too. Case-insensitive because Chromium switch
+/// parsing is, and an uppercase spelling should not be a bypass.
+fn is_media_permission_switch(token: &str) -> bool {
+    let name = token.split_once('=').map(|(k, _)| k).unwrap_or(token);
+    let name = name.trim().to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "enable-media-stream" | "use-fake-ui-for-media-stream"
+    )
+}
+
+#[cfg(test)]
+mod media_switch_guard_tests {
+    use super::is_media_permission_switch;
+
+    #[test]
+    fn rejects_the_documented_bypass_and_its_value_spellings() {
+        assert!(is_media_permission_switch("enable-media-stream"));
+        assert!(is_media_permission_switch("enable-media-stream=1"));
+        assert!(is_media_permission_switch("use-fake-ui-for-media-stream"));
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        // Chromium's own switch parsing is case-insensitive; an uppercase
+        // spelling must not be a way around the guard.
+        assert!(is_media_permission_switch("Enable-Media-Stream"));
+        assert!(is_media_permission_switch("ENABLE-MEDIA-STREAM=1"));
+    }
+
+    #[test]
+    fn leaves_the_gpu_diagnostics_flags_this_var_exists_for_alone() {
+        // AGENTMUX_CEF_EXTRA_FLAGS' actual purpose — these must still pass.
+        assert!(!is_media_permission_switch("use-angle=gl"));
+        assert!(!is_media_permission_switch("ignore-gpu-blocklist"));
+        assert!(!is_media_permission_switch("disable-gpu"));
+        assert!(!is_media_permission_switch("enable-features=Vulkan"));
+    }
+
+    #[test]
+    fn does_not_over_match_unrelated_switches_containing_media() {
+        // Guard against a substring-matching regression: these are not
+        // permission bypasses and must keep working.
+        assert!(!is_media_permission_switch("autoplay-policy=no-user-gesture-required"));
+        assert!(!is_media_permission_switch("enable-media-session-service"));
     }
 }

--- a/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
@@ -231,10 +231,18 @@ Verified ingress paths, both unfiltered today:
    Chromium switch. It exists to A/B GPU flags without a recompile, and has no
    allowlist, denylist, or validation of any kind. `AGENTMUX_CEF_EXTRA_FLAGS=--enable-media-stream`
    is sufficient.
-2. **Launcher → host argument forwarding** — the launcher passes Chromium
-   switches through to the host (`--disable-gpu` is forwarded exactly this way,
-   `agentmux-launcher/src/host_spawn.rs:79`), with no filtering on what may
-   pass.
+2. **Launcher → host argument forwarding** — `agentmux-launcher/src/main.rs:309`
+   collects the launcher's own CLI arguments verbatim
+   (`std::env::args().skip(1).collect()`) and they reach the host process
+   through `.args(args)` in `host_spawn.rs` (`:41` supervised, `:138` unix),
+   with no filtering on what may pass. So anything on the launcher's command
+   line arrives at CEF.
+
+   (An earlier revision cited `host_spawn.rs:79` here. That is wrong and worth
+   correcting explicitly, since a reader auditing this would have gone to the
+   wrong place and concluded the claim was unfounded: `:79` is a *conditional,
+   internally-controlled* `--disable-gpu` added from retry state, not arbitrary
+   pass-through.)
 
 So an environment variable — settable by a user, a shell profile, a CI config,
 or **an agent with shell access** — silently grants camera and microphone to


### PR DESCRIPTION
Closes the ingress documented in `SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` §3.8 (found by Codex on #2885, spec'd in #2888).

## The problem

`AGENTMUX_CEF_EXTRA_FLAGS` splits an env var on whitespace and appends **every token verbatim** as a Chromium switch, with no validation. It exists to A/B GPU flags without a recompile.

But `--enable-media-stream` makes CEF **skip `OnRequestMediaAccessPermission` entirely** and grant all media permissions — per its own header: *"this method will not be called if the `--enable-media-stream` command-line switch is used."*

That's a **bypass, not a grant.** Browser panes deliberately install *no* permission handler so CEF's Alloy default denies. This switch turns that deliberate deny into a blanket allow for every origin with no prompt, and does it somewhere no handler-based guard can observe. So an env var — from a shell profile, a CI config, or **an agent with shell access** — silently gives every browser pane camera and microphone.

## Why this ships now rather than with the camera work

It's a **present-day exposure for microphone**, not a camera-feature prerequisite: it applies today, with none of the camera spec built. Waiting for Phase 2 of a feature that may never be funded would be the wrong call.

## The fix

Rejects `enable-media-stream` and `use-fake-ui-for-media-stream` (same outcome by a different route, and the flag most likely reached for while testing). Matching is on the switch **name**, so `=value` spellings are caught, and **case-insensitive** since Chromium's own parsing is — an uppercase spelling must not be a way around the guard. Rejection is logged loudly: someone who set it deliberately deserves to know it didn't apply.

Tests cover the bypass spellings, case-insensitivity, that the GPU diagnostics flags this variable exists for still pass unaffected, and that matching doesn't over-reach to unrelated switches containing "media" (`autoplay-policy`, `enable-media-session-service`).

## One deliberate limitation

This is a **denylist, not an allowlist**. An allowlist would be stricter but would break the variable's diagnostic purpose. §3.8 records the uncomfortable part honestly: this leaves a diagnostics escape hatch serving as a security boundary, which it was never designed to be. If that tradeoff is wrong, the alternative is dropping `AGENTMUX_CEF_EXTRA_FLAGS` to an allowlist entirely — a bigger call than I'd make unilaterally.

## Test plan

- `cargo check -p agentmux-cef` — clean
- `cargo test -p agentmux-cef media_switch_guard` — 4/4 pass

<!-- agentmux:agent_id=agenty -->