### PR TITLE
feat(cef): resolve which pane a CEF Browser belongs to (camera Phase 1)

### DIFF
--- a/.changesets/1788271781-feat-cef-resolve-which-browser-pane-a-cef-browser-belongs-to-ok7h.md
+++ b/.changesets/1788271781-feat-cef-resolve-which-browser-pane-a-cef-browser-belongs-to-ok7h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(cef): resolve which browser pane a CEF Browser belongs to (camera Phase 1)

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use parking_lot::Mutex;
 
-use cef::{Browser, Frame};
+use cef::{Browser, Frame, ImplBrowser};
 
 mod drag;
 mod window_meta;
@@ -776,6 +776,50 @@ impl AppState {
             .browsers
             .get(label)
             .map(|h| h.browser.clone())
+    }
+
+    /// Which browser pane does this CEF `Browser` belong to, if any?
+    ///
+    /// The reverse of the usual `block_id → label → Browser` chain
+    /// (`live_browser_pane_label` then `get_browser`). CEF callbacks hand us a
+    /// `Browser` and nothing else, so any per-pane policy — notably the media
+    /// permission handler, which must decide *which pane* is asking before it
+    /// can consult that pane's grants — needs to walk back to the block id.
+    ///
+    /// Resolving identity at request time, rather than storing it on the
+    /// client at construction, is deliberate: a **prewarmed pool pane**
+    /// (`CreatePanePoolWindowWin32Task`) is created with no identity at all and
+    /// only becomes a specific block's pane later, at promote. A field captured
+    /// at construction would be permanently `None` for exactly those panes;
+    /// this lookup starts working the moment the pane is registered.
+    ///
+    /// Returns `None` for the main app client, a not-yet-promoted pool pane, a
+    /// pane mid-teardown, and any browser that isn't a pane — all of which
+    /// callers must treat as "no pane-scoped grant applies", never as "allow".
+    ///
+    /// Only `Live` panes match, via `live_browser_pane_label`: a `Closing` pane
+    /// must not resolve, or a permission decision could be attributed to a pane
+    /// that is going away.
+    pub fn block_id_for_browser(&self, browser: &mut Browser) -> Option<String> {
+        let block_ids: Vec<String> = self
+            .host_state
+            .lock()
+            .browser_panes
+            .keys()
+            .cloned()
+            .collect();
+        for block_id in block_ids {
+            let Some(label) = self.live_browser_pane_label(&block_id) else {
+                continue;
+            };
+            let Some(mut candidate) = self.get_browser(&label) else {
+                continue;
+            };
+            if candidate.is_same(Some(browser)) != 0 {
+                return Some(block_id);
+            }
+        }
+        None
     }
 
     /// Are there any registered browsers?


### PR DESCRIPTION
Phase 1 of `SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` — but **not** the Phase 1 the spec described, and the difference matters.

## The spec's design was wrong

§3.3 called for threading `block_id` into the browser-pane client at construction, so the permission handler could tell which pane is asking. Two things surfaced while implementing it:

1. **There are five construction sites, not three.** `app/mod.rs`, `browser_pane/creation.rs`, `creation_views.rs`, and `floating_pane.rs` **twice**.

2. **One of them creates a pane with no identity.** `CreatePanePoolWindowWin32Task` builds a *prewarmed pool pane* that only becomes a specific block's pane later, at promote.

That second point makes the spec's approach actively harmful. Changing `is_browser_pane: bool` into an `Option` carrying the id would have made pooled panes resolve as **not browser panes** — silently losing their focus handler, context menu, and permission-deny. And a field captured at construction stays `None` for exactly the panes that later matter.

I nearly shipped that before checking each site.

## What this does instead

Resolve identity **at request time**: `AppState::block_id_for_browser` walks the `browser_panes` registry, maps each block id to its label via `live_browser_pane_label`, fetches that label's `Browser`, and compares with `is_same` — the reverse of the existing `block_id → label → Browser` chain.

- No construction site changes
- Cannot regress the pooled-pane case
- Starts working the moment a pane is registered, **including a pool pane after promote**

**Only `Live` panes match.** A `Closing` pane must not resolve, or a permission decision could be attributed to a pane that's going away. Returns `None` for the main client, an unpromoted pool pane, a pane mid-teardown, and any non-pane browser — all of which callers must treat as *"no pane-scoped grant applies"*, never as *"allow"*.

## Scope

**No behaviour change — nothing calls this yet.** Phase 2 (handler + grant store + prompt) is the consumer. Landing it separately keeps the pooled-pane reasoning reviewable on its own rather than buried in the feature diff.

## Test plan

- `cargo check -p agentmux-cef` — clean
- `cargo test -p agentmux-cef` — 290/290 pass

The `unused imports` warning in `state/mod.rs` is **pre-existing on `main`** — confirmed by stashing and re-checking, not assumed.

Not unit-tested directly: the lookup needs live CEF `Browser` handles, which aren't constructible under `cargo test` (same constraint recorded in #2890). Its correctness rests on the registry chain it mirrors, which is exercised throughout the pane code.

<!-- agentmux:agent_id=agenty -->