### PR TITLE
docs(spec): camera spec says "not implemented" while phases 0-2c are live

### DIFF
--- a/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
@@ -1,10 +1,33 @@
 # Browser pane — camera (getUserMedia video) access
 
 **Date:** 2026-09-01
-**Status:** Proposal. Not implemented.
+**Status:** **Phases 0–2c implemented. Phase 3 NOT implemented** — see the
+warning below.
 **Owner:** unassigned
-**Issue:** #2871 (AgentX-asaf) — "Browser pane: camera (getUserMedia video)
-access is unconditionally denied"
+**Issue:** #2871 (AgentX-asaf, closed 2026-09-01) — "Browser pane:
+getUserMedia video access is unconditionally denied". Phase 3 tracked
+separately as #2904.
+
+> **⚠ This spec's own v1 gate is not currently met.**
+>
+> §4 lists two non-negotiables for v1. The first (no silent grants) shipped
+> with the Phase 2c prompt. The second — *"Visible while live. An active
+> capture must be indicated on the pane itself, persistently, and must be
+> visible without focusing the pane"* — **has not shipped**, and §6 (Phasing)
+> states plainly: *if Phase 3 is not shipping, Phase 2 should not ship either.*
+>
+> Phase 2 shipped anyway. So today a page can hold a live camera grant in a
+> browser pane with no persistent capture indicator and no user-facing revoke
+> (the grant store has a `revoke()` primitive, but `media_grants.rs:101` notes
+> that call alone is not a revoke). Tracked in #2904.
+
+**Shipped:** Phase 0 (#2885, #2888 — callback contract verified from CEF
+source), Phase 1 (#2893 — pane identity), Phase 2a (#2895 — per-pane,
+per-origin grant store), Phase 2b (#2897 — grant-store-driven handler),
+Phase 2c (#2899 — prompt). Also #2889, closing the `--enable-media-stream`
+ingress this spec's §5 required be shut before Phase 2.
+
+**Not shipped:** Phase 3 (§4 — capture indicator + user-facing revoke).
 **Scope:** `agentmux-cef/src/client/handlers.rs` (permission handler +
 `permission_handler()` getter), `agentmux-cef/src/client/mod.rs`
 (`new_with_browser_pane`), `agentmux-cef/src/browser_pane/creation.rs`,

--- a/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
@@ -10,16 +10,32 @@ separately as #2904.
 
 > **⚠ This spec's own v1 gate is not currently met.**
 >
-> §4 lists two non-negotiables for v1. The first (no silent grants) shipped
-> with the Phase 2c prompt. The second — *"Visible while live. An active
-> capture must be indicated on the pane itself, persistently, and must be
-> visible without focusing the pane"* — **has not shipped**, and §6 (Phasing)
-> states plainly: *if Phase 3 is not shipping, Phase 2 should not ship either.*
+> §4 lists **four** non-negotiables for v1. Two shipped, two did not:
 >
-> Phase 2 shipped anyway. So today a page can hold a live camera grant in a
-> browser pane with no persistent capture indicator and no user-facing revoke
-> (the grant store has a `revoke()` primitive, but `media_grants.rs:101` notes
-> that call alone is not a revoke). Tracked in #2904.
+> | # | Non-negotiable (§4) | Status |
+> |---|---|---|
+> | 1 | **No silent grants** — every first grant is an explicit user action | ✅ Phase 2c prompt |
+> | 2 | **Visible while live** — persistent capture indication on the pane, visible without focusing it | ❌ **not shipped** |
+> | 3 | **Revocable** — one click, which actually stops the stream | ❌ **not shipped** |
+> | 4 | **Deny is the default and the failure mode** | ✅ handler denies until a grant exists; unanswered prompts time out to deny |
+>
+> §6 (Phasing) states plainly: *if Phase 3 is not shipping, Phase 2 should not
+> ship either.* Phase 2 shipped anyway.
+>
+> So today a page can hold a live camera grant in a browser pane with no
+> persistent capture indicator and no user-facing revoke. The grant store does
+> have a `revoke()` primitive, but `media_grants.rs:101` notes that call alone
+> is not a revoke — the stream-teardown half required by #3 does not exist.
+> Tracked in #2904.
+
+> **📖 How to read the rest of this document.** Everything below this header is
+> the ORIGINAL PROPOSAL, written before any of it shipped, and it is preserved
+> as the design record rather than rewritten. Several sections therefore
+> describe the pre-implementation world in the present tense — §1 says a browser
+> pane can never grant camera access, §2 says no origin scoping or grant store
+> exists, §3.8 says both switch ingress paths are unfiltered, and §6 presents
+> Phases 1–2 as future work. **All four of those are now out of date**; the
+> status block above is authoritative for what actually ships today.
 
 **Shipped:** Phase 0 (#2885, #2888 — callback contract verified from CEF
 source), Phase 1 (#2893 — pane identity), Phase 2a (#2895 — per-pane,

--- a/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
@@ -7,6 +7,23 @@ warning below.
 **Issue:** #2871 (AgentX-asaf, closed 2026-09-01) — "Browser pane:
 getUserMedia video access is unconditionally denied". Phase 3 tracked
 separately as #2904.
+**Shipped:** Phase 0 (#2885, #2888 — callback contract verified from CEF
+source), Phase 1 (#2893 — pane identity), Phase 2a (#2895 — per-pane,
+per-origin grant store), Phase 2b (#2897 — grant-store-driven handler),
+Phase 2c (#2899 — prompt). Also #2889, closing the `--enable-media-stream`
+ingress this spec's §5 required be shut before Phase 2.
+
+**Not shipped:** Phase 3 (§4 — capture indicator + user-facing revoke).
+**Scope:** `agentmux-cef/src/client/handlers.rs` (permission handler +
+`permission_handler()` getter), `agentmux-cef/src/client/mod.rs`
+(`new_with_browser_pane`), `agentmux-cef/src/browser_pane/creation.rs`,
+`agentmux-cef/src/browser_pane/creation_views.rs`, a new grant store in
+`agentmux-srv`, and a prompt surface in the frontend.
+**Related:** `SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md` §Phase 4 — specifically its
+`4a. CEF mic-permission handler` (the handler this extends) and
+`4b. OS-permission UX (frontend)` (the layer-B precedent in §3.6) — #1591/#1602, `SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md`,
+`SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md` (per-pane surface
+precedent)
 
 > **⚠ This spec's own v1 gate is not currently met.**
 >
@@ -37,27 +54,15 @@ separately as #2904.
 > Phases 1–2 as future work. **All four of those are now out of date**; the
 > status block above is authoritative for what actually ships today.
 
-**Shipped:** Phase 0 (#2885, #2888 — callback contract verified from CEF
-source), Phase 1 (#2893 — pane identity), Phase 2a (#2895 — per-pane,
-per-origin grant store), Phase 2b (#2897 — grant-store-driven handler),
-Phase 2c (#2899 — prompt). Also #2889, closing the `--enable-media-stream`
-ingress this spec's §5 required be shut before Phase 2.
-
-**Not shipped:** Phase 3 (§4 — capture indicator + user-facing revoke).
-**Scope:** `agentmux-cef/src/client/handlers.rs` (permission handler +
-`permission_handler()` getter), `agentmux-cef/src/client/mod.rs`
-(`new_with_browser_pane`), `agentmux-cef/src/browser_pane/creation.rs`,
-`agentmux-cef/src/browser_pane/creation_views.rs`, a new grant store in
-`agentmux-srv`, and a prompt surface in the frontend.
-**Related:** `SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md` §Phase 4 — specifically its
-`4a. CEF mic-permission handler` (the handler this extends) and
-`4b. OS-permission UX (frontend)` (the layer-B precedent in §3.6) — #1591/#1602, `SPEC_SETTINGS_RECORDING_INPUT_SECTION_2026_08_19.md`,
-`SPEC_BROWSER_PANE_UNIFIED_CONTEXT_MENU_2026_08_15.md` (per-pane surface
-precedent)
-
 ---
 
-## 1. Current behaviour (verified)
+## 1. ~~Current behaviour~~ Behaviour BEFORE this spec shipped (verified at the time)
+
+> **⛔ SUPERSEDED as of 2026-09-01.** This section described the world before
+> Phases 1–2c. It is **no longer true**: `permission_handler()` now returns a
+> pane handler backed by the grant store (`handlers.rs:74-93`), and a user can
+> grant camera to a page in a browser pane. Kept because the reasoning below is
+> what the design had to overcome — do not cite it as current behaviour.
 
 A browser pane cannot grant camera access to any page, ever. Two independent
 reasons, both deliberate:
@@ -84,6 +89,12 @@ decide audio and video independently for one request.** Any permission model
 that presents them as separate toggles will produce a UI that lies.
 
 ## 2. Correcting the premise of #2871
+
+> **⛔ SUPERSEDED as of 2026-09-01.** The gap identified here has since been
+> filled: a per-pane, per-origin grant store now exists
+> (`browser_panes/media_grants.rs`, Phase 2a / #2895). The paragraph below was
+> accurate when written and is kept because it is the finding that motivated
+> building one.
 
 The issue says the mic work "already solved the harder half of this problem for
 audio: per-pane origin-scoped grants."
@@ -257,6 +268,10 @@ not an implementation detail — the §4 revoke guarantee depends entirely on it
 
 ### 3.8 `--enable-media-stream` must be rejected at every ingress
 
+> **✅ IMPLEMENTED as of 2026-09-01 (#2889).** Both ingress paths are now
+> filtered. The text below describes the unfiltered state that made this a
+> blocking requirement, not current behaviour.
+
 An earlier revision of this spec said AgentMux "does not pass
 `--enable-media-stream` today (verified: no occurrence in `agentmux-cef` or
 `agentmux-launcher`)" and treated it as a standing constraint on future edits.
@@ -345,6 +360,12 @@ host. Scope it separately or not at all; do not let it ride along because the
 bitmask is adjacent.
 
 ## 6. Phasing
+
+> **STATUS as of 2026-09-01.** Phases 0, 1, 2a, 2b and 2c are **shipped** —
+> see the status block at the top of this document for the per-phase PR list.
+> **Phase 3 is not**, which is the unmet gate this section itself defines
+> below. The phases are described as future work in the prose that follows;
+> read them as the original plan, not as outstanding work.
 
 **~~Phase 0 — verify the async callback contract~~ — DONE (2026-09-01).**
 Answered from the CEF headers without needing a build; see §3.4 and §7 Q1/Q2.


### PR DESCRIPTION
Found while auditing open issues for anything already resolved by shipped code.

## The stale status

`SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md` still read **"Status: Proposal. Not implemented."** after #2885, #2888, #2889, #2893, #2895, #2897 and #2899 shipped everything through Phase 2c *today*. A reader would reasonably conclude none of it is live — the opposite of true.

Corrected, with a per-phase list of what shipped and its PR number so the next reader can verify rather than infer.

## The part the status line understates

§4 lists **two** non-negotiables for v1:

1. **No silent grants** — ✅ shipped (Phase 2c prompt)
2. **"Visible while live. An active capture must be indicated on the pane itself, persistently, and must be visible without focusing the pane"** — ❌ **not shipped**

And §6 (Phasing) is explicit:

> if Phase 3 is not shipping, Phase 2 should not ship either

Phase 2 shipped anyway. So today a page can hold a live camera grant in a browser pane with **no persistent capture indicator and no user-facing revoke**. The grant store *does* have a `revoke()` primitive, but `media_grants.rs:101` says that call alone is not a revoke — the live-capture teardown half doesn't exist.

Added a warning banner rather than burying this in a status line, since the doc was previously wrong in both directions at once: it understated what shipped, and gave no signal that a stated v1 gate had been skipped.

## Related

- **#2904** — new issue tracking Phase 3. Nothing was tracking it; I searched open issues and PRs first.
- **#2871** — closed separately. Its premise ("unconditionally denied") is genuinely fixed, and a stale issue is worse than a precise new one.

I'm **not** asserting the Phase 2 ship was wrong — that's the owner's call, and there may be good reason to sequence it this way. Recording that the spec set a gate, the gate wasn't met, and the doc said the opposite of the truth.

Docs-only; no behavior change.

<!-- agentmux:agent_id=agentx -->