### PR TITLE
docs: fix status on the docs I made stale this session (cleanup batch A)

### DIFF
--- a/.changesets/1788292739-docs-fix-status-on-the-docs-i-made-stale-this-session-cleanu-hgl2.md
+++ b/.changesets/1788292739-docs-fix-status-on-the-docs-i-made-stale-this-session-cleanu-hgl2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: fix status on the docs I made stale this session (cleanup batch A)

--- a/docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md
+++ b/docs/reports/REPORT_TAB_FLASH_SYSTEMIC_ANALYSIS_2026_08_31.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-08-31
 **Author:** AgentY
-**Status:** Analysis, written while the tab-close flash was still open and
+**Status:** historical — records the analysis and its outcome; not a plan for
+anyone. Written while the tab-close flash was still open and
 **revised after it was fixed** by PR #2818 (§§8-9 of
 `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md`). The outcome is recorded in
 §0 below and is the single most useful thing in this document — it is a

--- a/docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md
+++ b/docs/reports/REPORT_TRANSIENT_API_FAILURE_RETRY_STATE_2026_08_31.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-08-31
 **Author:** AgentY
-**Status:** Assessment. One gap fixed in the same PR (§4.1); the rest recorded,
+**Status:** historical — records the state of transient-failure retry as of
+2026-08-31 and the ladder fix that shipped in PR #2870. One gap fixed in the same PR (§4.1); the rest recorded,
 not fixed.
 **Scope:** `agentmux-srv/src/agents/failure.rs`,
 `frontend/app/view/agent/hooks/useAgentFailure.ts`,

--- a/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CAMERA_ACCESS_2026_09_01.md
@@ -1,7 +1,13 @@
 # Browser pane — camera (getUserMedia video) access
 
 **Date:** 2026-09-01
-**Status:** Proposal. Not implemented.
+**Status:** implemented — shipped 2026-09-01 across PRs #2893 (pane identity),
+#2896 (identity TOCTOU fix), #2895 (grant store), #2897 (permission handler),
+#2899 (prompt, live capture indicator, revoke). Phase 0 was answered from the
+CEF headers in #2885. Out of scope and NOT shipped: persisted grants (§3.2 —
+session-only by design) and desktop capture (§5). The prompt round-trip is
+unit-tested and reasoned-about but has **not** been observed end-to-end — see
+#2899's merge comment.
 **Owner:** unassigned
 **Issue:** #2871 (AgentX-asaf) — "Browser pane: camera (getUserMedia video)
 access is unconditionally denied"
@@ -312,19 +318,33 @@ Answered from the CEF headers without needing a build; see §3.4 and §7 Q1/Q2.
 The async design is viable and the bitmask values are confirmed. Phase 1 is now
 the entry point.
 
-**Phase 1 — pane identity.** Thread `block_id` into the browser-pane client
-(§3.3). Mechanical, independently reviewable, no behaviour change.
+**~~Phase 1 — pane identity~~ — DONE (#2893, TOCTOU fix #2896).** Shipped
+*differently from §3.3's design*: threading `block_id` into the client at
+construction would have silently reclassified prewarmed pool panes, which are
+created with no identity and only become a specific block's pane at promote. It
+resolves identity at request time instead (`AppState::block_id_for_browser`),
+which needs no construction-site changes and works the moment a pane registers.
+§3.3 is kept as written for the reasoning; the implementation note here is the
+correction.
 
-**Phase 2 — handler + in-memory grants + prompt.** The v1 feature: session-only,
-pane-scoped, origin-scoped, explicit-prompt grants (§3.1–3.5), with the §4
-guarantees.
+**~~Phase 2 — handler + in-memory grants + prompt~~ — DONE.** Split for review:
+the grant store (#2895), the handler wired to it (#2897, behaviour-neutral —
+nothing could create a grant yet), then the prompt (#2899).
 
-**Phase 3 — capture indicator + revoke** (§4). Deliberately *not* deferred past
-v1 in spirit — if Phase 3 is not shipping, Phase 2 should not ship either. Split
-only for review size.
+**~~Phase 3 — capture indicator + revoke~~ — DONE (#2899), shipped with Phase 2**
+as this section required. The indicator is driven by CEF's own
+`OnMediaAccessChange` rather than by grants, so it means "is capturing now"
+rather than "may capture".
 
-**Later, separately:** persisted grants, a Settings surface for reviewing and
-revoking them, and any desktop-capture work.
+**Still not built, deliberately:** persisted grants (§3.2 — a materially
+different threat model), a Settings surface for reviewing and revoking grants
+across panes, and any desktop-capture work (§5).
+
+**Not verified end-to-end.** The prompt round-trip — prompt appears, user
+allows, capture starts, indicator lights, Stop reloads — is unit-tested and
+reasoned-about but has never been observed in a running build; that needs a
+person driving a `getUserMedia` page in a pane. The `pane-media` log target
+traces every decision step if it misbehaves.
 
 ## 7. Open questions
 

--- a/docs/specs/SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md
+++ b/docs/specs/SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md
@@ -1,7 +1,10 @@
 # Transient-failure retry for turns with no rendered pane
 
 **Date:** 2026-08-31
-**Status:** Proposal. Not implemented.
+**Status:** active — Phase 0(a) (instrumentation) shipped in PR #2886; the
+classification is now logged at `persist_last_failure`. Phase 0(b) (read the
+data and decide whether to build) and Phases 1-3 are not started, and per §4
+Phase 0(b) may well conclude this should not be built.
 **Owner:** unassigned
 **Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`,
 `agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs`,

--- a/docs/specs/SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md
+++ b/docs/specs/SPEC_TAB_WINDOW_RENDER_ARCHITECTURE_2026_08_31.md
@@ -1,7 +1,9 @@
 # Tab / window render architecture — coherent-frame design
 
 **Date:** 2026-08-31
-**Status:** Proposal. Not implemented. Revised after PR #2818 fixed the
+**Status:** active — §3.1/§3.2 are **rejected** (see §0; four review passes each
+found a fresh unsoundness). §3.3 and §3.4 remain open proposals, §3.4 being the
+highest-value item. Nothing here has been implemented. Revised after PR #2818 fixed the
 tab-close flash by *optimistic removal* (§§8-9 of the 08-25 spec) — see §0.
 That resolution validates this spec's thesis and **shrinks its urgency**: the
 cheap structural move beat the expensive one. Read §0 before funding any phase


### PR DESCRIPTION
Batch A of the merged plan (#2906). **My own contribution first**, before proposing anyone else's docs be touched.

## One was actively wrong

`SPEC_BROWSER_PANE_CAMERA_ACCESS` said **"Not implemented"** on the same day the feature shipped across #2893/#2895/#2896/#2897/#2899. That's exactly the failure the hardening spec opens with — a doc misleading within 48 hours — and I produced it *while being asked to clean up drift*.

## Statuses moved onto the closed enum

| Doc | New status |
|---|---|
| camera access | `implemented` — cites all five PRs, **and names what did *not* ship** (persisted grants, desktop capture) |
| render architecture | `active` — §3.1/§3.2 rejected, §3.3/§3.4 still open |
| headless retry | `active` — Phase 0(a) shipped in #2886; 0(b) may well conclude the rest shouldn't be built |
| both reports | `historical` |

## Phasing corrected too, not just the header

The camera spec's §6 still read as a forward plan. Now marked done — with one thing worth calling out:

**Phase 1 is recorded as having shipped *differently from §3.3's design*.** Threading `block_id` into the client at construction would have silently reclassified prewarmed pool panes, which are created with no identity and only become a specific block's pane at promote. I kept §3.3 as written for its reasoning and put the correction beside it, rather than rewriting the spec to look like the plan had been right.

Also added an explicit note that **the prompt round-trip has never been observed end-to-end** — `implemented` shouldn't be read as `verified in use`.

## Verification

All six of this session's docs now carry a first word in the enum: `implemented`, `active`, `active`, `proposed`, `historical`, `historical`.

Next: Batch B (2 `superseded` docs missing their required `Superseded-by:` pointer).

<!-- agentmux:agent_id=agenty -->