### PR TITLE
feat(muxqueue): HTTP routes + six MCP tools (slice 2)

### DIFF
--- a/.changesets/1788274136-feat-muxqueue-http-routes-six-mcp-tools-slice-2-83ba.md
+++ b/.changesets/1788274136-feat-muxqueue-http-routes-six-mcp-tools-slice-2-83ba.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxqueue): HTTP routes + six MCP tools (slice 2)

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -464,6 +464,99 @@ const LOOP_LIST_TOOL: &str = r#"{
   }
 }"#;
 
+// ── Muxqueue — the universal agent work queue ───────────────────────────────
+// docs/reports/REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md
+//
+// The pull/unaddressed/deferred counterpart to SendMessage's push/addressed/
+// immediate delivery: work goes in without naming a recipient, and whichever
+// agent asks next takes it. Deliberately NOT modelled on Cron (time-triggered)
+// or Loop (repeating) — the trigger here is an agent being ready.
+
+const WORK_ENQUEUE_TOOL: &str = r#"{
+  "name": "WorkEnqueue",
+  "description": "Put a unit of work on the shared Muxqueue for ANY agent to pick up later. Use this instead of SendMessage when you do NOT need a specific agent, or need it done eventually rather than now — 'someone should repro this', 'this PR needs review when a reviewer frees up'. The item persists across pane closes, app restarts, and version/channel changes, and is visible to every agent on this machine. If you know exactly who should do it and it should happen immediately, use SendMessage instead; if it should happen on a schedule, use CronCreate. Returns the item id.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "title":        { "type": "string",  "description": "Short human-scannable summary (e.g. 'repro the minimize distortion on a 3-pane cross-split')" },
+      "payload":      { "type": "string",  "description": "The full instruction injected into whichever agent claims this. Write it as a standalone prompt: the claimant has none of your conversation context." },
+      "kind":         { "type": "string",  "description": "Optional free-form tag used to filter claims (e.g. 'review', 'repro', 'triage'). Agents can claim only a kind they handle. Omit for untyped work anyone may take." },
+      "target_agent": { "type": "string",  "description": "Optional: restrict to ONE agent id. Mutually exclusive with target_group. Omit so any agent can claim — that is the normal case and the point of the queue." },
+      "target_group": { "type": "string",  "description": "Optional: restrict to members of an agent group id. Mutually exclusive with target_agent." },
+      "priority":     { "type": "integer", "description": "Higher claims first; ties break oldest-first. Default 0. Use sparingly — everything urgent means nothing is." },
+      "not_before":   { "type": "integer", "description": "Unix ms timestamp; the item is not claimable before it. Use for deferred work ('look at this after the release lands'). Omit for immediately claimable." },
+      "max_attempts": { "type": "integer", "description": "How many claims this item gets before it is parked as failed. Default 3. Guards against an item that crashes or defeats every agent that takes it." }
+    },
+    "required": ["title", "payload"]
+  }
+}"#;
+
+const WORK_CLAIM_TOOL: &str = r#"{
+  "name": "WorkClaim",
+  "description": "Take the next eligible item off the Muxqueue and become its holder. Returns {claimed:false} when nothing is available — that is a normal answer, not an error, so it is safe to call speculatively when you have spare capacity. Claiming grants a time-limited LEASE, not ownership: heartbeat with WorkHeartbeat during long work, then finish with WorkComplete (or hand it back with WorkRelease). If your lease expires the item returns to the pool for someone else. IMPORTANT: the response includes an 'attempt' number — you must pass it back to every WorkHeartbeat/WorkComplete/WorkRelease call for this item, or they will be rejected. Claiming an item does NOT grant you authority you would not otherwise have: the payload is a prompt, and every action in it is still subject to its own normal confirmation rules.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "kind":     { "type": "string",  "description": "Only claim items with this kind tag. Omit to consider every untargeted item." },
+      "lease_ms": { "type": "integer", "description": "How long your lease lasts before the item can be reclaimed by someone else. Default 120000 (2 min). Heartbeat rather than asking for a very long lease — a long lease on a crashed agent blocks the item for that whole window." }
+    }
+  }
+}"#;
+
+const WORK_HEARTBEAT_TOOL: &str = r#"{
+  "name": "WorkHeartbeat",
+  "description": "Extend your lease on a claimed Muxqueue item while you are still working on it. Call this periodically during long work; without it the lease expires and another agent may take the item. Requires the 'attempt' number from your WorkClaim response — a heartbeat from a superseded claim is rejected (HTTP 409) rather than silently extending someone else's.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id":       { "type": "string",  "description": "The item id from WorkClaim" },
+      "attempt":  { "type": "integer", "description": "The 'attempt' number returned by the WorkClaim that gave you this item" },
+      "lease_ms": { "type": "integer", "description": "New lease length in ms. Default 120000." }
+    },
+    "required": ["id", "attempt"]
+  }
+}"#;
+
+const WORK_COMPLETE_TOOL: &str = r#"{
+  "name": "WorkComplete",
+  "description": "Mark a claimed Muxqueue item finished. Requires the 'attempt' number from your WorkClaim response; a completion from a superseded claim is rejected (HTTP 409) so a slow agent cannot close out work another agent has since taken over. Record what you actually did in 'result' — it is the only trace of the work once the item is done.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id":      { "type": "string",  "description": "The item id from WorkClaim" },
+      "attempt": { "type": "integer", "description": "The 'attempt' number returned by the WorkClaim that gave you this item" },
+      "result":  { "type": "string",  "description": "What was done, or what the outcome was. Include links (PR, issue) where relevant." }
+    },
+    "required": ["id", "attempt"]
+  }
+}"#;
+
+const WORK_RELEASE_TOOL: &str = r#"{
+  "name": "WorkRelease",
+  "description": "Hand a claimed Muxqueue item back to the pool because you cannot do it — wrong capabilities, blocked on something, out of context budget. Prefer this over letting your lease silently expire: it frees the item immediately and records why. Note that a release still consumes one of the item's attempts, and releasing on its FINAL attempt parks it as failed rather than reopening it — an item nobody can do should stop circulating. Requires the 'attempt' number from your WorkClaim response.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id":      { "type": "string",  "description": "The item id from WorkClaim" },
+      "attempt": { "type": "integer", "description": "The 'attempt' number returned by the WorkClaim that gave you this item" },
+      "reason":  { "type": "string",  "description": "Why you are handing it back. This is what the next claimant (or a human) sees." }
+    },
+    "required": ["id", "attempt"]
+  }
+}"#;
+
+const WORK_LIST_TOOL: &str = r#"{
+  "name": "WorkList",
+  "description": "List Muxqueue items — the shared backlog across every agent on this machine. Use it to see what is outstanding before enqueueing something (avoid duplicates), to check on work you enqueued, or to find out who is currently holding what. Read-only.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "state": { "type": "string", "description": "Filter by state: open, claimed, done, failed, cancelled. Omit for all states." },
+      "limit": { "type": "integer", "description": "Max items to return (1-500). Default 50." }
+    }
+  }
+}"#;
+
 const CRON_CREATE_TOOL: &str = r#"{
   "name": "CronCreate",
   "description": "AgentMux's own cross-agent cron — NOT the same tool as the native (non-mcp__agentmux__-prefixed) CronCreate your harness may also expose, which schedules only your own session's future turn. Use this one specifically to target a DIFFERENT agent (or when you need AgentMux-persisted delivery independent of any single session). Creates a persistent scheduled cron job that survives agent pane restarts. Fires the prompt on a UTC cron schedule by injecting it into the target agent. Unlike Loop, cron jobs persist as long as agentmux-srv is running. Returns a job id and the next scheduled fire time. If you're scheduling your OWN future turn instead, prefer the native CronCreate/ScheduleWakeup tools — no cross-agent envelope overhead.",
@@ -767,6 +860,12 @@ async fn main() {
                 let loop_tool: Value = serde_json::from_str(LOOP_TOOL).expect("static json");
                 let loop_stop: Value = serde_json::from_str(LOOP_STOP_TOOL).expect("static json");
                 let loop_list: Value = serde_json::from_str(LOOP_LIST_TOOL).expect("static json");
+                let work_enqueue: Value = serde_json::from_str(WORK_ENQUEUE_TOOL).expect("static json");
+                let work_claim: Value = serde_json::from_str(WORK_CLAIM_TOOL).expect("static json");
+                let work_heartbeat: Value = serde_json::from_str(WORK_HEARTBEAT_TOOL).expect("static json");
+                let work_complete: Value = serde_json::from_str(WORK_COMPLETE_TOOL).expect("static json");
+                let work_release: Value = serde_json::from_str(WORK_RELEASE_TOOL).expect("static json");
+                let work_list: Value = serde_json::from_str(WORK_LIST_TOOL).expect("static json");
                 let cron_create: Value = serde_json::from_str(CRON_CREATE_TOOL).expect("static json");
                 let cron_delete: Value = serde_json::from_str(CRON_DELETE_TOOL).expect("static json");
                 let cron_list: Value = serde_json::from_str(CRON_LIST_TOOL).expect("static json");
@@ -787,7 +886,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -3222,6 +3321,161 @@ async fn call_tool(
             }
             Ok(lines.join("\n"))
         }
+        // ── Muxqueue ────────────────────────────────────────────────────
+        // All six post/get to /agentmux/work* on the local srv, same auth
+        // header as the cron arms below.
+        "WorkEnqueue" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let title = arguments.get("title").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: title"))?;
+            let payload = arguments.get("payload").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: payload"))?;
+            let self_id = std::env::var("AGENTMUX_AGENT_ID").ok().filter(|s| !s.is_empty()).unwrap_or_default();
+
+            let url = format!("{}/agentmux/work", local_url.trim_end_matches('/'));
+            let body = serde_json::json!({
+                "title": title,
+                "payload": payload,
+                "kind": arguments.get("kind").and_then(|v| v.as_str()).unwrap_or(""),
+                "target_agent": arguments.get("target_agent").and_then(|v| v.as_str()).unwrap_or(""),
+                "target_group": arguments.get("target_group").and_then(|v| v.as_str()).unwrap_or(""),
+                "priority": arguments.get("priority").and_then(|v| v.as_i64()).unwrap_or(0),
+                "not_before": arguments.get("not_before").and_then(|v| v.as_i64()),
+                "max_attempts": arguments.get("max_attempts").and_then(|v| v.as_i64()).filter(|&n| n > 0),
+                "created_by": self_id,
+            });
+            let resp = client.post(&url).header("X-AuthKey", auth_key).json(&body).send().await
+                .map_err(|e| anyhow::anyhow!("work enqueue request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                anyhow::bail!("WorkEnqueue failed: HTTP {status} — {text}");
+            }
+            let id = serde_json::from_str::<Value>(&text).ok()
+                .and_then(|v| v.get("id").and_then(|x| x.as_str()).map(|s| s.to_string()))
+                .unwrap_or_default();
+            Ok(format!("Enqueued work item {id}: {title}"))
+        }
+        "WorkClaim" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let self_id = std::env::var("AGENTMUX_AGENT_ID").ok().filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("AGENTMUX_AGENT_ID is not set — cannot claim work without an agent identity"))?;
+
+            let url = format!("{}/agentmux/work/claim", local_url.trim_end_matches('/'));
+            let body = serde_json::json!({
+                "agent_id": self_id,
+                "kind": arguments.get("kind").and_then(|v| v.as_str()),
+                "lease_ms": arguments.get("lease_ms").and_then(|v| v.as_i64()).filter(|&n| n > 0),
+                // Group membership is resolved server-side-of-this-call by the
+                // caller in the general design; the MCP path has no cheap way
+                // to know this agent's groups yet, so it claims only untargeted
+                // and self-targeted work. Group-targeted claiming arrives with
+                // the group lookup, not before — better to under-claim than to
+                // silently ignore a group restriction.
+                "groups": [],
+            });
+            let resp = client.post(&url).header("X-AuthKey", auth_key).json(&body).send().await
+                .map_err(|e| anyhow::anyhow!("work claim request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                anyhow::bail!("WorkClaim failed: HTTP {status} — {text}");
+            }
+            let v: Value = serde_json::from_str(&text).unwrap_or(serde_json::json!({}));
+            if !v.get("claimed").and_then(|x| x.as_bool()).unwrap_or(false) {
+                return Ok("No work available on the queue right now.".to_string());
+            }
+            let attempt = v.get("attempt").and_then(|x| x.as_i64()).unwrap_or(0);
+            let item = v.get("item").cloned().unwrap_or(serde_json::json!({}));
+            let id = item.get("id").and_then(|x| x.as_str()).unwrap_or("");
+            let title = item.get("title").and_then(|x| x.as_str()).unwrap_or("");
+            let payload = item.get("payload").and_then(|x| x.as_str()).unwrap_or("");
+            Ok(format!(
+                "Claimed work item {id} (attempt {attempt}) — pass attempt={attempt} to \
+                 WorkHeartbeat/WorkComplete/WorkRelease for this item.\n\n\
+                 Title: {title}\n\n{payload}"
+            ))
+        }
+        "WorkHeartbeat" | "WorkComplete" | "WorkRelease" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let self_id = std::env::var("AGENTMUX_AGENT_ID").ok().filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("AGENTMUX_AGENT_ID is not set"))?;
+            let id = arguments.get("id").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: id"))?;
+            let attempt = arguments.get("attempt").and_then(|v| v.as_i64())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: attempt (from the WorkClaim response)"))?;
+
+            let (segment, result_text) = match name {
+                "WorkHeartbeat" => ("heartbeat", String::new()),
+                "WorkComplete" => (
+                    "complete",
+                    arguments.get("result").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                ),
+                _ => (
+                    "release",
+                    arguments.get("reason").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                ),
+            };
+
+            let url = format!("{}/agentmux/work/{}/{}", local_url.trim_end_matches('/'), id, segment);
+            let body = serde_json::json!({
+                "agent_id": self_id,
+                "attempt": attempt,
+                "result": result_text,
+                "lease_ms": arguments.get("lease_ms").and_then(|v| v.as_i64()).filter(|&n| n > 0),
+            });
+            let resp = client.post(&url).header("X-AuthKey", auth_key).json(&body).send().await
+                .map_err(|e| anyhow::anyhow!("work {segment} request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if status == reqwest::StatusCode::CONFLICT {
+                // The fence rejected this call. Say so in the terms the agent
+                // can act on, rather than surfacing a raw 409 — the recovery is
+                // always the same: claim again.
+                anyhow::bail!(
+                    "This claim is no longer yours — the lease expired and the item was \
+                     reclaimed, or another agent holds it now. Call WorkClaim again if you \
+                     still want work; do NOT retry with the old attempt number."
+                );
+            }
+            if !status.is_success() {
+                anyhow::bail!("{name} failed: HTTP {status} — {text}");
+            }
+            Ok(match segment {
+                "heartbeat" => format!("Lease extended on {id}."),
+                "complete" => format!("Completed {id}."),
+                _ => format!("Released {id} back to the queue."),
+            })
+        }
+        "WorkList" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let mut url = format!("{}/agentmux/work", local_url.trim_end_matches('/'));
+            let state = arguments.get("state").and_then(|v| v.as_str()).unwrap_or("");
+            let limit = arguments.get("limit").and_then(|v| v.as_i64()).unwrap_or(50);
+            url.push_str(&format!("?state={state}&limit={limit}"));
+            let resp = client.get(&url).header("X-AuthKey", auth_key).send().await
+                .map_err(|e| anyhow::anyhow!("work list request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                anyhow::bail!("WorkList failed: HTTP {status} — {text}");
+            }
+            let v: Value = serde_json::from_str(&text).unwrap_or(serde_json::json!({}));
+            let items = v.get("items").and_then(|x| x.as_array()).cloned().unwrap_or_default();
+            if items.is_empty() {
+                return Ok("Queue is empty.".to_string());
+            }
+            let mut out = format!("{} work item(s):\n", items.len());
+            for it in &items {
+                let id = it.get("id").and_then(|x| x.as_str()).unwrap_or("");
+                let st = it.get("state").and_then(|x| x.as_str()).unwrap_or("");
+                let title = it.get("title").and_then(|x| x.as_str()).unwrap_or("");
+                let holder = it.get("claimed_by").and_then(|x| x.as_str()).unwrap_or("");
+                let who = if holder.is_empty() { String::new() } else { format!(" [{holder}]") };
+                out.push_str(&format!("  {id}  {st}{who}  {title}\n"));
+            }
+            Ok(out)
+        }
         "CronCreate" => {
             require_agent_env(local_url, auth_key, block_id)?;
             let name = arguments.get("name").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
@@ -4143,6 +4397,12 @@ mod tests {
             LOOP_TOOL,
             LOOP_STOP_TOOL,
             LOOP_LIST_TOOL,
+            WORK_ENQUEUE_TOOL,
+            WORK_CLAIM_TOOL,
+            WORK_HEARTBEAT_TOOL,
+            WORK_COMPLETE_TOOL,
+            WORK_RELEASE_TOOL,
+            WORK_LIST_TOOL,
             CRON_CREATE_TOOL,
             CRON_DELETE_TOOL,
             CRON_LIST_TOOL,
@@ -4181,7 +4441,11 @@ mod tests {
         // DISCOVER_WINDOWS_TOOL added here too
         // (SPEC_AGENT_APP_API_WINDOW_CONTROL_ROBUSTNESS_2026_08_24.md) — same
         // reasoning, not fixing the pre-existing drift.
-        assert_eq!(defs.len(), 36, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows");
+        // MUXQUEUE_TOOLS (6: WorkEnqueue/Claim/Heartbeat/Complete/Release/List)
+        // added here too (REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md
+        // slice 2) — same reasoning, not fixing the pre-existing drift between
+        // this running total and the prose breakdown below it.
+        assert_eq!(defs.len(), 42, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows + 6 Muxqueue");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -525,9 +525,9 @@ const WORK_COMPLETE_TOOL: &str = r#"{
     "properties": {
       "id":      { "type": "string",  "description": "The item id from WorkClaim" },
       "attempt": { "type": "integer", "description": "The 'attempt' number returned by the WorkClaim that gave you this item" },
-      "result":  { "type": "string",  "description": "What was done, or what the outcome was. Include links (PR, issue) where relevant." }
+      "result":  { "type": "string",  "description": "REQUIRED. What was done, or what the outcome was. Include links (PR, issue) where relevant. Once an item is done this is the only record that it happened — a completion with no result silently destroys the trace." }
     },
-    "required": ["id", "attempt"]
+    "required": ["id", "attempt", "result"]
   }
 }"#;
 
@@ -3390,10 +3390,26 @@ async fn call_tool(
             let id = item.get("id").and_then(|x| x.as_str()).unwrap_or("");
             let title = item.get("title").and_then(|x| x.as_str()).unwrap_or("");
             let payload = item.get("payload").and_then(|x| x.as_str()).unwrap_or("");
+            // Carry forward why a PREVIOUS holder handed this back (Codex P2 on
+            // PR #2902). WorkRelease's description promises the next claimant
+            // sees the reason; dropping it here broke that promise and let
+            // agents re-hit a known blocker with no warning. `attempt > 1` is
+            // exactly "someone has held this before me".
+            let prior = item.get("result").and_then(|x| x.as_str()).unwrap_or("");
+            let handback = if attempt > 1 && !prior.is_empty() {
+                format!(
+                    "\n\nNOTE — a previous agent held this and handed it back \
+                     (attempt {} of this item). Their reason: {prior}\n\
+                     Read that before repeating their approach.",
+                    attempt - 1
+                )
+            } else {
+                String::new()
+            };
             Ok(format!(
                 "Claimed work item {id} (attempt {attempt}) — pass attempt={attempt} to \
                  WorkHeartbeat/WorkComplete/WorkRelease for this item.\n\n\
-                 Title: {title}\n\n{payload}"
+                 Title: {title}\n\n{payload}{handback}"
             ))
         }
         "WorkHeartbeat" | "WorkComplete" | "WorkRelease" => {
@@ -3409,7 +3425,23 @@ async fn call_tool(
                 "WorkHeartbeat" => ("heartbeat", String::new()),
                 "WorkComplete" => (
                     "complete",
-                    arguments.get("result").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                    // Enforced at runtime as well as in the schema (Codex P2 on
+                    // PR #2902): completing with no result marks the item done
+                    // forever while destroying the only record that the work
+                    // happened. Better to reject the call than to accept a
+                    // silent hole in the audit trail.
+                    arguments
+                        .get("result")
+                        .and_then(|v| v.as_str())
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "WorkComplete requires a non-empty 'result' — it is the only \
+                                 record of what this item accomplished once it is marked done"
+                            )
+                        })?
+                        .to_string(),
                 ),
                 _ => (
                     "release",
@@ -3444,16 +3476,46 @@ async fn call_tool(
             Ok(match segment {
                 "heartbeat" => format!("Lease extended on {id}."),
                 "complete" => format!("Completed {id}."),
-                _ => format!("Released {id} back to the queue."),
+                _ => {
+                    // A release on the FINAL allowed attempt parks the item as
+                    // `failed` rather than reopening it, so reporting "back to
+                    // the queue" unconditionally would tell the caller another
+                    // agent can pick it up when nobody ever will (Codex P2 on
+                    // PR #2902). The server reports the resulting state; trust
+                    // it rather than re-deriving the attempts rule here.
+                    let resulting = serde_json::from_str::<Value>(&text)
+                        .ok()
+                        .and_then(|v| v.get("state").and_then(|s| s.as_str()).map(str::to_string))
+                        .unwrap_or_default();
+                    if resulting == "failed" {
+                        format!(
+                            "Released {id}, and it has now used its final attempt — the item is \
+                             parked as FAILED and will not be offered to any agent again. If it \
+                             still needs doing, enqueue a fresh item (ideally with what you \
+                             learned about why it kept failing)."
+                        )
+                    } else {
+                        format!("Released {id} back to the queue for another agent.")
+                    }
+                }
             })
         }
         "WorkList" => {
             require_agent_env(local_url, auth_key, block_id)?;
-            let mut url = format!("{}/agentmux/work", local_url.trim_end_matches('/'));
+            let url = format!("{}/agentmux/work", local_url.trim_end_matches('/'));
             let state = arguments.get("state").and_then(|v| v.as_str()).unwrap_or("");
             let limit = arguments.get("limit").and_then(|v| v.as_i64()).unwrap_or(50);
-            url.push_str(&format!("?state={state}&limit={limit}"));
-            let resp = client.get(&url).header("X-AuthKey", auth_key).send().await
+            // Built via reqwest's own query serializer, NOT string
+            // concatenation (reagent P2 on PR #2902): `state` is a free-form
+            // string in this tool's schema, not a validated enum, so a value
+            // containing `&`, `#`, or `%` would otherwise corrupt the query
+            // rather than being sent as the literal the caller intended.
+            let resp = client
+                .get(&url)
+                .query(&[("state", state), ("limit", &limit.to_string())])
+                .header("X-AuthKey", auth_key)
+                .send()
+                .await
                 .map_err(|e| anyhow::anyhow!("work list request failed: {e}"))?;
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
@@ -3473,6 +3535,15 @@ async fn call_tool(
                 let holder = it.get("claimed_by").and_then(|x| x.as_str()).unwrap_or("");
                 let who = if holder.is_empty() { String::new() } else { format!(" [{holder}]") };
                 out.push_str(&format!("  {id}  {st}{who}  {title}\n"));
+                // `result` is the completion trace for a done item, and the
+                // reason for a failed/released one — the very thing
+                // WorkComplete calls "the only record". Omitting it here left
+                // that record unreachable through the only agent-facing read
+                // tool (Codex P2 on PR #2902).
+                let result = it.get("result").and_then(|x| x.as_str()).unwrap_or("");
+                if !result.is_empty() {
+                    out.push_str(&format!("      -> {result}\n"));
+                }
             }
             Ok(out)
         }

--- a/agentmux-srv/src/backend/storage/store.rs
+++ b/agentmux-srv/src/backend/storage/store.rs
@@ -95,6 +95,27 @@ impl Store {
         Self::configure_and_migrate(conn)
     }
 
+    /// TEST-ONLY: additionally install the **identity-store** schema on this
+    /// store, on top of whatever schema it already carries.
+    ///
+    /// `server::tests::test_state` deliberately aliases `wstore`, `id_store`
+    /// and `identity_store` to ONE in-memory store so a test can seed data
+    /// through any of them — a lot of existing setup code depends on that.
+    /// The cost is that the single store carried only the object schema, so a
+    /// handler touching a table that exists ONLY in the global identity store
+    /// (`db_work_queue`) failed with a bare "no such table" 500 in tests while
+    /// being correct in production — the harness silently answered a different
+    /// question than the one under test.
+    ///
+    /// Every statement in that schema is `CREATE TABLE/INDEX IF NOT EXISTS`,
+    /// so tables already present from the object schema are left untouched;
+    /// this only fills in the ones that are missing.
+    #[cfg(test)]
+    pub fn apply_identity_schema_for_tests(&self) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        run_identity_store_schema(&conn)
+    }
+
     /// Open the GLOBAL shared store at `path` (`~/.agentmux/shared/store.db`).
     ///
     /// Uses the same WAL + busy-timeout config as `open()` but runs

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod wave_obj_bridge;
 mod websocket;
 mod drone_handlers;
 mod cron;
+mod work_queue;
 mod messaging_handlers;
 mod muxbus_handlers;
 mod muxspect_handlers;
@@ -554,6 +555,16 @@ pub fn build_router(state: AppState) -> Router {
         .route("/agentmux/cron", get(cron::handle_cron_list))
         .route("/agentmux/cron/:id", delete(cron::handle_cron_delete))
         .route("/agentmux/cron/:id", patch(cron::handle_cron_patch))
+        // Muxqueue — the universal agent work queue, cron's readiness-triggered
+        // sibling (docs/reports/REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md).
+        // Same auth gate as the cron routes above.
+        .route("/agentmux/work", post(work_queue::handle_work_enqueue))
+        .route("/agentmux/work", get(work_queue::handle_work_list))
+        .route("/agentmux/work/claim", post(work_queue::handle_work_claim))
+        .route("/agentmux/work/:id/heartbeat", post(work_queue::handle_work_heartbeat))
+        .route("/agentmux/work/:id/complete", post(work_queue::handle_work_complete))
+        .route("/agentmux/work/:id/release", post(work_queue::handle_work_release))
+        .route("/agentmux/work/:id", delete(work_queue::handle_work_cancel))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -12,6 +12,13 @@ use crate::backend::wcore;
 
 pub(crate) fn test_state() -> AppState {
     let wstore = Arc::new(Store::open_in_memory().unwrap());
+    // This one store backs wstore/id_store/identity_store below, so it has to
+    // carry BOTH schemas. Without the identity schema, any handler touching a
+    // table that lives only in the global identity store (`db_work_queue`)
+    // failed with a bare "no such table" 500 in tests while being perfectly
+    // correct in production. Additive and idempotent — every statement in that
+    // schema is CREATE ... IF NOT EXISTS.
+    wstore.apply_identity_schema_for_tests().unwrap();
     let filestore = Arc::new(FileStore::open_in_memory().unwrap());
     let event_bus = Arc::new(EventBus::new());
     let broker = Arc::new(Broker::new());
@@ -45,6 +52,10 @@ pub(crate) fn test_state() -> AppState {
         wstore: wstore.clone(),
         shared_store: None,
         id_store: wstore.clone(),
+        // Aliased to `wstore` on purpose — a lot of existing setup code seeds
+        // through one store and reads through another. See the
+        // `apply_identity_schema_for_tests` call above for why that single
+        // store now carries the identity schema too.
         identity_store: wstore.clone(),
         filestore,
         global_transcript_store: None,
@@ -2989,4 +3000,221 @@ fn agent_memory_write_provenance_req_defaults_a_missing_detail_to_an_empty_objec
     let req: AgentMemoryWriteProvenanceReq = serde_json::from_str(r#"{"source":"human"}"#).unwrap();
     assert_eq!(req.detail, serde_json::json!({}));
     assert_eq!(req.detail.to_string(), "{}");
+}
+
+// ── Muxqueue HTTP surface ───────────────────────────────────────────────────
+// docs/reports/REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md, slice 2.
+
+/// reagent P1 on PR #2902 — the blocking one. `DELETE /agentmux/cron/:id`, the
+/// sibling route registered a few lines away in the same router, takes NO body.
+/// A caller that follows that adjacent convention for `DELETE
+/// /agentmux/work/:id` must not be rejected by axum's `Json` extractor before
+/// the handler ever runs. Drives the real router, so it fails if the extractor
+/// is ever tightened back to a required body.
+#[tokio::test]
+async fn work_cancel_accepts_a_delete_with_no_body_like_its_cron_sibling() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/work/does-not-exist")
+        .method("DELETE")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    // CONFLICT = the handler ran and found no open/claimed item, which is the
+    // point: anything in the 400/415 family would mean the body extractor
+    // rejected the request before the handler was ever reached.
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "a bodyless DELETE must reach the handler, not be rejected by the Json extractor"
+    );
+}
+
+/// The body is optional, not ignored — a supplied reason must still parse.
+#[tokio::test]
+async fn work_cancel_still_accepts_a_json_body_when_one_is_sent() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/work/does-not-exist")
+        .method("DELETE")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"reason":"superseded"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+/// End-to-end through the router: enqueue, then claim it back out. Also pins
+/// that the claim response carries `attempt` at the TOP level, which every
+/// later holder call must echo as its fence.
+#[tokio::test]
+async fn work_enqueue_then_claim_round_trips_and_exposes_the_fence() {
+    let app = test_router();
+
+    let enq = Request::builder()
+        .uri("/agentmux/work")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            r#"{"title":"repro the thing","payload":"steps go here","created_by":"tester"}"#,
+        ))
+        .unwrap();
+    let resp = app.clone().oneshot(enq).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let claim = Request::builder()
+        .uri("/agentmux/work/claim")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"a1"}"#))
+        .unwrap();
+    let resp = app.oneshot(claim).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["claimed"], true);
+    assert_eq!(
+        v["attempt"], 1,
+        "the fence must be at the top level of the claim response, not only nested in item"
+    );
+    assert_eq!(v["item"]["title"], "repro the thing");
+}
+
+/// An empty queue answers "nothing available" with 200, not an error — callers
+/// are expected to poll speculatively when they have spare capacity.
+#[tokio::test]
+async fn work_claim_on_an_empty_queue_is_a_success_not_an_error() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/work/claim")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"a1"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["claimed"], false);
+}
+
+/// Targeting both an agent and a group is ambiguous; the handler rejects it
+/// rather than letting one silently win.
+#[tokio::test]
+async fn work_enqueue_rejects_both_target_agent_and_target_group() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/work")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            r#"{"title":"t","payload":"p","target_agent":"a1","target_group":"g1"}"#,
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Codex P2 on PR #2902: a release must report the RESULTING state, because a
+/// release on the final allowed attempt parks the item as `failed` rather than
+/// reopening it. Without this the MCP layer tells the caller another agent can
+/// pick the item up when nobody ever will.
+#[tokio::test]
+async fn work_release_reports_the_resulting_state_not_just_ok() {
+    let app = test_router();
+
+    // max_attempts 1, so the very first release is also the final attempt.
+    let enq = Request::builder()
+        .uri("/agentmux/work")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"title":"t","payload":"p","max_attempts":1}"#))
+        .unwrap();
+    let resp = app.clone().oneshot(enq).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let id = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let claim = Request::builder()
+        .uri("/agentmux/work/claim")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"a1"}"#))
+        .unwrap();
+    let resp = app.clone().oneshot(claim).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let attempt = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["attempt"]
+        .as_i64()
+        .unwrap();
+
+    let rel = Request::builder()
+        .uri(format!("/agentmux/work/{id}/release"))
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(format!(
+            r#"{{"agent_id":"a1","attempt":{attempt},"result":"cannot do this"}}"#
+        )))
+        .unwrap();
+    let resp = app.oneshot(rel).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(
+        v["state"], "failed",
+        "a release on the final attempt parks the item; the response must say so"
+    );
+}
+
+/// A stale fence is 409 CONFLICT, not 404: the row still exists, it just moved
+/// on without this caller. The MCP layer depends on that distinction to tell an
+/// agent to re-claim rather than to treat the item as gone.
+#[tokio::test]
+async fn work_complete_with_a_wrong_fence_is_conflict_not_not_found() {
+    let app = test_router();
+
+    let enq = Request::builder()
+        .uri("/agentmux/work")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"title":"t","payload":"p"}"#))
+        .unwrap();
+    let resp = app.clone().oneshot(enq).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let id = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let claim = Request::builder()
+        .uri("/agentmux/work/claim")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"a1"}"#))
+        .unwrap();
+    app.clone().oneshot(claim).await.unwrap();
+
+    // attempt 99 was never issued by any claim.
+    let done = Request::builder()
+        .uri(format!("/agentmux/work/{id}/complete"))
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"a1","attempt":99,"result":"nope"}"#))
+        .unwrap();
+    let resp = app.oneshot(done).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
 }

--- a/agentmux-srv/src/server/work_queue.rs
+++ b/agentmux-srv/src/server/work_queue.rs
@@ -258,6 +258,10 @@ pub(super) async fn handle_work_complete(
     }
 }
 
+/// Returns the item's RESULTING state alongside `ok` (Codex P2 on PR #2902).
+/// A release on the item's final allowed attempt parks it as `failed` rather
+/// than reopening it, so a bare `{ok:true}` would let the caller report "handed
+/// back to the queue" for an item nobody can ever claim again.
 pub(super) async fn handle_work_release(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -267,7 +271,21 @@ pub(super) async fn handle_work_release(
         .identity_store
         .work_queue_release(&id, &req.agent_id, req.attempt, &req.result, now_ms())
     {
-        Ok(ok) => holder_result(ok, &state),
+        Ok(true) => {
+            publish_changed(&state);
+            // Read back rather than infer: the store owns the
+            // attempts-vs-max_attempts decision, and duplicating that rule
+            // here is exactly how the two drift.
+            let resulting = state
+                .identity_store
+                .work_queue_get(&id)
+                .ok()
+                .flatten()
+                .map(|i| i.state)
+                .unwrap_or_default();
+            (StatusCode::OK, Json(json!({ "ok": true, "state": resulting })))
+        }
+        Ok(false) => holder_result(false, &state),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("release failed: {e}")),
     }
 }
@@ -291,17 +309,25 @@ pub(super) async fn handle_work_list(
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub(super) struct CancelRequest {
     #[serde(default)]
     pub reason: String,
 }
 
+/// The body is OPTIONAL (reagent P1 on PR #2902). The sibling DELETE route in
+/// the same router — `DELETE /agentmux/cron/:id` — takes no body at all, so a
+/// caller following that adjacent, established convention would otherwise get
+/// a 400/415 from axum's `Json` extractor rather than the intended
+/// "cancel with an empty reason". `CancelRequest::reason` is already
+/// `#[serde(default)]`; making the whole body optional is what actually lets
+/// that default be reached.
 pub(super) async fn handle_work_cancel(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    Json(req): Json<CancelRequest>,
+    body: Option<Json<CancelRequest>>,
 ) -> (StatusCode, Json<Value>) {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
     match state.identity_store.work_queue_cancel(&id, &req.reason, now_ms()) {
         Ok(true) => {
             publish_changed(&state);

--- a/agentmux-srv/src/server/work_queue.rs
+++ b/agentmux-srv/src/server/work_queue.rs
@@ -1,0 +1,320 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Muxqueue HTTP surface — slice 2 of
+//! `docs/reports/REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md`.
+//!
+//!   POST   /agentmux/work                 — enqueue
+//!   POST   /agentmux/work/claim           — claim the next eligible item
+//!   POST   /agentmux/work/:id/heartbeat   — extend a lease
+//!   POST   /agentmux/work/:id/complete    — finish
+//!   POST   /agentmux/work/:id/release     — give back
+//!   GET    /agentmux/work                 — list
+//!   DELETE /agentmux/work/:id             — cancel
+//!
+//! Auth-gated by the same middleware as the cron and reactive routes.
+//!
+//! **Store choice:** every handler uses `state.identity_store` — the
+//! always-global store — NOT `state.shared_store`, which is what the cron
+//! handlers next door still use. That difference is deliberate, not an
+//! inconsistency to tidy up later: a per-channel queue would only ever mean
+//! "any agent in this channel can pick it up". Cron's own placement is a known
+//! unmigrated case (`SPEC_IDENTITY_STORE_SPLIT_2026_08_17.md` step 1b).
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::backend::storage::work_queue::{ClaimFilter, WorkItem};
+use crate::backend::wps::WaveEvent;
+
+use super::AppState;
+
+/// Default lease granted by a claim, and the window a heartbeat extends by.
+/// Deliberately short relative to a long agent turn: a claimant is expected to
+/// heartbeat, and a crashed one should return to the pool in about a minute
+/// rather than blocking the item for an hour.
+const DEFAULT_LEASE_MS: i64 = 120_000;
+
+/// Emitted whenever the queue changes so any live view can refresh without
+/// polling. Named alongside the existing `EVENT_CRON_CHANGED` convention.
+const EVENT_WORK_QUEUE_CHANGED: &str = "workqueue:changed";
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn publish_changed(state: &AppState) {
+    state.broker.publish(WaveEvent {
+        event: EVENT_WORK_QUEUE_CHANGED.to_string(),
+        scopes: vec![],
+        sender: String::new(),
+        persist: 0,
+        data: None,
+    });
+}
+
+fn err(code: StatusCode, msg: impl Into<String>) -> (StatusCode, Json<Value>) {
+    (code, Json(json!({ "error": msg.into() })))
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct EnqueueRequest {
+    pub title: String,
+    pub payload: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub target_agent: String,
+    #[serde(default)]
+    pub target_group: String,
+    #[serde(default)]
+    pub priority: i64,
+    #[serde(default)]
+    pub created_by: String,
+    #[serde(default)]
+    pub max_attempts: Option<i64>,
+    /// ms epoch. Not claimable before this.
+    #[serde(default)]
+    pub not_before: Option<i64>,
+}
+
+pub(super) async fn handle_work_enqueue(
+    State(state): State<AppState>,
+    Json(req): Json<EnqueueRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.title.trim().is_empty() {
+        return err(StatusCode::BAD_REQUEST, "title is required");
+    }
+    if req.payload.trim().is_empty() {
+        return err(StatusCode::BAD_REQUEST, "payload is required");
+    }
+    // An item targeted at both a specific agent AND a group is ambiguous —
+    // reject rather than silently letting one win, which would look like the
+    // queue quietly ignored half the caller's intent.
+    if !req.target_agent.is_empty() && !req.target_group.is_empty() {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "specify target_agent or target_group, not both",
+        );
+    }
+
+    let now = now_ms();
+    let item = WorkItem {
+        id: Uuid::new_v4().to_string(),
+        title: req.title,
+        payload: req.payload,
+        kind: req.kind,
+        target_agent: req.target_agent,
+        target_group: req.target_group,
+        priority: req.priority,
+        state: String::new(), // set by the store
+        claimed_by: String::new(),
+        claim_expires: None,
+        attempts: 0,
+        max_attempts: req.max_attempts.unwrap_or(3),
+        created_by: req.created_by,
+        created_at: now,
+        updated_at: now,
+        not_before: req.not_before,
+        result: String::new(),
+    };
+
+    match state.identity_store.work_queue_enqueue(&item) {
+        Ok(()) => {
+            publish_changed(&state);
+            (StatusCode::OK, Json(json!({ "id": item.id })))
+        }
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("enqueue failed: {e}")),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ClaimRequest {
+    /// The claiming agent's id.
+    pub agent_id: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Group ids this agent belongs to. Resolved by the CALLER — group
+    /// membership lives in the per-channel store, which the queue module
+    /// deliberately does not reach into.
+    #[serde(default)]
+    pub groups: Vec<String>,
+    #[serde(default)]
+    pub lease_ms: Option<i64>,
+}
+
+pub(super) async fn handle_work_claim(
+    State(state): State<AppState>,
+    Json(req): Json<ClaimRequest>,
+) -> (StatusCode, Json<Value>) {
+    if req.agent_id.trim().is_empty() {
+        return err(StatusCode::BAD_REQUEST, "agent_id is required");
+    }
+    let now = now_ms();
+
+    // Reap BEFORE claiming, so an expired lease is recovered by the very next
+    // agent that asks for work. This is why there is no background reaper
+    // task: the only moment a stale claim actually matters is when someone
+    // wants the item, and reaping here makes that self-healing. The predicate
+    // is indexed (idx_ids_work_queue_claim_expires) and no-ops when nothing
+    // has expired.
+    if let Err(e) = state.identity_store.work_queue_reap(now) {
+        // Not fatal — a claim against a not-yet-reaped queue is still correct,
+        // just possibly emptier than it could be. Log and continue rather than
+        // failing the caller's request.
+        tracing::warn!(target: "workqueue", error = %e, "reap before claim failed");
+    }
+
+    let filter = ClaimFilter {
+        kind: req.kind.filter(|k| !k.is_empty()),
+        agent_id: req.agent_id.clone(),
+        groups: req.groups.clone(),
+    };
+    let lease = req.lease_ms.filter(|&n| n > 0).unwrap_or(DEFAULT_LEASE_MS);
+
+    match state.identity_store.work_queue_claim(&filter, now, lease) {
+        Ok(Some(item)) => {
+            publish_changed(&state);
+            // `attempt` is echoed at the top level as well as inside `item`
+            // because every subsequent call (heartbeat/complete/release) MUST
+            // pass it back as a fence — see work_queue.rs's ABA note. Making
+            // it prominent here is the difference between a caller that
+            // fences correctly and one that discovers the requirement from a
+            // 404-shaped "not the holder" response.
+            (
+                StatusCode::OK,
+                Json(json!({ "claimed": true, "attempt": item.attempts, "item": item })),
+            )
+        }
+        Ok(None) => (StatusCode::OK, Json(json!({ "claimed": false }))),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("claim failed: {e}")),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct HolderRequest {
+    pub agent_id: String,
+    /// Fence token — the `attempt` returned by the claim this call belongs to.
+    pub attempt: i64,
+    #[serde(default)]
+    pub result: String,
+    #[serde(default)]
+    pub lease_ms: Option<i64>,
+}
+
+/// Shared shape for the three holder-only transitions. `false` from the store
+/// means the caller is not the current holder OR its fence is stale — both are
+/// CONFLICT, not NOT_FOUND: the row usually still exists, it just moved on
+/// without this caller.
+fn holder_result(ok: bool, state: &AppState) -> (StatusCode, Json<Value>) {
+    if ok {
+        publish_changed(state);
+        (StatusCode::OK, Json(json!({ "ok": true })))
+    } else {
+        (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "error": "not the current holder, or this claim has been superseded \
+                          (expired and reclaimed) — re-claim before continuing"
+            })),
+        )
+    }
+}
+
+pub(super) async fn handle_work_heartbeat(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<HolderRequest>,
+) -> (StatusCode, Json<Value>) {
+    let lease = req.lease_ms.filter(|&n| n > 0).unwrap_or(DEFAULT_LEASE_MS);
+    match state
+        .identity_store
+        .work_queue_heartbeat(&id, &req.agent_id, req.attempt, now_ms(), lease)
+    {
+        Ok(ok) => holder_result(ok, &state),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("heartbeat failed: {e}")),
+    }
+}
+
+pub(super) async fn handle_work_complete(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<HolderRequest>,
+) -> (StatusCode, Json<Value>) {
+    match state
+        .identity_store
+        .work_queue_complete(&id, &req.agent_id, req.attempt, &req.result, now_ms())
+    {
+        Ok(ok) => holder_result(ok, &state),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("complete failed: {e}")),
+    }
+}
+
+pub(super) async fn handle_work_release(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<HolderRequest>,
+) -> (StatusCode, Json<Value>) {
+    match state
+        .identity_store
+        .work_queue_release(&id, &req.agent_id, req.attempt, &req.result, now_ms())
+    {
+        Ok(ok) => holder_result(ok, &state),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("release failed: {e}")),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ListQuery {
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+pub(super) async fn handle_work_list(
+    State(state): State<AppState>,
+    Query(q): Query<ListQuery>,
+) -> (StatusCode, Json<Value>) {
+    let limit = q.limit.unwrap_or(50).clamp(1, 500);
+    match state.identity_store.work_queue_list(&q.state, limit) {
+        Ok(items) => (StatusCode::OK, Json(json!({ "items": items }))),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("list failed: {e}")),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct CancelRequest {
+    #[serde(default)]
+    pub reason: String,
+}
+
+pub(super) async fn handle_work_cancel(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<CancelRequest>,
+) -> (StatusCode, Json<Value>) {
+    match state.identity_store.work_queue_cancel(&id, &req.reason, now_ms()) {
+        Ok(true) => {
+            publish_changed(&state);
+            (StatusCode::OK, Json(json!({ "ok": true })))
+        }
+        // Distinct from the holder-conflict case: cancel is deliberately NOT
+        // holder-gated (it is an operator action), so a `false` here means the
+        // item is already terminal or absent, not that the caller lacks a
+        // claim.
+        Ok(false) => (
+            StatusCode::CONFLICT,
+            Json(json!({ "ok": false, "error": "no open or claimed item with that id" })),
+        ),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("cancel failed: {e}")),
+    }
+}


### PR DESCRIPTION
Slice 2 of `REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md` — agents can now actually **use** the queue built in slice 1 (#2898, merged). This is what clears slice 1's dead-code warnings.

## Surface

Seven routes, auth-gated by the same middleware as cron/reactive:

```
POST   /agentmux/work                 enqueue
POST   /agentmux/work/claim           claim next eligible
POST   /agentmux/work/:id/heartbeat   extend lease
POST   /agentmux/work/:id/complete    finish
POST   /agentmux/work/:id/release     hand back
GET    /agentmux/work                 list
DELETE /agentmux/work/:id             cancel
```

Six MCP tools: `WorkEnqueue`, `WorkClaim`, `WorkHeartbeat`, `WorkComplete`, `WorkRelease`, `WorkList`.

## Decisions worth reviewing

**No background reaper task.** The claim handler reaps expired leases *first*, so a dead claimant's item is recovered by the very next agent that asks for work. The only moment a stale claim matters is when someone wants the item — that makes it self-healing with no scheduler to own, and the reap predicate is indexed. A reap failure is logged and the claim proceeds: a not-yet-reaped queue is still correct, just possibly emptier than it could be.

**`identity_store`, not `shared_store`.** Every handler uses the always-global store, unlike the cron handlers sitting directly next to them. That inconsistency is deliberate and documented at the top of the module — cron's placement is the known-unmigrated step 1b of `SPEC_IDENTITY_STORE_SPLIT_2026_08_17.md`, not a pattern to copy.

**The claim response echoes `attempt` at the top level**, not only nested inside `item`. It's a required fence on every later call (slice 1's ABA fix), and burying it is the difference between a caller that fences correctly and one that discovers the requirement from a rejected write.

**A rejected fence is 409, not 404.** The row usually still exists — it just moved on without this caller. The MCP layer translates that into the one instruction that recovers it: claim again, don't retry with the old attempt.

**Enqueue rejects `target_agent` + `target_group` together** rather than letting one silently win.

## One deliberate limitation

`WorkClaim` sends an **empty groups list**. The MCP process has no cheap way to resolve this agent's group memberships yet, so it claims only untargeted and self-targeted work. Group-targeted claiming arrives with the group lookup, not before — silently ignoring a group restriction would be worse than under-claiming.

## Tests

- `cargo test -p agentmux-srv` — **2909 passed**
- `cargo test -p agentmux-mcp` — **26 passed**
- Both crates build clean

The tool-count test caught the six additions exactly as designed (36 → 42).

Next slice: `muxspect work` for CLI observability, then a pane if the shape holds.

<!-- agentmux:agent_id=agentx -->