### PR TITLE
Manoz@Area54: feat(armory): drop the host CLI config block from Global Memory

### DIFF
--- a/.changesets/1788273379-feat-armory-drop-the-host-cli-config-block-from-global-memor-mgtl.md
+++ b/.changesets/1788273379-feat-armory-drop-the-host-cli-config-block-from-global-memor-mgtl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(armory): drop the host CLI config block from Global Memory

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -239,8 +239,8 @@ pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
 /// companion when foreign), written by `agent_config.rs`'s
 /// `write_claude_md_respecting_ownership`, a per-agent path this command
 /// does not cover. This command exists purely to surface a
-/// Claude-Code-managed reference file for operator visibility ("External
-/// Claude Code files" section — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
+/// Claude-Code-managed reference file for operator visibility ("Claude
+/// Code provider config" section — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
 /// §7 is the main feature this whole spec chain converged on). No
 /// parameters (the path is fixed, not caller-supplied — no
 /// path-traversal surface) and no write counterpart. See

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -260,7 +260,6 @@ pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
 /// command/its UI badge dropped the word entirely rather than picking a
 /// second meaning for it. No parameters, no write counterpart. See
 /// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
-pub const COMMAND_GET_CLAUDE_HOST_CONFIG: &str = "getclaudehostconfig";
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -246,20 +246,6 @@ pub const COMMAND_DELETE_SYSTEM_MEMORY: &str = "deletesystemmemory";
 /// path-traversal surface) and no write counterpart. See
 /// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5, §7.
 pub const COMMAND_GET_CLAUDE_GLOBAL_CONFIG: &str = "getclaudeglobalconfig";
-/// Read-only. Returns `~/.claude/CLAUDE.md` — Claude Code's own global
-/// config, read by a host-level Claude Code CLI running outside
-/// AgentMux's `CLAUDE_CONFIG_DIR` isolation entirely (e.g. an external
-/// coding-agent harness). Deliberately a SEPARATE command/block from
-/// `getclaudeglobalconfig` above rather than a replacement — the two
-/// paths have different audiences and neither implies coverage of the
-/// other; both are "External Claude Code files" reference displays, not
-/// part of AgentMux's own Global Memory composition (see that command's
-/// doc comment). Renamed from `getclaudeambientconfig` (§7) — "ambient"
-/// already means something else in this codebase (`term:ambient_summary`,
-/// a per-turn activity paraphrase — see `activitySummary.ts`), so this
-/// command/its UI badge dropped the word entirely rather than picking a
-/// second meaning for it. No parameters, no write counterpart. See
-/// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
 
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";

--- a/agentmux-srv/src/server/agent_handlers/memory.rs
+++ b/agentmux-srv/src/server/agent_handlers/memory.rs
@@ -12,7 +12,7 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
     COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY, COMMAND_REORDER_GLOBAL_BRAIN,
     COMMAND_UPSERT_SYSTEM_MEMORY, COMMAND_DELETE_SYSTEM_MEMORY,
-    COMMAND_GET_CLAUDE_GLOBAL_CONFIG, COMMAND_GET_CLAUDE_HOST_CONFIG,
+    COMMAND_GET_CLAUDE_GLOBAL_CONFIG,
     CommandGetMemoryData, CommandDeleteMemoryData, CommandReorderGlobalBrainData,
 };
 use crate::backend::storage::store::Memory;
@@ -249,21 +249,6 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
-    // ---- Read-only: ~/.claude/CLAUDE.md — Claude Code's own global
-    // config, read by a host-level CLI outside AgentMux's CLAUDE_CONFIG_DIR
-    // isolation. A SEPARATE block from the one above, not a replacement —
-    // see docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
-    engine.register_handler(
-        COMMAND_GET_CLAUDE_HOST_CONFIG,
-        Box::new(move |_data, _ctx| {
-            Box::pin(async move {
-                let claude_dir = crate::backend::base::get_home_dir().join(".claude");
-                let result = read_claude_global_config(&claude_dir)
-                    .map_err(|e| format!("getclaudehostconfig: {e}"))?;
-                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
-            })
-        }),
-    );
 }
 
 /// The directory a spawned Claude agent's `CLAUDE_CONFIG_DIR` env var
@@ -315,11 +300,10 @@ fn read_claude_global_config(claude_dir: &std::path::Path) -> std::io::Result<Cl
     Ok(ClaudeGlobalConfig { path: path.to_string_lossy().into_owned(), content, exists })
 }
 
-// Covers both getclaudeglobalconfig (resolve_shared_claude_provider_dir)
-// and getclaudehostconfig (~/.claude) — both handlers call this same
-// generic function against different directories, so exists/missing/
-// empty-file coverage here applies to both call sites. See
-// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
+// Covers getclaudeglobalconfig (resolve_shared_claude_provider_dir).
+// The sibling getclaudehostconfig (~/.claude) handler was removed
+// 2026-09-01 — SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md.
+// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §5.
 #[cfg(test)]
 mod claude_global_config_tests {
     use super::*;

--- a/docs/specs/SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md
+++ b/docs/specs/SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md
@@ -1,0 +1,83 @@
+# Spec: Drop the "Claude Code — host CLI config" block from Armory Global Memory
+
+**Date:** 2026-09-01
+**Status:** Proposed
+**Motivated by:** direct request — *"now that we know leaks are squashed, we
+don't need the host cli config at all in the armory."*
+
+## Problem
+
+Armory → Memory → Global renders an "External Claude Code files" section with
+two read-only reference blocks
+(`frontend/app/view/brain/global-brain-manager.tsx`):
+
+| Block | Path shown | Caption | Keep? |
+|---|---|---|---|
+| Claude Code — **shared provider config** | `DataPaths::provider_auth_dir("claude")` (`~/.agentmux/shared/providers/claude/CLAUDE.md`) | "Used by default spawned agents." | **Yes** |
+| Claude Code — **host CLI config** | `~/.claude/CLAUDE.md` | "Used outside AgentMux." | **No — remove** |
+
+The host block was added by
+`SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md` §6–§7 at a time when it was
+genuinely unclear which file a spawned agent read. That ambiguity is now
+resolved: `REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md` proved
+by controlled experiment that a spawned agent reads
+`$CLAUDE_CONFIG_DIR/CLAUDE.md` and — once seeded, which
+`prepare_provider_auth_dir()` now guarantees at every spawn — **never** the
+host file.
+
+So the host block now shows a file that has no bearing on any AgentMux agent.
+Its own tooltip already says as much ("Not read by spawned in-app agents").
+Surfacing a file in Armory whose entire description is "this does not affect
+anything here" is noise, and worse, it invites the misreading that editing it
+would change agent behaviour.
+
+## Design
+
+Remove the host-CLI-config block and its entire supporting chain. Keep the
+shared-provider block: that one shows the file agents genuinely do read, and
+is now *more* useful than before — post-fix it displays the AgentMux isolation
+placeholder, which is a direct, legible confirmation that isolation is in
+effect.
+
+### Frontend
+
+- `frontend/app/view/brain/global-brain-manager.tsx` — delete the second
+  `<Show when={model.claudeHostConfigAtom()}>` block; narrow the wrapping
+  `<Show>` condition to `model.claudeGlobalConfigAtom()` alone.
+- **Reword the section heading.** "External Claude Code files" only made sense
+  as a plural covering both. The single remaining block is not "external" at
+  all — it is AgentMux's own isolated provider dir. New heading: *"Claude Code
+  provider config — reference only, not part of Global Memory."* The
+  "reference only, not part of Global Memory" clause is load-bearing and stays
+  (it is what stops the block being mistaken for an editable Global Memory
+  section) — only the misleading "External … files" framing goes.
+- `frontend/app/view/brain/global-brain-model.ts` — remove the
+  `_claudeHostConfig` signal, `claudeHostConfigAtom`, `setClaudeHostConfig`,
+  and the `GetClaudeHostConfigCommand` fetch.
+- `frontend/app/store/rpc-api/memory.ts` — remove `GetClaudeHostConfigCommand`.
+- `frontend/app/view/brain/global-brain-model.test.ts` — remove the three
+  `claudeHostConfigAtom` tests.
+
+### Backend
+
+- `agentmux-srv/src/server/agent_handlers/memory.rs` — remove the
+  `COMMAND_GET_CLAUDE_HOST_CONFIG` handler.
+- `agentmux-srv/src/backend/rpc_types/commands.rs` — remove the
+  `COMMAND_GET_CLAUDE_HOST_CONFIG` constant.
+- **Keep** `read_claude_global_config()` and
+  `resolve_shared_claude_provider_dir()` — both still serve the surviving
+  `getclaudeglobalconfig` handler. Keep that function's tests; update the
+  module comment that currently says it "covers both" handlers, since it will
+  cover one.
+
+## Non-goals
+
+- **No change to the shared-provider block.** It is the useful half and gets
+  more useful post-isolation-fix.
+- **No change to isolation behaviour.** This is a pure UI/RPC-surface removal;
+  nothing here touches `prepare_provider_auth_dir()`, the seeding, or any
+  spawn path. Removing the *display* of the host file cannot affect whether it
+  is *read* — that is settled independently and proven.
+- **No removal of `SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md`.** It stays
+  as the record of why the block existed; this spec supersedes only its §6/§7
+  host-block half.

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -86,23 +86,6 @@ export const MemoryApi = {
         return client.rpcCall("getclaudeglobalconfig", data, opts);
     },
 
-    // Read-only. Returns ~/.claude/CLAUDE.md — Claude Code's own global
-    // config, read by a host-level CLI outside AgentMux's
-    // CLAUDE_CONFIG_DIR isolation. A SEPARATE block from
-    // GetClaudeGlobalConfigCommand above, not a replacement — both are
-    // "External Claude Code files" reference displays, not part of
-    // AgentMux's own Global Memory composition. Renamed from
-    // GetClaudeAmbientConfigCommand — "ambient" already means something
-    // else in this codebase (term:ambient_summary, activitySummary.ts).
-    // See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7.
-    // No parameters, no write counterpart.
-    GetClaudeHostConfigCommand(
-        client: RpcClient,
-        data: Record<string, never> = {},
-        opts?: RpcOpts,
-    ): Promise<{ path: string; content: string | null; exists: boolean }> {
-        return client.rpcCall("getclaudehostconfig", data, opts);
-    },
 
     NativeMemoryListCommand(client: RpcClient, data: { agent_id: string }, opts?: RpcOpts): Promise<NativeMemoryListResult> {
         return client.rpcCall("agent:memory:list", data, opts);

--- a/frontend/app/store/rpc-api/memory.ts
+++ b/frontend/app/store/rpc-api/memory.ts
@@ -75,7 +75,7 @@ export const MemoryApi = {
     // is Claude Code's own home-relocation path, NOT the file AgentMux's
     // Global Memory actually composes into (that's
     // <agent working_directory>/CLAUDE.md, a per-agent path this doesn't
-    // cover) — this is an "External Claude Code files" reference display
+    // cover) — this is a "Claude Code provider config" reference display
     // only. See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md
     // §5, §7. No parameters, no write counterpart.
     GetClaudeGlobalConfigCommand(

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -1,11 +1,13 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Covers the read-only "External Claude Code files" displays in
-// GlobalBrainManager (files Claude Code itself manages, NOT part of
-// AgentMux's own Global Memory composition — codex P1, PR #2794; renamed
-// from "ambient" in PR follow-up, see §7 for why).
-// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4, §7.
+// Covers the read-only "Claude Code provider config" display in
+// GlobalBrainManager — the CLAUDE.md in the isolated config dir a spawned
+// agent actually launches with, NOT part of AgentMux's own Global Memory
+// composition (codex P1, PR #2794).
+// See docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §4, §7 and
+// docs/specs/SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md (which
+// removed the sibling ~/.claude host-CLI-config display).
 
 import { cleanup, render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -86,11 +88,6 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         expect(block?.querySelector("button")).toBeNull();
     });
 });
-
-// docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6/§7 — a
-// SEPARATE block, independently fetched, rendered alongside the
-// shared-provider-config block above, under the same "External Claude
-// Code files" heading.
 
 // The former "GlobalBrainManager host-config block" describe (and the
 // "both blocks render under the shared heading" test) were removed with the

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -55,9 +55,10 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
         expect(screen.getByText("/home/user/.agentmux/shared/providers/claude/CLAUDE.md")).toBeInTheDocument();
         expect(screen.getByText("# Global rules")).toBeInTheDocument();
-        // Scoped to this block — the sibling host-config block legitimately
-        // renders its own "No file..." empty state under the beforeEach
-        // default, which is not this block's concern.
+        // Scoped to this block rather than the whole pane. Kept scoped even
+        // though only one block renders now (the sibling host-config block it
+        // originally disambiguated from is gone) — a pane-wide assertion
+        // would silently start covering any block added later.
         const block = screen.getByText("Claude Code — shared provider config").closest(".global-brain-machine-config");
         expect(block?.querySelector(".global-brain-machine-config-empty")).toBeNull();
     });

--- a/frontend/app/view/brain/global-brain-manager.test.tsx
+++ b/frontend/app/view/brain/global-brain-manager.test.tsx
@@ -16,16 +16,10 @@ const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({
     content: null,
     exists: false,
 });
-const getClaudeHostConfigMock = vi.fn().mockResolvedValue({
-    path: "/home/user/.claude/CLAUDE.md",
-    content: null,
-    exists: false,
-});
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
         GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
-        GetClaudeHostConfigCommand: (...args: unknown[]) => getClaudeHostConfigMock(...args),
     },
 }));
 
@@ -40,12 +34,6 @@ describe("GlobalBrainManager shared-provider-config block", () => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
-        getClaudeHostConfigMock.mockClear();
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: null,
-            exists: false,
-        });
     });
 
     test("renders nothing before the fetch resolves", () => {
@@ -78,14 +66,6 @@ describe("GlobalBrainManager shared-provider-config block", () => {
             content: null,
             exists: false,
         });
-        // Sibling host-config block set to exists:true so only this block's
-        // empty state renders — avoids a duplicate-text ambiguity when
-        // both blocks are empty simultaneously.
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
         render(() => <GlobalBrainManager />);
 
         const block = (await screen.findByText("Claude Code — shared provider config")).closest(".global-brain-machine-config");
@@ -111,100 +91,37 @@ describe("GlobalBrainManager shared-provider-config block", () => {
 // SEPARATE block, independently fetched, rendered alongside the
 // shared-provider-config block above, under the same "External Claude
 // Code files" heading.
-describe("GlobalBrainManager host-config block", () => {
+
+// The former "GlobalBrainManager host-config block" describe (and the
+// "both blocks render under the shared heading" test) were removed with the
+// block itself — SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md. Once
+// REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md proved a spawned
+// agent never reads ~/.claude/CLAUDE.md, surfacing it in Armory was noise.
+describe("GlobalBrainManager — host CLI config block is gone", () => {
     beforeEach(() => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
-        getClaudeHostConfigMock.mockClear();
-    });
-
-    test("renders nothing before the fetch resolves", () => {
-        getClaudeHostConfigMock.mockReturnValue(new Promise(() => {})); // never resolves within this test
-        render(() => <GlobalBrainManager />);
-        expect(screen.queryByText("Claude Code — host CLI config")).not.toBeInTheDocument();
-    });
-
-    test("renders the path and content when the file exists", async () => {
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
-        render(() => <GlobalBrainManager />);
-
-        expect(await screen.findByText("Claude Code — host CLI config")).toBeInTheDocument();
-        expect(screen.getByText("/home/user/.claude/CLAUDE.md")).toBeInTheDocument();
-        expect(screen.getByText("# Host CLI rules")).toBeInTheDocument();
-    });
-
-    test("renders the empty-state fallback when no file exists at that path", async () => {
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: null,
-            exists: false,
-        });
-        // Sibling shared-provider-config block set to exists:true so only
-        // this block's empty state renders — avoids a duplicate-text
-        // ambiguity when both blocks are empty simultaneously.
         getClaudeGlobalConfigMock.mockResolvedValue({
             path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Shared rules\n",
             exists: true,
         });
-        render(() => <GlobalBrainManager />);
-
-        const block = (await screen.findByText("Claude Code — host CLI config")).closest(".global-brain-machine-config");
-        expect(block?.querySelector(".global-brain-machine-config-empty")?.textContent).toBe("No file at this path yet.");
     });
 
-    test("is read-only — no textarea or save affordance inside the block", async () => {
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
-        render(() => <GlobalBrainManager />);
-        await screen.findByText("Claude Code — host CLI config");
-
-        const block = screen.getByText("Claude Code — host CLI config").closest(".global-brain-machine-config");
-        expect(block?.querySelector("textarea")).toBeNull();
-        expect(block?.querySelector("button")).toBeNull();
-    });
-
-    test("renders alongside the shared-provider-config block, both visible with distinct badges", async () => {
-        getClaudeGlobalConfigMock.mockResolvedValue({
-            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
-            content: "# Shared rules\n",
-            exists: true,
-        });
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
+    test("renders the shared-provider block but no host CLI config block", async () => {
         render(() => <GlobalBrainManager />);
 
         expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
-        expect(await screen.findByText("Claude Code — host CLI config")).toBeInTheDocument();
+        expect(screen.queryByText("Claude Code — host CLI config")).toBeNull();
+        // The host path must not appear anywhere in the rendered pane.
+        expect(document.body.textContent).not.toContain("/home/user/.claude/CLAUDE.md");
     });
 
-    test("both blocks render under the shared 'External Claude Code files' heading", async () => {
-        getClaudeGlobalConfigMock.mockResolvedValue({
-            path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
-            content: "# Shared rules\n",
-            exists: true,
-        });
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
+    test("the section heading no longer claims to list multiple external files", async () => {
         render(() => <GlobalBrainManager />);
 
-        const heading = await screen.findByText(/External Claude Code files/);
-        const wrapper = heading.closest(".global-brain-external-files");
-        expect(wrapper?.textContent).toContain("Claude Code — shared provider config");
-        expect(wrapper?.textContent).toContain("Claude Code — host CLI config");
+        expect(await screen.findByText(/Claude Code provider config — reference only/)).toBeInTheDocument();
+        expect(screen.queryByText(/External Claude Code files/)).toBeNull();
     });
 });

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -156,36 +156,39 @@ export const GlobalBrainManager = (): JSX.Element => {
                 proved by experiment that a spawned agent never reads the host
                 file, surfacing it here was noise that invited the misreading
                 that editing it would change agent behaviour. */}
+            {/* Single <Show>: this used to be nested, the outer gating the
+                whole section on `globalConfig || hostConfig` and the inner
+                picking out this one block. With the host block gone both
+                conditions collapsed to the same atom, leaving the inner one
+                unreachable-when-false (ReAgent P2, PR #2900). The callback
+                form supplies the non-null accessor the body needs. */}
             <Show when={model.claudeGlobalConfigAtom()}>
-                <div class="global-brain-external-files">
-                    <p class="global-brain-external-files-heading">
-                        Claude Code provider config — reference only, not part of Global Memory.
-                    </p>
+                {(cfg) => (
+                    <div class="global-brain-external-files">
+                        <p class="global-brain-external-files-heading">
+                            Claude Code provider config — reference only, not part of Global Memory.
+                        </p>
 
-                    <Show when={model.claudeGlobalConfigAtom()}>
-                        {(cfg) => (
-                            <div class="global-brain-machine-config">
-                                <div class="global-brain-machine-config-header">
-                                    <span
-                                        class="global-brain-machine-config-badge"
-                                        title="Hand-maintained on disk. Identity-bound agents use a separate dir, not shown here."
-                                    >
-                                        Claude Code — shared provider config
-                                    </span>
-                                    <code class="global-brain-machine-config-path">{cfg().path}</code>
-                                </div>
-                                <p class="global-brain-machine-config-caption">Used by default spawned agents.</p>
-                                <Show
-                                    when={cfg().exists}
-                                    fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+                        <div class="global-brain-machine-config">
+                            <div class="global-brain-machine-config-header">
+                                <span
+                                    class="global-brain-machine-config-badge"
+                                    title="Hand-maintained on disk. Identity-bound agents use a separate dir, not shown here."
                                 >
-                                    <pre class="global-brain-machine-config-content">{cfg().content}</pre>
-                                </Show>
+                                    Claude Code — shared provider config
+                                </span>
+                                <code class="global-brain-machine-config-path">{cfg().path}</code>
                             </div>
-                        )}
-                    </Show>
-
-                </div>
+                            <p class="global-brain-machine-config-caption">Used by default spawned agents.</p>
+                            <Show
+                                when={cfg().exists}
+                                fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
+                            >
+                                <pre class="global-brain-machine-config-content">{cfg().content}</pre>
+                            </Show>
+                        </div>
+                    </div>
+                )}
             </Show>
 
             {/* System tier — pinned above ordinary sections, always injected

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -141,19 +141,25 @@ export const GlobalBrainManager = (): JSX.Element => {
                 <div class="global-brain-error">{model.errorAtom()}</div>
             </Show>
 
-            {/* "External Claude Code files" — read-only reference displays
-                of files Claude Code itself manages, NOT part of AgentMux's
-                own Global Memory composition (that's
-                <agent working_directory>/CLAUDE.md, a per-agent path
-                already previewed accurately above via the "Combined
-                preview"). This section is the main feature this spec chain
-                converged on — an operator explicitly asked to be able to
-                peruse these files here. See
-                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7. */}
-            <Show when={model.claudeGlobalConfigAtom() || model.claudeHostConfigAtom()}>
+            {/* Read-only reference display of the CLAUDE.md in the isolated
+                provider config dir a default spawned agent actually launches
+                with (CLAUDE_CONFIG_DIR). NOT part of AgentMux's own Global
+                Memory composition (that's <agent working_directory>/CLAUDE.md,
+                a per-agent path already previewed accurately above via the
+                "Combined preview"). See
+                docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7.
+
+                The sibling "Claude Code — host CLI config" block (~/.claude)
+                was removed 2026-09-01
+                (SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md): once
+                REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md
+                proved by experiment that a spawned agent never reads the host
+                file, surfacing it here was noise that invited the misreading
+                that editing it would change agent behaviour. */}
+            <Show when={model.claudeGlobalConfigAtom()}>
                 <div class="global-brain-external-files">
                     <p class="global-brain-external-files-heading">
-                        External Claude Code files — reference only, not part of Global Memory.
+                        Claude Code provider config — reference only, not part of Global Memory.
                     </p>
 
                     <Show when={model.claudeGlobalConfigAtom()}>
@@ -179,28 +185,6 @@ export const GlobalBrainManager = (): JSX.Element => {
                         )}
                     </Show>
 
-                    <Show when={model.claudeHostConfigAtom()}>
-                        {(cfg) => (
-                            <div class="global-brain-machine-config">
-                                <div class="global-brain-machine-config-header">
-                                    <span
-                                        class="global-brain-machine-config-badge"
-                                        title="Claude Code's own config on this machine. Not read by spawned in-app agents — see the block above for what they use."
-                                    >
-                                        Claude Code — host CLI config
-                                    </span>
-                                    <code class="global-brain-machine-config-path">{cfg().path}</code>
-                                </div>
-                                <p class="global-brain-machine-config-caption">Used outside AgentMux.</p>
-                                <Show
-                                    when={cfg().exists}
-                                    fallback={<p class="global-brain-machine-config-empty">No file at this path yet.</p>}
-                                >
-                                    <pre class="global-brain-machine-config-content">{cfg().content}</pre>
-                                </Show>
-                            </div>
-                        )}
-                    </Show>
                 </div>
             </Show>
 

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -70,12 +70,10 @@ describe("formatGlobalBrainBlock", () => {
 // frontend/app/view/memory/memory-model.test.ts.
 const listMemoriesMock = vi.fn().mockResolvedValue([]);
 const getClaudeGlobalConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
-const getClaudeHostConfigMock = vi.fn().mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListMemoriesCommand: (...args: unknown[]) => listMemoriesMock(...args),
         GetClaudeGlobalConfigCommand: (...args: unknown[]) => getClaudeGlobalConfigMock(...args),
-        GetClaudeHostConfigCommand: (...args: unknown[]) => getClaudeHostConfigMock(...args),
     },
 }));
 
@@ -85,8 +83,6 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
         getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
-        getClaudeHostConfigMock.mockClear();
-        getClaudeHostConfigMock.mockResolvedValue({ path: "/home/user/.claude/CLAUDE.md", content: null, exists: false });
     });
 
     test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {
@@ -183,44 +179,19 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
     // the host CLI config block is a SEPARATE atom/fetch from
     // claudeGlobalConfigAtom (renamed from "ambient" — that word already
     // means something else in this codebase, term:ambient_summary).
-    test("claudeHostConfigAtom starts null and populates from GetClaudeHostConfigCommand", async () => {
-        getClaudeHostConfigMock.mockResolvedValue({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
-        const { GlobalBrainViewModel } = await import("./global-brain-model");
-        const model = new GlobalBrainViewModel();
 
-        expect(model.claudeHostConfigAtom()).toBeNull();
-        await Promise.resolve();
-        await Promise.resolve();
 
-        expect(model.claudeHostConfigAtom()).toEqual({
-            path: "/home/user/.claude/CLAUDE.md",
-            content: "# Host CLI rules\n",
-            exists: true,
-        });
-    });
-
-    test("claudeHostConfigAtom stays null (not an error) when the fetch rejects", async () => {
-        getClaudeHostConfigMock.mockRejectedValue(new Error("boom"));
-        const { GlobalBrainViewModel } = await import("./global-brain-model");
-        const model = new GlobalBrainViewModel();
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(model.claudeHostConfigAtom()).toBeNull();
-        expect(model.errorAtom()).toBeNull();
-    });
-
-    test("a rejected host-config fetch does not clear or block the shared-provider-config atom, and vice versa", async () => {
+    // The former sibling assertion here — that a rejected ~/.claude host-config
+    // fetch couldn't clear or block this atom — went away with the host block
+    // itself (SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md). Only the
+    // shared-provider config, the dir a spawned agent actually launches with,
+    // is surfaced now.
+    test("the shared-provider-config atom populates from GetClaudeGlobalConfigCommand", async () => {
         getClaudeGlobalConfigMock.mockResolvedValue({
             path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md",
             content: "# Shared rules\n",
             exists: true,
         });
-        getClaudeHostConfigMock.mockRejectedValue(new Error("boom"));
         const { GlobalBrainViewModel } = await import("./global-brain-model");
         const model = new GlobalBrainViewModel();
         await Promise.resolve();
@@ -231,7 +202,6 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
             content: "# Shared rules\n",
             exists: true,
         });
-        expect(model.claudeHostConfigAtom()).toBeNull();
     });
 });
 

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -175,12 +175,6 @@ describe("GlobalBrainViewModel system/ordinary split", () => {
         expect(model.errorAtom()).toBeNull();
     });
 
-    // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6/§7 —
-    // the host CLI config block is a SEPARATE atom/fetch from
-    // claudeGlobalConfigAtom (renamed from "ambient" — that word already
-    // means something else in this codebase, term:ambient_summary).
-
-
     // The former sibling assertion here — that a rejected ~/.claude host-config
     // fetch couldn't clear or block this atom — went away with the host block
     // itself (SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md). Only the

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -153,13 +153,18 @@ export class GlobalBrainViewModel {
      *  to" callout rather than silently omitted. */
     noFileProvidersAtom: Accessor<string[]>;
 
-    // Both signals below back the "External Claude Code files" section —
-    // read-only reference displays of files Claude Code itself manages,
-    // NOT the file AgentMux's own Global Memory actually composes into
-    // (that's <agent working_directory>/CLAUDE.md, a per-agent path
-    // neither of these covers — already previewed accurately via
+    // Backs the "Claude Code provider config" section — a read-only
+    // reference display of the CLAUDE.md in the isolated config dir a
+    // spawned agent actually launches with. NOT the file AgentMux's own
+    // Global Memory composes into (that's <agent working_directory>/CLAUDE.md,
+    // a per-agent path this doesn't cover — already previewed accurately via
     // previewAtom above). See
     // docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7.
+    //
+    // Was a PAIR of signals until 2026-09-01: the sibling ~/.claude host-CLI
+    // config signal went away with its block
+    // (SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md), once a spawned
+    // agent was proven never to read that file.
 
     private _claudeGlobalConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
     /** The CLAUDE.md at AgentMux's shared Claude provider config dir — the

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -174,21 +174,6 @@ export class GlobalBrainViewModel {
         this._claudeGlobalConfig[0];
     private setClaudeGlobalConfig = this._claudeGlobalConfig[1];
 
-    private _claudeHostConfig = createSignal<{ path: string; content: string | null; exists: boolean } | null>(null);
-    /** ~/.claude/CLAUDE.md — Claude Code's own global config, read by a
-     *  host-level Claude Code CLI running outside AgentMux's
-     *  CLAUDE_CONFIG_DIR isolation (e.g. an external coding-agent
-     *  harness). A spawned in-app Claude agent does NOT read this file —
-     *  see claudeGlobalConfigAtom above for what it actually reads.
-     *  Independent atom, independent fetch: neither block's success or
-     *  failure affects the other. Named claudeHostConfigAtom, not
-     *  "ambient" — that word already means something else in this
-     *  codebase (term:ambient_summary, activitySummary.ts). See
-     *  docs/specs/SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §6, §7. */
-    claudeHostConfigAtom: Accessor<{ path: string; content: string | null; exists: boolean } | null> =
-        this._claudeHostConfig[0];
-    private setClaudeHostConfig = this._claudeHostConfig[1];
-
     constructor() {
         this.sectionsAtom = createMemo(() =>
             this.allAtom()
@@ -219,7 +204,6 @@ export class GlobalBrainViewModel {
         );
         void this.refresh();
         void this.fetchClaudeGlobalConfig();
-        void this.fetchClaudeHostConfig();
     }
 
     /** Fetches the shared Claude provider config's CLAUDE.md once. Failure
@@ -238,18 +222,6 @@ export class GlobalBrainViewModel {
         }
     }
 
-    /** Fetches ~/.claude/CLAUDE.md once. Same silent-failure and
-     *  read-once-at-mount reasoning as fetchClaudeGlobalConfig above —
-     *  independent of it, so a failure here doesn't touch
-     *  claudeGlobalConfigAtom or the ordinary Global Memory sections. */
-    private async fetchClaudeHostConfig(): Promise<void> {
-        try {
-            const cfg = await RpcApi.GetClaudeHostConfigCommand(TabRpcClient, {});
-            this.setClaudeHostConfig(cfg);
-        } catch {
-            // Silent — see doc comment above.
-        }
-    }
 
     async refresh(): Promise<void> {
         try {

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -45,11 +45,15 @@
     font-size: var(--text-sm);
 }
 
-// ── External Claude Code files (read-only — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7) ──
-// Files Claude Code itself manages, NOT part of AgentMux's own Global
-// Memory composition (that's <agent working_directory>/CLAUDE.md,
-// previewed above via the "Combined preview" — a per-agent path this
-// section does not represent).
+// ── Claude Code provider config (read-only — SPEC_SURFACE_CLAUDE_GLOBAL_CONFIG_2026_08_24.md §7) ──
+// The CLAUDE.md in the isolated config dir a spawned agent actually
+// launches with. NOT part of AgentMux's own Global Memory composition
+// (that's <agent working_directory>/CLAUDE.md, previewed above via the
+// "Combined preview" — a per-agent path this section does not represent).
+// Class names keep the `-external-files` prefix: the sibling ~/.claude
+// block this section once also held was removed in
+// SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md, but renaming the
+// selectors would be churn for no behavioural gain.
 
 .global-brain-external-files {
     display: flex;


### PR DESCRIPTION
## Summary

Armory → Memory → Global surfaced `~/.claude/CLAUDE.md` as a read-only "Claude Code — host CLI config" block. Removing it.

That block existed because it was once genuinely unclear which file a spawned agent read. **That ambiguity is now settled** — the three-arm experiment in `REPORT_CLAUDE_CONFIG_DIR_ISOLATION_EVIDENCE_2026_09_01.md` (#2894) proved a spawned agent reads `$CLAUDE_CONFIG_DIR/CLAUDE.md`, and — once seeded, which `prepare_provider_auth_dir()` now guarantees at every spawn — **never** the host file.

So the block showed a file with no bearing on any AgentMux agent. Its own tooltip already conceded this ("Not read by spawned in-app agents"). Surfacing a file in Armory whose entire description is *"this doesn't affect anything here"* is noise, and worse, invites the misreading that editing it would change agent behaviour.

## What's removed

The whole chain, not just the JSX: model signal + fetch, `GetClaudeHostConfigCommand` RPC, the backend `getclaudehostconfig` handler, and the `COMMAND_GET_CLAUDE_HOST_CONFIG` constant.

## What's kept

The **shared-provider-config block** — it shows the file agents genuinely do read, and is now *more* useful than before: post-isolation-fix it displays the AgentMux placeholder, which is a direct, legible confirmation that isolation is in effect.

Section heading reworded: "External Claude Code files" was a plural covering both blocks, and the survivor isn't "external" at all — it's AgentMux's own isolated provider dir. Now "Claude Code provider config". The load-bearing *"reference only, not part of Global Memory"* clause stays — that's what stops the block being mistaken for an editable Global Memory section.

`read_claude_global_config()` / `resolve_shared_claude_provider_dir()` and their tests stay — still serving the surviving handler.

See `docs/specs/SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md`.

## Test plan
- [x] `npx vitest run frontend/app/view/brain` — 20/20 passing
- [x] Replaced the 5 now-obsolete host-block tests with 2 regression tests asserting the block is *gone* (no host badge, host path absent from the pane, heading no longer claims multiple external files)
- [x] `npx tsc --noEmit` — clean
- [x] `cargo check -p agentmux-srv` — clean, no new warnings

<!-- agentmux:agent_id=manoz -->