### PR TITLE
test(cef): record why the command-line removal path can't be unit-tested

### DIFF
--- a/agentmux-cef/src/app/mod.rs
+++ b/agentmux-cef/src/app/mod.rs
@@ -1198,6 +1198,22 @@ mod media_switch_guard_tests {
         assert!(!is_media_permission_switch("enable-features=Vulkan"));
     }
 
+    // NOT TESTED HERE, and the reason is worth recording so nobody spends
+    // the afternoon I just did: the command-line removal path
+    // (`on_before_command_line_processing`'s `remove_switch` loop) cannot be
+    // unit-tested in this crate. `cef::command_line_create()` returns an
+    // `Option`, which looks safe, but calling it without the CEF library
+    // loaded aborts the test process outright (exit 0x80000003) rather than
+    // yielding `None` — verified by trying it. A test that kills the suite is
+    // worse than an acknowledged gap.
+    //
+    // What IS covered below is the shared switch list and the name predicate.
+    // The removal loop's correctness rests on both guards reading the same
+    // `MEDIA_PERMISSION_SWITCHES` constant, which is why that constant exists
+    // rather than two literal lists. End-to-end coverage would need a running
+    // host launched with the switch — worth doing as a manual check when
+    // touching this code.
+
     #[test]
     fn does_not_over_match_unrelated_switches_containing_media() {
         // Guard against a substring-matching regression: these are not


### PR DESCRIPTION
Follow-up to #2889. I flagged a coverage gap there and then tried to close it rather than leave it as prose. It turned out to be **genuinely closed off**, which is worth recording so nobody repeats the attempt.

## What I tried

`cef::command_line_create()` exists in the crate bindings and returns an `Option<CommandLine>` — which *looks* like it degrades safely when CEF isn't loaded. So a unit test could construct a command line, append the prohibited switches, run the same removal loop, and assert they're gone.

## Why it doesn't work

It doesn't degrade safely. Calling it under `cargo test` **aborts the test process** (exit `0x80000003`) rather than returning `None` — the CEF library simply isn't loaded, and the `Option` is about API-level failure, not that.

A test that kills the suite is worse than an acknowledged gap: it either gets `#[ignore]`d and rots, or it trains people to ignore a red suite. So the attempt is reverted and the finding is now a comment at the site.

## What's actually covered

The shared switch list and the name predicate (4 tests, passing). The removal loop's correctness rests on **both guards reading the same `MEDIA_PERMISSION_SWITCHES` constant** — which is precisely why that constant exists rather than two literal lists. That's the invariant doing the work, and it's structural rather than tested.

End-to-end coverage needs a running host launched with the switch. **I have a portable build running now to do exactly that** — if it shows the guard firing, I'll report it on #2889; if it shows a problem, that's a follow-up fix rather than a doc change.

## Test plan

`cargo test -p agentmux-cef media_switch_guard` — 4/4 pass. Comment and test-module only, no behaviour change.

<!-- agentmux:agent_id=agenty -->