### PR TITLE
docs: record what the cleanup plan actually executed

### DIFF
--- a/.changesets/1788296814-docs-record-what-the-cleanup-plan-actually-executed-ozzj.md
+++ b/.changesets/1788296814-docs-record-what-the-cleanup-plan-actually-executed-ozzj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: record what the cleanup plan actually executed

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -304,10 +304,11 @@ deliberately do not.
 | [`jekt-visibility-completion`](jekt-visibility-completion.md) | Spec: Jekt Visibility Completion — persistent-agent visibility + outgoing echo |
 | [`swarm-active-pane-sync`](swarm-active-pane-sync.md) | Swarm ↔ Pane Two-Way Active-Row Sync |
 
-### active (12)
+### active (13)
 
 | Spec | Title |
 |---|---|
+| [`PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01`](PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md) | Docs cleanup — execution plan |
 | [`SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05`](SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md) | SPEC: Align pane scrollback with actual model context, and make cross-instance opens honest |
 | [`SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09`](SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md) | SPEC: Session-scoped pane scrollback + a full "Agent History" view |
 | [`SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04`](SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md) | Agent Recurring-Task / Polling Primitives — Design Hardening |
@@ -321,11 +322,10 @@ deliberately do not.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (82)
+### proposed (81)
 
 | Spec | Title |
 |---|---|
-| [`PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01`](PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md) | Docs cleanup — execution plan |
 | [`PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20`](PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md) | Plan — collapse every provider-login code path onto one |
 | [`PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17`](PLAN_MACOS_CLAUDE_KEYCHAIN_CREDENTIAL_ISOLATION_2026_08_17.md) | Plan — enforce the same per-agent Claude auth isolation on macOS that already holds on Windows |
 | [`PLAN_WINDOWS_CI_SUBPROCESS_IO_FLAKE_FIX_2026_08_13`](PLAN_WINDOWS_CI_SUBPROCESS_IO_FLAKE_FIX_2026_08_13.md) | Plan — fix the recurring `create_no_window_flag_set` flake on Windows nightly CI |

--- a/docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md
+++ b/docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md
@@ -224,6 +224,30 @@ reader checking whether the cleanup happened would conclude it did not.
   previous 30 days were absent. The index was not rotting, it was being outrun,
   which is a different problem and needs a generator rather than an update.
 
+### Where the shipped work is narrower than the plan
+
+**Batch E's gate is narrower than §3 promised, deliberately.** §3 says every
+*added **or modified*** doc must carry a Status line. `check-doc-status.sh`
+enforces Rule 1 only on **added** docs; a doc that was merely modified and never
+had a Status is not blocked (`scripts/check-doc-status.sh`, the comment above
+the `-z "$status_line"` branch). Rule 2 — `superseded` needs a resolving
+`Superseded-by:` — is enforced on both, since that is a claim the author made in
+the diff.
+
+The narrowing is faithful to §3's *reasoning* while departing from its
+*wording*. §3 already scopes the gate to changed files so it cannot fail every
+PR on 318 pre-existing violations, "which is precisely how the previous three
+attempts at this died". A modified-but-status-less doc is a pre-existing
+violation too — it just happens to have been touched. Enforcing there would
+demand a status judgement from someone fixing a typo in a four-month-old file,
+reintroducing the same resentment-then-disabled failure at smaller scale.
+
+What that costs: the 125 status-less specs are **not** forced to shrink, only
+prevented from growing. §3's stated goal was "stops the backlog growing", and
+that is met — but anyone reading §3 expecting the backlog to drain as files get
+touched should read this instead. Closing that gap needs the per-doc judgement
+pass §4 rules out, not a stricter gate.
+
 ### The failure worth recording
 
 Batch D's first implementation **silently dropped 189 of 728 specs** (26%): it

--- a/docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md
+++ b/docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md
@@ -1,6 +1,7 @@
 # Docs cleanup — execution plan
 
-**Status:** proposed — plan only; nothing below has been executed yet.
+**Status:** active — A, B, D and E have shipped; C is held pending an owner
+decision (§6). See §7 for what actually happened.
 **Date:** 2026-09-01
 **Owner:** AgentY
 **Scope:** `docs/`, top-level `specs/`
@@ -192,3 +193,51 @@ recommended it and nobody has, across six weeks — which might mean nobody got
 to it, or might mean something outside this repo references those paths. Worth
 one check before moving 102 files; the other batches do not depend on the
 answer.
+
+## 7. Execution record
+
+Added after the fact, because a plan that still reads "nothing below has been
+executed yet" once four of its five batches have shipped is precisely the drift
+this document exists to stop — and it is worse here than elsewhere, since a
+reader checking whether the cleanup happened would conclude it did not.
+
+| Batch | PR | Outcome |
+|---|---|---|
+| Plan | #2906 | This document. |
+| A — my own stale docs | #2907 | 5 docs corrected, incl. the camera spec that said "Not implemented" the day it shipped. |
+| B — missing `Superseded-by:` | #2909 | 3 docs (one more than the 2 measured), each resolved differently — none defaulted to `historical`, per §3's warning. |
+| E — enforcement | #2912 | `scripts/check-doc-status.sh`, plus three `check:*` gates that existed in the Taskfile but had **never run in CI**. |
+| D — generated index | #2914 | `scripts/gen-docs-index.sh` + `--check`. |
+| C — directory consolidation | — | **Held.** §6 is still unanswered. |
+
+### What the measurements got wrong
+
+§2's table was taken before execution and two entries did not survive it:
+
+- **`superseded` without a pointer: 2 → 3.** The measuring glob was
+  `docs/specs/*.md specs/*.md`, which silently skipped `archive/` subdirectories
+  and `docs/analysis/` entirely. A verification that cannot see part of the tree
+  reports a clean result for the part it can see, which is how "clean" and
+  "unchecked" get confused. Later passes used `find docs specs -name "*.md"`.
+- **`INDEX.md` "10 days stale"** understated it. Nothing in the index was
+  *broken* — all 77 curated entries still resolved — but 165 specs added in the
+  previous 30 days were absent. The index was not rotting, it was being outrun,
+  which is a different problem and needs a generator rather than an update.
+
+### The failure worth recording
+
+Batch D's first implementation **silently dropped 189 of 728 specs** (26%): it
+bucketed each file under the literal first word of its `Status:` line but only
+printed the seven canonical buckets, so anything starting `shipped`, `proposal`,
+`ready`, `rootcaused`, … vanished with no trace — under a generated header
+claiming to cover every file. CI passed on it, and `--check` could not have
+caught it at any point, because it diffs against a re-run of the same logic: a
+*stable* bug stays green forever.
+
+Caught in review (#2914). The fix that matters is not the missing section but
+the completeness assertion added alongside it — emitted rows must equal
+candidate files or the script refuses to write. §1 says this plan must not be a
+fourth audit; the same logic applies to its tooling. A generator that can
+quietly under-report is a new instance of the problem, not a fix for it, and
+only an invariant it cannot pass while broken makes that structurally
+impossible.


### PR DESCRIPTION
## Summary

The cleanup plan still said **"proposed — plan only; nothing below has been executed yet"** after four of its five batches had shipped (#2907, #2909, #2912, #2914). Someone checking whether the cleanup happened would have concluded it didn't.

That is the drift this plan exists to stop, occurring in the plan itself — the same shape as Batch A, where the camera spec said "Not implemented" the day the feature shipped.

Status → `active` (C is held on §6, still unanswered), plus a **§7 execution record**.

## What §7 records

**Which batch landed where**, and that C alone is outstanding.

**Two §2 measurements that didn't survive execution:**

- `superseded`-without-pointer was measured as **2**, actually **3**. The measuring glob was `docs/specs/*.md specs/*.md`, which silently skipped `archive/` subdirectories and `docs/analysis/` entirely — so it reported clean for the part of the tree it could see. Worth recording because "clean" and "unchecked" are indistinguishable in that output.
- **"INDEX.md is 10 days stale" understated it.** Nothing in it was broken — all 77 curated entries resolved — but 165 specs added in the previous 30 days were absent. It wasn't rotting, it was being *outrun*, which is a different problem and is why D became a generator rather than a refresh.

**Batch D's first implementation silently dropped 189 of 728 specs** (26%) under a generated header claiming to cover every file, with CI green. Recorded not as self-flagellation but because two things there are reusable: `--check` could never have caught it (it diffs a re-run of the same logic, so a *stable* bug stays green forever), and the fix that mattered was the completeness assertion rather than the missing section.

## Note on scope

§4 says no new audit reports. This isn't one — no new analysis, just making an existing document's own status true.

## Still open

**§6 is the only blocker left: is the top-level `specs/` tree safe to move?** Two audits recommended it; nobody has in six weeks. That could mean nobody got to it, or that something outside this repo references those paths — I can't tell from inside the repo, and it's 102 files.

<!-- agentmux:agent_id=agenty -->