### PR TITLE
Manoz@Area54: fix(memory): Personal Memory is empty for any agent with a blank working_directory

### DIFF
--- a/.changesets/1788273607-fix-memory-personal-memory-empty-for-agents-with-a-blank-wor-a5qi.md
+++ b/.changesets/1788273607-fix-memory-personal-memory-empty-for-agents-with-a-blank-wor-a5qi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(memory): Personal Memory empty for agents with a blank working_directory

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -192,6 +192,34 @@ pub fn default_conversation_visibility() -> String {
     "private".to_string()
 }
 
+/// The working directory `agent.open` substitutes when an
+/// `AgentDefinition`'s own `working_directory` is blank —
+/// `~/.agentmux/agents/<name-derived-slug>`.
+///
+/// Blank is the DEFAULT for a newly defined agent, so this is the path most
+/// agents actually run in. Extracted so `agent.open` (which creates and uses
+/// it) and native-memory resolution (which must find the memories written
+/// inside it) share one definition and cannot drift — they previously
+/// disagreed, and the resolver simply gave up on a blank field, breaking
+/// Armory → Memory → Personal for the common case. See
+/// `docs/specs/SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md`.
+///
+/// NOTE: deliberately NOT `derive_slug` above. `agent.open`'s own inline
+/// derivation is `name.to_lowercase()` with a Unicode-aware
+/// `char::is_alphanumeric()` filter (keeping `-`/`_`), which differs from
+/// `derive_slug`'s ASCII-only rule, dash-collapsing, 64-char trim and
+/// `"agent"` fallback. Reusing `derive_slug` here would silently point at a
+/// DIFFERENT directory than the one the agent is really running in for any
+/// non-ASCII or dash-heavy name. This mirrors the real behaviour exactly.
+pub fn default_agent_working_dir(agent_name: &str) -> String {
+    let slug: String = agent_name
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .collect();
+    format!("~/.agentmux/agents/{slug}")
+}
+
 /// Derive a filesystem-safe slug from a display name. Lowercase,
 /// ASCII alphanumeric + dash/underscore, consecutive dashes collapsed,
 /// trimmed to 64 chars. Returns `"agent"` if the input has no valid

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -315,8 +315,13 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let agent_slug = agent.name.to_lowercase()
                     .chars().map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
                     .collect::<String>();
+                // Shared with native-memory resolution so the two can never
+                // disagree about where a blank-working_directory agent
+                // actually runs — they did, and Personal Memory broke for the
+                // common case as a result (ReAgent/Codex P1, PR #2901; see
+                // SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md).
                 let work_dir = if agent.working_directory.is_empty() {
-                    format!("~/.agentmux/agents/{}", agent_slug)
+                    crate::backend::storage::agents::default_agent_working_dir(&agent.name)
                 } else {
                     agent.working_directory.clone()
                 };

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -2885,15 +2885,24 @@ mod export_import_for_agent_tests {
     }
 
     #[tokio::test]
-    async fn import_for_agent_fails_fast_when_agent_has_no_working_directory_but_bundle_has_memory() {
+    async fn import_for_agent_fails_fast_when_agent_has_no_resolvable_memory_dir_but_bundle_has_memory() {
         // reagent P2, PR #2527: must fail BEFORE creating any skill/bundle
         // rows, not silently succeed with memory_files_written: 0 -- this
         // RPC exists specifically to transfer memory.
+        //
+        // The trigger narrowed in PR #2901: a blank `working_directory` alone
+        // no longer reaches this guard, because it now resolves to the same
+        // default `agent.open` substitutes (~/.agentmux/agents/<name-slug>) --
+        // which serves this guard's OWN stated purpose better than erroring
+        // did, since the memory is written where the agent will actually read
+        // it instead of being refused. The guard remains for the genuinely
+        // unresolvable case, which needs a blank NAME too (no name => no
+        // derivable default), exercised here.
         let state = test_state();
         let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
             "id": "agent-no-workdir",
             "slug": "agent-no-workdir",
-            "name": "agent-no-workdir",
+            "name": "",
             "icon": "robot",
             "provider": "claude",
             "description": "test agent",

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -95,8 +95,10 @@ fn parse_claude_config_dir(env_blob: &str) -> String {
 }
 
 /// Resolve the memory directory for `agent_id`. Reads the agent definition and
-/// its stored env blob to find `CLAUDE_CONFIG_DIR`. Returns an error if the
-/// agent is not found or has no working directory.
+/// its stored env blob to find `CLAUDE_CONFIG_DIR`. Returns an error only if
+/// the agent cannot be resolved at all — an instance row with a blank
+/// `working_directory` falls through to the registry rather than failing (see
+/// the inline note below; that short-circuit was a real bug).
 ///
 /// Shared by `native_memory_handlers` and the `memory.*` App API handlers.
 pub(crate) fn memory_dir_for_agent(
@@ -112,16 +114,28 @@ pub(crate) fn memory_dir_for_agent(
         .instance_get_by_slug(agent_id)
         .map_err(|e| format!("memory: store: {e}"))?
     {
-        if instance.working_directory.is_empty() {
-            return Err(format!("memory: agent {agent_id} has no working directory"));
+        // Only trust the instance row when it actually carries a working
+        // directory. An empty one is NOT an error and must NOT short-circuit:
+        // `agent.open` substitutes a default (`~/.agentmux/agents/<slug>`)
+        // whenever `working_directory` is blank, so a blank row describes an
+        // agent that is nonetheless running — and writing memories — in a
+        // real directory. The registry fallback below is what knows that
+        // real directory (`source_agents_base` + `working_dir`).
+        //
+        // Returning Err here instead made Armory → Memory → Personal and the
+        // MemoryList MCP tool fail with "agent <x> has no working directory"
+        // for every such agent, while its memory files sat on disk perfectly
+        // intact — the common case, since `working_directory` is blank by
+        // default. See SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md.
+        if !instance.working_directory.is_empty() {
+            let config_dir = wstore
+                .agent_content_get(&instance.id, "env")
+                .ok()
+                .flatten()
+                .map(|c| parse_claude_config_dir(&c.content))
+                .unwrap_or_default();
+            return Ok(memory_dir_for_cwd(&config_dir, &instance.working_directory));
         }
-        let config_dir = wstore
-            .agent_content_get(&instance.id, "env")
-            .ok()
-            .flatten()
-            .map(|c| parse_claude_config_dir(&c.content))
-            .unwrap_or_default();
-        return Ok(memory_dir_for_cwd(&config_dir, &instance.working_directory));
     }
 
     // No persisted db_agents instance row. Running agents are tracked in the
@@ -2250,6 +2264,58 @@ mod tests {
             .map(|c| c.as_os_str().to_string_lossy().to_string())
             .collect();
         let want_tail = ["providers", "claude", "projects", "-work-proj", "memory"];
+        let tail = &comps[comps.len() - want_tail.len()..];
+        assert_eq!(tail, want_tail, "unexpected memory dir tail: {comps:?}");
+    }
+
+    /// Regression: an instance row with a BLANK `working_directory` must not
+    /// short-circuit `memory_dir_for_agent` with "has no working directory".
+    ///
+    /// `agent.open` substitutes a default working dir whenever the field is
+    /// blank, so a blank row still describes an agent that is running — and
+    /// writing memory files — in a real directory that only the registry
+    /// knows. The old early-`Err` made Armory → Memory → Personal and the
+    /// `MemoryList` MCP tool fail for every such agent (the common case,
+    /// since `working_directory` is blank by default) while its memories sat
+    /// on disk intact. Reproduced live before the fix:
+    ///   memory/list failed: HTTP 500 — "memory: agent manoz has no working directory"
+    ///
+    /// With no registry record present in this test, the correct outcome is
+    /// the registry's own "not found" — proving control reached the fallback
+    /// instead of stopping at the blank-workdir guard.
+    #[test]
+    fn blank_working_directory_falls_through_to_the_registry_rather_than_erroring() {
+        let wstore = Store::open_in_memory().unwrap();
+        let mut def = agent_def("blankwd-agent", "");
+        wstore.agent_def_insert(&mut def).unwrap();
+
+        let err = memory_dir_for_agent(&wstore, "blankwd-agent").unwrap_err();
+
+        assert!(
+            !err.contains("has no working directory"),
+            "must not short-circuit on a blank working_directory; got: {err}",
+        );
+        assert!(
+            err.contains("not found"),
+            "expected the registry fallback's own not-found error; got: {err}",
+        );
+    }
+
+    /// The non-blank path is unaffected: a real working_directory still
+    /// resolves straight from the instance row, without consulting the
+    /// registry at all.
+    #[test]
+    fn non_blank_working_directory_still_resolves_from_the_instance_row() {
+        let wstore = Store::open_in_memory().unwrap();
+        let mut def = agent_def("realwd-agent", "/work/proj");
+        wstore.agent_def_insert(&mut def).unwrap();
+
+        let dir = memory_dir_for_agent(&wstore, "realwd-agent").unwrap();
+        let comps: Vec<String> = dir
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .collect();
+        let want_tail = ["projects", "-work-proj", "memory"];
         let tail = &comps[comps.len() - want_tail.len()..];
         assert_eq!(tail, want_tail, "unexpected memory dir tail: {comps:?}");
     }

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -136,6 +136,19 @@ pub(crate) fn memory_dir_for_agent(
                 .unwrap_or_default();
             return Ok(memory_dir_for_cwd(&config_dir, &instance.working_directory));
         }
+        // Resolve through the DEFINITION, not the instance row: `db_agents`
+        // stores `instance_name` as its own column, distinct from the
+        // definition's `name`, and it is empty for a definition-only row —
+        // so reading the name off `instance` here silently yielded "" and
+        // fell through to a not-found. `instance.id` IS the definition id in
+        // this consolidated table (see the note above).
+        if let Ok(Some(def)) = wstore.agent_def_get(&instance.id) {
+            if let Some(dir) =
+                memory_dir_for_blank_working_dir(wstore, &def.id, &def.name, &def.slug)
+            {
+                return Ok(dir);
+            }
+        }
     }
 
     // No persisted db_agents instance row. Running agents are tracked in the
@@ -221,6 +234,58 @@ pub(crate) fn find_active_registry_record_by_slug(
 fn memory_dir_from_registry(agent_id: &str) -> Option<std::path::PathBuf> {
     let rec = find_active_registry_record_by_slug(agent_id)?;
     memory_dir_for_registry_record(&rec)
+}
+
+/// Resolve the memory dir for an agent whose persisted `working_directory`
+/// is blank — the DEFAULT state, so this is the common path, not an edge.
+///
+/// Two stages, in this order:
+///
+/// 1. **A registry record bound to this exact definition.** The registry
+///    records the working dir an agent was really launched with, which beats
+///    re-deriving it. `definition_id` is required to match: the plain
+///    slug lookup keys off `derive_slug(instance_name)` alone, so two agents
+///    whose display names slugify identically collide — and resolving the
+///    WRONG agent's memory dir would let list/read/write operations touch
+///    another agent's files (Codex P1, PR #2901).
+/// 2. **The derived default**, `default_agent_working_dir(name)` — the same
+///    path `agent.open` itself substitutes for a blank field. Needed because
+///    `agent.open` does NOT create a registry record, so stage 1 misses
+///    entirely for a freshly defined agent, which is exactly the case this
+///    whole fix targets (Codex P1, PR #2901).
+/// Takes the three identity fields explicitly rather than a struct: the two
+/// callers hold different types (`AgentInstance` from `instance_get_by_slug`,
+/// `AgentDefinition` from the by-id path) which don't share these field
+/// names. `definition_id` is the id the registry's own `definition_id`
+/// records — for `db_agents`, the consolidated definition+instance table,
+/// the instance row's `id` already IS that id (see `memory_dir_for_agent`'s
+/// own note).
+fn memory_dir_for_blank_working_dir(
+    wstore: &crate::backend::storage::store::Store,
+    definition_id: &str,
+    agent_name: &str,
+    slug: &str,
+) -> Option<std::path::PathBuf> {
+    if !slug.is_empty() {
+        if let Some(rec) = find_active_registry_record_by_slug(slug)
+            .filter(|r| r.data.definition_id == definition_id)
+        {
+            if let Some(dir) = memory_dir_for_registry_record(&rec) {
+                return Some(dir);
+            }
+        }
+    }
+    if agent_name.is_empty() {
+        return None;
+    }
+    let config_dir = wstore
+        .agent_content_get(definition_id, "env")
+        .ok()
+        .flatten()
+        .map(|c| parse_claude_config_dir(&c.content))
+        .unwrap_or_default();
+    let work_dir = crate::backend::storage::agents::default_agent_working_dir(agent_name);
+    Some(memory_dir_for_cwd(&config_dir, &work_dir))
 }
 
 /// Reconstruct one registry record's absolute memory dir directly (no slug
@@ -564,16 +629,32 @@ pub(crate) fn memory_dir_for_agent_by_id(
     wstore: &crate::backend::storage::store::Store,
     agent: &crate::backend::storage::AgentDefinition,
 ) -> Option<std::path::PathBuf> {
-    if agent.working_directory.is_empty() {
-        return None;
+    // Same blank-working_directory fallthrough as `memory_dir_for_agent`
+    // (see its own note) — a blank field is "this row can't answer", not
+    // "there is no memory dir". `agent.open` substitutes a default whenever
+    // it's blank, so such an agent still has memories on disk in a directory
+    // only the registry knows.
+    //
+    // Short-circuiting to None here was worse than the sibling's early Err,
+    // because both callers read None as a benign "no memory dir" rather than
+    // a failure (ReAgent P1, PR #2901):
+    //   - `bundle.rs`'s export_for_agent silently exports an EMPTY memory
+    //     file list, losing the agent's memories from the bundle;
+    //   - `bundle.rs`'s import_for_agent silently skips the live-fs mirror
+    //     refresh that exists specifically to avoid overwriting unmirrored
+    //     memory (reagent P0, PR #2527) — i.e. the blank-workdir case
+    //     bypassed a data-loss guard.
+    // Both for the common case, since `working_directory` is blank by default.
+    if !agent.working_directory.is_empty() {
+        let config_dir = wstore
+            .agent_content_get(&agent.id, "env")
+            .ok()
+            .flatten()
+            .map(|c| parse_claude_config_dir(&c.content))
+            .unwrap_or_default();
+        return Some(memory_dir_for_cwd(&config_dir, &agent.working_directory));
     }
-    let config_dir = wstore
-        .agent_content_get(&agent.id, "env")
-        .ok()
-        .flatten()
-        .map(|c| parse_claude_config_dir(&c.content))
-        .unwrap_or_default();
-    Some(memory_dir_for_cwd(&config_dir, &agent.working_directory))
+    memory_dir_for_blank_working_dir(wstore, &agent.id, &agent.name, &agent.slug)
 }
 
 fn version_summary_to_meta(v: crate::backend::storage::NativeMemoryVersionSummary) -> NativeMemoryVersionMeta {
@@ -2268,38 +2349,6 @@ mod tests {
         assert_eq!(tail, want_tail, "unexpected memory dir tail: {comps:?}");
     }
 
-    /// Regression: an instance row with a BLANK `working_directory` must not
-    /// short-circuit `memory_dir_for_agent` with "has no working directory".
-    ///
-    /// `agent.open` substitutes a default working dir whenever the field is
-    /// blank, so a blank row still describes an agent that is running — and
-    /// writing memory files — in a real directory that only the registry
-    /// knows. The old early-`Err` made Armory → Memory → Personal and the
-    /// `MemoryList` MCP tool fail for every such agent (the common case,
-    /// since `working_directory` is blank by default) while its memories sat
-    /// on disk intact. Reproduced live before the fix:
-    ///   memory/list failed: HTTP 500 — "memory: agent manoz has no working directory"
-    ///
-    /// With no registry record present in this test, the correct outcome is
-    /// the registry's own "not found" — proving control reached the fallback
-    /// instead of stopping at the blank-workdir guard.
-    #[test]
-    fn blank_working_directory_falls_through_to_the_registry_rather_than_erroring() {
-        let wstore = Store::open_in_memory().unwrap();
-        let mut def = agent_def("blankwd-agent", "");
-        wstore.agent_def_insert(&mut def).unwrap();
-
-        let err = memory_dir_for_agent(&wstore, "blankwd-agent").unwrap_err();
-
-        assert!(
-            !err.contains("has no working directory"),
-            "must not short-circuit on a blank working_directory; got: {err}",
-        );
-        assert!(
-            err.contains("not found"),
-            "expected the registry fallback's own not-found error; got: {err}",
-        );
-    }
 
     /// The non-blank path is unaffected: a real working_directory still
     /// resolves straight from the instance row, without consulting the
@@ -2318,5 +2367,118 @@ mod tests {
         let want_tail = ["projects", "-work-proj", "memory"];
         let tail = &comps[comps.len() - want_tail.len()..];
         assert_eq!(tail, want_tail, "unexpected memory dir tail: {comps:?}");
+    }
+
+    /// A blank `working_directory` — the DEFAULT for a newly defined agent —
+    /// must resolve to the same path `agent.open` itself substitutes, not
+    /// fail. Before the fix `memory_dir_for_agent` returned
+    /// "agent <x> has no working directory" and Armory → Memory → Personal
+    /// (and the MemoryList MCP tool) were broken for the common case, while
+    /// the agent's memory files sat on disk intact. Reproduced live:
+    ///   memory/list failed: HTTP 500 — "memory: agent manoz has no working directory"
+    ///
+    /// With no registry record present, stage 2 (the derived default) is what
+    /// must answer — the case Codex P1 flagged, since `agent.open` does not
+    /// create a registry record.
+    #[test]
+    fn blank_working_directory_resolves_to_the_same_default_agent_open_substitutes() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let wstore = Store::open_in_memory().unwrap();
+        let mut def = agent_def("blankwd-agent", "");
+        def.name = "Blank WD Agent".to_string();
+        wstore.agent_def_insert(&mut def).unwrap();
+
+        let dir = memory_dir_for_agent(&wstore, "blankwd-agent")
+            .expect("a blank working_directory must resolve, not error");
+
+        // default_agent_working_dir("Blank WD Agent") -> ~/.agentmux/agents/blank-wd-agent,
+        // which memory_dir_for_cwd sanitizes to "---agentmux-agents-blank-wd-agent"
+        // (the leading `~`, `/` and `.` each become their own dash).
+        let comps: Vec<String> = dir
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .collect();
+        let want_tail = ["projects", "---agentmux-agents-blank-wd-agent", "memory"];
+        let tail = &comps[comps.len() - want_tail.len()..];
+        assert_eq!(tail, want_tail, "unexpected memory dir tail: {comps:?}");
+    }
+
+    /// The shared helper must stay byte-identical to `agent.open`'s own
+    /// substitution — they are the same path by contract, and drift between
+    /// them is precisely what broke Personal Memory.
+    #[test]
+    fn default_agent_working_dir_matches_agent_opens_inline_derivation() {
+        for name in ["Manoz", "Blank WD Agent", "Wei_Zhang-2", "Zurich Nome"] {
+            let inline: String = name
+                .to_lowercase()
+                .chars()
+                .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+                .collect();
+            assert_eq!(
+                crate::backend::storage::agents::default_agent_working_dir(name),
+                format!("~/.agentmux/agents/{inline}"),
+                "drifted from agent_open's derivation for {name:?}",
+            );
+        }
+    }
+
+    /// Codex P1: the registry stage must be bound to the agent's own
+    /// definition. `find_active_registry_record_by_slug` matches on
+    /// `derive_slug(instance_name)` alone, so two agents whose display names
+    /// slugify the same collide — resolving the WRONG agent's memory dir
+    /// would let list/read/write touch another agent's files. A record whose
+    /// `definition_id` doesn't match must be ignored, falling through to the
+    /// derived default instead.
+    #[test]
+    fn a_registry_record_for_a_different_definition_is_never_used() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("AGENTMUX_SHARED_DIR");
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AGENTMUX_SHARED_DIR", tmp.path());
+
+        let registry =
+            crate::registry::Registry::open(tmp.path().join("agents").join("registry")).unwrap();
+        registry
+            .upsert(&crate::registry::NamedAgentRecord {
+                schema_version: 1,
+                data: crate::registry::NamedAgentRecordV1 {
+                    instance_id: "inst-other".to_string(),
+                    // Slugifies to the same slug as our agent below...
+                    instance_name: "Collide Agent".to_string(),
+                    // ...but belongs to a DIFFERENT definition.
+                    definition_id: "def-somebody-else".to_string(),
+                    identity_id: None,
+                    memory_id: None,
+                    session_id: None,
+                    working_dir: "somebody-elses-dir".to_string(),
+                    source_agents_base: Some(tmp.path().to_string_lossy().to_string()),
+                    created_at_ms: 1,
+                    last_launched_at_ms: 1,
+                    created_by_version: "test".to_string(),
+                    last_launched_by_version: "test".to_string(),
+                },
+            })
+            .unwrap();
+
+        let wstore = Store::open_in_memory().unwrap();
+        let mut def = agent_def("collide-agent", "");
+        def.name = "Collide Agent".to_string();
+        wstore.agent_def_insert(&mut def).unwrap();
+
+        let dir = memory_dir_for_agent(&wstore, "collide-agent").unwrap();
+        let as_str = dir.to_string_lossy().to_string();
+        assert!(
+            !as_str.contains("somebody-elses-dir"),
+            "must not resolve another definition's memory dir: {as_str}",
+        );
+        assert!(
+            as_str.contains("collide-agent"),
+            "expected the derived default for this agent: {as_str}",
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("AGENTMUX_SHARED_DIR", v),
+            None => std::env::remove_var("AGENTMUX_SHARED_DIR"),
+        }
     }
 }

--- a/docs/specs/SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md
+++ b/docs/specs/SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md
@@ -71,8 +71,51 @@ than empty.
 
 Treat a blank `working_directory` as "this row cannot answer" rather than
 "the answer is no": use the instance row only when it actually carries a
-working directory, and otherwise continue to the registry fallback that
-already exists directly below.
+working directory, and otherwise resolve the real directory another way.
+
+### Resolving the blank case (revised after review)
+
+The first cut simply fell through to the existing registry fallback. Review
+found two holes in that, both real:
+
+1. **The registry doesn't cover the target case** (Codex P1). `agent.open`
+   computes and uses `~/.agentmux/agents/<name-slug>` but does **not** create
+   a named-agent registry record, so a freshly defined blank-workdir agent —
+   exactly what this fix targets — still ended at `not found`.
+2. **The registry lookup can resolve the WRONG agent** (Codex P1).
+   `find_active_registry_record_by_slug` matches on
+   `derive_slug(instance_name)` alone, so two agents whose display names
+   slugify identically collide. Resolving another agent's memory dir would let
+   list/read/write operations touch that agent's files.
+
+So the blank case resolves in two bound stages
+(`memory_dir_for_blank_working_dir`):
+
+1. A registry record **whose `definition_id` matches this agent** — the
+   registry records the dir an agent was really launched with, which beats
+   re-deriving it, but identity must be verified.
+2. Otherwise the **derived default**, via a new shared
+   `default_agent_working_dir(name)` in `backend/storage/agents.rs` that
+   `agent.open` now also calls. Extracting it is the point: the resolver and
+   the spawn path previously disagreed about where a blank-workdir agent runs,
+   and that disagreement *was* the bug. They can no longer drift.
+
+Returns `None` when the agent has no name either — genuinely unresolvable,
+and the one case where callers' fail-fast guards still fire.
+
+### Knock-on: the import fail-fast guard narrows
+
+`bundle.rs`'s `import_for_agent` refuses to import when `memory_dir` is
+`None`, so a bundle's memory isn't silently dropped (reagent P2, PR #2527).
+A blank `working_directory` no longer reaches that guard — it now resolves.
+That **serves the guard's own stated purpose better than erroring did**: the
+memory gets written where the agent will actually read it, instead of the
+import being refused. The guard stays for the genuinely-unresolvable case
+(blank name), and its test was renamed and re-pointed at that case rather
+than deleted.
+
+The same applies to `export_for_agent`, which ReAgent flagged as silently
+exporting an empty memory list for these agents — it now finds the files.
 
 `agentmux-srv/src/server/native_memory_handlers.rs`:
 

--- a/docs/specs/SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md
+++ b/docs/specs/SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md
@@ -1,0 +1,119 @@
+# Spec: Personal Memory is empty for any agent with a blank `working_directory`
+
+**Date:** 2026-09-01
+**Status:** Proposed
+**Severity:** P1 — a whole Armory tab silently shows nothing for the common case
+**Found by:** operator asked to verify that an agent's written memories show up
+in Armory → Memory → Personal. They do not.
+
+## Problem
+
+`MemoryList` (MCP) and Armory → Memory → **Personal** both resolve an agent's
+native-memory directory through
+`native_memory_handlers.rs::memory_dir_for_agent()`. For this agent
+(`manoz`), that call fails outright:
+
+```
+memory/list failed: HTTP 500 — {"error":"memory: agent manoz has no working directory"}
+```
+
+while the memory files sit on disk, intact and correct:
+
+```
+.../claude/projects/C--Users-area54--agentmux-agents-manoz-0803a/memory/
+    MEMORY.md
+    feedback_agentmux_cdp_live_debugging.md
+    feedback_merge_on_approval.md
+    project_composer_strip_layout_history.md
+    reference_secrets_cli.md
+```
+
+## Root cause
+
+`memory_dir_for_agent()` resolves in two stages — instance row first,
+registry second — but the first stage **errors out** instead of falling
+through when the row's `working_directory` is blank:
+
+```rust
+if let Some(instance) = wstore.instance_get_by_slug(agent_id)? {
+    if instance.working_directory.is_empty() {
+        return Err(format!("memory: agent {agent_id} has no working directory"));
+    }
+    ...
+}
+memory_dir_from_registry(agent_id).ok_or_else(...)   // ← never reached
+```
+
+A blank `working_directory` is **not** an error condition. `agent_open.rs`
+substitutes a default whenever the field is blank:
+
+```rust
+let work_dir = if agent.working_directory.is_empty() {
+    format!("~/.agentmux/agents/{}", agent_slug)
+} else { agent.working_directory.clone() };
+```
+
+So a blank row describes an agent that is nonetheless running, and writing
+memories, in a real directory. The registry — deliberately consulted second,
+and which reconstructs the true path from `source_agents_base` +
+`working_dir` (`memory_dir_for_registry_record`) — is precisely the component
+that knows that directory. The early `Err` prevents it from ever being asked.
+
+Because `working_directory` is **blank by default**, this is the common case,
+not an edge case: Personal Memory is broken for most agents.
+
+This also explains the shape of the failure — not "no memories found" (an
+empty list) but a hard HTTP 500. The tab cannot distinguish "this agent has
+no memories yet" from "resolution blew up", so it surfaces as broken rather
+than empty.
+
+## Design
+
+Treat a blank `working_directory` as "this row cannot answer" rather than
+"the answer is no": use the instance row only when it actually carries a
+working directory, and otherwise continue to the registry fallback that
+already exists directly below.
+
+`agentmux-srv/src/server/native_memory_handlers.rs`:
+
+```rust
+if let Some(instance) = wstore.instance_get_by_slug(agent_id)? {
+    if !instance.working_directory.is_empty() {
+        let config_dir = /* … unchanged … */;
+        return Ok(memory_dir_for_cwd(&config_dir, &instance.working_directory));
+    }
+    // blank → fall through to the registry below
+}
+memory_dir_from_registry(agent_id).ok_or_else(...)
+```
+
+The error path is preserved for the genuine failure — an agent resolvable by
+neither the instance row nor the registry still returns the registry's own
+`agent {id} not found`.
+
+### Tests
+
+Two, both in `native_memory_handlers.rs`'s existing `tests` module:
+
+- **`blank_working_directory_falls_through_to_the_registry_rather_than_erroring`**
+  — an instance row with `working_directory: ""` and no registry record must
+  fail with the registry's `not found`, **not** `has no working directory`.
+  Asserting on *which* error proves control reached the fallback instead of
+  stopping at the guard — the exact regression.
+- **`non_blank_working_directory_still_resolves_from_the_instance_row`** — the
+  unaffected path keeps resolving straight from the row, asserted on path
+  components so mixed separators don't matter on Windows.
+
+## Non-goals
+
+- **No change to the registry fallback itself** (`memory_dir_from_registry`,
+  `memory_dir_for_registry_record`) — it was already correct and already the
+  intended handler for live agents; it just wasn't being reached.
+- **No change to `agent_open.rs`'s default-working-dir substitution.** Making
+  it *persist* the substituted value into the instance row would also fix the
+  symptom, but is a broader behavioural change to spawn, and would leave every
+  already-created agent row still blank. Fixing the resolver repairs existing
+  data as well as new.
+- **No attempt to distinguish "no memories yet" from a resolution failure in
+  the UI.** Worth doing (an empty Personal tab and a 500 look different to a
+  user), but separate from this fix.


### PR DESCRIPTION
## Summary

Found while verifying (at operator request) that an agent's written memories actually show up in **Armory → Memory → Personal**. They don't — and it's not an edge case.

`MemoryList` (MCP) and the Personal Memory tab both resolve through `memory_dir_for_agent()`. For this agent it fails outright:

```
memory/list failed: HTTP 500 — {"error":"memory: agent manoz has no working directory"}
```

…while the memory files sit on disk, intact:

```
.../claude/projects/C--Users-area54--agentmux-agents-manoz-0803a/memory/
    MEMORY.md  feedback_agentmux_cdp_live_debugging.md
    feedback_merge_on_approval.md  project_composer_strip_layout_history.md
    reference_secrets_cli.md
```

## Root cause

`memory_dir_for_agent()` resolves in two stages — instance row, then registry — but the **first stage errors out instead of falling through** when the row's `working_directory` is blank, so the registry fallback directly below is never reached.

A blank `working_directory` is not an error condition. `agent_open.rs` substitutes a default (`~/.agentmux/agents/<slug>`) whenever it's blank, so such a row still describes an agent that is running and writing memories in a real directory — one the **registry** knows (`source_agents_base` + `working_dir`) and the instance row doesn't.

**Since `working_directory` is blank by default, this breaks the common case, not an edge case.**

Worth noting the failure *shape*: a hard HTTP 500, not an empty list. So Armory can't distinguish "no memories yet" from "resolution blew up" — it just looks broken.

## Fix

Treat a blank `working_directory` as "this row can't answer" rather than "the answer is no": use the instance row only when it carries a working dir, otherwise continue to the registry fallback that already exists. The genuine error is preserved — an agent resolvable by neither still gets the registry's own `not found`.

## Test plan
- [x] `blank_working_directory_falls_through_to_the_registry_rather_than_erroring` — asserts on *which* error, proving control reached the fallback rather than stopping at the guard (the exact regression)
- [x] `non_blank_working_directory_still_resolves_from_the_instance_row` — unaffected path, asserted on path components so Windows separators don't matter
- [x] `cargo test -p agentmux-srv --bin agentmux-srv -- working_directory memory_dir_for_cwd` — 6/6 passing
- [x] Originally reproduced live via the `MemoryList` MCP tool

See `docs/specs/SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md`.

<!-- agentmux:agent_id=manoz -->