### PR TITLE
fix(cef): close a TOCTOU in block_id_for_browser's lifecycle check

### DIFF
--- a/.changesets/1788272250-fix-cef-close-a-toctou-in-block-id-for-browser-lifecycle-che-tghs.md
+++ b/.changesets/1788272250-fix-cef-close-a-toctou-in-block-id-for-browser-lifecycle-che-tghs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): close a TOCTOU in block_id_for_browser lifecycle check

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -797,24 +797,44 @@ impl AppState {
     /// pane mid-teardown, and any browser that isn't a pane — all of which
     /// callers must treat as "no pane-scoped grant applies", never as "allow".
     ///
-    /// Only `Live` panes match, via `live_browser_pane_label`: a `Closing` pane
-    /// must not resolve, or a permission decision could be attributed to a pane
-    /// that is going away.
+    /// # Locking
+    ///
+    /// The `Live` filter and the browser-handle clone happen under **one** lock
+    /// acquisition, then the lock is dropped before any `is_same` FFI call —
+    /// satisfying both the module's snapshot-and-drop rule ("callers never hold
+    /// the lock across CEF FFI calls") and consistency between the two facts.
+    ///
+    /// An earlier version took three separate locks (collect ids, then
+    /// `live_browser_pane_label`, then `get_browser`). A close landing between
+    /// the second and third could flip an entry to `Closing` while its handle
+    /// was still registered, so the comparison would succeed and hand back a
+    /// block id for a closing pane — exactly the case this helper promises not
+    /// to return (codex P2 on PR #2893).
+    ///
+    /// **Residual, and callers must account for it:** the snapshot can still go
+    /// stale after the lock drops — a pane may begin closing while the FFI
+    /// comparison runs. This narrows the window rather than removing it, which
+    /// snapshot-and-drop cannot do. Anything acting on the result (granting
+    /// capture, say) must re-check liveness at the point of use rather than
+    /// treating a returned id as proof the pane is still alive.
     pub fn block_id_for_browser(&self, browser: &mut Browser) -> Option<String> {
-        let block_ids: Vec<String> = self
-            .host_state
-            .lock()
-            .browser_panes
-            .keys()
-            .cloned()
-            .collect();
-        for block_id in block_ids {
-            let Some(label) = self.live_browser_pane_label(&block_id) else {
-                continue;
-            };
-            let Some(mut candidate) = self.get_browser(&label) else {
-                continue;
-            };
+        // One lock: lifecycle and handle are read together, so they cannot
+        // disagree with each other.
+        let candidates: Vec<(String, Browser)> = {
+            let st = self.host_state.lock();
+            st.browser_panes
+                .iter()
+                .filter(|(_, e)| e.lifecycle == BrowserPaneLifecycle::Live)
+                .filter_map(|(block_id, e)| {
+                    st.browsers
+                        .get(&e.label)
+                        .map(|h| (block_id.clone(), h.browser.clone()))
+                })
+                .collect()
+        };
+
+        // FFI only after the lock is dropped.
+        for (block_id, mut candidate) in candidates {
             if candidate.is_same(Some(browser)) != 0 {
                 return Some(block_id);
             }


### PR DESCRIPTION
Follow-up to #2893 (merged), fixing a real race Codex found. The helper **promises never to return a `Closing` pane's id, and could.**

## The race

It took **three separate lock acquisitions** — collect ids, then `live_browser_pane_label`, then `get_browser`. A close landing between the second and third flips the entry to `Closing` while its browser handle is *still registered* (notably on the async non-Windows detach path). `is_same` then succeeds and hands back the id of a pane that's going away — letting a future pane-scoped media grant be attributed during teardown.

## The fix, and the constraint that shaped it

One lock acquisition now covers **both** the `Live` filter and the handle clone, so those two facts can't disagree with each other.

The obvious fix — hold the lock across the comparison — would have been wrong. These helpers carry an explicit convention documented right above them:

> *"Snapshot-and-drop: each helper takes the relevant lock briefly, clones what's needed, drops the lock. **Callers never hold the lock across CEF FFI calls.**"*

And `is_same` is an FFI call. So the shape is: snapshot both facts under one lock → drop → compare outside.

## Residual, documented rather than glossed

The snapshot can still go stale after the lock drops — a pane may begin closing while the comparison runs. **Snapshot-and-drop cannot remove that, only narrow it.**

So the doc comment now states the obligation explicitly: anything acting on the result (granting capture, say) must **re-check liveness at the point of use** rather than treating a returned id as proof the pane is still alive. That's where Phase 2b will read it, which is the point of writing it down rather than claiming the race is gone.

## Test plan

- `cargo check -p agentmux-cef` — clean
- `cargo test -p agentmux-cef` — 290/290 pass

Still not directly unit-testable (needs live CEF `Browser` handles — same constraint as #2890); the fix is structural, in the locking shape.

<!-- agentmux:agent_id=agenty -->