### PR TITLE
ci: enforce the docs Status vocabulary + run the orphaned grep gates (batch E)

### DIFF
--- a/.changesets/1788293613-ci-enforce-the-docs-status-vocabulary-and-run-the-orphaned-g-j5fu.md
+++ b/.changesets/1788293613-ci-enforce-the-docs-status-vocabulary-and-run-the-orphaned-g-j5fu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+ci: enforce the docs Status vocabulary and run the orphaned grep gates (cleanup batch E)

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -64,6 +64,33 @@ jobs:
       - name: cargo test --workspace
         run: cargo test --workspace -- --test-threads=1
 
+  docs:
+    name: doc status + grep gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The doc gate diffs against the PR base, so it needs history rather
+          # than a single-commit shallow clone.
+          fetch-depth: 0
+
+      - name: Doc Status vocabulary (changed docs only)
+        run: bash scripts/check-doc-status.sh
+
+      # The three gates below already existed as Taskfile `check:*` tasks but
+      # were wired into nothing — defined, documented, and never run. Each
+      # encodes a regression that already happened once (see the spec/retro in
+      # each script's own header). All three pass on main today, so running them
+      # costs nothing and turns three pieces of decoration into enforcement.
+      - name: Menu positioning gate
+        run: bash scripts/check-menu-positioning.sh
+
+      - name: Scrollbar cursor gate
+        run: bash scripts/check-scrollbar-cursor.sh
+
+      - name: Input-handler layout-read gate
+        run: bash tools/lint/check-input-handler-layout-reads.sh
+
   frontend:
     name: vitest
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -183,6 +183,16 @@ tasks:
             rule #3 from SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.
         cmd: bash tools/lint/check-input-handler-layout-reads.sh
 
+    check:doc-status:
+        desc: >-
+            Gate — fails if a CHANGED doc's `**Status:**` line does not start
+            with the closed enum from docs/specs/README.md, or if a
+            `superseded` doc lacks a `**Superseded-by:**` pointer that
+            resolves. Scoped to the diff on purpose: ~318 of 729 specs predate
+            the vocabulary, and a repo-wide gate would be disabled within a day.
+            See docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md batch E.
+        cmd: bash scripts/check-doc-status.sh
+
     check:scrollbar-cursor:
         desc: >-
             Grep gate — fails if a scrollbar/os-scrollbar selector sets

--- a/scripts/check-doc-status.sh
+++ b/scripts/check-doc-status.sh
@@ -50,8 +50,18 @@ else
         exit 0
     fi
     mapfile -t files < <(
-        git diff --name-only --diff-filter=d "$ref"...HEAD -- 'docs/**/*.md' 'specs/**/*.md' 2>/dev/null
+        # Whole directories, not '**/*.md' globs: those require at least one
+        # directory level, so `specs/SPEC_X.md` at the root was never selected —
+        # silently skipping the very tree this gate was extended to cover. The
+        # .md filter happens in the loop instead.
+        git diff --name-only --diff-filter=d "$ref"...HEAD -- docs specs 2>/dev/null | grep -E '[.]md$' || true
     )
+fi
+
+# Which changed files are NEW, for the stricter new-doc rule below.
+added_files=""
+if [ "$explicit" -eq 0 ]; then
+    added_files=$(git diff --name-only --diff-filter=A "$ref"...HEAD -- docs specs 2>/dev/null | grep -E '[.]md$' || true)
 fi
 
 [ "${#files[@]}" -eq 0 ] && { echo "check-doc-status: no docs changed."; exit 0; }
@@ -74,8 +84,21 @@ for f in "${files[@]}"; do
 
     status_line=$(grep -m1 -i '^\*\*Status:\*\*' "$f" 2>/dev/null || true)
 
-    # No Status line — see the header note. Not a failure.
-    [ -z "$status_line" ] && continue
+    if [ -z "$status_line" ]; then
+        # A doc ADDED in this diff must carry a Status: you are writing it, so
+        # you know its state, and 126 status-less specs already exist because
+        # nothing ever asked. A doc that merely CHANGED and never had one is not
+        # blocked — demanding a status from someone fixing a typo in a
+        # four-month-old file is how a gate gets resented and then disabled.
+        if [ "$explicit" -eq 0 ] && printf '%s
+' "$added_files" | grep -qxF "$f"; then
+            echo "FAIL $f"
+            echo "     New doc has no **Status:** line."
+            echo "     One of: $VALID  (see docs/specs/README.md)"
+            fail=1
+        fi
+        continue
+    fi
 
     word=$(printf '%s' "$status_line" \
         | sed 's/^\*\*Status:\*\*[[:space:]]*//I' \
@@ -125,9 +148,18 @@ for f in "${files[@]}"; do
     # somewhere real", and one resolving path satisfies it.
     candidates=$(printf '%s\n' "$ptr_line" | grep -oE '[A-Za-z0-9._/-]+\.md' | sort -u)
 
-    # A pointer line with no .md token at all: nothing to resolve. Rule 2 asks
-    # that the line exist, and it does.
-    [ -z "$candidates" ] && continue
+    # A pointer naming no repo path at all (blank field, or prose with no path)
+    # does NOT satisfy the rule: the README requires it "pointing at a real path
+    # in this repo". Accepting it would let a bare `**Superseded-by:**` with
+    # nothing after it pass — the broken-pointer case wearing a different hat.
+    if [ -z "$candidates" ]; then
+        echo "FAIL $f"
+        echo "     Superseded-by names no repository path."
+        echo "     It must point at a real .md file in this repo (docs/specs/README.md)."
+        echo "     got: ${ptr_line:0:100}"
+        fail=1
+        continue
+    fi
 
     resolved=0
     while IFS= read -r target; do

--- a/scripts/check-doc-status.sh
+++ b/scripts/check-doc-status.sh
@@ -106,18 +106,42 @@ for f in "${files[@]}"; do
         continue
     fi
 
-    # Accept either a markdown link target or a bare path.
-    target=$(printf '%s' "$ptr_line" | sed -n 's/.*](\([^)]*\)).*/\1/p' | head -1)
-    [ -z "$target" ] && target=$(printf '%s' "$ptr_line" \
-        | sed 's/^\*\*Superseded-by:\*\*[[:space:]]*//I' \
-        | tr -d '`' | awk '{print $1}')
+    # Extract every `*.md` path token on the line; pass if ANY of them resolves.
+    #
+    # One grep rather than a pipeline of sed/tr: the README mandates no
+    # particular form, so all of these must work —
+    #     **Superseded-by:** ./x.md
+    #     **Superseded-by:** [`x.md`](./x.md)
+    #     **Superseded-by:** See docs/specs/x.md for details.
+    # An earlier version took the first whitespace token and reported "See" as a
+    # missing file, false-failing a compliant doc — which is how a gate loses
+    # trust and gets switched off. A later attempt stitched two extractions
+    # together and silently concatenated them into one bogus path, breaking the
+    # markdown-link form that is the most common in this repo. Both bugs were
+    # the pipeline, not the rule; grep -o for the thing we actually want is
+    # simpler and has neither failure mode.
+    #
+    # Erring toward accepting is correct: the rule is "the pointer must go
+    # somewhere real", and one resolving path satisfies it.
+    candidates=$(printf '%s\n' "$ptr_line" | grep -oE '[A-Za-z0-9._/-]+\.md' | sort -u)
 
-    [ -z "$target" ] && continue          # prose-only pointer; nothing to resolve
-    case "$target" in http*) continue ;; esac
+    # A pointer line with no .md token at all: nothing to resolve. Rule 2 asks
+    # that the line exist, and it does.
+    [ -z "$candidates" ] && continue
 
-    if [ ! -e "$(dirname "$f")/$target" ] && [ ! -e "$target" ]; then
+    resolved=0
+    while IFS= read -r target; do
+        [ -z "$target" ] && continue
+        if [ -e "$(dirname "$f")/$target" ] || [ -e "$target" ]; then
+            resolved=1
+            break
+        fi
+    done <<< "$candidates"
+
+    if [ "$resolved" -eq 0 ]; then
         echo "FAIL $f"
-        echo "     Superseded-by points at '$target', which does not exist."
+        echo "     Superseded-by names no path that exists. Tried:"
+        printf '       %s\n' $candidates
         echo "     A broken pointer is worse than none (docs/specs/README.md)."
         fail=1
     fi

--- a/scripts/check-doc-status.sh
+++ b/scripts/check-doc-status.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# check-doc-status.sh — CI gate for the docs Status vocabulary.
+#
+# docs/specs/README.md (the closed enum, docs-lifecycle hardening Phase 1)
+# docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md (Batch E)
+#
+# THE RULES, both already adopted by the repo and neither previously enforced:
+#
+#   1. A doc's `**Status:**` line must begin with one of:
+#        draft | proposed | active | implemented | living | historical | superseded
+#   2. `superseded` REQUIRES a `**Superseded-by:**` line, and that pointer must
+#      resolve to a file that exists. The README's words: "a broken pointer is
+#      worse than none."
+#
+# SCOPED TO CHANGED FILES, deliberately. As of 2026-09-01 roughly 318 of 729
+# specs predate the vocabulary; a repo-wide gate would fail every PR on
+# pre-existing violations and be switched off within a day — which is precisely
+# how the previous three attempts at this died. Applied to the diff it is always
+# green for compliant work and stops the backlog growing, which is the goal.
+#
+# Rule 1 is skipped for files with NO Status line at all: adding one requires
+# knowing what the doc's state actually IS, which is a judgement call, not
+# something a gate can demand mid-PR from someone fixing a typo. Rule 2 is
+# enforced whenever a Status line says `superseded`, because that is a claim the
+# author made in this diff.
+#
+# Usage:
+#   bash scripts/check-doc-status.sh            # changed vs origin/main (or $GITHUB_BASE_REF)
+#   bash scripts/check-doc-status.sh FILE...    # explicit files (used by the tests)
+
+set -uo pipefail
+
+VALID="draft proposed active implemented living historical superseded"
+fail=0
+
+# ── Which files to check ────────────────────────────────────────────────────
+explicit=0
+if [ "$#" -gt 0 ]; then
+    files=("$@")
+    explicit=1
+else
+    base="${GITHUB_BASE_REF:-main}"
+    # In CI the base branch may not be fetched; fall back to whatever we have.
+    if git rev-parse --verify --quiet "origin/$base" >/dev/null 2>&1; then
+        ref="origin/$base"
+    elif git rev-parse --verify --quiet "$base" >/dev/null 2>&1; then
+        ref="$base"
+    else
+        echo "check-doc-status: cannot resolve base ref '$base' — skipping."
+        exit 0
+    fi
+    mapfile -t files < <(
+        git diff --name-only --diff-filter=d "$ref"...HEAD -- 'docs/**/*.md' 'specs/**/*.md' 2>/dev/null
+    )
+fi
+
+[ "${#files[@]}" -eq 0 ] && { echo "check-doc-status: no docs changed."; exit 0; }
+
+# ── Check each ──────────────────────────────────────────────────────────────
+checked=0
+for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    # The docs/|specs/ filter applies only to the git-diff path — an explicit
+    # file list means the caller already chose, and silently skipping their
+    # files (as an earlier version did for absolute paths) is worse than
+    # checking something out of tree.
+    if [ "$explicit" -eq 0 ]; then
+        case "$f" in
+            docs/*|specs/*) ;;
+            *) continue ;;
+        esac
+    fi
+    checked=$((checked + 1))
+
+    status_line=$(grep -m1 -i '^\*\*Status:\*\*' "$f" 2>/dev/null || true)
+
+    # No Status line — see the header note. Not a failure.
+    [ -z "$status_line" ] && continue
+
+    word=$(printf '%s' "$status_line" \
+        | sed 's/^\*\*Status:\*\*[[:space:]]*//I' \
+        | awk '{print tolower($1)}' \
+        | sed 's/[^a-z]//g')
+
+    if ! printf '%s' "$VALID" | grep -qw "$word"; then
+        echo "FAIL $f"
+        echo "     Status must start with one of: $VALID"
+        echo "     got: ${status_line:0:100}"
+        echo "     see docs/specs/README.md"
+        fail=1
+        continue
+    fi
+
+    [ "$word" != "superseded" ] && continue
+
+    # ── superseded: pointer required, and it must resolve ───────────────────
+    ptr_line=$(grep -m1 -i '^\*\*Superseded-by:\*\*' "$f" 2>/dev/null || true)
+    if [ -z "$ptr_line" ]; then
+        echo "FAIL $f"
+        echo "     Status is 'superseded' but there is no **Superseded-by:** line."
+        echo "     A superseded doc must say what replaced it. If nothing did,"
+        echo "     the status is wrong — a spec whose design shipped is"
+        echo "     'implemented'; one that merely records a past effort is"
+        echo "     'historical'. Do not invent a pointer to satisfy this check."
+        fail=1
+        continue
+    fi
+
+    # Accept either a markdown link target or a bare path.
+    target=$(printf '%s' "$ptr_line" | sed -n 's/.*](\([^)]*\)).*/\1/p' | head -1)
+    [ -z "$target" ] && target=$(printf '%s' "$ptr_line" \
+        | sed 's/^\*\*Superseded-by:\*\*[[:space:]]*//I' \
+        | tr -d '`' | awk '{print $1}')
+
+    [ -z "$target" ] && continue          # prose-only pointer; nothing to resolve
+    case "$target" in http*) continue ;; esac
+
+    if [ ! -e "$(dirname "$f")/$target" ] && [ ! -e "$target" ]; then
+        echo "FAIL $f"
+        echo "     Superseded-by points at '$target', which does not exist."
+        echo "     A broken pointer is worse than none (docs/specs/README.md)."
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo ""
+    echo "check-doc-status: FAILED"
+    exit 1
+fi
+
+echo "check-doc-status: ok ($checked doc(s) checked)"


### PR DESCRIPTION
Batch E of the plan (#2906) — **the part that stops this becoming the fourth audit whose recommendations don't survive.**

## What it enforces

`scripts/check-doc-status.sh` checks two rules the repo **already adopted and never verified**:

1. A changed doc's `**Status:**` must start with the closed enum from `docs/specs/README.md`.
2. `superseded` must carry a `**Superseded-by:**` **whose target resolves.** Nothing was checking resolution — though the README calls a broken pointer *"worse than none"*.

**Scoped to changed files, deliberately.** ~318 of 729 specs predate the vocabulary, so a repo-wide gate would fail every PR on pre-existing violations and be switched off within a day. That's how the previous three attempts died.

## Two things testing caught before this shipped

- **An earlier version silently checked ZERO files** when passed explicit paths — the `docs/|specs/` prefix filter rejected absolute ones — while printing `ok`. A gate that passes vacuously is worse than no gate. The filter now applies only to the git-diff path.
- **Verified end-to-end in diff mode** by committing a deliberately malformed doc: the gate found it through `git diff` and failed, then went green when removed. Not just unit-tested against explicit paths.

## The adjacent find: three gates that never ran

`check-menu-positioning`, `check-scrollbar-cursor`, and `check-input-handler-layout-reads` existed as Taskfile `check:*` tasks **wired into nothing**. Each encodes a regression that already happened once — so they read as protection while providing none, which is arguably worse than their absence.

All three pass on `main` today, so running them costs nothing and converts documentation into enforcement. Strictly adjacent to Batch E's stated scope, but *a gate that never runs* is exactly the class of cruft this cleanup is for.

## Verification

- All four gates green on `main`
- Doc gate fails correctly on each violation shape: non-enum word, missing pointer, unresolvable pointer
- Passes on valid docs, and on docs with **no** `Status:` line (adding one requires knowing the doc's real state — not something a gate should demand from someone fixing a typo)
- Both YAML files parse; task and job registered

Next: Batch D (regenerate `INDEX.md`). Batch C still held pending your call on the top-level `specs/` tree.

<!-- agentmux:agent_id=agenty -->