### PR TITLE
test(srv): raise subprocess_io liveness timeouts, fixing a recurring CI flake

### DIFF
--- a/.changesets/1788293231-test-srv-raise-subprocess-io-liveness-timeouts-to-fix-a-recu-tzl1.md
+++ b/.changesets/1788293231-test-srv-raise-subprocess-io-liveness-timeouts-to-fix-a-recu-tzl1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+test(srv): raise subprocess_io liveness timeouts to fix a recurring CI flake

--- a/agentmux-srv/tests/subprocess_io.rs
+++ b/agentmux-srv/tests/subprocess_io.rs
@@ -15,6 +15,25 @@ use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::time::{timeout, Duration};
 
+/// Liveness bound for every wait/read in this file — **not** a performance
+/// assertion.
+///
+/// Every timeout here exists for one reason: if a pipe read or `child.wait()`
+/// never returns, fail the test instead of hanging the suite forever. None of
+/// them assert anything about how *fast* a child starts or exits, so the value
+/// only needs to be comfortably above the worst plausible scheduling delay.
+///
+/// It was 5s, which is a wall-clock budget covering `node` process startup on a
+/// shared GitHub runner already saturated by `cargo test --workspace`. That is
+/// tight enough to lose the race intermittently, and it did — twice, on
+/// **docs-only** PRs (#2861 and #2905), where the change under test could not
+/// possibly have caused it. See issue #2863.
+///
+/// 30s costs nothing on the happy path (these children exit in milliseconds)
+/// and removes the flake. If a test here ever actually takes 30s, something is
+/// genuinely wedged and the failure is real.
+const IO_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
 }
@@ -58,7 +77,7 @@ async fn stdin_stdout_roundtrip() {
 
     // Read stdout
     let mut reader = BufReader::new(stdout).lines();
-    let line = timeout(Duration::from_secs(10), reader.next_line())
+    let line = timeout(IO_TIMEOUT, reader.next_line())
         .await
         .expect("stdout read timed out")
         .expect("stdout read error")
@@ -85,7 +104,7 @@ async fn stdin_flush_required() {
     drop(stdin);
 
     let mut reader = BufReader::new(stdout).lines();
-    let result = timeout(Duration::from_secs(5), reader.next_line()).await;
+    let result = timeout(IO_TIMEOUT, reader.next_line()).await;
     assert!(result.is_ok(), "stdin data did not arrive — flush may be broken");
 
     let line = result.unwrap().unwrap().unwrap();
@@ -101,7 +120,7 @@ async fn stderr_captured() {
     let stderr = child.stderr.take().unwrap();
 
     let mut reader = BufReader::new(stderr).lines();
-    let line = timeout(Duration::from_secs(5), reader.next_line())
+    let line = timeout(IO_TIMEOUT, reader.next_line())
         .await
         .expect("stderr read timed out")
         .expect("stderr read error")
@@ -114,11 +133,15 @@ async fn stderr_captured() {
 #[tokio::test]
 async fn exit_code_nonzero() {
     let mut child = spawn_node("exit-code.js", &["42"]);
-    // Drain stderr so the pipe doesn't block
+    // Close our ends of the pipes we are not reading. Note this CLOSES them, it
+    // does not drain them — the previous comment here said "drain", which would
+    // matter if the fixture wrote enough to fill a pipe buffer. It does not:
+    // `exit-code.js` writes one short line to stderr and nothing to stdout, so
+    // there is no buffer to block on either way.
     drop(child.stderr.take());
     drop(child.stdin.take());
 
-    let status = timeout(Duration::from_secs(5), child.wait())
+    let status = timeout(IO_TIMEOUT, child.wait())
         .await
         .expect("wait timed out")
         .expect("wait error");
@@ -136,7 +159,7 @@ async fn stdout_eof_on_process_exit() {
     let mut reader = BufReader::new(stdout).lines();
 
     // Should get Ok(None) = EOF, not an error
-    let result = timeout(Duration::from_secs(5), reader.next_line())
+    let result = timeout(IO_TIMEOUT, reader.next_line())
         .await
         .expect("stdout read timed out")
         .expect("stdout read error");
@@ -159,7 +182,7 @@ async fn large_stdin_payload() {
     drop(stdin);
 
     let mut reader = BufReader::new(stdout).lines();
-    let line = timeout(Duration::from_secs(15), reader.next_line())
+    let line = timeout(IO_TIMEOUT, reader.next_line())
         .await
         .expect("stdout read timed out on large payload")
         .expect("stdout read error")


### PR DESCRIPTION
Closes #2863, using the fix that issue already prescribed.

## Why now

`subprocess_io::exit_code_nonzero` has now blocked **two docs-only PRs**: #2861 (which prompted #2863) and **#2905 today** — my own single-markdown-file change, where the diff could not possibly have caused it. That is the second time this test has cost a review cycle on work it has nothing to do with.

## The cause

The test gives a spawned `node` process **5 seconds** to start and exit. That is a wall-clock budget covering process startup on a shared GitHub runner already saturated by `cargo test --workspace`, and it is tight enough to lose the race intermittently.

Every timeout in this file exists for one reason: stop the suite hanging forever if a pipe read or `child.wait()` never returns. **None of them assert anything about how fast a child starts or exits.** So the value only has to clear the worst plausible scheduling delay — and 5s doesn't.

## The change

Replaced all six call-site literals with one documented `IO_TIMEOUT` constant at 30s. A constant rather than six edited numbers, so the next person changing it changes it once and the rationale lives somewhere other than a commit message.

30s costs nothing on the happy path (these children exit in milliseconds), and a test here that genuinely takes 30s *is* wedged — a real failure worth reporting.

## Deliberately not touched

The Windows-only `create_no_window_flag_set` keeps its own `PER_ATTEMPT_TIMEOUT` (15s) and bounded-retry loop. That's a different, already-considered design for the same underlying problem, and its comment records the two specific cold-start flakes it was built for. Folding it into the constant would discard that.

## One comment correction

The failing test carried `// Drain stderr so the pipe doesn't block` above `drop(child.stderr.take())`. **Dropping closes the pipe; it does not drain it** — and that distinction would matter if the fixture filled a buffer.

It doesn't: `exit-code.js` writes one short line to stderr and nothing to stdout. Worth stating explicitly, because that comment is the first thing someone debugging this test reads, and it points at a buffer-blocking theory that I checked and ruled out before concluding the timeout was simply too tight.

## Tests

`cargo test -p agentmux-srv --test subprocess_io` — **7 passed**.

<!-- agentmux:agent_id=agentx -->