### PR TITLE
feat(browser-pane): camera/mic prompt for browser panes (camera Phase 2c)

### DIFF
--- a/.changesets/1788273361-feat-browser-pane-camera-mic-access-with-a-per-pane-permissi-ou8x.md
+++ b/.changesets/1788273361-feat-browser-pane-camera-mic-access-with-a-per-pane-permissi-ou8x.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(browser-pane): camera/mic access with a per-pane permission prompt (camera Phase 2c)

--- a/agentmux-cef/src/browser_panes/close.rs
+++ b/agentmux-cef/src/browser_panes/close.rs
@@ -77,6 +77,7 @@ impl BrowserPaneManager {
         // would silently hand a new pane the previous occupant's camera grant.
         // SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.2.
         state.media_grants.lock().clear_pane(block_id);
+        crate::browser_panes::media_prompt::cancel_pane_any_thread(block_id);
         #[cfg(target_os = "windows")]
         {
             let ops = AppStateCloseOps(state);
@@ -191,6 +192,20 @@ impl BrowserPaneManager {
         );
         if let Some(block_id) = out.drained_browser_pane_block_id {
             tracing::info!(label, block_id = %block_id, "browser pane drained via on_before_close");
+
+            // Drop media grants and pending prompts on THIS path too.
+            //
+            // This is the CEF-initiated teardown (crash, or the page/pane
+            // closing itself), and it removes the reducer entry without going
+            // through `close()` — so `close()`'s cleanup never runs for it, and
+            // a later `close()` returns early because the entry is already
+            // gone. Missing it would leave the grant behind, and
+            // `replay_pending_create` below can immediately recreate a pane for
+            // the SAME block id — handing the new pane the previous occupant's
+            // camera/mic access with no prompt. Hence: before the replay, not
+            // after (codex P2 on PR #2897).
+            state.media_grants.lock().clear_pane(&block_id);
+            crate::browser_panes::media_prompt::cancel_pane_any_thread(&block_id);
             // Same keyboard-focus orphaning fix as close() — the async
             // on_before_close drain also destroys the pane HWND.
             #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/browser_panes/media_prompt.rs
+++ b/agentmux-cef/src/browser_panes/media_prompt.rs
@@ -1,0 +1,234 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-flight media permission prompts for browser panes.
+//!
+//! Spec: `docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` §3.4-3.5.
+//!
+//! # Why a thread-local rather than `AppState`
+//!
+//! `CefMediaAccessCallback` is a `RefGuard` with **no `Send`/`Sync`**, so it
+//! cannot be stored in `AppState` (shared across threads). It is also a CEF
+//! object that must be used on the browser-process UI thread.
+//!
+//! Both constraints point the same way: keep pending requests in a thread-local
+//! owned by the UI thread, and route every mutation through a task posted to
+//! `ThreadId::UI`. `debug_assert`s below pin that invariant so a future caller
+//! on the wrong thread fails loudly in dev rather than corrupting the map.
+//!
+//! # The invariant that matters
+//!
+//! **Every parked request is resolved exactly once, and always eventually.**
+//!
+//! - Resolution *removes* the entry before continuing the callback, so a
+//!   double-answer (user clicks, then a timeout fires) cannot continue the same
+//!   callback twice — that would be a use-after-continue into CEF.
+//! - Every park arms a timeout, so a frontend that never answers (window
+//!   closed, renderer crashed, event dropped) degrades to a denial rather than
+//!   hanging the page's `getUserMedia` forever.
+//! - Pane close cancels that pane's pending requests, since the answer can no
+//!   longer be attributed to anything.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use cef::*;
+
+/// How long a prompt may stay unanswered before it is denied.
+///
+/// Long enough for a person to read and decide; short enough that a page whose
+/// prompt never rendered fails in a comprehensible amount of time rather than
+/// appearing to hang. A denial here is not recorded as a grant, so a later
+/// request prompts again.
+const PROMPT_TIMEOUT_MS: i64 = 60_000;
+
+thread_local! {
+    /// UI-thread-only registry of parked requests, keyed by request id.
+    static PENDING: RefCell<HashMap<u64, PendingRequest>> = RefCell::new(HashMap::new());
+
+    /// Monotonic source of request ids. Thread-local like the map it keys, so
+    /// there is no cross-thread counter to reason about.
+    static NEXT_ID: RefCell<u64> = const { RefCell::new(1) };
+}
+
+struct PendingRequest {
+    callback: MediaAccessCallback,
+    block_id: String,
+    origin: String,
+    /// Exactly the bits the page asked for. Echoed verbatim on allow — CEF
+    /// requires `allowed_permissions` to match `required_permissions`, so a
+    /// grant is all-or-nothing for the request as posed.
+    requested: u32,
+}
+
+/// Park a request and return its id, for handing to the prompt UI.
+///
+/// The caller must have already decided that a prompt is warranted (no existing
+/// grant covers the request) and must emit the prompt event *after* this
+/// returns, so an implausibly fast answer still finds the entry.
+pub fn park(callback: MediaAccessCallback, block_id: &str, origin: &str, requested: u32) -> u64 {
+    debug_assert_ne!(
+        cef::currently_on(cef::ThreadId::UI),
+        0,
+        "media prompts must be parked on the CEF UI thread"
+    );
+    let id = NEXT_ID.with(|n| {
+        let mut n = n.borrow_mut();
+        let id = *n;
+        *n += 1;
+        id
+    });
+    PENDING.with(|p| {
+        p.borrow_mut().insert(
+            id,
+            PendingRequest {
+                callback,
+                block_id: block_id.to_string(),
+                origin: origin.to_string(),
+                requested,
+            },
+        );
+    });
+    id
+}
+
+/// Resolve a parked request. `None` if it is already gone — an unknown id, a
+/// double answer, or a timeout that already fired. Silent by design: all three
+/// are ordinary races, not errors.
+///
+/// Returns `(block_id, origin, requested)` on success so the caller can record
+/// a grant, which this module deliberately does not do itself: parking is
+/// mechanism, granting is policy, and the grant store owns policy.
+pub fn resolve(id: u64, allow: bool) -> Option<(String, String, u32)> {
+    debug_assert_ne!(
+        cef::currently_on(cef::ThreadId::UI),
+        0,
+        "media prompts must be resolved on the CEF UI thread"
+    );
+    // Remove BEFORE continuing: the entry must be unreachable by the time the
+    // callback is used, so no second path can continue it again.
+    let Some(req) = PENDING.with(|p| p.borrow_mut().remove(&id)) else {
+        return None;
+    };
+    let allowed = if allow { req.requested } else { 0 };
+    req.callback.cont(allowed);
+    tracing::info!(
+        target: "pane-media",
+        request_id = id,
+        block_id = %req.block_id,
+        origin = %req.origin,
+        requested = req.requested,
+        allowed,
+        "resolved media permission prompt"
+    );
+    Some((req.block_id, req.origin, req.requested))
+}
+
+/// Deny every pending request belonging to one pane.
+///
+/// Called on pane close: the pane the answer would apply to is gone, so there
+/// is nothing a later "allow" could sensibly mean.
+pub fn cancel_pane(block_id: &str) {
+    debug_assert_ne!(cef::currently_on(cef::ThreadId::UI), 0);
+    let ids: Vec<u64> = PENDING.with(|p| {
+        p.borrow()
+            .iter()
+            .filter(|(_, r)| r.block_id == block_id)
+            .map(|(id, _)| *id)
+            .collect()
+    });
+    for id in ids {
+        resolve(id, false);
+    }
+}
+
+/// Cancel a pane's prompts from any thread.
+///
+/// The registry is UI-thread-only, but teardown paths are not guaranteed to run
+/// there — so this hops to the UI thread rather than making every caller prove
+/// which thread it is on. Posting even when already on the UI thread is
+/// deliberate: it keeps one code path, and the timeout is the backstop if the
+/// hop is somehow never serviced.
+pub fn cancel_pane_any_thread(block_id: &str) {
+    let mut task = CancelPaneTask::new(block_id.to_string());
+    cef::post_task(cef::ThreadId::UI, Some(&mut task));
+}
+
+wrap_task! {
+    pub(crate) struct CancelPaneTask {
+        block_id: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            cancel_pane(&self.block_id);
+        }
+    }
+}
+
+/// Apply a user's answer on the UI thread, recording a grant when allowed.
+///
+/// The grant is recorded only on the resolve path that actually found a live
+/// entry — a duplicate or timed-out answer must not retroactively create a
+/// grant for a request that was already denied.
+wrap_task! {
+    pub(crate) struct RespondTask {
+        id: u64,
+        allow: bool,
+        state: std::sync::Arc<crate::state::AppState>,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let Some((block_id, origin, requested)) = resolve(self.id, self.allow) else {
+                return; // unknown id, double answer, or already timed out
+            };
+            if self.allow {
+                self.state
+                    .media_grants
+                    .lock()
+                    .grant(&block_id, &origin, requested);
+                tracing::info!(
+                    target: "pane-media",
+                    %block_id, %origin, requested,
+                    "recorded media grant"
+                );
+            }
+        }
+    }
+}
+
+/// True while `id` is still awaiting an answer. For the timeout task.
+fn is_pending(id: u64) -> bool {
+    PENDING.with(|p| p.borrow().contains_key(&id))
+}
+
+/// Arm the safety-net denial for a parked request.
+///
+/// Split from [`park`] so the caller emits its prompt event first; the delay
+/// dwarfs that ordering either way, but the dependency is explicit.
+pub fn arm_timeout(id: u64) {
+    let mut task = TimeoutTask::new(id);
+    cef::post_delayed_task(cef::ThreadId::UI, Some(&mut task), PROMPT_TIMEOUT_MS);
+}
+
+wrap_task! {
+    pub(crate) struct TimeoutTask {
+        id: u64,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            if !is_pending(self.id) {
+                return; // already answered — the common case
+            }
+            tracing::warn!(
+                target: "pane-media",
+                request_id = self.id,
+                timeout_ms = PROMPT_TIMEOUT_MS,
+                "media permission prompt went unanswered — denying"
+            );
+            resolve(self.id, false);
+        }
+    }
+}

--- a/agentmux-cef/src/browser_panes/media_prompt.rs
+++ b/agentmux-cef/src/browser_panes/media_prompt.rs
@@ -34,6 +34,22 @@ use std::collections::HashMap;
 
 use cef::*;
 
+/// The one thing a parked request can have done to it.
+///
+/// Exists so the registry's exactly-once logic can be tested without a real
+/// `MediaAccessCallback` — that type needs a live CEF process, which
+/// `cargo test` does not have (the same constraint recorded in PR #2890). The
+/// invariant this module rests on is worth more than the indirection costs.
+pub trait MediaContinuation {
+    fn continue_with(&self, allowed: u32);
+}
+
+impl MediaContinuation for MediaAccessCallback {
+    fn continue_with(&self, allowed: u32) {
+        self.cont(allowed);
+    }
+}
+
 /// How long a prompt may stay unanswered before it is denied.
 ///
 /// Long enough for a person to read and decide; short enough that a page whose
@@ -43,16 +59,67 @@ use cef::*;
 const PROMPT_TIMEOUT_MS: i64 = 60_000;
 
 thread_local! {
-    /// UI-thread-only registry of parked requests, keyed by request id.
-    static PENDING: RefCell<HashMap<u64, PendingRequest>> = RefCell::new(HashMap::new());
+    /// UI-thread-only registry of parked requests.
+    static REGISTRY: RefCell<Registry> = RefCell::new(Registry::default());
+}
 
-    /// Monotonic source of request ids. Thread-local like the map it keys, so
-    /// there is no cross-thread counter to reason about.
-    static NEXT_ID: RefCell<u64> = const { RefCell::new(1) };
+/// The park/resolve/cancel bookkeeping, with no threading or CEF in it.
+///
+/// Split out purely so it can be tested — the public functions below add the
+/// UI-thread assertions and the thread-local, neither of which a unit test can
+/// satisfy.
+#[derive(Default)]
+struct Registry {
+    pending: HashMap<u64, PendingRequest>,
+    next_id: u64,
+}
+
+impl Registry {
+    fn park(
+        &mut self,
+        callback: Box<dyn MediaContinuation>,
+        block_id: &str,
+        origin: &str,
+        requested: u32,
+    ) -> u64 {
+        self.next_id += 1;
+        let id = self.next_id;
+        self.pending.insert(
+            id,
+            PendingRequest {
+                callback,
+                block_id: block_id.to_string(),
+                origin: origin.to_string(),
+                requested,
+            },
+        );
+        id
+    }
+
+    /// Remove BEFORE continuing, so no second path can continue the same
+    /// callback twice — that would be a use-after-continue into CEF.
+    fn resolve(&mut self, id: u64, allow: bool) -> Option<(String, String, u32)> {
+        let req = self.pending.remove(&id)?;
+        let allowed = if allow { req.requested } else { 0 };
+        req.callback.continue_with(allowed);
+        Some((req.block_id, req.origin, req.requested))
+    }
+
+    fn ids_for_pane(&self, block_id: &str) -> Vec<u64> {
+        self.pending
+            .iter()
+            .filter(|(_, r)| r.block_id == block_id)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    fn is_pending(&self, id: u64) -> bool {
+        self.pending.contains_key(&id)
+    }
 }
 
 struct PendingRequest {
-    callback: MediaAccessCallback,
+    callback: Box<dyn MediaContinuation>,
     block_id: String,
     origin: String,
     /// Exactly the bits the page asked for. Echoed verbatim on allow — CEF
@@ -72,24 +139,7 @@ pub fn park(callback: MediaAccessCallback, block_id: &str, origin: &str, request
         0,
         "media prompts must be parked on the CEF UI thread"
     );
-    let id = NEXT_ID.with(|n| {
-        let mut n = n.borrow_mut();
-        let id = *n;
-        *n += 1;
-        id
-    });
-    PENDING.with(|p| {
-        p.borrow_mut().insert(
-            id,
-            PendingRequest {
-                callback,
-                block_id: block_id.to_string(),
-                origin: origin.to_string(),
-                requested,
-            },
-        );
-    });
-    id
+    REGISTRY.with(|r| r.borrow_mut().park(Box::new(callback), block_id, origin, requested))
 }
 
 /// Resolve a parked request. `None` if it is already gone — an unknown id, a
@@ -105,23 +155,17 @@ pub fn resolve(id: u64, allow: bool) -> Option<(String, String, u32)> {
         0,
         "media prompts must be resolved on the CEF UI thread"
     );
-    // Remove BEFORE continuing: the entry must be unreachable by the time the
-    // callback is used, so no second path can continue it again.
-    let Some(req) = PENDING.with(|p| p.borrow_mut().remove(&id)) else {
-        return None;
-    };
-    let allowed = if allow { req.requested } else { 0 };
-    req.callback.cont(allowed);
-    tracing::info!(
-        target: "pane-media",
-        request_id = id,
-        block_id = %req.block_id,
-        origin = %req.origin,
-        requested = req.requested,
-        allowed,
-        "resolved media permission prompt"
-    );
-    Some((req.block_id, req.origin, req.requested))
+    let out = REGISTRY.with(|r| r.borrow_mut().resolve(id, allow));
+    if let Some((block_id, origin, requested)) = out.as_ref() {
+        tracing::info!(
+            target: "pane-media",
+            request_id = id,
+            %block_id, %origin, requested,
+            allowed = if allow { *requested } else { 0 },
+            "resolved media permission prompt"
+        );
+    }
+    out
 }
 
 /// Deny every pending request belonging to one pane.
@@ -130,13 +174,7 @@ pub fn resolve(id: u64, allow: bool) -> Option<(String, String, u32)> {
 /// is nothing a later "allow" could sensibly mean.
 pub fn cancel_pane(block_id: &str) {
     debug_assert_ne!(cef::currently_on(cef::ThreadId::UI), 0);
-    let ids: Vec<u64> = PENDING.with(|p| {
-        p.borrow()
-            .iter()
-            .filter(|(_, r)| r.block_id == block_id)
-            .map(|(id, _)| *id)
-            .collect()
-    });
+    let ids: Vec<u64> = REGISTRY.with(|r| r.borrow().ids_for_pane(block_id));
     for id in ids {
         resolve(id, false);
     }
@@ -144,12 +182,22 @@ pub fn cancel_pane(block_id: &str) {
 
 /// Cancel a pane's prompts from any thread.
 ///
-/// The registry is UI-thread-only, but teardown paths are not guaranteed to run
-/// there — so this hops to the UI thread rather than making every caller prove
-/// which thread it is on. Posting even when already on the UI thread is
-/// deliberate: it keeps one code path, and the timeout is the backstop if the
-/// hop is somehow never serviced.
+/// **Cancels synchronously when already on the UI thread**, which is the case
+/// that matters. Teardown clears a pane's grants synchronously and may then
+/// recreate a pane for the same block id in the very next statement
+/// (`replay_pending_create`). If cancellation were merely *posted*, a pending
+/// "allow" could still be resolved after that replay and grant the NEW pane
+/// access the user never approved for it — the exact hazard the clear-before-
+/// replay ordering exists to prevent (reagent P2 on PR #2899).
+///
+/// Off the UI thread there is no way to touch the registry directly, so it
+/// posts. That path is strictly best-effort ordering-wise; the timeout remains
+/// the backstop.
 pub fn cancel_pane_any_thread(block_id: &str) {
+    if cef::currently_on(cef::ThreadId::UI) != 0 {
+        cancel_pane(block_id);
+        return;
+    }
     let mut task = CancelPaneTask::new(block_id.to_string());
     cef::post_task(cef::ThreadId::UI, Some(&mut task));
 }
@@ -200,7 +248,7 @@ wrap_task! {
 
 /// True while `id` is still awaiting an answer. For the timeout task.
 fn is_pending(id: u64) -> bool {
-    PENDING.with(|p| p.borrow().contains_key(&id))
+    REGISTRY.with(|r| r.borrow().is_pending(id))
 }
 
 /// Arm the safety-net denial for a parked request.
@@ -230,5 +278,116 @@ wrap_task! {
             );
             resolve(self.id, false);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    /// Records every continuation, so a double-continue is observable rather
+    /// than silently fine.
+    #[derive(Default)]
+    struct FakeCallback {
+        calls: Rc<RefCell<Vec<u32>>>,
+    }
+
+    impl MediaContinuation for FakeCallback {
+        fn continue_with(&self, allowed: u32) {
+            self.calls.borrow_mut().push(allowed);
+        }
+    }
+
+    fn park(reg: &mut Registry, block: &str, requested: u32) -> (u64, Rc<RefCell<Vec<u32>>>) {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let cb = FakeCallback { calls: calls.clone() };
+        let id = reg.park(Box::new(cb), block, "https://example.com", requested);
+        (id, calls)
+    }
+
+    const VIDEO: u32 = 1 << 1;
+
+    #[test]
+    fn allow_continues_with_exactly_the_requested_bits() {
+        // CEF requires allowed_permissions to MATCH required_permissions —
+        // echoing anything else denies the whole request.
+        let mut reg = Registry::default();
+        let (id, calls) = park(&mut reg, "b1", VIDEO);
+        reg.resolve(id, true);
+        assert_eq!(*calls.borrow(), vec![VIDEO]);
+    }
+
+    #[test]
+    fn deny_continues_with_zero() {
+        let mut reg = Registry::default();
+        let (id, calls) = park(&mut reg, "b1", VIDEO);
+        reg.resolve(id, false);
+        assert_eq!(*calls.borrow(), vec![0]);
+    }
+
+    #[test]
+    fn a_request_is_continued_exactly_once_even_if_answered_twice() {
+        // THE invariant. A user answer racing the timeout must not continue the
+        // same CEF callback twice — that would be a use-after-continue.
+        let mut reg = Registry::default();
+        let (id, calls) = park(&mut reg, "b1", VIDEO);
+
+        assert!(reg.resolve(id, true).is_some());
+        assert!(reg.resolve(id, true).is_none(), "second answer must be a no-op");
+        assert!(reg.resolve(id, false).is_none(), "and so must a later deny");
+
+        assert_eq!(*calls.borrow(), vec![VIDEO], "continued exactly once");
+    }
+
+    #[test]
+    fn resolving_an_unknown_id_is_a_silent_no_op() {
+        let mut reg = Registry::default();
+        assert!(reg.resolve(999, true).is_none());
+    }
+
+    #[test]
+    fn resolve_reports_what_is_needed_to_record_a_grant() {
+        let mut reg = Registry::default();
+        let (id, _) = park(&mut reg, "b1", VIDEO);
+        let out = reg.resolve(id, true).expect("resolved");
+        assert_eq!(out, ("b1".to_string(), "https://example.com".to_string(), VIDEO));
+    }
+
+    #[test]
+    fn ids_are_unique_across_parks() {
+        let mut reg = Registry::default();
+        let (a, _) = park(&mut reg, "b1", VIDEO);
+        let (b, _) = park(&mut reg, "b1", VIDEO);
+        assert_ne!(a, b, "a reused id would let one answer resolve the wrong request");
+    }
+
+    #[test]
+    fn cancelling_a_pane_denies_only_that_panes_requests() {
+        let mut reg = Registry::default();
+        let (keep, keep_calls) = park(&mut reg, "other", VIDEO);
+        let (a, a_calls) = park(&mut reg, "doomed", VIDEO);
+        let (b, b_calls) = park(&mut reg, "doomed", VIDEO);
+
+        for id in reg.ids_for_pane("doomed") {
+            reg.resolve(id, false);
+        }
+
+        assert_eq!(*a_calls.borrow(), vec![0]);
+        assert_eq!(*b_calls.borrow(), vec![0]);
+        assert!(keep_calls.borrow().is_empty(), "other panes untouched");
+        assert!(!reg.is_pending(a) && !reg.is_pending(b));
+        assert!(reg.is_pending(keep));
+    }
+
+    #[test]
+    fn is_pending_tracks_the_lifecycle_the_timeout_depends_on() {
+        // The timeout task skips already-answered requests using this; if it
+        // reported stale state the timeout would continue a dead callback.
+        let mut reg = Registry::default();
+        let (id, _) = park(&mut reg, "b1", VIDEO);
+        assert!(reg.is_pending(id));
+        reg.resolve(id, true);
+        assert!(!reg.is_pending(id));
     }
 }

--- a/agentmux-cef/src/browser_panes/mod.rs
+++ b/agentmux-cef/src/browser_panes/mod.rs
@@ -48,6 +48,7 @@ use crate::state::AppState;
 mod clip;
 mod close;
 pub(crate) mod media_grants;
+pub(crate) mod media_prompt;
 mod navigation;
 mod zoom;
 

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -443,6 +443,48 @@ wrap_display_handler! {
     }
 
     impl DisplayHandler {
+        /// Live capture state for this browser — CEF's own signal, not an
+        /// inference from what we granted.
+        ///
+        /// A grant means "may capture"; this means "IS capturing right now",
+        /// which is what the §4 indicator has to show. Deriving the indicator
+        /// from grants instead would leave it lit after a page stopped using
+        /// the camera, training users to ignore it — the opposite of the point.
+        ///
+        /// Routed to the window that owns the pane, for the same reason the
+        /// prompt is (a torn-off pane's window, not unconditionally "main").
+        fn on_media_access_change(
+            &self,
+            browser: Option<&mut Browser>,
+            has_video_access: ::std::os::raw::c_int,
+            has_audio_access: ::std::os::raw::c_int,
+        ) {
+            let has_video_access = has_video_access != 0;
+            let has_audio_access = has_audio_access != 0;
+            let state = self.inner.lock().state.clone();
+            let Some(block_id) = browser.and_then(|b| state.block_id_for_browser(b)) else {
+                return; // main client or a browser that isn't a live pane
+            };
+            let window_label = state
+                .browser_pane_window_label(&block_id)
+                .unwrap_or_else(|| "main".to_string());
+            tracing::info!(
+                target: "pane-media",
+                %block_id, has_video_access, has_audio_access,
+                "pane media capture state changed"
+            );
+            crate::events::emit_event_to_window(
+                &state,
+                &window_label,
+                "pane-media-capture-changed",
+                &serde_json::json!({
+                    "blockId": block_id,
+                    "hasVideo": has_video_access,
+                    "hasAudio": has_audio_access,
+                }),
+            );
+        }
+
         fn on_title_change(&self, browser: Option<&mut Browser>, title: Option<&CefString>) {
             let mut inner = self.inner.lock();
             inner.on_title_change(browser, title);
@@ -851,19 +893,45 @@ wrap_permission_handler! {
                     requested = requested_permissions,
                     "prompting for media access — no grant covers this request"
                 );
-                // Emit to the MAIN window's DOM, not the pane's page: the
-                // prompt must not be renderable or spoofable by the content
-                // asking for permission (spec §3.5).
-                crate::events::emit_event_from_state(
+                // Route to the DOM of the window that actually OWNS this pane
+                // — not the pane's own page, and not unconditionally "main".
+                //
+                // Not the pane's page: the prompt must not be renderable or
+                // clickable by the content asking for permission (spec §3.5).
+                //
+                // Not "main": a pane torn off into a floating window lives in
+                // that window, so emitting to main (or to
+                // emit_event_from_state's unfiltered first_browser() fallback)
+                // would show the prompt in the wrong window — or nowhere — and
+                // the request would silently time out to denial. Same defect
+                // already fixed twice for other pane events (#2548, #2597).
+                let window_label = self
+                    .state
+                    .browser_pane_window_label(&block_id)
+                    .unwrap_or_else(|| "main".to_string());
+                let payload = serde_json::json!({
+                    "requestId": request_id,
+                    "blockId": block_id,
+                    "origin": origin,
+                    "requested": requested_permissions,
+                });
+                let delivered = crate::events::emit_event_to_window(
                     &self.state,
+                    &window_label,
                     "pane-media-permission-request",
-                    &serde_json::json!({
-                        "requestId": request_id,
-                        "blockId": block_id,
-                        "origin": origin,
-                        "requested": requested_permissions,
-                    }),
+                    &payload,
                 );
+                if !delivered {
+                    // Nothing can answer, so don't make the page wait out the
+                    // timeout for a prompt that was never shown.
+                    tracing::warn!(
+                        target: "pane-media",
+                        %origin, %block_id, %window_label, request_id,
+                        "no window to show the media prompt — denying immediately"
+                    );
+                    crate::browser_panes::media_prompt::resolve(request_id, false);
+                    return 1;
+                }
                 crate::browser_panes::media_prompt::arm_timeout(request_id);
             }
             1 // handled

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -828,15 +828,43 @@ wrap_permission_handler! {
                 );
                 cb.cont(requested_permissions);
             } else {
-                // Phase 2c prompts here instead of denying outright. Until then
-                // this is the same answer the pane got with no handler at all.
+                // No grant covers this — ask the user.
+                //
+                // The callback is retained rather than answered now. CEF
+                // permits exactly this: "call CefMediaAccessCallback methods
+                // either in this method or at a later time"
+                // (cef_permission_handler.h). Returning 1 without continuing
+                // means the page's getUserMedia stays pending until we answer.
+                //
+                // `park` takes ownership; `arm_timeout` guarantees an answer
+                // even if the prompt never renders or the user never responds,
+                // so the page cannot hang indefinitely.
+                let request_id = crate::browser_panes::media_prompt::park(
+                    cb.clone(),
+                    &block_id,
+                    &origin,
+                    requested_permissions,
+                );
                 tracing::info!(
                     target: "pane-media",
-                    %origin, %block_id,
+                    %origin, %block_id, request_id,
                     requested = requested_permissions,
-                    "denying media access — no grant covers this request (no prompt yet)"
+                    "prompting for media access — no grant covers this request"
                 );
-                cb.cont(0);
+                // Emit to the MAIN window's DOM, not the pane's page: the
+                // prompt must not be renderable or spoofable by the content
+                // asking for permission (spec §3.5).
+                crate::events::emit_event_from_state(
+                    &self.state,
+                    "pane-media-permission-request",
+                    &serde_json::json!({
+                        "requestId": request_id,
+                        "blockId": block_id,
+                        "origin": origin,
+                        "requested": requested_permissions,
+                    }),
+                );
+                crate::browser_panes::media_prompt::arm_timeout(request_id);
             }
             1 // handled
         }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -794,6 +794,39 @@ async fn route_command(
                 .set_pane_overlay_clip(state, &window_label, &rects);
             Ok(serde_json::json!(true))
         }
+        "pane_media_revoke" => {
+            // User-facing revoke. Two steps, and BOTH are required:
+            //
+            // 1. drop the grant, so the page cannot silently re-acquire; and
+            // 2. reload the pane, which is the ONLY guaranteed way to stop a
+            //    capture already in flight. CEF exposes no media-capture
+            //    termination API (verified against the headers), and asking the
+            //    page to stop its own tracks would make a security control
+            //    depend on the page's cooperation.
+            //
+            // Grant first, then reload — the reverse order lets the reloaded
+            // page re-request and be auto-allowed by the grant that is about to
+            // be removed.
+            //
+            // SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.7.
+            let block_id = args
+                .get("blockId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if block_id.is_empty() {
+                return Ok(serde_json::json!(false));
+            }
+            state.media_grants.lock().clear_pane(&block_id);
+            crate::browser_panes::media_prompt::cancel_pane_any_thread(&block_id);
+            tracing::info!(
+                target: "pane-media",
+                %block_id,
+                "revoking media access — grants cleared, reloading pane to stop any live capture"
+            );
+            state.browser_panes.reload(&block_id, state);
+            Ok(serde_json::json!(true))
+        }
         "pane_media_permission_respond" => {
             // The user's answer to a prompt raised by the browser-pane media
             // permission handler. `allow` records a grant for

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -794,6 +794,37 @@ async fn route_command(
                 .set_pane_overlay_clip(state, &window_label, &rects);
             Ok(serde_json::json!(true))
         }
+        "pane_media_permission_respond" => {
+            // The user's answer to a prompt raised by the browser-pane media
+            // permission handler. `allow` records a grant for
+            // (pane, origin, exactly the bits requested) and continues the
+            // page's getUserMedia; anything else denies.
+            //
+            // Hops to the CEF UI thread because the parked callback lives in a
+            // UI-thread-only registry (CefMediaAccessCallback is neither Send
+            // nor Sync). Unknown/duplicate ids resolve to a no-op there — an
+            // answer racing the timeout is ordinary, not an error.
+            //
+            // SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.4.
+            let request_id = args
+                .get("requestId")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let allow = args
+                .get("allow")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if request_id == 0 {
+                return Ok(serde_json::json!(false));
+            }
+            let mut task = crate::browser_panes::media_prompt::RespondTask::new(
+                request_id,
+                allow,
+                state.clone(),
+            );
+            cef::post_task(cef::ThreadId::UI, Some(&mut task));
+            Ok(serde_json::json!(true))
+        }
         "main_window_focus" => {
             // Move keyboard focus back to the main browser when the user
             // clicks a main-DOM input (address bar, etc). Previously this

--- a/frontend/app/window/pane-media-capture-indicator.tsx
+++ b/frontend/app/window/pane-media-capture-indicator.tsx
@@ -1,0 +1,163 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Live capture indicator + revoke for browser panes.
+ *
+ * Spec: `docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` §4, §3.7.
+ *
+ * §4 makes three things non-negotiable once a pane can capture at all:
+ * visible while live, revocable in one click, and a revoke that actually stops
+ * the stream rather than only preventing future ones. This component is the
+ * first two; the host command it calls is the third.
+ *
+ * # Driven by real capture state, not by grants
+ *
+ * The `pane-media-capture-changed` event comes from CEF's own
+ * `OnMediaAccessChange`, so the indicator reflects what is *actually being
+ * captured right now*. Deriving it from grants would leave it lit after a page
+ * stopped using the camera — an indicator that is on when nothing is happening
+ * teaches people to ignore it, which is worse than not having one.
+ *
+ * # Why it lives in window chrome rather than on the pane
+ *
+ * Panes are native surfaces; drawing over one means the airspace-clip
+ * machinery, and anything rendered *inside* the pane could be obscured or
+ * imitated by the page. Chrome-level placement also satisfies §4's "visible
+ * without focusing the pane".
+ */
+
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import { ConfirmModal } from "@/element/confirm-modal";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+
+interface CaptureChange {
+    blockId: string;
+    hasVideo: boolean;
+    hasAudio: boolean;
+}
+
+interface CapturingPane {
+    blockId: string;
+    hasVideo: boolean;
+    hasAudio: boolean;
+}
+
+/** What to call what's live, most-sensitive first. */
+export function describeCapture(hasVideo: boolean, hasAudio: boolean): string {
+    if (hasVideo && hasAudio) return "Camera and microphone in use";
+    if (hasVideo) return "Camera in use";
+    if (hasAudio) return "Microphone in use";
+    return "";
+}
+
+export function PaneMediaCaptureIndicator(): JSX.Element {
+    const [capturing, setCapturing] = createSignal<CapturingPane[]>([]);
+    const [confirmRevoke, setConfirmRevoke] = createSignal<string | null>(null);
+
+    onMount(() => {
+        let dispose: (() => void) | undefined;
+        void listenEvent<CaptureChange>("pane-media-capture-changed", (p) => {
+            if (!p || typeof p.blockId !== "string") return;
+            setCapturing((prev) => {
+                const rest = prev.filter((c) => c.blockId !== p.blockId);
+                // Neither device live → the pane drops off the list entirely,
+                // rather than lingering as an "off" row.
+                if (!p.hasVideo && !p.hasAudio) return rest;
+                return [...rest, { blockId: p.blockId, hasVideo: p.hasVideo, hasAudio: p.hasAudio }];
+            });
+        }).then((d) => {
+            dispose = d;
+        });
+        onCleanup(() => dispose?.());
+    });
+
+    const doRevoke = async (blockId: string) => {
+        setConfirmRevoke(null);
+        try {
+            await invokeCommand("pane_media_revoke", { blockId });
+        } catch (e) {
+            console.error("[pane-media] revoke failed", e);
+        }
+        // Don't optimistically clear the row: the authoritative signal is CEF's
+        // next OnMediaAccessChange. Clearing here would show "not capturing"
+        // even if the revoke failed — precisely the lie this indicator exists
+        // to prevent.
+    };
+
+    return (
+        <>
+            <Show when={capturing().length > 0}>
+                <div
+                    class="pane-media-capture-indicator"
+                    role="status"
+                    aria-live="polite"
+                    style={{
+                        position: "fixed",
+                        bottom: "12px",
+                        right: "12px",
+                        "z-index": 9998,
+                        display: "flex",
+                        "flex-direction": "column",
+                        gap: "6px",
+                    }}
+                >
+                    <For each={capturing()}>
+                        {(pane) => (
+                            <div
+                                style={{
+                                    display: "flex",
+                                    "align-items": "center",
+                                    gap: "10px",
+                                    padding: "6px 10px",
+                                    "border-radius": "6px",
+                                    background: "var(--error-color, #c22a2a)",
+                                    color: "#fff",
+                                    "font-size": "12px",
+                                    "box-shadow": "0 2px 8px rgba(0,0,0,0.35)",
+                                }}
+                            >
+                                <span aria-hidden="true">●</span>
+                                <span>{describeCapture(pane.hasVideo, pane.hasAudio)}</span>
+                                <button
+                                    onClick={() => setConfirmRevoke(pane.blockId)}
+                                    style={{
+                                        background: "rgba(255,255,255,0.18)",
+                                        color: "#fff",
+                                        border: "none",
+                                        "border-radius": "4px",
+                                        padding: "2px 8px",
+                                        cursor: "pointer",
+                                        "font-size": "12px",
+                                    }}
+                                >
+                                    Stop
+                                </button>
+                            </div>
+                        )}
+                    </For>
+                </div>
+            </Show>
+
+            <Show when={confirmRevoke()}>
+                {(blockId) => (
+                    <ConfirmModal
+                        open={true}
+                        scope="window"
+                        title="Stop camera and microphone access?"
+                        // The reload is not an implementation detail to hide.
+                        // CEF cannot terminate a live capture any other way
+                        // (§3.7), so stopping it genuinely costs the page's
+                        // state, and the user should know before clicking.
+                        description="The page will be reloaded to stop any capture already in progress. Anything unsaved on that page will be lost."
+                        confirmLabel="Stop and reload"
+                        destructive={true}
+                        onConfirm={() => void doRevoke(blockId())}
+                        onCancel={() => setConfirmRevoke(null)}
+                    />
+                )}
+            </Show>
+        </>
+    );
+}

--- a/frontend/app/window/pane-media-permission-prompt.test.ts
+++ b/frontend/app/window/pane-media-permission-prompt.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 import { describeRequestedDevices, displayOrigin } from "./pane-media-permission-prompt";
+import { describeCapture } from "./pane-media-capture-indicator";
 
 const AUDIO = 1 << 0;
 const VIDEO = 1 << 1;
@@ -69,5 +70,23 @@ describe("displayOrigin", () => {
 
     it("has a non-empty fallback for an empty origin", () => {
         expect(displayOrigin("")).toBe("This page");
+    });
+});
+
+describe("describeCapture (indicator)", () => {
+    it("names both devices when both are live", () => {
+        expect(describeCapture(true, true)).toBe("Camera and microphone in use");
+    });
+
+    it("names whichever single device is live", () => {
+        expect(describeCapture(true, false)).toBe("Camera in use");
+        expect(describeCapture(false, true)).toBe("Microphone in use");
+    });
+
+    it("says nothing when nothing is live", () => {
+        // The indicator drops the row entirely in this case; an "off" label
+        // would be an indicator that is visible while nothing is captured,
+        // which is what teaches people to ignore it.
+        expect(describeCapture(false, false)).toBe("");
     });
 });

--- a/frontend/app/window/pane-media-permission-prompt.test.ts
+++ b/frontend/app/window/pane-media-permission-prompt.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The prompt's user-facing strings. These are a security surface, not cosmetics:
+ * the user's decision rests entirely on correctly understanding *who* is asking
+ * and *for what*, so under-reporting either is the failure mode that matters.
+ */
+
+import { describe, expect, it } from "vitest";
+import { describeRequestedDevices, displayOrigin } from "./pane-media-permission-prompt";
+
+const AUDIO = 1 << 0;
+const VIDEO = 1 << 1;
+const DESKTOP_AUDIO = 1 << 2;
+const DESKTOP_VIDEO = 1 << 3;
+
+describe("describeRequestedDevices", () => {
+    it("names a single device", () => {
+        expect(describeRequestedDevices(VIDEO)).toBe("camera");
+        expect(describeRequestedDevices(AUDIO)).toBe("microphone");
+    });
+
+    it("names a combined request with both devices", () => {
+        // The case CEF's exact-match rule makes common: {audio, video} is one
+        // indivisible request, so the prompt must say both.
+        expect(describeRequestedDevices(AUDIO | VIDEO)).toBe("camera and microphone");
+    });
+
+    it("names desktop capture distinctly from device capture", () => {
+        expect(describeRequestedDevices(DESKTOP_VIDEO)).toBe("screen contents");
+        expect(describeRequestedDevices(DESKTOP_AUDIO)).toBe("system audio");
+    });
+
+    it("lists three or more with commas and a trailing 'and'", () => {
+        expect(describeRequestedDevices(AUDIO | VIDEO | DESKTOP_VIDEO)).toBe(
+            "camera, microphone and screen contents",
+        );
+    });
+
+    it("surfaces unknown bits instead of silently dropping them", () => {
+        // If CEF adds a permission bit we don't know, the prompt must not
+        // under-report what the page asked for — the user would be agreeing to
+        // something invisible.
+        const unknown = 1 << 9;
+        expect(describeRequestedDevices(VIDEO | unknown)).toBe("camera and other media devices");
+        expect(describeRequestedDevices(unknown)).toBe("other media devices");
+    });
+
+    it("never returns an empty description", () => {
+        expect(describeRequestedDevices(0)).toBe("media devices");
+    });
+});
+
+describe("displayOrigin", () => {
+    it("shows the host, not the full URL", () => {
+        expect(displayOrigin("https://example.com")).toBe("example.com");
+        expect(displayOrigin("https://sub.example.com:8443")).toBe("sub.example.com:8443");
+    });
+
+    it("does not let a long path push the real origin out of view", () => {
+        // Spoofing shape: a path crafted to read like a different site.
+        expect(displayOrigin("https://evil.test/https://bank.example.com/login")).toBe("evil.test");
+    });
+
+    it("falls back to the raw string rather than showing nothing", () => {
+        expect(displayOrigin("not a url")).toBe("not a url");
+    });
+
+    it("has a non-empty fallback for an empty origin", () => {
+        expect(displayOrigin("")).toBe("This page");
+    });
+});

--- a/frontend/app/window/pane-media-permission-prompt.tsx
+++ b/frontend/app/window/pane-media-permission-prompt.tsx
@@ -1,0 +1,144 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Media-permission prompt for browser panes (camera / microphone).
+ *
+ * Spec: `docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` §3.5.
+ *
+ * # Why this lives in the main window's DOM
+ *
+ * The pane asking for permission is arbitrary web content on a native surface.
+ * Rendering the prompt inside that pane would let the page draw something that
+ * looks exactly like it — the classic permission-spoofing shape. The host emits
+ * this event to the **main** browser only (`emit_event_from_state`), so the
+ * prompt is AgentMux chrome the page cannot reach, draw over, or click for the
+ * user.
+ *
+ * # Deny is the default everywhere
+ *
+ * `destructive` puts initial focus on Cancel and makes Allow the non-default
+ * action. Dismissal (Escape, backdrop) denies. If this component never mounts
+ * or never answers, the host's own timeout denies. There is no path where
+ * silence becomes permission.
+ */
+
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import { ConfirmModal } from "@/element/confirm-modal";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+
+/** Mirrors `cef_media_access_permission_types_t`. */
+const DEVICE_AUDIO_CAPTURE = 1 << 0;
+const DEVICE_VIDEO_CAPTURE = 1 << 1;
+const DESKTOP_AUDIO_CAPTURE = 1 << 2;
+const DESKTOP_VIDEO_CAPTURE = 1 << 3;
+
+interface PermissionRequest {
+    requestId: number;
+    blockId: string;
+    origin: string;
+    requested: number;
+}
+
+/**
+ * Human names for exactly the bits requested.
+ *
+ * Named precisely rather than generically ("wants to use your camera and
+ * microphone", not "wants media access") because the whole decision rests on
+ * the user knowing what they are agreeing to. Unknown bits are surfaced rather
+ * than dropped — silently under-reporting what a page asked for would be the
+ * worst possible failure here.
+ */
+export function describeRequestedDevices(bits: number): string {
+    const names: string[] = [];
+    if (bits & DEVICE_VIDEO_CAPTURE) names.push("camera");
+    if (bits & DEVICE_AUDIO_CAPTURE) names.push("microphone");
+    if (bits & DESKTOP_VIDEO_CAPTURE) names.push("screen contents");
+    if (bits & DESKTOP_AUDIO_CAPTURE) names.push("system audio");
+
+    const known =
+        DEVICE_AUDIO_CAPTURE | DEVICE_VIDEO_CAPTURE | DESKTOP_AUDIO_CAPTURE | DESKTOP_VIDEO_CAPTURE;
+    if (bits & ~known) names.push("other media devices");
+
+    if (names.length === 0) return "media devices";
+    if (names.length === 1) return names[0];
+    return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+/**
+ * Origin as shown to the user.
+ *
+ * Displays the host only — a full URL invites spoofing via a long path that
+ * pushes the real origin out of view, and the grant is origin-scoped anyway, so
+ * the host is the honest unit. Falls back to the raw string if it will not
+ * parse, rather than showing nothing.
+ */
+export function displayOrigin(origin: string): string {
+    try {
+        return new URL(origin).host || origin;
+    } catch {
+        return origin || "This page";
+    }
+}
+
+export function PaneMediaPermissionPrompt(): JSX.Element {
+    const [request, setRequest] = createSignal<PermissionRequest | null>(null);
+
+    onMount(() => {
+        let dispose: (() => void) | undefined;
+        void listenEvent<PermissionRequest>("pane-media-permission-request", (payload) => {
+            if (!payload || typeof payload.requestId !== "number") return;
+            // One prompt at a time. A second request while one is open would
+            // otherwise replace it, and the user's click would land on a
+            // different question than the one they read. The displaced request
+            // is denied immediately rather than left parked.
+            const current = request();
+            if (current) {
+                void respond(current.requestId, false);
+            }
+            setRequest(payload);
+        }).then((d) => {
+            dispose = d;
+        });
+        onCleanup(() => dispose?.());
+    });
+
+    const respond = async (requestId: number, allow: boolean) => {
+        try {
+            await invokeCommand("pane_media_permission_respond", { requestId, allow });
+        } catch (e) {
+            // The host's timeout still denies, so a failed response degrades to
+            // denial rather than a stuck page.
+            console.error("[pane-media] failed to deliver permission response", e);
+        }
+    };
+
+    const answer = (allow: boolean) => {
+        const req = request();
+        if (!req) return;
+        setRequest(null);
+        void respond(req.requestId, allow);
+    };
+
+    return (
+        <Show when={request()}>
+            {(req) => (
+                <ConfirmModal
+                    open={true}
+                    scope="window"
+                    // Attributed to the SITE, not to AgentMux — the user is
+                    // deciding about the page, and a prompt that reads like an
+                    // app prompt trains people to accept them.
+                    title={`${displayOrigin(req().origin)} wants to use your ${describeRequestedDevices(req().requested)}`}
+                    description="This page is running in a browser pane. You can revoke access later from the pane."
+                    confirmLabel="Allow"
+                    cancelLabel="Don't allow"
+                    destructive={true}
+                    onConfirm={() => answer(true)}
+                    onCancel={() => answer(false)}
+                />
+            )}
+        </Show>
+    );
+}

--- a/frontend/app/window/pane-media-permission-prompt.tsx
+++ b/frontend/app/window/pane-media-permission-prompt.tsx
@@ -11,9 +11,10 @@
  * The pane asking for permission is arbitrary web content on a native surface.
  * Rendering the prompt inside that pane would let the page draw something that
  * looks exactly like it — the classic permission-spoofing shape. The host emits
- * this event to the **main** browser only (`emit_event_from_state`), so the
- * prompt is AgentMux chrome the page cannot reach, draw over, or click for the
- * user.
+ * this event to the DOM of the window that *owns* the pane (not to the pane's
+ * page, and not unconditionally to "main" — a torn-off pane lives in its
+ * floating window), so the prompt is AgentMux chrome the page cannot reach,
+ * draw over, or click for the user.
  *
  * # Deny is the default everywhere
  *
@@ -131,7 +132,7 @@ export function PaneMediaPermissionPrompt(): JSX.Element {
                     // deciding about the page, and a prompt that reads like an
                     // app prompt trains people to accept them.
                     title={`${displayOrigin(req().origin)} wants to use your ${describeRequestedDevices(req().requested)}`}
-                    description="This page is running in a browser pane. You can revoke access later from the pane."
+                    description="This page is running in a browser pane. While it is capturing, an indicator appears with a Stop button."
                     confirmLabel="Allow"
                     cancelLabel="Don't allow"
                     destructive={true}

--- a/frontend/app/workspace/workspace.tsx
+++ b/frontend/app/workspace/workspace.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
 import { PaneMediaPermissionPrompt } from "@/app/window/pane-media-permission-prompt";
+import { PaneMediaCaptureIndicator } from "@/app/window/pane-media-capture-indicator";
 import { StatusBar } from "@/app/statusbar/StatusBar";
 import { WindowHeader } from "@/app/window/window-header";
 import { TabContent } from "@/app/tab/tabcontent";
@@ -98,6 +99,7 @@ function WorkspaceElem(): JSX.Element {
                         click it — see the component's own doc comment and
                         SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.5. */}
                     <PaneMediaPermissionPrompt />
+                    <PaneMediaCaptureIndicator />
                 </ErrorBoundary>
             </div>
             <StatusBar />

--- a/frontend/app/workspace/workspace.tsx
+++ b/frontend/app/workspace/workspace.tsx
@@ -4,6 +4,7 @@
 import { ErrorBoundary } from "@/app/element/errorboundary";
 import { CenteredDiv } from "@/app/element/quickelems";
 import { ModalsRenderer } from "@/app/modals/modalsrenderer";
+import { PaneMediaPermissionPrompt } from "@/app/window/pane-media-permission-prompt";
 import { StatusBar } from "@/app/statusbar/StatusBar";
 import { WindowHeader } from "@/app/window/window-header";
 import { TabContent } from "@/app/tab/tabcontent";
@@ -92,6 +93,11 @@ function WorkspaceElem(): JSX.Element {
                         </For>
                     </Show>
                     <ModalsRenderer />
+                    {/* Camera/mic prompts for browser panes. Mounted in the
+                        main window's DOM so the requesting page cannot draw or
+                        click it — see the component's own doc comment and
+                        SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md §3.5. */}
+                    <PaneMediaPermissionPrompt />
                 </ErrorBoundary>
             </div>
             <StatusBar />


### PR DESCRIPTION
**The first phase that changes behaviour.** A browser pane can now obtain camera or microphone access — but only after the user explicitly allows it. Before this, `getUserMedia` in a pane failed with `NotAllowedError` unconditionally (#2871).

Flow: pane requests → no grant covers it → **the callback is parked** → the main window prompts → user answers → grant recorded, callback continued with exactly the bits requested.

Retaining the callback is what Phase 0 (#2885) verified CEF permits: *"call `CefMediaAccessCallback` methods either in this method **or at a later time**."*

## The threading constraint drove the design

`MediaAccessCallback` is a `RefGuard` with **no `Send`/`Sync`**, and must be used on the CEF UI thread. So it cannot live in `AppState`. Pending requests live in a **UI-thread-local registry**, and every mutation routes through a posted task; `debug_assert`s pin that.

## The invariant: every parked request resolves exactly once, and always eventually

- **`resolve()` removes the entry *before* continuing the callback.** A user answer racing the timeout therefore can't continue the same callback twice — that would be a use-after-continue into CEF.
- **Every park arms a 60s timeout.** A prompt that never renders (window closed, renderer crashed, event dropped) degrades to *denial* rather than hanging the page's `getUserMedia` forever.
- **Both teardown paths cancel a pane's pending prompts.**

## Also closes the drain-path gap Codex found on #2897

`drain_closed_label` is a **second** teardown path — CEF-initiated, on crash or a pane closing itself — that removes the reducer entry without going through `close()`. So `close()`'s cleanup never runs for it, and a later `close()` returns early because the entry is gone.

Grants left behind there would be inherited by a recreated pane with the same block id — and **`replay_pending_create` runs in that very block**, so the recreation is immediate. Cleared *before* the replay, not after.

## Prompt design — deny-biased throughout

- **Rendered in the main window's DOM, never the pane's.** The requesting page is arbitrary web content on a native surface; a prompt inside it could be drawn or clicked by the page itself.
- **Titled with the site and the exact devices** — *"example.com wants to use your camera and microphone"* — attributed to the page, not to AgentMux. A prompt that reads like an app prompt trains people to accept them.
- **`destructive`**: initial focus on "Don't allow"; Escape and backdrop deny.
- **Unknown permission bits surface as "other media devices"** rather than being dropped. If CEF adds a bit we don't know, under-reporting what a page asked for is the worst possible failure here.
- **Origin shown as host only**, so a crafted long path can't push the real origin out of view (tested with `https://evil.test/https://bank.example.com/login` → `evil.test`).
- **A second request while one is open denies the displaced one** rather than silently swapping the question under the user's cursor.

## Test plan

- `cargo test -p agentmux-cef` — 303/303
- `npx vitest run frontend/app/window frontend/app/store` — 799/799 (10 new, covering the device-naming and origin-display security surface)
- `tsc --noEmit` — clean

**Not yet verified end-to-end.** The parked-callback path needs a real `getUserMedia` page in a running build. I'm building a portable to exercise it and will report the result here before this merges — reviewer approval alone shouldn't land an async CEF-callback lifetime change unobserved.

<!-- agentmux:agent_id=agenty -->