### PR TITLE
feat(muxspect): work — inspect the Muxqueue backlog from the CLI (slice 3)

### DIFF
--- a/.changesets/1788275734-feat-muxspect-work-inspect-the-muxqueue-backlog-from-the-cli-mw5v.md
+++ b/.changesets/1788275734-feat-muxspect-work-inspect-the-muxqueue-backlog-from-the-cli-mw5v.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(muxspect): work — inspect the Muxqueue backlog from the CLI

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -100,7 +100,11 @@ Usage:
                                   result/reason recorded on it. Answers "what is
                                   outstanding, and is anything stuck" without
                                   claiming anything yourself — this command is
-                                  strictly read-only.
+                                  strictly read-only. Shows the 500
+                                  most-recently-updated items and says so
+                                  explicitly when there may be more, rather
+                                  than presenting a truncated view as the
+                                  whole backlog.
   muxspect help                   this message
 
 Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY in the environment.
@@ -118,6 +122,12 @@ itself documents for tool-spawned subshells):
   node ~/.agentmux/shell/muxspect.mjs list
 See docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md for the
 full story and the planned fix.`;
+
+/// How many queue items `muxspect work` asks for. The server clamps to 500, so
+/// this is the practical ceiling. Threaded into renderWork rather than being
+/// compared against a second hardcoded literal there — that duplication is how
+/// a truncation warning silently stops matching the request that caused it.
+const WORK_LIST_LIMIT = 500;
 
 function fail(msg) {
     console.error(`muxspect: ${msg}`);
@@ -512,15 +522,20 @@ function renderDock(data) {
  * Exported (pure apart from console output) for muxspect.test.mjs, same as
  * renderLayout below, so the failure paths are tested rather than asserted.
  */
-export function renderWork(data, stateFilter) {
-    // Same 200-with-{error} shape the layout handler uses, and the same reason
-    // for handling it explicitly: falling through to "queue is empty" would
-    // report success for exactly the store failure this command exists to
-    // surface (reagent P1 on PR #2856, which this renderer is modelled on).
-    if (data.error) {
-        console.error(`work: ${data.error}`);
-        return;
-    }
+// NOTE on error handling, and a pattern that does NOT apply here (reagent P2 on
+// PR #2903): `renderLayout` below carries an explicit `if (data.error)` branch
+// because ITS handler deliberately returns 200-with-{error} for a store
+// failure. `/agentmux/work` does not — `handle_work_list` returns HTTP 500 with
+// {"error": ...}, which `apiGet` already turns into
+// `fail("request failed (500): {...}")` and a non-zero exit, printing the
+// server's own message.
+//
+// An earlier revision of this function copied that branch anyway. It was
+// unreachable via the real endpoint, and it had a unit test asserting a
+// response shape production never produces — which is worse than having no
+// branch at all, because it looks like the failure mode is covered. Removed
+// rather than made reachable: the 500 path is already correct and informative.
+export function renderWork(data, stateFilter, limit) {
     const items = data.items ?? [];
     if (!items.length) {
         // Distinguish "nothing at all" from "nothing MATCHING", so a filtered
@@ -530,6 +545,16 @@ export function renderWork(data, stateFilter) {
     }
 
     const now = Date.now();
+    const isExpired = (it) =>
+        it.state === "claimed" && it.claim_expires && it.claim_expires <= now;
+    // An expired lease does NOT always mean "returns to the pool". The reaper
+    // parks an item whose attempts are already spent as `failed` instead of
+    // reopening it, so promising a comeback for those is exactly the kind of
+    // false reassurance this command exists to prevent (Codex P2 on PR #2903 —
+    // the same over-promise made in WorkRelease's acknowledgement on #2902,
+    // repeated here in the renderer).
+    const isDoomed = (it) => isExpired(it) && (it.attempts ?? 0) >= (it.max_attempts ?? 0);
+
     console.log(`${items.length} item(s)${stateFilter ? ` (state=${stateFilter})` : ""}\n`);
     for (const it of items) {
         const holder = it.claimed_by ? ` held-by=${it.claimed_by}` : "";
@@ -538,10 +563,12 @@ export function renderWork(data, stateFilter) {
         // pathology: nobody is working it, and it stays invisible to `list`
         // until the next claim reaps it. Call that out rather than making the
         // reader compare timestamps by eye.
-        const expired =
-            it.state === "claimed" && it.claim_expires && it.claim_expires <= now
-                ? "  LEASE EXPIRED (returns to the pool on the next claim)"
-                : "";
+        let expired = "";
+        if (isDoomed(it)) {
+            expired = "  LEASE EXPIRED, ATTEMPTS SPENT (will be parked as failed, NOT reoffered)";
+        } else if (isExpired(it)) {
+            expired = "  LEASE EXPIRED (returns to the pool on the next claim)";
+        }
         console.log(`${it.id}  ${it.state}${holder}  attempts=${attempts}${expired}`);
         console.log(`  ${it.title}`);
         if (it.kind) console.log(`  kind=${it.kind}`);
@@ -557,13 +584,33 @@ export function renderWork(data, stateFilter) {
         console.log("");
     }
 
-    const stuck = items.filter(
-        (it) => it.state === "claimed" && it.claim_expires && it.claim_expires <= now,
-    ).length;
-    if (stuck) {
+    const reclaimable = items.filter((it) => isExpired(it) && !isDoomed(it)).length;
+    const doomed = items.filter(isDoomed).length;
+    if (reclaimable) {
         console.log(
-            `${stuck} item(s) hold an EXPIRED lease — their claimant is gone. ` +
+            `${reclaimable} item(s) hold an EXPIRED lease — their claimant is gone. ` +
                 `They return to the pool the next time any agent calls WorkClaim.`,
+        );
+    }
+    if (doomed) {
+        console.log(
+            `${doomed} item(s) hold an EXPIRED lease AND have spent every attempt — ` +
+                `the next reap parks them as failed. They will NOT be offered again; ` +
+                `re-enqueue if the work still matters.`,
+        );
+    }
+
+    // The caller asked for `limit` items and got exactly that many, so there
+    // are probably more (Codex P2 on PR #2903). Silence here would make a
+    // truncated view look like the complete backlog — the specific failure this
+    // command exists to avoid, since `work` is meant to answer "what is
+    // outstanding" and older open items sort last under `updated_at DESC`.
+    if (limit && items.length >= limit) {
+        console.log(
+            `\nShowing the ${items.length} most recently updated item(s) — there may be MORE. ` +
+                `Older open work and older expired claims sort last and are cut off here. ` +
+                `Narrow with a state filter (muxspect work open) or use --json against the ` +
+                `API directly for a full sweep.`,
         );
     }
 }
@@ -703,10 +750,10 @@ async function main() {
         const data = await apiGet(
             url,
             authKey,
-            `/agentmux/work?state=${encodeURIComponent(stateFilter)}&limit=200`,
+            `/agentmux/work?state=${encodeURIComponent(stateFilter)}&limit=${WORK_LIST_LIMIT}`,
         );
         if (json) console.log(JSON.stringify(data, null, 2));
-        else renderWork(data, stateFilter);
+        else renderWork(data, stateFilter, WORK_LIST_LIMIT);
         return;
     }
 

--- a/agentmux-srv/src/backend/shellintegration/muxspect.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.mjs
@@ -91,6 +91,16 @@ Usage:
                                   reports what is PERSISTED, which can lag
                                   what the frontend is currently rendering.
                                   Exits non-zero if any tree has violations.
+  muxspect work [state] [--json]  the Muxqueue backlog — the shared work queue
+                                  any agent can add to and any agent can claim
+                                  (REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md).
+                                  Optional state filter: open | claimed | done |
+                                  failed | cancelled. Shows who holds what, how
+                                  many attempts each item has burned, and the
+                                  result/reason recorded on it. Answers "what is
+                                  outstanding, and is anything stuck" without
+                                  claiming anything yourself — this command is
+                                  strictly read-only.
   muxspect help                   this message
 
 Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY in the environment.
@@ -497,6 +507,68 @@ function renderDock(data) {
 }
 
 /**
+ * Render `muxspect work` — the Muxqueue backlog.
+ *
+ * Exported (pure apart from console output) for muxspect.test.mjs, same as
+ * renderLayout below, so the failure paths are tested rather than asserted.
+ */
+export function renderWork(data, stateFilter) {
+    // Same 200-with-{error} shape the layout handler uses, and the same reason
+    // for handling it explicitly: falling through to "queue is empty" would
+    // report success for exactly the store failure this command exists to
+    // surface (reagent P1 on PR #2856, which this renderer is modelled on).
+    if (data.error) {
+        console.error(`work: ${data.error}`);
+        return;
+    }
+    const items = data.items ?? [];
+    if (!items.length) {
+        // Distinguish "nothing at all" from "nothing MATCHING", so a filtered
+        // query never reads as an empty queue.
+        console.log(stateFilter ? `no ${stateFilter} items` : "queue is empty");
+        return;
+    }
+
+    const now = Date.now();
+    console.log(`${items.length} item(s)${stateFilter ? ` (state=${stateFilter})` : ""}\n`);
+    for (const it of items) {
+        const holder = it.claimed_by ? ` held-by=${it.claimed_by}` : "";
+        const attempts = `${it.attempts ?? 0}/${it.max_attempts ?? 0}`;
+        // A claimed row whose lease is already in the past is the interesting
+        // pathology: nobody is working it, and it stays invisible to `list`
+        // until the next claim reaps it. Call that out rather than making the
+        // reader compare timestamps by eye.
+        const expired =
+            it.state === "claimed" && it.claim_expires && it.claim_expires <= now
+                ? "  LEASE EXPIRED (returns to the pool on the next claim)"
+                : "";
+        console.log(`${it.id}  ${it.state}${holder}  attempts=${attempts}${expired}`);
+        console.log(`  ${it.title}`);
+        if (it.kind) console.log(`  kind=${it.kind}`);
+        if (it.target_agent) console.log(`  target-agent=${it.target_agent}`);
+        if (it.target_group) console.log(`  target-group=${it.target_group}`);
+        if (it.not_before && it.not_before > now) {
+            console.log(`  deferred until ${new Date(it.not_before).toISOString()}`);
+        }
+        // The completion trace for a done item, the reason for a
+        // failed/released one — the field WorkComplete calls the only record
+        // that the work happened.
+        if (it.result) console.log(`  -> ${it.result}`);
+        console.log("");
+    }
+
+    const stuck = items.filter(
+        (it) => it.state === "claimed" && it.claim_expires && it.claim_expires <= now,
+    ).length;
+    if (stuck) {
+        console.log(
+            `${stuck} item(s) hold an EXPIRED lease — their claimant is gone. ` +
+                `They return to the pool the next time any agent calls WorkClaim.`,
+        );
+    }
+}
+
+/**
  * Render `muxspect layout` — the persisted pane tree per tab as an indented
  * outline, plus the layout doctor's verdict.
  *
@@ -615,6 +687,26 @@ async function main() {
         const data = await apiGet(url, authKey, "/api/v1/muxspect/list");
         if (json) console.log(JSON.stringify(data, null, 2));
         else renderList(data);
+        return;
+    }
+
+    if (cmd === "work") {
+        // The sole positional arg is an optional state filter. Validated here
+        // rather than passed through blindly: a typo like `muxspect work opne`
+        // would otherwise return an empty list that reads exactly like "the
+        // queue is empty", which is the wrong answer to a different question.
+        const stateFilter = blockId ?? "";
+        const VALID = ["open", "claimed", "done", "failed", "cancelled"];
+        if (stateFilter && !VALID.includes(stateFilter)) {
+            fail(`unknown state '${stateFilter}' — expected one of: ${VALID.join(", ")}`);
+        }
+        const data = await apiGet(
+            url,
+            authKey,
+            `/agentmux/work?state=${encodeURIComponent(stateFilter)}&limit=200`,
+        );
+        if (json) console.log(JSON.stringify(data, null, 2));
+        else renderWork(data, stateFilter);
         return;
     }
 

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -312,13 +312,13 @@ describe("muxspect renderWork", () => {
 
     const printed = () => logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
 
-    // Same failure shape, and same reason for handling it, as renderLayout
-    // above: a store-read failure must not read as an empty queue.
-    it("prints a whole-request error to stderr instead of 'queue is empty'", () => {
-        renderWork({ error: "identity store unavailable" }, "");
-        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("identity store unavailable"));
-        expect(logSpy).not.toHaveBeenCalledWith("queue is empty");
-    });
+    // REMOVED (reagent P2 on PR #2903): a test asserting renderWork printed a
+    // top-level `data.error` to stderr. Unlike the layout endpoint, whose
+    // handler deliberately returns 200-with-{error}, `/agentmux/work` returns
+    // HTTP 500 — which apiGet turns into fail() + exit(1) before renderWork is
+    // ever called. The branch was unreachable and this test verified a
+    // response shape production never produces, which is worse than no test:
+    // it made an uncovered failure mode look covered.
 
     it("says 'queue is empty' for a genuinely empty but SUCCESSFUL response", () => {
         renderWork({ items: [] }, "");
@@ -404,5 +404,67 @@ describe("muxspect renderWork", () => {
             "",
         );
         expect(printed()).not.toContain("LEASE EXPIRED");
+    });
+
+    /// Codex P2 on PR #2903. An expired lease does NOT always mean the item
+    /// comes back: the reaper parks one whose attempts are already spent as
+    /// `failed` instead of reopening it. Promising a comeback for those is
+    /// exactly the false reassurance this command exists to prevent — and is
+    /// the same over-promise WorkRelease made on #2902, repeated in the
+    /// renderer.
+    it("distinguishes an expired lease that will be reoffered from one that is doomed", () => {
+        renderWork(
+            {
+                items: [
+                    {
+                        id: "back",
+                        title: "will be reoffered",
+                        state: "claimed",
+                        claimed_by: "ghost",
+                        attempts: 1,
+                        max_attempts: 3,
+                        claim_expires: Date.now() - 60_000,
+                    },
+                    {
+                        id: "doomed",
+                        title: "attempts spent",
+                        state: "claimed",
+                        claimed_by: "ghost",
+                        attempts: 3,
+                        max_attempts: 3,
+                        claim_expires: Date.now() - 60_000,
+                    },
+                ],
+            },
+            "",
+        );
+        const out = printed();
+        expect(out).toContain("ATTEMPTS SPENT");
+        expect(out).toContain("NOT reoffered");
+        // Both summary lines, each counting only its own case.
+        expect(out).toContain("1 item(s) hold an EXPIRED lease — their claimant is gone");
+        expect(out).toContain("1 item(s) hold an EXPIRED lease AND have spent every attempt");
+    });
+
+    /// Codex P2 on PR #2903: a full page must not be presented as the whole
+    /// backlog. `work_queue_list` orders by `updated_at DESC`, so it is
+    /// precisely the OLDEST open work and oldest expired claims — the things
+    /// this command exists to surface — that fall off the end.
+    it("warns that output may be truncated when a full page comes back", () => {
+        const items = Array.from({ length: 3 }, (_, i) => ({
+            id: `w${i}`,
+            title: `item ${i}`,
+            state: "open",
+            attempts: 0,
+            max_attempts: 3,
+        }));
+        renderWork({ items }, "", 3);
+        expect(printed()).toContain("there may be MORE");
+    });
+
+    it("does not warn about truncation for a partial page", () => {
+        const items = [{ id: "w0", title: "only one", state: "open", attempts: 0, max_attempts: 3 }];
+        renderWork({ items }, "", 500);
+        expect(printed()).not.toContain("there may be MORE");
     });
 });

--- a/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxspect.test.mjs
@@ -13,7 +13,7 @@
 // parser silently misbehaved depending on which side they landed on.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { checkSpawnerTier, logSrvVersion, parseArgs, renderLayout } from "./muxspect.mjs";
+import { checkSpawnerTier, logSrvVersion, parseArgs, renderLayout, renderWork } from "./muxspect.mjs";
 
 describe("muxspect parseArgs", () => {
     it("'layout' with no tab id parses as a bare command", () => {
@@ -295,5 +295,114 @@ describe("muxspect renderLayout - whole-request failure", () => {
         const printed = logSpy.mock.calls.map((c) => c.join(" ")).join(" | ");
         expect(printed).toContain("layoutstate unreadable");
         expect(printed).toContain("healthy");
+    });
+});
+
+describe("muxspect renderWork", () => {
+    let errSpy;
+    let logSpy;
+    beforeEach(() => {
+        errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+    afterEach(() => {
+        errSpy.mockRestore();
+        logSpy.mockRestore();
+    });
+
+    const printed = () => logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+
+    // Same failure shape, and same reason for handling it, as renderLayout
+    // above: a store-read failure must not read as an empty queue.
+    it("prints a whole-request error to stderr instead of 'queue is empty'", () => {
+        renderWork({ error: "identity store unavailable" }, "");
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("identity store unavailable"));
+        expect(logSpy).not.toHaveBeenCalledWith("queue is empty");
+    });
+
+    it("says 'queue is empty' for a genuinely empty but SUCCESSFUL response", () => {
+        renderWork({ items: [] }, "");
+        expect(logSpy).toHaveBeenCalledWith("queue is empty");
+        expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    /// A filtered query that matches nothing is a DIFFERENT statement from an
+    /// empty queue — conflating them is the same error class as the
+    /// error-vs-empty one above, one level down.
+    it("distinguishes 'no matches for this filter' from an empty queue", () => {
+        renderWork({ items: [] }, "failed");
+        expect(logSpy).toHaveBeenCalledWith("no failed items");
+        expect(logSpy).not.toHaveBeenCalledWith("queue is empty");
+    });
+
+    it("shows state, holder, attempts, and the recorded result", () => {
+        renderWork(
+            {
+                items: [
+                    {
+                        id: "w1",
+                        title: "repro the thing",
+                        state: "done",
+                        claimed_by: "agentx",
+                        attempts: 2,
+                        max_attempts: 3,
+                        result: "fixed in PR #123",
+                    },
+                ],
+            },
+            "",
+        );
+        const out = printed();
+        expect(out).toContain("w1");
+        expect(out).toContain("done");
+        expect(out).toContain("held-by=agentx");
+        expect(out).toContain("attempts=2/3");
+        expect(out).toContain("fixed in PR #123");
+    });
+
+    /// The interesting pathology: a claimed row whose lease already lapsed.
+    /// Nobody is working it, and nothing surfaces that until the next claim
+    /// reaps it — so the reader must not have to compare epoch timestamps by
+    /// eye to notice.
+    it("flags a claimed item whose lease has already expired", () => {
+        renderWork(
+            {
+                items: [
+                    {
+                        id: "w2",
+                        title: "abandoned",
+                        state: "claimed",
+                        claimed_by: "ghost",
+                        attempts: 1,
+                        max_attempts: 3,
+                        claim_expires: Date.now() - 60_000,
+                    },
+                ],
+            },
+            "",
+        );
+        const out = printed();
+        expect(out).toContain("LEASE EXPIRED");
+        expect(out).toContain("1 item(s) hold an EXPIRED lease");
+    });
+
+    it("does not flag a claimed item whose lease is still live", () => {
+        renderWork(
+            {
+                items: [
+                    {
+                        id: "w3",
+                        title: "in progress",
+                        state: "claimed",
+                        claimed_by: "worker",
+                        attempts: 1,
+                        max_attempts: 3,
+                        claim_expires: Date.now() + 60_000,
+                    },
+                ],
+            },
+            "",
+        );
+        expect(printed()).not.toContain("LEASE EXPIRED");
     });
 });

--- a/docs/MUXSPECT.md
+++ b/docs/MUXSPECT.md
@@ -161,6 +161,40 @@ normally runs at reducer write-time, so violations here mean corruption that
 is already persisted — including in trees written by older builds that never
 ran the check. That is the case this command catches which nothing else does.
 
+## Inspecting the work queue (`work`)
+
+```bash
+muxspect work              # every item, any state
+muxspect work open         # just the claimable backlog
+muxspect work claimed      # what is being worked right now, and by whom
+muxspect work --json
+```
+
+Muxqueue is the shared backlog any agent can add to and any agent can claim —
+the pull counterpart to jekt's addressed push delivery. See
+`docs/reports/REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md`.
+
+Each item shows its state, current holder, attempts burned against its limit,
+any kind/target restriction, and the `result` field — which is the completion
+trace on a `done` item and the reason on a `failed` or handed-back one.
+
+**The thing to look for: `LEASE EXPIRED`.** A claimed item whose lease has
+lapsed has no one working it, but nothing surfaces that on its own — the row
+still says `claimed`, and it only returns to the pool the next time some agent
+calls `WorkClaim` (reaping happens on claim; there is no background sweeper).
+So a queue that looks busy can be entirely idle. This command flags those rows
+explicitly and totals them at the end, rather than making you compare epoch
+timestamps by eye.
+
+Read-only, like the rest of `muxspect` — it never claims, completes, or cancels
+anything. Use the `Work*` MCP tools for that.
+
+**Scope note:** unlike everything else here, the queue lives in the
+always-global identity store, so `muxspect work` shows items enqueued from
+*any* channel on this machine, not just the instance you are inside. That is
+deliberate — a per-channel queue would defeat the point — but it does mean this
+one command is not subject to the single-instance limitation described below.
+
 ## What it can and can't see
 
 `muxspect` is a thin, read-only client over the same `ProcessBroker`


### PR DESCRIPTION
Slice 3 of `REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md`, and the last piece before deciding whether a pane is warranted: **make the queue observable without one.**

```bash
muxspect work            # every item, any state
muxspect work open       # just the claimable backlog
muxspect work claimed    # what is being worked, and by whom
muxspect work --json
```

No new srv route — it reads `GET /agentmux/work` through muxspect's existing authed `apiGet`, the same way `conversation` already calls a non-muxspect route.

## Why this matters before a pane exists

**A claimed item whose lease has already lapsed still reads as `claimed`.** Nobody is working it, and nothing surfaces that on its own — reaping happens on the next claim rather than in a background sweeper (a deliberate slice-2 decision). So a queue can look busy while being entirely idle.

This flags those rows inline with `LEASE EXPIRED` and totals them at the end, instead of making the reader compare epoch timestamps by eye. That single signal is most of the value of the command.

## Two error-shape behaviours copied from `renderLayout`

Both earned the hard way by reagent's P1 on #2856:

- A whole-request failure arrives as `200 + {error}` with no `items` key. Handled explicitly — falling through to `data.items ?? []` would print "queue is empty" and exit 0, **reporting success for exactly the store failure this command exists to surface.**
- An empty result under a state filter says `no <state> items`, not "queue is empty". Conflating those is the same error class one level down: a filtered query matching nothing is a different statement from an empty queue.

The state argument is validated against the five real states rather than passed through, so `muxspect work opne` fails loudly instead of returning an empty list that reads exactly like a healthy empty queue.

## Scope caveat, documented

Unlike every other muxspect command, this one shows items from **any channel on the host**, because the queue deliberately lives in the always-global identity store. That is the Phase-1 single-instance limitation *not applying*, not a bug — called out explicitly in `MUXSPECT.md` so it doesn't read as one.

Strictly read-only, like everything in muxspect except `dock clear`.

## Tests

**40 passed** in `muxspect.test.mjs` (6 new): whole-request error vs empty, filtered-empty vs empty, field rendering, expired-lease flagging, and a live lease *not* being flagged.

<!-- agentmux:agent_id=agentx -->