### PR TITLE
Manoz@Area54: fix(identity): make provider auth-dir isolation correct by construction, with measured evidence

### DIFF
--- a/.changesets/1788272085-fix-identity-make-provider-auth-dir-isolation-correct-by-con-8lg7.md
+++ b/.changesets/1788272085-fix-identity-make-provider-auth-dir-isolation-correct-by-con-8lg7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): make provider auth-dir isolation correct by construction

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -700,6 +700,35 @@ pub fn seed_claude_md_placeholder_if_missing(
     Ok(true)
 }
 
+/// Prepare an isolated provider auth/config directory for use as
+/// `CLAUDE_CONFIG_DIR` (or a provider's equivalent): create it, then apply
+/// every isolation guarantee that directory needs before a CLI is pointed
+/// at it.
+///
+/// Exists so callers cannot obtain a usable auth dir WITHOUT its isolation
+/// guarantees — the spawn paths call this instead of `create_dir_all` +
+/// a separately-skippable seed step. Deleting the isolation from a spawn
+/// path now means deleting the directory preparation too, which fails
+/// loudly instead of silently reopening the leak. See
+/// `docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md` and
+/// `docs/reports/REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md`
+/// (the live three-arm experiment proving the leak is real and this closes
+/// it).
+pub fn prepare_provider_auth_dir(
+    provider: &ProviderConfig,
+    auth_dir: &str,
+) -> std::io::Result<()> {
+    if auth_dir.trim().is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "auth_dir is empty",
+        ));
+    }
+    std::fs::create_dir_all(auth_dir)?;
+    seed_claude_md_placeholder_if_missing(provider, auth_dir)?;
+    Ok(())
+}
+
 /// The actual comparison, split out with the reference side pre-resolved
 /// (not calling `get_home_dir()` internally) so it's directly testable
 /// against a tempdir instead of the real `$HOME`/`%USERPROFILE%` — same
@@ -1118,6 +1147,59 @@ mod tests {
         fn rejects_a_whitespace_only_config_dir() {
             let claude = get_provider("claude").unwrap();
             let err = seed_claude_md_placeholder_if_missing(claude, "   ").unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        }
+    }
+
+    mod prepare_provider_auth_dir_tests {
+        use super::*;
+
+        // The default spawn path (agent_open.rs) previously did
+        // `create_dir_all` and the isolation seed as two separate,
+        // independently-deletable statements, with no test covering the
+        // seed call at all — removing that one line reopened the leak
+        // silently. Fusing them means a caller cannot get a usable auth
+        // dir without its isolation guarantees.
+        #[test]
+        fn creates_the_dir_and_seeds_the_claude_placeholder_together() {
+            let base = tempfile::tempdir().unwrap();
+            let dir = base.path().join("not").join("yet").join("there");
+            let claude = get_provider("claude").unwrap();
+            prepare_provider_auth_dir(claude, &dir.to_string_lossy()).unwrap();
+            assert!(dir.is_dir(), "auth dir must be created");
+            let content = std::fs::read_to_string(dir.join("CLAUDE.md")).unwrap();
+            assert!(content.contains("AgentMux: intentionally empty"));
+        }
+
+        #[test]
+        fn creates_the_dir_without_a_claude_md_for_a_non_claude_provider() {
+            let base = tempfile::tempdir().unwrap();
+            let dir = base.path().join("codexhome");
+            let codex = get_provider("codex").unwrap();
+            prepare_provider_auth_dir(codex, &dir.to_string_lossy()).unwrap();
+            assert!(dir.is_dir(), "auth dir must still be created");
+            assert!(!dir.join("CLAUDE.md").exists(), "must not seed a foreign provider's dir");
+        }
+
+        #[test]
+        fn is_idempotent_and_never_clobbers_existing_content() {
+            let base = tempfile::tempdir().unwrap();
+            let dir = base.path().join("iso");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("CLAUDE.md"), "real user content").unwrap();
+            let claude = get_provider("claude").unwrap();
+            prepare_provider_auth_dir(claude, &dir.to_string_lossy()).unwrap();
+            prepare_provider_auth_dir(claude, &dir.to_string_lossy()).unwrap();
+            assert_eq!(
+                std::fs::read_to_string(dir.join("CLAUDE.md")).unwrap(),
+                "real user content",
+            );
+        }
+
+        #[test]
+        fn rejects_an_empty_auth_dir_instead_of_touching_the_cwd() {
+            let claude = get_provider("claude").unwrap();
+            let err = prepare_provider_auth_dir(claude, "   ").unwrap_err();
             assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         }
     }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -338,24 +338,27 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let auth_dir = agentmux_common::DataPaths::from_env()
                     .map(|p| p.provider_auth_dir(provider.auth_dir_name).to_string_lossy().into_owned())
                     .unwrap_or_else(|| format!("{}/.agentmux/shared/providers/{}", home, provider.auth_dir_name));
-                let _ = std::fs::create_dir_all(&auth_dir);
-                env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
-                // Claude Code CLI's own user-level CLAUDE.md discovery falls
-                // through to the real $HOME/.claude/CLAUDE.md when this
-                // isolated dir has none of its own — CLAUDE_CONFIG_DIR only
-                // relocates credential/session/project storage, not this.
-                // Fail closed (block the spawn) rather than warn-and-continue
-                // on a seed failure: continuing would launch the agent with
-                // exactly the unprotected condition this fix exists to
-                // close (Codex P1 + ReAgent P1 on PR #2854). No-op (Ok) for
-                // non-claude providers, so this never blocks their spawns.
+                // Create the dir AND apply its isolation guarantees in one
+                // inseparable step. Claude Code CLI's own user-level CLAUDE.md
+                // discovery falls through to the real $HOME/.claude/CLAUDE.md
+                // when this isolated dir has none of its own — CLAUDE_CONFIG_DIR
+                // relocates credential/session/project storage but NOT that
+                // lookup (proven live, three-arm experiment:
+                // docs/reports/REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md).
+                //
+                // Fail closed (block the spawn) rather than warn-and-continue:
+                // continuing would launch the agent with exactly the
+                // unprotected condition this exists to close (Codex P1 +
+                // ReAgent P1, PR #2854). Non-claude providers get the dir
+                // created and nothing else, so this never blocks their spawns.
                 // See SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md.
-                providers::seed_claude_md_placeholder_if_missing(provider, &auth_dir).map_err(|e| {
+                providers::prepare_provider_auth_dir(provider, &auth_dir).map_err(|e| {
                     format!(
                         "failed to isolate this agent's Claude Code config ({auth_dir}): {e}. \
                          Refusing to launch with an unprotected config dir."
                     )
                 })?;
+                env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
                 for (k, v) in provider.auth_extra_env {
                     env_vars.insert(k.to_string(), json!(v));
                 }

--- a/docs/reports/REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md
+++ b/docs/reports/REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md
@@ -1,0 +1,152 @@
+# Report — what `CLAUDE_CONFIG_DIR` actually isolates, measured
+
+**Date:** 2026-09-01
+**Author:** Manoz
+**Status:** Complete. Live experiments; every claim below is measured, not inferred.
+**Context:** `SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md` shipped a fix
+(PR #2854) on the *inferred* premise that an isolated `CLAUDE_CONFIG_DIR`
+with no `CLAUDE.md` falls back to the operator's personal
+`~/.claude/CLAUDE.md`. The operator then asked the sharper question — *"is
+the global claude completely isolated?"* — which that spec could not answer,
+because it had never tested the premise or the other surfaces. This report
+answers it.
+
+## 0. Summary
+
+| Surface | Isolated by `CLAUDE_CONFIG_DIR` alone? | Evidence |
+|---|---|---|
+| `CLAUDE.md` (user memory) | **NO — leaks** | §2, three-arm experiment |
+| `settings.json` (`env`, hooks, permissions) | **YES** | §3 |
+| `skills/` | **YES** | §4 |
+| `.claude.json` (MCP servers) | N/A on this machine — none defined | §5 |
+| `plugins/` | N/A — sole plugin is project-scoped to `C:\Systems` | §5 |
+| Other providers (`AGENTS.md`, `GEMINI.md`, …) | **UNTESTED** — no host file exists to leak today | §6 |
+
+**Net: the `CLAUDE.md` leak was real, is the only confirmed one, and the
+shipped fix closes it.** The rest of `~/.claude` was already isolated —
+which is *why* the leak was easy to miss: the boundary works for
+credentials, settings and skills, so nothing else pointed at it.
+
+## 1. Method, and one methodological trap worth recording
+
+Each surface gets a three-arm test, all from a working directory whose
+entire parent chain is verified free of `CLAUDE.md` (otherwise project-level
+discovery confounds the result):
+
+1. **Control** — isolated config dir *without* the file under test. Does the
+   host's version leak in?
+2. **Treatment** — the same dir *with* the file. Is the leak closed?
+3. **Sensitivity** — a distinctive sentinel in the config dir's own copy.
+   Proves the instrument can actually see this surface at all.
+
+**Arm 3 is not optional.** The first pass of this investigation ran arms 1
+and 2 only, phrased as *"do your system instructions contain 'Global Claude
+Code Rules'?"*, and got `NO` from every arm — which reads as "no leak,
+fix unnecessary." That conclusion would have been wrong. Memory files arrive
+as a user-turn reminder, not as literal system instructions, so the model was
+answering the question as asked, truthfully and uselessly. Re-phrased to
+*"quote the first markdown heading of any user-level instructions in your
+context"*, the same arms immediately separated. **A null result from an
+uncalibrated instrument is not evidence of absence** — anyone re-running this
+should keep arm 3.
+
+## 2. `CLAUDE.md` — leaks (the fix is load-bearing)
+
+Prompt: *"Quote the first markdown heading of any user-level or global
+instructions in your context. Reply with just that heading line, or NONE."*
+
+| Arm | `CLAUDE_CONFIG_DIR` contents | Result |
+|---|---|---|
+| Control | `.credentials.json` only | **`# Global Claude Code Rules`** ← host file |
+| Treatment | `+ CLAUDE.md` (AgentMux placeholder) | **`NONE`** |
+| Sensitivity | `+ CLAUDE.md` containing `ZORBLAX_SENTINEL_9931` | returned the sentinel |
+
+The sensitivity arm also establishes the *mechanism*:
+`$CLAUDE_CONFIG_DIR/CLAUDE.md` **is** the user-memory location and **is**
+read. So the failure mode is specifically *fallback on absence* — an empty
+isolated dir reaches past itself to `~/.claude/CLAUDE.md`. Seeding any file
+at that path stops it.
+
+## 3. `settings.json` — isolated
+
+The highest-stakes surface: this machine's host `settings.json` carries
+`env.BASH_ENV`, a `PostToolUse` hook shelling out to an unrelated repo
+(`/c/Systems/agentmux`), and `skipDangerousModePermissionPrompt: true`. A
+fallback here would be materially worse than leaked instructions.
+
+| Arm | Config dir | Observable (`echo $BASH_ENV` / `$AMX_SENTINEL` via Bash) | Result |
+|---|---|---|---|
+| Control | no `settings.json` | `BASH_ENV` | **empty** — host `env` did not leak |
+| Sensitivity | `settings.json` with `env.AMX_SENTINEL=TRIPWIRE_7742` | `AMX_SENTINEL` | **`TRIPWIRE_7742`** |
+
+Config-dir settings are read and applied; absence does **not** fall back.
+`settings.local.json` is loaded by the same config-dir resolution and is
+assumed to behave identically — *inferred by analogy, not directly measured*,
+because the host copy contains no observable (`enableAllProjectMcpServers`,
+`enabledMcpjsonServers: ["agentmux"]`) that can be detected without a
+purpose-built MCP fixture.
+
+## 4. `skills/` — isolated
+
+Host has three custom skills (`build`, `deploy`, `pr`).
+
+| Arm | Config dir | Skills listed |
+|---|---|---|
+| Control | no `skills/` | built-ins only — **no `build`/`deploy`/`pr`** |
+| Sensitivity | `+ skills/zorbtest/SKILL.md` | **`zorbtest`** appeared, first in the list |
+
+## 5. Surfaces with nothing to leak here
+
+- **`.claude.json`** — parsed: zero top-level `mcpServers`, zero project-scoped
+  ones. No MCP definitions exist to leak on this machine.
+- **`plugins/`** — one installed plugin (`rust-analyzer-lsp`), `scope: project`,
+  `projectPath: C:\Systems`. AgentMux agents do not run under that path.
+
+Both are "no exposure *today*" rather than "isolated by construction" — a
+user who later defines a global MCP server would need this re-checked.
+
+## 6. Other providers — open, but not currently exposed
+
+The same class of bug could exist for any provider with a user-level
+instructions convention: Codex (`AGENTS.md`), Gemini (`GEMINI.md`), Qwen
+(`QWEN.md`). Host config dirs **do** exist for `.codex`, `.gemini`, `.kimi`,
+`.openclaw` — but **none of them contains its instructions file**, so there is
+nothing to leak right now:
+
+```
+absent: ~/.codex/AGENTS.md     absent: ~/.gemini/GEMINI.md
+absent: ~/.qwen/QWEN.md        absent: ~/.openclaw/{AGENTS,CLAUDE}.md
+```
+
+The fix stays deliberately `claude`-only. Extending it generically was
+considered and **rejected**: `ProviderConfig::startup_instructions_filename`
+describes the file AgentMux writes into the agent's *working directory*
+(project level), which is not necessarily the same as that provider's
+*user-config-level* filename. Reusing it for the config-dir placeholder would
+conflate two different concepts on a guess. Closing this properly means
+running §1's three-arm method per provider, which needs each CLI installed and
+authenticated (`codex`, `qwen`, `openclaw` are not installed here).
+
+## 7. Coverage on disk
+
+Seeding happens at spawn time, so a dir is protected the moment it is
+actually used. At time of writing **1 of 37** isolated `claude` config dirs on
+this machine carries the placeholder — the rest are overwhelmingly dead
+per-build channels that will never be spawned into again. The number is
+expected to stay low and is not itself a defect.
+
+The real exposure window is different: an agent spawned from a build
+**older than v0.55.30** still runs the pre-fix code and will leak regardless
+of what is on disk.
+
+## 8. Hardening applied after this investigation
+
+The default spawn path (`agent_open.rs`) originally did `create_dir_all` and
+the isolation seed as two independent statements, with **no test covering the
+seed call at all** — deleting that one line would have silently reopened the
+leak with a green test suite. Both are now fused into
+`providers::prepare_provider_auth_dir()`, so a caller cannot obtain a usable
+auth dir without its isolation guarantees; removing the isolation now means
+removing the directory creation too, which fails loudly. Four tests cover it
+(creation+seed together, non-claude no-op, idempotence/never-clobber, empty-path
+rejection).

--- a/docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md
+++ b/docs/specs/SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md
@@ -32,6 +32,18 @@ in-app agents — see the block above for what they use."* That claim is
 
 ### Root cause
 
+> **Verified 2026-09-01.** This section originally stated the mechanism as
+> an *inference* from circumstantial evidence. It has since been proven by
+> a controlled three-arm experiment — control (leaks the host file),
+> treatment (does not), sensitivity (instrument confirmed able to see this
+> surface). See
+> `docs/reports/REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md`,
+> which also measures the *other* `~/.claude` surfaces: `settings.json` and
+> `skills/` turn out to be **properly isolated** already, making `CLAUDE.md`
+> the only confirmed leak. That report additionally records a methodological
+> trap — a first pass with imprecise prompt phrasing returned a false "no
+> leak" from every arm — worth reading before re-testing any of this.
+
 `CLAUDE_CONFIG_DIR` relocates Claude Code CLI's credential/session/
 project storage (confirmed on-disk: `.credentials.json`, `.claude.json`,
 `projects/`, `sessions/`), but AgentMux never writes a `CLAUDE.md` into


### PR DESCRIPTION
## Summary

Follow-up to #2854, prompted by the operator asking the sharper question that spec couldn't answer: *"is the global claude completely isolated?"*

#2854 shipped on an **inferred** mechanism. This PR measures it, and measures the surfaces #2854 never checked.

### What was measured

Three-arm experiment per surface (control / treatment / **sensitivity**), from a cwd with a verified-clean `CLAUDE.md` ancestry:

| Surface | Isolated by `CLAUDE_CONFIG_DIR` alone? | Evidence |
|---|---|---|
| `CLAUDE.md` | **NO — leaks** | control returned `# Global Claude Code Rules` (host file); treatment returned `NONE` |
| `settings.json` | **YES** | host `env.BASH_ENV` absent in control; config-dir sentinel applied |
| `skills/` | **YES** | host `build`/`deploy`/`pr` absent; config-dir `zorbtest` appeared |
| `.claude.json` / `plugins/` | no exposure on this machine | zero MCP servers defined; sole plugin project-scoped elsewhere |
| Other providers | **untested, not currently exposed** | no host `AGENTS.md`/`GEMINI.md`/`QWEN.md` exists to leak |

**#2854's premise was correct, and `CLAUDE.md` is the only confirmed leak** — which is exactly why it was easy to miss: the boundary already works for credentials, settings and skills, so nothing else pointed at it.

Worth noting `settings.json` was the highest-stakes unknown going in — on this machine it carries `env.BASH_ENV`, a `PostToolUse` hook shelling into an unrelated repo, and `skipDangerousModePermissionPrompt: true`. Confirmed isolated.

### Hardening

`agent_open.rs` did `create_dir_all` and the isolation seed as two independently-deletable statements, and **the seed call had no test at all** — deleting that one line would have silently reopened the leak against a fully green suite. Both are now fused into `providers::prepare_provider_auth_dir()`: you cannot obtain a usable auth dir without its isolation guarantees, and removing the isolation now means removing the directory creation too, which fails loudly.

### Deliberately NOT done

Extending the seed generically to all providers. `ProviderConfig::startup_instructions_filename` describes the file written into the agent's *working directory* (project level), which isn't necessarily the provider's *user-config-level* filename — reusing it for the config-dir placeholder would conflate two concepts on a guess. Closing that properly needs the same three-arm method per provider, which requires each CLI installed and authed (`codex`/`qwen`/`openclaw` aren't). Documented as open in the report.

### One methodological note

My first pass ran only arms 1–2, phrased *"do your system instructions contain X?"*, and got `NO` from every arm — which reads as "no leak, fix unnecessary." That would have been the wrong conclusion: memory arrives as a user-turn reminder, not literal system instructions, so the model answered truthfully and uselessly. Rephrasing separated the arms immediately. Recorded in the report so a re-test doesn't repeat it.

Full evidence: `docs/reports/REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md`

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — **2890 passed, 0 failed**
- [x] 25 isolation-specific tests pass (21 existing + 4 new for `prepare_provider_auth_dir`: creation+seed together, non-claude no-op, idempotence/never-clobber, empty-path rejection)
- [x] `cargo check -p agentmux-srv` — clean, no new warnings
- [x] Live experiments run against real isolated dirs; all temp dirs and copied credentials cleaned up afterward

<!-- agentmux:agent_id=manoz -->