### PR TITLE
feat(cef): grant-store-driven permission handler for browser panes (camera Phase 2b)

### DIFF
--- a/.changesets/1788272736-feat-cef-grant-store-driven-permission-handler-for-browser-p-neyb.md
+++ b/.changesets/1788272736-feat-cef-grant-store-driven-permission-handler-for-browser-p-neyb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(cef): grant-store-driven permission handler for browser panes (camera Phase 2b)

--- a/agentmux-cef/src/browser_panes/close.rs
+++ b/agentmux-cef/src/browser_panes/close.rs
@@ -65,6 +65,18 @@ impl BrowserPaneManager {
             Some(l) => l,
             None => return,
         };
+
+        // Drop this pane's media grants. Placed after the Live→Closing
+        // transition fired (a None above means "missing or already closing" —
+        // another close is mid-teardown and owns the cleanup), so it runs
+        // exactly once per real close.
+        //
+        // Grants must not outlive their pane: they are pane-scoped precisely so
+        // that a decision made for one pane cannot apply to another, and block
+        // ids are not reused in practice — but if one ever were, a stale entry
+        // would silently hand a new pane the previous occupant's camera grant.
+        // SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.2.
+        state.media_grants.lock().clear_pane(block_id);
         #[cfg(target_os = "windows")]
         {
             let ops = AppStateCloseOps(state);

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -72,12 +72,22 @@ wrap_client! {
         }
 
         fn permission_handler(&self) -> Option<PermissionHandler> {
-            // Microphone (getUserMedia) access for voice input. ONLY the main app
-            // client gets a handler — browser panes load arbitrary web content, so
-            // auto-granting them media access would hand the mic to any site with no
-            // prompt. For panes we return None → CEF's default Alloy handling (deny).
+            // Two different policies, deliberately two different handlers.
+            //
+            // Main app client: AgentMux's own first-party UI. Unconditionally
+            // grants the audio bits for voice input (#1591/#1602). Unchanged.
+            //
+            // Browser pane: arbitrary web content, so the answer depends on
+            // what the user actually allowed for that pane and origin —
+            // consulted from the media grant store. Previously this returned
+            // None and let CEF's Alloy default deny; the pane handler denies
+            // identically until a grant exists, but gives the Phase 2c prompt
+            // somewhere to live and makes each decision explicit in the log.
+            //
+            // SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.1-3.4.
             if self.is_browser_pane {
-                return None;
+                let state = self.inner.lock().state.clone();
+                return Some(AgentMuxPanePermissionHandler::new(state));
             }
             Some(AgentMuxPermissionHandler::new())
         }
@@ -716,6 +726,119 @@ wrap_permission_handler! {
                     0 // not handled — CEF default (deny under Alloy)
                 }
             }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Browser-pane permission handler — grant-store driven (camera Phase 2b)
+// ---------------------------------------------------------------------------
+//
+// Distinct from `AgentMuxPermissionHandler` above, which is the MAIN app
+// client's handler and unconditionally grants the audio bits for AgentMux's own
+// first-party voice input. That policy must not apply to browser panes: they
+// load arbitrary web content, so the answer depends on what the user has
+// actually allowed for *that pane and that origin*.
+//
+// Kept as a separate type rather than branching inside one handler, so the
+// shipped voice-input path is untouched by this work.
+//
+// Spec: docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.1-3.4.
+//
+// CURRENT BEHAVIOUR IS UNCHANGED FROM NO-HANDLER-AT-ALL. Nothing creates a
+// grant yet (the prompt is Phase 2c), so `covers` is always false and every
+// request is denied — exactly what CEF's Alloy default did when
+// `permission_handler()` returned `None` for panes. The difference is that the
+// denial is now explicit, logged, and has somewhere for the prompt to go.
+
+wrap_permission_handler! {
+    struct AgentMuxPanePermissionHandler {
+        state: Arc<crate::state::AppState>,
+    }
+
+    impl PermissionHandler {
+        fn on_request_media_access_permission(
+            &self,
+            browser: Option<&mut Browser>,
+            _frame: Option<&mut Frame>,
+            requesting_origin: Option<&CefString>,
+            requested_permissions: u32,
+            callback: Option<&mut MediaAccessCallback>,
+        ) -> ::std::os::raw::c_int {
+            let origin = requesting_origin.map(|s| s.to_string()).unwrap_or_default();
+
+            // No callback to answer with: fall through to CEF's default, which
+            // denies under Alloy. Returning 1 here would leave the request
+            // dangling forever instead.
+            let Some(cb) = callback else {
+                tracing::warn!(
+                    target: "pane-media",
+                    %origin,
+                    "media-access request had no callback — deferring to default (deny)"
+                );
+                return 0;
+            };
+
+            // Which pane is asking? `None` covers the main client, an
+            // unpromoted pool pane, a pane mid-teardown, and any non-pane
+            // browser. Every one of those means "no pane-scoped grant applies",
+            // which is a denial — never an allow.
+            let block_id = browser.and_then(|b| self.state.block_id_for_browser(b));
+            let Some(block_id) = block_id else {
+                tracing::info!(
+                    target: "pane-media",
+                    %origin,
+                    requested = requested_permissions,
+                    "denying media access — request could not be attributed to a live pane"
+                );
+                cb.cont(0);
+                return 1;
+            };
+
+            // Re-check liveness at the point of use. `block_id_for_browser`
+            // snapshots under a lock and drops it before its FFI comparison, so
+            // its answer can go stale — its own doc comment requires callers to
+            // re-check rather than treat the id as proof the pane is alive.
+            if self.state.live_browser_pane_label(&block_id).is_none() {
+                tracing::info!(
+                    target: "pane-media",
+                    %origin, %block_id,
+                    "denying media access — pane stopped being live while resolving"
+                );
+                cb.cont(0);
+                return 1;
+            }
+
+            let covered = self
+                .state
+                .media_grants
+                .lock()
+                .covers(&block_id, &origin, requested_permissions);
+
+            if covered {
+                // Echo the request EXACTLY. Per the CEF contract,
+                // allowed_permissions must match required_permissions for a
+                // getUserMedia request — narrowing here would deny the whole
+                // request rather than grant a subset.
+                tracing::info!(
+                    target: "pane-media",
+                    %origin, %block_id,
+                    requested = requested_permissions,
+                    "allowing media access — covered by an existing grant"
+                );
+                cb.cont(requested_permissions);
+            } else {
+                // Phase 2c prompts here instead of denying outright. Until then
+                // this is the same answer the pane got with no handler at all.
+                tracing::info!(
+                    target: "pane-media",
+                    %origin, %block_id,
+                    requested = requested_permissions,
+                    "denying media access — no grant covers this request (no prompt yet)"
+                );
+                cb.cont(0);
+            }
+            1 // handled
         }
     }
 }

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -336,6 +336,14 @@ pub struct AppState {
     /// `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`.
     pub host_state: Mutex<crate::reducer::HostState>,
 
+    /// Per-pane, per-origin media capture grants (camera/mic in browser panes).
+    ///
+    /// Session-only by design — see
+    /// `docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` §3.2. Absence
+    /// of a grant is denial, so an empty store (the state at startup, and the
+    /// state until a user explicitly allows something) denies every request.
+    pub media_grants: Mutex<crate::browser_panes::media_grants::MediaGrantStore>,
+
     /// Phase F.7 host-bridge dedup. Keyed by `"{event_kind}|{label}|{hwnd}"`,
     /// value is the highest launcher-event version dispatched to renderers
     /// for that key. The bridge skips dispatch if the incoming event's
@@ -695,6 +703,9 @@ impl Default for AppState {
             // browsers field removed in H.2.e — see comment near struct decl.
             window_meta: Mutex::new(HashMap::new()),
             host_state: Mutex::new(crate::reducer::HostState::default()),
+            media_grants: Mutex::new(
+                crate::browser_panes::media_grants::MediaGrantStore::new(),
+            ),
             launcher_bridge_dedup: Mutex::new(crate::launcher_event_bridge::DedupCache::new()),
             #[cfg(not(target_os = "windows"))]
             windows: Mutex::new(HashMap::new()),


### PR DESCRIPTION
Browser panes get a media permission handler for the first time. It consults the Phase 2a grant store and denies when nothing covers the request.

## Behaviour is unchanged — verified, not asserted

- **Nothing anywhere creates a grant yet** — `grep` finds no `.grant()` call sites outside the store's own tests. So `covers()` is always `false`.
- Therefore every request takes the deny path, which is exactly what CEF's Alloy default did when `permission_handler()` returned `None` for panes.

What changes is that the denial is now **explicit, attributed to a pane, logged**, and has somewhere for the Phase 2c prompt to go.

## Separate handler, deliberately

Kept as its own type rather than branching inside the existing one:

- **Main client** — AgentMux's own first-party UI, unconditionally grants the audio bits for voice input (#1591/#1602). **That code is untouched by this diff** (confirmed: the change is additive, no removed lines in the audio path).
- **Browser pane** — arbitrary web content, so the answer depends on what the user allowed for that pane and origin.

Branching inside one handler would have put the shipped voice path one editing mistake away from this work.

## Decision order — every step a denial, never a fallthrough

1. **No callback** → return `0` (CEF default deny). Returning `1` would leave the request dangling forever.
2. **Browser doesn't resolve to a pane** → deny. Covers the main client, an unpromoted pool pane, a pane mid-teardown, and any non-pane browser. All mean *"no pane-scoped grant applies"*, which is never an allow.
3. **Pane no longer `Live`** → deny. This discharges the obligation `block_id_for_browser`'s docs impose after #2896: it snapshots under a lock and drops it before its FFI comparison, so callers must re-check liveness at point of use rather than treat the returned id as proof.
4. **Grant covers the request** → echo `requested_permissions` **exactly**. Narrowing would deny the whole request under CEF's match rule, not grant a subset.

## Grants die with their pane

Cleanup on close, placed *after* the `Live→Closing` transition fires so it runs exactly once per real close (a `None` there means another close already owns the teardown). Grants are pane-scoped precisely so one pane's decision can't apply to another; block ids aren't reused in practice, but a stale entry would silently hand a new pane the previous occupant's camera grant.

## Test plan

- `cargo check -p agentmux-cef` — clean
- `cargo test -p agentmux-cef` — 303/303 pass

The handler itself isn't unit-testable (needs live CEF `Browser` handles — same constraint as #2890); its policy logic lives in the grant store, which has 13 tests. End-to-end verification comes with Phase 2c, when a grant can actually exist.

<!-- agentmux:agent_id=agenty -->